### PR TITLE
teach buildLinux some version magic

### DIFF
--- a/lib/kernel.nix
+++ b/lib/kernel.nix
@@ -23,4 +23,20 @@ with lib;
     whenBetween = verLow: verHigh: mkIf (versionAtLeast version verLow && versionOlder version verHigh);
   };
 
+  # Normalize kernel versions as appropriate for modDirVersion
+  versionToModDir = version:
+    let parts = splitVersion version;
+    in
+      if length parts >= 3
+      then version
+      else if length parts == 2
+      then let
+          maj = builtins.elemAt parts 0;
+          rem = splitString "-" (builtins.elemAt parts 1);
+          min = builtins.head rem;
+          postfix = builtins.concatStringsSep "-" (builtins.tail rem);
+        in builtins.concatStringsSep "." [ maj min "0" ]
+          + (if postfix != "" then "-${postfix}" else "")
+      else throw "versionToModDir: ${version} invalid";
+
 }

--- a/lib/kernel.nix
+++ b/lib/kernel.nix
@@ -25,7 +25,7 @@ with lib;
 
   # Normalize kernel versions as appropriate for modDirVersion
   versionToModDir = version:
-    let parts = splitVersion version;
+    let parts = splitString "." version;
     in
       if length parts >= 3
       then version
@@ -37,6 +37,6 @@ with lib;
           postfix = builtins.concatStringsSep "-" (builtins.tail rem);
         in builtins.concatStringsSep "." [ maj min "0" ]
           + (if postfix != "" then "-${postfix}" else "")
-      else throw "versionToModDir: ${version} invalid";
+      else throw "versionToModDir: don't know how to normalize version: ${version}";
 
 }

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -28,7 +28,8 @@
  structuredExtraConfig ? {}
 
 , # The version number used for the module directory
-  modDirVersion ? version
+  # needs to be x.y.z, will automatically add .0 if needed
+  modDirVersion ? lib.kernel.versionToModDir version
 
 , # An attribute set whose attributes express the availability of
   # certain features in this kernel.  E.g. `{iwlwifi = true;}'
@@ -181,7 +182,10 @@ let
   }; # end of configfile derivation
 
   kernel = (callPackage ./manual-config.nix { inherit buildPackages;  }) {
-    inherit version modDirVersion src kernelPatches randstructSeed lib stdenv extraMakeFlags extraMeta configfile;
+    inherit version modDirVersion src kernelPatches randstructSeed lib stdenv extraMakeFlags configfile;
+
+    # branchVersion needs to be x.y
+    extraMeta = { branch = lib.versions.majorMinor version; } // extraMeta;
 
     config = { CONFIG_MODULES = "y"; CONFIG_FW_LOADER = "m"; };
   };


### PR DESCRIPTION
###### Motivation for this change
This is more of an RFC at the moment. I would like to hear some opinions on whether this is a good idea, and why it wasn't done like that before.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
