### PR TITLE
Pantheon updates 2021-10-30

### DIFF
--- a/pkgs/desktops/pantheon/apps/elementary-videos/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-videos/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
-, fetchpatch
 , nix-update-script
 , pantheon
 , pkg-config
@@ -12,6 +12,7 @@
 , gtk3
 , granite
 , libgee
+, libhandy
 , clutter-gst
 , clutter-gtk
 , gst_all_1
@@ -21,7 +22,7 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-videos";
-  version = "2.7.3";
+  version = "2.8.0";
 
   repoName = "videos";
 
@@ -29,22 +30,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "04nl9kn33dysvsg0n5qx1z8qgrifkgfwsm7gh1l308v3n8c69lh7";
-  };
-
-  patches = [
-    # Upstream code not respecting our localedir
-    # https://github.com/elementary/videos/pull/233
-    (fetchpatch {
-      url = "https://github.com/elementary/videos/commit/19ba2a9148be09ea521d2e9ac29dede6b9c6fa07.patch";
-      sha256 = "0ffp7ana98846xi7vxrzfg6dbs4yy28x2i4ky85mqs1gj6fjqin5";
-    })
-  ];
-
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
+    sha256 = "sha256-FFCtQ42LygfjowehwZcISWTfv8PBZTH0X8mPrpiG8Ug=";
   };
 
   nativeBuildInputs = [
@@ -70,12 +56,19 @@ stdenv.mkDerivation rec {
     gstreamer
     gtk3
     libgee
+    libhandy
   ];
 
   postPatch = ''
     chmod +x meson/post_install.py
     patchShebangs meson/post_install.py
   '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Video player and library app designed for elementary OS";

--- a/pkgs/desktops/pantheon/desktop/elementary-default-settings/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-default-settings/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , nix-update-script
 , pantheon
 , meson
@@ -17,7 +16,7 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-default-settings";
-  version = "6.0.1";
+  version = "6.0.2";
 
   repoName = "default-settings";
 
@@ -25,17 +24,8 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "0gqnrm968j4v699yhhiyw5fqjy4zbvvrjci2v1jrlycn09c2yrwf";
+    sha256 = "sha256-qaPj/Qp7RYzHgElFdM8bHV42oiPUbCMTC9Q+MUj4Q6Y=";
   };
-
-  patches = [
-    # Update gtk-theme-name and gtk-font-name for Pantheon 6
-    # https://github.com/elementary/default-settings/pull/252
-    (fetchpatch {
-      url = "https://github.com/elementary/default-settings/commit/be24c151492bb9115c75bd1a7abc88714240294a.patch";
-      sha256 = "sha256-EglFiN4CLbL8osfNGLvjD220Al35uBXuRNC9Ud3QYBI=";
-    })
-  ];
 
   nativeBuildInputs = [
     accountsservice

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/datetime/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/datetime/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
-, fetchpatch
 , nix-update-script
 , substituteAll
 , pantheon
@@ -24,20 +24,24 @@
 
 stdenv.mkDerivation rec {
   pname = "wingpanel-indicator-datetime";
-  version = "2.3.0";
+  version = "2.3.1";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "1mdm0fsnmmyw8c0ik2jmfri3kas9zkz1hskzf8wvbd51vnazfpgw";
+    sha256 = "sha256-/kbwZVzOlC3ATCuXVMdf2RIskoGQKG1evaDYO3yFerg=";
   };
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      elementary_calendar = elementary-calendar;
+    })
+    # Fix incorrect month shown on re-opening indicator if previously changed month
+    # https://github.com/elementary/wingpanel-indicator-datetime/pull/284
+    ./fix-incorrect-month.patch
+  ];
 
   nativeBuildInputs = [
     libxml2
@@ -60,23 +64,16 @@ stdenv.mkDerivation rec {
     libgdata # required by some dependency transitively
   ];
 
-  patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
-      elementary_calendar = elementary-calendar;
-    })
-    # Upstream code not respecting our localedir
-    # https://github.com/elementary/wingpanel-indicator-datetime/pull/269
-    (fetchpatch {
-      url = "https://github.com/elementary/wingpanel-indicator-datetime/commit/f7befa68a9fd6215297c334a366919d3431cae65.patch";
-      sha256 = "0l997b1pnpjscs886xy28as5yykxamxacvxdv8466zin7zynarfs";
-    })
-  ];
-
   postPatch = ''
     chmod +x meson/post_install.py
     patchShebangs meson/post_install.py
   '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Date & Time Indicator for Wingpanel";

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/datetime/fix-incorrect-month.patch
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/datetime/fix-incorrect-month.patch
@@ -1,0 +1,26 @@
+From 401cb05d7181e69ae8edd347644f2518904e9acb Mon Sep 17 00:00:00 2001
+From: Jeremy Paul Wootten <jeremywootten@gmail.com>
+Date: Sat, 30 Oct 2021 17:44:12 +0100
+Subject: [PATCH] Reset position and relative position after rebuilding
+ carousel
+
+---
+ src/Widgets/calendar/CalendarView.vala | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/Widgets/calendar/CalendarView.vala b/src/Widgets/calendar/CalendarView.vala
+index a41b37a4..f946b91c 100644
+--- a/src/Widgets/calendar/CalendarView.vala
++++ b/src/Widgets/calendar/CalendarView.vala
+@@ -216,7 +216,11 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
+             carousel.add (right_grid);
+             carousel.scroll_to (start_month_grid);
+             label.label = calmodel.month_start.format (_("%OB, %Y"));
++
++            position = 1;
++            rel_postion = 0;
+         }
++
+         carousel.no_show_all = false;
+     }
+ 


### PR DESCRIPTION
###### Motivation for this change

Part of Pantheon 6.0.3 updates (previous one at #143790).

### wingpanel-indicator-datetime

https://github.com/elementary/wingpanel-indicator-datetime/releases/tag/2.3.1
https://github.com/elementary/wingpanel-indicator-datetime/compare/2.3.0...2.3.1

> Fixes:
> 
> - Update current day when opening
> - Fix disappearing dates when changing between dark and light styles
> - Fix potential memory leak
> 
> Improvements:
> 
> - Updated translations

I decided I will still bring necessary patches to make things work.

### elementary-default-settings

No change for us, we fetchpatch https://github.com/elementary/default-settings/pull/252 in advance and for https://github.com/elementary/default-settings/pull/253 we handle dockitem ourselves.

### elementary-videos

https://github.com/elementary/videos/releases/tag/2.8.0
https://github.com/elementary/videos/compare/2.7.3...2.8.0

> New features:
> 
> - Two-finger swipe to go back
> 
> Other updates:
> 
> - Translation updates

Seems that changes are far more than what is written on change log.

---

Overall changes: https://blog.elementary.io/elementary-os-6-odin-updates-october-2021/

Starting from 6.0.4 we will target NixOS 22.05 first and backport 21.11 when ready.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
