### PR TITLE
test.trivial-builders: Add test cases, fix test runner, rename

### DIFF
--- a/pkgs/build-support/trivial-builders/test/references-test.sh
+++ b/pkgs/build-support/trivial-builders/test/references-test.sh
@@ -8,11 +8,11 @@
 #
 #  This file can be run independently (quick):
 #
-#      $ pkgs/build-support/trivial-builders/test.sh
+#      $ pkgs/build-support/trivial-builders/references-test.sh
 #
 #  or in the build sandbox with a ~20s VM overhead
 #
-#      $ nix-build -A tests.trivial-builders
+#      $ nix-build -A tests.trivial-builders.references
 #
 # -------------------------------------------------------------------------- #
 
@@ -26,9 +26,15 @@ set -euo pipefail
 cd "$(dirname ${BASH_SOURCE[0]})"  # nixpkgs root
 
 if [[ -z ${SAMPLE:-} ]]; then
-  sample=( `nix-build test/sample.nix` )
-  directRefs=( `nix-build test/invoke-writeDirectReferencesToFile.nix` )
-  references=( `nix-build test/invoke-writeReferencesToFile.nix` )
+  echo "Running the script directly is currently not supported."
+  echo "If you need to iterate, remove the raw path, which is not returned by nix-build."
+  exit 1
+#   sample=( `nix-build --no-out-link sample.nix` )
+#   directRefs=( `nix-build --no-out-link invoke-writeDirectReferencesToFile.nix` )
+#   references=( `nix-build --no-out-link invoke-writeReferencesToFile.nix` )
+#   echo "sample: ${#sample[@]}"
+#   echo "direct: ${#directRefs[@]}"
+#   echo "indirect: ${#references[@]}"
 else
   # Injected by Nix (to avoid evaluating in a derivation)
   # turn them into arrays

--- a/pkgs/build-support/trivial-builders/test/references.nix
+++ b/pkgs/build-support/trivial-builders/test/references.nix
@@ -8,11 +8,11 @@
 #
 #  This file can be run independently (quick):
 #
-#      $ pkgs/build-support/trivial-builders/test.sh
+#      $ pkgs/build-support/trivial-builders/references-test.sh
 #
 #  or in the build sandbox with a ~20s VM overhead
 #
-#      $ nix-build -A tests.trivial-builders
+#      $ nix-build -A tests.trivial-builders.references
 #
 # -------------------------------------------------------------------------- #
 
@@ -33,30 +33,15 @@ nixosTest {
       builtins.toJSON [hello figlet stdenvNoCC]
     );
     environment.variables = {
-      SAMPLE = invokeSamples ./test/sample.nix;
-      REFERENCES = invokeSamples ./test/invoke-writeReferencesToFile.nix;
-      DIRECT_REFS = invokeSamples ./test/invoke-writeDirectReferencesToFile.nix;
+      SAMPLE = invokeSamples ./sample.nix;
+      REFERENCES = invokeSamples ./invoke-writeReferencesToFile.nix;
+      DIRECT_REFS = invokeSamples ./invoke-writeDirectReferencesToFile.nix;
     };
   };
   testScript =
-    let
-      sample = import ./test/sample.nix { inherit pkgs; };
-      samplePaths = lib.unique (lib.attrValues sample);
-      sampleText = pkgs.writeText "sample-text" (lib.concatStringsSep "\n" samplePaths);
-      stringReferencesText =
-        pkgs.writeStringReferencesToFile
-          ((lib.concatMapStringsSep "fillertext"
-            (d: "${d}")
-            (lib.attrValues sample)) + ''
-              STORE=${builtins.storeDir};\nsystemctl start bar-foo.service
-            '');
-    in ''
+    ''
       machine.succeed("""
-        ${./test.sh} 2>/dev/console
-      """)
-      machine.succeed("""
-        echo >&2 Testing string references...
-        diff -U3 <(sort ${stringReferencesText}) <(sort ${sampleText})
+        ${./references-test.sh} 2>/dev/console
       """)
     '';
   meta = {

--- a/pkgs/build-support/trivial-builders/test/sample.nix
+++ b/pkgs/build-support/trivial-builders/test/sample.nix
@@ -1,10 +1,11 @@
-{ pkgs ? import ../../../.. { config = {}; overlays = []; } }:
+{ pkgs ? import ../../../.. { config = { }; overlays = [ ]; } }:
 let
   inherit (pkgs)
     figlet
     zlib
     hello
     writeText
+    runCommand
     ;
 in
 {
@@ -17,7 +18,10 @@ in
   helloRef = writeText "hi" "hello ${hello}";
   helloRefDup = writeText "hi" "hello ${hello}";
   path = ./invoke-writeReferencesToFile.nix;
+  pathLike.outPath = ./invoke-writeReferencesToFile.nix;
   helloFigletRef = writeText "hi" "hello ${hello} ${figlet}";
+  selfRef = runCommand "self-ref-1" {} "echo $out >$out";
+  selfRef2 = runCommand "self-ref-2" {} ''echo "${figlet}, $out" >$out'';
   inherit (pkgs)
     emptyFile
     emptyDirectory

--- a/pkgs/build-support/trivial-builders/test/writeStringReferencesToFile.nix
+++ b/pkgs/build-support/trivial-builders/test/writeStringReferencesToFile.nix
@@ -1,0 +1,18 @@
+{ callPackage, lib, pkgs, runCommand, writeText, writeStringReferencesToFile }:
+let
+  sample = import ./sample.nix { inherit pkgs; };
+  samplePaths = lib.unique (lib.attrValues sample);
+  stri = x: "${x}";
+  sampleText = writeText "sample-text" (lib.concatStringsSep "\n" (lib.unique (map stri samplePaths)));
+  stringReferencesText =
+    writeStringReferencesToFile
+      ((lib.concatMapStringsSep "fillertext"
+        stri
+        (lib.attrValues sample)) + ''
+        STORE=${builtins.storeDir};\nsystemctl start bar-foo.service
+      '');
+in
+runCommand "test-writeStringReferencesToFile" { } ''
+  diff -U3 <(sort ${stringReferencesText}) <(sort ${sampleText})
+  touch $out
+''

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -51,8 +51,11 @@ with pkgs;
 
   cuda = callPackage ./cuda { };
 
-  trivial = callPackage ../build-support/trivial-builders/test.nix {};
-  trivial-overriding = callPackage ../build-support/trivial-builders/test-overriding.nix {};
+  trivial-builders = recurseIntoAttrs {
+    writeStringReferencesToFile = callPackage ../build-support/trivial-builders/test/writeStringReferencesToFile.nix {};
+    references = callPackage ../build-support/trivial-builders/test/references.nix {};
+    overriding = callPackage ../build-support/trivial-builders/test-overriding.nix {};
+  };
 
   writers = callPackage ../build-support/writers/test.nix {};
 }


### PR DESCRIPTION
The writeStringReferencesToFile didn't handle non-unique references
to the same path correctly.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

 - Tidy things up so perhaps it's more obvious where new tests should go.
 - Move things that should not be in a NixOS test out of a NixOS test into a `runCommand` test
 - More test cases!

Successor of #141746

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
