### PR TITLE
gtkd: 3.9.0 -> 3.10.0 and add possibility to use different D compilers

### DIFF
--- a/pkgs/development/libraries/gtkd/default.nix
+++ b/pkgs/development/libraries/gtkd/default.nix
@@ -1,17 +1,17 @@
-{ lib, stdenv, fetchzip, fetchpatch, atk, cairo, dcompiler, gdk-pixbuf, gnome, gst_all_1, librsvg
+{ lib, stdenv, fetchzip, atk, cairo, dcompiler, gdk-pixbuf, gnome, gst_all_1, librsvg
 , glib, gtk3, gtksourceview4, libgda, libpeas, pango, pkg-config, which, vte }:
 
 let
   inherit (gst_all_1) gstreamer gst-plugins-base gst-plugins-bad;
 in stdenv.mkDerivation rec {
   pname = "gtkd";
-  version = "3.9.0";
+  version = "3.10.0";
 
   outputs = [ "out" "dev" ];
 
   src = fetchzip {
     url = "https://gtkd.org/Downloads/sources/GtkD-${version}.zip";
-    sha256 = "12kc4s5gp6gn456d8pzhww1ggi9qbxldmcpp6855297g2x8xxy5p";
+    sha256 = "DEKVDexGyg/T3SdnnvRjaHq1LbDo8ekNslxKROpMCCE=";
     stripRoot = false;
   };
 
@@ -21,20 +21,7 @@ in stdenv.mkDerivation rec {
     libgda libpeas librsvg pango vte
   ];
 
-  patches = [
-    # Fix makefile not installing .pc's
-    (fetchpatch {
-      url = "https://github.com/gtkd-developers/GtkD/commit/a9db09117ab27127ca4c3b8d2f308fae483a9199.patch";
-      sha256 = "0ngyqifw1kandc1vk01kms3z65pcisfd75q7z09rml96glhfzjd6";
-    })
-    # Fix breakage with dmd ldc 1.26 and newer
-    (fetchpatch {
-      url = "https://github.com/gtkd-developers/GtkD/commit/323ff96c648882eaca2faee170bd9e90c6e1e9c3.patch";
-      sha256 = "1rhyi0isl6fl5i6fgsinvgq6v72xq7c6sajrxcsnmrzpvw91il3d";
-    })
-  ];
-
-  prePatch = ''
+  postPatch = ''
     substituteAll ${./paths.d} generated/gtkd/gtkd/paths.d
 
     substituteInPlace generated/gstreamer/gst/app/c/functions.d \

--- a/pkgs/development/libraries/gtkd/default.nix
+++ b/pkgs/development/libraries/gtkd/default.nix
@@ -7,8 +7,6 @@ in stdenv.mkDerivation rec {
   pname = "gtkd";
   version = "3.10.0";
 
-  outputs = [ "out" "dev" ];
-
   src = fetchzip {
     url = "https://gtkd.org/Downloads/sources/GtkD-${version}.zip";
     sha256 = "DEKVDexGyg/T3SdnnvRjaHq1LbDo8ekNslxKROpMCCE=";

--- a/pkgs/development/libraries/gtkd/default.nix
+++ b/pkgs/development/libraries/gtkd/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchzip, fetchpatch, atk, cairo, ldc, gdk-pixbuf, gnome, gst_all_1, librsvg
+{ lib, stdenv, fetchzip, fetchpatch, atk, cairo, dcompiler, gdk-pixbuf, gnome, gst_all_1, librsvg
 , glib, gtk3, gtksourceview4, libgda, libpeas, pango, pkg-config, which, vte }:
 
 let
@@ -15,7 +15,7 @@ in stdenv.mkDerivation rec {
     stripRoot = false;
   };
 
-  nativeBuildInputs = [ ldc pkg-config which ];
+  nativeBuildInputs = [ dcompiler pkg-config which ];
   propagatedBuildInputs = [
     atk cairo gdk-pixbuf glib gstreamer gst-plugins-base gtk3 gtksourceview4
     libgda libpeas librsvg pango vte
@@ -133,6 +133,10 @@ in stdenv.mkDerivation rec {
         --replace "$out/include" "$dev/include"
     done
   '';
+
+  passthru = {
+    inherit dcompiler;
+  };
 
   meta = with lib; {
     description = "D binding and OO wrapper for GTK";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6703,7 +6703,7 @@ with pkgs;
 
   gtdialog = callPackage ../development/libraries/gtdialog {};
 
-  gtkd = callPackage ../development/libraries/gtkd { };
+  gtkd = callPackage ../development/libraries/gtkd { dcompiler = ldc; };
 
   gtkgnutella = callPackage ../tools/networking/p2p/gtk-gnutella { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

*   Add the possibility to switch to other compilers:
    Specify the D compiler to use with argument `dcompiler` as some other PRs do. In addition, the attribute is pass-throughed to make it accessible for down-stream packages. (Continued work of #115265)

    *   ~~Possible future work: Fallback to `gdc` where `ldc` are not supported:
    `ldc` seems preferred by packagers here. However, the package currently supports only `x86_64-linux`, `i686-linux` and `x86_64-darwin`.
    Aarch64 build (with gdc) seems to encounter a bug in GDC that generate duplicate symbols and causes `multiple definition` errors. See
    https://github.com/gtkd-developers/GtkD/issues/282
    https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92216
    After the fixed version get merged, we could make `gdc` as the fallback compiler option, so that `gtkd` would build on `aarch64-linux`.~~
    gtkd now compiles on `aarch64-linux` with `ldc`

*   Update 3.9.0 -> 3.10.0
    *   Remove the previously-specified patches
    *   Remove the `dev` output to resolve circular dependency between `out` and `dev` after update (Cc: @hedning )

*   Darwin build seems broken (probably due to the update).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
