### PR TITLE
profiles/all-hardware.nix: add reset-raspberry for USB on RPi 4

### DIFF
--- a/nixos/modules/profiles/all-hardware.nix
+++ b/nixos/modules/profiles/all-hardware.nix
@@ -106,6 +106,9 @@ in
       # USB drivers
       "xhci-pci-renesas"
 
+      # Reset controllers
+      "reset-raspberrypi" # Triggers USB chip firmware load.
+
       # Misc "weak" dependencies
       "analogix-dp"
       "analogix-anx6345" # For DP or eDP (e.g. integrated display)


### PR DESCRIPTION
This is needed for USB to work on RPi 4. Kernel's defconfig demoted the module from built-in to module in 5.14. See [1].

Fixes #143884 

[1] https://lore.kernel.org/linux-arm-kernel/ab43364b-55cc-08e6-a647-6e50a1743f03@gmail.com/