### PR TITLE
qtwayland: include screenAdded behavior patch for KDE

### DIFF
--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -121,6 +121,14 @@ let
     qtdeclarative = [ ./qtdeclarative.patch ];
     qtscript = [ ./qtscript.patch ];
     qtserialport = [ ./qtserialport.patch ];
+    qtwayland = [
+      # Fix KDE behavior when re-plugging the only primary display under wayland.
+      (fetchpatch {
+        name = "qtwayland-announce-an-output-after-receiving-more-complete-state.patch";
+        url = "https://invent.kde.org/qt/qt/qtwayland/-/commit/d5186701e27ad6f09f3944809cec2a25c5328026.patch";
+        sha256 = "sha256-kixkhIf8c1e9vvzK2TXvpmWjftgeEa0HmNSEvswO/Oo=";
+      })
+    ];
     qtwebengine = [
       # Fix invisible fonts with glibc 2.33: https://github.com/NixOS/nixpkgs/issues/131074
       (fetchpatch {


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Without this patch, KDE lockscreen and menu will disappear when re-plugging the only primary display under wayland.

Tested `plasmashell` and `kscreenlocker`. They are fixed with this patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
