### PR TITLE
python3Packages.{xdis,uncompyle6}: bump to latest to support python 3.8.12

### DIFF
--- a/pkgs/development/python-modules/uncompyle6/default.nix
+++ b/pkgs/development/python-modules/uncompyle6/default.nix
@@ -12,12 +12,12 @@
 
 buildPythonPackage rec {
   pname = "uncompyle6";
-  version = "3.7.4";
+  version = "3.8.0";
   disabled = pythonAtLeast "3.9"; # See: https://github.com/rocky/python-uncompyle6/issues/331
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "af8330861bf940e7a3ae0f06d129b8e645191a36bf73ca15ff51997a837d41f8";
+    sha256 = "sha256-YgYzYY9t/B8+eBh+Igk014/8Y5wOOdrsofxTWquBcBQ=";
   };
 
   checkInputs = [ nose pytest hypothesis six ];

--- a/pkgs/development/python-modules/xdis/default.nix
+++ b/pkgs/development/python-modules/xdis/default.nix
@@ -6,14 +6,14 @@
 
 buildPythonPackage rec {
   pname = "xdis";
-  version = "5.0.11";
+  version = "6.0.2";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "rocky";
     repo = "python-xdis";
     rev = version;
-    sha256 = "sha256-KTPu0+bERLRCVESqJgBPtcftlniWl2+C9GDcf84ssiA=";
+    sha256 = "sha256-P8mUkAO3usFCE+E9cna2x1iA2uyHVPX9FHDpX+kTFWQ=";
   };
 
   checkInputs = [ pytest ];


### PR DESCRIPTION
* xdis needs a bump to support python 3.8.12 (currently in staging-next https://github.com/NixOS/nixpkgs/pull/141684/)
* uncompyle6 needs bump to support newer xdis

###### Motivation for this change



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
