### PR TITLE
python3Package.panda3d: init at 1.10.10

### DIFF
--- a/pkgs/development/python-modules/panda3d/binary-hashes.nix
+++ b/pkgs/development/python-modules/panda3d/binary-hashes.nix
@@ -1,0 +1,19 @@
+version : builtins.getAttr version {
+  "1.10.10" = {
+    x86_64-linux-37 = {
+      name = "panda3d-1.10.10-cp37-cp37m-manylinux1_x86_64.whl";
+      url = https://files.pythonhosted.org/packages/06/39/2b26af1140e46f95f745378ab92bd15ea8c496ef28556b6f7b6caba34f76/panda3d-1.10.10-cp37-cp37m-manylinux1_x86_64.whl;
+      sha256 = "1g7j5c1868y3nm8062w2968hjhy5pdkm6p3lpd06ji56w8795k5c";
+    };
+    x86_64-linux-38 = {
+      name = "panda3d-1.10.10-cp38-cp38-manylinux1_x86_64.whl";
+      url = https://files.pythonhosted.org/packages/64/5d/6bc0cad9778637833caf66493f682f8f42e3ed011f8b8352f40a59520b69/panda3d-1.10.10-cp38-cp38-manylinux1_x86_64.whl;
+      sha256 = "0krhb3jmyv5l0rf77dwy22327p5r0zxjpqi0aagz17kznh1386zs";
+    };
+    x86_64-linux-39 = {
+      name = "panda3d-1.10.10-cp39-cp39-manylinux1_x86_64.whl";
+      url = https://files.pythonhosted.org/packages/3f/20/87b34580f6bfc414cd8b7b874a18e32da939ed102e48cf6e33c170edcd2c/panda3d-1.10.10-cp39-cp39-manylinux1_x86_64.whl;
+      sha256 = "0w5q1yddb300r9vij3k9mmxr874vjfmz9ca0b2mrk5sgjh14a8mq";
+    };
+  };
+}

--- a/pkgs/development/python-modules/panda3d/default.nix
+++ b/pkgs/development/python-modules/panda3d/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchurl
+, python
+, isPy37
+, isPy38
+, isPy39
+, autoPatchelfHook
+, libXext
+, libGL
+, gdk-pixbuf
+, cairo
+, pango }:
+
+let pyVerNoDot = builtins.replaceStrings [ "." ] [ "" ] python.pythonVersion;
+    version = "1.10.10";
+    srcs = import ./binary-hashes.nix version;
+    unsupported = throw "Unsupported system";
+in buildPythonPackage rec {
+  pname = "panda3d";
+
+  inherit version;
+
+  format = "wheel";
+
+  src = fetchurl srcs."${stdenv.system}-${pyVerNoDot}" or unsupported;
+
+  disabled = !(isPy37 || isPy38 || isPy39);
+
+  # NOTE(breakds): Panda3d comes with a set of binary tools. There is one tool
+  # called `pstats` that I cannot find proper libraries to patchelf it. Since it
+  # does not affect using panda3d as a library, remove it before applying
+  # patchelf.
+  postInstall = ''
+   rm $out/lib/python${python.pythonVersion}/site-packages/panda3d_tools/pstats
+  '';
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    libXext
+    libGL
+    gdk-pixbuf
+    cairo
+    pango
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  pythonImportsCheck = [ "panda3d" "panda3d.core" ];
+
+  meta = with lib; {
+    homepage = "https://www.panda3d.org";
+    description = ''
+      Powerful, mature open-source cross-platform game engine for
+      Python and C++, developed by Disney and CMU
+    '';
+    changelog = "https://github.com/panda3d/panda3d/releases/tag/v${version}";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ breakds ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/development/python-modules/panda3d/default.nix
+++ b/pkgs/development/python-modules/panda3d/default.nix
@@ -60,6 +60,6 @@ in buildPythonPackage rec {
     changelog = "https://github.com/panda3d/panda3d/releases/tag/v${version}";
     license = licenses.bsd3;
     maintainers = with maintainers; [ breakds ];
-    platforms = with platforms; linux;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5374,6 +5374,8 @@ in {
 
   pamqp = callPackage ../development/python-modules/pamqp { };
 
+  panda3d = callPackage ../development/python-modules/panda3d { };
+
   pandas = callPackage ../development/python-modules/pandas { };
 
   pandas-datareader = callPackage ../development/python-modules/pandas-datareader { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Panda3D is a popular library for creating games and simulators developed by Disney and CMU. It is necessary to run the games and simulators built on top of it such as https://github.com/decisionforce/metadrive

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
