### PR TITLE
nixos/{gollum,borgbackup,radicale}: specifiy systemd `WorkingDirectory`

### DIFF
--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -152,6 +152,7 @@ let
       serviceConfig = {
         # The service's only task is to ensure that the specified path exists
         Type = "oneshot";
+        WorkingDirectory = cfg.path;
       };
       wantedBy = [ "multi-user.target" ];
     };

--- a/nixos/modules/services/misc/gollum.nix
+++ b/nixos/modules/services/misc/gollum.nix
@@ -100,6 +100,7 @@ in
       serviceConfig = {
         User = config.users.users.gollum.name;
         Group = config.users.groups.gollum.name;
+        WorkingDirectory = cfg.stateDir;
         ExecStart = ''
           ${pkgs.gollum}/bin/gollum \
             --port ${toString cfg.port} \

--- a/nixos/modules/services/networking/radicale.nix
+++ b/nixos/modules/services/networking/radicale.nix
@@ -195,6 +195,7 @@ in {
         SystemCallArchitectures = "native";
         SystemCallFilter = [ "@system-service" "~@privileged" "~@resources" ];
         UMask = "0027";
+        WorkingDirectory = "/var/lib/radicale";
       };
     };
   };


### PR DESCRIPTION
###### Motivation for this change

These services already have their state in `/var/lib/servicename`. By setting `WorkingDirectory` to that directory, systemd automatically sets `Requires` and `After` for systemd mounts that are necessary for the paths. So I guess this would be sensible for pretty much every service, but these are the ones I'm actively using.

I'm using this for over a year now without a problem.

From `man 5 systemd.exec`:

```
IMPLICIT DEPENDENCIES
       A few execution parameters result in additional, automatic dependencies to be added:

       •   Units with WorkingDirectory=, RootDirectory=, RootImage=, RuntimeDirectory=, StateDirectory=,
           CacheDirectory=, LogsDirectory= or ConfigurationDirectory= set automatically gain dependencies
           of type Requires= and After= on all mount units required to access the specified paths. This is
           equivalent to having them listed explicitly in RequiresMountsFor=.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
