### PR TITLE
tenacity: init at 0.0.1

### DIFF
--- a/pkgs/applications/audio/tenacity/default.nix
+++ b/pkgs/applications/audio/tenacity/default.nix
@@ -1,0 +1,148 @@
+{ stdenv
+, lib
+, fetchFromSourcehut
+, cmake
+, wxGTK
+, pkg-config
+, python3
+, gettext
+, glib
+, file
+, lame
+, libvorbis
+, libmad
+, libjack2
+, lv2
+, lilv
+, makeWrapper
+, serd
+, sord
+, sqlite
+, sratom
+, suil
+, alsa-lib
+, libsndfile
+, soxr
+, flac
+, twolame
+, expat
+, libid3tag
+, libopus
+, ffmpeg
+, soundtouch
+, pcre
+, portaudio
+, linuxHeaders
+, at-spi2-core
+, dbus
+, epoxy
+, libXdmcp
+, libXtst
+, libpthreadstubs
+, libselinux
+, libsepol
+, libxkbcommon
+, util-linux
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tenacity";
+  version = "unstable-2021-10-18";
+
+  src = fetchFromSourcehut {
+    owner = "~tenacity";
+    repo = "tenacity";
+    rev = "697c0e764ccb19c1e2f3073ae08ecdac7aa710e4";
+    sha256 = "1fc9xz8lyl8si08wkzncpxq92vizan60c3640qr4kbnxg7vi2iy4";
+  };
+
+  postPatch = ''
+    touch src/RevisionIdent.h
+
+    substituteInPlace src/FileNames.cpp \
+      --replace /usr/include/linux/magic.h ${linuxHeaders}/include/linux/magic.h
+  '';
+
+  postFixup = ''
+    rm $out/tenacity
+    wrapProgram "$out/bin/tenacity" \
+      --suffix AUDACITY_PATH : "$out/share/tenacity" \
+      --suffix AUDACITY_MODULES_PATH : "$out/lib/tenacity/modules" \
+      --prefix LD_LIBRARY_PATH : "$out/lib/tenacity" \
+      --prefix XDG_DATA_DIRS : "$out/share:$GSETTINGS_SCHEMAS_PATH"
+  '';
+
+  NIX_CFLAGS_COMPILE = "-D GIT_DESCRIBE=\"\"";
+
+  # tenacity only looks for ffmpeg at runtime, so we need to link it in manually
+  NIX_LDFLAGS = toString [
+    "-lavcodec"
+    "-lavdevice"
+    "-lavfilter"
+    "-lavformat"
+    "-lavresample"
+    "-lavutil"
+    "-lpostproc"
+    "-lswresample"
+    "-lswscale"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    gettext
+    makeWrapper
+    pkg-config
+    python3
+  ] ++ lib.optionals stdenv.isLinux [
+    linuxHeaders
+  ];
+
+  buildInputs = [
+    alsa-lib
+    expat
+    ffmpeg
+    file
+    flac
+    glib
+    lame
+    libid3tag
+    libjack2
+    libmad
+    libopus
+    libsndfile
+    libvorbis
+    lilv
+    lv2
+    pcre
+    portaudio
+    serd
+    sord
+    soundtouch
+    soxr
+    sqlite
+    sratom
+    suil
+    twolame
+    wxGTK
+    wxGTK.gtk
+  ] ++ lib.optionals stdenv.isLinux [
+    at-spi2-core
+    dbus
+    epoxy
+    libXdmcp
+    libXtst
+    libpthreadstubs
+    libxkbcommon
+    libselinux
+    libsepol
+    util-linux
+  ];
+
+  meta = with lib; {
+    description = "Sound editor with graphical UI";
+    homepage = "https://tenacityaudio.org/";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ irenes lheckemann ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28240,6 +28240,8 @@ with pkgs;
 
   temporal = callPackage ../applications/networking/cluster/temporal { };
 
+  tenacity = callPackage ../applications/audio/tenacity { wxGTK = wxGTK31-gtk3; };
+
   tendermint = callPackage ../tools/networking/tendermint { };
 
   termdbms = callPackage ../development/tools/database/termdbms { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Tenacity is a fork of Audacity, over privacy concerns. I believe it makes sense to have both Audacity and Tenacity in nixpkgs, going forward, so I packaged Tenacity. It is heavily based on the Audacity derivation, but there has already been significant technical divergence and it's clear that there will be more in the future, so I gave it its own directory.

There is not yet any upstream stable release, but the project is in a usable state.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
