### PR TITLE
nix-daemon: fix collision warning of bash completions

### DIFF
--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -529,7 +529,9 @@ in
       [ nix
         pkgs.nix-info
       ]
-      ++ optional (config.programs.bash.enableCompletion && !versionAtLeast nixVersion "2.4pre") pkgs.nix-bash-completions;
+      ++ optional
+        (config.programs.bash.enableCompletion && !versionAtLeast nixVersion "2.4pre")
+        (mkAfter pkgs.nix-bash-completions);
 
     environment.etc."nix/nix.conf".source = nixConf;
 


### PR DESCRIPTION
###### Motivation for this change

Bash completions installed by nix-bash-completions and nixos-container try to install "/share/bash-completion/completions/nixos-container".

Log messages like
```
collision between `/nix/store/xzp8yxv1m4i3n5ghiddvgv38q2aivbn6-nixos-container/share/bash-completion/completions/nixos-container' and `/nix/store/ii06nl46nlpzar1zwrywhfwr4yzaj7av-nix-bash-completions-0.6.8/share/bash-completion/completions/nixos-container'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
