### PR TITLE
gnat: 9 -> 11; update AdaCore packages

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -1241,6 +1241,13 @@ Superuser created successfully.
           <literal>services.ddclient.passwordFile</literal>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          The default GNAT version has been changed: The
+          <literal>gnat</literal> attribute now points to
+          <literal>gnat11</literal> instead of <literal>gnat9</literal>.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-21.11-notable-changes">

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -379,6 +379,9 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The `services.ddclient.password` option was removed, and replaced with `services.ddclient.passwordFile`.
 
+- The default GNAT version has been changed: The `gnat` attribute now points to `gnat11`
+  instead of `gnat9`.
+
 ## Other Notable Changes {#sec-release-21.11-notable-changes}
 
 

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
@@ -36,14 +36,16 @@ self: let
     inherit (self) emacs;
   };
 
+  # Use custom elpa url fetcher with fallback/uncompress
+  fetchurl = buildPackages.callPackage ./fetchelpa.nix { };
+
   generateElpa = lib.makeOverridable ({
     generated ? ./elpa-generated.nix
   }: let
 
     imported = import generated {
       callPackage = pkgs: args: self.callPackage pkgs (args // {
-        # Use custom elpa url fetcher with fallback/uncompress
-        fetchurl = buildPackages.callPackage ./fetchelpa.nix { };
+        inherit fetchurl;
       });
     };
 
@@ -69,12 +71,7 @@ self: let
         dontUnpack = false;
         srcs = [
           super.ada-mode.src
-          # ada-mode needs a specific version of wisi, check NEWS or ada-mode's
-          # package-requires to find the version to use.
-          (pkgs.fetchurl {
-            url = "https://elpa.gnu.org/packages/wisi-3.1.3.tar.lz";
-            sha256 = "18dwcc0crds7aw466vslqicidlzamf8avn59gqi2g7y2x9k5q0as";
-          })
+          self.wisi.src
         ];
 
         sourceRoot = "ada-mode-${self.ada-mode.version}";

--- a/pkgs/development/compilers/ghdl/default.nix
+++ b/pkgs/development/compilers/ghdl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, callPackage, gnat, zlib, llvm, lib
+{ stdenv, fetchFromGitHub, fetchpatch, callPackage, gnat, zlib, llvm, lib
 , backend ? "mcode" }:
 
 assert backend == "mcode" || backend == "llvm";
@@ -13,6 +13,15 @@ stdenv.mkDerivation rec {
     rev    = "v${version}";
     sha256 = "1gyh0xckwbzgslbpw9yrpj4gqs9fm1a2qpbzl0sh143fk1kwjlly";
   };
+
+  patches = [
+    # Allow compilation with GNAT 11, picked from master
+    (fetchpatch {
+      name = "fix-gnat-11-compilation.patch";
+      url = "https://github.com/ghdl/ghdl/commit/8356ea3bb4e8d0e5ad8638c3d50914b64fc360ec.patch";
+      sha256 = "04pzn8g7xha8000wbjjmry6h1grfqyn3bjvj47hi4qwgl21wfjra";
+    })
+  ];
 
   LIBRARY_PATH = "${stdenv.cc.libc}/lib";
 

--- a/pkgs/development/libraries/ada/gnatcoll/bindings.nix
+++ b/pkgs/development/libraries/ada/gnatcoll/bindings.nix
@@ -68,13 +68,13 @@ stdenv.mkDerivation rec {
 
   buildPhase = ''
     runHook preBuild
-    python3 ${component}/setup.py build --prefix $out $buildFlags
+    ${python3.interpreter} ${component}/setup.py build --prefix $out $buildFlags
     runHook postBuild
   '';
 
   installPhase = ''
     runHook preInstall
-    python3 ${component}/setup.py install --prefix $out
+    ${python3.interpreter} ${component}/setup.py install --prefix $out
     runHook postInstall
   '';
 

--- a/pkgs/development/libraries/ada/gnatcoll/bindings.nix
+++ b/pkgs/development/libraries/ada/gnatcoll/bindings.nix
@@ -33,13 +33,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "gnatcoll-${component}";
-  version = "21.0.0";
+  version = "22.0.0";
 
   src = fetchFromGitHub {
     owner = "AdaCore";
     repo = "gnatcoll-bindings";
     rev = "v${version}";
-    sha256 = "1214hf0m8iz289rjpxdiddnixj65l2xjwbcr7mq5ysbddmig5992";
+    sha256 = "0wbwnd6jccwfd4jdxbnzhc0jhm8ad4phz6y9b1gk8adykkk6jcz4";
   };
 
   patches = [
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
 
   buildPhase = ''
     runHook preBuild
-    python3 ${component}/setup.py build $buildFlags
+    python3 ${component}/setup.py build --prefix $out $buildFlags
     runHook postBuild
   '';
 

--- a/pkgs/development/libraries/ada/gnatcoll/core.nix
+++ b/pkgs/development/libraries/ada/gnatcoll/core.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnatcoll-core";
-  version = "21.0.0";
+  version = "22.0.0";
 
   src = fetchFromGitHub {
     owner = "AdaCore";
     repo = "gnatcoll-core";
     rev = "v${version}";
-    sha256 = "0jgs2299zfbr6jg5bxlhqizi60si2m8vw7zq6ns4yhr38qqdskqg";
+    sha256 = "0fn28dp6bgpp1sshr09m1x85g2gx11xqkiy410hiicfyg5hamh1l";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/ada/gnatcoll/db.nix
+++ b/pkgs/development/libraries/ada/gnatcoll/db.nix
@@ -51,13 +51,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "gnatcoll-${component}";
-  version = "21.0.0";
+  version = "22.0.0";
 
   src = fetchFromGitHub {
     owner = "AdaCore";
     repo = "gnatcoll-db";
     rev = "v${version}";
-    sha256 = "0fdfng3yfy645nlw8l3c2za0zkn6pdhkvyrw20wnjx4k26glgb6r";
+    sha256 = "1c39yg13faadg5mzpq3s83rn24npmpc4yjj0cvj7kqwpqxci4m55";
   };
 
   patches = lib.optionals (component == "sqlite") [

--- a/pkgs/development/libraries/ada/xmlada/default.nix
+++ b/pkgs/development/libraries/ada/xmlada/default.nix
@@ -9,14 +9,14 @@
 
 stdenv.mkDerivation rec {
   pname = "xmlada";
-  version = "21.0.0";
+  version = "22.0.0";
 
   src = fetchFromGitHub {
     name = "xmlada-${version}-src";
     owner = "AdaCore";
     repo = "xmlada";
     rev = "v${version}";
-    sha256 = "00vljkvck951nj853v9sda5qbfm1mp8y2k61ja2595rmp8qcrazw";
+    sha256 = "1pg6m0sfc1vwvd18r80jv2vwrsb2qgvyl8jmmrmpbdni0npx0kv3";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/build-managers/gprbuild/boot.nix
+++ b/pkgs/development/tools/build-managers/gprbuild/boot.nix
@@ -7,13 +7,13 @@
 }:
 
 let
-  version = "21.0.0";
+  version = "22.0.0";
 
   gprConfigKbSrc = fetchFromGitHub {
     name = "gprconfig-kb-${version}-src";
     owner = "AdaCore";
     repo = "gprconfig_kb";
-    rev = "v${version}";
+    rev = "v21.0.0"; # TODO(@sternenseemann): no 22.0.0 yet
     sha256 = "11qmzfdd0ipmhxl4k2hjidqc9i40bywrfkbiivd3lhscxca5pxpg";
   };
 in
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
     owner = "AdaCore";
     repo = "gprbuild";
     rev = "v${version}";
-    sha256 = "1knpwasbrz6sxh3dhkc4izchcz4km04j77r4vxxhi23fbd8v1ynj";
+    sha256 = "0rv0ha0kxzab5hhv0jzkjkmchhlvlx8fci8xalnngrgb9nd4r3v8";
   };
 
   nativeBuildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11847,8 +11847,7 @@ with pkgs;
     inherit (gnome2) libart_lgpl;
   });
 
-  # aarch64-darwin doesn't support earlier gcc
-  gnat = if (stdenv.isDarwin && stdenv.isAarch64) then gnat11 else gnat9;
+  gnat = gnat11;
 
   gnat6 = wrapCC (gcc6.cc.override {
     name = "gnat";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* Closes #143714.

* GNAT 11 is now required to build AdaCore's packages and we can also compile everything in nixpkgs so far using it, so we may as well upgrade to the latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
