### PR TITLE
tree-sitter: add Rukiza/tree-sitter-prolog

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -30,6 +30,7 @@
   tree-sitter-norg = (builtins.fromJSON (builtins.readFile ./tree-sitter-norg.json));
   tree-sitter-ocaml = (builtins.fromJSON (builtins.readFile ./tree-sitter-ocaml.json));
   tree-sitter-php = (builtins.fromJSON (builtins.readFile ./tree-sitter-php.json));
+  tree-sitter-prolog = (builtins.fromJSON (builtins.readFile ./tree-sitter-prolog.json));
   tree-sitter-python = (builtins.fromJSON (builtins.readFile ./tree-sitter-python.json));
   tree-sitter-ql = (builtins.fromJSON (builtins.readFile ./tree-sitter-ql.json));
   tree-sitter-regex = (builtins.fromJSON (builtins.readFile ./tree-sitter-regex.json));

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-prolog.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-prolog.json
@@ -1,0 +1,11 @@
+{
+  "url": "https://github.com/Rukiza/tree-sitter-prolog",
+  "rev": "db66ca3f5b80e27a3328a8dcec828df93d7250a6",
+  "date": "2021-06-05T12:57:22+12:00",
+  "path": "/nix/store/namaxw9jb8qkdikcii4l8chwylvbnmxb-tree-sitter-prolog",
+  "sha256": "0dfly0faprcf2cfgi4xqv65fmyn5x7b68ip9bzcfv941y6r88yd8",
+  "fetchLFS": false,
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -110,6 +110,10 @@ let
       orga = "ikatyang";
       repo = "tree-sitter-markdown";
     };
+    "tree-sitter-prolog" = {
+      orga = "Rukiza";
+      repo = "tree-sitter-prolog";
+    };
     "tree-sitter-rst" = {
       orga = "stsewd";
       repo = "tree-sitter-rst";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
