### PR TITLE
python38Packages.upass: 0.1.4 -> 0.2.1

### DIFF
--- a/pkgs/development/python-modules/upass/default.nix
+++ b/pkgs/development/python-modules/upass/default.nix
@@ -6,8 +6,9 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.2.1";
   pname = "upass";
+  version = "0.2.1";
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "Kwpolska";
@@ -16,14 +17,27 @@ buildPythonPackage rec {
     sha256 = "0bgplq07dmlld3lp6jag1w055glqislfgwwq2k7cb2bzjgvysdnj";
   };
 
-  propagatedBuildInputs = [ pyperclip urwid ];
+  propagatedBuildInputs = [
+    pyperclip
+    urwid
+  ];
 
+  # Projec thas no tests
   doCheck = false;
+
+  postInstall = ''
+    export HOME=$(mktemp -d);
+    mkdir $HOME/.config
+  '';
+
+  pythonImportsCheck = [
+    "upass"
+  ];
 
   meta = with lib; {
     description = "Console UI for pass";
     homepage = "https://github.com/Kwpolska/upass";
     license = licenses.bsd3;
+    maintainers = with maintainers; [ ];
   };
-
 }

--- a/pkgs/development/python-modules/upass/default.nix
+++ b/pkgs/development/python-modules/upass/default.nix
@@ -6,14 +6,14 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.1.4";
+  version = "0.2.1";
   pname = "upass";
 
   src = fetchFromGitHub {
     owner = "Kwpolska";
     repo = "upass";
     rev = "v${version}";
-    sha256 = "sha256-1y/OE8Gbc8bShEiLWg8w4J6icAcoldYQLI10WSQuO1Y=";
+    sha256 = "0bgplq07dmlld3lp6jag1w055glqislfgwwq2k7cb2bzjgvysdnj";
   };
 
   propagatedBuildInputs = [ pyperclip urwid ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Successor of #143929

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
