### PR TITLE
tinyssh: init at 20210601-unstable

### DIFF
--- a/pkgs/tools/networking/tinyssh/default.nix
+++ b/pkgs/tools/networking/tinyssh/default.nix
@@ -3,17 +3,21 @@
 stdenv.mkDerivation rec {
   pname = "tinyssh";
   version = "20210601";
+
   src = fetchFromGitHub {
     owner = "janmojzis";
     repo = "tinyssh";
     rev = version;
     sha256 = "sha256-+THoPiD6dW5ZuiQmmLckOJGyjhzdF3qF0DgC51zjGY8=";
   };
+
   preConfigure = ''
     echo /bin       > conf-bin
     echo /share/man > conf-man
   '';
+
   DESTDIR = placeholder "out";
+
   meta = with lib; {
     description = "minimalistic SSH server";
     homepage = "https://tinyssh.org";

--- a/pkgs/tools/networking/tinyssh/default.nix
+++ b/pkgs/tools/networking/tinyssh/default.nix
@@ -1,0 +1,24 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "tinyssh";
+  version = "20210601";
+  src = fetchFromGitHub {
+    owner = "janmojzis";
+    repo = "tinyssh";
+    rev = version;
+    sha256 = "sha256-+THoPiD6dW5ZuiQmmLckOJGyjhzdF3qF0DgC51zjGY8=";
+  };
+  preConfigure = ''
+    echo /bin       > conf-bin
+    echo /share/man > conf-man
+  '';
+  DESTDIR = placeholder "out";
+  meta = with lib; {
+    description = "minimalistic SSH server";
+    homepage = "https://tinyssh.org";
+    license = licenses.publicDomain;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.kaction ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8156,6 +8156,8 @@ with pkgs;
 
   opensm = callPackage ../tools/networking/opensm { };
 
+  tinyssh = callPackage ../tools/networking/tinyssh { };
+
   opensshPackages = dontRecurseIntoAttrs (callPackage ../tools/networking/openssh {});
 
   openssh = opensshPackages.openssh.override {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
