### PR TITLE
pythonPackages.pulsectl-asyncio: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9511,6 +9511,13 @@
     githubId = 801525;
     name = "rembo10";
   };
+  remexre = {
+    email = "nathan+nixpkgs@remexre.xyz";
+    github = "remexre";
+    githubId = 4196789;
+    matrix = "@nathan:remexre.xyz";
+    name = "Nathan Ringo";
+  };
   renatoGarcia = {
     email = "fgarcia.renato@gmail.com";
     github = "renatoGarcia";

--- a/pkgs/development/python-modules/pulsectl-asyncio/default.nix
+++ b/pkgs/development/python-modules/pulsectl-asyncio/default.nix
@@ -1,0 +1,23 @@
+{ buildPythonPackage, fetchPypi, lib, pulsectl, pythonOlder }:
+
+buildPythonPackage rec {
+  pname = "pulsectl-asyncio";
+  version = "0.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-qBMIH/HOnt9SXrnrGtZTG4fOb0fftR7mBaU7K4mcYvo=";
+  };
+
+  disabled = pythonOlder "3.6";
+  propagatedBuildInputs = [ pulsectl ];
+  pythonImportsCheck = [ "pulsectl_asyncio" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/mhthies/pulsectl-asyncio";
+    description =
+      "A Python 3 asyncio interface on top of the pulsectl library for monitoring and controlling the PulseAudio sound server";
+    license = licenses.mit;
+    maintainers = with maintainers; [ remexre ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5998,6 +5998,8 @@ in {
 
   pulsectl = callPackage ../development/python-modules/pulsectl { };
 
+  pulsectl-asyncio = callPackage ../development/python-modules/pulsectl-asyncio { };
+
   pur = callPackage ../development/python-modules/pur { };
 
   pure-cdb = callPackage ../development/python-modules/pure-cdb { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

~~Note that this only builds for Python 3; is there some way I ought to indicate this in the package?~~

~~Doesn't have a maintainer, so doesn't fit CONTRIBUTING.md; should I add myself as one? (I have some scripts that depend on this, so I intend to maintain it for the future, and can commit to doing so for at least 24 months.)~~

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
