### PR TITLE
gnucash: fix icon loading

### DIFF
--- a/pkgs/applications/office/gnucash/default.nix
+++ b/pkgs/applications/office/gnucash/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, fetchpatch, lib, stdenv, pkg-config, makeWrapper, cmake, gtest
 , boost, icu, libxml2, libxslt, gettext, swig, isocodes, gtk3, glibcLocales
 , webkitgtk, dconf, hicolor-icon-theme, libofx, aqbanking, gwenhywfar, libdbi
-, libdbiDrivers, guile, perl, perlPackages
+, libdbiDrivers, guile, perl, perlPackages, librsvg
 }:
 
 let
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     boost icu libxml2 libxslt gettext isocodes gtk3 glibcLocales
-    webkitgtk dconf libofx aqbanking gwenhywfar libdbi
+    webkitgtk dconf libofx aqbanking gwenhywfar libdbi librsvg
     libdbiDrivers guile
     perlWrapper perl
   ] ++ (with perlPackages; [ FinanceQuote DateManip ]);


### PR DESCRIPTION
gnucash still requires an icon theme to be installed, but at least now
having eg. adwaita installed it'll show the icons

Fixes #55565

### nixpkgs-check report

**version:** `nixpkgs-check v0.1.0` on NixOS 21.05, sandbox = "true"
**packages declared changed:** {"gnucash"}
**manual tests declared performed:**
 * ✔ built on NixOS
 * 😢 not built on MacOS
 * 😢 not built on Other Linux distributions
 * run a version rebased to 21.05 on a 21.05 machine

**complies with contributing.md:** ✔ yes
**package gnucash:** ✔ continued building
**closure size for gnucash:** ✔ stayed constant, at 795.9 MB
**tests of gnucash:** 😢 there are no tests
**binaries of gnucash:**
  * *updated binaries:*
    * ✔ gnc-fq-helper continued running successfully
    * ✔ gnc-fq-dump continued running successfully
    * ✔ gnucash-cli continued running successfully
    * ✔ gnucash continued running successfully
    * ✔ gnc-fq-check continued running successfully