### PR TITLE
python3Packages.pyclip: init at 0.5.4

### DIFF
--- a/pkgs/development/python-modules/pyclip/default.nix
+++ b/pkgs/development/python-modules/pyclip/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, buildPythonPackage
+, pytest
+, xclip
+, xvfb-run
+}:
+
+buildPythonPackage rec {
+  pname = "pyclip";
+  version = "0.5.4";
+
+  src = fetchFromGitHub {
+    owner = "spyoungtech";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "19ff9cgnfx03mbmy5zpbdi986ppx38a5jf97vkqnic4g5sd1qyrn";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace docs/README.md README.md
+  '';
+
+  checkInputs = [ pytest ] ++ lib.optionals stdenv.isLinux [ xclip xvfb-run ];
+
+  checkPhase = ''
+    runHook preCheck
+    ${lib.optionalString stdenv.isLinux "xvfb-run -s '-screen 0 800x600x24'"} pytest tests
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "Cross-platform clipboard utilities supporting both binary and text data";
+    homepage = "https://github.com/spyoungtech/pyclip";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mcaju ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6176,6 +6176,8 @@ in {
 
   pyclimacell = callPackage ../development/python-modules/pyclimacell { };
 
+  pyclip = callPackage ../development/python-modules/pyclip { };
+
   pyclipper = callPackage ../development/python-modules/pyclipper { };
 
   pycm = callPackage ../development/python-modules/pycm { };


### PR DESCRIPTION
###### Motivation for this change
Required by waydroid for sharing the clipboard between host and container.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
