### PR TITLE
mtr: fix build against upcoming ncurses-6.3

### DIFF
--- a/pkgs/tools/networking/mtr/default.nix
+++ b/pkgs/tools/networking/mtr/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, autoreconfHook, pkg-config
+{ stdenv, lib, fetchFromGitHub, fetchpatch, autoreconfHook, pkg-config
 , libcap, ncurses
 , withGtk ? false, gtk3 }:
 
@@ -12,6 +12,16 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "0wnz87cr2lcl74bj8qxq9xgai40az3pk9k0z893scyc8svd61xz6";
   };
+
+  patches = [
+    # pull patch to fix build failure against ncurses-6.3:
+    #  https://github.com/traviscross/mtr/pull/411
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/traviscross/mtr/commit/aeb493e08eabcb4e6178bda0bb84e9cd01c9f213.patch";
+      sha256 = "1qk8lf4sha18g36mr84vbdvll2s8khgbzyyq0as3ifx44lv0qlf2";
+    })
+  ];
 
   # we need this before autoreconfHook does its thing
   postPatch = ''


### PR DESCRIPTION
On ncurses-6.3 with extra printf() annotations gcc now detects
use of user input in place of format strings:

    ui/curses.c:765:42:
      error: format not a string literal and no format arguments [-Werror=format-security]
      765 |         mvprintw(rowstat - 1, startstat, msg);
          |                                          ^~~
