### PR TITLE
aewan: fix build against ncurses-6.3

### DIFF
--- a/pkgs/applications/editors/aewan/default.nix
+++ b/pkgs/applications/editors/aewan/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, zlib, ncurses }:
+{ lib, stdenv, fetchurl, fetchpatch, zlib, ncurses }:
 
 stdenv.mkDerivation rec {
   pname = "aewan";
@@ -8,6 +8,17 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/aewan/${pname}-${version}.tar.gz";
     sha256 = "5266dec5e185e530b792522821c97dfa5f9e3892d0dca5e881d0c30ceac21817";
   };
+
+  patches = [
+    # Pull patch pending upstream inclusion:
+    #  https://sourceforge.net/p/aewan/bugs/13/
+    (fetchpatch {
+      url = "https://sourceforge.net/p/aewan/bugs/13/attachment/aewan-cvs-ncurses-6.3.patch";
+      sha256 = "0pgpk1l3d6d5y37lvvavipwnmv9gmpfdy21jkz6baxhlkgf43r4p";
+      # patch is in CVS diff format, add 'a/' prefix
+      extraPrefix = "";
+    })
+  ];
 
   buildInputs = [ zlib ncurses ];
 


### PR DESCRIPTION
`ncuses-6.3` added printf-style function attributes and now makes
it easier to catch cases when user input is used in palce of format
string when built with CFLAGS=-Werror=format-security:

    aewan.c: In function 'paint_screen':
    aewan.c:147:7: error: format not a string literal and no format arguments [-Werror=format-security]
      147 |       printw(msg);
          |       ^~~~~~

Let's pull a patch pending upstream inclusion.