### PR TITLE
btrfs-snap: init at 1.7.3

### DIFF
--- a/pkgs/tools/filesystems/btrfs-snap/default.nix
+++ b/pkgs/tools/filesystems/btrfs-snap/default.nix
@@ -1,0 +1,32 @@
+{ bash, btrfs-progs, coreutils, fetchFromGitHub, gnugrep, lib, makeWrapper, stdenvNoCC, util-linuxMinimal }:
+stdenvNoCC.mkDerivation rec {
+  pname = "btrfs-snap";
+  version = "1.7.3";
+  src = fetchFromGitHub {
+    owner = "jf647";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-SDzLjgNRuR9XpmcYCD9T10MLS+//+pWFGDiTAb8NiLQ=";
+  };
+  buildInputs = [ bash ];
+  nativeBuildInputs = [ makeWrapper ];
+  dontConfigure = true;
+  dontBuild = true;
+  installPhase = ''
+    mkdir -p $out/bin
+    cp btrfs-snap $out/bin/
+    wrapProgram $out/bin/btrfs-snap --prefix PATH : ${lib.makeBinPath [
+      btrfs-progs       # btrfs
+      coreutils         # cut, date, head, ls, mkdir, readlink, stat, tail, touch, test, [
+      gnugrep           # grep
+      util-linuxMinimal # logger, mount
+    ]}
+  '';
+  meta = with lib; {
+    description = "btrfs-snap creates and maintains the history of snapshots of btrfs filesystems.";
+    homepage = "https://github.com/jf647/btrfs-snap";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ lionello ];
+    platforms = platforms.linux;
+ };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2280,6 +2280,8 @@ with pkgs;
 
   btrfs-progs = callPackage ../tools/filesystems/btrfs-progs { };
 
+  btrfs-snap = callPackage ../tools/filesystems/btrfs-snap { };
+
   btlejack = python3Packages.callPackage ../applications/radio/btlejack { };
 
   btrbk = callPackage ../tools/backup/btrbk {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Nixpkgs was missing a `btrfs-snap` derivation, from https://github.com/jf647/btrfs-snap. This is a bash script, only depends on `btrfs-progs`.

###### Things done
Adding a new derivation for `btrfs-snap`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
