### PR TITLE
nixos/nextcloud: Adapt cron frequency to changed upstream requirement

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -586,7 +586,7 @@ in {
     { systemd.timers.nextcloud-cron = {
         wantedBy = [ "timers.target" ];
         timerConfig.OnBootSec = "5m";
-        timerConfig.OnUnitActiveSec = "15m";
+        timerConfig.OnUnitActiveSec = "5m";
         timerConfig.Unit = "nextcloud-cron.service";
       };
 


### PR DESCRIPTION
https://docs.nextcloud.com/server/22/admin_manual/configuration_server/background_jobs_configuration.html

Says that the job should be run every 5 minutes.
Nextcloud shows a warning in the settings screen whenever the last run
was more than 10 minutes ago.

\cc @Ma27 