### PR TITLE
nixpkgs-basic-release-checks: check for use of url literals

### DIFF
--- a/pkgs/top-level/nixpkgs-basic-release-checks.nix
+++ b/pkgs/top-level/nixpkgs-basic-release-checks.nix
@@ -36,6 +36,7 @@ pkgs.runCommand "nixpkgs-release-checks" { src = nixpkgs; buildInputs = [nix]; }
         nix-env -f $src \
             --show-trace --argstr system "$platform" \
             --arg config '{ allowAliases = false; }' \
+            --option experimental-features 'no-url-literals' \
             -qa --drv-path --system-filter \* --system \
             "''${opts[@]}" 2>&1 >/dev/null | tee eval-warnings.log
 
@@ -48,6 +49,7 @@ pkgs.runCommand "nixpkgs-release-checks" { src = nixpkgs; buildInputs = [nix]; }
         nix-env -f $src \
             --show-trace --argstr system "$platform" \
             --arg config '{ allowAliases = false; }' \
+            --option experimental-features 'no-url-literals' \
             -qa --drv-path --system-filter \* --system --meta --xml \
             "''${opts[@]}" > /dev/null
     done


### PR DESCRIPTION
###### Motivation for this change
Nixpkgs should not rely on that deprecated feature.
See https://github.com/NixOS/rfcs/blob/master/rfcs/0045-deprecate-url-syntax.md for the rfc.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
