### PR TITLE
iceportal: init at 2021-11-15

### DIFF
--- a/pkgs/tools/misc/iceportal/default.nix
+++ b/pkgs/tools/misc/iceportal/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "iceportal";
+  version = "2021-11-15";
+
+  src = fetchFromGitHub {
+    owner = "craftamap";
+    repo = "${pname}-api";
+    rev = "f73278c28cb5de53e6ab5ec0a99c0e606582cc3d";
+    sha256 = "0lg5iaj9pb3am7i17zfl33pv9bkwbfxaz9wc6s9m1z6mxg4s0a1y";
+  };
+
+  vendorSha256 = "1in0gf4adhlwxphqm56dyv4dn81m7v9in26nd26zjf5ggfq8s3sb";
+
+  meta = with lib; {
+    description = "client to interact with the REST API of iceportal.de";
+    longDescription = ''
+      iceportal-api is a Golang client implementation to interact with the REST
+      API of iceportal.de when connected to the WiFi-Network offered in German
+      ICE Trains.
+    '';
+    homepage = "https://github.com/craftamap/iceportal-api";
+    maintainers = [ maintainers.matthiasbeyer ];
+    license = licenses.mit;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1370,7 +1370,11 @@ with pkgs;
     name = "use-old-cxx-abi-hook";
   } ../build-support/setup-hooks/use-old-cxx-abi.sh;
 
-  iconConvTools = callPackage ../build-support/icon-conv-tools { };
+  ical2org = callPackage ../tools/misc/ical2org {};
+
+  iceportal = callPackage ../tools/misc/iceportal {};
+
+  iconConvTools = callPackage ../build-support/icon-conv-tools {};
 
   validatePkgConfig = makeSetupHook
     { name = "validate-pkg-config"; propagatedBuildInputs = [ findutils pkg-config ]; }


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Can someone with go-lang packaging experience tell me why this does not build and help me getting it to build?