### PR TITLE
coreboot-utils: Rework and update to latest release

### DIFF
--- a/pkgs/tools/misc/coreboot-utils/default.nix
+++ b/pkgs/tools/misc/coreboot-utils/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchgit, zlib, pciutils, coreutils, acpica-tools, makeWrapper, gnugrep, gnused, file, buildEnv }:
 
 let
-  version = "4.14";
+  version = "4.15";
 
   commonMeta = with lib; {
     description = "Various coreboot-related tools";
@@ -16,8 +16,8 @@ let
 
     src = fetchgit {
       url = "https://review.coreboot.org/coreboot";
-      rev = version;
-      sha256 = "00xr74yc0kj9rrqa1a8b7bih865qlp9i4zs67ysavkfrjrwwssxm";
+      rev = "18b34f98ba55f10cb7a0d9e8cbbe2b0e3387d843";
+      sha256 = "05vbxnkqnqk77kr1p1xyfs98m34p9jw5v2mvikif7yvnc0cs89sg";
     };
 
     enableParallelBuilding = true;

--- a/pkgs/tools/misc/coreboot-utils/default.nix
+++ b/pkgs/tools/misc/coreboot-utils/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, zlib, pciutils, coreutils, acpica-tools, makeWrapper, gnugrep, gnused, file, buildEnv }:
+{ lib, stdenv, fetchgit, zlib, pciutils, coreutils, acpica-tools, makeWrapper, gnugrep, gnused, file, buildEnv }:
 
 let
   version = "4.14";
@@ -14,9 +14,10 @@ let
   generic = { pname, path ? "util/${pname}", ... }@args: stdenv.mkDerivation (rec {
     inherit pname version;
 
-    src = fetchurl {
-      url = "https://coreboot.org/releases/coreboot-${version}.tar.xz";
-      sha256 = "0viw2x4ckjwiylb92w85k06b0g9pmamjy2yqs7fxfqbmfadkf1yr";
+    src = fetchgit {
+      url = "https://review.coreboot.org/coreboot";
+      rev = version;
+      sha256 = "00xr74yc0kj9rrqa1a8b7bih865qlp9i4zs67ysavkfrjrwwssxm";
     };
 
     enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change
* Use fetchgit instead of fetchurl
* Update to latest release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
