### PR TITLE
vpnc-scripts: 2021-03-21 -> 2021-09-24

### DIFF
--- a/pkgs/tools/networking/vpnc-scripts/default.nix
+++ b/pkgs/tools/networking/vpnc-scripts/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation {
   pname = "vpnc-scripts";
-  version = "unstable-2021-03-21";
+  version = "unstable-2021-09-24";
   src = fetchgit {
-    url = "git://git.infradead.org/users/dwmw2/vpnc-scripts.git";
-    rev = "8fff06090ed193c4a7285e9a10b42e6679e8ecf3";
-    sha256 = "14bzzpwz7kdmlbx825h6s4jjdml9q6ziyrq8311lp8caql68qdq1";
+    url = "https://gitlab.com/openconnect/vpnc-scripts.git";
+    rev = "b749c2cadc2f32e2efffa69302861f9a7d4a4e5f";
+    sha256 = "sha256:19aj6mfkclbkx6ycyd4xm7id1bq78ismw0y6z23f6s016k3sjc8c";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

Inspired  by #143302, but done correctly by a human.  ;-)

- [x] test at work this week

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
