### PR TITLE
antimicrox: 3.0.1 -> 3.2.0

### DIFF
--- a/pkgs/tools/misc/antimicrox/default.nix
+++ b/pkgs/tools/misc/antimicrox/default.nix
@@ -4,40 +4,39 @@
 , extra-cmake-modules
 , pkg-config
 , SDL2
-, qtbase
 , qttools
-, qtx11extras
 , xorg
 , fetchFromGitHub
 , itstool
 }:
 
 mkDerivation rec {
-  pname = "antimicroX";
-  version = "3.0.1";
+  pname = "antimicrox";
+  version = "3.2.0";
 
   src = fetchFromGitHub {
-    owner = "juliagoda";
-    repo = "antimicroX";
+    owner = "AntiMicroX";
+    repo = pname;
     rev = version;
-    sha256 = "05asxlkgb4cgvpcyksw1cx8cz8nzi8hmw8b91lw92892j7a2r7wj";
+    sha256 = "sha256-brG3DTpWRYmDemTeteuuNbF0JoDAXdcFwO12JC6/0/Q=";
   };
 
   nativeBuildInputs = [ cmake extra-cmake-modules pkg-config itstool ];
   buildInputs = [
     SDL2
-    qtbase
     qttools
-    qtx11extras
-    xorg.libX11
     xorg.libXtst
-    xorg.libXi
   ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+        --replace "/usr/lib/udev/rules.d/" "$out/lib/udev/rules.d/"
+  '';
 
   meta = with lib; {
     description = "GUI for mapping keyboard and mouse controls to a gamepad";
     inherit (src.meta) homepage;
-    maintainers = with maintainers; [ jb55 ];
+    maintainers = with maintainers; [ jb55 sbruder ];
     license = licenses.gpl3Plus;
     platforms = with platforms; linux;
   };

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -54,7 +54,8 @@ mapAliases ({
   ammonite-repl = ammonite; # added 2017-05-02
   amsn = throw "amsn has been removed due to being unmaintained."; # added 2020-12-09
   angelfish = libsForQt5.plasmaMobileGear.angelfish; # added 2021-10-06
-  antimicro = throw "antimicro has been removed as it was broken, see antimicroX instead."; # added 2020-08-06
+  antimicro = throw "antimicro has been removed as it was broken, see antimicrox instead."; # added 2020-08-06
+  antimicroX = antimicrox; # added 2021-10-31
   arduino_core = arduino-core;  # added 2015-02-04
   ardour_5 = throw "ardour_5 has been removed. see https://github.com/NixOS/nixpkgs/issues/139549"; # added 2021-09-28
   arora = throw "arora has been removed."; # added 2020-09-09

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31822,7 +31822,7 @@ with pkgs;
 
   android-file-transfer = libsForQt5.callPackage ../tools/filesystems/android-file-transfer { };
 
-  antimicroX = libsForQt5.callPackage ../tools/misc/antimicroX { };
+  antimicrox = libsForQt5.callPackage ../tools/misc/antimicrox { };
 
   atari800 = callPackage ../misc/emulators/atari800 { };
 


### PR DESCRIPTION
This changes the source from the (now archived) [original antimicroX](https://github.com/juliagoda/antimicroX) to [a
fork](https://github.com/AntiMicroX/antimicrox) that is actively maintained and includes new features like uinput
support for wayland.

Since upstream [changed the executable name from antimicroX to
antimicrox](https://github.com/AntiMicroX/antimicrox/commit/5d80c59fa16ecbdf644e45d2889435d7d99198da), this also changes the name of the derivation and the file
names to work with Nix 2.4’s nix run and to be consistent. An alias for
antimicroX is added to ensure existing configurations will continue
working.

###### Motivation for this change

Keeping packages up-to-date and making antimicrox work with wayland.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
