### PR TITLE
nixos/specialisation: Rephrase in terms of extendModules, noUserModules

### DIFF
--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -51,23 +51,28 @@ let
     };
   };
 
-in rec {
-
-  # Merge the option definitions in all modules, forming the full
-  # system configuration.
-  inherit (lib.evalModules {
+  noUserModules = lib.evalModules {
     inherit prefix check;
-    modules = baseModules ++ extraModules ++ [ pkgsModule ] ++ modules;
+    modules = baseModules ++ extraModules ++ [ pkgsModule ];
     args = extraArgs;
     specialArgs =
       { modulesPath = builtins.toString ../modules; } // specialArgs;
-  }) config options _module type;
+  };
 
   # These are the extra arguments passed to every module.  In
   # particular, Nixpkgs is passed through the "pkgs" argument.
   extraArgs = extraArgs_ // {
-    inherit baseModules extraModules modules;
+    inherit noUserModules baseModules extraModules modules;
   };
+
+in rec {
+
+  # Merge the option definitions in all modules, forming the full
+  # system configuration.
+  inherit (noUserModules.extendModules { inherit modules; })
+    config options _module type;
+
+  inherit extraArgs;
 
   inherit (_module.args) pkgs;
 }

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, modules, baseModules, specialArgs, ... }:
+{ config, lib, pkgs, extendModules, noUserModules, ... }:
 
 with lib;
 
@@ -11,16 +11,10 @@ let
   # you can provide an easy way to boot the same configuration
   # as you use, but with another kernel
   # !!! fix this
-  children = mapAttrs (childName: childConfig:
-      (import ../../../lib/eval-config.nix {
-        inherit lib baseModules specialArgs;
-        system = config.nixpkgs.initialSystem;
-        modules =
-           (optionals childConfig.inheritParentConfig modules)
-        ++ [ ./no-clone.nix ]
-        ++ [ childConfig.configuration ];
-      }).config.system.build.toplevel
-    ) config.specialisation;
+  children =
+    mapAttrs
+      (childName: childConfig: childConfig.configuration.system.build.toplevel)
+      config.specialisation;
 
   systemBuilder =
     let
@@ -176,7 +170,11 @@ in
         </screen>
       '';
       type = types.attrsOf (types.submodule (
-        { ... }: {
+        local@{ ... }: let
+          extend = if local.config.inheritParentConfig
+            then extendModules
+            else noUserModules.extendModules;
+        in {
           options.inheritParentConfig = mkOption {
             type = types.bool;
             default = true;
@@ -185,7 +183,15 @@ in
 
           options.configuration = mkOption {
             default = {};
-            description = "Arbitrary NixOS configuration options.";
+            description = ''
+              Arbitrary NixOS configuration.
+
+              Anything you can add to a normal NixOS configuration, you can add
+              here, including imports and config values, although nested
+              specialisations will be ignored.
+            '';
+            visible = "shallow";
+            inherit (extend { modules = [ ./no-clone.nix ]; }) type;
           };
         })
       );


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

By using the new extendModules function #143207 to produce the specialisations,
we avoid reimplementing the eval-config.nix logic in reverse and fix
cross compilation support for specialisations in the process.

This does change the order of the modules, leading to ordering changes in list-typed options such as `environment.systemPackages`. This is a slight conceptual flaw in the module system, but at least some of us are aware of the potential issue and others have been saved by the fact that in many cases the order does not matter.
Normally I would consider this an acceptable change when refactoring, but I'm a little hesitant to do it right now, considering the imminent 21.11 branch-off.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
