### PR TITLE
python2Packages.brotlicffi: fix python2 compatibility

### DIFF
--- a/pkgs/development/python-modules/brotlicffi/default.nix
+++ b/pkgs/development/python-modules/brotlicffi/default.nix
@@ -4,12 +4,12 @@
 , pythonOlder
 , cffi
 , brotli
+, enum34
 }:
 
 buildPythonPackage rec {
   pname = "brotlicffi";
   version = "1.0.9.2";
-  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "python-hyper";
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     cffi
-  ];
+  ] ++ lib.optional (pythonOlder "3.4") enum34;
 
   preBuild = ''
     export USE_SHARED_BROTLI=1


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python 2 support is missing for brotlicffi.

###### Things done
Added optional dependency as suggested in https://github.com/python-hyper/brotlicffi/blob/f9255f2d76c29db343fb28df4edda4f3b6ee8597/setup.py#L100

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
