### PR TITLE
nxpmicro-mfgtools: 1.4.72 -> 1.4.165

### DIFF
--- a/pkgs/development/tools/misc/nxpmicro-mfgtools/default.nix
+++ b/pkgs/development/tools/misc/nxpmicro-mfgtools/default.nix
@@ -3,6 +3,7 @@
 , cmake
 , pkg-config
 , bzip2
+, installShellFiles
 , libusb1
 , libzip
 , openssl
@@ -10,16 +11,16 @@
 
 stdenv.mkDerivation rec {
   pname = "nxpmicro-mfgtools";
-  version = "1.4.72";
+  version = "1.4.165";
 
   src = fetchFromGitHub {
     owner = "NXPmicro";
     repo = "mfgtools";
     rev = "uuu_${version}";
-    sha256 = "1s3wlz4yb2p8by5p66vr0z72n84mxkrmda63x9yr6pinqinsyrvv";
+    sha256 = "0k309lp27d4k6x4qq0badbk8i47xsc6f3fffz73650iyfs4hcniw";
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  nativeBuildInputs = [ cmake pkg-config installShellFiles ];
 
   buildInputs = [ bzip2 libusb1 libzip openssl ];
 
@@ -31,6 +32,8 @@ stdenv.mkDerivation rec {
     $out/bin/uuu -udev > udev-rules 2>stderr.txt
     rules_file="$(cat stderr.txt|grep '1: put above udev run into'|sed 's|^.*/||')"
     install -D udev-rules "$out/lib/udev/rules.d/$rules_file"
+    installShellCompletion --cmd uuu \
+      --bash ../snap/local/bash-completion/universal-update-utility
   '';
 
   meta = with lib; {
@@ -48,7 +51,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/NXPmicro/mfgtools";
     license = licenses.bsd3;
-    maintainers = [ maintainers.bmilanov ];
+    maintainers = with maintainers; [ bmilanov jraygauthier ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
Also:

 -  Add support for provided bash completions.
 -  Add myself as maintainer.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Update package to latest.
- Add missing support for bash completion.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
