### PR TITLE
Add filebeat service

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -443,6 +443,7 @@
   ./services/hardware/xow.nix
   ./services/logging/SystemdJournal2Gelf.nix
   ./services/logging/awstats.nix
+  ./services/logging/filebeat.nix
   ./services/logging/fluentd.nix
   ./services/logging/graylog.nix
   ./services/logging/heartbeat.nix

--- a/nixos/modules/services/logging/filebeat.nix
+++ b/nixos/modules/services/logging/filebeat.nix
@@ -1,0 +1,74 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.filebeat;
+
+  filebeatYml = pkgs.writeText "filebeat.yml" ''
+    ${cfg.extraConfig}
+  '';
+
+  # This is extremely ugly.
+  # Using `.out` here pulls in all source code of all recursive go
+  # dependencies of filebeat.
+  # We do this so that filebeat can find `filebeat.template.json`
+  # (and other files that for the Debian bindist would be in /etc/filebeat).
+  # Unfortunately it's not clear how we can add them to the `buildGoPackage`
+  # that creates `pkgs.filebeat`, and it is also not clear how we can
+  # determine from the filebeat source code which files we have to copy.
+  configDir = "${pkgs.filebeat.out}/share/go/src/github.com/elastic/beats/filebeat";
+in
+{
+  options = {
+
+    services.filebeat = {
+
+      enable = mkEnableOption "filebeat";
+
+      stateDir = mkOption {
+        type = types.str;
+        default = "/var/lib/filebeat";
+        description = "The state directory. filebeat's own logs and other data are stored here.";
+      };
+
+      extraConfig = mkOption {
+        type = types.lines;
+        # TODO: Update this examples, `filebeat.prospectors` has been renamed
+        #       to `inputs` in filebeat 6.3, see:
+        #       https://discuss.elastic.co/t/filebeat-prospectors-has-been-removed/205563
+        default = ''
+          filebeat.prospectors:
+          - type: log
+            enabled: true
+            paths:
+            - /var/log/*.log
+        '';
+        description = "Any other configuration options you want to add";
+      };
+
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    systemd.services.filebeat = with pkgs; {
+      description = "filebeat log shipper";
+      wantedBy = [ "multi-user.target" ];
+      preStart = ''
+        mkdir -p "${cfg.stateDir}"/{data,logs}
+        chown nobody:nogroup "${cfg.stateDir}"/{data,logs}
+      '';
+      serviceConfig = {
+        # TODO: Don't run filebeat as root.
+        # Right now we do it so that it can read any program's logs.
+        # But we might do it in a more restrictive fashion by adding a filebeat
+        # user and ACLs for specific log files, e.g. as described here:
+        #   https://discuss.elastic.co/t/filebeat-as-a-non-root-user/58946
+        # User = "...";
+        PermissionsStartOnly = true; # so `preStart` can create the dirs, even when we're not running as root
+        ExecStart = ''${pkgs.filebeat}/bin/filebeat -c "${filebeatYml}" -path.data "${cfg.stateDir}/data" -path.logs "${cfg.stateDir}/logs" -path.config "${configDir}"'';
+      };
+    };
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Upstreaming the `filebeat` service I wrote (but currently don't use, as we're currently using Grafana + Loki).

I wrote it for an older version of `filebeat`, so the example is out of date.

The running as `root` is ugly but probably OK, but the `nobody:nogroup` approach might not be the best way to do it any more.

I'd be happy if somebody else who cares about `filebeat` could pick this up, thus makng this a draft PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- module-only change
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
