### PR TITLE
nixosTests.podman: Test that a volume is writable

### DIFF
--- a/nixos/tests/podman.nix
+++ b/nixos/tests/podman.nix
@@ -141,6 +141,10 @@ import ./make-test-python.nix (
           podman.succeed("podman run --rm --name vol-write -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin -v test-volume:/data scratchimg /bin/sh -c 'echo volume-works >/data/file'")
           podman.succeed("podman run --rm --name vol-read -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin -v test-volume:/data scratchimg /bin/cat /data/file | grep volume-works")
 
+      with subtest("Podman volumes are writable and persistent, when created via docker socket"):
+          podman.succeed("docker run --rm --name vol-write -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin -v test-volume-2:/data scratchimg /bin/sh -c 'echo volume-works >/data/file'")
+          podman.succeed("docker run --rm --name vol-read -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin -v test-volume-2:/data scratchimg /bin/cat /data/file | grep volume-works")
+
       # TODO: add docker-compose test
 
     '';

--- a/nixos/tests/podman.nix
+++ b/nixos/tests/podman.nix
@@ -137,6 +137,10 @@ import ./make-test-python.nix (
       with subtest("A podman non-member can not use the docker cli"):
           podman.fail(su_cmd("docker version", user="mallory"))
 
+      with subtest("Podman volumes are writable and persistent"):
+          podman.succeed("podman run --rm --name vol-write -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin -v test-volume:/data scratchimg /bin/sh -c 'echo volume-works >/data/file'")
+          podman.succeed("podman run --rm --name vol-read -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin -v test-volume:/data scratchimg /bin/cat /data/file | grep volume-works")
+
       # TODO: add docker-compose test
 
     '';


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This could find a configuration problem where a read-only location
is used for volumes.

I'm troubleshooting this problem in an arion project, but it
appears not to be as simple as this test case.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
