### PR TITLE
fortran-language-server: init at 1.12.0

### DIFF
--- a/pkgs/development/tools/fortran-language-server/default.nix
+++ b/pkgs/development/tools/fortran-language-server/default.nix
@@ -1,0 +1,21 @@
+{ lib, fetchPypi, buildPythonApplication }:
+
+buildPythonApplication rec {
+  pname = "fortran-language-server";
+  version = "1.12.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "7Dkh7yPX4rULkzfJFxg47YxrCaxuHk+k3TOINHS9T5A=";
+  };
+
+  checkPhase = "$out/bin/fortls --help 1>/dev/null";
+  pythonImportsCheck = [ "fortls" ];
+
+  meta = with lib; {
+    description = "FORTRAN Language Server for the Language Server Protocol";
+    homepage = "https://pypi.org/project/fortran-language-server/";
+    license = [ licenses.mit ];
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14439,6 +14439,8 @@ with pkgs;
 
   fprettify = callPackage ../development/tools/fprettify { };
 
+  fortran-language-server = python3.pkgs.callPackage ../development/tools/fortran-language-server { };
+
   framac = callPackage ../development/tools/analysis/frama-c { };
 
   frame = callPackage ../development/libraries/frame { };


### PR DESCRIPTION
###### Motivation for this change
Adds the Fortran-Language-Server, which adds editor integration for Fortran developers.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
