### PR TITLE
ducking-proxy: init at 2021-07-23

### DIFF
--- a/pkgs/servers/duckling-proxy/default.nix
+++ b/pkgs/servers/duckling-proxy/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule {
+  pname = "duckling-proxy";
+  version = "2021-07-23-unstable";
+
+  src = fetchFromGitHub {
+    owner = "LukeEmmet";
+    repo = "duckling-proxy";
+    rev = "e2bfd73a60d7afa43f13a9d420d514131fee8fd1";
+    sha256 = "134hnfa4f5sb1z1j5684wmqzascsrlagx8z36i1470yggb00j4hr";
+  };
+  vendorSha256 = "0wxk1a5gn9a7q2kgq11a783rl5cziipzhndgp71i365y3p1ssqyf";
+
+  meta = with lib; {
+    description = "Gemini proxy to access the Small Web";
+    homepage = "https://github.com/LukeEmmet/duckling-proxy";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kaction ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21374,6 +21374,8 @@ with pkgs;
 
   squid = callPackage ../servers/squid { };
 
+  duckling-proxy = callPackage ../servers/duckling-proxy { };
+
   sslh = callPackage ../servers/sslh { };
 
   thttpd = callPackage ../servers/http/thttpd { };


### PR DESCRIPTION
Quoting official README,

    The Duckling proxy is a scheme-specific filtering proxy for Gemini clients
    to access the web. It behaves as a normal Gemini server, except it
    retrieves its content from the web.

    You can tailor its behaviour when it starts, to tailor how web pages are
    transformed to gemtext.

    It is scheme-specific, i.e. it is designed to handle HTTP requests only.
    Web pages are translated to text/gemini. Other web resources are returned
    directly.

    The primary intended use case for this proxy is as a personal proxy to make
    the web accessible to your favourite Gemini client.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
