### PR TITLE
nix-du: 0.3.3 -> 0.4

### DIFF
--- a/pkgs/tools/package-management/nix-du/default.nix
+++ b/pkgs/tools/package-management/nix-du/default.nix
@@ -1,17 +1,27 @@
-{ lib, stdenv, fetchFromGitHub, rustPlatform, nix, boost, graphviz, Security, pkg-config }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, rustPlatform
+, nix
+, nlohmann_json
+, boost
+, graphviz
+, Security
+, pkg-config
+}:
 
 rustPlatform.buildRustPackage rec {
   pname = "nix-du";
-  version = "0.3.4";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "symphorien";
     repo = "nix-du";
     rev = "v${version}";
-    sha256 = "0iwlprjbphwsrxdhgsxa8ja73snsyh0rdxrpsf1ygid2ky5vc83f";
+    sha256 = "0nl451xfby8krxl2wyn91mm0rvacj1718qbqw6k56dwsqlnnxmx0";
   };
 
-  cargoSha256 = "19fwkw9iswzkhqgfq7pmcabqmq5c7vvirwaxbfjshkwcgn47rgjl";
+  cargoSha256 = "0swdlp3qdisr8gxihg5syplzssggx9avmdb2w70056436046gs1r";
 
   doCheck = true;
   checkInputs = [ nix graphviz ];
@@ -19,6 +29,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [
     boost
     nix
+    nlohmann_json
   ] ++ lib.optionals stdenv.isDarwin [ Security ];
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
support for the up and coming nix 2.4

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
