### PR TITLE
cpprestsdk: init at 2.10.18

### DIFF
--- a/pkgs/development/libraries/cpprestsdk/default.nix
+++ b/pkgs/development/libraries/cpprestsdk/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchFromGitHub, cmake, boost165, openssl, zlib, gcc9
+}:
+
+
+
+stdenv.mkDerivation {
+  pname = "libcpprestsdk";
+  version = "2.10.18";
+  buildInputs = [
+    boost165 openssl zlib
+  ];
+  nativeBuildInputs = [
+    cmake gcc9 
+  ];
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "cpprestsdk";
+    rev = "2.10.18";
+    sha256 = "07qyip57wyzpmlgyz1fri4ljmla7ar3isddvfkm8hzv6q35bx2rn";
+    fetchSubmodules = true;
+  };
+  meta = {
+    description = "Cloud-based client-server communication in native code using a modern asynchronous C++ API design";
+    homepage = "https://github.com/Microsoft/cpprestsdk";
+    license = lib.licenses.mit;
+    maintainers = [ "retonlage <retonlage@retonlage.xyz>" ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Package the cpprestsdk library

###### Things done

  - [x] Have tested building application depending on cpprestsdk.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
