### PR TITLE
shadowsocks-rust: 1.10.7 -> 1.11.2

### DIFF
--- a/pkgs/tools/networking/shadowsocks-rust/default.nix
+++ b/pkgs/tools/networking/shadowsocks-rust/default.nix
@@ -2,28 +2,36 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "shadowsocks-rust";
-  version = "1.10.7";
+  version = "1.11.2";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "shadowsocks";
     repo = pname;
-    sha256 = "08k5j469750bhlq49qc5nwc2jjgmy9qsm58nf2jfwhxlpflv12sc";
+    sha256 = "0ry3zfwxs5j243jpbp5ymnz14ycyk6gpgb50lcazhn1yy52p8wac";
   };
 
-  cargoSha256 = "1r8w5cdygd26m95q9qpqa85aixx25jr510hpjlllbpfvm7zjpbqk";
+  cargoSha256 = "1hvrp3zf5h33j6fgqyzn2jvjbyi8c8pyqwrj5wg3lw38h0z5rvaj";
 
   RUSTC_BOOTSTRAP = 1;
 
   buildInputs = lib.optionals stdenv.isDarwin [ CoreServices libiconv ];
 
-  checkFlags = [ "--skip=http_proxy" "--skip=udp_tunnel" ];
+  # all of these rely on connecting to www.example.com:80
+  checkFlags = [
+    "--skip=http_proxy"
+    "--skip=tcp_tunnel"
+    "--skip=udp_tunnel"
+    "--skip=udp_relay"
+    "--skip=socks4_relay_connect"
+    "--skip=socks5_relay_aead"
+    "--skip=socks5_relay_stream"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/shadowsocks/shadowsocks-rust";
     description = "A Rust port of shadowsocks";
     license = licenses.mit;
     maintainers = [ maintainers.marsam ];
-    broken = stdenv.isAarch64;  # crypto2 crate doesn't build on aarch64
   };
 }


### PR DESCRIPTION
###### Motivation for this change

[New version](https://github.com/shadowsocks/shadowsocks-rust/releases/tag/v1.11.2). Upstream added a few more tests which connect to `www.example.com:80` and won't work without network connection. Also this now successfully builds on `aarch64`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
