### PR TITLE
kde-rounded-corners: init at unstable-2021-11-06

### DIFF
--- a/pkgs/data/themes/kwin-decorations/kde-rounded-corners/default.nix
+++ b/pkgs/data/themes/kwin-decorations/kde-rounded-corners/default.nix
@@ -5,7 +5,7 @@
 , wrapQtAppsHook
 , kwin
 , kdelibs4support
-, epoxy
+, libepoxy
 , libXdmcp
 , lib
 }:
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ cmake extra-cmake-modules wrapQtAppsHook ];
-  buildInputs = [ kwin kdelibs4support epoxy libXdmcp ];
+  buildInputs = [ kwin kdelibs4support libepoxy libXdmcp ];
 
   meta = with lib; {
     description = "Rounds the corners of your windows";

--- a/pkgs/data/themes/kwin-decorations/kde-rounded-corners/default.nix
+++ b/pkgs/data/themes/kwin-decorations/kde-rounded-corners/default.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, extra-cmake-modules
+, wrapQtAppsHook
+, kwin
+, kdelibs4support
+, epoxy
+, libXdmcp
+, lib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "kde-rounded-corners";
+  version = "unstable-2021-11-06";
+
+  src = fetchFromGitHub {
+    owner = "matinlotfali";
+    repo = "KDE-Rounded-Corners";
+    rev = "8ad8f5f5eff9d1625abc57cb24dc484d51f0e1bd";
+    sha256 = "0xbskf7jd03d2invfz1nnfc82klzvc784snw539n4kn6c6rc381p";
+  };
+
+  postConfigure = ''
+    substituteInPlace cmake_install.cmake \
+      --replace "${kdelibs4support}" "$out"
+  '';
+
+  nativeBuildInputs = [ cmake extra-cmake-modules wrapQtAppsHook ];
+  buildInputs = [ kwin kdelibs4support epoxy libXdmcp ];
+
+  meta = with lib; {
+    description = "Rounds the corners of your windows";
+    homepage = "https://github.com/matinlotfali/KDE-Rounded-Corners";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ flexagoon ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22801,6 +22801,8 @@ with pkgs;
 
   kawkab-mono-font = callPackage ../data/fonts/kawkab-mono {};
 
+  kde-rounded-corners = libsForQt5.callPackage ../data/themes/kwin-decorations/kde-rounded-corners { };
+
   kochi-substitute = callPackage ../data/fonts/kochi-substitute {};
 
   kochi-substitute-naga10 = callPackage ../data/fonts/kochi-substitute-naga10 {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Package [KDE-Rounded-Corners](https://github.com/matinlotfali/KDE-Rounded-Corners)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
