### PR TITLE
python3Packages.dask, python3Packages.distributed: 2021.09.1 -> 2021.10.0

### DIFF
--- a/pkgs/development/python-modules/dask/default.nix
+++ b/pkgs/development/python-modules/dask/default.nix
@@ -5,6 +5,7 @@
 , cloudpickle
 , distributed
 , fetchFromGitHub
+, fetchpatch
 , fsspec
 , jinja2
 , numpy
@@ -22,7 +23,7 @@
 
 buildPythonPackage rec {
   pname = "dask";
-  version = "2021.09.1";
+  version = "2021.10.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -31,8 +32,18 @@ buildPythonPackage rec {
     owner = "dask";
     repo = pname;
     rev = version;
-    sha256 = "sha256-+UkbXbWV5R/QtVb5rWm/5SA+IoWsIfBciL3vg138jkc=";
+    sha256 = "07ysrs46x5w8rc2df0j06rsw58ahcysd6lwjk5riqpjlpwdfmg7p";
   };
+
+  patches = [
+    # remove with next bump
+    (fetchpatch {
+      name = "fix-tests-against-distributed-2021.10.0.patch";
+      url = "https://github.com/dask/dask/commit/cd65507841448ad49001cf27564102e2fb964d0a.patch";
+      includes = [ "dask/tests/test_distributed.py" ];
+      sha256 = "1i4i4k1lzxcydq9l80jyifq21ny0j3i47rviq07ai488pvx1r2al";
+    })
+  ];
 
   propagatedBuildInputs = [
     cloudpickle

--- a/pkgs/development/python-modules/distributed/default.nix
+++ b/pkgs/development/python-modules/distributed/default.nix
@@ -19,13 +19,13 @@
 
 buildPythonPackage rec {
   pname = "distributed";
-  version = "2021.9.1";
+  version = "2021.10.0";
   disabled = pythonOlder "3.6";
 
   # get full repository need conftest.py to run tests
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-9N65ap2+9bBK0DCrkF3+1xuJPXmjaL1Xh7ISaLTtX/g=";
+    sha256 = "0kfq7lwv2n2wiws4v2rj36wx56jvkp2fl6zxg04p2lc3vcgha9za";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/streamz/default.nix
+++ b/pkgs/development/python-modules/streamz/default.nix
@@ -7,7 +7,7 @@
 , flaky
 , graphviz
 , networkx
-, pytest
+, pytestCheckHook
 , requests
 , six
 , toolz
@@ -18,18 +18,20 @@
 
 buildPythonPackage rec {
   pname = "streamz";
-  version = "0.6.2";
+  version = "0.6.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "04446ece273c041506b1642bd3d8380367a8372196be4d6d6d03faafadc590b2";
+    sha256 = "0vvyk9khxryqb0c0ji2fyy1gxchm5ky2v80zyl5h4i65saapa1nk";
   };
 
   patches = [
-    # Fix apply import from dask
+    # remove with next bump
     (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/python-streamz/streamz/pull/423.patch";
-      sha256 = "sha256-CR+uRvzaFu9WQ633tbvX3gAnudhlVN6VvmxKiR37diw=";
+      name = "fix-tests-against-distributed-2021.10.0.patch";
+      url = "https://github.com/python-streamz/streamz/commit/5bd3bc4d305ff40c740bc2550c8491be9162778a.patch";
+      sha256 = "1xzxcbf7yninkyizrwm3ahqk6ij2fmh0454iqjx2n7mmzx3sazx7";
+      includes = ["streamz/tests/test_dask.py"];
     })
   ];
 
@@ -42,24 +44,28 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
+    pytestCheckHook
     confluent-kafka
     distributed
     flaky
     graphviz
-    pytest
     requests
   ];
 
-  disabled = pythonOlder "3.6";
+  disabledTests = [
+    # test_tcp_async fails on sandbox build
+    "test_tcp_async"
+    "test_tcp"
+    "test_partition_timeout"
+    # flaky
+    "test_from_iterable_backpressure"
+  ];
+  disabledTestPaths = [
+    # disable kafka tests
+    "streamz/tests/test_kafka.py"
+  ];
 
-  # Disable test_tcp_async because fails on sandbox build
-  # disable kafka tests
-  checkPhase = ''
-    pytest --deselect=streamz/tests/test_sources.py::test_tcp_async \
-      --deselect=streamz/tests/test_sources.py::test_tcp \
-      --deselect=streamz/tests/test_core.py::test_partition_timeout \
-      --ignore=streamz/tests/test_kafka.py
-  '';
+  disabled = pythonOlder "3.6";
 
   meta = with lib; {
     description = "Pipelines to manage continuous streams of data";


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-42343

Patch (https://github.com/dask/distributed/commit/afce4be8e05fb180e50a9d9e38465f1a82295e1b) looks trivially backportable so I'll probably do that for 21.05.

~Not fully tested yet.~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
