### PR TITLE
kyocera-ecosys-m2x35-40-p2x35-40dnw: init at 8.1606

### DIFF
--- a/pkgs/misc/cups/drivers/kyocera-ecosys-m2x35-40-p2x35-40dnw/default.nix
+++ b/pkgs/misc/cups/drivers/kyocera-ecosys-m2x35-40-p2x35-40dnw/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, lib
+, fetchzip
+  # can either be "EU" or "Global"; it's unclear what the difference is
+, region ? "Global"
+  # can be either "English", "French", "German", "Italian", "Portguese" or "Spanish"
+, language ? "English"
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cups-kyocera-ecosys-m2x35-40-p2x35-40dnw";
+  version = "8.1606";
+
+  src = let
+    urlVersion = builtins.replaceStrings [ "." ] [ "_" ] version;
+  in fetchzip {
+    url = "https://www.kyoceradocumentsolutions.de/content/download-center/de/drivers/all/Linux_${urlVersion}_ECOSYS_M2x35_40_P2x35_40dnw_zip.download.zip";
+    sha256 = "10crxdfj62ini70vv471445zi6q0l9fmg2jsd74sp6fr0qa0kvr7";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/cups/model/Kyocera
+    cp ${region}/${language}/*.PPD $out/share/cups/model/Kyocera/
+  '';
+
+  meta = with lib; {
+    description = "PPD files for Kyocera ECOSYS M2040dn/M2135dn/M2540dn/M2540dw/M2635dn/M2635dw/M2640idw/M2735dw/P2040dn/M2040dw/P2235dn/P2235dw";
+    homepage = "https://www.kyoceradocumentsolutions.com";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ hexa ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31862,6 +31862,8 @@ with pkgs;
 
   cups-kyocera = callPackage ../misc/cups/drivers/kyocera {};
 
+  cups-kyocera-ecosys-m2x35-40-p2x35-40dnw = callPackage ../misc/cups/drivers/kyocera-ecosys-m2x35-40-p2x35-40dnw {};
+
   cups-kyocera-ecosys-m552x-p502x = callPackage ../misc/cups/drivers/kyocera-ecosys-m552x-p502x {};
 
   cups-kyodialog3 = callPackage ../misc/cups/drivers/kyodialog3 {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I love setting up printers on Linux! \s

Very selfcontained, so backport should be a no-brainer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
