### PR TITLE
wine{,64,Wow}Packages: add {stable,unstable,staging}Full

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33028,7 +33028,7 @@ with pkgs;
     inherit wineBuild;
 
     inherit (callPackage ./wine-packages.nix {})
-      minimal base full stable unstable staging fonts;
+      minimal base full stable stableFull unstable unstableFull staging stagingFull fonts;
   });
 
   winePackages = recurseIntoAttrs (winePackagesFor (config.wine.build or "wine32"));

--- a/pkgs/top-level/wine-packages.nix
+++ b/pkgs/top-level/wine-packages.nix
@@ -51,6 +51,11 @@ rec {
   };
 
   stable = base.override { wineRelease = "stable"; };
+  stableFull = full.override { wineRelease = "stable"; };
+
   unstable = base.override { wineRelease = "unstable"; };
+  unstableFull = full.override { wineRelease = "unstable"; };
+
   staging = base.override { wineRelease = "staging"; };
+  stagingFull = full.override { wineRelease = "staging"; };
 }


### PR DESCRIPTION
###### Motivation for this change

Needed for games using 64-bit XACT - can't be installed by Winetricks.

If this is not suitable, an alternative is to add `stagingFull = full.override { wineRelease = "staging"; };`
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
