### PR TITLE
lighthouse-steamvr: init at unstable-2021-03-28

### DIFF
--- a/pkgs/tools/misc/lighthouse-steamvr/default.nix
+++ b/pkgs/tools/misc/lighthouse-steamvr/default.nix
@@ -1,0 +1,27 @@
+{ fetchFromGitHub, lib, rustPlatform, pkg-config, dbus }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "Lighthouse";
+  version = "unstable-2021-03-28";
+
+  src = fetchFromGitHub {
+    owner = "ShayBox";
+    repo = "Lighthouse";
+    rev = "a090889077557fe92610ca503979b5cfc0724d61";
+    sha256 = "0vfl4y61cdrah98x6xcnb3cyi8rwhlws8ps6vfdlmr3dv30mbnbb";
+  };
+
+  cargoSha256 = "0aqd9ixszwq6qmj751gxx453gwbhwqi16m72bkbkj9s6nfyqihql";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ dbus ];
+
+  meta = with lib; {
+    description = "VR Lighthouse power state management";
+    homepage = "https://github.com/ShayBox/Lighthouse";
+    license = licenses.mit;
+    maintainers = with maintainers; [ expipiplus1 ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26231,6 +26231,8 @@ with pkgs;
 
   lighthouse = callPackage ../applications/misc/lighthouse { };
 
+  lighthouse-steamvr = callPackage ../tools/misc/lighthouse-steamvr { };
+
   lighttable = callPackage ../applications/editors/lighttable {};
 
   libdsk = callPackage ../misc/emulators/libdsk { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).