### PR TITLE
nixos/luksroot: added requiresPin option for fido2luks

### DIFF
--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -442,7 +442,6 @@ let
           ${f2lopen} --salt string:$passphrase &
           f2lopen_pid=$!
           echo -n $fido_pin > ${fifo_tmp_fido_pin}
-          # Clean up after ourselves
           unset fido_pin
           rm ${fifo_tmp_fido_pin}
           # Wait for the key to open the disk

--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -148,10 +148,9 @@ let
            + optionalString (dev.header != null) " --header=${dev.header}";
     cschange = "cryptsetup luksChangeKey ${dev.device} ${optionalString (dev.header != null) "--header=${dev.header}"}";
     fifo_tmp_fido_pin = "/dev/temporary_fido_pin";
-    f2lopen = "fido2luks open ${dev.device} ${dev.name}"
-              + " ${dev.fido2.credential}"
-              + optionalString dev.fido2.requiresPin " --pin --pin-source ${fifo_tmp_fido_pin}"
-              + " --await-dev ${toString dev.fido2.gracePeriod}";
+    f2lopen = "fido2luks open ${dev.device} ${dev.name} ${dev.fido2.credential}"
+      + optionalString dev.fido2.requiresPin " --pin --pin-source ${fifo_tmp_fido_pin}"
+      + " --await-dev ${toString dev.fido2.gracePeriod}";
   in ''
     # Wait for luksRoot (and optionally keyFile and/or header) to appear, e.g.
     # if on a USB drive.
@@ -435,11 +434,9 @@ let
           echo "On systems with Linux Kernel < 5.4, it might take a while to initialize the CRNG, you might want to use linuxPackages_latest."
           echo "Please move your mouse to create needed randomness."
         ''}
-        ${if dev.fido2.requiresPin then ''
+        ${lib.optionalString dev.fido2.requiresPin ''
           mkfifo ${fifo_tmp_fido_pin}
           read -rsp "FIDO2 pin for ${dev.device}: " fido_pin
-        '' else ''
-          # Dont make a fifo queue or ask for pin since no pin entry is required
         ''}
           echo "Waiting for your FIDO2 device..."
           ${f2lopen} --salt string:$passphrase &


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fido2Luks allows you to unlock a LUKS partition using a SHA256-HMAC handshake. For devices that require a pin number (Trezor, Yubikey, Nitrokey?) this can prove difficult to operate. Therefore, I made a change that allows people to set `boot.initrd.luks.devices.<name>.fido2.requiresPin` as mentioned in the issue here: https://github.com/NixOS/nixpkgs/issues/141824#issue-1027903851

Due to issues with fido2luks requiring a working TTY (which isn't available in initrd), and with files being the only other option to supply a pin to fido2luks non-interactively (source: https://github.com/shimunn/fido2luks/issues/14#issuecomment-683430118), I used named pipes and in-memory variables (which I delete instantly after they have been used).

**This is according to my knowledge and experience the safest way to approach pin-based FIDO2 authentication on fully encrypted disks, and no harm was intended with this change.**

For people that use fido2luks already and have it working, nothing will change, as the default value to `requiresPin` will be false, which will make sure the behavior will not change for existing users.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
