### PR TITLE
stdenv: single make jobserver across multiple nix builds

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,6 +67,9 @@
 /nixos/lib/make-disk-image.nix                 @raitobezarius
 
 # Nix, the package manager
+# @raitobezarius is not "code owner", but is listed here to be notified of changes
+# pertaining to the Nix package manager.
+# i.e. no authority over those files.
 pkgs/tools/package-management/nix/                    @raitobezarius @ma27
 nixos/modules/installer/tools/nix-fallback-paths.nix  @raitobezarius @ma27
 

--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -1368,8 +1368,8 @@ Helper function for running a command as a client of the global jobserver, if ap
 but separators must always be given.
 
 **Note**:
-The global jobserver must be bound to `/jobserver` in the Nix sandbox to be found by this function.
-If the provided `/jobserver` is not a `nixos-jobserver` token file it will not be used.
+The global jobserver must be bound to `/build-support/jobserver` in the Nix sandbox to be found by this function.
+If the provided `/build-support/jobserver` is not a `nixos-jobserver` token file it will not be used.
 
 Example:
 

--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -1355,6 +1355,30 @@ name="/nix/store/9s9r019176g7cvn2nvcw41gsp862y6b4-coreutils-8.24"
 someVar=$(stripHash $name)
 ```
 
+### `runInJobServer` \<command\> \-\-\-\- \<defArgs\> \-\-\-\- \<args\> {#fun-runInJobServer}
+
+Helper function for running a command as a client of the global jobserver, if applicable.
+
+ - If a global jobserver is available, runs `<command> <args>` with a GNU Make compatible jobserver made
+   available in `MAKEFLAGS`. The client is automatically limited to `NIX_BUILD_CORES` tokens.
+ - If no global jobserver is available, runs `<command> <defArgs> <args>` instead.
+
+\<command\>, \<defArgs\> and \<args\> may be more than one shell word each, hence they are separated by
+`----`. \<command\> and \<defArgs\> may not contain `----`. Each set except \<command\> may be empty,
+but separators must always be given.
+
+**Note**:
+The global jobserver must be bound to `/jobserver` in the Nix sandbox to be found by this function.
+If the provided `/jobserver` is not a `nixos-jobserver` token file it will not be used.
+
+Example:
+
+```bash
+runInJobServer cargo build ---- \
+    -j $NIX_BUILD_CORES ---- \
+    ${cargoBuildFlags}
+```
+
 ### `wrapProgram` \<executable\> \<makeWrapperArgs\> {#fun-wrapProgram}
 
 Convenience function for `makeWrapper` that replaces `<executable>` with a wrapper that executes the original program. It takes all the same arguments as `makeWrapper`, except for `--inherit-argv0` (used by the `makeBinaryWrapper` implementation) and `--argv0` (used by both `makeWrapper` and `makeBinaryWrapper` wrapper implementations).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -759,6 +759,7 @@
   ./services/misc/nitter.nix
   ./services/misc/nix-gc.nix
   ./services/misc/nix-optimise.nix
+  ./services/misc/nixos-jobserver.nix
   ./services/misc/nix-ssh-serve.nix
   ./services/misc/novacomd.nix
   ./services/misc/ntfy-sh.nix

--- a/nixos/modules/services/misc/nixos-jobserver.nix
+++ b/nixos/modules/services/misc/nixos-jobserver.nix
@@ -1,0 +1,78 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.nixos.jobserver;
+  tokenDir = "/run/nixos-jobserver";
+  tokenFile = "${tokenDir}/tokens";
+in
+{
+  options = {
+    nixos.jobserver = {
+      enable = mkEnableOption "the global NixOS jobserver";
+
+      owner = mkOption {
+        type = types.str;
+        default = "root";
+        description = ''
+          Owner of the jobserver token file.
+        '';
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "nixbld";
+        description = ''
+          Group of the jobserver token file.
+        '';
+      };
+
+      tokens = mkOption {
+        type = types.ints.unsigned;
+        default = 0;
+        description = ''
+          Number of tokens to provide via the jobserver. Uses the number of CPUs in the
+          system when set to 0.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    nix.sandboxPaths = [ "/jobserver=${tokenFile}?" ];
+
+    systemd.services.nixos-jobserver = {
+      wantedBy = [ "multi-user.target" ];
+
+      path = [ pkgs.nixos-jobserver pkgs.util-linux ];
+
+      preStart = ''
+        mkdir -p ${tokenDir}
+
+        umask 0777
+        touch ${tokenFile}
+      '';
+
+      script = ''
+        exec nixos-jobserver \
+          -t ${toString cfg.tokens} \
+          -u ${escapeShellArg cfg.owner} \
+          -g ${escapeShellArg cfg.group} \
+          ${tokenFile}
+      '';
+
+      # we explicitly *do not* kill the jobserver.
+      # doing so would cause all running builds to fail.
+      # instead we want to make the jobserver unavailable to new builds, but allow
+      # running builds to finish and the jobserver to exit once they're all done.
+      # systemd *does not* want to allow this kind of thing, so we instruct it to
+      # only kill the wrapper script. with the token file unmounted the jobserver
+      # process will exit once all builds have finished.
+      preStop = ''
+        umount ${tokenFile}
+      '';
+      serviceConfig.KillMode = "process";
+    };
+  };
+}

--- a/nixos/modules/services/misc/nixos-jobserver.nix
+++ b/nixos/modules/services/misc/nixos-jobserver.nix
@@ -40,7 +40,7 @@ in
   };
 
   config = mkIf cfg.enable {
-    nix.sandboxPaths = [ "/jobserver=${tokenFile}?" ];
+    nix.sandboxPaths = [ "/build-support/jobserver=${tokenFile}?" ];
 
     systemd.services.nixos-jobserver = {
       wantedBy = [ "multi-user.target" ];

--- a/pkgs/applications/audio/pyradio/default.nix
+++ b/pkgs/applications/audio/pyradio/default.nix
@@ -6,13 +6,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "pyradio";
-  version = "0.9.3.6";
+  version = "0.9.3.7";
 
   src = fetchFromGitHub {
     owner = "coderholic";
     repo = "pyradio";
     rev = "refs/tags/${version}";
-    hash = "sha256-As4xjwJtEKlnFuBigC7nN0kAPe0+99rE9KZ0F6i7qIQ=";
+    hash = "sha256-NwDVytD6nIM++ixGmLh02FIE+hLKHBwwD3aEAXVZn7I=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/audio/tidal-hifi/default.nix
+++ b/pkgs/applications/audio/tidal-hifi/default.nix
@@ -36,11 +36,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tidal-hifi";
-  version = "5.12.0";
+  version = "5.13.0";
 
   src = fetchurl {
     url = "https://github.com/Mastermindzh/tidal-hifi/releases/download/${finalAttrs.version}/tidal-hifi_${finalAttrs.version}_amd64.deb";
-    sha256 = "sha256-DwUKoDaXA99ILxlyay5dRL/ewnzyqSSR6fxPxkr8X34=";
+    sha256 = "sha256-d7JAvpZKdhG9BzCdfwyPlmXcqE49heVLskusaB0uOhg=";
   };
 
   nativeBuildInputs = [ autoPatchelfHook dpkg makeWrapper ];

--- a/pkgs/applications/file-managers/felix-fm/default.nix
+++ b/pkgs/applications/file-managers/felix-fm/default.nix
@@ -4,6 +4,7 @@
 , pkg-config
 , bzip2
 , libgit2
+, nix-update-script
 , zlib
 , zstd
 , zoxide
@@ -44,6 +45,8 @@ rustPlatform.buildRustPackage rec {
     "--skip=functions::tests::test_list_up_contents"
     "--skip=state::tests::test_has_write_permission"
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "A tui file manager with vim-like key mapping";

--- a/pkgs/applications/graphics/komikku/default.nix
+++ b/pkgs/applications/graphics/komikku/default.nix
@@ -19,7 +19,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "komikku";
-  version = "1.46.0";
+  version = "1.47.0";
 
   format = "other";
 
@@ -28,7 +28,7 @@ python3.pkgs.buildPythonApplication rec {
     owner = "valos";
     repo = "Komikku";
     rev = "v${version}";
-    hash = "sha256-0yobGclfZzv0S0HtqeTr4vzK5d6PTQNWMszP0B4k770=";
+    hash = "sha256-ZYQjH3NUPeq5XgCZ6L78lJpgbK69ZMf2AzztbCgbYBo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/1password/default.nix
+++ b/pkgs/applications/misc/1password/default.nix
@@ -12,12 +12,12 @@ let
     if extension == "zip" then fetchzip args else fetchurl args;
 
   pname = "1password-cli";
-  version = "2.28.0";
+  version = "2.29.0";
   sources = rec {
-    aarch64-linux = fetch "linux_arm64" "sha256-rF0HWKLdLDmT5nXqZyn+nwd3DZxkP76Jm+xofvA1dpU=" "zip";
-    i686-linux = fetch "linux_386" "sha256-b9OPsZJTGoAeedj/dv88lkX2Q4p9HG585mWyl7ZfDz4=" "zip";
-    x86_64-linux = fetch "linux_amd64" "sha256-5ZiMQaQLYUR9BZroyG0o+M79cR4GQb6rDyVmIcTZh3o=" "zip";
-    aarch64-darwin = fetch "apple_universal" "sha256-5VmogWqCYMdrg9dyRt4lurPmSRdUUHt4LT3lkOEKdEI=" "pkg";
+    aarch64-linux = fetch "linux_arm64" "sha256-sBbdkoacGI/gawM4YH+BBCLDhC2B+cE4iKVGHBhwkic=" "zip";
+    i686-linux = fetch "linux_386" "sha256-TTd5juT0Aqp1+OfunXcuk0KbL6HIHQV31+1Q1e0GYMY=" "zip";
+    x86_64-linux = fetch "linux_amd64" "sha256-Bb6fNoeNxlbDfwt7Jr8BaKCmFUwSdsLQdVoCmQCNmLA=" "zip";
+    aarch64-darwin = fetch "apple_universal" "sha256-/ryklZnGhrgJggDIa8HmuDsHAXkdrWeXKCQGGVwUAAo=" "pkg";
     x86_64-darwin = aarch64-darwin;
   };
   platforms = builtins.attrNames sources;

--- a/pkgs/applications/misc/gum/default.nix
+++ b/pkgs/applications/misc/gum/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "gum";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "charmbracelet";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-TpLaZ/935S57K60NdgJXVY+YQEedralZMoQHWRgkH+A=";
+    hash = "sha256-rQSSbDHMSWJDSxn/SNNMaOrdZJUhQPnZutmpY9828t0=";
   };
 
-  vendorHash = "sha256-UgpOHZ/CEnGsmUTyNrhh+qDmKEplr18b/OrO2qcIhF4=";
+  vendorHash = "sha256-pkQ8UvWLIWH8gXux/dd0HLdiz7RDrmFJ8SX63Q+nNyw=";
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/applications/misc/oxker/default.nix
+++ b/pkgs/applications/misc/oxker/default.nix
@@ -2,14 +2,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "oxker";
-  version = "0.6.3";
+  version = "0.6.4";
 
   src = fetchCrate {
     inherit pname version;
-    sha256 = "sha256-L03r4PHCu+jsUC5vVSG77SR2ak/AsuVAhTd7P1WibAk=";
+    sha256 = "sha256-dBehxqr/UCXIQDMrGFN6ID+v0NYi50JTHuML3su2O0A=";
   };
 
-  cargoHash = "sha256-5UxbZZdVioy1OZCbE6qESGKVnVT6TS4VHzsKlQ8XP2c=";
+  cargoHash = "sha256-wI7yqRvaszBP4OtlWbWIZ9RLf5y7dx2KufYLaK+PWps=";
 
   meta = with lib; {
     description = "A simple tui to view & control docker containers";

--- a/pkgs/applications/misc/uni/default.nix
+++ b/pkgs/applications/misc/uni/default.nix
@@ -5,16 +5,16 @@
 
 buildGoModule rec {
   pname = "uni";
-  version = "2.6.0";
+  version = "2.7.0";
 
   src = fetchFromGitHub {
     owner = "arp242";
     repo = "uni";
     rev = "refs/tags/v${version}";
-    hash = "sha256-Ij/jUbXl3GkeNZmGJ82i++6VkOW46YFI9m83otY6M7Q=";
+    hash = "sha256-ociPkuRtpBS+x1zSVNYk8oqAsJZGv31/TUUUlBOYhJA=";
   };
 
-  vendorHash = "sha256-88SSrGvZSs6Opi3IKSNNqptuOWMmtTQ4ZDR7ViuGugk=";
+  vendorHash = "sha256-/PvBn2RRYuVpjnrIL1xAcVqAKZuIV2KTSyVtBW1kqj4=";
 
   ldflags = [
     "-s"

--- a/pkgs/applications/networking/blocky/default.nix
+++ b/pkgs/applications/networking/blocky/default.nix
@@ -6,20 +6,20 @@
 
 buildGoModule rec {
   pname = "blocky";
-  version = "0.23";
+  version = "0.24";
 
   src = fetchFromGitHub {
     owner = "0xERR0R";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-IB5vi+nFXbV94YFtY2eMKTgzUgX8q8i8soSrso2zaD4=";
+    hash = "sha256-K+Zdb6l2WUhxVm/gi9U2vVR69bxr2ntLyIrkwTuc0Do=";
   };
 
   # needs network connection and fails at
   # https://github.com/0xERR0R/blocky/blob/development/resolver/upstream_resolver_test.go
   doCheck = false;
 
-  vendorHash = "sha256-h1CkvI7M1kt2Ix3D8+gDl97CFElV+0/9Eram1burOaM=";
+  vendorHash = "sha256-I4UXTynulsRuu9U8tsLbPQO1MMPfUC5dAZE420sW1sU=";
 
   ldflags = [ "-s" "-w" "-X github.com/0xERR0R/blocky/util.Version=${version}" ];
 

--- a/pkgs/applications/networking/browsers/floorp/default.nix
+++ b/pkgs/applications/networking/browsers/floorp/default.nix
@@ -7,7 +7,7 @@
 
 ((buildMozillaMach rec {
   pname = "floorp";
-  packageVersion = "11.13.2";
+  packageVersion = "11.13.3";
   applicationName = "Floorp";
   binaryName = "floorp";
   branding = "browser/branding/official";
@@ -22,7 +22,7 @@
     repo = "Floorp";
     fetchSubmodules = true;
     rev = "v${packageVersion}";
-    hash = "sha256-sFtGtxk3vdR5JoZb1yiITybIfGmOYzKLb9NtbhWjBt8=";
+    hash = "sha256-9EDTVckSqv/nyDi4qjMd54I69WiqM8v6om7zQLT+pQc=";
   };
 
   extraConfigureFlags = [

--- a/pkgs/applications/networking/cluster/atlantis/default.nix
+++ b/pkgs/applications/networking/cluster/atlantis/default.nix
@@ -2,20 +2,20 @@
 
 buildGoModule rec {
   pname = "atlantis";
-  version = "0.27.3";
+  version = "0.28.0";
 
   src = fetchFromGitHub {
     owner = "runatlantis";
     repo = "atlantis";
     rev = "v${version}";
-    hash = "sha256-BC4WSyKnDM9RhM+2iU9dBZLbtxDM/UoMmIDTP6DB3no=";
+    hash = "sha256-ROve0R2k65CChu1nlkObvipxi66TA2XTTRmQ8qpJLO8=";
   };
   ldflags = [
     "-X=main.version=${version}"
     "-X=main.date=1970-01-01T00:00:00Z"
   ];
 
-  vendorHash = "sha256-6Di8XLX1rOjVnIA+5kQB59aZ3qRmkjciWD0+GD9Lpzw=";
+  vendorHash = "sha256-eYS7dO9BCnn9p1HgDOt4vliPYLsR0TaNwSpUoMO6eAk=";
 
   subPackages = [ "." ];
 

--- a/pkgs/applications/networking/cluster/kubecm/default.nix
+++ b/pkgs/applications/networking/cluster/kubecm/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "kubecm";
-  version = "0.28.0";
+  version = "0.29.0";
 
   src = fetchFromGitHub {
     owner = "sunny0826";
     repo = "kubecm";
     rev = "v${version}";
-    hash = "sha256-v2frNvJUvDjPhV1RCR3DHk04kYEqP6hMXeA4j3cWlss=";
+    hash = "sha256-zspAtLomgdIymP3xj3VG2rAhMJAquJCNWRdAM5wPcLg=";
   };
 
-  vendorHash = "sha256-uM9/rqu5WOXK6bqxhtmje+Zd9dtdv3qwt+Xr0SJHjPs=";
+  vendorHash = "sha256-eWKGmVkvMP/vN03pWiShPzZN0vSkhneSK48S4AVBdkM=";
   ldflags = [ "-s" "-w" "-X github.com/sunny0826/kubecm/version.Version=${version}"];
 
   doCheck = false;

--- a/pkgs/applications/networking/cluster/kubeseal/default.nix
+++ b/pkgs/applications/networking/cluster/kubeseal/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "kubeseal";
-  version = "0.26.2";
+  version = "0.26.3";
 
   src = fetchFromGitHub {
     owner = "bitnami-labs";
     repo = "sealed-secrets";
     rev = "v${version}";
-    sha256 = "sha256-96yaWHRfEHjXYZ9Hsh9bXk5O5viSOYhmwJ18JCbtv2U=";
+    sha256 = "sha256-2MU1/znfp2LfojfgFPovgcJbZLtqY+6O7YKZNhPIT8k=";
   };
 
-  vendorHash = "sha256-91GKy7tNKSOiJmpArgp56RXegYP7sdGpaRAxS9xwTXA=";
+  vendorHash = "sha256-B50+G29ze1jPBTlFA0nvMfh25t4Xb3YCxEkPkjxKMj0=";
 
   subPackages = [ "cmd/kubeseal" ];
 

--- a/pkgs/applications/networking/cluster/kyverno/default.nix
+++ b/pkgs/applications/networking/cluster/kyverno/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "kyverno";
-  version = "1.12.1";
+  version = "1.12.2";
 
   src = fetchFromGitHub {
     owner = "kyverno";
     repo = "kyverno";
     rev = "v${version}";
-    hash = "sha256-2x5xLh+v1/RXG3h93Ff49pT9NwHWNx4tubnmCf0SAdY=";
+    hash = "sha256-gR/gpoldtwW0bVjWr5xwbfcKb6VJ43otWnSFrcYerII=";
   };
 
   ldflags = [
@@ -18,7 +18,7 @@ buildGoModule rec {
     "-X github.com/kyverno/kyverno/pkg/version.BuildTime=1970-01-01_00:00:00"
   ];
 
-  vendorHash = "sha256-5tBHmHfBHTsAVDk3i0z2R2amTfOvWHJutTNW2ofGZuQ=";
+  vendorHash = "sha256-sSsLs3EedStYlMYKFXIMdNHtrG8ijyu9+2MCYjjzZR4=";
 
   subPackages = [ "cmd/cli/kubectl-kyverno" ];
 

--- a/pkgs/applications/networking/cluster/pachyderm/default.nix
+++ b/pkgs/applications/networking/cluster/pachyderm/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "pachyderm";
-  version = "2.9.5";
+  version = "2.10.1";
 
   src = fetchFromGitHub {
     owner = "pachyderm";
     repo = "pachyderm";
     rev = "v${version}";
-    hash = "sha256-9ykJMK51fm36sbICyuHJR7dSRnwIHhaQV2foKOuFmz0=";
+    hash = "sha256-ok3TaQ8Vn+dDnlfJ/5n6qFTkYER/jVhFRPAqzGXp1iI=";
   };
 
-  vendorHash = "sha256-bAB2vMPHIcJaMobPukQyKiCq0Af0n4b5mjImTswGFTo=";
+  vendorHash = "sha256-AxKhxXZQ2sBvXs9C6b7WkjpNsYl6MSO/C2ttmRRtBGw=";
 
   subPackages = [ "src/server/cmd/pachctl" ];
 

--- a/pkgs/applications/networking/coreth/default.nix
+++ b/pkgs/applications/networking/coreth/default.nix
@@ -6,19 +6,19 @@
 
 buildGoModule rec {
   pname = "coreth";
-  version = "0.13.3";
+  version = "0.13.4";
 
   src = fetchFromGitHub {
     owner = "ava-labs";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-XVACkk/DUI4AIPRSQgu0g9WHmedjqscZbcz84HIi7jY=";
+    hash = "sha256-jksJgWh2FyP2iYOgA9XiRKUpKvINfIv8ini3X36Zy9U=";
   };
 
   # go mod vendor has a bug, see: golang/go#57529
   proxyVendor = true;
 
-  vendorHash = "sha256-zqvo0hZIOyF5Bzig1hi4KRUDETNiiy1Ll/FFO9hRmYU=";
+  vendorHash = "sha256-2shBVIn/qJQlY+f0xsS9NTZkzcWEnhJpEezNYT6+8F4=";
 
   ldflags = [
     "-s"

--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -48,23 +48,23 @@ let
   # and often with different versions.  We write them on three lines
   # like this (rather than using {}) so that the updater script can
   # find where to edit them.
-  versions.aarch64-darwin = "6.0.2.33403";
-  versions.x86_64-darwin = "6.0.2.33403";
-  versions.x86_64-linux = "6.0.2.4680";
+  versions.aarch64-darwin = "6.0.11.35001";
+  versions.x86_64-darwin = "6.0.11.35001";
+  versions.x86_64-linux = "6.0.10.5325";
 
   srcs = {
     aarch64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.aarch64-darwin}/zoomusInstallerFull.pkg?archType=arm64";
       name = "zoomusInstallerFull.pkg";
-      hash = "sha256-2JQf+gvMUUBsPuiP0VKkX9UR6IqL0NK0gtG4TdugJQ4=";
+      hash = "sha256-U8CdizMicbBLrKWYSRYl8u5tD/1276HwdHlr4kVHbiQ=";
     };
     x86_64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-darwin}/zoomusInstallerFull.pkg";
-      hash = "sha256-M6JsABqbzvj6rlHI2QyqRH6R+hQkf0yx10t4lDVppso=";
+      hash = "sha256-iAETUWviaaQeEg6/FM1GWSJ3Qyvc0zBfuqOfA6X7HpY=";
     };
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-linux}/zoom_x86_64.pkg.tar.xz";
-      hash = "sha256-027oAblhH8EJWRXKIEs9upNvjsSFkA0wxK1t8m8nwj8=";
+      hash = "sha256-EStiiTUwSZFM9hyYXHDErlb0m6yjRwNl7O7XLXtkvjI=";
     };
   };
 

--- a/pkgs/applications/networking/juju/default.nix
+++ b/pkgs/applications/networking/juju/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "juju";
-  version = "3.3.5";
+  version = "3.5.0";
 
   src = fetchFromGitHub {
     owner = "juju";
     repo = "juju";
     rev = "v${version}";
-    hash = "sha256-sp4KLRKII1oEmdbCHzs5fbE/68NbKrHE3bxO14byYFk=";
+    hash = "sha256-35m6e7AWhYnCl+s/i78krYA8As14inI3os8HMBJwCJY=";
   };
 
-  vendorHash = "sha256-a50W9V1xxmItHS2DZkkXYEZ7I6aJxDo1+IriOlMPDyw=";
+  vendorHash = "sha256-4G4GspvNMVbfJJ8MfQtrhp5MRcDw0nhHvdlNdRJgpIM=";
 
   subPackages = [
     "cmd/juju"

--- a/pkgs/applications/radio/cloudlog/default.nix
+++ b/pkgs/applications/radio/cloudlog/default.nix
@@ -8,13 +8,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "cloudlog";
-  version = "2.6.12";
+  version = "2.6.13";
 
   src = fetchFromGitHub {
     owner = "magicbug";
     repo = "Cloudlog";
     rev = version;
-    hash = "sha256-djY+TqkA+YFCmUwZd1x4YeJDOS6ZtxDb4EhBmyftSzI=";
+    hash = "sha256-jhg6Rdd/QhsKZHaeE/2Rh0o0uLD5Jd+3mfXmkpbFcEM=";
   };
 
   postPatch = ''

--- a/pkgs/applications/science/biology/last/default.nix
+++ b/pkgs/applications/science/biology/last/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "last";
-  version = "1543";
+  version = "1544";
 
   src = fetchFromGitLab {
     owner = "mcfrith";
     repo = "last";
     rev = "refs/tags/${version}";
-    hash = "sha256-APHPv7Q64JITfHsvjCThZ6hvGHerk6wjOm32KdTv4k8=";
+    hash = "sha256-jxNudfUvSqV1QUzdvG8LWtL977oho9QuOQImmwbQiIM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/science/math/gretl/default.nix
+++ b/pkgs/applications/science/math/gretl/default.nix
@@ -19,11 +19,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gretl";
-  version = "2024a";
+  version = "2024b";
 
   src = fetchurl {
     url = "mirror://sourceforge/gretl/gretl-${finalAttrs.version}.tar.xz";
-    hash = "sha256-6ha0d/n75Xf0hZM0GRHLOnM274P1h2MerB/8SHWTh+o=";
+    hash = "sha256-mkmOmKO2tiAysZhwC8kNuCXNml8NdFPfaNFykdxYFAY=";
   };
 
   buildInputs = [

--- a/pkgs/applications/science/misc/snakemake/default.nix
+++ b/pkgs/applications/science/misc/snakemake/default.nix
@@ -6,14 +6,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "snakemake";
-  version = "8.11.4";
+  version = "8.11.6";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "snakemake";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-nfPA2sQCeRc12A4rrlo17UPpiB8plKYbiumZjS7Yhz8=";
+    hash = "sha256-00Zh8NenBikdingmx34WYYH5SF+yazeAs+7h1/3UIJY=";
     # https://github.com/python-versioneer/python-versioneer/issues/217
     postFetch = ''
       sed -i "$out"/snakemake/_version.py -e 's#git_refnames = ".*"#git_refnames = " (tag: v${version})"#'

--- a/pkgs/applications/version-management/commitizen/default.nix
+++ b/pkgs/applications/version-management/commitizen/default.nix
@@ -11,7 +11,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "commitizen";
-  version = "3.26.0";
+  version = "3.27.0";
   format = "pyproject";
 
   disabled = python3.pythonOlder "3.8";
@@ -20,7 +20,7 @@ python3.pkgs.buildPythonApplication rec {
     owner = "commitizen-tools";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-tj+zH94IiFqkmkIqyNmgQgQNjvqWgCviLzfGrrCHX1k=";
+    hash = "sha256-Bfz9MBpFsbAcsyQ7CYyObE14q7UE9ZyeY1GVFb9maKk=";
   };
 
   pythonRelaxDeps = [

--- a/pkgs/applications/video/kodi/addons/orftvthek/default.nix
+++ b/pkgs/applications/video/kodi/addons/orftvthek/default.nix
@@ -3,13 +3,13 @@
 buildKodiAddon rec {
   pname = "orftvthek";
   namespace = "plugin.video.orftvthek";
-  version = "0.12.9";
+  version = "0.12.12";
 
   src = fetchFromGitHub {
     owner = "s0faking";
     repo = namespace;
     rev = version;
-    sha256 = "sha256-bqGY9PPukn5/HJa3OqU5NM+ReeDJdVn60jXh1+2Qef8=";
+    sha256 = "sha256-4VLr4DFxioCrlq5JtiPyd7E4a+++cWgxCnRb3KPppWE=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/applications/video/mpv/scripts/mpvacious.nix
+++ b/pkgs/applications/video/mpv/scripts/mpvacious.nix
@@ -10,13 +10,13 @@
 
 buildLua rec {
   pname = "mpvacious";
-  version = "0.33";
+  version = "0.34";
 
   src = fetchFromGitHub {
     owner = "Ajatt-Tools";
     repo = "mpvacious";
     rev = "v${version}";
-    sha256 = "sha256-VHMXW2AzgX88EDnNshxo9Gh8mpXzRoTAq+58HKasUdo=";
+    sha256 = "sha256-YsbeMWGpRi9wUdnrMA2YQXXWQUALxDOTs+gBJ56okkI=";
   };
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 

--- a/pkgs/build-support/rust/hooks/cargo-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-build-hook.sh
@@ -37,7 +37,8 @@ cargoBuildHook() {
 
     (
     set -x
-    @setEnv@ cargo build -j $NIX_BUILD_CORES \
+    runInJobserver -F CARGO_MAKEFLAGS @setEnv@ \
+      cargo build ---- -j $NIX_BUILD_CORES ---- \
         --target @rustHostPlatformSpec@ \
         --frozen \
         ${cargoBuildProfileFlag} \

--- a/pkgs/build-support/rust/hooks/cargo-check-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-check-hook.sh
@@ -33,8 +33,8 @@ cargoCheckHook() {
 
     (
         set -x
-        cargo test \
-              -j $NIX_BUILD_CORES \
+        runInJobserver cargo test ---- \
+              -j $NIX_BUILD_CORES ---- \
               ${argstr} -- \
               --test-threads=${threads} \
               ${checkFlags} \

--- a/pkgs/by-name/ar/arc-browser/package.nix
+++ b/pkgs/by-name/ar/arc-browser/package.nix
@@ -9,11 +9,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "arc-browser";
-  version = "1.43.1-50198";
+  version = "1.44.2-50412";
 
   src = fetchurl {
     url = "https://releases.arc.net/release/Arc-${finalAttrs.version}.dmg";
-    hash = "sha256-++C3COEs0ycfj+vV4PdlWloc4M0hGZG5fdJ+rbyBo7w=";
+    hash = "sha256-0UrvCTGnbt+jQ4UpEt5vsgKZ/UDJz3I1obK4GPshNjg=";
   };
 
   nativeBuildInputs = [ undmg ];

--- a/pkgs/by-name/be/beekeeper-studio/package.nix
+++ b/pkgs/by-name/be/beekeeper-studio/package.nix
@@ -7,7 +7,7 @@
 
 let
   pname = "beekeeper-studio";
-  version = "4.3.1";
+  version = "4.3.4";
 
   plat = {
     aarch64-linux = "-arm64";
@@ -16,7 +16,7 @@ let
 
   hash = {
     aarch64-linux = "sha256-7ZjyzWeu19zUX1u8t0hMu8F+1LN5/CtEotLNe/5rwPM=";
-    x86_64-linux = "sha256-vhKvOPPo/a9gwQ8FsC28dStQHI8SYzEbhdEW4elD7bU=";
+    x86_64-linux = "sha256-RT+A2rq0rMv2o0au5cfcZJysGy+7xYvBDfEJ/TyJmZw=";
   }.${stdenv.hostPlatform.system};
 
   src = fetchurl {

--- a/pkgs/by-name/bo/boogie/package.nix
+++ b/pkgs/by-name/bo/boogie/package.nix
@@ -2,13 +2,13 @@
 
 buildDotnetModule rec {
   pname = "Boogie";
-  version = "3.1.5";
+  version = "3.1.6";
 
   src = fetchFromGitHub {
     owner = "boogie-org";
     repo = "boogie";
     rev = "v${version}";
-    sha256 = "sha256-/6x4NzlSJ2uswVlfFpevXaQxUxPnh3KvnbPIb8SFX9E=";
+    sha256 = "sha256-Bli/vEzzVQTWicQJskK9cQC2XsFRwMxX9cAePXN511c=";
   };
 
   projectFile = [ "Source/Boogie.sln" ];

--- a/pkgs/by-name/cl/clash-verge-rev/package.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/package.nix
@@ -5,11 +5,11 @@
 
 clash-verge.overrideAttrs (old: rec {
   pname = "clash-verge-rev";
-  version = "1.6.2";
+  version = "1.6.3";
 
   src = fetchurl {
     url = "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v${version}/clash-verge_${version}_amd64.deb";
-    hash = "sha256-7Nto/vEsatQ9cMNM+6aOw5jBvF/hUxElJ/SRm12yJFA=";
+    hash = "sha256-QMc2lFY9Xt3rk2zcTsF9omTllv6fGa8hag6+c3qN9tg=";
   };
 
   meta = old.meta // (with lib; {

--- a/pkgs/by-name/fe/felix-fm/package.nix
+++ b/pkgs/by-name/fe/felix-fm/package.nix
@@ -1,6 +1,7 @@
 { lib
 , rustPlatform
 , fetchFromGitHub
+, fetchpatch2
 , pkg-config
 , bzip2
 , libgit2
@@ -12,16 +13,25 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "felix";
-  version = "2.12.1";
+  version = "2.13.0";
 
   src = fetchFromGitHub {
     owner = "kyoheiu";
     repo = "felix";
     rev = "v${version}";
-    hash = "sha256-M+auLJeD5rDk5LJfTBg9asZ3J4DHsZG4UGRhXdZZVkc=";
+    hash = "sha256-7KuL3YkKhjcZSMSipbNITaA9/MGo54f3lz3fVOgy52s=";
   };
 
-  cargoHash = "sha256-GzaBaaGjBCz+xd1bpU2cebQvg5DO0qipHwhOerbq+ow=";
+  cargoPatches = [
+    # https://github.com/kyoheiu/felix/pull/292
+    (fetchpatch2 {
+      name = "update-cargo.lock-for-2.13.0.patch";
+      url = "https://github.com/kyoheiu/felix/commit/5085b147103878ee8138d4fcf7b204223ba2c3eb.patch";
+      hash = "sha256-7Bga9hcJCXExA/jnrR/HuZgOOVBbWs1tdTwxldcvdU8=";
+    })
+  ];
+
+  cargoHash = "sha256-FX3AsahU5ZLMuylwo1jihP9G4Dw1SFv1oMXcuOqDTF8=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/by-name/fl/flashmq/package.nix
+++ b/pkgs/by-name/fl/flashmq/package.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "flashmq";
-  version = "1.13.0";
+  version = "1.13.1";
 
   src = fetchFromGitHub {
     owner = "halfgaar";
     repo = "FlashMQ";
     rev = "v${version}";
-    hash = "sha256-MoBLV39auDz5oicpX6CVvrHMifGpUozocq4E3J+8xWA=";
+    hash = "sha256-ZKDoh2eZDs7iQpfsvfsG7ic+A8NG+UUGgq9l2tmfhVI=";
   };
 
   nativeBuildInputs = [ cmake installShellFiles ];

--- a/pkgs/by-name/fo/fooyin/package.nix
+++ b/pkgs/by-name/fo/fooyin/package.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fooyin";
-  version = "0.4.2";
+  version = "0.4.3";
 
   src = fetchFromGitHub {
     owner = "ludouzi";
     repo = "fooyin";
     rev = "v" + finalAttrs.version;
-    hash = "sha256-1U7eqXVcp0lO/X92oNQ3mWdozgJ1eroQPojscSWH6+I=";
+    hash = "sha256-S74Y7Q3MmKfxMGyO8un+YDHmCJUYNKY6KqTSPn+CynE=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/jn/jnv/package.nix
+++ b/pkgs/by-name/jn/jnv/package.nix
@@ -7,16 +7,16 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "jnv";
-  version = "0.2.2";
+  version = "0.2.3";
 
   src = fetchFromGitHub {
     owner = "ynqa";
     repo = "jnv";
     rev = "v${version}";
-    hash = "sha256-IvpbVcTGGD7cn59SPlcqMuu9YXB3ur3AFaoWDVADoqI=";
+    hash = "sha256-yAyhXXWXsFkQq34aCG+IwE+wkYicu4vmOmX1uSs3R4o=";
   };
 
-  cargoHash = "sha256-dqWQi0DYl2P1qPzmtYOcarnfu2bfSnLk/SVQq5d+Z8Y=";
+  cargoHash = "sha256-PcEQSp4GrMRT6zjbINSZ3lojkpvCyZC2fRHqnG6aPOw=";
 
   nativeBuildInputs = [
     autoconf

--- a/pkgs/by-name/ni/nixos-jobserver/nixos-jobserver.cpp
+++ b/pkgs/by-name/ni/nixos-jobserver/nixos-jobserver.cpp
@@ -1,0 +1,476 @@
+/* the nixos-jobserver FUSE filesystem.
+ *
+ * provides a single file (the token file) from which a client can pull tokens
+ * out of a global pool, and to which clients return tokens when they are done
+ * with them. if a client exits without returning all tokens they are returned
+ * to the global pool. the token file is compatible with the GNU Make jobserver
+ * protocol.
+ *
+ * the original make jobserver uses simple pipes for token storage and transfer.
+ * this works fine for make, where one job does not substantially outlive its first
+ * failing component. it is not suitable for global jobservers, since a job may
+ * have failed without being able to return its tokens (eg because it was killed
+ * by SIGKILL, as nix-daemon does). we thus have to track how many tokens a client
+ * has acquired and return them if the client goes away, but to do this we also
+ * need to know when a client dies. this can be done with FUSE as done here, but
+ * could also be achieved with simple pipes or unix domain sockets. neither of
+ * these are a good choice for this problem:
+ *
+ * pipes are a resource shared between all processes that have opened said pipe.
+ * to be useful for a global jobserver we'd have to provide a unique pipe for
+ * each client, which requires more invasive changes to a nix configuration than
+ * using FUSE.
+ *
+ * both pipes and sockets have buffers. it is not possible to poll a pipe or
+ * socket for "the other end wants to read a byte", it is only possible to poll
+ * for available buffer space. distributing tokens among multiple clients of the
+ * jobserver must then be done by partitioning the available tokens and giving
+ * one partition to each client and periodically rebalancing according to actual
+ * usage. this periodic process necessarily causes more overhead than using the
+ * kernel as a notification source for "the other end wants to read a byte" and
+ * introduces unnecessary latency into token transfers between jobs.
+ */
+
+#define FUSE_USE_VERSION 35
+
+#include <errno.h>
+#include <fuse.h>
+#include <fuse_lowlevel.h>
+#include <grp.h>
+#include <poll.h>
+#include <pwd.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/sysinfo.h>
+#include <sys/xattr.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <atomic>
+#include <iostream>
+#include <limits>
+#include <list>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+// This parses an unsigned with no trailing whitespace.
+// This returns 1 if it's valid.
+// 2 or more if it's invalid.
+#define parse_unsigned(input, dst) sscanf(input, "%u%c", &dst, (char*) &dst)
+
+// 0x0A is ^J :)
+#define JOBSRV_IOC_SET_LIMIT _IOW(0x0A, 0, unsigned)
+
+struct PollHandleDestroy {
+    void operator()(fuse_pollhandle* ph) { fuse_pollhandle_destroy(ph); }
+};
+
+using PollHandle = std::unique_ptr<fuse_pollhandle, PollHandleDestroy>;
+
+struct Context {
+    unsigned tokens_held{0};
+    unsigned limit{std::numeric_limits<unsigned>::max()};
+    PollHandle poll;
+};
+
+struct stat jobserver_st = {
+    .st_ino = FUSE_ROOT_ID,
+    .st_mode = S_IFREG | 0660,
+    .st_uid = getuid(),
+    .st_gid = getgid(),
+};
+static const std::string acl_name = "system.posix_acl_access";
+static std::optional<std::vector<char>> acl;
+
+static unsigned tokens = 0;
+static std::unordered_set<Context*> poll_waiters;
+static std::unordered_map<fuse_req_t, Context*> read_waiters;
+
+/*
+ * NOTE:
+ *
+ * This will wake up everyone instead of just waking up someone waiting,
+ * causing a thundering herd on `read()`.
+ * Additionally, this will prioritize blocking IO consumers compared to poll/async IO consumers.
+ *
+ */
+static void wake_waiters()
+{
+    for (auto it = read_waiters.begin(); it != read_waiters.end() && tokens > 0; ) {
+        auto& ctx = *it->second;
+
+        if (ctx.tokens_held >= ctx.limit) {
+            it++;
+            continue;
+        }
+
+        fuse_reply_buf(it->first, "+", 1);
+        ctx.tokens_held++;
+        tokens--;
+        read_waiters.erase(it++);
+    }
+
+    if (tokens > 0) {
+        for (auto it = poll_waiters.begin(); it != poll_waiters.end(); ) {
+            auto waiter = *it;
+
+            if (waiter->tokens_held >= waiter->limit) {
+                it++;
+                continue;
+            }
+
+            fuse_lowlevel_notify_poll(waiter->poll.get());
+            poll_waiters.erase(it++);
+        }
+    }
+}
+
+static void interrupt_func(fuse_req_t req, void* data)
+{
+    fuse_reply_err(req, EINTR);
+    read_waiters.erase(req);
+}
+
+static Context* fi_ctx(fuse_file_info* fi)
+{
+    static_assert(sizeof(fi->fh) >= sizeof(Context*));
+    return reinterpret_cast<Context*>(fi->fh);
+}
+
+static void jobserver_getattr(fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi)
+{
+    // long attribute cache times are preferrable for purely local systems like this.
+    // this also affects xattr caching, which in turn affects acl caching.
+    fuse_reply_attr(req, &jobserver_st, 120);
+}
+
+static void jobserver_setattr(fuse_req_t req, fuse_ino_t ino, struct stat* attr, int to_set, fuse_file_info* fi)
+{
+    if ((to_set & ~(FUSE_SET_ATTR_MODE | FUSE_SET_ATTR_UID | FUSE_SET_ATTR_GID))
+            || !S_ISREG(attr->st_mode)) {
+        fuse_reply_err(req, EINVAL);
+        return;
+    }
+
+    if (to_set & FUSE_SET_ATTR_MODE) {
+        jobserver_st.st_mode = attr->st_mode;
+    }
+    if (to_set & FUSE_SET_ATTR_UID) {
+        jobserver_st.st_uid = attr->st_uid;
+    }
+    if (to_set & FUSE_SET_ATTR_GID) {
+        jobserver_st.st_gid = attr->st_gid;
+    }
+
+    fuse_reply_attr(req, &jobserver_st, 120);
+}
+
+static void jobserver_open(fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi)
+{
+    auto ctx = new Context;
+    static_assert(sizeof(fi->fh) >= sizeof(ctx));
+    fi->fh = reinterpret_cast<uint64_t>(ctx);
+    fi->direct_io = 1;
+    fuse_reply_open(req, fi);
+}
+
+static void jobserver_release(fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi)
+{
+    auto ctx = fi_ctx(fi);
+    poll_waiters.erase(ctx);
+    tokens += ctx->tokens_held;
+    delete ctx;
+    fuse_reply_err(req, 0);
+    wake_waiters();
+}
+
+static void jobserver_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off, fuse_file_info* fi)
+{
+    if (size == 0) {
+        fuse_reply_buf(req, "", 0);
+        return;
+    }
+
+    auto& ctx = *fi_ctx(fi);
+
+    if (tokens > 0 && ctx.tokens_held < ctx.limit) {
+        tokens--;
+        ctx.tokens_held++;
+        fuse_reply_buf(req, "+", 1);
+    } else if (fi->flags & O_NONBLOCK) {
+        fuse_reply_err(req, EAGAIN);
+    } else {
+        read_waiters.emplace(req, &ctx);
+        // if we're already interrupted the emplace will be undone
+        fuse_req_interrupt_func(req, interrupt_func, nullptr);
+    }
+}
+
+static void jobserver_write(fuse_req_t req, fuse_ino_t ino, const char* buf, size_t size, off_t off,
+        fuse_file_info* fi)
+{
+    auto& ctx = *fi_ctx(fi);
+
+    size = std::min<size_t>(size, ctx.tokens_held);
+    tokens += size;
+    ctx.tokens_held -= size;
+    fuse_reply_write(req, size);
+    wake_waiters();
+}
+
+static void jobserver_setxattr(fuse_req_t req, fuse_ino_t ino, const char* name, const char* value,
+        size_t size, int flags)
+{
+    if (name != acl_name) {
+        fuse_reply_err(req, EINVAL);
+    } else if ((flags & XATTR_CREATE) && acl) {
+        fuse_reply_err(req, EEXIST);
+    } else if ((flags & XATTR_REPLACE) && !acl) {
+        fuse_reply_err(req, ENODATA);
+    } else {
+        // we need to update file permission bits according to the new acl.
+        // parsing an acl is not pretty and setting this acl should be rare, so we'll just
+        // be incredibly lazy about it and let the kernel do the heavy lifting.
+        int mfd = memfd_create("acl_tmp", 0);
+        std::unique_ptr<int, void(*)(int*)> const _mfd(&mfd, [] (int* fd) { close(*fd); });
+        struct stat tmp;
+
+        if (fsetxattr(mfd, name, value, size, 0) == 0
+                && fstat(mfd, &tmp) == 0) {
+            jobserver_st.st_mode = S_IFREG | (tmp.st_mode & 07777);
+            acl.emplace(value, value + size);
+            fuse_reply_err(req, 0);
+        } else {
+            fuse_reply_err(req, errno);
+        }
+    }
+}
+
+static void jobserver_getxattr(fuse_req_t req, fuse_ino_t ino, const char* name, size_t size)
+{
+    if (name != acl_name) {
+        fuse_reply_err(req, EINVAL);
+    } else if (!acl) {
+        fuse_reply_err(req, ENODATA);
+    } else if (size == 0) {
+        fuse_reply_xattr(req, acl->size());
+    } else if (size < acl->size()) {
+        fuse_reply_err(req, ERANGE);
+    } else {
+        fuse_reply_buf(req, acl->data(), acl->size());
+    }
+}
+
+static void jobserver_listxattr(fuse_req_t req, fuse_ino_t ino, size_t size)
+{
+    if (size == 0) {
+        fuse_reply_xattr(req, acl_name.size() + 1);
+    } else if (size < acl_name.size() + 1) {
+        fuse_reply_err(req, ERANGE);
+    } else {
+        fuse_reply_buf(req, acl_name.c_str(), acl_name.size() + 1);
+    }
+}
+
+static void jobserver_removexattr(fuse_req_t req, fuse_ino_t ino, const char* name)
+{
+    if (name != acl_name) {
+        fuse_reply_err(req, EINVAL);
+    } else if (acl) {
+        acl.reset();
+        fuse_reply_err(req, 0);
+    } else {
+        fuse_reply_err(req, ENODATA);
+    }
+}
+
+static void jobserver_ioctl(fuse_req_t req, fuse_ino_t ino, unsigned int cmd, void* arg,
+        fuse_file_info* fi, unsigned flags, const void* in_buf, size_t in_bufsz, size_t out_bufsz)
+{
+    auto& ctx = *fi_ctx(fi);
+
+    if (flags & FUSE_IOCTL_COMPAT) {
+        fuse_reply_err(req, ENOSYS);
+        return;
+    }
+
+    switch (cmd) {
+    case JOBSRV_IOC_SET_LIMIT:
+        ctx.limit = *reinterpret_cast<const unsigned*>(in_buf);
+        if (ctx.limit == 0) {
+            ctx.limit = std::numeric_limits<unsigned>::max();
+        }
+        fuse_reply_ioctl(req, 0, nullptr, 0);
+        break;
+
+    default:
+        fuse_reply_err(req, ENOTTY);
+    }
+}
+
+static void jobserver_poll(fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi, fuse_pollhandle* ph)
+{
+    auto& ctx = *fi_ctx(fi);
+
+    ctx.poll.reset(ph);
+    if (ph) {
+        poll_waiters.insert(&ctx);
+    }
+    const auto avail = tokens > 0 && ctx.tokens_held < ctx.limit;
+    fuse_reply_poll(req, ((avail ? POLLIN : 0) | POLLOUT) & fi->poll_events);
+}
+
+static const struct fuse_lowlevel_ops jobserver_ops = {
+    .init = [] (void* userdata, fuse_conn_info* conn) {
+        conn->want = FUSE_CAP_POSIX_ACL;
+    },
+    .getattr = jobserver_getattr,
+    .setattr = jobserver_setattr,
+    .open = jobserver_open,
+    .read = jobserver_read,
+    .write = jobserver_write,
+    .release = jobserver_release,
+    .setxattr = jobserver_setxattr,
+    .getxattr = jobserver_getxattr,
+    .listxattr = jobserver_listxattr,
+    .removexattr = jobserver_removexattr,
+    .ioctl = jobserver_ioctl,
+    .poll = jobserver_poll,
+};
+
+static void print_help(std::ostream& to)
+{
+    to << R"(usage: nixos-jobserver -t <tokens> <mount point>
+
+starts a job server with the given number of tokens at the specified mount
+point. must be started as root to allow other users access to the jobserver.
+
+arguments:
+
+  -h           print help text
+  -t <tokens>  set number of tokens available (uses number of CPUs when 0)
+  -u <user>    mount jobserver with owner <user>
+  -g <group>   mount jobserver with group <group>
+  -d           debug mode (log fuse requests)
+)";
+}
+
+int main(int argc, char* argv[])
+{
+    std::string mount, user, group;
+    std::vector<std::string> args{
+        argv[0],
+        "-odefault_permissions",
+    };
+
+    if (geteuid() == 0) {
+        args.push_back("-oallow_other");
+    }
+
+    for (;;) {
+        int opt = getopt(argc, argv, "hdu:g:t:");
+        if (opt == -1)
+            break;
+        switch (opt) {
+        case 'd':
+            args.push_back("-d");
+            break;
+        case 'u':
+            user = optarg;
+            break;
+        case 'g':
+            group = optarg;
+            break;
+        case 't': {
+            char* end;
+            auto res = strtoul(optarg, &end, 10);
+            if (errno || isspace(optarg[0]) || *end || res > std::numeric_limits<unsigned>::max()) {
+                std::cerr << "bad argument for -t" << std::endl;
+                return 1;
+            }
+            tokens = res;
+            break;
+        }
+        case 'h':
+            print_help(std::cout);
+            return 0;
+        default:
+            print_help(std::cerr);
+            return 1;
+        }
+    }
+
+    if (optind >= argc) {
+        std::cerr << "missing mount point" << std::endl;
+        return 1;
+    } else if (optind + 1 < argc) {
+        std::cerr << "extraneous arguments after mount point" << std::endl;
+        return 1;
+    } else {
+        mount = argv[optind];
+    }
+
+    if (tokens == 0) {
+        tokens = get_nprocs_conf();
+    }
+
+    if (!user.empty()) {
+        if (auto pw = getpwnam(user.c_str()); pw) {
+            jobserver_st.st_uid = pw->pw_uid;
+        } else if (uid_t uid; parse_unsigned(user.c_str(), uid) == 1) {
+            jobserver_st.st_uid = uid;
+        } else {
+            std::cerr << "invalid argument for -u" << std::endl;
+            return 1;
+        }
+    }
+
+    if (!group.empty()) {
+        if (auto gr = getgrnam(group.c_str()); gr) {
+            jobserver_st.st_gid = gr->gr_gid;
+        } else if (gid_t gid; parse_unsigned(group.c_str(), gid) == 1) {
+            jobserver_st.st_gid = gid;
+        } else {
+            std::cerr << "invalid argument for -g" << std::endl;
+            return 1;
+        }
+    }
+
+    using Session = std::unique_ptr<fuse_session, void(*)(fuse_session*)>;
+
+    std::vector<char*> args_ptrs(args.size());
+    std::transform(args.begin(), args.end(), args_ptrs.begin(),
+            [] (auto& str) { return &str[0]; });
+    fuse_args fuse_args = FUSE_ARGS_INIT(int(args_ptrs.size()), args_ptrs.data());
+
+    Session se{
+        fuse_session_new(&fuse_args, &jobserver_ops, sizeof(jobserver_ops), nullptr),
+        fuse_session_destroy
+    };
+    if (!se) {
+        std::cerr << "fuse_session failed" << std::endl;
+        return 1;
+    }
+
+    if (fuse_set_signal_handlers(&*se) != 0) {
+        std::cerr << "fuse_set_signal_handlers failed" << std::endl;
+        return 1;
+    }
+    const Session _signals{&*se, fuse_remove_signal_handlers};
+
+    if (fuse_session_mount(&*se, mount.c_str()) != 0) {
+        std::cerr << "fuse_session_mount failed" << std::endl;
+        return 1;
+    }
+    const Session _unmount{&*se, fuse_session_unmount};
+
+    return fuse_session_loop(&*se) ? 2 : 0;
+}

--- a/pkgs/by-name/ni/nixos-jobserver/package.nix
+++ b/pkgs/by-name/ni/nixos-jobserver/package.nix
@@ -1,0 +1,42 @@
+{ acl
+, fuse3
+, pkg-config
+, lib
+, stdenv
+}:
+
+stdenv.mkDerivation {
+  pname = "nixos-jobserver";
+  version = "unstable-2021-11-14";
+
+  src = ./nixos-jobserver.cpp;
+
+  buildInputs = [ fuse3 ];
+  nativeBuildInputs = [ pkg-config ];
+
+  dontUnpack = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    (
+      set -x
+      $CXX -std=c++17 -c -Wall -Werror -O2 $(pkg-config --cflags fuse3) -o nixos-jobserver.o $src
+      $CXX $(pkg-config --libs fuse3) -o nixos-jobserver nixos-jobserver.o
+    )
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preBuild
+
+    install -D nixos-jobserver $out/bin/nixos-jobserver
+
+    runHook postBuild
+  '';
+
+  meta = with lib; {
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/by-name/op/openvas-scanner/package.nix
+++ b/pkgs/by-name/op/openvas-scanner/package.nix
@@ -31,13 +31,13 @@
 
 stdenv.mkDerivation rec {
   pname = "openvas-scanner";
-  version = "23.3.0";
+  version = "23.3.1";
 
   src = fetchFromGitHub {
     owner = "greenbone";
     repo = "openvas-scanner";
     rev = "refs/tags/v${version}";
-    hash = "sha256-CkwDhHPdTbXNrqY/obg1rOtGB1HC+fUwZ5+5d82vlV4=";
+    hash = "sha256-0vcGKC979bJLhq/9e+DYaRrsUktjMyMuZNqZYK6BCWQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pi/pinact/package.nix
+++ b/pkgs/by-name/pi/pinact/package.nix
@@ -7,18 +7,18 @@
 
 let
   pname = "pinact";
-  version = "0.1.3";
+  version = "0.2.0";
   src = fetchFromGitHub {
     owner = "suzuki-shunsuke";
     repo = "pinact";
     rev = "v${version}";
-    hash = "sha256-ifUnF7u4/vMy89xb7sk4tPKQYdFBYAIHc0GYVBMWvWM=";
+    hash = "sha256-ndlyfp+neoOEzofIlQEQp/6masnzMQFWAPmhan3hlb0=";
   };
 in
 buildGoModule {
   inherit pname version src;
 
-  vendorHash = "sha256-ht4eV62w9AWKYahrd83LmBI+Tu2Q64YA3t90N4BR1e4=";
+  vendorHash = "sha256-qu4CHh2013q7e7mBuymlKEhjpdtSOaWGVutjegoVP7E=";
 
   doCheck = true;
 

--- a/pkgs/by-name/pm/pm2/package.nix
+++ b/pkgs/by-name/pm/pm2/package.nix
@@ -5,16 +5,16 @@
 
 buildNpmPackage rec {
   pname = "pm2";
-  version = "5.3.1";
+  version = "5.4.0";
 
   src = fetchFromGitHub {
     owner = "Unitech";
     repo = "pm2";
     rev = "v${version}";
-    hash = "sha256-thShqrnM5S3/IImEm+2vHVRLCsLJN5NGaSRYubtULW0=";
+    hash = "sha256-hmciDjlmlIaqOWl9rYWQ6muq6LFzQb5tfpdzL0vV/ZM=";
   };
 
-  npmDepsHash = "sha256-6M8kwiCHaQzcFyUUx7Yax/dobATWXG0Di7enEzlO8YE=";
+  npmDepsHash = "sha256-je+GwPkUiGPWgKQgSPlx2OEWMbDKdwEM/idTjgINLHY=";
 
   dontNpmBuild = true;
 

--- a/pkgs/by-name/py/pyright/package.nix
+++ b/pkgs/by-name/py/pyright/package.nix
@@ -1,13 +1,13 @@
 { lib, buildNpmPackage, fetchFromGitHub, runCommand, jq }:
 
 let
-  version = "1.1.362";
+  version = "1.1.364";
 
   src = fetchFromGitHub {
     owner = "Microsoft";
     repo = "pyright";
     rev = "${version}";
-    hash = "sha256-sz+Om2bfsJJTe2W8l49pI+K9phCTwoczeG1Q7qlMIig=";
+    hash = "sha256-7XQ/DGba00sEg/DxcKuX2ehc4V96557yvtGXFFyHD74=";
   };
 
   patchedPackageJSON = runCommand "package.json" { } ''
@@ -37,7 +37,7 @@ let
     pname = "pyright-internal";
     inherit version src;
     sourceRoot = "${src.name}/packages/pyright-internal";
-    npmDepsHash = "sha256-xcr9j5/90gfV/r0yI9ifj6Nrr9WrawwvukuVkl387r4=";
+    npmDepsHash = "sha256-ce3338ugei4R7CYKn3676ijpgYKcuyY8CgkWbf8unKw=";
     dontNpmBuild = true;
     installPhase = ''
       runHook preInstall
@@ -51,7 +51,7 @@ buildNpmPackage rec {
   inherit version src;
 
   sourceRoot = "${src.name}/packages/pyright";
-  npmDepsHash = "sha256-79tXMdOt1XH3KTT46bq35J4AcCVyoB2d4KEkr9EjqVY=";
+  npmDepsHash = "sha256-E6txhG+1DNcAR9Nia8ggWL0tDaTXs9sF4je5nDqroys=";
 
   postPatch = ''
     chmod +w ../../

--- a/pkgs/by-name/wl/wldash/0001-Update-Cargo.lock.patch
+++ b/pkgs/by-name/wl/wldash/0001-Update-Cargo.lock.patch
@@ -1,0 +1,25 @@
+From 2538e41f001fa363d3459efe3b8102a354b06dd0 Mon Sep 17 00:00:00 2001
+From: Kenny Levinsen <kl@kl.wtf>
+Date: Sun, 16 Jan 2022 23:16:30 +0100
+Subject: [PATCH 1/2] Update Cargo.lock
+
+---
+ Cargo.lock | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 3da9a07..1ad4a86 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -796,7 +796,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+ 
+ [[package]]
+ name = "wldash"
+-version = "0.2.0"
++version = "0.3.0"
+ dependencies = [
+  "alsa",
+  "bitflags",
+-- 
+2.44.0
+

--- a/pkgs/by-name/wl/wldash/0002-Update-fontconfig.patch
+++ b/pkgs/by-name/wl/wldash/0002-Update-fontconfig.patch
@@ -1,0 +1,112 @@
+From b2ae30bab412472f1d2ff90439134a8a465fdf9a Mon Sep 17 00:00:00 2001
+From: Kenny Levinsen <kl@kl.wtf>
+Date: Mon, 2 May 2022 11:21:47 +0200
+Subject: [PATCH 2/2] Update fontconfig
+
+---
+ Cargo.lock | 38 +++++++++++++++++++++++++++++---------
+ Cargo.toml |  2 +-
+ 2 files changed, 30 insertions(+), 10 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 1ad4a86..6821181 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -137,7 +137,16 @@ version = "0.4.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "b11f15d1e3268f140f68d390637d5e76d849782d971ae7063e0da69fe9709a76"
+ dependencies = [
+- "libloading",
++ "libloading 0.6.7",
++]
++
++[[package]]
++name = "dlib"
++version = "0.5.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "ac1b7517328c04c2aa68422fc60a41b92208182142ed04a25879c26c8f878794"
++dependencies = [
++ "libloading 0.7.3",
+ ]
+ 
+ [[package]]
+@@ -166,9 +175,9 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+ 
+ [[package]]
+ name = "fontconfig"
+-version = "0.2.0"
++version = "0.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a5570e7ce35ffb621b31934530c4b3b8ce9fdd8bf8436e98f9c7ebadff2ef259"
++checksum = "a25320ad784a9578ada0b395dd7dcd2321109404bbb341ec27e64b01a1e49b47"
+ dependencies = [
+  "yeslogic-fontconfig-sys",
+ ]
+@@ -237,6 +246,16 @@ dependencies = [
+  "winapi",
+ ]
+ 
++[[package]]
++name = "libloading"
++version = "0.7.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
++dependencies = [
++ "cfg-if 1.0.0",
++ "winapi",
++]
++
+ [[package]]
+ name = "libpulse-binding"
+ version = "2.23.0"
+@@ -398,9 +417,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "once_cell"
+-version = "1.5.2"
++version = "1.10.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
++checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+ 
+ [[package]]
+ name = "opaque-debug"
+@@ -803,7 +822,7 @@ dependencies = [
+  "byteorder",
+  "chrono",
+  "dbus",
+- "dlib",
++ "dlib 0.4.2",
+  "fontconfig",
+  "fuzzy-matcher",
+  "itertools",
+@@ -843,11 +862,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "yeslogic-fontconfig-sys"
+-version = "2.11.1"
++version = "3.0.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e194a0c5cd1b5c87215eed9d26aca9799fa1b599fe2e178977d6f8ccc812e3d3"
++checksum = "cb3f5a91c31bef6650d3a1b69192b4217fd88e4cfedc8101813e4dc3394ecbb8"
+ dependencies = [
+  "const-cstr",
+- "libc",
++ "dlib 0.5.0",
++ "once_cell",
+  "pkg-config",
+ ]
+diff --git a/Cargo.toml b/Cargo.toml
+index abb3807..691daa7 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -46,5 +46,5 @@ serde_yaml = { version = "0.8", optional = true }
+ 
+ libpulse-binding = { version = "2.22", optional = true }
+ alsa = { version = "0.4.0", optional = true }
+-fontconfig = "0.2.0"
++fontconfig = "0.5.0"
+ unicode-segmentation = "1.6.0"
+-- 
+2.44.0
+

--- a/pkgs/by-name/wl/wldash/package.nix
+++ b/pkgs/by-name/wl/wldash/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  alsa-lib,
+  dbus,
+  fetchFromGitHub,
+  fontconfig,
+  libffi,
+  libpulseaudio,
+  libxkbcommon,
+  pkg-config,
+  rustPlatform,
+  wayland,
+  enableAlsaWidget ? true,
+  enablePulseaudioWidget ? true,
+}:
+
+let
+  pname = "wldash";
+  version = "0.3.0";
+  libraryPath = lib.makeLibraryPath [
+    wayland
+    libxkbcommon
+  ];
+in
+rustPlatform.buildRustPackage {
+  inherit pname version;
+
+  buildNoDefaultFeatures = true;
+  buildFeatures =
+    [
+      "yaml-cfg"
+      "json-cfg"
+    ]
+    ++ lib.optionals enableAlsaWidget [ "alsa-widget" ]
+    ++ lib.optionals enablePulseaudioWidget [ "pulseaudio-widget" ];
+
+  src = fetchFromGitHub {
+    owner = "kennylevinsen";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-ZzsBD3KKTT+JGiFCpdumPyVAE2gEJvzCq+nRnK3RdxI=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs =
+    [
+      dbus
+      fontconfig
+    ]
+    ++ lib.optionals enableAlsaWidget [ alsa-lib ]
+    ++ lib.optionals enablePulseaudioWidget [ libpulseaudio ];
+
+  cargoPatches = [
+    ./0001-Update-Cargo.lock.patch
+    ./0002-Update-fontconfig.patch
+  ];
+
+  cargoSha256 = "sha256-Y7nhj8VpO6sEzVkM3uPv8Tlk2jPn3c/uPJqFc/HjHI0=";
+
+  dontPatchELF = true;
+
+  postInstall = ''
+    patchelf --set-rpath ${libraryPath}:$(patchelf --print-rpath $out/bin/wldash) $out/bin/wldash
+  '';
+
+  meta = {
+    description = "Wayland launcher/dashboard";
+    homepage = "https://github.com/kennylevinsen/wldash";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ bbenno ];
+    mainProgram = "wldash";
+    platforms = lib.platforms.linux;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+  };
+}

--- a/pkgs/data/themes/kwin-decorations/kde-rounded-corners/default.nix
+++ b/pkgs/data/themes/kwin-decorations/kde-rounded-corners/default.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "kde-rounded-corners";
-  version = "0.6.5";
+  version = "0.6.6";
 
   src = fetchFromGitHub {
     owner = "matinlotfali";
     repo = "KDE-Rounded-Corners";
     rev = "v${version}";
-    hash = "sha256-g7gNFv4/ighfxYz/VXF5KvcoT6t4lT5soDLlV3oAKvc=";
+    hash = "sha256-pmUuYD0RPyF5I2p5MBErziehBrfc5MswQVvfwl4ozg8=";
   };
 
   nativeBuildInputs = [ cmake extra-cmake-modules wrapQtAppsHook ];

--- a/pkgs/desktops/gnome/core/gnome-remote-desktop/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-remote-desktop/default.nix
@@ -30,11 +30,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-remote-desktop";
-  version = "46.1";
+  version = "46.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    hash = "sha256-fGKkKB/fqVIhEK/7910JlzA18q3H+kV3UR1zMYa+to8=";
+    hash = "sha256-l0Q+r/5LGmliaIakHSXL6ywUjT/tQ9khFcG30g1SOKs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/compilers/corretto/17.nix
+++ b/pkgs/development/compilers/corretto/17.nix
@@ -1,4 +1,5 @@
 { fetchFromGitHub
+, fetchurl
 , gradle_7
 , jdk17
 , lib
@@ -9,17 +10,25 @@
 }:
 
 let
-  corretto = import ./mk-corretto.nix {
+  corretto = import ./mk-corretto.nix rec {
     inherit lib stdenv rsync runCommand testers;
     jdk = jdk17;
     gradle = gradle_7;
-    version = "17.0.8.8.1";
+    version = "17.0.11.9.1";
     src = fetchFromGitHub {
       owner = "corretto";
       repo = "corretto-17";
-      rev = "9a3cc984f76cb5f90598bdb43215bad20e0f7319";
-      sha256 = "sha256-/VuB3ocD5VvDqCU7BoTG+fQ0aKvK1TejegRYmswInqQ=";
+      rev = version;
+      sha256 = "sha256-LxZSFILFfyh8oBiYEnuBQ0Og2i713qdK2jIiCBnrlj0=";
     };
   };
 in
-corretto
+corretto.overrideAttrs (final: prev: {
+  # HACK: Removes the FixNullPtrCast patch, as it fails to apply. Need to figure out what causes it to fail to apply.
+  patches = lib.remove
+    (fetchurl {
+      url = "https://git.alpinelinux.org/aports/plain/community/openjdk17/FixNullPtrCast.patch?id=41e78a067953e0b13d062d632bae6c4f8028d91c";
+      sha256 = "sha256-LzmSew51+DyqqGyyMw2fbXeBluCiCYsS1nCjt9hX6zo=";
+    })
+    prev.patches;
+})

--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -39,26 +39,26 @@ let
 in
 openjdk17.overrideAttrs (oldAttrs: rec {
   pname = "jetbrains-jdk" + lib.optionalString withJcef "-jcef";
-  javaVersion = "17.0.8";
-  build = "1000.8";
+  javaVersion = "17.0.11";
+  build = "1207.24";
   # To get the new tag:
   # git clone https://github.com/jetbrains/jetbrainsruntime
   # cd jetbrainsruntime
   # git reset --hard [revision]
   # git log --simplify-by-decoration --decorate=short --pretty=short | grep "jbr-" --color=never | cut -d "(" -f2 | cut -d ")" -f1 | awk '{print $2}' | sort -t "-" -k 2 -g | tail -n 1 | tr -d ","
-  openjdkTag = "jbr-17.0.7+7";
+  openjdkTag = "jbr-17.0.8+7";
   version = "${javaVersion}-b${build}";
 
   src = fetchFromGitHub {
     owner = "JetBrains";
     repo = "JetBrainsRuntime";
     rev = "jb${version}";
-    hash = "sha256-PXS8wRF37D9vzeC4CvmB3szFMbt+NRqhQqtPZcbeAO8=";
+    hash = "sha256-a7cJF2iCW/1GK0/GmVbaY5pYcn3YtZy5ngFkyAGRhu0=";
   };
 
   BOOT_JDK = openjdk17-bootstrap.home;
   # run `git log -1 --pretty=%ct` in jdk repo for new value on update
-  SOURCE_DATE_EPOCH = 1691119859;
+  SOURCE_DATE_EPOCH = 1715809405;
 
   patches = [ ];
 

--- a/pkgs/development/compilers/openjdk/17.nix
+++ b/pkgs/development/compilers/openjdk/17.nix
@@ -11,8 +11,8 @@
 let
   version = {
     feature = "17";
-    interim = ".0.7";
-    build = "7";
+    interim = ".0.11";
+    build = "9";
   };
 
   # when building a headless jdk, also bootstrap it with a headless jdk
@@ -26,7 +26,7 @@ let
       owner = "openjdk";
       repo = "jdk${version.feature}u";
       rev = "jdk-${version.feature}${version.interim}+${version.build}";
-      sha256 = "sha256-S6QOB4Tbi+K1yjvvywTfvwFI2eX8AiqIx5c3zfxcskc=";
+      sha256 = "sha256-aO4iSc9MklW/4q9U86WEfiiWnlq6iZSbxzq2fbsqd0A=";
     };
 
     nativeBuildInputs = [ pkg-config autoconf unzip ];

--- a/pkgs/development/compilers/openjdk/openjfx/17.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/17.nix
@@ -7,8 +7,8 @@
 
 let
   major = "17";
-  update = ".0.6";
-  build = "+3";
+  update = ".0.11";
+  build = "-ga";
   repover = "${major}${update}${build}";
   gradle_ = (gradle_7.override {
     java = openjdk17_headless;
@@ -31,7 +31,7 @@ let
       owner = "openjdk";
       repo = "jfx${major}u";
       rev = repover;
-      sha256 = "sha256-9VfXk2EfMebMyVKPohPRP2QXRFf8XemUtfY0JtBCHyw=";
+      sha256 = "sha256-WV8NHlYlt7buGbirLSorLnS2TnyBD17zUquFfwSL3xE=";
     };
 
     buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4-headless ];

--- a/pkgs/development/libraries/geos/3.11.nix
+++ b/pkgs/development/libraries/geos/3.11.nix
@@ -29,6 +29,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
 
+  # https://github.com/libgeos/geos/issues/930
+  cmakeFlags = lib.optionals (stdenv.isDarwin && stdenv.isx86_64) [
+    "-DCMAKE_CTEST_ARGUMENTS=--exclude-regex;unit-geom-Envelope"
+  ];
+
   doCheck = true;
 
   passthru.tests = {

--- a/pkgs/development/libraries/libuninameslist/default.nix
+++ b/pkgs/development/libraries/libuninameslist/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libuninameslist";
-  version = "20230916";
+  version = "20240524";
 
   src = fetchFromGitHub {
     owner = "fontforge";
     repo = pname;
     rev = version;
-    sha256 = "sha256-8mLXTvi4KbU4NiCPaJINTeFbnTAabGDg8ufpSHSqy0Y=";
+    sha256 = "sha256-LANwM0fhCsscXAdI/qGOmUWDzAhe3g9w3J68g4szDZQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -37,6 +37,11 @@ stdenv.mkDerivation (finalAttrs: rec {
     hash = "sha256-JK54/xNjqXPm2L66lBp5RdoqwFbhm1OVautpJ/1s+1Y=";
   };
 
+  # https://gitlab.gnome.org/GNOME/libxml2/-/issues/725
+  postPatch = if stdenv.hostPlatform.isFreeBSD then ''
+    substituteInPlace ./configure.ac --replace-fail pthread_join pthread_create
+  '' else null;
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -4,7 +4,6 @@
 , zlib
 , pkg-config
 , autoreconfHook
-, xz
 , libintl
 , python
 , gettext
@@ -57,11 +56,6 @@ stdenv.mkDerivation (finalAttrs: rec {
     ncurses
   ] ++ lib.optionals (stdenv.isDarwin && pythonSupport && python?isPy2 && python.isPy2) [
     libintl
-  ] ++ lib.optionals stdenv.isFreeBSD [
-    # Libxml2 has an optional dependency on liblzma.  However, on impure
-    # platforms, it may end up using that from /usr/lib, and thus lack a
-    # RUNPATH for that, leading to undefined references for its users.
-    xz
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/libraries/openxr-loader/default.nix
+++ b/pkgs/development/libraries/openxr-loader/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "openxr-loader";
-  version = "1.1.36";
+  version = "1.1.37";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "OpenXR-SDK-Source";
     rev = "release-${version}";
-    sha256 = "sha256-Ki2tp8a67AjIMIGDpWWqCnpMmeZpJ8uPezKE2KWrOjA=";
+    sha256 = "sha256-J9IfhTFFSY+rK0DqFdXtINo7nlGUcy2Lljq81T417qc=";
   };
 
   nativeBuildInputs = [ cmake python3 pkg-config ];

--- a/pkgs/development/libraries/sentry-native/default.nix
+++ b/pkgs/development/libraries/sentry-native/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "sentry-native";
-  version = "0.7.2";
+  version = "0.7.4";
 
   src = fetchFromGitHub {
     owner = "getsentry";
     repo = "sentry-native";
     rev = version;
-    hash = "sha256-0yFRDQ/f0oVbpZ4wev28xCTVkbXr58Tt0Czda3ppRWk=";
+    hash = "sha256-vmoBTFhSSYMzbjQIGTCvMvOvVv+2y23RZx589rMR5bs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/aioswitcher/default.nix
+++ b/pkgs/development/python-modules/aioswitcher/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "aioswitcher";
-  version = "3.4.2";
+  version = "3.4.3";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "TomerFi";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-UpwIzwOl1yKqK8KxFDXAWoZFkQ+1r1sUcDfx6AxRdNw=";
+    hash = "sha256-yKHSExtnO9m8Tc3BmCqV8tJs59ynKOqUmekaOatGRTc=";
   };
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/python-modules/clickgen/default.nix
+++ b/pkgs/development/python-modules/clickgen/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "clickgen";
-  version = "2.2.2";
+  version = "2.2.3";
   format = "setuptools";
 
   disabled = pythonOlder "3.8";
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "ful1e5";
     repo = "clickgen";
     rev = "refs/tags/v${version}";
-    hash = "sha256-Lsb0FvJohwsXofpcq7OgWfhl/3qVxAqY0wdvum6ywSQ=";
+    hash = "sha256-hYorjqm/FCnff3ZTgIlicwmSLA9ZnHGDyPt1BcijBII=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/django-modeltranslation/default.nix
+++ b/pkgs/development/python-modules/django-modeltranslation/default.nix
@@ -11,7 +11,7 @@
 let
   # 0.18.12 was yanked from PyPI, it refers to this issue:
   # https://github.com/deschler/django-modeltranslation/issues/701
-  version = "0.18.13";
+  version = "0.19.0";
 in
 buildPythonPackage {
   pname = "django-modeltranslation";
@@ -21,7 +21,7 @@ buildPythonPackage {
     owner = "deschler";
     repo = "django-modeltranslation";
     rev = "refs/tags/v${version}";
-    hash = "sha256-9tfB5/XMLnwn+AgaT9TkHtc3HcHiD4pme/+BW1uztIs=";
+    hash = "sha256-Ypz1C+Dx1v61A7LvIsW644qfFjNHQ7KXeKewQ5MAgi0=";
   };
 
   # Remove all references to pytest-cov

--- a/pkgs/development/python-modules/elasticsearch8/default.nix
+++ b/pkgs/development/python-modules/elasticsearch8/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "elasticsearch8";
-  version = "8.13.1";
+  version = "8.13.2";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-jVi5yYPll7ej8lmDEbvcLCEdBbpMiZUi2n4AORre81E=";
+    hash = "sha256-rl8IoV8kt68AJSkPMDx3d9eB6+2yPBgFpGEU6g+RjQ4=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/foolscap/default.nix
+++ b/pkgs/development/python-modules/foolscap/default.nix
@@ -1,32 +1,42 @@
 {
-  lib,
   buildPythonPackage,
   fetchPypi,
+  lib,
   mock,
   pyopenssl,
   pytestCheckHook,
   pythonOlder,
-  service-identity,
+  setuptools,
   six,
   twisted,
   txi2p-tahoe,
   txtorcon,
+  versioneer,
 }:
 
 buildPythonPackage rec {
   pname = "foolscap";
   version = "23.3.0";
 
-  disabled = pythonOlder "3.7";
+  pyproject = true;
+  build-system = [
+    setuptools
+    versioneer
+  ];
 
-  format = "setuptools";
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-Vu7oXC1brsgBwr2q59TAgx8j1AFRbi5mjRNIWZTbkUU=";
   };
 
-  propagatedBuildInputs = [
+  postPatch = ''
+    # Remove vendorized versioneer.py
+    rm versioneer.py
+  '';
+
+  dependencies = [
     six
     twisted
     pyopenssl

--- a/pkgs/development/python-modules/plugwise/default.nix
+++ b/pkgs/development/python-modules/plugwise/default.nix
@@ -22,7 +22,7 @@
 
 buildPythonPackage rec {
   pname = "plugwise";
-  version = "0.37.8";
+  version = "0.37.9";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     owner = "plugwise";
     repo = "python-plugwise";
     rev = "refs/tags/v${version}";
-    hash = "sha256-Mh4BZ0Gnsy046I537R4SZ/rC9Jm7XjF0slAP/0e5Ov8=";
+    hash = "sha256-8o2cTGkoYLrHQsAWnTg7cj9bJ+Wv1/lbHJiZ50jjFxo=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/pyexploitdb/default.nix
+++ b/pkgs/development/python-modules/pyexploitdb/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "pyexploitdb";
-  version = "0.2.18";
+  version = "0.2.19";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "pyExploitDb";
     inherit version;
-    hash = "sha256-pwlS0304aTSrGZFIj5f+jstcFwcy/liqQBW8p7hUhKE=";
+    hash = "sha256-coxO3WQt60b6I2QfhViuTiOp+VuktUoddWjbMxUOx7E=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/pytubefix/default.nix
+++ b/pkgs/development/python-modules/pytubefix/default.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools-scm,
+}:
+
+buildPythonPackage rec {
+  pname = "pytubefix";
+  version = "5.6.3";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-qYNIQhwSZ3ZG3WMY6qCul1OEno1PWgMlfcFSxN3c6aw=";
+  };
+
+  nativeBuildInputs = [ setuptools-scm ];
+
+  pythonImportsCheck = [ "pytubefix" ];
+
+  meta = {
+    homepage = "https://github.com/JuanBindez/pytubefix";
+    description = "A pytube fork with additional features and fixes";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ roshaen ];
+  };
+}

--- a/pkgs/development/python-modules/teslajsonpy/default.nix
+++ b/pkgs/development/python-modules/teslajsonpy/default.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "teslajsonpy";
-  version = "3.10.3";
+  version = "3.11.0";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "zabuldon";
     repo = "teslajsonpy";
     rev = "refs/tags/v${version}";
-    hash = "sha256-g5csh014gXdYJ28cBn0Frk5g3zFuZ9ufrypcLcNPwg0=";
+    hash = "sha256-Hb/O4kdmJVN6yGhg/FQ6i0qUrtEuD1dZooJ6pbZ+qig=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/ytmusicapi/default.nix
+++ b/pkgs/development/python-modules/ytmusicapi/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "ytmusicapi";
-  version = "1.7.1";
+  version = "1.7.2";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "sigma67";
     repo = "ytmusicapi";
     rev = "refs/tags/${version}";
-    hash = "sha256-HMWb9NScT4rRMFsUXw6TW/T0P1eH0a46OegUZ0JceiE=";
+    hash = "sha256-mFjNtZdLpS1jfqF/KZ1p8H0pWUGsIdFDxhc4dZnv6HM=";
   };
 
   build-system = [

--- a/pkgs/development/tools/analysis/tflint-plugins/tflint-ruleset-google.nix
+++ b/pkgs/development/tools/analysis/tflint-plugins/tflint-ruleset-google.nix
@@ -5,16 +5,16 @@
 
 buildGoModule rec {
   pname = "tflint-ruleset-google";
-  version = "0.28.0";
+  version = "0.29.0";
 
   src = fetchFromGitHub {
     owner = "terraform-linters";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-9/JCpT7zwuT8Tf8Pa2cj/pVlowFbQ8kv2XPvwJf/b10=";
+    hash = "sha256-cflmuvILMJX7jsz6OKPcaN/KezvWiqiv20Sw4vJ/mUk=";
   };
 
-  vendorHash = "sha256-mh8RXD+RD8juhSY2jWGsmwqAnnudIZIZmq8JjHh/eNQ=";
+  vendorHash = "sha256-xxSOjnzqESCOWtXsAGuTwVEoinvBNuJFaxDrIVc1O08=";
 
   # upstream Makefile also does a go test $(go list ./... | grep -v integration)
   preCheck = ''

--- a/pkgs/development/tools/bazel-gazelle/default.nix
+++ b/pkgs/development/tools/bazel-gazelle/default.nix
@@ -5,13 +5,13 @@
 
 buildGoModule rec {
   pname = "bazel-gazelle";
-  version = "0.36.0";
+  version = "0.37.0";
 
   src = fetchFromGitHub {
     owner = "bazelbuild";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-jT+h3ehaqA6LLg2Q5JdWeHPwUomRDIapNALwa7nFDJ4=";
+    hash = "sha256-YtgqhwPpkw+lPgsBDCDxkcNsSu1/ZoIhXMuQeZgLXNU=";
   };
 
   vendorHash = null;

--- a/pkgs/development/tools/build-managers/scala-cli/sources.json
+++ b/pkgs/development/tools/build-managers/scala-cli/sources.json
@@ -1,21 +1,21 @@
 {
-  "version": "1.3.1",
+  "version": "1.3.2",
   "assets": {
     "aarch64-darwin": {
       "asset": "scala-cli-aarch64-apple-darwin.gz",
-      "sha256": "04piwgd7jy7m4mx263lmlxfwh839q02b9jzycrr9bydqgfx7i0sk"
+      "sha256": "0xs60pnqsxxkamcq0n0am4jbnx4lgnr91ngcwxk0ccfpqf24jpk8"
     },
     "aarch64-linux": {
       "asset": "scala-cli-aarch64-pc-linux.gz",
-      "sha256": "0f01ilxr7zc0p6jcmn034j16ynjv1r2miik25pqlhcafjhv9sp20"
+      "sha256": "1419s6dnwk703mkp209m5fxqphx8g65h0b2kam3zs9z9rii3mjvs"
     },
     "x86_64-darwin": {
       "asset": "scala-cli-x86_64-apple-darwin.gz",
-      "sha256": "1yj49fskajf1fffkxh5hyg3vcrxyhjgcha1hj61dw0iblazfa440"
+      "sha256": "0ms7yggldckkyayz8wksyg79kgk6xl13g47a2jc7q66syzr495yw"
     },
     "x86_64-linux": {
       "asset": "scala-cli-x86_64-pc-linux.gz",
-      "sha256": "1kr035l4vwv76041yy82347f01kvbl8n676jd3dayzw48xg6j5l2"
+      "sha256": "1jy5xz8n79ck8gxcmy14ldsaj7dfrwrqgdfhp5h39hzvgcs1mjvl"
     }
   }
 }

--- a/pkgs/development/tools/earthly/default.nix
+++ b/pkgs/development/tools/earthly/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "earthly";
-  version = "0.8.11";
+  version = "0.8.12";
 
   src = fetchFromGitHub {
     owner = "earthly";
     repo = "earthly";
     rev = "v${version}";
-    hash = "sha256-73Ftm5/eGqgjtYcvKcRuHGzKnKYdCJ5WqDBsMSSiMuA=";
+    hash = "sha256-9yo2LgZ/c23FcZuOxUTlp1CfwFmg6yvhlOsDpY71Pic=";
   };
 
-  vendorHash = "sha256-Uj7GGRknXtcu64rzS7SSnwQyE84hnGAyiT62vyppDE4=";
+  vendorHash = "sha256-OuZypIUIUDG1Gipg4RYkQZVUD8+G/U3N2VkbP+rnbkc=";
   subPackages = [ "cmd/earthly" "cmd/debugger" ];
 
   CGO_ENABLED = 0;

--- a/pkgs/development/tools/firebase-tools/default.nix
+++ b/pkgs/development/tools/firebase-tools/default.nix
@@ -8,16 +8,16 @@
 
 buildNpmPackage rec {
   pname = "firebase-tools";
-  version = "13.10.0";
+  version = "13.10.1";
 
   src = fetchFromGitHub {
     owner = "firebase";
     repo = "firebase-tools";
     rev = "v${version}";
-    hash = "sha256-g6VmfVBGAjMH2a+oQpS3fVJm9rRNrYFaVfZ/GeqLSus=";
+    hash = "sha256-20YDBbkMJblZisFewTXLcvgT+Jtr7T/iaCukoTpbNF8=";
   };
 
-  npmDepsHash = "sha256-W+XiuYTFmPgcS03U579/J3HsdPkX9WIHMR33DzWQlr8=";
+  npmDepsHash = "sha256-HSzX4Ptl2WVRf0kw4pDrRoBH6b6JVOB+FD7LymJeaO0=";
 
   postPatch = ''
     ln -s npm-shrinkwrap.json package-lock.json

--- a/pkgs/development/tools/jaq/default.nix
+++ b/pkgs/development/tools/jaq/default.nix
@@ -7,16 +7,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "jaq";
-  version = "1.3.0";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "01mf02";
     repo = "jaq";
     rev = "v${version}";
-    hash = "sha256-QXlHiVlKx9qmW5Cw4IGzjuUSUfoc9IvA5ZkTc1Ev37Q=";
+    hash = "sha256-6HqZBJeUaYykTZLSrqQN0Rt6rvnvzb53T56oy06wIUw=";
   };
 
-  cargoHash = "sha256-9fv8Z9AE9GV/Bq+iAsxUkD/CS25/kOBKKS4SAke/tFk=";
+  cargoHash = "sha256-Zais+yGfrzxKrKA4uAG65uzhamnuYxQEKkIaeiOlcLQ=";
 
   buildInputs = lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.Security

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -217,6 +217,14 @@ stdenv.mkDerivation (finalAttrs: {
   ] ++ (if enableShared
       then [ "--enable-shared" "--disable-static" ]
       else [ "--disable-shared" "--enable-static" ])
+  ++ (lib.optionals (stdenv.cc.bintools.isLLVM && lib.versionAtLeast stdenv.cc.bintools.version "17") [
+      # lld17+ passes `--no-undefined-version` by default and makes this a hard
+      # error; libctf.ver version script references symbols that aren't present.
+      #
+      # This is fixed upstream and can be removed with the future release of 2.43.
+      # For now we allow this with `--undefined-version`:
+      "LDFLAGS=-Wl,--undefined-version"
+  ])
   ;
 
   # Fails

--- a/pkgs/development/tools/wasmedge/default.nix
+++ b/pkgs/development/tools/wasmedge/default.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wasmedge";
-  version = "0.13.5";
+  version = "0.14.0";
 
   src = fetchFromGitHub {
     owner = "WasmEdge";
     repo = "WasmEdge";
     rev = finalAttrs.version;
-    sha256 = "sha256-JaFaqYIwcRXYl5JukAfViUn8VTpMPThFO8EaVTPIudA=";
+    sha256 = "sha256-JPuJIM5OU1qCvFZEQ3gDNBZsIiJijtWLAVGp54z7lt0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/web/bun/default.nix
+++ b/pkgs/development/web/bun/default.nix
@@ -12,7 +12,7 @@
 }:
 
 stdenvNoCC.mkDerivation rec {
-  version = "1.1.8";
+  version = "1.1.9";
   pname = "bun";
 
   src = passthru.sources.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
@@ -51,19 +51,19 @@ stdenvNoCC.mkDerivation rec {
     sources = {
       "aarch64-darwin" = fetchurl {
         url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-darwin-aarch64.zip";
-        hash = "sha256-n5ElTDuD0fap+llzrXN7de937jYaAG8dpJlKUB0npT4=";
+        hash = "sha256-gk3Zi8AcpMTCexL8ASY29W2LcwYICpD2QwpvuEbQpB4=";
       };
       "aarch64-linux" = fetchurl {
         url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-aarch64.zip";
-        hash = "sha256-4/kEyaF2kmu8MAjlrPgBqKFDId8bBibu3Zll3b0w8Ro=";
+        hash = "sha256-F5yfovHAsWeLiQ4Uigrm0hy3gwz8pK5PA6AuZiyrfOI=";
       };
       "x86_64-darwin" = fetchurl {
         url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-darwin-x64.zip";
-        hash = "sha256-btyslaKqdk86whAnQV0on7NWTBTRTegFvMsOl0YyloY=";
+        hash = "sha256-HV8iVZwHPPyini8rCVMnSHmqL7HUM27uOSfaTcdnnZ0=";
       };
       "x86_64-linux" = fetchurl {
         url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-x64.zip";
-        hash = "sha256-JuDT+8FHbamdMVCDeSTGPYOvhPY2EZ9XeD2zjHEj36Y=";
+        hash = "sha256-yIz/CWKTSKoeOTb/2rxbyYovw0rralSj0r2ZMPu29i8=";
       };
     };
     updateScript = writeShellScript "update-bun" ''

--- a/pkgs/games/fheroes2/default.nix
+++ b/pkgs/games/fheroes2/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "fheroes2";
-  version = "1.0.13";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "ihhub";
     repo = "fheroes2";
     rev = version;
-    hash = "sha256-uR46G1DISurBk17GQdo+x94F2cP0+157PxjdG2s1Ik4=";
+    hash = "sha256-a4IZX0aq2iXLPKTVRWxkr50vhCEqAMUA0z50rOpEIjU=";
   };
 
   nativeBuildInputs = [ imagemagick ];

--- a/pkgs/misc/seafile-shared/default.nix
+++ b/pkgs/misc/seafile-shared/default.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "seafile-shared";
-  version = "9.0.5";
+  version = "9.0.6";
 
   src = fetchFromGitHub {
     owner = "haiwen";
     repo = "seafile";
     rev = "v${version}";
-    sha256 = "sha256-ENxmRnnQVwRm/3OXouM5Oj0fLVRSj0aOHJeVT627UdY=";
+    sha256 = "sha256-ig22Rw9VWPqOsJS1Wxy69OjdMRcxh2fOyqMHBEky/Uo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/os-specific/linux/pcm/default.nix
+++ b/pkgs/os-specific/linux/pcm/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "pcm";
-  version = "202403";
+  version = "202405";
 
   src = fetchFromGitHub {
     owner = "opcm";
     repo = "pcm";
     rev = version;
-    hash = "sha256-qefqtuxRaQEsWpXNAuGxuIT3LiH2b8xQb54B0RkzKGA=";
+    hash = "sha256-yEe1lWbvafc3N3+K9WMMlIXVVX+fVO8QsuKdyIqiKAg=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -65,6 +65,7 @@ rec {
       nativeBuildInputs = [ jq ];
       value = builtins.toJSON value;
       passAsFile = [ "value" ];
+      preferLocalBuild = true;
     } ''
       jq . "$valuePath"> $out
     '') {};
@@ -77,6 +78,7 @@ rec {
       nativeBuildInputs = [ remarshal ];
       value = builtins.toJSON value;
       passAsFile = [ "value" ];
+      preferLocalBuild = true;
     } ''
       json2yaml "$valuePath" "$out"
     '') {};
@@ -270,6 +272,7 @@ rec {
       nativeBuildInputs = [ remarshal ];
       value = builtins.toJSON value;
       passAsFile = [ "value" ];
+      preferLocalBuild = true;
     } ''
       json2toml "$valuePath" "$out"
     '') {};
@@ -467,6 +470,7 @@ rec {
           value = toConf value;
           passAsFile = [ "value" ];
           nativeBuildInputs = [ elixir ];
+          preferLocalBuild = true;
         } ''
         cp "$valuePath" "$out"
         mix format "$out"
@@ -501,6 +505,7 @@ rec {
                 print(f"{key} = {repr(value)}")
       '';
       passAsFile = [ "value" "pythonGen" ];
+      preferLocalBuild = true;
     } ''
       cat "$valuePath"
       python3 "$pythonGenPath" > $out

--- a/pkgs/pkgs-lib/formats/hocon/default.nix
+++ b/pkgs/pkgs-lib/formats/hocon/default.nix
@@ -153,6 +153,7 @@ in
           inherit name;
 
           dontUnpack = true;
+          preferLocalBuild = true;
 
           json = builtins.toJSON finalValue;
           passAsFile = [ "json" ];

--- a/pkgs/pkgs-lib/formats/java-properties/default.nix
+++ b/pkgs/pkgs-lib/formats/java-properties/default.nix
@@ -46,7 +46,7 @@ in
       in attrsOf elemType;
 
     generate = name: value:
-      pkgs.runCommandLocal name
+      pkgs.runCommand name
         {
           # Requirements
           # ============
@@ -80,6 +80,7 @@ in
           #    libraries, but we can't rely on this in
           #    general.
 
+          preferLocalBuild = true;
           passAsFile = [ "value" ];
           value = builtins.toJSON value;
           nativeBuildInputs = [

--- a/pkgs/pkgs-lib/formats/libconfig/default.nix
+++ b/pkgs/pkgs-lib/formats/libconfig/default.nix
@@ -85,6 +85,7 @@ in
           inherit name;
 
           dontUnpack = true;
+          preferLocalBuild = true;
 
           json = builtins.toJSON value;
           passAsFile = [ "json" ];

--- a/pkgs/servers/adguardhome/bins.nix
+++ b/pkgs/servers/adguardhome/bins.nix
@@ -1,31 +1,31 @@
 { fetchurl, fetchzip }:
 {
 x86_64-darwin = fetchzip {
-  sha256 = "sha256-97o4rMNwikQZR3DPhhE+OPlY3gA9HqCQxBf+mZSfDMs=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.48/AdGuardHome_darwin_amd64.zip";
+  sha256 = "sha256-T5iD2Ojo+/125NeEhy911kitypLNcyJq9JPnPd/91HE=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.50/AdGuardHome_darwin_amd64.zip";
 };
 aarch64-darwin = fetchzip {
-  sha256 = "sha256-ZTGqn6xM9vRHmw2ask5P4vu+5BqkWfGS3ROzTN9VfXM=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.48/AdGuardHome_darwin_arm64.zip";
+  sha256 = "sha256-cge+z/oAiRcbZXijm6FDP7C5L7jLoi/QCr4unYoN+jQ=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.50/AdGuardHome_darwin_arm64.zip";
 };
 i686-linux = fetchurl {
-  sha256 = "sha256-EbRiiThZsmBD/grtm58Su78OeF/6buwMbx6eBsusgII=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.48/AdGuardHome_linux_386.tar.gz";
+  sha256 = "sha256-PHUUqWL3ILlQutWqUyd9jGi80lC/PQPInFQa66sx3CI=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.50/AdGuardHome_linux_386.tar.gz";
 };
 x86_64-linux = fetchurl {
-  sha256 = "sha256-FUnQJ3RRtsWz4DIO8Zi9Y6dO130qTdwj6RhJ6RNpljc=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.48/AdGuardHome_linux_amd64.tar.gz";
+  sha256 = "sha256-krxAIJSQrvZrXsAfFZOr/ons4mSKnaQ+fIdHULKcvyA=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.50/AdGuardHome_linux_amd64.tar.gz";
 };
 aarch64-linux = fetchurl {
-  sha256 = "sha256-OZDryRiwyM6XgoiOhCsM6AFOE9masnGu2m6sDRUAaeY=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.48/AdGuardHome_linux_arm64.tar.gz";
+  sha256 = "sha256-JDGOE+tdRo6De7+zQK8hKNu7YwJKphm2/PY8jfaE8QE=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.50/AdGuardHome_linux_arm64.tar.gz";
 };
 armv6l-linux = fetchurl {
-  sha256 = "sha256-aL/wKQ9lbPgaTGCjZAph5iggSTJB1+Rrxbpf6IVgjuU=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.48/AdGuardHome_linux_armv6.tar.gz";
+  sha256 = "sha256-yDtOpbfuiI0kt4XSLZvwf5Uvai2N0zpJhg6kKxyyM+8=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.50/AdGuardHome_linux_armv6.tar.gz";
 };
 armv7l-linux = fetchurl {
-  sha256 = "sha256-siWf7frIciYGVP7KgqS4Dr7o52y3QqGYvQlxtw2HnEo=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.48/AdGuardHome_linux_armv7.tar.gz";
+  sha256 = "sha256-UvuWyrinTozuc+SEc7twUhYbYUCUc6cG66sqmUS01nk=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.50/AdGuardHome_linux_armv7.tar.gz";
 };
 }

--- a/pkgs/servers/adguardhome/default.nix
+++ b/pkgs/servers/adguardhome/default.nix
@@ -7,7 +7,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "adguardhome";
-  version = "0.107.48";
+  version = "0.107.50";
   src = sources.${system} or (throw "Source for ${pname} is not available for ${system}");
 
   installPhase = ''

--- a/pkgs/servers/apcupsd/default.nix
+++ b/pkgs/servers/apcupsd/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Daemon for controlling APC UPSes";
     homepage = "http://www.apcupsd.com/";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];
   };

--- a/pkgs/servers/brickd/default.nix
+++ b/pkgs/servers/brickd/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation {
     homepage = "https://www.tinkerforge.com/";
     description = "A daemon (or service on Windows) that acts as a bridge between the Bricks/Bricklets and the API bindings for the different programming languages";
     maintainers = [ lib.maintainers.qknight ];
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.all;
     mainProgram = "brickd";
   };

--- a/pkgs/servers/dns/dnsdist/default.nix
+++ b/pkgs/servers/dns/dnsdist/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     description = "DNS Loadbalancer";
     mainProgram = "dnsdist";
     homepage = "https://dnsdist.org";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     maintainers = with maintainers; [ jojosch ];
   };
 }

--- a/pkgs/servers/dns/pdns/default.nix
+++ b/pkgs/servers/dns/pdns/default.nix
@@ -97,7 +97,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.powerdns.com";
     platforms = platforms.unix;
     broken = stdenv.isDarwin;
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     maintainers = with maintainers; [ mic92 disassembler nickcao ];
   };
 })

--- a/pkgs/servers/freeradius/default.nix
+++ b/pkgs/servers/freeradius/default.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://freeradius.org/";
     description = "A modular, high performance free RADIUS suite";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ sheenobu willibutz lheckemann ];
     platforms = with platforms; linux;
   };

--- a/pkgs/servers/ftp/vsftpd/default.nix
+++ b/pkgs/servers/ftp/vsftpd/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A very secure FTP daemon";
     mainProgram = "vsftpd";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     maintainers = with maintainers; [ peterhoeg ];
     platforms = platforms.linux;
   };

--- a/pkgs/servers/gopher/gofish/default.nix
+++ b/pkgs/servers/gopher/gofish/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A lightweight Gopher server";
     homepage = "https://gofish.sourceforge.net/";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = [ maintainers.AndersonTorres ];
     platforms = platforms.unix;
   };

--- a/pkgs/servers/gpm/default.nix
+++ b/pkgs/servers/gpm/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://www.nico.schottelius.org/software/gpm/";
     description = "A daemon that provides mouse support on the Linux console";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     platforms = platforms.linux ++ platforms.cygwin;
     maintainers = with maintainers; [ eelco ];
   };

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2024.5.4";
+  version = "2024.5.5";
   format = "pyproject";
 
   disabled = python.version != home-assistant.python.version;
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     rev = "refs/tags/${version}";
-    hash = "sha256-wW3qRXdT3FmAj5bOBzBmrD97o/pONowi7F0Cbj6ndLg=";
+    hash = "sha256-lZuP6DL9nuc5md2vDVGucOE8MrQOg7QHx5vYPuvFw50=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/servers/http/apache-modules/mod_tile/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_tile/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/openstreetmap/mod_tile";
     description = "Efficiently render and serve OpenStreetMap tiles using Apache and Mapnik";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ jglukasik ];
     platforms = platforms.linux;
   };

--- a/pkgs/servers/http/gatling/default.nix
+++ b/pkgs/servers/http/gatling/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A high performance web server";
     homepage = "http://www.fefe.de/gatling/";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Only;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/servers/http/hiawatha/default.nix
+++ b/pkgs/servers/http/hiawatha/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://www.hiawatha-webserver.org";
     description = "An advanced and secure webserver";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     platforms = platforms.unix;    # "Hiawatha runs perfectly on Linux, BSD and MacOS X"
     maintainers = [];
   };

--- a/pkgs/servers/http/lwan/default.nix
+++ b/pkgs/servers/http/lwan/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
       support.
     ";
     homepage = "https://lwan.ws/";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ leenaars ];
   };

--- a/pkgs/servers/http/webfs/default.nix
+++ b/pkgs/servers/http/webfs/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "HTTP server for purely static content";
     homepage    = "http://linux.bytesex.org/misc/webfs.html";
-    license     = licenses.gpl2;
+    license     = licenses.gpl2Plus;
     platforms   = platforms.all;
     maintainers = with maintainers; [ zimbatm ];
     mainProgram = "webfsd";

--- a/pkgs/servers/icecast/default.nix
+++ b/pkgs/servers/icecast/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     '';
 
     homepage = "https://www.icecast.org";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ jcumming ];
     platforms = with lib.platforms; unix;
   };

--- a/pkgs/servers/icecream/default.nix
+++ b/pkgs/servers/icecream/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Distributed compiler with a central scheduler to share build load";
     inherit (src.meta) homepage;
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ emantor ];
     platforms = with platforms; linux ++ darwin;
   };

--- a/pkgs/servers/identd/nullidentdmod/default.nix
+++ b/pkgs/servers/identd/nullidentdmod/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Simple identd that just replies with a random string or customized userid";
     mainProgram = "nullidentdmod";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     homepage = "http://acidhub.click/NullidentdMod";
     maintainers = with maintainers; [ das_j ];
     platforms = platforms.linux; # Must be run by systemd

--- a/pkgs/servers/identd/oidentd/default.nix
+++ b/pkgs/servers/identd/oidentd/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     description = "Configurable Ident protocol server";
     mainProgram = "oidentd";
     homepage = "https://oidentd.janikrabe.com/";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/servers/irc/charybdis/default.nix
+++ b/pkgs/servers/irc/charybdis/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "IRCv3 server designed to be highly scalable";
     homepage    = "https://github.com/charybdis-ircd/charybdis";
-    license     = licenses.gpl2;
+    license     = licenses.gpl2Plus;
     maintainers = with maintainers; [ lassulus ];
     platforms   = platforms.unix;
   };

--- a/pkgs/servers/irc/ngircd/default.nix
+++ b/pkgs/servers/irc/ngircd/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     description = "Next Generation IRC Daemon";
     mainProgram = "ngircd";
     homepage    = "https://ngircd.barton.de";
-    license     = lib.licenses.gpl2;
+    license     = lib.licenses.gpl2Plus;
     platforms   = lib.platforms.all;
   };
 }

--- a/pkgs/servers/klipper/default.nix
+++ b/pkgs/servers/klipper/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "klipper";
-  version = "0.12.0-unstable-2024-05-16";
+  version = "0.12.0-unstable-2024-05-25";
 
   src = fetchFromGitHub {
     owner = "KevinOConnor";
     repo = "klipper";
-    rev = "b7f7b8a346388cc32d80b6e6f60e5fdb4cbd3ce6";
-    sha256 = "sha256-TkhDLy7H1U2tjLJikkOgP+2apRJtZe9EIsNHzzljiB4=";
+    rev = "3078912f1d9e063906b9b40eda73d63065900212";
+    sha256 = "sha256-DvGxsUJ24yfbSR8gNA6vBBSw72VIOr1R6mGXzcpQZ7I=";
   };
 
   sourceRoot = "${src.name}/klippy";

--- a/pkgs/servers/kwakd/default.nix
+++ b/pkgs/servers/kwakd/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "A super small webserver that serves blank pages";
     mainProgram = "kwakd";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     maintainers = [ maintainers.nicknovitski ];
     platforms = platforms.unix;
   };

--- a/pkgs/servers/limesurvey/default.nix
+++ b/pkgs/servers/limesurvey/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Open source survey application";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     homepage = "https://www.limesurvey.org";
     maintainers = with maintainers; [offline];
     platforms = with platforms; unix;

--- a/pkgs/servers/mail/nullmailer/default.nix
+++ b/pkgs/servers/mail/nullmailer/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
       A sendmail/qmail/etc replacement MTA for hosts which relay to a fixed set of smart relays.
       It is designed to be simple to configure, secure, and easily extendable.
     '';
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers ; [ sargon ];
   };

--- a/pkgs/servers/mail/postgrey/default.nix
+++ b/pkgs/servers/mail/postgrey/default.nix
@@ -19,7 +19,7 @@ in runCommand name {
     description = "A postfix policy server to provide greylisting";
     homepage = "https://postgrey.schweikert.ch/";
     platforms = postfix.meta.platforms;
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
   };
 } ''
     mkdir -p $out/bin

--- a/pkgs/servers/mail/postsrsd/default.nix
+++ b/pkgs/servers/mail/postsrsd/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/roehling/postsrsd";
     description = "Postfix Sender Rewriting Scheme daemon";
     mainProgram = "postsrsd";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     platforms = platforms.all;
     maintainers = with maintainers; [ abbradar ];
   };

--- a/pkgs/servers/mail/smtprelay/default.nix
+++ b/pkgs/servers/mail/smtprelay/default.nix
@@ -5,16 +5,16 @@
 
 buildGoModule rec {
   pname = "smtprelay";
-  version = "1.10.0";
+  version = "1.11.0";
 
   src = fetchFromGitHub {
     owner = "decke";
     repo = "smtprelay";
     rev = "refs/tags/v${version}";
-    hash = "sha256-zZ3rgbo8nvrpFMtUmhyXnTgoVd0FIh1kWzuM2hCh5gY=";
+    hash = "sha256-8N+JJp0/d59s8rU7t0YtrTepVXpxXc8PET1f+AgEpG0=";
   };
 
-  vendorHash = "sha256-assGzM8/APNVVm2vZapPK6sh3tWNTnw6PSFwvEqNDPk=";
+  vendorHash = "sha256-BX1Ll0EEo59p+Pe5oM6+6zT6fvnv1RsfX8YEh9RKkWU=";
 
   subPackages = [
     "."

--- a/pkgs/servers/mail/sympa/default.nix
+++ b/pkgs/servers/mail/sympa/default.nix
@@ -111,7 +111,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Open source mailing list manager";
     homepage = "https://www.sympa.org";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ sorki mmilata ];
     platforms = platforms.all;
   };

--- a/pkgs/servers/monitoring/consul-alerts/default.nix
+++ b/pkgs/servers/monitoring/consul-alerts/default.nix
@@ -22,7 +22,7 @@ buildGoPackage rec {
     homepage = "https://github.com/AcalephStorage/consul-alerts";
     # As per README
     platforms = platforms.linux ++ platforms.freebsd ++ platforms.darwin;
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     maintainers = with maintainers; [ nh2 ];
   };
 }

--- a/pkgs/servers/monitoring/fusion-inventory/default.nix
+++ b/pkgs/servers/monitoring/fusion-inventory/default.nix
@@ -78,7 +78,7 @@ perlPackages.buildPerlPackage rec {
   meta = with lib; {
     homepage = "http://www.fusioninventory.org";
     description = "FusionInventory unified Agent for UNIX, Linux, Windows and MacOSX";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Only;
     maintainers = [ maintainers.phile314 ];
   };
 }

--- a/pkgs/servers/monitoring/lcdproc/default.nix
+++ b/pkgs/servers/monitoring/lcdproc/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Client/server suite for controlling a wide variety of LCD devices";
     homepage = "https://lcdproc.org/";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ peterhoeg ];
     platforms = platforms.unix;
     # never built on aarch64-darwin since first introduction in nixpkgs

--- a/pkgs/servers/monitoring/munin/default.nix
+++ b/pkgs/servers/monitoring/munin/default.nix
@@ -142,7 +142,7 @@ stdenv.mkDerivation rec {
       to kill our performance?' problems.
     '';
     homepage = "https://munin-monitoring.org/";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     maintainers = [ maintainers.bjornfor ];
     platforms = platforms.linux;
   };

--- a/pkgs/servers/monitoring/nagios/default.nix
+++ b/pkgs/servers/monitoring/nagios/default.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "A host, service and network monitoring program";
     homepage = "https://www.nagios.org/";
     changelog = "https://github.com/NagiosEnterprises/nagioscore/blob/nagios-${finalAttrs.version}/Changelog";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Only;
     platforms = lib.platforms.unix;
     mainProgram = "nagios";
     maintainers = with lib.maintainers; [ immae thoughtpolice relrod anthonyroussel ];

--- a/pkgs/servers/monitoring/plugins/esxi.nix
+++ b/pkgs/servers/monitoring/plugins/esxi.nix
@@ -31,7 +31,7 @@ in python3Packages.buildPythonApplication rec {
 
   meta = with lib; {
     homepage = "https://www.claudiokuenzler.com/nagios-plugins/";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ peterhoeg ];
   };
 }

--- a/pkgs/servers/monitoring/plugins/labs_consol_de.nix
+++ b/pkgs/servers/monitoring/plugins/labs_consol_de.nix
@@ -44,7 +44,7 @@ let
 
     meta = with lib; {
       homepage    = "https://labs.consol.de/";
-      license     = licenses.gpl2;
+      license     = licenses.gpl2Only;
       maintainers = with maintainers; [ peterhoeg ];
       inherit description;
     };

--- a/pkgs/servers/monitoring/plugins/wmiplus/default.nix
+++ b/pkgs/servers/monitoring/plugins/wmiplus/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A sensu/nagios plugin using WMI to query Windows hosts";
     homepage = "http://edcint.co.nz/checkwmiplus";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ peterhoeg ];
   };
 }

--- a/pkgs/servers/monitoring/zabbix/agent.nix
+++ b/pkgs/servers/monitoring/zabbix/agent.nix
@@ -36,7 +36,7 @@ import ./versions.nix ({ version, hash, ... }:
     meta = with lib; {
       description = "An enterprise-class open source distributed monitoring solution (client-side agent)";
       homepage = "https://www.zabbix.com/";
-      license = licenses.gpl2;
+      license = licenses.gpl2Plus;
       maintainers = with maintainers; [ mmahut psyanticy ];
       platforms = platforms.linux;
     };

--- a/pkgs/servers/monitoring/zabbix/proxy.nix
+++ b/pkgs/servers/monitoring/zabbix/proxy.nix
@@ -81,7 +81,7 @@ in
       meta = with lib; {
         description = "An enterprise-class open source distributed monitoring solution (client-server proxy)";
         homepage = "https://www.zabbix.com/";
-        license = licenses.gpl2;
+        license = licenses.gpl2Plus;
         maintainers = [ maintainers.mmahut ];
         platforms = platforms.linux;
       };

--- a/pkgs/servers/monitoring/zabbix/server.nix
+++ b/pkgs/servers/monitoring/zabbix/server.nix
@@ -90,7 +90,7 @@ in
       meta = with lib; {
         description = "An enterprise-class open source distributed monitoring solution";
         homepage = "https://www.zabbix.com/";
-        license = licenses.gpl2;
+        license = licenses.gpl2Plus;
         maintainers = with maintainers; [ mmahut psyanticy ];
         platforms = platforms.linux;
       };

--- a/pkgs/servers/monitoring/zabbix/web.nix
+++ b/pkgs/servers/monitoring/zabbix/web.nix
@@ -25,7 +25,7 @@ import ./versions.nix ({ version, hash, ... }:
     meta = with lib; {
       description = "An enterprise-class open source distributed monitoring solution (web frontend)";
       homepage = "https://www.zabbix.com/";
-      license = licenses.gpl2;
+      license = licenses.gpl2Plus;
       maintainers = [ maintainers.mmahut ];
       platforms = platforms.linux;
     };

--- a/pkgs/servers/search/sphinxsearch/default.nix
+++ b/pkgs/servers/search/sphinxsearch/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "An open source full text search server";
     homepage    = "http://sphinxsearch.com";
-    license     = lib.licenses.gpl2;
+    license     = lib.licenses.gpl2Plus;
     platforms   = lib.platforms.all;
     maintainers = with lib.maintainers; [ ederoyd46 valodim ];
   };

--- a/pkgs/servers/silc-server/default.nix
+++ b/pkgs/servers/silc-server/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     homepage = "http://silcnet.org/";
     description = "Secure Internet Live Conferencing server";
     mainProgram = "silcd";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [viric];
     platforms = with lib.platforms; linux;
   };

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -139,7 +139,7 @@ let
       meta = with lib; {
         description = "An enhanced, drop-in replacement for MySQL";
         homepage    = "https://mariadb.org/";
-        license     = licenses.gpl2;
+        license     = licenses.gpl2Plus;
         maintainers = with maintainers; [ thoughtpolice ] ++ teams.helsinki-systems.members;
         platforms   = platforms.all;
       };

--- a/pkgs/servers/sql/mysql/8.0.x.nix
+++ b/pkgs/servers/sql/mysql/8.0.x.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = with lib; {
     homepage = "https://www.mysql.com/";
     description = "The world's most popular open source database";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     maintainers = with maintainers; [ orivej ];
     platforms = platforms.unix;
   };

--- a/pkgs/servers/sql/mysql/jdbc/default.nix
+++ b/pkgs/servers/sql/mysql/jdbc/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     changelog = "https://dev.mysql.com/doc/relnotes/connector-j/en/";
     maintainers = with maintainers; [ ];
     platforms = platforms.unix;
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
   };
 }

--- a/pkgs/servers/sql/percona-server/lts.nix
+++ b/pkgs/servers/sql/percona-server/lts.nix
@@ -89,7 +89,7 @@ stdenv.mkDerivation (finalAttrs: {
       A free, fully compatible, enhanced, open source drop-in replacement for
       MySQL® that provides superior performance, scalability and instrumentation.
     '';
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = teams.flyingcircus.members;
     platforms = platforms.unix;
   };

--- a/pkgs/servers/sql/postgresql/ext/pg_similarity.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_similarity.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
        operators (= and <>) you can use ~~~ and ~!~ (any of these operators represents a similarity function).
     '';
     platforms = postgresql.meta.platforms;
-    license = lib.licenses.gpl2;
+    license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ danbst ];
   };
 }

--- a/pkgs/servers/sql/postgresql/ext/postgis.nix
+++ b/pkgs/servers/sql/postgresql/ext/postgis.nix
@@ -80,7 +80,7 @@ stdenv.mkDerivation rec {
     description = "Geographic Objects for PostgreSQL";
     homepage = "https://postgis.net/";
     changelog = "https://git.osgeo.org/gitea/postgis/postgis/raw/tag/${version}/NEWS";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; teams.geospatial.members ++ [ marcweber wolfgangwalther ];
     inherit (postgresql.meta) platforms;
   };

--- a/pkgs/servers/ums/default.nix
+++ b/pkgs/servers/ums/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   meta = {
       description = "Universal Media Server: a DLNA-compliant UPnP Media Server";
-      license = lib.licenses.gpl2;
+      license = lib.licenses.gpl2Only;
       platforms = lib.platforms.linux;
       maintainers = with lib.maintainers; [ thall snicket2100 ];
       mainProgram = "ums";

--- a/pkgs/servers/uwsgi/default.nix
+++ b/pkgs/servers/uwsgi/default.nix
@@ -165,7 +165,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "A fast, self-healing and developer/sysadmin-friendly application container server coded in pure C";
     homepage = "https://uwsgi-docs.readthedocs.org/en/latest/";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ abbradar schneefux globin ];
     platforms = lib.platforms.unix;
     mainProgram = "uwsgi";

--- a/pkgs/servers/web-apps/dokuwiki/default.nix
+++ b/pkgs/servers/web-apps/dokuwiki/default.nix
@@ -83,7 +83,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Simple to use and highly versatile Open Source wiki software that doesn't require a database";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     homepage = "https://www.dokuwiki.org";
     platforms = platforms.all;
     maintainers = with maintainers; [ _1000101 ];

--- a/pkgs/servers/web-apps/engelsystem/default.nix
+++ b/pkgs/servers/web-apps/engelsystem/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     description =
       "Coordinate your volunteers in teams, assign them to work shifts or let them decide for themselves when and where they want to help with what";
     homepage = "https://engelsystem.de";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     mainProgram = "migrate";
     maintainers = with maintainers; [ ];
     platforms = platforms.all;

--- a/pkgs/servers/web-apps/freshrss/default.nix
+++ b/pkgs/servers/web-apps/freshrss/default.nix
@@ -7,13 +7,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "FreshRSS";
-  version = "1.23.1";
+  version = "1.24.0";
 
   src = fetchFromGitHub {
     owner = "FreshRSS";
     repo = "FreshRSS";
     rev = version;
-    hash = "sha256-uidTsL8TREZ/qcqO/J+6hguP6Dr6J+995WNWCJCduBw=";
+    hash = "sha256-QMSSSSyInkWJP9im6RhyVItSgY30Nt2p1pRDdPPoaYI=";
   };
 
   passthru.tests = {

--- a/pkgs/servers/web-apps/wordpress/generic.nix
+++ b/pkgs/servers/web-apps/wordpress/generic.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://wordpress.org";
     description = "WordPress is open source software you can use to create a beautiful website, blog, or app";
-    license = [ licenses.gpl2 ];
+    license = [ licenses.gpl2Plus ];
     maintainers = [ maintainers.basvandijk ];
     platforms = platforms.all;
   };

--- a/pkgs/servers/xmpp/ejabberd/default.nix
+++ b/pkgs/servers/xmpp/ejabberd/default.nix
@@ -119,7 +119,7 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Open-source XMPP application server written in Erlang";
     mainProgram = "ejabberdctl";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     homepage = "https://www.ejabberd.im";
     platforms = platforms.linux;
     maintainers = with maintainers; [ sander abbradar ];

--- a/pkgs/shells/liquidprompt/default.nix
+++ b/pkgs/shells/liquidprompt/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
   installPhase = ''
+    runHook preInstall
+
     install -D -m 0444 liquidprompt $out/bin/liquidprompt
     install -D -m 0444 liquidpromptrc-dist $out/share/doc/liquidprompt/liquidpromptrc-dist
     install -D -m 0444 liquid.theme $out/share/doc/liquidprompt/liquid.theme
@@ -21,6 +23,8 @@ stdenv.mkDerivation rec {
       $out/share/zsh/plugins/liquidprompt/liquidprompt.plugin.zsh
     install -D -m 0444 liquidprompt \
       $out/share/zsh/plugins/liquidprompt/liquidprompt
+
+    runHook postInstall
   '';
 
   passthru.updateScript = gitUpdater { };

--- a/pkgs/shells/liquidprompt/default.nix
+++ b/pkgs/shells/liquidprompt/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "2.1.2";
 
   src = fetchFromGitHub {
-    owner = "nojhan";
+    owner = "liquidprompt";
     repo = pname;
     rev = "v${version}";
     sha256 = "sha256-7mnrXLqnCdOuS2aRs4tVLfO8SRFrqZHNM40gWE/CVFI=";
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A full-featured & carefully designed adaptive prompt for Bash & Zsh";
-    homepage = "https://github.com/nojhan/liquidprompt";
+    homepage = "https://github.com/liquidprompt/liquidprompt";
     license = licenses.agpl3Plus;
     platforms = platforms.all;
     maintainers = with maintainers; [ gerschtli ];

--- a/pkgs/shells/liquidprompt/default.nix
+++ b/pkgs/shells/liquidprompt/default.nix
@@ -2,27 +2,40 @@
 
 stdenv.mkDerivation rec {
   pname = "liquidprompt";
-  version = "2.1.2";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "liquidprompt";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-7mnrXLqnCdOuS2aRs4tVLfO8SRFrqZHNM40gWE/CVFI=";
+    hash = "sha256-ra+uJg9E2Cr1k0Ni1+xG9yKFF9iMInJFB5oAFnc52lc=";
   };
 
   strictDeps = true;
+
+  postPatch = ''
+    patchShebangs tools/*.sh
+  '';
+
   installPhase = ''
     runHook preInstall
 
     install -D -m 0444 liquidprompt $out/bin/liquidprompt
-    install -D -m 0444 liquidpromptrc-dist $out/share/doc/liquidprompt/liquidpromptrc-dist
-    install -D -m 0444 liquid.theme $out/share/doc/liquidprompt/liquid.theme
 
     install -D -m 0444 liquidprompt.plugin.zsh \
       $out/share/zsh/plugins/liquidprompt/liquidprompt.plugin.zsh
     install -D -m 0444 liquidprompt \
       $out/share/zsh/plugins/liquidprompt/liquidprompt
+
+    # generate default config file
+    mkdir -p $out/share/doc/liquidprompt
+    tools/config-from-doc.sh --verbose > $out/share/doc/liquidprompt/liquidpromptrc-dist
+
+    mkdir -p $out/share/liquidprompt
+    cp -a themes $out/share/liquidprompt/
+
+    mkdir -p $out/share/liquidprompt/contrib
+    cp -a contrib/presets $out/share/liquidprompt/contrib/
 
     runHook postInstall
   '';

--- a/pkgs/shells/liquidprompt/default.nix
+++ b/pkgs/shells/liquidprompt/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, stdenv, fetchFromGitHub, gitUpdater }:
 
 stdenv.mkDerivation rec {
   pname = "liquidprompt";
@@ -22,6 +22,8 @@ stdenv.mkDerivation rec {
     install -D -m 0444 liquidprompt \
       $out/share/zsh/plugins/liquidprompt/liquidprompt
   '';
+
+  passthru.updateScript = gitUpdater { };
 
   meta = with lib; {
     description = "A full-featured & carefully designed adaptive prompt for Bash & Zsh";

--- a/pkgs/stdenv/generic/jscall.c
+++ b/pkgs/stdenv/generic/jscall.c
@@ -1,0 +1,224 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <signal.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define JOBSRV_IOC_SET_LIMIT _IOW(0x0A, 0, unsigned)
+
+static int r = -1, w = -1;
+static char token = 0;
+
+static void return_token()
+{
+    for (;;) {
+        ssize_t written = written = write(w, &token, 1);
+        if (written < 0 && errno == EINTR) {
+            continue;
+        } else if (written < 1) {
+            perror("jscall token return failed");
+        }
+        break;
+    }
+}
+
+static void handle_signal(int sig)
+{
+    if (w >= 0 && token != 0) {
+        return_token();
+        w = -1;
+    }
+    signal(sig, SIG_DFL);
+    raise(sig);
+}
+
+static int find_separator(char** argv)
+{
+    for (int i = 0; argv[i]; i++) {
+        if (strcmp(argv[i], "----") == 0) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+static void shift_args(char** low, char** high)
+{
+    for (; high[0]; low++, high++) {
+        low[0] = high[0];
+    }
+    low[0] = NULL;
+}
+
+static void shift_once(char** args)
+{
+    shift_args(args, args + 1);
+}
+
+static int run_child(char** argv)
+{
+    execvp(argv[0], argv);
+    perror("execvp");
+    return 1;
+}
+
+static const char* usage =
+    "invocation: jscall [-F flags] <jobserver> <token-limit> <main...> ---- [def-args...] ---- [args...]\n"
+    "\n"
+    "runs `main... args...` with a GNU jobserver fd set in MAKEFLAGS if `jobserver`\n"
+    "exists on is a nixos-jobserver endpoint. otherwise runs\n"
+    "`main... def-args... args...`. if -F is given, `flags` is a space-separated\n"
+    "of environment variables to add jobserver arguments to instead of MAKEFLAGS.\n"
+    "\n"
+    "when running with nixos-jobserver available `main` and its children are\n"
+    "limited to `token-limit` tokens, which may be less than the system limit.\n"
+    "\n"
+    "arguments beginning with ---- are not allowed except in `args`.\n";
+
+int main(int argc, char* argv[])
+{
+    // we'll later pass this to strtok, which needs it to be mutable
+    char vars_raw[] = "MAKEFLAGS";
+    char* vars = vars_raw;
+
+    for (int opt; (opt = getopt(argc, argv, "+F:")) != -1; ) {
+        switch (opt) {
+        case 'F':
+            vars = optarg;
+            break;
+        case '?':
+        default:
+            fprintf(stderr, "%s", usage);
+            return 1;
+        }
+    }
+
+    shift_args(argv + 1, argv + optind);
+    argc -= optind - 1;
+
+    // create a default command first by removing the separators.
+    // if we can use the jobserver we'll shift the default args out of the arguments
+    // list.
+
+    char** cmd = argv + 3;
+    int cmd_length = find_separator(cmd);
+    if (cmd_length < 0) {
+        fprintf(stderr, "main command not terminated\n\n%s", usage);
+        return 1;
+    } else if (cmd_length == 0) {
+        fprintf(stderr, "main command not given\n\n%s", usage);
+        return 1;
+    }
+    shift_once(cmd + cmd_length);
+
+    char** def_args = cmd + cmd_length;
+    int def_args_length = find_separator(def_args);
+    if (def_args_length < 0) {
+        fprintf(stderr, "def-args command not terminated\n\n%s", usage);
+        return 1;
+    }
+    shift_once(def_args + def_args_length);
+
+    char** args = def_args + def_args_length;
+
+    struct stat st;
+    if (stat(argv[1], &st)) {
+        perror("stat() jobserver pipe");
+        return 1;
+    }
+
+    unsigned token_limit;
+    if (sscanf(argv[2], "%u%c", &token_limit, (char*) &token_limit) != 1) {
+        fprintf(stderr, "token limit must be an unsigned integer\n");
+        return 1;
+    }
+
+    // we only support nixos-jobserver files here. supporting named pipes would be possible,
+    // but since we're a part of stdenv and stdenv is occasionally SIGKILLed by nix we would
+    // lose tokens when using normal pipes.
+    r = open(argv[1], O_RDWR);
+    w = dup(r);
+
+    if (r < 0 || w < 0) {
+        fprintf(stderr, "failed to open jobserver pipe, executing without jobserver\n");
+        close(r);
+        close(w);
+        return run_child(cmd);
+    }
+    if (ioctl(r, JOBSRV_IOC_SET_LIMIT, &token_limit)) {
+        perror("failed to set token limit");
+        fprintf(stderr, "is %s a nixos-jobserver instance? attempting to run without jobserver\n", argv[1]);
+        close(r);
+        close(w);
+        return run_child(cmd);
+    }
+
+    for (char* flag, *toks = NULL;
+            (flag = strtok_r(toks ? NULL : vars, " ", &toks)); ) {
+        char* flags = getenv(flag);
+        if (!flags) {
+            flags = "";
+        }
+        if (asprintf(&flags, "%s -j --jobserver-auth=%i,%i", flags, r, w) < 0) {
+            perror("asprintf");
+            return 1;
+        }
+        if (setenv(flag, flags, 1)) {
+            fprintf(stderr, "invalid environment variable %s\n", flag);
+            return 1;
+        }
+    }
+
+    signal(SIGINT, handle_signal);
+    signal(SIGHUP, handle_signal);
+    signal(SIGTERM, handle_signal);
+
+    // older make versions use blocking read fds, newer version use nonblocking.
+    // we don't need to worry about that here since we are the server and haven't given
+    // any tokens to children yet.
+    if (read(r, &token, 1) != 1) {
+        perror("failed to acquire initial job token");
+        return 1;
+    }
+
+    // set O_NONBLOCK on the jobserver file description.
+    // make itself does not need this, but other tools (like cargo) expect to receive
+    // nonblocking fds and get stuck when given a blocking fd.
+    if (fcntl(r, F_SETFL, O_NONBLOCK)) {
+        perror("fcntl");
+        return 1;
+    }
+
+    pid_t p = fork();
+    if (p < 0) {
+        return_token();
+        perror("fork");
+        return 1;
+    } else if (p == 0) {
+        shift_args(def_args, args);
+        return run_child(cmd);
+    } else {
+        int status;
+        waitpid(p, &status, 0);
+
+        if (WIFEXITED(status)) {
+            return_token();
+            return WEXITSTATUS(status);
+        } else if (WIFSIGNALED(status)) {
+            raise(WTERMSIG(status));
+        } else {
+            return_token();
+            fprintf(stderr, "unexpected return from waitpid: %i\n", status);
+            return 1;
+        }
+    }
+}

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -397,6 +397,8 @@ else let
       inherit doCheck doInstallCheck;
 
       inherit outputs;
+    } // optionalAttrs (stdenv ? jscall) {
+      inherit (stdenv) jscall;
     } // optionalAttrs (__contentAddressed) {
       inherit __contentAddressed;
       # Provide default values for outputHashMode and outputHashAlgo because

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1032,8 +1032,8 @@ runInJobserver() {
     done
     shift
 
-    if [[ -n "$jscall" && -e /jobserver ]]; then
-        cmd=("$jscall" "${opts[@]}" /jobserver $NIX_BUILD_CORES "${cmd[@]}"
+    if [[ -n "$jscall" && -e /build-support/jobserver ]]; then
+        cmd=("$jscall" "${opts[@]}" /build-support/jobserver $NIX_BUILD_CORES "${cmd[@]}"
             ---- "${defArgs[@]}" ----)
         kind='with'
     else

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1002,6 +1002,48 @@ stripHash() {
     if (( casematchOpt )); then shopt -s nocasematch; fi
 }
 
+# Takes a command line of the form
+#   runInJobserver command... ---- defArgs... ---- programArgs...
+# and runs
+#   command... programArgs... # if a jobserver is available
+#   command... defArgs... programArgs... # if no jobserver is available
+runInJobserver() {
+    local opts=() cmd=() defArgs=()
+    local kind="without"
+
+    while [[ "$1" == -* ]]; do
+        case "$1" in
+            --) break ;;
+            -F) opts+=("${@:1:2}"); shift 2 ;;
+            -F*) opts+=("$1"); shift ;;
+            *) echo "unexpected pre-command argument $1" >&2; return 1 ;;
+        esac
+    done
+
+    while [[ $# > 0 && "$1" != "----" ]]; do
+        cmd+=("$1")
+        shift
+    done
+    shift
+
+    while [[ $# > 0 && "$1" != "----" ]]; do
+        defArgs+=("$1")
+        shift
+    done
+    shift
+
+    if [[ -n "$jscall" && -e /jobserver ]]; then
+        cmd=("$jscall" "${opts[@]}" /jobserver $NIX_BUILD_CORES "${cmd[@]}"
+            ---- "${defArgs[@]}" ----)
+        kind='with'
+    else
+        cmd+=("${defArgs[@]}")
+    fi
+
+    echoCmd "running $kind jobserver" "${cmd[@]}" "$@"
+    "${cmd[@]}" "$@"
+}
+
 
 recordPropagatedDependencies() {
     # Propagate dependencies into the development output.
@@ -1317,13 +1359,19 @@ buildPhase() {
 
         # shellcheck disable=SC2086
         local flagsArray=(
-            ${enableParallelBuilding:+-j${NIX_BUILD_CORES}}
             SHELL=$SHELL
         )
         _accumFlagsArray makeFlags makeFlagsArray buildFlags buildFlagsArray
 
         echoCmd 'build flags' "${flagsArray[@]}"
-        make ${makefile:+-f $makefile} "${flagsArray[@]}"
+        if [[ -n "$enableParallelBuilding" ]]; then
+            runInJobserver \
+                make ---- \
+                -j${NIX_BUILD_CORES} -l${NIX_BUILD_CORES} ---- \
+                ${makefile:+-f $makefile} "${flagsArray[@]}"
+        else
+            make ${makefile:+-f $makefile} "${flagsArray[@]}"
+        fi
         unset flagsArray
     fi
 
@@ -1355,7 +1403,6 @@ checkPhase() {
         # Old bash empty array hack
         # shellcheck disable=SC2086
         local flagsArray=(
-            ${enableParallelChecking:+-j${NIX_BUILD_CORES}}
             SHELL=$SHELL
         )
 
@@ -1369,7 +1416,14 @@ checkPhase() {
         flagsArray+=( ${checkTarget} )
 
         echoCmd 'check flags' "${flagsArray[@]}"
-        make ${makefile:+-f $makefile} "${flagsArray[@]}"
+        if [[ -n "$enableParallelChecking" ]]; then
+            runInJobserver \
+                make ---- \
+                -j${NIX_BUILD_CORES} -l${NIX_BUILD_CORES} ---- \
+                ${makefile:+-f $makefile} "${flagsArray[@]}"
+        else
+            make ${makefile:+-f $makefile} "${flagsArray[@]}"
+        fi
 
         unset flagsArray
     fi
@@ -1483,7 +1537,6 @@ installCheckPhase() {
         # Old bash empty array hack
         # shellcheck disable=SC2086
         local flagsArray=(
-            ${enableParallelChecking:+-j${NIX_BUILD_CORES}}
             SHELL=$SHELL
         )
 
@@ -1492,7 +1545,14 @@ installCheckPhase() {
         flagsArray+=( ${installCheckTarget:-installcheck} )
 
         echoCmd 'installcheck flags' "${flagsArray[@]}"
-        make ${makefile:+-f $makefile} "${flagsArray[@]}"
+        if [[ -n "$enableParallelChecking" ]]; then
+            runInJobserver \
+                make ---- \
+                -j${NIX_BUILD_CORES} -l${NIX_BUILD_CORES} ---- \
+                ${makefile:+-f $makefile} "${flagsArray[@]}"
+        else
+            make ${makefile:+-f $makefile} "${flagsArray[@]}"
+        fi
         unset flagsArray
     fi
 

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -631,6 +631,19 @@ in
       extraAttrs = {
         inherit bootstrapTools;
         shellPackage = prevStage.bash;
+
+        # jobserver call program (jscall)
+        jscall = derivation {
+          inherit system;
+          name = "jscall";
+          src = ../generic/jscall.c;
+          builder = cc.shell;
+          args = [
+            "-e"
+            "-c"
+            "${cc}/bin/cc -Wall -o $out $src"
+          ];
+        };
       };
 
       disallowedRequisites = [ bootstrapTools.out ];

--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -10,12 +10,12 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "salt";
-  version = "3007.0";
+  version = "3007.1";
   format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-Qb+E5x/GVb+KS1LrRA0GIa6WEJaghtIOEy4VEuLt3/g=";
+    hash = "sha256-uTOsTLPksRGLRtraVcnMa9xvD5S0ySh3rsRLJcaijJo=";
   };
 
   patches = [

--- a/pkgs/tools/filesystems/gcsfuse/default.nix
+++ b/pkgs/tools/filesystems/gcsfuse/default.nix
@@ -5,16 +5,16 @@
 
 buildGoModule rec {
   pname = "gcsfuse";
-  version = "2.0.1";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "googlecloudplatform";
     repo = "gcsfuse";
     rev = "v${version}";
-    hash = "sha256-8O8JIN2KmTw5bMmcxu9ZeNiS48XkMUUpAX3+6Km13Y8=";
+    hash = "sha256-1SKTwHvSCkkYhPY2yVTIRVsddW/Gt8Vke6W+a4VO6fc=";
   };
 
-  vendorHash = "sha256-nw2b0lDUJ9B+LloySns4cUzXeJ8uv4oYkZY0Jjg4hxc=";
+  vendorHash = "sha256-7IEF11gqou3Dk+CdU1HKPV7MyksldMmciQ74I9MEtuo=";
 
   subPackages = [ "." "tools/mount_gcsfuse" ];
 

--- a/pkgs/tools/misc/you-get/default.nix
+++ b/pkgs/tools/misc/you-get/default.nix
@@ -8,7 +8,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "you-get";
-  version = "0.4.1650";
+  version = "0.4.1700";
   format = "setuptools";
 
   # Tests aren't packaged, but they all hit the real network so
@@ -17,7 +17,7 @@ python3.pkgs.buildPythonApplication rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-s8lEz3pjzEaMzMiBbc5/wAjC5rW6Uq7+XOIIGBijrUc=";
+    sha256 = "sha256-XNIUkgEqRGrBtSxvfkSUSqxltZ6ZdkWoTc9kz4BD6Zw=";
   };
 
   patches = [

--- a/pkgs/tools/networking/miniupnpc/default.nix
+++ b/pkgs/tools/networking/miniupnpc/default.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, fetchurl
+, fetchFromGitHub
 , cmake
 }:
 
@@ -8,13 +8,14 @@ stdenv.mkDerivation rec {
   pname = "miniupnpc";
   version = "2.2.7";
 
-  src = fetchurl {
-    urls = [
-      "https://miniupnp.tuxfamily.org/files/${pname}-${version}.tar.gz"
-      "http://miniupnp.free.fr/files/${pname}-${version}.tar.gz"
-    ];
-    sha256 = "sha256-sMOicFaED9DskyilqbrD3F4OxtLoczNJz1d7CqHnCsE=";
+  src = fetchFromGitHub {
+    owner = "miniupnp";
+    repo = "miniupnp";
+    rev = "miniupnpc_${lib.replaceStrings ["."] ["_"] version}";
+    hash = "sha256-cIijY1NcdF169tibfB13845UT9ZoJ/CZ+XLES9ctWTY=";
   };
+
+  sourceRoot = "${src.name}/miniupnpc";
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/tools/networking/oneshot/default.nix
+++ b/pkgs/tools/networking/oneshot/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "oneshot";
-  version = "2.0.2";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "forestnode-io";
     repo = "oneshot";
     rev = "v${version}";
-    hash = "sha256-aIbKXBJNcBbYJRzETT0mkaqTRo+/8o6z882G21V74rg=";
+    hash = "sha256-zGeXc/dzll5fYURufljVBbTyVhrI9pkqLufOB8ZdV0E=";
   };
 
   vendorHash = "sha256-TktSQMIHYXF9eyY6jyfE31WLXEq7VZU3qnVIMGjMMcA=";

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -138,7 +138,7 @@ in lib.makeExtensible (self: ({
     patches = [
       patch-monitorfdhup
     ];
-    maintainers = with lib.maintainers; [ flokli raitobezarius ];
+    maintainers = with lib.maintainers; [ flokli ];
   }).override { boehmgc = boehmgc-nix_2_3; }).overrideAttrs {
     # https://github.com/NixOS/nix/issues/10222
     # spurious test/add.sh failures

--- a/pkgs/tools/security/smbmap/default.nix
+++ b/pkgs/tools/security/smbmap/default.nix
@@ -1,21 +1,24 @@
-{ lib
-, fetchFromGitHub
-, python3
+{
+  lib,
+  fetchFromGitHub,
+  python3,
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "smbmap";
-  version = "1.10.2";
-  format = "setuptools";
+  version = "1.10.3";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ShawnDEvans";
     repo = "smbmap";
     rev = "refs/tags/v${version}";
-    hash = "sha256-6+kO2Wfz3gGABS4fGxoebCubzvFAaJIGnMPA+k1mckc=";
+    hash = "sha256-ZzNiNAGf0FYfo3Zow4crWFQQb4+GhUeHpwJfuM5P9Ds=";
   };
 
-  propagatedBuildInputs = with python3.pkgs; [
+  build-system = with python3.pkgs; [ setuptools ];
+
+  dependencies = with python3.pkgs; [
     impacket
     pyasn1
     pycrypto
@@ -26,16 +29,14 @@ python3.pkgs.buildPythonApplication rec {
   # Project has no tests
   doCheck = false;
 
-  pythonImportsCheck = [
-    "smbmap"
-  ];
+  pythonImportsCheck = [ "smbmap" ];
 
   meta = with lib; {
     description = "SMB enumeration tool";
-    mainProgram = "smbmap";
     homepage = "https://github.com/ShawnDEvans/smbmap";
     changelog = "https://github.com/ShawnDEvans/smbmap/releases/tag/v${version}";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ fab ];
+    mainProgram = "smbmap";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2897,8 +2897,6 @@ with pkgs;
     inherit (qt5) wrapQtAppsHook;
   };
 
-  felix-fm = callPackage ../applications/file-managers/felix-fm { };
-
   krusader = libsForQt5.callPackage ../applications/file-managers/krusader { };
 
   lesscpy = callPackage ../development/compilers/lesscpy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12667,6 +12667,8 @@ self: super: with self; {
 
   pytube = callPackage ../development/python-modules/pytube { };
 
+  pytubefix = callPackage ../development/python-modules/pytubefix { };
+
   pytun = callPackage ../development/python-modules/pytun { };
 
   pyturbojpeg = callPackage ../development/python-modules/pyturbojpeg { };


### PR DESCRIPTION
###### Motivation for this change

`make -jN -lN` in stdenv is a very blunt instrument. it works well when max-jobs=1, but as nix-level paralellism increases it becomes increasingly deficient. starting from a low-load situation we start max-jobs * N compilers, loadavg goes through the roof, the `-lN` load limit kicks in and inhibits new compilers starting until loadavg has fallen below N—at which point all make instances spawn a lot of new compilers and loadavg goes through the roof again. this oscillation leaves the system underutilized in low phases and overcommitted in high phases.

testing the current stdenv against a jobserver with 26 tokens on a 12C/24T machine shows that parallel builds of llvm_{8..11} run about 7% faster (35:52min for stdenv, 33:30min with jobserver), a larger build of llvm{5..13} is about about 11% faster (1:27h for stdenv, 1:17h with jobserver). (<del>removing the `-l` from stdenv also improves utilization but is less efficient. preliminary testing here shows that `-l${1.5 * N}` may be a good alternative to `-lN` as used currently, #141266 could be a good vector to go for that instead of this whole mess.</del> [more testing says that `-l2N` would be a minimum to get better utilization, but so far every `-l` setting we've tried has produced *some* underutilization except excessive large numbers like 6N or higher])

nothing in here should be regarded as a final suggestion in any way, it's more of a "hey look, this might just work". as such it's extremely rough around the edges, eg to use the jobserver the experimenter currently has to bring a `/jobserver` fifo filled with tokens into the nix sandbox:
```sh
nix-build -E 'with import ./. {}; pkgs.callPackage ./pkgs/os-specific/linux/nixos-jobserver {}'
touch /tmp/jobserver
sudo ./result -t 24 -g nixbld /tmp/jobserver&
nix build --extra-sandbox-paths "/jobserver=/tmp/jobserver" #...
```

is this something worth pursuing? a 10% speedup for hydra does seem tempting

todos before this is more generally usable:
 - [x] re-add $NIX_BUILD_CORES support (ioctl on the jobserver fd should do it)
 - [x] maybe port from cuse to fuse to not require root for everything (mmap problems may be solved by reporting jobserver file size as 0 at all times, needs testing)
 - [x] usability of tools (error messages, runtime configuration, etc)
 - [x] add support for other build systems (cargo can honor MAKEFLAGS, maybe others too)
 - [x] nixos module
 - [x] make configurable which env var(s) jscall adds jobserver information to
 - [ ] metrics?
 - [ ] \<your suggestion here\>

cc @vcunat @Artturin 