### PR TITLE
lib/modules: Short-circuit unmatchedDefns when configs is empty

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -430,26 +430,27 @@ rec {
 
       # an attrset 'name' => list of unmatched definitions for 'name'
       unmatchedDefnsByName =
-        if configs == []
-        then
-          # When no config values exist, there can be no unmatched config, so
-          # we short circuit and avoid evaluating more _options_ than necessary.
-          {}
-        else
-          # Propagate all unmatched definitions from nested option sets
-          mapAttrs (n: v: v.unmatchedDefns) resultsByName
-          # Plus the definitions for the current prefix that don't have a matching option
-          // removeAttrs defnsByName' (attrNames matchedOptions);
+        # Propagate all unmatched definitions from nested option sets
+        mapAttrs (n: v: v.unmatchedDefns) resultsByName
+        # Plus the definitions for the current prefix that don't have a matching option
+        // removeAttrs defnsByName' (attrNames matchedOptions);
     in {
       inherit matchedOptions;
 
       # Transforms unmatchedDefnsByName into a list of definitions
-      unmatchedDefns = concatLists (mapAttrsToList (name: defs:
-        map (def: def // {
-          # Set this so we know when the definition first left unmatched territory
-          prefix = [name] ++ (def.prefix or []);
-        }) defs
-      ) unmatchedDefnsByName);
+      unmatchedDefns =
+        if configs == []
+        then
+          # When no config values exist, there can be no unmatched config, so
+          # we short circuit and avoid evaluating more _options_ than necessary.
+          []
+        else
+          concatLists (mapAttrsToList (name: defs:
+            map (def: def // {
+              # Set this so we know when the definition first left unmatched territory
+              prefix = [name] ++ (def.prefix or []);
+            }) defs
+          ) unmatchedDefnsByName);
     };
 
   /* Merge multiple option declarations into a single declaration.  In

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -13,7 +13,6 @@ let
     elem
     filter
     findFirst
-    flip
     foldl
     foldl'
     getAttrFromPath
@@ -403,7 +402,7 @@ rec {
           [{ inherit (module) file; inherit value; }]
         ) configs;
 
-      resultsByName = flip mapAttrs declsByName (name: decls:
+      resultsByName = mapAttrs (name: decls:
         # We're descending into attribute ‘name’.
         let
           loc = prefix ++ [name];
@@ -424,7 +423,7 @@ rec {
             in
               throw "The option `${showOption loc}' in `${firstOption._file}' is a prefix of options in `${firstNonOption._file}'."
           else
-            mergeModules' loc decls defns);
+            mergeModules' loc decls defns) declsByName;
 
       matchedOptions = mapAttrs (n: v: v.matchedOptions) resultsByName;
 

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -430,10 +430,16 @@ rec {
 
       # an attrset 'name' => list of unmatched definitions for 'name'
       unmatchedDefnsByName =
-        # Propagate all unmatched definitions from nested option sets
-        mapAttrs (n: v: v.unmatchedDefns) resultsByName
-        # Plus the definitions for the current prefix that don't have a matching option
-        // removeAttrs defnsByName' (attrNames matchedOptions);
+        if configs == []
+        then
+          # When no config values exist, there can be no unmatched config, so
+          # we short circuit and avoid evaluating more _options_ than necessary.
+          {}
+        else
+          # Propagate all unmatched definitions from nested option sets
+          mapAttrs (n: v: v.unmatchedDefns) resultsByName
+          # Plus the definitions for the current prefix that don't have a matching option
+          // removeAttrs defnsByName' (attrNames matchedOptions);
     in {
       inherit matchedOptions;
 

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -947,7 +947,7 @@ rec {
 
   /* Use this function to import a JSON file as NixOS configuration.
 
-     importJSON -> path -> attrs
+     modules.importJSON :: path -> attrs
   */
   importJSON = file: {
     _file = file;
@@ -956,7 +956,7 @@ rec {
 
   /* Use this function to import a TOML file as NixOS configuration.
 
-     importTOML -> path -> attrs
+     modules.importTOML :: path -> attrs
   */
   importTOML = file: {
     _file = file;

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -13,7 +13,6 @@ let
     elem
     filter
     findFirst
-    foldl
     foldl'
     getAttrFromPath
     head
@@ -863,7 +862,7 @@ rec {
   mkMergedOptionModule = from: to: mergeFn:
     { config, options, ... }:
     {
-      options = foldl recursiveUpdate {} (map (path: setAttrByPath path (mkOption {
+      options = foldl' recursiveUpdate {} (map (path: setAttrByPath path (mkOption {
         visible = false;
         # To use the value in mergeFn without triggering errors
         default = "_mkMergedOptionModule";

--- a/lib/tests/modules/declare-attrsOf.nix
+++ b/lib/tests/modules/declare-attrsOf.nix
@@ -1,6 +1,13 @@
-{ lib, ... }: {
+{ lib, ... }:
+let
+  deathtrapArgs = lib.mapAttrs
+    (k: _: throw "The module system is too strict, accessing an unused option's ${k} mkOption-attribute.")
+    (lib.functionArgs lib.mkOption);
+in
+{
   options.value = lib.mkOption {
     type = lib.types.attrsOf lib.types.str;
     default = {};
   };
+  options.testing-laziness-so-don't-read-me = lib.mkOption deathtrapArgs;
 }

--- a/lib/tests/modules/freeform-nested.nix
+++ b/lib/tests/modules/freeform-nested.nix
@@ -1,7 +1,14 @@
-{ lib, ... }: {
+{ lib, ... }:
+let
+  deathtrapArgs = lib.mapAttrs
+    (k: _: throw "The module system is too strict, accessing an unused option's ${k} mkOption-attribute.")
+    (lib.functionArgs lib.mkOption);
+in
+{
   options.nest.foo = lib.mkOption {
     type = lib.types.bool;
     default = false;
   };
+  options.nest.unused = lib.mkOption deathtrapArgs;
   config.nest.bar = "bar";
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Improve performance.

By short-circuiting, we don't have to evaluate as much of the
`options` trees.

Allocation stats show -0.55% percent in heap size.
`bench` shows

Before:

```
benchmarking nix-instantiate -A nixosTests.specialisation -A nixosTests.installer -A nixosTests.nginx -A nixosTests.postgresql
time                 122.2 s    (118.7 s .. 124.9 s, ci 0.990)
                     1.000 R²   (1.000 R² .. 1.000 R², ci 0.990)
mean                 120.8 s    (119.2 s .. 121.8 s, ci 0.990)
std dev              1.170 s    (310.6 ms .. 1.601 s, ci 0.990)
variance introduced by outliers: 19% (moderately inflated)
```

After:

```
time                 121.9 s    (116.2 s .. 128.3 s, ci 0.990)
                     1.000 R²   (NaN R² .. 1.000 R², ci 0.990)
mean                 120.2 s    (118.7 s .. 121.4 s, ci 0.990)
std dev              1.340 s    (313.6 ms .. 1.656 s, ci 0.990)
variance introduced by outliers: 19% (moderately inflated)
```

suggesting a 1.6% performance improvement, although that number is still bogus, considering the possible range of each combined measurement. Maybe I should have picked a lower confidence interval. I was hoping it would produce more samples for a high ci. I might still try that.

Performance report for d6ebd53 https://github.com/NixOS/nixpkgs/pull/144022/checks?check_run_id=4062089224

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
