### PR TITLE
cpprestsdk: init at 2.10.18

### DIFF
--- a/pkgs/development/libraries/cpprestsdk/default.nix
+++ b/pkgs/development/libraries/cpprestsdk/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
     boost165 openssl zlib
   ];
   nativeBuildInputs = [
-    cmake gcc9 
+    cmake gcc9
   ];
   src = fetchFromGitHub {
     owner = "microsoft";

--- a/pkgs/development/libraries/cpprestsdk/default.nix
+++ b/pkgs/development/libraries/cpprestsdk/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchFromGitHub, cmake, boost165, openssl, zlib, gcc9
+}:
+
+
+
+stdenv.mkDerivation {
+  pname = "libcpprestsdk";
+  version = "2.10.18";
+  buildInputs = [
+    boost165 openssl zlib
+  ];
+  nativeBuildInputs = [
+    cmake gcc9 
+  ];
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "cpprestsdk";
+    rev = "2.10.18";
+    sha256 = "07qyip57wyzpmlgyz1fri4ljmla7ar3isddvfkm8hzv6q35bx2rn";
+    fetchSubmodules = true;
+  };
+  meta = {
+    description = "Cloud-based client-server communication in native code using a modern asynchronous C++ API design";
+    homepage = "https://github.com/Microsoft/cpprestsdk";
+    license = lib.licenses.mit;
+    maintainers = [ "retonlage <retonlage@retonlage.xyz>" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14209,6 +14209,8 @@ with pkgs;
 
   coccinelle = callPackage ../development/tools/misc/coccinelle { };
 
+  cpprestsdk = callPackage ../development/libraries/cpprestsdk { };
+
   cpptest = callPackage ../development/libraries/cpptest { };
 
   cppi = callPackage ../development/tools/misc/cppi { };


### PR DESCRIPTION
###### Motivation for this change

Package the cpprestsdk library 

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

 - [X] Tested building and running application depending on cpprest

- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
