### PR TITLE
 python3Packages.cachecontrol: 0.12.6 -> 0.12.8 

### DIFF
--- a/pkgs/development/python-modules/cachecontrol/default.nix
+++ b/pkgs/development/python-modules/cachecontrol/default.nix
@@ -1,34 +1,46 @@
 { lib
 , buildPythonPackage
-, fetchPypi
-, requests
+, cherrypy
+, fetchFromGitHub
+, lockfile
+, mock
 , msgpack
-, pytest
+, pytestCheckHook
+, requests
 }:
 
 buildPythonPackage rec {
+  pname = "cachecontrol";
   version = "0.12.8";
-  pname = "CacheControl";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-JUBDwbq3SMicCaiQ+RKKD7LGVOlGvPRzwS0p/fnLbFs=";
+  src = fetchFromGitHub {
+    owner = "ionrock";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0y15xbaqw2lxidwbyrgpy42v3cxgv4ys63fx2586h1szlrd4f3p4";
   };
 
-  checkInputs = [ pytest ];
-  propagatedBuildInputs = [ requests msgpack ];
+  propagatedBuildInputs = [
+    msgpack
+    requests
+  ];
 
-  # tests not included with pypi release
-  doCheck = false;
+  checkInputs = [
+    cherrypy
+    mock
+    lockfile
+    pytestCheckHook
+  ];
 
-  checkPhase = ''
-    pytest tests
-  '';
+  pythonImportsCheck = [
+    "cachecontrol"
+  ];
 
   meta = with lib; {
-    homepage = "https://github.com/ionrock/cachecontrol";
     description = "Httplib2 caching for requests";
+    homepage = "https://github.com/ionrock/cachecontrol";
     license = licenses.asl20;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc ];
   };
 }

--- a/pkgs/development/python-modules/cachecontrol/default.nix
+++ b/pkgs/development/python-modules/cachecontrol/default.nix
@@ -7,12 +7,12 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.12.6";
+  version = "0.12.8";
   pname = "CacheControl";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "be9aa45477a134aee56c8fac518627e1154df063e85f67d4f83ce0ccc23688e8";
+    sha256 = "sha256-JUBDwbq3SMicCaiQ+RKKD7LGVOlGvPRzwS0p/fnLbFs=";
   };
 
   checkInputs = [ pytest ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.12.8

- Enable tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
