### PR TITLE
lxd: Add upstream patch for LXC 4.0.11 compatibility

### DIFF
--- a/pkgs/tools/admin/lxd/default.nix
+++ b/pkgs/tools/admin/lxd/default.nix
@@ -1,4 +1,4 @@
-{ lib, hwdata, pkg-config, lxc, buildGoPackage, fetchurl
+{ lib, hwdata, pkg-config, lxc, buildGoPackage, fetchurl, fetchpatch
 , makeWrapper, acl, rsync, gnutar, xz, btrfs-progs, gzip, dnsmasq, attr
 , squashfsTools, iproute2, iptables, ebtables, iptables-nftables-compat, libcap
 , dqlite, raft-canonical, sqlite-replication, udev
@@ -27,6 +27,14 @@ buildGoPackage rec {
     url = "https://linuxcontainers.org/downloads/lxd/lxd-${version}.tar.gz";
     sha256 = "0mxbzg8xra0qpd3g3z1b230f0519h56x4jnn09lbbqa92p5zck3f";
   };
+
+  patches = [
+    # lxd/checkfeature: check whether the kernel supports core scheduling
+    (fetchpatch {
+      url = "https://github.com/lxc/lxd/commit/ba6be1043714458b29c4b37687d4f624ee421943.patch";
+      sha256 = "0716129n70c6i695fyi1j8q6cls7g62vkdpcrlfrr9i324y3w1dx";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace shared/usbid/load.go \


### PR DESCRIPTION
###### Motivation for this change

Without this patch, the LXC 4.0.10 → 4.0.11 upgrade (#142284) has broken LXD such that it can’t start any containers (“ERROR start - start.c:core_scheduling:1570 - Invalid argument - The kernel does not support core scheduling”):

```console
$ lxc launch ubuntu:20.04
Creating the instance
Instance name is: enjoyed-quagga
Starting enjoyed-quagga
Error: Failed to run: /nix/store/nbyg5bdvi5mrrqlymyn9k5c2sa01ni6g-lxd-4.19/bin/.lxd-wrapped forkstart enjoyed-quagga /var/lib/lxd/containers /var/log/lxd/enjoyed-quagga/lxc.conf: 
Try `lxc info --show-log local:enjoyed-quagga` for more info

$ lxc info --show-log local:enjoyed-quagga
Name: enjoyed-quagga
Status: STOPPED
Type: container
Architecture: x86_64
Created: 2021/11/02 00:31 PDT
Last Used: 2021/11/02 00:32 PDT

Log:

lxc enjoyed-quagga 20211102073203.424 ERROR    start - start.c:core_scheduling:1570 - Invalid argument - The kernel does not support core scheduling
lxc enjoyed-quagga 20211102073203.424 ERROR    lxccontainer - lxccontainer.c:wait_on_daemonized_start:867 - Received container state "ABORTING" instead of "RUNNING"
lxc enjoyed-quagga 20211102073203.424 ERROR    start - start.c:__lxc_start:2068 - Failed to spawn container "enjoyed-quagga"
lxc enjoyed-quagga 20211102073203.424 WARN     start - start.c:lxc_abort:1038 - No such process - Failed to send SIGKILL via pidfd 41 for process 85291
lxc enjoyed-quagga 20211102073208.432 WARN     conf - conf.c:lxc_map_ids:3574 - newuidmap binary is missing
lxc enjoyed-quagga 20211102073208.432 WARN     conf - conf.c:lxc_map_ids:3580 - newgidmap binary is missing
lxc 20211102073208.449 ERROR    af_unix - af_unix.c:lxc_abstract_unix_recv_fds_iov:218 - Connection reset by peer - Failed to receive response
lxc 20211102073208.449 ERROR    commands - commands.c:lxc_cmd_rsp_recv_fds:127 - Failed to receive file descriptors
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
