### PR TITLE
buildDotnetModule: add support for running unit tests

### DIFF
--- a/doc/languages-frameworks/dotnet.section.md
+++ b/doc/languages-frameworks/dotnet.section.md
@@ -77,9 +77,13 @@ To package Dotnet applications, you can use `buildDotnetModule`. This has simila
 * `runtimeDeps` is used to wrap libraries into `LD_LIBRARY_PATH`. This is how dotnet usually handles runtime dependencies.
 * `buildType` is used to change the type of build. Possible values are `Release`, `Debug`, etc. By default, this is set to `Release`.
 * `dotnet-sdk` is useful in cases where you need to change what dotnet SDK is being used.
-* `dotnet-runtime` is useful in cases where you need to change what dotnet runtime is being used.
+* `dotnet-runtime` is useful in cases where you need to change what dotnet runtime is being used. This can be either a regular dotnet runtime, or an aspnetcore.
+* `dotnet-test-sdk` is useful in cases where unit tests expect a different dotnet SDK. By default, this is set to the `dotnet-sdk` attribute.
+* `testProjectFile` is useful in cases where the regular project file does not contain the unit tests. By default, this is set to the `projectFile` attribute.
+* `disabledTests` is used to disable running specific unit tests. This gets passed as: `dotnet test --filter "FullyQualifiedName!={}"`, to ensure compatibility with all unit test frameworks.
 * `dotnetRestoreFlags` can be used to pass flags to `dotnet restore`.
 * `dotnetBuildFlags` can be used to pass flags to `dotnet build`.
+* `dotnetTestFlags` can be used to pass flags to `dotnet test`.
 * `dotnetInstallFlags` can be used to pass flags to `dotnet install`.
 * `dotnetFlags` can be used to pass flags to all of the above phases.
 

--- a/pkgs/tools/games/opentracker/default.nix
+++ b/pkgs/tools/games/opentracker/default.nix
@@ -25,9 +25,13 @@ buildDotnetModule rec {
   };
 
   dotnet-runtime = dotnetCorePackages.runtime_3_1;
-  projectFile = "OpenTracker.sln";
   nugetDeps = ./deps.nix;
+
+  projectFile = "OpenTracker.sln";
   executables = [ "OpenTracker" ];
+
+  doCheck = true;
+  dotnet-test-sdk = dotnetCorePackages.sdk_3_1;
 
   nativeBuildInputs = [
     autoPatchelfHook


### PR DESCRIPTION
###### Motivation for this change
`FullyQualifiedName` seems to be the only property supported by all test frameworks, so that's what the `disabledTests` implementation uses (https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-test#filter-option-details).

This all seems to work quite well, all tests for `alttpr-opentracker` succeed:
```
opentracker> Test Run Successful.
opentracker> Total tests: 3451
opentracker> Passed: 3451
opentracker> Total time: 2.1548 Minutes
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
