### PR TITLE
virtualbox: 6.1.26 -> 6.1.28

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -23,14 +23,14 @@ let
   buildType = "release";
   # Use maintainers/scripts/update.nix to update the version and all related hashes or
   # change the hashes in extpack.nix and guest-additions/default.nix as well manually.
-  version = "6.1.26";
+  version = "6.1.28";
 in stdenv.mkDerivation {
   pname = "virtualbox";
   inherit version;
 
   src = fetchurl {
     url = "https://download.virtualbox.org/virtualbox/${version}/VirtualBox-${version}.tar.bz2";
-    sha256 = "0212602eea878d6c9fd7f4a3e0182da3e4505f31d25f5539fb8f7b1fbe366195";
+    sha256 = "8d34993d8e9c0cf35e7bd44dd26c8c757f17a3b7d5a64052f945d00fd798ebfe";
   };
 
   outputs = [ "out" "modsrc" ];
@@ -94,9 +94,6 @@ in stdenv.mkDerivation {
     })
   ++ [
     ./qtx11extras.patch
-    # Temporary workaround for broken build
-    # https://www.virtualbox.org/pipermail/vbox-dev/2021-July/015670.html
-    ./fix-configure-pkgconfig-qt.patch
     # https://github.com/NixOS/nixpkgs/issues/123851
     ./fix-audio-driver-loading.patch
   ];
@@ -200,11 +197,6 @@ in stdenv.mkDerivation {
         mkdir -p $out/share/icons/hicolor/$size/apps
         ln -s $libexec/icons/$size/*.png $out/share/icons/hicolor/$size/apps
       done
-    ''}
-
-    # https://github.com/NixOS/nixpkgs/issues/137104
-    ${optionalString (enableHardening || headless) ''
-      rm $libexec/components/VBoxREM.so
     ''}
 
     cp -rv out/linux.*/${buildType}/bin/src "$modsrc"

--- a/pkgs/applications/virtualization/virtualbox/extpack.nix
+++ b/pkgs/applications/virtualization/virtualbox/extpack.nix
@@ -12,7 +12,7 @@ fetchurl rec {
     # Manually sha256sum the extensionPack file, must be hex!
     # Thus do not use `nix-prefetch-url` but instead plain old `sha256sum`.
     # Checksums can also be found at https://www.virtualbox.org/download/hashes/${version}/SHA256SUMS
-    let value = "aaa1a1f8615d5bd2e08b158ce6f415262fbb595e169e2d415c5b1844ac258eee";
+    let value = "85d7858a95d802c41cb86e1b573dc501d782e5d040937e0d8505a37c29509774";
     in assert (builtins.stringLength value) == 64; value;
 
   meta = {

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -27,7 +27,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://download.virtualbox.org/virtualbox/${version}/VBoxGuestAdditions_${version}.iso";
-    sha256 = "22d02ec417cd7723d7269dbdaa71c48815f580c0ca7a0606c42bd623f84873d7";
+    sha256 = "eab85206cfb9d7087982deb2635d19a4244a3c6783622a4817fb1a31e48e98e5";
   };
 
   KERN_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";

--- a/pkgs/applications/virtualization/virtualbox/hardened.patch
+++ b/pkgs/applications/virtualization/virtualbox/hardened.patch
@@ -1,8 +1,8 @@
 diff --git a/include/iprt/mangling.h b/include/iprt/mangling.h
-index c1daa8f..8618371 100644
+index 25b918d1..1420ff1d 100644
 --- a/include/iprt/mangling.h
 +++ b/include/iprt/mangling.h
-@@ -1440,6 +1440,7 @@
+@@ -1695,6 +1695,7 @@
  # define RTPathStripSuffix                              RT_MANGLER(RTPathStripSuffix)
  # define RTPathStripFilename                            RT_MANGLER(RTPathStripFilename)
  # define RTPathStripTrailingSlash                       RT_MANGLER(RTPathStripTrailingSlash)
@@ -10,7 +10,7 @@ index c1daa8f..8618371 100644
  # define RTPathTemp                                     RT_MANGLER(RTPathTemp)
  # define RTPathTraverseList                             RT_MANGLER(RTPathTraverseList)
  # define RTPathUnlink                                   RT_MANGLER(RTPathUnlink)
-@@ -1478,6 +1479,7 @@
+@@ -1734,6 +1735,7 @@
  # define RTProcGetAffinityMask                          RT_MANGLER(RTProcGetAffinityMask)
  # define RTProcGetExecutablePath                        RT_MANGLER(RTProcGetExecutablePath)
  # define RTProcGetPriority                              RT_MANGLER(RTProcGetPriority)
@@ -19,13 +19,14 @@ index c1daa8f..8618371 100644
  # define RTProcQueryParent                              RT_MANGLER(RTProcQueryParent)
  # define RTProcQueryUsername                            RT_MANGLER(RTProcQueryUsername)
 diff --git a/include/iprt/path.h b/include/iprt/path.h
-index 8bd42bc..2c23d3e 100644
+index 99060e35..ccfbeb76 100644
 --- a/include/iprt/path.h
 +++ b/include/iprt/path.h
-@@ -1064,6 +1064,15 @@ RTDECL(int) RTPathCalcRelative(char *pszPathDst, size_t cbPathDst,
+@@ -1221,6 +1221,15 @@ RTDECL(int) RTPathCalcRelative(char *pszPathDst, size_t cbPathDst, const char *p
+  */
  RTDECL(int) RTPathExecDir(char *pszPath, size_t cchPath);
-
- /**
+ 
++/**
 + * Gets the path to the NixOS setuid wrappers directory.
 + *
 + * @returns iprt status code.
@@ -34,18 +35,18 @@ index 8bd42bc..2c23d3e 100644
 + */
 +RTDECL(int) RTPathSuidDir(char *pszPath, size_t cchPath);
 +
-+/**
+ /**
   * Gets the user home directory.
   *
-  * @returns iprt status code.
 diff --git a/include/iprt/process.h b/include/iprt/process.h
-index 043653e..1070280 100644
+index f4f67dd4..ab882a19 100644
 --- a/include/iprt/process.h
 +++ b/include/iprt/process.h
-@@ -327,6 +327,16 @@ RTR3DECL(const char *) RTProcShortName(void);
+@@ -352,6 +352,16 @@ RTR3DECL(const char *) RTProcExecutablePath(void);
+  */
  RTR3DECL(char *) RTProcGetExecutablePath(char *pszExecPath, size_t cbExecPath);
-
- /**
+ 
++/**
 + * Gets the path to the NixOS setuid wrappers directory.
 + *
 + * @returns pszExecPath on success. NULL on buffer overflow or other errors.
@@ -55,15 +56,14 @@ index 043653e..1070280 100644
 + */
 +RTR3DECL(char *) RTProcGetSuidPath(char *pszExecPath, size_t cbExecPath);
 +
-+/**
+ /**
   * Daemonize the current process, making it a background process.
   *
-  * The way this work is that it will spawn a detached / backgrounded /
 diff --git a/src/VBox/HostDrivers/Support/SUPR3HardenedVerify.cpp b/src/VBox/HostDrivers/Support/SUPR3HardenedVerify.cpp
-index ce0f288..6193108 100644
+index 75ff8572..18a077b7 100644
 --- a/src/VBox/HostDrivers/Support/SUPR3HardenedVerify.cpp
 +++ b/src/VBox/HostDrivers/Support/SUPR3HardenedVerify.cpp
-@@ -1502,9 +1502,9 @@ static int supR3HardenedVerifyFsObject(PCSUPR3HARDENEDFSOBJSTATE pFsObjState, bo
+@@ -1531,9 +1531,9 @@ static int supR3HardenedVerifyFsObject(PCSUPR3HARDENEDFSOBJSTATE pFsObjState, bo
          bool fBad = !fRelaxed || pFsObjState->Stat.st_gid != 2 /*bin*/ || suplibHardenedStrCmp(pszPath, "/usr/lib/iconv");
  # else
          NOREF(fRelaxed);
@@ -75,20 +75,46 @@ index ce0f288..6193108 100644
              return supR3HardenedSetError3(VERR_SUPLIB_WRITE_NON_SYS_GROUP, pErrInfo,
                                            "An unknown (and thus untrusted) group has write access to '", pszPath,
                                            "' and we therefore cannot trust the directory content or that of any subdirectory");
+diff --git a/src/VBox/Main/src-all/MachineLaunchVMCommonWorker.cpp b/src/VBox/Main/src-all/MachineLaunchVMCommonWorker.cpp
+index 2991d3a7..d042a08b 100644
+--- a/src/VBox/Main/src-all/MachineLaunchVMCommonWorker.cpp
++++ b/src/VBox/Main/src-all/MachineLaunchVMCommonWorker.cpp
+@@ -90,7 +90,7 @@ int MachineLaunchVMCommonWorker(const Utf8Str &aNameOrId,
+ 
+     /* Get the path to the executable directory w/ trailing slash: */
+     char szPath[RTPATH_MAX];
+-    int vrc = RTPathAppPrivateArch(szPath, sizeof(szPath));
++    int vrc = RTStrCopy(szPath, sizeof(szPath) - 1, "/run/wrappers/bin");
+     AssertRCReturn(vrc, vrc);
+     size_t cbBufLeft = RTPathEnsureTrailingSeparator(szPath, sizeof(szPath));
+     AssertReturn(cbBufLeft > 0, VERR_FILENAME_TOO_LONG);
+diff --git a/src/VBox/Main/src-server/NetworkServiceRunner.cpp b/src/VBox/Main/src-server/NetworkServiceRunner.cpp
+index 2e57690a..3272c840 100644
+--- a/src/VBox/Main/src-server/NetworkServiceRunner.cpp
++++ b/src/VBox/Main/src-server/NetworkServiceRunner.cpp
+@@ -188,7 +188,7 @@ int NetworkServiceRunner::start(bool aKillProcessOnStop)
+      * ASSUME it is relative to the directory that holds VBoxSVC.
+      */
+     char szExePath[RTPATH_MAX];
+-    AssertReturn(RTProcGetExecutablePath(szExePath, RTPATH_MAX), VERR_FILENAME_TOO_LONG);
++    AssertReturn(RTProcGetSuidPath(szExePath, RTPATH_MAX), VERR_FILENAME_TOO_LONG);
+     RTPathStripFilename(szExePath);
+     int vrc = RTPathAppend(szExePath, sizeof(szExePath), m->pszProcName);
+     AssertLogRelRCReturn(vrc, vrc);
 diff --git a/src/VBox/Main/src-server/generic/NetIf-generic.cpp b/src/VBox/Main/src-server/generic/NetIf-generic.cpp
-index 98dc91a..43a819f 100644
+index af155966..3b8e793d 100644
 --- a/src/VBox/Main/src-server/generic/NetIf-generic.cpp
 +++ b/src/VBox/Main/src-server/generic/NetIf-generic.cpp
-@@ -47,7 +47,7 @@ static int NetIfAdpCtl(const char * pcszIfName, const char *pszAddr, const char
+@@ -48,7 +48,7 @@ static int NetIfAdpCtl(const char * pcszIfName, const char *pszAddr, const char
      const char *args[] = { NULL, pcszIfName, pszAddr, pszOption, pszMask, NULL };
-
+ 
      char szAdpCtl[RTPATH_MAX];
 -    int rc = RTPathExecDir(szAdpCtl, sizeof(szAdpCtl) - sizeof("/" VBOXNETADPCTL_NAME));
 +    int rc = RTPathSuidDir(szAdpCtl, sizeof(szAdpCtl) - sizeof("/" VBOXNETADPCTL_NAME));
      if (RT_FAILURE(rc))
      {
          LogRel(("NetIfAdpCtl: failed to get program path, rc=%Rrc.\n", rc));
-@@ -89,7 +89,7 @@ static int NetIfAdpCtl(HostNetworkInterface * pIf, const char *pszAddr, const ch
+@@ -95,7 +95,7 @@ static int NetIfAdpCtl(HostNetworkInterface * pIf, const char *pszAddr, const ch
  int NetIfAdpCtlOut(const char * pcszName, const char * pcszCmd, char *pszBuffer, size_t cBufSize)
  {
      char szAdpCtl[RTPATH_MAX];
@@ -97,23 +123,23 @@ index 98dc91a..43a819f 100644
      if (RT_FAILURE(rc))
      {
          LogRel(("NetIfAdpCtlOut: Failed to get program path, rc=%Rrc\n", rc));
-@@ -201,7 +201,7 @@ int NetIfCreateHostOnlyNetworkInterface(VirtualBox *pVirtualBox,
+@@ -210,7 +210,7 @@ int NetIfCreateHostOnlyNetworkInterface(VirtualBox *pVirtualBox,
              progress.queryInterfaceTo(aProgress);
-
+ 
              char szAdpCtl[RTPATH_MAX];
--            int rc = RTPathExecDir(szAdpCtl, sizeof(szAdpCtl) - sizeof("/" VBOXNETADPCTL_NAME " add"));
-+            int rc = RTPathSuidDir(szAdpCtl, sizeof(szAdpCtl) - sizeof("/" VBOXNETADPCTL_NAME " add"));
-             if (RT_FAILURE(rc))
+-            vrc = RTPathExecDir(szAdpCtl, sizeof(szAdpCtl) - sizeof("/" VBOXNETADPCTL_NAME " add"));
++            vrc = RTPathSuidDir(szAdpCtl, sizeof(szAdpCtl) - sizeof("/" VBOXNETADPCTL_NAME " add"));
+             if (RT_FAILURE(vrc))
              {
                  progress->i_notifyComplete(E_FAIL,
 diff --git a/src/VBox/Runtime/r3/path.cpp b/src/VBox/Runtime/r3/path.cpp
-index 944848e..744a261 100644
+index 4b1a0ada..7f6dd707 100644
 --- a/src/VBox/Runtime/r3/path.cpp
 +++ b/src/VBox/Runtime/r3/path.cpp
 @@ -81,6 +81,12 @@ RTDECL(int) RTPathExecDir(char *pszPath, size_t cchPath)
  }
-
-
+ 
+ 
 +RTDECL(int) RTPathSuidDir(char *pszPath, size_t cchPath)
 +{
 +    return RTStrCopy(pszPath, cchPath, "/run/wrappers/bin");
@@ -124,13 +150,13 @@ index 944848e..744a261 100644
  {
  #if !defined(RT_OS_WINDOWS) && defined(RTPATH_APP_PRIVATE)
 diff --git a/src/VBox/Runtime/r3/process.cpp b/src/VBox/Runtime/r3/process.cpp
-index 2aab645..9795f21 100644
+index 5f7c7a87..59461cfa 100644
 --- a/src/VBox/Runtime/r3/process.cpp
 +++ b/src/VBox/Runtime/r3/process.cpp
-@@ -111,6 +111,26 @@ RTR3DECL(char *) RTProcGetExecutablePath(char *pszExecPath, size_t cbExecPath)
-     return NULL;
+@@ -117,6 +117,25 @@ RTR3DECL(const char *) RTProcExecutablePath(void)
+     return g_szrtProcExePath;
  }
-
+ 
 +/*
 + * Note the / at the end! This is important, because the functions using this
 + * will cut off everything after the rightmost / as this function is analogous
@@ -150,33 +176,6 @@ index 2aab645..9795f21 100644
 +    AssertMsgFailed(("Buffer too small (%zu <= %zu)\n", cbExecPath, sizeof(SUIDDIR)));
 +    return NULL;
 +}
-+
-
+ 
  RTR3DECL(const char *) RTProcShortName(void)
  {
-diff --git a/src/VBox/Main/src-server/NetworkServiceRunner.cpp b/src/VBox/Main/src-server/NetworkServiceRunner.cpp
-index 2e57690..3272c84 100644
---- a/src/VBox/Main/src-server/NetworkServiceRunner.cpp
-+++ b/src/VBox/Main/src-server/NetworkServiceRunner.cpp
-@@ -188,7 +188,7 @@ int NetworkServiceRunner::start(bool aKillProcessOnStop)
-      * ASSUME it is relative to the directory that holds VBoxSVC.
-      */
-     char szExePath[RTPATH_MAX];
--    AssertReturn(RTProcGetExecutablePath(szExePath, RTPATH_MAX), VERR_FILENAME_TOO_LONG);
-+    AssertReturn(RTProcGetSuidPath(szExePath, RTPATH_MAX), VERR_FILENAME_TOO_LONG);
-     RTPathStripFilename(szExePath);
-     int vrc = RTPathAppend(szExePath, sizeof(szExePath), m->pszProcName);
-     AssertLogRelRCReturn(vrc, vrc);
-diff --git a/src/VBox/Main/src-all/MachineLaunchVMCommonWorker.cpp b/src/VBox/Main/src-all/MachineLaunchVMCommonWorker.cpp
-index 2991d3a7..d042a08b 100644
---- a/src/VBox/Main/src-all/MachineLaunchVMCommonWorker.cpp
-+++ b/src/VBox/Main/src-all/MachineLaunchVMCommonWorker.cpp
-@@ -90,7 +90,7 @@ int MachineLaunchVMCommonWorker(const Utf8Str &aNameOrId,
- 
-     /* Get the path to the executable directory w/ trailing slash: */
-     char szPath[RTPATH_MAX];
--    int vrc = RTPathAppPrivateArch(szPath, sizeof(szPath));
-+    int vrc = RTStrCopy(szPath, sizeof(szPath) - 1, "/run/wrappers/bin");
-     AssertRCReturn(vrc, vrc);
-     size_t cbBufLeft = RTPathEnsureTrailingSeparator(szPath, sizeof(szPath));
-     AssertReturn(cbBufLeft > 0, VERR_FILENAME_TOO_LONG);


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
