### PR TITLE
nfd: init at 0.7.1

### DIFF
--- a/pkgs/servers/nfd/default.nix
+++ b/pkgs/servers/nfd/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenv
+, ndn-cxx
+, libpcap
+, fetchFromGitHub
+, boost
+, pkgconfig
+, openssl
+, doxygen
+, wafHook
+, systemd
+, python3
+, python3Packages
+, withSystemd ? true
+, withWebSocket ? true
+}:
+let
+  pname = "nfd";
+  version = "0.7.1";
+  pythonPackages = p: with p; [ sphinx ];
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "named-data";
+    repo = lib.toUpper pname;
+    rev = "${lib.toUpper pname}-${version}";
+    sha256 = "1l9bchj8c68r6qw4vr1kc96jgxl0vpqa2vjkvy1xmhz92sivr6gi";
+    fetchSubmodules = withWebSocket;
+  };
+
+  nativeBuildInputs = [ wafHook doxygen pkgconfig python3 python3Packages.sphinx ];
+  buildInputs = [ libpcap boost openssl ndn-cxx ] ++ lib.optional withSystemd systemd;
+
+  wafConfigureFlags = [
+    "--boost-includes=${boost.dev}/include"
+    "--boost-libs=${boost.out}/lib"
+  ] ++ lib.optional (!withWebSocket) "--without-websocket";
+
+  outputs = [ "out" "dev" ];
+  meta = with lib; {
+    homepage = "http://named-data.net/";
+    description = "Named Data Neworking (NDN) Forwarding Daemon";
+    license = licenses.gpl3;
+    platforms = lib.platforms.unix;
+    maintainers = [ maintainers.bertof ];
+  };
+}

--- a/pkgs/servers/nfd/default.nix
+++ b/pkgs/servers/nfd/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "http://named-data.net/";
     description = "Named Data Neworking (NDN) Forwarding Daemon";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.unix;
     maintainers = [ maintainers.bertof ];
   };

--- a/pkgs/servers/nfd/default.nix
+++ b/pkgs/servers/nfd/default.nix
@@ -29,10 +29,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config sphinx wafHook ];
   buildInputs = [ libpcap ndn-cxx openssl websocketpp ] ++ lib.optional withSystemd systemd;
 
-  preConfigure = ''
-    export PREFIX=$out
-  '';
-
   wafConfigureFlags = [
     "--boost-includes=${boost.dev}/include"
     "--boost-libs=${boost.out}/lib"

--- a/pkgs/servers/nfd/default.nix
+++ b/pkgs/servers/nfd/default.nix
@@ -23,15 +23,11 @@ stdenv.mkDerivation rec {
     repo = lib.toUpper pname;
     rev = "NFD-${version}";
     sha256 = "1l9bchj8c68r6qw4vr1kc96jgxl0vpqa2vjkvy1xmhz92sivr6gi";
+    fetchSubmodules = withWebSocket;
   };
 
   nativeBuildInputs = [ pkg-config sphinx wafHook ];
-  buildInputs = [ libpcap ndn-cxx openssl ] ++ lib.optional withSystemd systemd;
-
-  preConfigurePhase =
-    if withWebSocket then ''
-      ln -s ${websocketpp} websocketpp
-    '' else "";
+  buildInputs = [ libpcap ndn-cxx openssl websocketpp ] ++ lib.optional withSystemd systemd;
 
   wafConfigureFlags = [
     "--boost-includes=${boost.dev}/include"

--- a/pkgs/servers/nfd/default.nix
+++ b/pkgs/servers/nfd/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
     repo = lib.toUpper pname;
     rev = "${lib.toUpper pname}-${version}";
     sha256 = "1l9bchj8c68r6qw4vr1kc96jgxl0vpqa2vjkvy1xmhz92sivr6gi";
+    fetchSubmodules = withWebSocket; # uses websocket++ 0.8.1-hotfix, nixpkgs contains old version 0.8.1
   };
 
   nativeBuildInputs = [ wafHook doxygen pkg-config (python3.withPackages pythonPackages) ];
@@ -41,7 +42,7 @@ stdenv.mkDerivation rec {
     homepage = "http://named-data.net/";
     description = "Named Data Neworking (NDN) Forwarding Daemon";
     license = licenses.gpl3;
-    platforms = lib.platforms.unix;
+    platforms = platforms.unix;
     maintainers = [ maintainers.bertof ];
   };
 }

--- a/pkgs/servers/nfd/default.nix
+++ b/pkgs/servers/nfd/default.nix
@@ -37,10 +37,12 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
   checkPhase = ''
+    runHook preCheck
     build/unit-tests-core
     # build/unit-tests-daemon # 3 tests fail
     build/unit-tests-rib
     build/unit-tests-tools
+    runHook postCheck
   '';
 
   meta = with lib; {

--- a/pkgs/servers/nfd/default.nix
+++ b/pkgs/servers/nfd/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "named-data";
     repo = lib.toUpper pname;
-    rev = "$NFD-${version}";
+    rev = "NFD-${version}";
     sha256 = "1l9bchj8c68r6qw4vr1kc96jgxl0vpqa2vjkvy1xmhz92sivr6gi";
   };
 

--- a/pkgs/servers/nfd/default.nix
+++ b/pkgs/servers/nfd/default.nix
@@ -29,6 +29,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config sphinx wafHook ];
   buildInputs = [ libpcap ndn-cxx openssl websocketpp ] ++ lib.optional withSystemd systemd;
 
+  preConfigure = ''
+    export PREFIX=$out
+  '';
+
   wafConfigureFlags = [
     "--boost-includes=${boost.dev}/include"
     "--boost-libs=${boost.out}/lib"

--- a/pkgs/servers/nfd/default.nix
+++ b/pkgs/servers/nfd/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     repo = lib.toUpper pname;
     rev = "NFD-${version}";
     sha256 = "1l9bchj8c68r6qw4vr1kc96jgxl0vpqa2vjkvy1xmhz92sivr6gi";
-    fetchSubmodules = withWebSocket;
+    fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ pkg-config sphinx wafHook ];
@@ -33,7 +33,8 @@ stdenv.mkDerivation rec {
     "--boost-includes=${boost.dev}/include"
     "--boost-libs=${boost.out}/lib"
     "--with-tests"
-  ] ++ lib.optional (!withWebSocket) "--without-websocket";
+    (lib.optionalString (!withWebSocket) "--without-websocket")
+  ];
 
   doCheck = true;
   checkPhase = ''

--- a/pkgs/servers/nfd/default.nix
+++ b/pkgs/servers/nfd/default.nix
@@ -33,8 +33,7 @@ stdenv.mkDerivation rec {
     "--boost-includes=${boost.dev}/include"
     "--boost-libs=${boost.out}/lib"
     "--with-tests"
-    (lib.optionalString (!withWebSocket) "--without-websocket")
-  ];
+  ] ++ lib.optional (!withWebSocket) "--without-websocket";
 
   doCheck = true;
   checkPhase = ''

--- a/pkgs/servers/nfd/default.nix
+++ b/pkgs/servers/nfd/default.nix
@@ -4,41 +4,39 @@
 , libpcap
 , fetchFromGitHub
 , boost
-, pkgconfig
+, pkg-config
 , openssl
 , doxygen
 , wafHook
 , systemd
 , python3
 , python3Packages
-, withSystemd ? true
+, websocketpp
+, withSystemd ? stdenv.isLinux
 , withWebSocket ? true
 }:
 let
-  pname = "nfd";
-  version = "0.7.1";
   pythonPackages = p: with p; [ sphinx ];
 in
-stdenv.mkDerivation {
-  inherit pname version;
+stdenv.mkDerivation rec {
+  pname = "nfd";
+  version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "named-data";
     repo = lib.toUpper pname;
     rev = "${lib.toUpper pname}-${version}";
     sha256 = "1l9bchj8c68r6qw4vr1kc96jgxl0vpqa2vjkvy1xmhz92sivr6gi";
-    fetchSubmodules = withWebSocket;
   };
 
-  nativeBuildInputs = [ wafHook doxygen pkgconfig python3 python3Packages.sphinx ];
-  buildInputs = [ libpcap boost openssl ndn-cxx ] ++ lib.optional withSystemd systemd;
+  nativeBuildInputs = [ wafHook doxygen pkg-config (python3.withPackages pythonPackages) ];
+  buildInputs = [ libpcap boost openssl ndn-cxx ] ++ lib.optional withSystemd systemd ++ lib.optional withSystemd websocketpp;
 
   wafConfigureFlags = [
     "--boost-includes=${boost.dev}/include"
     "--boost-libs=${boost.out}/lib"
   ] ++ lib.optional (!withWebSocket) "--without-websocket";
 
-  outputs = [ "out" "dev" ];
   meta = with lib; {
     homepage = "http://named-data.net/";
     description = "Named Data Neworking (NDN) Forwarding Daemon";

--- a/pkgs/servers/nfd/default.nix
+++ b/pkgs/servers/nfd/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://named-data.net/";
+    homepage = "https://named-data.net/";
     description = "Named Data Neworking (NDN) Forwarding Daemon";
     license = licenses.gpl3Plus;
     platforms = platforms.unix;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15725,6 +15725,8 @@ with pkgs;
 
   ndn-tools = callPackage ../tools/networking/ndn-tools { };
 
+  nfd = callPackage ../servers/nfd { };
+
   cddlib = callPackage ../development/libraries/cddlib {};
 
   cdk = callPackage ../development/libraries/cdk {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Package the named Data Networking Forwarder Daemon (NFD)

###### Things done
- Add NFD derivation
- Link NFD derivation as a top-level package

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
