### PR TITLE
weylus: 0.11.2 -> 0.11.3

### DIFF
--- a/pkgs/applications/graphics/weylus/default.nix
+++ b/pkgs/applications/graphics/weylus/default.nix
@@ -14,11 +14,11 @@
 
 stdenv.mkDerivation rec {
   pname = "weylus";
-  version = "0.11.2";
+  version = "0.11.3";
 
   src = fetchzip {
     url = "https://github.com/H-M-H/Weylus/releases/download/v${version}/linux.zip";
-    sha256 = "sha256-coA8qUpUgRjVBF/0LZgimx61fTTpdck/AO6e+r2uNu0=";
+    sha256 = "sha256-1nEdn3KKCMWIzYv4ryqTxtQvR9eln9IX1Z4Y6/vuo7o=";
     stripRoot = false;
   };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
