### PR TITLE
crc32c: 1.1.0 -> 1.1.2

### DIFF
--- a/pkgs/development/libraries/crc32c/default.nix
+++ b/pkgs/development/libraries/crc32c/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, lib, fetchFromGitHub, cmake, gflags
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, gflags
 , staticOnly ? stdenv.hostPlatform.isStatic
 }:
 
@@ -17,7 +21,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ gflags ];
   NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isAarch64 "-march=armv8-a+crc";
-  cmakeFlags = lib.optionals (!staticOnly) [ "-DBUILD_SHARED_LIBS=1"  ];
+  cmakeFlags = lib.optionals (!staticOnly) [ "-DBUILD_SHARED_LIBS=1" ];
 
   meta = with lib; {
     homepage = "https://github.com/google/crc32c";

--- a/pkgs/development/libraries/crc32c/default.nix
+++ b/pkgs/development/libraries/crc32c/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "crc32c";
-  version = "1.1.0";
+  version = "1.1.2";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "crc32c";
     rev = version;
-    sha256 = "1sazkis9rzbrklfrvk7jn1mqywnq4yghmzg94mxd153h8b1sb149";
+    sha256 = "0c383p7vkfq9rblww6mqxz8sygycyl27rr0j3bzb8l8ga71710ii";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/libraries/crc32c/default.nix
+++ b/pkgs/development/libraries/crc32c/default.nix
@@ -45,6 +45,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/google/crc32c";
     description = "CRC32C implementation with support for CPU-specific acceleration instructions";
     license = with licenses; [ bsd3 ];
-    maintainers = with maintainers; [ andir ];
+    maintainers = with maintainers; [ andir cpcloud ];
   };
 }

--- a/pkgs/development/libraries/crc32c/default.nix
+++ b/pkgs/development/libraries/crc32c/default.nix
@@ -23,6 +23,13 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isAarch64 "-march=armv8-a+crc";
 
+  cmakeFlags = [
+    "-DCRC32C_INSTALL=1"
+    "-DCRC32C_BUILD_TESTS=1"
+    "-DCRC32C_BUILD_BENCHMARKS=0"
+    "-DCRC32C_USE_GLOG=0"
+  ] ++ lib.optionals (!staticOnly) [ "-DBUILD_SHARED_LIBS=1" ];
+
   doCheck = false;
   doInstallCheck = true;
 
@@ -34,12 +41,6 @@ stdenv.mkDerivation rec {
     runHook postInstallCheck
   '';
 
-  cmakeFlags = [
-    "-DCRC32C_INSTALL=1"
-    "-DCRC32C_BUILD_TESTS=1"
-    "-DCRC32C_BUILD_BENCHMARKS=0"
-    "-DCRC32C_USE_GLOG=0"
-  ] ++ lib.optionals (!staticOnly) [ "-DBUILD_SHARED_LIBS=1" ];
 
   meta = with lib; {
     homepage = "https://github.com/google/crc32c";

--- a/pkgs/development/libraries/crc32c/default.nix
+++ b/pkgs/development/libraries/crc32c/default.nix
@@ -20,8 +20,23 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ gflags ];
+
   NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isAarch64 "-march=armv8-a+crc";
+
+  doCheck = false;
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    ctest
+
+    runHook postInstallCheck
+  '';
+
   cmakeFlags = [
+    "-DCRC32C_INSTALL=1"
+    "-DCRC32C_BUILD_TESTS=1"
     "-DCRC32C_BUILD_BENCHMARKS=0"
     "-DCRC32C_USE_GLOG=0"
   ] ++ lib.optionals (!staticOnly) [ "-DBUILD_SHARED_LIBS=1" ];

--- a/pkgs/development/libraries/crc32c/default.nix
+++ b/pkgs/development/libraries/crc32c/default.nix
@@ -21,7 +21,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ gflags ];
   NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isAarch64 "-march=armv8-a+crc";
-  cmakeFlags = lib.optionals (!staticOnly) [ "-DBUILD_SHARED_LIBS=1" ];
+  cmakeFlags = [
+    "-DCRC32C_BUILD_BENCHMARKS=0"
+    "-DCRC32C_USE_GLOG=0"
+  ] ++ lib.optionals (!staticOnly) [ "-DBUILD_SHARED_LIBS=1" ];
 
   meta = with lib; {
     homepage = "https://github.com/google/crc32c";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Update `crc32c`
- Enable tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
