### PR TITLE
SHADERed: 1.4.1 -> 1.5.6

### DIFF
--- a/pkgs/development/tools/shadered/default.nix
+++ b/pkgs/development/tools/shadered/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     repo = pname;
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "sha256:0drf8wwx0gcmi22jq2yyjy7ppxynfq172wqakchscm313j248fjr";
+    sha256 = "0drf8wwx0gcmi22jq2yyjy7ppxynfq172wqakchscm313j248fjr";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/shadered/default.nix
+++ b/pkgs/development/tools/shadered/default.nix
@@ -11,14 +11,14 @@
 
 stdenv.mkDerivation rec {
   pname = "SHADERed";
-  version = "1.4.1";
+  version = "1.5.6";
 
   src = fetchFromGitHub {
     owner = "dfranx";
     repo = pname;
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "ivOd4NJgx5KWSDnXSBQLMrdvBuOm8NRzcb2S4lvOrms=";
+    sha256 = "sha256:0drf8wwx0gcmi22jq2yyjy7ppxynfq172wqakchscm313j248fjr";
   };
 
   nativeBuildInputs = [
@@ -32,6 +32,10 @@ stdenv.mkDerivation rec {
     glm
     python3
     sfml
+  ];
+
+  patches = [
+    ./install_path_fix.patch
   ];
 
   NIX_CFLAGS_COMPILE = "-Wno-error=format-security";

--- a/pkgs/development/tools/shadered/install_path_fix.patch
+++ b/pkgs/development/tools/shadered/install_path_fix.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 55eb05c..18f7fc3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -234,7 +234,7 @@ endif()
+ 
+ set(BINARY_INST_DESTINATION "bin")
+ set(RESOURCE_INST_DESTINATION "share/shadered")
+-install(PROGRAMS bin/SHADERed DESTINATION "${BINARY_INST_DESTINATION}" RENAME shadered)
++install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/bin/SHADERed DESTINATION "${BINARY_INST_DESTINATION}" RENAME shadered)
+ install(DIRECTORY bin/data bin/templates bin/themes bin/plugins DESTINATION "${RESOURCE_INST_DESTINATION}")
+ 
+ if (UNIX AND NOT APPLE)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
