### PR TITLE
sbcl: enable linkable runtime on aarch64-linux

### DIFF
--- a/pkgs/development/compilers/sbcl/common.nix
+++ b/pkgs/development/compilers/sbcl/common.nix
@@ -1,9 +1,14 @@
 { version, sha256 }:
 
-{ lib, stdenv, fetchurl, fetchpatch, writeText, sbclBootstrap
+{ lib
+, stdenv
+, fetchurl
+, fetchpatch
+, writeText
+, sbclBootstrap
 , sbclBootstrapHost ? "${sbclBootstrap}/bin/sbcl --disable-debugger --no-userinit --no-sysinit"
 , threadSupport ? (stdenv.isi686 || stdenv.isx86_64 || "aarch64-linux" == stdenv.hostPlatform.system || "aarch64-darwin" == stdenv.hostPlatform.system)
-, linkableRuntime ? (stdenv.isi686 || stdenv.isx86_64)
+, linkableRuntime ? (stdenv.isi686 || stdenv.isx86_64 || "aarch64-linux" == stdenv.hostPlatform.system)
 , disableImmobileSpace ? false
   # Meant for sbcl used for creating binaries portable to non-NixOS via save-lisp-and-die.
   # Note that the created binaries still need `patchelf --set-interpreter ...`
@@ -21,7 +26,7 @@ stdenv.mkDerivation rec {
     inherit sha256;
   };
 
-  buildInputs = [texinfo];
+  buildInputs = [ texinfo ];
 
   patches = lib.optional
     (lib.versionAtLeast version "2.1.2" && lib.versionOlder version "2.1.8")
@@ -52,19 +57,19 @@ stdenv.mkDerivation rec {
     sed -e '5,$d' -i contrib/sb-simple-streams/*test*.lisp
   ''
   + (if purgeNixReferences
-    then
-      # This is the default location to look for the core; by default in $out/lib/sbcl
-      ''
-        sed 's@^\(#define SBCL_HOME\) .*$@\1 "/no-such-path"@' \
-          -i src/runtime/runtime.c
-      ''
-    else
-      # Fix software version retrieval
-      ''
-        sed -e "s@/bin/uname@$(command -v uname)@g" -i src/code/*-os.lisp \
-          src/code/run-program.lisp
-      ''
-    );
+  then
+  # This is the default location to look for the core; by default in $out/lib/sbcl
+    ''
+      sed 's@^\(#define SBCL_HOME\) .*$@\1 "/no-such-path"@' \
+        -i src/runtime/runtime.c
+    ''
+  else
+  # Fix software version retrieval
+    ''
+      sed -e "s@/bin/uname@$(command -v uname)@g" -i src/code/*-os.lisp \
+        src/code/run-program.lisp
+    ''
+  );
 
 
   preBuild = ''


### PR DESCRIPTION
Linkable runtime seems to be working fine on aarch64-linux too, therefore I think it would be wise to enable it. 

I also ran nixpkgs-fmt on the file. 

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
