### PR TITLE
freeswitch: 1.10.6 -> 1.10.7

### DIFF
--- a/pkgs/development/libraries/libks/default.nix
+++ b/pkgs/development/libraries/libks/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, pkg-config
+, libuuid
+, openssl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libks";
+  version = "1.7.0";
+
+  src = fetchFromGitHub {
+    owner = "signalwire";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1wvl8kzi1fx7pg58r5x1lw4gwkvrkljqajsn72yq6sbsd3iqn8wr";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/openwrt/telephony/5ced7ea4fc9bd746273d564bf3c102f253d2182e/libs/libks/patches/01-find-libm.patch";
+      sha256 = "1hyrsdxg69d08qzvf3mbrx2363lw52jcybw8i3ynzqcl228gcg8a";
+    })
+  ];
+
+  dontUseCmakeBuildDir = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libuuid
+    openssl
+  ];
+
+  meta = with lib; {
+    description = "Foundational support for signalwire C products";
+    homepage = "https://github.com/signalwire/libks";
+    maintainers = with lib.maintainers; [ misuzu ];
+    platforms = platforms.linux;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/libraries/sofia-sip/default.nix
+++ b/pkgs/development/libraries/sofia-sip/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "sofia-sip";
-  version = "1.13.3";
+  version = "1.13.6";
 
   src = fetchFromGitHub {
     owner = "freeswitch";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-qMgZpLo/BHGJbJ0DDN8COHAhU3ujWgVK9oZOnnMwKas=";
+    sha256 = "0b1gq499ksgsi16f5nf3dzbj6s8knwkiak5j810jzdfm7vkm0vvm";
   };
 
   buildInputs = [ glib openssl ] ++ lib.optional stdenv.isDarwin SystemConfiguration;

--- a/pkgs/servers/sip/freeswitch/default.nix
+++ b/pkgs/servers/sip/freeswitch/default.nix
@@ -88,12 +88,12 @@ in
 
 stdenv.mkDerivation rec {
   pname = "freeswitch";
-  version = "1.10.6";
+  version = "1.10.7";
   src = fetchFromGitHub {
     owner = "signalwire";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1i5n06pds3kvzhhzfwvhwxnvcb2p2fcr8k52157aplm2i7prl4q2";
+    sha256 = "0npdvidvsi4dhwswdwilff4p3x04qmz7hgs9sdadiy2w83qb6alf";
   };
 
   postPatch = ''
@@ -124,6 +124,8 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   NIX_CFLAGS_COMPILE = "-Wno-error";
+
+  CFLAGS = "-D_ANSI_SOURCE";
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/servers/sip/freeswitch/modules.nix
+++ b/pkgs/servers/sip/freeswitch/modules.nix
@@ -11,6 +11,7 @@
 , postgresql
 , spandsp3
 , sofia_sip
+, libks
 }:
 
 let
@@ -139,7 +140,7 @@ in
     rtmp = mk "endpoints/mod_rtmp" [];
     skinny = mk "endpoints/mod_skinny" [];
     sofia = mk "endpoints/mod_sofia" [ sofia_sip ];
-    verto = mk "endpoints/mod_verto" [];
+    verto = mk "endpoints/mod_verto" [ libks ];
   };
 
   event_handlers = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17817,6 +17817,8 @@ with pkgs;
 
   libkml = callPackage ../development/libraries/libkml { };
 
+  libks = callPackage ../development/libraries/libks { };
+
   libksba = callPackage ../development/libraries/libksba { };
 
   libksi = callPackage ../development/libraries/libksi { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/signalwire/freeswitch/releases/tag/v1.10.7

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
