### PR TITLE
snapmaker-luban: init at 4.0.3

### DIFF
--- a/pkgs/applications/misc/snapmaker-luban/default.nix
+++ b/pkgs/applications/misc/snapmaker-luban/default.nix
@@ -1,0 +1,88 @@
+{ lib, stdenv, autoPatchelfHook, makeDesktopItem, copyDesktopItems, wrapGAppsHook, fetchurl
+, alsa-lib, at-spi2-atk, at-spi2-core, atk, cairo, cups
+, gtk3, nss, glib, dbus, nspr, gdk-pixbuf
+, libX11, libXScrnSaver, libXcomposite, libXcursor, libXdamage, libXext
+, libXfixes, libXi, libXrandr, libXrender, libXtst, libxcb, pango
+, gcc-unwrapped, udev
+}:
+
+stdenv.mkDerivation rec {
+  pname = "snapmaker-luban";
+  version = "4.0.3";
+
+  src = fetchurl {
+    url = "https://github.com/Snapmaker/Luban/releases/download/v${version}/snapmaker-luban-${version}-linux-x64.tar.gz";
+    sha256 = "13qk7ssfawjaa5p4mnml4ndzzsqs26qpi76hc9qaipi74ss3jih4";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    wrapGAppsHook
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    cairo
+    cups
+    gcc-unwrapped
+    gtk3
+    libXdamage
+    libX11
+    libXScrnSaver
+    libXtst
+    libxcb
+    nspr
+    nss
+  ];
+
+  libPath = lib.makeLibraryPath [
+    stdenv.cc.cc alsa-lib atk at-spi2-atk at-spi2-core cairo cups
+    gdk-pixbuf glib gtk3 libX11 libXcomposite
+    libXcursor libXdamage libXext libXfixes libXi libXrandr libXrender
+    libXtst nspr nss libxcb pango libXScrnSaver udev
+  ];
+
+  dontWrapGApps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,opt,share/pixmaps}/
+    mv * $out/opt/
+
+    patchelf --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
+      $out/opt/snapmaker-luban
+
+    wrapProgram $out/opt/snapmaker-luban \
+      "''${gappsWrapperArgs[@]}" \
+      --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
+      --prefix LD_LIBRARY_PATH : ${libPath}:$out/snapmaker-luban
+
+    ln -s $out/opt/snapmaker-luban $out/bin/snapmaker-luban
+    ln -s $out/opt/resources/app/app/resources/images/snap-luban-logo-64x64.png $out/share/pixmaps/snapmaker-luban.png
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = "snapmaker-luban";
+      icon = "snapmaker-luban";
+      desktopName = "Snapmaker Luban";
+      genericName = meta.description;
+      categories = "Office;Printing;";
+    })
+  ];
+
+  meta = with lib; {
+    description = "Snapmaker Luban is an easy-to-use 3-in-1 software tailor-made for Snapmaker machines";
+    homepage = "https://github.com/Snapmaker/Luban";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.simonkampe ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27993,6 +27993,8 @@ with pkgs;
 
   super-slicer-staging = (callPackage ../applications/misc/prusa-slicer/super-slicer.nix { }).staging;
 
+  snapmaker-luban = callPackage ../applications/misc/snapmaker-luban { };
+
   robustirc-bridge = callPackage ../servers/irc/robustirc-bridge { };
 
   skrooge = libsForQt5.callPackage ../applications/office/skrooge {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Added missing derivation for Snapmaker Luban software, used to control the Snapmaker 3-in-1 (CNC, Laser, 3D-printing) machines.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
