### PR TITLE
perlPackages: version bump IOCompress, CompressRawZlib, CompressRawBzip2

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3540,11 +3540,11 @@ let
 
   CompressRawZlib = buildPerlPackage {
     pname = "Compress-Raw-Zlib";
-    version = "2.096";
+    version = "2.101";
 
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PM/PMQS/Compress-Raw-Zlib-2.096.tar.gz";
-      sha256 = "04jrqvqsa2c655idw7skv5rhb9vx9997h4n9if5p99srq4hblk6d";
+      url = "mirror://cpan/authors/id/P/PM/PMQS/Compress-Raw-Zlib-2.101.tar.gz";
+      sha256 = "1cmb39dw928jssa3fzk4pxb7sw8q1zyx3yikgq01nz17x0ara6wx";
     };
 
     preConfigure = ''

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3501,10 +3501,10 @@ let
 
   CompressRawBzip2 = buildPerlPackage {
     pname = "Compress-Raw-Bzip2";
-    version = "2.096";
+    version = "2.101";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PM/PMQS/Compress-Raw-Bzip2-2.096.tar.gz";
-      sha256 = "1glcjnbqksaviwyrprh9i4dybsb12kzfy0bx932l0xya9riyfr55";
+      url = "mirror://cpan/authors/id/P/PM/PMQS/Compress-Raw-Bzip2-2.101.tar.gz";
+      sha256 = "1n5q01akpsw1skn59c3nivwjfqcn00wzdj8gx4q0wac8sd7i76qc";
     };
 
     # Don't build a private copy of bzip2.

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -10980,10 +10980,10 @@ let
 
   IOCompress = buildPerlPackage {
     pname = "IO-Compress";
-    version = "2.096";
+    version = "2.102";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PM/PMQS/IO-Compress-2.096.tar.gz";
-      sha256 = "9d219fd5df4b490b5d2f847921e3cb1c3392758fa0bae9b05a8992b3620ba572";
+      url = "mirror://cpan/authors/id/P/PM/PMQS/IO-Compress-2.102.tar.gz";
+      sha256 = "193jvi4800cbcac5n1swj9zgwwqck9c47g0g592ldr7fbfd7zynn";
     };
     propagatedBuildInputs = [ CompressRawBzip2 CompressRawZlib ];
     meta = {


### PR DESCRIPTION
###### Summary

Version bump (minor) of `perlPackages.{IOCompress,CompressRawZlib,CompressRawBzip2}`.

`perlPackages.IOCompress`: 2.096 -> 2.102
`perlPackages.CompressRawBzip2`: 2.096 -> 2.101
`perlPackages.CompressRawZlib`: 2.096 -> 2.101

Changelogs contain no notable changes.

###### Motivation for this change

Perl fails on a version check when `Compress::Raw::Zlib` is included by `Compress::Zlib` (part of perl?).

```
Compress::Raw::Zlib version 2.101 required--this is only version 2.096 at /nix/store/ypr273yvmr07n5n1w1gbcqnhpw7lbbvz-perl-5.34.0/lib/perl5/5.34.0/Compress/Zlib.pm line 11.
```

This PR updates `perlPackages.{IOCompress,CompressRawZlib,CompressRawBzip2}` all at once to keep inter-dependencies in check and avoid needlessly rebuilding `libreoffice`.

*Note:* causes rebuild of `libreoffice`, which I cannot build in reasonable time myself. 

##### Reproduce
Somehow I can't reproduce this outside of a derivation being built (perl path issue?).

```
$ cat test.pl 
use Compress::Zlib ;
```

```
with import <nixpkgs> {};
stdenv.mkDerivation {
  pname = "test";
  version = "test";

  src = ./test.pl;

  unpackPhase = ''
    perl $src
  '';

  nativeBuildInputs = with pkgs.perlPackages; [
    perl
    CompressRawZlib
  ];
}
```
```shell
$ nix-build -I nixpkgs=$PWD test.nix 
these derivations will be built:
  /nix/store/c9mdanmivfndnrzkgjvj78s4nilx6sqh-test-test.drv
building '/nix/store/c9mdanmivfndnrzkgjvj78s4nilx6sqh-test-test.drv'...
unpacking sources
Compress::Raw::Zlib version 2.101 required--this is only version 2.096 at /nix/store/ypr273yvmr07n5n1w1gbcqnhpw7lbbvz-perl-5.34.0/lib/perl5/5.34.0/Compress/Zlib.pm line 11.
...
error: build of '/nix/store/c9mdanmivfndnrzkgjvj78s4nilx6sqh-test-test.drv' failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
