### PR TITLE
calibre-web: 0.6.13 -> 0.6.14

### DIFF
--- a/pkgs/servers/calibre-web/default.nix
+++ b/pkgs/servers/calibre-web/default.nix
@@ -7,22 +7,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "calibre-web";
-  version = "0.6.13";
+  version = "0.6.14";
 
   src = fetchFromGitHub {
     owner = "janeczku";
     repo = "calibre-web";
     rev = version;
-    sha256 = "sha256-zU7ujvFPi4UaaEglIK3YX3TJxBME35NEKKblnJRt0tM=";
+    sha256 = "sha256-rR5pUB3A0WNQxq7ZJ6ykua7hMlzs49aMmVbBUOkOVfA=";
   };
-
-  prePatch = ''
-    substituteInPlace setup.cfg \
-      --replace "requests>=2.11.1,<2.25.0" "requests" \
-      --replace "cps = calibreweb:main" "calibre-web = calibreweb:main" \
-      --replace "PyPDF3>=1.0.0,<1.0.4" "PyPDF3>=1.0.0" \
-      --replace "unidecode>=0.04.19,<1.3.0" "unidecode>=0.04.19"
-  '';
 
   patches = [
     # default-logger.patch switches default logger to /dev/stdout. Otherwise calibre-web tries to open a file relative
@@ -42,6 +34,13 @@ python3.pkgs.buildPythonApplication rec {
     mkdir -p src/calibreweb
     mv cps.py src/calibreweb/__init__.py
     mv cps src/calibreweb
+
+    substituteInPlace setup.cfg \
+      --replace "requests>=2.11.1,<2.25.0" "requests" \
+      --replace "cps = calibreweb:main" "calibre-web = calibreweb:main" \
+      --replace "PyPDF3>=1.0.0,<1.0.4" "PyPDF3>=1.0.0" \
+      --replace "unidecode>=0.04.19,<1.3.0" "unidecode>=0.04.19" \
+      --replace "flask-wtf>=0.14.2,<0.16.0" "flask-wtf>=0.14.2"
   '';
 
   # Upstream repo doesn't provide any tests.
@@ -52,6 +51,7 @@ python3.pkgs.buildPythonApplication rec {
     flask-babel
     flask_login
     flask_principal
+    flask_wtf
     iso-639
     lxml
     pypdf3


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The PR updates calibre-web from 0.6.13 to 0.6.14

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
