### PR TITLE
kodi.packages.libretro-snes9x: init at 1.60.0.29

### DIFF
--- a/pkgs/applications/video/kodi-packages/libretro-snes9x/default.nix
+++ b/pkgs/applications/video/kodi-packages/libretro-snes9x/default.nix
@@ -1,0 +1,31 @@
+{ lib, rel, buildKodiBinaryAddon, fetchFromGitHub, libretro, snes9x }:
+
+buildKodiBinaryAddon rec {
+  pname = "kodi-libretro-snes9x";
+  namespace = "game.libretro.snes9x";
+  version = "1.60.0.29";
+
+  src = fetchFromGitHub {
+    owner = "kodi-game";
+    repo = "game.libretro.snes9x";
+    rev = "${version}-${rel}";
+    sha256 = "1wyfkg4fncc604alnbaqk92fi1h80n7bwiqfkb8479x5517byab1";
+  };
+
+  extraCMakeFlags = [
+    "-DSNES9X_LIB=${snes9x}/lib/retroarch/cores/snes9x_libretro.so"
+  ];
+
+  extraBuildInputs = [ snes9x ];
+  propagatedBuildInputs = [
+    libretro
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/kodi-game/game.libretro.snes9x";
+    description = "Snes9X GameClient for Kodi";
+    platforms = platforms.all;
+    license = licenses.gpl2Only;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/applications/video/kodi-packages/libretro/default.nix
+++ b/pkgs/applications/video/kodi-packages/libretro/default.nix
@@ -1,0 +1,24 @@
+{ lib, rel, buildKodiBinaryAddon, fetchFromGitHub, tinyxml }:
+
+buildKodiBinaryAddon rec {
+  pname = "libretro";
+  namespace = "game.libretro";
+  version = "19.0.0";
+
+  src = fetchFromGitHub {
+    owner = "kodi-game";
+    repo = "game.libretro";
+    rev = "${version}-${rel}";
+    sha256 = "1831wbbc4a545lr4mg1fm4sbx75k5lkrfqaa5fh308aar0nm974d";
+  };
+
+  extraBuildInputs = [ tinyxml ];
+
+  meta = with lib; {
+    homepage = "https://github.com/kodi-game/game.libretro";
+    description = "Libretro wrapper for Kodi's Game API";
+    platforms = platforms.all;
+    license = licenses.gpl2Only;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/applications/video/kodi/build-kodi-binary-addon.nix
+++ b/pkgs/applications/video/kodi/build-kodi-binary-addon.nix
@@ -5,6 +5,7 @@
 , extraNativeBuildInputs ? []
 , extraBuildInputs ? []
 , extraRuntimeDependencies ? []
+, extraCMakeFlags ? []
 , extraInstallPhase ? "", ... } @ attrs:
 toKodiAddon (stdenv.mkDerivation ({
   name = "kodi-" + name;
@@ -19,7 +20,7 @@ toKodiAddon (stdenv.mkDerivation ({
   # disables check ensuring install prefix is that of kodi
   cmakeFlags = [
     "-DOVERRIDE_PATHS=1"
-  ];
+  ] ++ extraCMakeFlags;
 
   # kodi checks for addon .so libs existance in the addon folder (share/...)
   # and the non-wrapped kodi lib/... folder before even trying to dlopen
@@ -28,7 +29,10 @@ toKodiAddon (stdenv.mkDerivation ({
     runHook preInstall
 
     make install
-    ln -s $out/lib/addons/${n}/${n}.so.${version} $out${addonDir}/${n}/${n}.so.${version}
+
+    [[ -f $out/lib/addons/${n}/${n}.so ]] && ln -s $out/lib/addons/${n}/${n}.so $out${addonDir}/${n}/${n}.so || true
+    [[ -f $out/lib/addons/${n}/${n}.so.${version} ]] && ln -s $out/lib/addons/${n}/${n}.so.${version} $out${addonDir}/${n}/${n}.so.${version} || true
+
     ${extraInstallPhase}
 
     runHook postInstall

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -1,6 +1,10 @@
-{ lib, newScope, kodi }:
+{ lib, newScope, kodi, libretro }:
 
 with lib;
+
+let
+  inherit (libretro) snes9x;
+in
 
 let self = rec {
 
@@ -69,6 +73,8 @@ let self = rec {
   };
 
   libretro = callPackage ../applications/video/kodi-packages/libretro { };
+
+  libretro-snes9x = callPackage ../applications/video/kodi-packages/libretro-snes9x { inherit snes9x; };
 
   jellyfin = callPackage ../applications/video/kodi-packages/jellyfin { };
 

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -68,6 +68,8 @@ let self = rec {
     snes = callPackage ../applications/video/kodi-packages/controllers { controller = "snes"; };
   };
 
+  libretro = callPackage ../applications/video/kodi-packages/libretro { };
+
   jellyfin = callPackage ../applications/video/kodi-packages/jellyfin { };
 
   joystick = callPackage ../applications/video/kodi-packages/joystick { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
one step closer to my ultimate htpc setup :sunglasses:

~~note: i'm still doing a bit of testing on this~~
adequately tested now

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
