### PR TITLE
public-sans: 1.008 -> 2.000

### DIFF
--- a/pkgs/data/fonts/public-sans/default.nix
+++ b/pkgs/data/fonts/public-sans/default.nix
@@ -1,7 +1,7 @@
 { lib, fetchzip }:
 
 let
-  version = "1.008";
+  version = "2.000";
 in fetchzip {
   name = "public-sans-${version}";
 
@@ -9,14 +9,11 @@ in fetchzip {
 
   postFetch = ''
     mkdir -p $out/share/fonts
-    unzip -j $downloadedFile binaries/otf/\*.otf -d $out/share/fonts/opentype
-    unzip -j $downloadedFile binaries/variable/\*.ttf -d $out/share/fonts/truetype
-    unzip -j $downloadedFile binaries/webfonts/\*.ttf -d $out/share/fonts/truetype
-    unzip -j $downloadedFile binaries/webfonts/\*.woff -d $out/share/fonts/woff
-    unzip -j $downloadedFile binaries/webfonts/\*.woff2 -d $out/share/fonts/woff2
+    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
   '';
 
-  sha256 = "1s4xmliri3r1gcn1ws3wa6davj6giliqjdbcv0bh9ryg3dfpjz74";
+  sha256 = "0r34h9mim5c3h48cpq2m2ixkdqhv3i594pip10pavkmskldpbha5";
 
   meta = with lib; {
     description = "A strong, neutral, principles-driven, open source typeface for text or display";


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/uswds/public-sans/releases/tag/v2.000

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
