### PR TITLE
nixos/testing-python: Avoid infinite recursion in node definitions

### DIFF
--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -101,7 +101,6 @@ rec {
 
   # Generate convenience wrappers for running the test driver
   # has vlans, vms and test script defaulted through env variables
-  # also instantiates test script with nodes, if it's a function (contract)
   setupDriverForTest = {
       testScript
     , testName
@@ -143,12 +142,6 @@ rec {
         (node: builtins.match "^[A-z_]([A-z0-9_]+)?$" node == null)
         nodeHostNames;
 
-      testScript' =
-        # Call the test script with the computed nodes.
-        if lib.isFunction testScript
-        then testScript { inherit nodes; }
-        else testScript;
-
     in
     if lib.length invalidNodeNames > 0 then
       throw ''
@@ -161,9 +154,8 @@ rec {
       ''
     else lib.warnIf skipLint "Linting is disabled" (runCommand testDriverName
       {
-        inherit testName;
+        inherit testName testScript;
         nativeBuildInputs = [ makeWrapper ];
-        testScript = testScript';
         preferLocalBuild = true;
         passthru = passthru // {
           inherit nodes;
@@ -207,14 +199,16 @@ rec {
     , ...
     } @ t:
     let
-      nodes = qemu_pkg:
-        let
-          testScript' =
-            # Call the test script with the computed nodes.
-            if lib.isFunction testScript
-            then testScript { nodes = nodes qemu_pkg; }
-            else testScript;
+      # Instantiates test script with nodes, if it's a function (contract)
+      mkTestScript = qemu_pkg:
+        # Call the test script with the computed nodes.
+        if lib.isFunction testScript
+        then testScript { nodes = nodes qemu_pkg false; }
+        else testScript;
 
+      nodes = qemu_pkg: addAdditionalPaths:
+        let
+          testScript' = mkTestScript qemu_pkg;
           build-vms = import ./build-vms.nix {
             inherit system lib pkgs minimal specialArgs;
             extraConfigurations = extraConfigurations ++ [(
@@ -231,17 +225,9 @@ rec {
                 # copied to the image.
                 virtualisation.additionalPaths =
                   lib.optional
-                    # A testScript may evaluate nodes, which has caused
-                    # infinite recursions. The demand cycle involves:
-                    #   testScript -->
-                    #   nodes -->
-                    #   toplevel -->
-                    #   additionalPaths -->
-                    #   hasContext testScript' -->
-                    #   testScript (ad infinitum)
-                    # If we don't need to build an image, we can break this
-                    # cycle by short-circuiting when useNixStoreImage is false.
-                    (config.virtualisation.useNixStoreImage && builtins.hasContext testScript')
+                    (config.virtualisation.useNixStoreImage
+                     && addAdditionalPaths
+                     && builtins.hasContext testScript')
                     (pkgs.writeStringReferencesToFile testScript');
 
                 # Ensure we do not use aliases. Ideally this is only set
@@ -256,16 +242,18 @@ rec {
           );
 
       driver = setupDriverForTest {
-        inherit testScript enableOCR skipLint passthru;
+        inherit enableOCR skipLint passthru;
+        testScript = mkTestScript pkgs.qemu_test;
         testName = name;
         qemu_pkg = pkgs.qemu_test;
-        nodes = nodes pkgs.qemu_test;
+        nodes = nodes pkgs.qemu_test true;
       };
       driverInteractive = setupDriverForTest {
-        inherit testScript enableOCR skipLint passthru;
+        inherit enableOCR skipLint passthru;
+        testScript = mkTestScript pkgs.qemu;
         testName = name;
         qemu_pkg = pkgs.qemu;
-        nodes = nodes pkgs.qemu;
+        nodes = nodes pkgs.qemu true;
       };
 
       test =


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This is a follow-up to #140792 and #144014.

#144014 solves the infinite recursion issue when `useNixStoreImage` is `false`. This follow-up solves it in the general case by passing a version of the nodes without `additionalPaths` to `testScript`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
