### PR TITLE
fclones: 0.17.0 -> 0.17.1

### DIFF
--- a/pkgs/tools/misc/fclones/default.nix
+++ b/pkgs/tools/misc/fclones/default.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
     owner = "pkolaczk";
     repo = pname;
     rev = "v${version}";
-    sha256 = "04zajrxz2c0dn98503w3r0cznasm8aqm0bxvvxbsps6k67lkwlwk";
+    sha256 = "0d5an35fnz9rdr2ssm952zpzn4jynpvbfyidnqcmp0lclr60c2ir";
   };
 
   cargoSha256 = "sha256-CtQ4grQqgMUYzPDw2Qankl8jmqwwCrawNCmaY97JPkQ=";

--- a/pkgs/tools/misc/fclones/default.nix
+++ b/pkgs/tools/misc/fclones/default.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "fclones";
-  version = "0.17.0";
+  version = "0.17.1";
 
   src = fetchFromGitHub {
     owner = "pkolaczk";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-JygW1Ri9BA4Qssu6MlQCCjnAok9OD2pcGdavOyHxbIo=";
+    sha256 = "04zajrxz2c0dn98503w3r0cznasm8aqm0bxvvxbsps6k67lkwlwk";
   };
 
-  cargoSha256 = "sha256-sDHsj0qxKW5JJCI9H0WytgugtEmLaLU2EIgCcXdfQH0=";
+  cargoSha256 = "sha256-CtQ4grQqgMUYzPDw2Qankl8jmqwwCrawNCmaY97JPkQ=";
 
   buildInputs = lib.optionals stdenv.isDarwin [
     AppKit


### PR DESCRIPTION
###### Motivation for this change

Updates fclones to v0.17.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
