### PR TITLE
nixos/zfs: replace parentheses with braces

### DIFF
--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -561,7 +561,8 @@ in
                                   then cfgZfs.requestEncryptionCredentials
                                   else cfgZfs.requestEncryptionCredentials != []) ''
                   ${cfgZfs.package}/sbin/zfs list -rHo name,keylocation ${pool} | while IFS=$'\t' read ds kl; do
-                    (${optionalString (!isBool cfgZfs.requestEncryptionCredentials) ''
+                    {
+                      ${optionalString (!isBool cfgZfs.requestEncryptionCredentials) ''
                          if ! echo '${concatStringsSep "\n" cfgZfs.requestEncryptionCredentials}' | grep -qFx "$ds"; then
                            continue
                          fi
@@ -575,7 +576,8 @@ in
                       * )
                         ${cfgZfs.package}/sbin/zfs load-key "$ds"
                         ;;
-                    esac) < /dev/null # To protect while read ds kl in case anything reads stdin
+                    esac
+                    } < /dev/null # To protect while read ds kl in case anything reads stdin
                   done
                 ''}
                 echo "Successfully imported ${pool}"


### PR DESCRIPTION
The parentheses prevent the `continue` line from working by running the
enclosed in a subshell -- I noticed that ZFS would start asking me for
my password to encrypted child datasets, even though they were not
specified in `requestEncryptionCredentials`. The following logs would
also be present in the import unit's journal:

    Oct 31 22:13:17 host systemd[1]: Starting Import ZFS pool "pool"...
    Oct 31 22:13:44 host zfs-import-pool-start[3711]: importing ZFS pool "pool"...
    Oct 31 22:13:44 host zfs-import-pool-start[4017]:pool/nix/store/39zij3xcxn4w38v6x8f88bx8y91nv0rm-unit-script-zfs-import-pool-start/bin/zfs-import-pool-start: line 31: continue: only meaningful in a `for', `while', or `until' loop
    Oct 31 22:13:44 host zfs-import-pool-start[4020]:pool/nix/store/39zij3xcxn4w38v6x8f88bx8y91nv0rm-unit-script-zfs-import-pool-start/bin/zfs-import-pool-start: line 31: continue: only meaningful in a `for', `while', or `until' loop
    Oct 31 22:15:14 host zfs-import-pool-start[4023]: Failed to query password: Timer expired
    Oct 31 22:15:14 host zfs-import-pool-start[4024]: Key load error: encryption failure
    Oct 31 22:15:14 host systemd[1]: zfs-import-pool.service: Main process exited, code=exited, status=255/EXCEPTION
    Oct 31 22:15:14 host systemd[1]: zfs-import-pool.service: Failed with result 'exit-code'.
    Oct 31 22:15:14 host systemd[1]: Failed to start Import ZFS pool "pool".

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
