### PR TITLE
Octave: improve package building function and update packages

### DIFF
--- a/pkgs/development/octave-modules/audio/default.nix
+++ b/pkgs/development/octave-modules/audio/default.nix
@@ -9,11 +9,11 @@
 
 buildOctavePackage rec {
   pname = "audio";
-  version = "2.0.2";
+  version = "2.0.3";
 
   src = fetchurl {
     url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
-    sha256 = "18lyvwmdy4b9pcv5sm7g17n3is32q23daw8fcsalkf4rj6cc6qdk";
+    sha256 = "1431pf7mhxsrnzrx8r3hsy537kha7jhaligmp2rghwyxhq25hs0r";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/octave-modules/control/default.nix
+++ b/pkgs/development/octave-modules/control/default.nix
@@ -7,11 +7,11 @@
 
 buildOctavePackage rec {
   pname = "control";
-  version = "3.3.0";
+  version = "3.3.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
-    sha256 = "1yksifligq2z3siqw701iq2ydgnj7pnkcw42bfmydcf6fc4drlvy";
+    sha256 = "0vndbzix34vfzdlsz57bgkyg31as4kv6hfg9pwrcqn75bzzjsivw";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/octave-modules/nan/default.nix
+++ b/pkgs/development/octave-modules/nan/default.nix
@@ -6,11 +6,11 @@
 
 buildOctavePackage rec {
   pname = "nan";
-  version = "3.5.3";
+  version = "3.6.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
-    sha256 = "1jailahbrh847875vszibn68lp4n5sdy68q51i7hd64qix8rmmpx";
+    sha256 = "1zxdg0yg5jnwq6ppnikd13zprazia6w6zpgw99f62mc03iqk5c4q";
   };
 
   buildInputs = [

--- a/pkgs/development/octave-modules/sparsersb/default.nix
+++ b/pkgs/development/octave-modules/sparsersb/default.nix
@@ -6,11 +6,11 @@
 
 buildOctavePackage rec {
   pname = "sparsersb";
-  version = "1.0.8";
+  version = "1.0.9";
 
   src = fetchurl {
     url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
-    sha256 = "0nl7qppa1cm51188hqhbfswlih9hmy1yz7v0f5i07z0g0kbd62xw";
+    sha256 = "0jyy2m7wylzyjqj9n6mjizhj0ccq8xnxm2g6pdlrmncxq1401khd";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/octave-modules/tsa/default.nix
+++ b/pkgs/development/octave-modules/tsa/default.nix
@@ -6,11 +6,11 @@
 
 buildOctavePackage rec {
   pname = "tsa";
-  version = "4.6.2";
+  version = "4.6.3";
 
   src = fetchurl {
     url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
-    sha256 = "0p2cjszzjwhp4ih3q3r67qnikgxc0fwxc12p3727jbdvzq2h10mn";
+    sha256 = "1pbxq77xc7pn0ki6rpijlq9v7inn0hn2adkx1skgwffl7pivrwsl";
   };
 
   requiredOctavePackages = [

--- a/pkgs/development/octave-modules/zeromq/default.nix
+++ b/pkgs/development/octave-modules/zeromq/default.nix
@@ -2,16 +2,31 @@
 , lib
 , fetchurl
 , zeromq
+, pkg-config
+, autoreconfHook
 }:
 
 buildOctavePackage rec {
   pname = "zeromq";
-  version = "1.5.2";
+  version = "1.5.3";
 
   src = fetchurl {
     url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
-    sha256 = "18h1039ri7dr37jv20cvj5vhw7b57frrda0hhbvlgixinbqmn9j7";
+    sha256 = "1h0pb2pqbnyiavf7r05j8bqxqd8syz16ab48hc74nlnx727anfwl";
   };
+
+  preAutoreconf = ''
+    cd src
+  '';
+
+  postAutoreconf = ''
+    cd ..
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+  ];
 
   propagatedBuildInputs = [
     zeromq

--- a/pkgs/top-level/octave-packages.nix
+++ b/pkgs/top-level/octave-packages.nix
@@ -214,7 +214,7 @@ makeScope newScope (self:
     windows = callPackage ../development/octave-modules/windows { };
 
     zeromq = callPackage ../development/octave-modules/zeromq {
-      inherit (pkgs) zeromq;
+      inherit (pkgs) zeromq autoreconfHook;
     };
 
   })


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
When building `octavePackages.zeromq` with this new version, it changed some of its tooling.
This required adding some `nativeBuildInputs`, which broke everything. So, the `buildOctavePackage` function was slightly revamped to allow end-users to provide additional information to the function to make building happen as planned.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
