### PR TITLE
elan: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/applications/science/logic/elan/default.nix
+++ b/pkgs/applications/science/logic/elan/default.nix
@@ -1,5 +1,4 @@
 { stdenv, lib, runCommand, patchelf, makeWrapper, pkg-config, curl
-, fetchpatch
 , openssl, gmp, zlib, fetchFromGitHub, rustPlatform, libiconv }:
 
 let
@@ -8,16 +7,16 @@ in
 
 rustPlatform.buildRustPackage rec {
   pname = "elan";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "leanprover";
     repo = "elan";
     rev = "v${version}";
-    sha256 = "0xmml81krr0i18b14dymfdq43szpzws7qj8k404qab51lkqxyxsb";
+    sha256 = "0q3gay0j45c6cmykbis14gmc7xm89d0gqyz7lnysl0pgr5k20j6b";
   };
 
-  cargoSha256 = "sha256-xjJ39hoSDn0VUH0YcL+mQBXbzFcIvZ38dPjBxV/yVNc=";
+  cargoSha256 = "1cklpi40fbiwz8m9p0cknmslpj0vwpr0x8j02vam6sng9dsb50i9";
 
   nativeBuildInputs = [ pkg-config makeWrapper ];
 
@@ -41,11 +40,6 @@ rustPlatform.buildRustPackage rec {
        --subst-var dynamicLinker \
        --subst-var libPath
     '')
-    # fix build, will be included in 1.1.1
-    (fetchpatch {
-      url = "https://github.com/leanprover/elan/commit/8d1dec09d67b2ac1768b111d24f1a1cabdd563fa.patch";
-      sha256 = "sha256-yMdnXqycu4VF9EKavZ85EuspvAqvzDSIm5894SB+3+A=";
-    })
   ];
 
   postInstall = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The move to 1.1.0 broke Darwin: the patch introduced during that move is also required on Darwin, but is hidden behind a Linux-specific optional. The patch has since made it upstream, so the easiest fix is simply to upgrade Elan.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
I've built on x86_64-darwin and checked that the resulting `elan --help` and `elan toolchain install stable` runs with output roughly as I would expect; I've done no further testing.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
