### PR TITLE
nix-option: init at 1.0

### DIFF
--- a/pkgs/tools/nix/nix-option/default.nix
+++ b/pkgs/tools/nix/nix-option/default.nix
@@ -1,0 +1,34 @@
+{
+  stdenv
+, lib
+, callPackage
+, makeWrapper
+, nixos-option
+, ncurses
+, ...
+}:
+let
+  inherit (lib) makeBinPath;
+in
+stdenv.mkDerivation {
+  pname = "nix-option";
+  version = "1.0";
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  installPhase = ''
+    # mkdir -p $out/bin
+    makeWrapper "${./options}" "$out/bin/nix-option" \
+      --prefix PATH : "${makeBinPath [ nixos-option ncurses ]}"
+  '';
+  dontUnpack = true;
+
+  meta = with lib; {
+    description = "nixos-option, but for the flake era";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lucasew ];
+    platforms = nixos-option.meta.platforms;
+  };
+}

--- a/pkgs/tools/nix/nix-option/options
+++ b/pkgs/tools/nix/nix-option/options
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+TEMPFILE=`mktemp`.nix
+
+echo '
+let
+    flake-compat = builtins.fetchTarball {
+        url = "https://github.com/edolstra/flake-compat/archive/master.tar.gz";
+    };
+in
+' > $TEMPFILE
+
+function usage {
+    echo "
+$(tput bold)nix-option$(tput sgr0) [my flags] [option] [nixos-option flags]
+
+$(tput bold)my flags$(tput sgr0)
+    --flake: which flake with configuration to inspect
+        If this flag is omitted then nixos-option will have the default behavior
+        Example: .#nixosConfigurations.main
+    -h, --help: show this help message
+    --no-delete-tmpfile, -n: do not delete the generated nix file
+
+$(tput bold)option$(tput sgr0)
+    the option to be inspected in the same format as is in nixos-option
+
+$(tput bold)nixos-option flags$(tput sgr0)
+    Same as nixos-option (8)
+    "
+}
+
+if [ $# == 0 ]; then
+    usage
+    exit 0
+fi
+
+function cleanup {
+    if [ $DELETE_TMPFILE == 1 ]; then
+        rm "$TEMPFILE"
+    fi
+}
+trap cleanup EXIT
+
+DELETE_TMPFILE=1
+FLAKED=0
+
+while true; do
+    case "$1" in
+        --help | -h)
+            usage
+            exit 0
+        ;;
+        --no-delete-tmpfile | -n)
+            shift
+            DELETE_TMPFILE=0
+        ;;
+        --flake)
+            shift
+            IFS='#' read -a FLAKE_PARTS <<< "$1"
+            shift
+            echo "$FLAKE_PARTS"
+            if [[ "${FLAKE_PARTS[0]}" =~ ^[./] ]]; then
+                DIR=`cd "${FLAKE_PARTS[0]}"; pwd`
+                echo "(import flake-compat {src = \"$DIR\";}).defaultNix.${FLAKE_PARTS[1]}" >> $TEMPFILE
+            else
+                echo "(import flake-compat {src = \"${FLAKE_PARTS[0]}\";}).defaultNix.${FLAKE_PARTS[1]}" >> $TEMPFILE
+            fi
+            FLAKED=1
+        ;;
+        *)
+            break
+        ;;
+    esac
+done
+
+if [ $FLAKED == 1 ]; then
+    nixos-option --config_expr "(import $TEMPFILE).config" --options_expr "(import "$TEMPFILE").options" "$@"
+else
+    nixos-option "$@"
+fi
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32359,6 +32359,8 @@ with pkgs;
     (import ../../nixos/lib/make-options-doc/default.nix)
     ({ inherit pkgs lib; } // attrs);
 
+  nix-option = callPackage ../tools/nix/nix-option {};
+
   nixos-install-tools = callPackage ../tools/nix/nixos-install-tools { };
 
   nixui = callPackage ../tools/package-management/nixui { node_webkit = nwjs_0_12; };


### PR DESCRIPTION
This commit adds a wrapper around `nixos-option` that brings it to
work in the flake era making it possible to use for other module systems
like home-manager and custom ones. The selected attr must expose the
options and config from evalModules.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
nixos-option doesn't support flakes and doing a shell script wrapper is way easier than editing C++ code

This script works outside the NixOS world, any `lib.evalModules` based system should work, it must only expose config and options.

As nixos-option, the code itself is on nixpkgs.

###### Things done
- Added `pkgs.options`
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
