### PR TITLE
edk2: pull upstream brotli fix for gcc-11

### DIFF
--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   clangStdenv,
-  fetchgit,
+  fetchFromGitHub,
   fetchpatch,
   libuuid,
   python3,
@@ -39,11 +39,26 @@ edk2 = buildStdenv.mkDerivation {
   version = "202108";
 
   # submodules
-  src = fetchgit {
+  src = fetchFromGitHub {
     url = "https://github.com/tianocore/edk2";
+    owner = "tianocore";
+    repo = "edk2";
     rev = "edk2-stable${edk2.version}";
+    fetchSubmodules = true;
     sha256 = "1ps244f7y43afxxw6z95xscy24f9mpp8g0mfn90rd4229f193ba2";
   };
+
+  patches = [
+    # Pull upstream fix for gcc-11 build.
+    (fetchpatch {
+      name = "gcc-11-vla.patch";
+      url = "https://github.com/google/brotli/commit/0a3944c8c99b8d10cc4325f721b7c273d2b41f7b.patch";
+      sha256 = "10c6ibnxh4f8lrh9i498nywgva32jxy2c1zzvr9mcqgblf9d19pj";
+      # Apply submodule patch to subdirectory: "a/" -> "BaseTools/Source/C/BrotliCompress/brotli/"
+      stripLen = 1;
+      extraPrefix = "BaseTools/Source/C/BrotliCompress/brotli/";
+    })
+  ];
 
   buildInputs = [ libuuid pythonEnv ];
 

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -1,10 +1,10 @@
 {
   stdenv,
   clangStdenv,
-  fetchFromGitHub,
-  fetchpatch,
-  libuuid,
-  python3,
+, fetchFromGitHub
+, fetchpatch
+, libuuid
+, python3
   bc,
   clang_9,
   llvmPackages_9,

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -40,7 +40,6 @@ edk2 = buildStdenv.mkDerivation {
 
   # submodules
   src = fetchFromGitHub {
-    url = "https://github.com/tianocore/edk2";
     owner = "tianocore";
     repo = "edk2";
     rev = "edk2-stable${edk2.version}";

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -1,15 +1,14 @@
-{
-  stdenv,
-  clangStdenv,
+{ stdenv
+, clangStdenv
 , fetchFromGitHub
 , fetchpatch
 , libuuid
 , python3
-  bc,
-  clang_9,
-  llvmPackages_9,
-  overrideCC,
-  lib,
+, bc
+, clang_9
+, llvmPackages_9
+, overrideCC
+, lib
 }:
 
 let


### PR DESCRIPTION
Before the patch build on gcc-11 failed as:

    $ nix build --impure --expr 'with import <nixpkgs> {}; edk2.override { stdenv = gcc11Stdenv; }'
    brotli/c/dec/decode.c:2034:14: error:
      argument 4 of type 'uint8_t *' {aka 'unsigned char *'} declared as a pointer [-Werror=vla-parameter]
      2034 |     uint8_t* decoded_buffer) {
           |     ~~~~~~~~~^~~~~~~~~~~~~~
