### PR TITLE
kwin: bypass environment variables from ld.so

### DIFF
--- a/pkgs/desktops/plasma-5/kwin/default.nix
+++ b/pkgs/desktops/plasma-5/kwin/default.nix
@@ -1,6 +1,6 @@
 {
   mkDerivation, lib,
-  extra-cmake-modules, kdoctools,
+  extra-cmake-modules, kdoctools, fetchpatch,
 
   epoxy, lcms2, libICE, libSM, libcap, libdrm, libinput, libxkbcommon, mesa,
   pipewire, udev, wayland, xcb-util-cursor, xwayland,
@@ -40,6 +40,15 @@ mkDerivation {
     ./0002-xwayland.patch
     ./0003-plugins-qpa-allow-using-nixos-wrapper.patch
     ./0001-NixOS-Unwrap-executable-name-for-.desktop-search.patch
+    # Pass special environments through arguemnts to `kwin_wayland`, bypassing
+    # ld.so(8) environment stripping due to `kwin_wayland`'s capabilities.
+    # We need this to have `TZDIR` correctly set for `plasmashell`, or
+    # everything related to timezone, like clock widgets, will be broken.
+    # https://invent.kde.org/plasma/kwin/-/merge_requests/1590
+    (fetchpatch {
+      url = "https://invent.kde.org/plasma/kwin/-/commit/9a008b223ad696db3bf5692750f2b74e578e08b8.diff";
+      sha256 = "sha256-f35G+g2MVABLDbAkCed3ZmtDWrzYn1rdD08mEx35j4k=";
+    })
   ];
   CXXFLAGS = [
     ''-DNIXPKGS_XWAYLAND=\"${lib.getBin xwayland}/bin/Xwayland\"''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix #143272
See discussion in https://github.com/NixOS/nixpkgs/issues/143272#issuecomment-955192377

Tested in NixOS VM with `time.timezone = "Asia/Shanghai"` and the clock widget works now.

cc @tobiasBora @drupol @robbins @SuperSandro2000 for testing

EDIT:
I also opened [a MR for upstream](https://invent.kde.org/plasma/kwin/-/merge_requests/1590), but it's not merged and may change later. So currently I put the patch directly in nixpkgs instead of fetching from that MR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
