### PR TITLE
libyaml-cpp: Fix wrong paths in pkg-config .pc file.

### DIFF
--- a/pkgs/development/libraries/libyaml-cpp/default.nix
+++ b/pkgs/development/libraries/libyaml-cpp/default.nix
@@ -18,6 +18,12 @@ stdenv.mkDerivation rec {
       url = "https://github.com/jbeder/yaml-cpp/commit/4f48727b365962e31451cd91027bd797bc7d2ee7.patch";
       sha256 = "sha256-jarZAh7NgwL3xXzxijDiAQmC/EC2WYfNMkYHEIQBPhM=";
     })
+    # TODO: Remove with the next release, when https://github.com/jbeder/yaml-cpp/pull/1058 is available
+    (fetchpatch {
+      name = "libyaml-cpp-Fix-pc-paths-for-absolute-GNUInstallDirs.patchj";
+      url = "https://github.com/jbeder/yaml-cpp/commit/328d2d85e833be7cb5a0ab246cc3f5d7e16fc67a.patch";
+      sha256 = "12g5h7lxzd5v16ykay03zww5g28j3k69k228yr3v8fnmyv2spkfl";
+    })
   ];
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Motivation for this change

Same as in #71669 and #81091 and https://github.com/NixOS/nixpkgs/commit/029c3f917edbe4a53fdd17cd797ca6ff9e8a7615.

See #144170 for the general issue.

Before this fix:

```
NIX_PATH=nixpkgs=. nix-shell -p libyamlcpp -p pkg-config --run 'pkg-config --cflags yaml-cpp'
-I/nix/store/bq106wng1cqk8r4y1y7yh5h7cz49jxpv-libyaml-cpp-0.7.0//nix/store/bq106wng1cqk8r4y1y7yh5h7cz49jxpv-libyaml-cpp-0.7.0/include
```

With this fix, the path is correct:

```
NIX_PATH=nixpkgs=. nix-shell -p libyamlcpp -p pkg-config --run 'pkg-config --cflags yaml-cpp'
-I/nix/store/9hwyd6im206isapba0i8gyc5i3g1df2j-libyaml-cpp-0.7.0/include
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
