### PR TITLE
buildOcaml: rename `name` to `pname`

### DIFF
--- a/pkgs/build-support/ocaml/default.nix
+++ b/pkgs/build-support/ocaml/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, writeText, ocaml, findlib, ocamlbuild, camlp4 }:
 
-{ name, version, nativeBuildInputs ? [],
+{ pname ? args.name, version, nativeBuildInputs ? [],
   createFindlibDestdir ?  true,
   dontStrip ? true,
   minimumSupportedOcamlVersion ? null,
@@ -17,13 +17,13 @@ in
           lib.versionOlder minimumSupportedOcamlVersion ocaml.version;
 
 stdenv.mkDerivation (args // {
-  name = "ocaml-${name}-${version}";
+  name = "ocaml-${pname}-${version}";
 
   nativeBuildInputs = [ ocaml findlib ocamlbuild camlp4 ] ++ nativeBuildInputs;
 
   setupHook = if setupHook == null && hasSharedObjects
   then writeText "setupHook.sh" ''
-    export CAML_LD_LIBRARY_PATH="''${CAML_LD_LIBRARY_PATH-}''${CAML_LD_LIBRARY_PATH:+:}''$1/lib/ocaml/${ocaml.version}/site-lib/${name}/"
+    export CAML_LD_LIBRARY_PATH="''${CAML_LD_LIBRARY_PATH-}''${CAML_LD_LIBRARY_PATH:+:}''$1/lib/ocaml/${ocaml.version}/site-lib/${pname}/"
     ''
   else setupHook;
 

--- a/pkgs/development/ocaml-modules/bin_prot/default.nix
+++ b/pkgs/development/ocaml-modules/bin_prot/default.nix
@@ -5,7 +5,7 @@ then throw "bin_prot-112.24.00 is not available for OCaml ${ocaml.version}"
 else
 
 buildOcaml rec {
-  name = "bin_prot";
+  pname = "bin_prot";
   version = "112.24.00";
 
   minimumSupportedOcamlVersion = "4.00";

--- a/pkgs/development/ocaml-modules/comparelib/default.nix
+++ b/pkgs/development/ocaml-modules/comparelib/default.nix
@@ -1,7 +1,7 @@
 {lib, buildOcaml, fetchurl, type_conv}:
 
 buildOcaml rec {
-  name = "comparelib";
+  pname = "comparelib";
   version = "113.00.00";
 
   minimumSupportedOcamlVersion = "4.00";

--- a/pkgs/development/ocaml-modules/estring/default.nix
+++ b/pkgs/development/ocaml-modules/estring/default.nix
@@ -5,7 +5,7 @@ then throw "estring is not available for OCaml ${ocaml.version}"
 else
 
 buildOcaml rec {
-  name = "estring";
+  pname = "estring";
   version = "1.3";
 
   src = fetchurl {

--- a/pkgs/development/ocaml-modules/faillib/default.nix
+++ b/pkgs/development/ocaml-modules/faillib/default.nix
@@ -6,7 +6,7 @@ else
 
 buildOcaml rec {
   minimumSupportedOcamlVersion = "4.00";
-  name = "faillib";
+  pname = "faillib";
   version = "111.17.00";
 
   src = fetchurl {

--- a/pkgs/development/ocaml-modules/herelib/default.nix
+++ b/pkgs/development/ocaml-modules/herelib/default.nix
@@ -2,7 +2,7 @@
 
 buildOcaml rec {
   version = "112.35.00";
-  name = "herelib";
+  pname = "herelib";
 
   minimumSupportedOcamlVersion = "4.00";
 

--- a/pkgs/development/ocaml-modules/janestreet/buildOcamlJane.nix
+++ b/pkgs/development/ocaml-modules/janestreet/buildOcamlJane.nix
@@ -1,14 +1,14 @@
 { buildOcaml, opaline, js_build_tools, ocaml_oasis, fetchurl } :
 
-{ name, version ? "113.33.03", buildInputs ? [],
+{ pname, version ? "113.33.03", buildInputs ? [],
   hash ? "",
   minimumSupportedOcamlVersion ? "4.02", ...
 }@args:
 
 buildOcaml (args // {
-  inherit name version minimumSupportedOcamlVersion;
+  inherit pname version minimumSupportedOcamlVersion;
   src = fetchurl {
-    url = "https://github.com/janestreet/${name}/archive/${version}.tar.gz";
+    url = "https://github.com/janestreet/${pname}/archive/${version}.tar.gz";
     sha256 = hash;
   };
 
@@ -20,10 +20,16 @@ buildOcaml (args // {
   dontAddStaticConfigureFlags = true;
   configurePlatforms = [];
 
-  configurePhase = "./configure --prefix $out";
+  configurePhase = ''
+    ./configure --prefix $out
+  '';
 
-  buildPhase = "OCAML_TOPLEVEL_PATH=`ocamlfind query findlib`/.. make";
+  buildPhase = ''
+    OCAML_TOPLEVEL_PATH=`ocamlfind query findlib`/.. make
+  '';
 
-  installPhase = "opaline -prefix $prefix -libdir $OCAMLFIND_DESTDIR ${name}.install";
+  installPhase = ''
+    opaline -prefix $prefix -libdir $OCAMLFIND_DESTDIR ${pname}.install
+  '';
 
 })

--- a/pkgs/development/ocaml-modules/janestreet/js-build-tools.nix
+++ b/pkgs/development/ocaml-modules/janestreet/js-build-tools.nix
@@ -1,13 +1,13 @@
 { lib, buildOcaml, fetchurl, ocaml_oasis, opaline }:
 
 buildOcaml rec {
-  name = "js-build-tools";
+  pname = "js-build-tools";
   version = "113.33.06";
 
   minimumSupportedOcamlVersion = "4.02";
 
   src = fetchurl {
-    url = "https://github.com/janestreet/${name}/archive/${version}.tar.gz";
+    url = "https://github.com/janestreet/js-build-tools/archive/${version}.tar.gz";
     sha256 = "1nvgyp4gsnlnpix3li6kr90b12iin5ihichv298p03i6h2809dia";
   };
 
@@ -19,7 +19,7 @@ buildOcaml rec {
   dontAddStaticConfigureFlags = true;
   configurePlatforms = [];
   configurePhase = "./configure --prefix $prefix";
-  installPhase = "opaline -prefix $prefix -libdir $OCAMLFIND_DESTDIR ${name}.install";
+  installPhase = "opaline -prefix $prefix -libdir $OCAMLFIND_DESTDIR js-build-tools.install";
 
   patches = [ ./js-build-tools-darwin.patch ];
 

--- a/pkgs/development/ocaml-modules/pa_bench/default.nix
+++ b/pkgs/development/ocaml-modules/pa_bench/default.nix
@@ -1,7 +1,7 @@
 {lib, buildOcaml, fetchurl, type_conv, pa_ounit}:
 
 buildOcaml rec {
-  name = "pa_bench";
+  pname = "pa_bench";
   version = "113.00.00";
 
   minimumSupportedOcamlVersion = "4.00";

--- a/pkgs/development/ocaml-modules/pa_ounit/default.nix
+++ b/pkgs/development/ocaml-modules/pa_ounit/default.nix
@@ -5,7 +5,7 @@ then throw "pa_ounit is not available for OCaml ${ocaml.version}"
 else
 
 buildOcaml rec {
-  name = "pa_ounit";
+  pname = "pa_ounit";
   version = "113.00.00";
 
   src = fetchurl {

--- a/pkgs/development/ocaml-modules/pipebang/default.nix
+++ b/pkgs/development/ocaml-modules/pipebang/default.nix
@@ -1,7 +1,7 @@
 {lib, buildOcaml, fetchurl}:
 
 buildOcaml rec {
-  name = "pipebang";
+  pname = "pipebang";
   version = "113.00.00";
 
   minimumSupportedOcamlVersion = "4.00";

--- a/pkgs/development/ocaml-modules/type_conv/112.01.01.nix
+++ b/pkgs/development/ocaml-modules/type_conv/112.01.01.nix
@@ -3,7 +3,7 @@
 buildOcaml rec {
   minimumSupportedOcamlVersion = "4.02";
 
-  name = "type_conv";
+  pname = "type_conv";
   version = "113.00.02";
 
   src = fetchurl {

--- a/pkgs/development/ocaml-modules/typerep/default.nix
+++ b/pkgs/development/ocaml-modules/typerep/default.nix
@@ -1,7 +1,7 @@
 { lib, buildOcaml, fetchFromGitHub, type_conv }:
 
 buildOcaml rec {
-  name = "typerep";
+  pname = "typerep";
   version = "112.24.00";
 
   minimumSupportedOcamlVersion = "4.00";

--- a/pkgs/development/ocaml-modules/variantslib/default.nix
+++ b/pkgs/development/ocaml-modules/variantslib/default.nix
@@ -5,7 +5,7 @@ then throw "variantslib-109.15.03 is not available for OCaml ${ocaml.version}"
 else
 
 buildOcaml rec {
-  name = "variantslib";
+  pname = "variantslib";
   version = "109.15.03";
 
   minimumSupportedOcamlVersion = "4.00";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
lately i was confused, why `buildOcaml` only accepts `name` and throws an error if `pname` is used.

All other packages prefere the use of  `pname`. Therefore i adapted this for `buildOcaml` as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
