### PR TITLE
sedutil: 1.15.1 -> 1.20.0

### DIFF
--- a/pkgs/tools/security/sedutil/default.nix
+++ b/pkgs/tools/security/sedutil/default.nix
@@ -1,28 +1,34 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+}:
 
 stdenv.mkDerivation rec {
   pname = "sedutil";
-  version = "1.15.1";
+  version = "1.20.0";
 
   src = fetchFromGitHub {
-    owner  = "Drive-Trust-Alliance";
-    repo   = "sedutil";
-    rev    = version;
-    sha256 = "0zg5v27vbrzzl2vqzks91zj48z30qgcshkqkm1g8ycnhi145l0mf";
+    owner = "Drive-Trust-Alliance";
+    repo = "sedutil";
+    rev = version;
+    sha256 = "sha256-NG/7aqe48ShHWW5hW8axYWV4+zX0dBE7Wy9q58l0S3E=";
   };
 
   postPatch = ''
     patchShebangs .
   '';
 
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
 
   enableParallelBuilding = true;
 
   meta = with lib; {
     description = "DTA sedutil Self encrypting drive software";
-    homepage    = "https://www.drivetrust.com";
-    license     = licenses.gpl3;
-    platforms   = platforms.linux;
+    homepage = "https://www.drivetrust.com";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.20.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
