### PR TITLE
yices: drop symlink hack, avoid ldconfig on linux

### DIFF
--- a/pkgs/applications/science/logic/yices/linux-no-ldconfig.patch
+++ b/pkgs/applications/science/logic/yices/linux-no-ldconfig.patch
@@ -1,0 +1,13 @@
+--- a/Makefile.build
++++ b/Makefile.build
+@@ -474,8 +474,9 @@ install-darwin: install-default
+ install-solaris: install-default
+ 	$(LDCONFIG) -n $(DESTDIR)$(libdir) && (cd $(DESTDIR)$(libdir) && $(LN_S) -f libyices.so.$(YICES_VERSION) libyices.so)
+ 
++# avoid ldconfig as it's not present on musl
+ install-linux install-unix: install-default
+-	$(LDCONFIG) -n $(DESTDIR)$(libdir) && (cd $(DESTDIR)$(libdir) && $(LN_S) -f libyices.so.$(YICES_VERSION) libyices.so)
++	(cd $(DESTDIR)$(libdir) && $(LN_S) -f libyices.so.$(YICES_VERSION) libyices.so.$(MAJOR).$(MINOR) && $(LN_S) -f libyices.so.$(MAJOR).$(MINOR) libyices.so)
+ 
+ # on FreeBSD: the library file is libyices.so.X.Y and ldconfig does not take -n
+ # TODO: fix this. We must also create a symbolic link: libyices.so.X in libdir


### PR DESCRIPTION
Reported by sternenseemann as a failure on darwin:
https://github.com/NixOS/nixpkgs/pull/141541#discussion_r739634263

Instead of emulating symlink creation in `.nix` file let's create
them in Makefile.build directly in a way that can be upstreamed.


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).