### PR TITLE
backscrub: init at 0.3.0 (WIP)

### DIFF
--- a/pkgs/applications/video/backscrub/default.nix
+++ b/pkgs/applications/video/backscrub/default.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, opencv
+, cmake
+, tensorflow-lite
+, flatbuffers
+, abseil-cpp
+}:
+stdenv.mkDerivation rec{
+  pname = "backscrub";
+  version = "0.3.0";
+  src = fetchFromGitHub {
+    repo = pname;
+    owner = "floe";
+    rev = "v${version}";
+    sha256 = "sha256-ad5arFE8JdouWvrjCwYPO34X+sDixwGfQnEUA2FUV2s=";
+    fetchSubmodules = true;
+  };
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ opencv tensorflow-lite ];
+  # dontConfigure = true;
+
+  postPatch =
+    ''
+      # mkdir -p tensorflow/tensorflow
+      # cp -a ${tensorflow-lite.src}/* tensorflow
+      pushd tensorflow
+      ${lib.strings.concatMapStringsSep "\n" (patch:"patch -p1 < ${patch}") tensorflow-lite.patches}
+      ${tensorflow-lite.postPatch}
+      ${tensorflow-lite.preBuild}
+      popd
+    '';
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1319,6 +1319,8 @@ with pkgs;
 
   automirror = callPackage ../tools/misc/automirror { };
 
+  backscrub= callPackage ../applications/video/backscrub {};
+
   barman = python3Packages.callPackage ../tools/misc/barman { };
 
   base16-universal-manager = callPackage ../applications/misc/base16-universal-manager { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
A virtual background program for linux

###### Things done

Building fails with
```
nix log /nix/store/k4yl5pz54qk1bq2k1xpn0w029pa78f8n-backscrub-0.3.0.drv
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking sources
unpacking source archive /nix/store/q4cc18jiamzz50i98anhl90hwsyrb4h3-source
source root is source
@nix { "action": "setPhase", "phase": "patchPhase" }
patching sources
/build/source/tensorflow /build/source
patching file tensorflow/lite/tools/make/Makefile
Hunk #1 succeeded at 139 with fuzz 1 (offset -1 lines).
patching file tensorflow/lite/tools/make/Makefile
Hunk #1 succeeded at 138 with fuzz 2 (offset -1 lines).
patching file tensorflow/lite/tools/make/Makefile
/build/source
@nix { "action": "setPhase", "phase": "configurePhase" }
configuring
fixing cmake files...
cmake flags: -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_SKIP_BUILD_RPATH=ON -DBUILD_TESTING=OFF -DCMAKE_INSTALL_LOCALEDIR=/nix/store/lv5ds11qy0himqxy83i2pdvrm1cfdmlx-backscrub-0.3.0/share/locale -DCMAKE_INSTALL_LIBEXECDIR=/nix/store/lv5ds11qy0himqxy83i2pdvrm1cfdmlx-backscrub-0.3.0/libexec -DCMAKE_INSTALL_LIBDIR=/nix/store/lv5ds11qy0himqxy83i2pdvrm1cfdmlx-backscrub-0.3.0/lib -DCMAKE_INSTALL_DOCDIR=/nix/store/lv5ds11qy0himqxy83i2pdvrm1cfdmlx-backscrub-0.3.0/share/doc/backscrub -DCMAKE_INSTALL_INFODIR=/nix/store/lv5ds11qy0himqxy83i2pdvrm1cfdmlx-backscrub-0.3.0/share/info -DCMAKE_INSTALL_MANDIR=/nix/store/lv5ds11qy0himqxy83i2pdvrm1cfdmlx-backscrub-0.3.0/share/man -DCMAKE_INSTALL_OLDINCLUDEDIR=/nix/store/lv5ds11qy0himqxy83i2pdvrm1cfdmlx-backscrub-0.3.0/include -DCMAKE_INSTALL_INCLUDEDIR=/nix/store/lv5ds11qy0himqxy83i2pdvrm1cfdmlx-backscrub-0.3.0/include -DCMAKE_INSTALL_SBINDIR=/nix/store/lv5ds11qy0himqxy83i2pdvrm1cfdmlx-backscrub-0.3.0/sbin -DCMAKE_INSTALL_BINDIR=/nix/store/lv5ds11qy0himqxy83i2pdvrm1cfdmlx-backscrub-0.3.0/bin -DCMAKE_INSTALL_NAME_DIR=/nix/store/lv5ds11qy0himqxy83i2pdvrm1cfdmlx-backscrub-0.3.0/lib -DCMAKE_POLICY_DEFAULT_CMP0025=NEW -DCMAKE_OSX_SYSROOT= -DCMAKE_FIND_FRAMEWORK=LAST -DCMAKE_STRIP=/nix/store/hy3lz2vfv9qq2v5jz9nzlx6mmiaq79rj-binutils-2.35.1/bin/strip -DCMAKE_RANLIB=/nix/store/hy3lz2vfv9qq2v5jz9nzlx6mmiaq79rj-binutils-2.35.1/bin/ranlib -DCMAKE_AR=/nix/store/hy3lz2vfv9qq2v5jz9nzlx6mmiaq79rj-binutils-2.35.1/bin/ar -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_INSTALL_PREFIX=/build/source/tensorflow/tensorflow/lite/tools/make/downloads  
-- The CXX compiler identification is GNU 10.3.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /nix/store/qvv5y4fx4x879rbsbs4g27mypl9wxbb9-gcc-wrapper-10.3.0/bin/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Could NOT find Git (missing: GIT_EXECUTABLE) 
Version: v0.2.0-no-git
-- Found OpenCV: / (found version "4.5.2") found components: core imgproc imgcodecs video videoio highgui 
-- The C compiler identification is GNU 10.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /nix/store/qvv5y4fx4x879rbsbs4g27mypl9wxbb9-gcc-wrapper-10.3.0/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
CMake Error at /nix/store/p1lk3bb1wzyn5v3nw8nyxrc44iy60vwk-cmake-3.19.7/share/cmake-3.19/Modules/ExternalProject.cmake:2542 (message):
  error: could not find git for clone of abseil-cpp-populate
Call Stack (most recent call first):
  /nix/store/p1lk3bb1wzyn5v3nw8nyxrc44iy60vwk-cmake-3.19.7/share/cmake-3.19/Modules/ExternalProject.cmake:3430 (_ep_add_download_command)
  CMakeLists.txt:13 (ExternalProject_Add)


-- Configuring incomplete, errors occurred!
See also "/build/source/build/_deps/abseil-cpp-subbuild/CMakeFiles/CMakeOutput.log".

CMake Error at /nix/store/p1lk3bb1wzyn5v3nw8nyxrc44iy60vwk-cmake-3.19.7/share/cmake-3.19/Modules/FetchContent.cmake:977 (message):
  CMake step for abseil-cpp failed: 1
Call Stack (most recent call first):
  /nix/store/p1lk3bb1wzyn5v3nw8nyxrc44iy60vwk-cmake-3.19.7/share/cmake-3.19/Modules/FetchContent.cmake:1118:EVAL:2 (__FetchContent_directPopulate)
  /nix/store/p1lk3bb1wzyn5v3nw8nyxrc44iy60vwk-cmake-3.19.7/share/cmake-3.19/Modules/FetchContent.cmake:1118 (cmake_language)
  tensorflow/tensorflow/lite/tools/cmake/modules/OverridableFetchContent.cmake:531 (FetchContent_Populate)
  tensorflow/tensorflow/lite/tools/cmake/modules/abseil-cpp.cmake:34 (OverridableFetchContent_Populate)
  tensorflow/tensorflow/lite/tools/cmake/modules/absl-config.cmake:18 (include)
  tensorflow/tensorflow/lite/CMakeLists.txt:128 (find_package)


-- Configuring incomplete, errors occurred!
See also "/build/source/build/CMakeFiles/CMakeOutput.log".
```

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
