### PR TITLE
python3Packages.qutip: init at 4.6.2

### DIFF
--- a/pkgs/development/python-modules/qutip/default.nix
+++ b/pkgs/development/python-modules/qutip/default.nix
@@ -1,0 +1,57 @@
+{ lib, stdenv, fetchFromGitHub, buildPythonPackage, python, packaging, numpy
+, cython, scipy, matplotlib, pytestCheckHook, pytest-rerunfailures }:
+
+buildPythonPackage rec {
+  pname = "qutip";
+  version = "4.6.2";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "04g7ixq1yrrid4lliqbcamnzyw5r0fjbl8ipklps234hvsjfwmxb";
+  };
+
+  # QuTiP says it needs specific (old) Numpy versions. We overwrite them here
+  # as the tests work perfectly fine with up-to-date packages.
+  postPatch = ''
+    substituteInPlace setup.cfg --replace "numpy>=1.16.6,<1.20" "numpy>=1.16.6"
+  '';
+
+  # Disabling OpenMP support on Darwin.
+  setupPyGlobalFlags = lib.optional (!stdenv.isDarwin) "--with-openmp";
+
+  propagatedBuildInputs = [
+    packaging
+    numpy
+    cython
+    scipy
+    matplotlib
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-rerunfailures
+  ];
+
+  # - QuTiP tries to access the home directory to create an rc file for us.
+  # This of course fails and therefore, we provide a writable temp dir as HOME.
+  # - We need to go to another directory to run the tests from there.
+  # This is due to the Cython-compiled modules not being in the correct location
+  # of the source tree.
+  # - For running tests, see:
+  # https://qutip.org/docs/latest/installation.html#verifying-the-installation
+  checkPhase = ''
+    export OMP_NUM_THREADS=$NIX_BUILD_CORES
+    export HOME=$(mktemp -d)
+    mkdir -p test && cd test
+    ${python.interpreter} -c "import qutip.testing; qutip.testing.run()"
+  '';
+
+  meta = with lib; {
+    description = "Open-source software for simulating the dynamics of closed and open quantum systems";
+    homepage = "https://qutip.org/";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.fabiangd ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7894,6 +7894,8 @@ in {
 
   queuelib = callPackage ../development/python-modules/queuelib { };
 
+  qutip = callPackage ../development/python-modules/qutip { };
+
   qmk-dotty-dict = callPackage ../development/python-modules/qmk-dotty-dict { };
 
   r2pipe = callPackage ../development/python-modules/r2pipe { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

QuTiP is a quite renowned quantum simulation library in Python. There is a stale attempt of getting it into nixpkgs (#103412), this is using the up-to-date version and has the checks fixed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
