### PR TITLE
fuzzel: refactor configure options

### DIFF
--- a/pkgs/applications/misc/fuzzel/default.nix
+++ b/pkgs/applications/misc/fuzzel/default.nix
@@ -13,13 +13,15 @@
 , tllist
 , fcft
 , enableCairo ? true
-, withPNGBackend ? "libpng"
-, withSVGBackend ? "librsvg"
-  # Optional dependencies
+, svgSupport ? true
+, pngSupport ? true
+# Optional dependencies
 , cairo
 , librsvg
 , libpng
 }:
+
+assert svgSupport -> enableCairo;
 
 stdenv.mkDerivation rec {
   pname = "fuzzel";
@@ -49,15 +51,15 @@ stdenv.mkDerivation rec {
     tllist
     fcft
   ] ++ lib.optional enableCairo cairo
-  ++ lib.optional (withPNGBackend == "libpng") libpng
-  ++ lib.optional (withSVGBackend == "librsvg") librsvg;
+    ++ lib.optional pngSupport libpng
+    ++ lib.optional svgSupport librsvg;
 
   mesonBuildType = "release";
 
   mesonFlags = [
     "-Denable-cairo=${if enableCairo then "enabled" else "disabled"}"
-    "-Dpng-backend=${withPNGBackend}"
-    "-Dsvg-backend=${withSVGBackend}"
+    "-Dpng-backend=${if pngSupport then "libpng" else "none"}"
+    "-Dsvg-backend=${if svgSupport then "librsvg" else "none"}"
   ];
 
   CFLAGS = "-Wno-error=comment"; # https://gitlab.gnome.org/GNOME/librsvg/-/issues/856

--- a/pkgs/applications/misc/fuzzel/default.nix
+++ b/pkgs/applications/misc/fuzzel/default.nix
@@ -62,8 +62,6 @@ stdenv.mkDerivation rec {
     "-Dsvg-backend=${if svgSupport then "librsvg" else "none"}"
   ];
 
-  CFLAGS = "-Wno-error=comment"; # https://gitlab.gnome.org/GNOME/librsvg/-/issues/856
-
   meta = with lib; {
     description = "Wayland-native application launcher, similar to rofi’s drun mode";
     homepage = "https://codeberg.org/dnkl/fuzzel";


### PR DESCRIPTION
The current configure options exposed emulates the `choices` type of the
SVG and PNG backends from upstream meson_options with a freeform string,
however this is error prone and require accompanying validation which
unnecessarily complicates the derivation. Two alternatives were considered:

1. Splits the possible choices into separate options nad perform assertions to
   ensure only one is selected.
2. Expose a set of sane default configure options, and structure the derivation
   around this subset. Users who wish to customize the choice used can do so
   using `override` or `overrideAttrs`.

Option 1 is not sustainable for large amounts of options which require large
amount of assertions just for ensuring uniqueness of selection, and adds
complexity to the configure phase. Option 2 minimally impairs the customizablity
of the derivation and was chosen in part to address option checking[1].

[1] - https://github.com/NixOS/nixpkgs/pull/141836#discussion_r739910095

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
