### PR TITLE
citra: 2020-12-07 -> 2021-11-01 & fix qt interface

### DIFF
--- a/pkgs/misc/emulators/citra/default.nix
+++ b/pkgs/misc/emulators/citra/default.nix
@@ -3,13 +3,13 @@
 
 mkDerivation {
   pname = "citra";
-  version = "2020-12-07";
+  version = "2021-11-01";
 
   # Submodules
   src = fetchgit {
     url = "https://github.com/citra-emu/citra";
-    rev = "3f13e1cc2419fac837952c44d7be9db78b054a2f";
-    sha256 = "1bbg8cwrgncmcavqpj3yp4dbfkip1i491krp6dcpgvsd5yfr7f0v";
+    rev = "5a7d80172dd115ad9bc6e8e85cee6ed9511c48d0";
+    sha256 = "sha256-vy2JMizBsnRK9NBEZ1dxT7fP/HFhOZSsC+5P+Dzi27s=";
   };
 
   nativeBuildInputs = [ cmake wrapQtAppsHook ];

--- a/pkgs/misc/emulators/citra/default.nix
+++ b/pkgs/misc/emulators/citra/default.nix
@@ -1,4 +1,5 @@
-{ mkDerivation, lib, fetchgit, cmake, SDL2, qtbase, qtmultimedia, boost }:
+{ mkDerivation, lib, fetchgit, cmake, SDL2, qtbase, qtmultimedia, boost
+, wrapQtAppsHook }:
 
 mkDerivation {
   pname = "citra";
@@ -11,10 +12,8 @@ mkDerivation {
     sha256 = "1bbg8cwrgncmcavqpj3yp4dbfkip1i491krp6dcpgvsd5yfr7f0v";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake wrapQtAppsHook ];
   buildInputs = [ SDL2 qtbase qtmultimedia boost ];
-
-  dontWrapQtApps = true;
 
   preConfigure = ''
     # Trick configure system.


### PR DESCRIPTION
###### motivation

citra was out of date and the qt ui didn't appear to work

###### things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
