### PR TITLE
sub-batch: 0.4.0 -> 0.4.1

### DIFF
--- a/pkgs/applications/video/sub-batch/default.nix
+++ b/pkgs/applications/video/sub-batch/default.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "sub-batch";
-  version = "0.4.0";
+  version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "kl";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-5fDnSmnnVB1RGrNrnmp40OGFF+OAhppnhOjVgnYxXr0=";
+    sha256 = "sha256-WUW+lOGbZ82NJxmW+Ogxslf3COOp62aZ/08Yn26l4T0=";
   };
 
-  cargoSha256 = "sha256-+ufa4Cgue8o9CTB3JDcQ38SlUq8PcRDyj+qNSAFpTas=";
+  cargoSha256 = "sha256-m9nBubmuuOcJyegmYGJizY/2b7oamBHKFNIaxOtikcA=";
 
   nativeBuildInputs = [ makeWrapper ];
 


### PR DESCRIPTION

###### Motivation for this change

This should fix all bad dependencies listed in https://github.com/NixOS/nixpkgs/issues/141368, except for `image`, which I'm pretty sure doesn't have any security implications for sub-batch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
