### PR TITLE
slack: fixes for wayland

### DIFF
--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -3,7 +3,7 @@
 , fetchurl
 , dpkg
 , undmg
-, makeWrapper
+, substituteAll
 , nodePackages
 , alsa-lib
 , at-spi2-atk
@@ -142,7 +142,7 @@ let
       gtk3 # needed for GSETTINGS_SCHEMAS_PATH
     ];
 
-    nativeBuildInputs = [ dpkg makeWrapper nodePackages.asar ];
+    nativeBuildInputs = [ dpkg nodePackages.asar ];
 
     dontUnpack = true;
     dontBuild = true;
@@ -168,9 +168,12 @@ let
 
       # Replace the broken bin/slack symlink with a startup wrapper
       rm $out/bin/slack
-      makeWrapper $out/lib/slack/slack $out/bin/slack \
-        --prefix XDG_DATA_DIRS : $GSETTINGS_SCHEMAS_PATH \
-        --prefix PATH : ${lib.makeBinPath [xdg-utils]}
+      NIX_DEBUG=1 substitute ${./wrapper.sh} $out/bin/slack \
+        --subst-var shell \
+        --subst-var GSETTINGS_SCHEMAS_PATH \
+        --subst-var out \
+        --subst-var-by xdg_utils ${lib.makeBinPath [xdg-utils]}
+      chmod +x $out/bin/slack
 
       # Fix the desktop link
       substituteInPlace $out/share/applications/slack.desktop \

--- a/pkgs/applications/networking/instant-messengers/slack/wrapper.sh
+++ b/pkgs/applications/networking/instant-messengers/slack/wrapper.sh
@@ -1,0 +1,10 @@
+#! @shell@
+
+export XDG_DATA_DIRS=@GSETTINGS_SCHEMAS_PATH@${XDG_DATA_DIRS:+':'}$XDG_DATA_DIRS
+export PATH=@xdg_utils@${PATH:+':'}$PATH
+
+if [ "${XDG_SESSION_TYPE}" == "wayland" ]; then
+    set -- --enable-features=UseOzonePlatform,WebRTCPipeWireCapturer --ozone-platform=wayland "$@"
+fi
+
+exec @out@/lib/slack/slack "$@"


### PR DESCRIPTION
###### Motivation for this change

Slack has to be told to use pipewire and ozone.
Fixes screen sharing and opening links in firefox.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
