### PR TITLE
hd-idle: package rewrite

### DIFF
--- a/pkgs/os-specific/linux/hd-idle/default.nix
+++ b/pkgs/os-specific/linux/hd-idle/default.nix
@@ -1,25 +1,28 @@
-{ lib, stdenv, fetchurl }:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
 
-stdenv.mkDerivation rec {
+buildGoModule rec {
   pname = "hd-idle";
-  version = "1.05";
+  version = "1.16";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/project/hd-idle/hd-idle-${version}.tgz";
-    sha256 = "031sm996s0rhy3z91b9xvyimsj2yd2fhsww2al2hxda5s5wzxzjf";
+  src = fetchFromGitHub {
+    owner = "adelolmo";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-LZcMwF/BhHiWWXMcrzbk8GyvwXdA3B2olmbOBxQwV5g=";
   };
 
-  prePatch = ''
-    substituteInPlace Makefile \
-      --replace "-g root -o root" ""
-  '';
+  vendorSha256 = null;
 
-  installFlags = [ "TARGET_DIR=$(out)" ];
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installManPage debian/hd-idle.8
+  '';
 
   meta = with lib; {
     description = "Spins down external disks after a period of idle time";
-    homepage = "http://hd-idle.sourceforge.net/";
-    license = licenses.gpl2Plus;
+    homepage = "https://github.com/adelolmo/hd-idle";
+    license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.rycee ];
   };


### PR DESCRIPTION
###### Motivation for this change

Someone ported the original hd-idle to Golang and is maintaining it.
This replaces the hd-idle package with the actively maintained Golang
port. I assume nobody will need unmaintained original version since
the Golang port can do everything the original version can do.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
