### PR TITLE
elixir-ls: build LS using the same Elixir version that is used to run LS

### DIFF
--- a/pkgs/development/beam-modules/elixir-ls/default.nix
+++ b/pkgs/development/beam-modules/elixir-ls/default.nix
@@ -5,6 +5,7 @@
 mixRelease rec {
   pname = "elixir-ls";
   version = "0.8.1";
+  inherit elixir;
 
   src = fetchFromGitHub {
     owner = "elixir-lsp";
@@ -16,7 +17,7 @@ mixRelease rec {
 
   mixFodDeps = fetchMixDeps {
     pname = "mix-deps-${pname}";
-    inherit src version;
+    inherit src version elixir;
     sha256 = "sha256-OzjToAg+q/ybCyqzNFk28OBsItjFTbdPi416EPh2qX0=";
   };
 

--- a/pkgs/development/beam-modules/fetch-mix-deps.nix
+++ b/pkgs/development/beam-modules/fetch-mix-deps.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, lib, elixir, hex, rebar, rebar3, cacert, git }:
+{ stdenvNoCC, lib, elixir, hex, rebar, rebar3, cacert, git }@inputs:
 
 { pname
 , version
@@ -8,6 +8,8 @@
 , debug ? false
 , meta ? { }
 , patches ? []
+, elixir ? inputs.elixir
+, hex ? inputs.hex.override { inherit elixir; }
 , ...
 }@attrs:
 

--- a/pkgs/development/beam-modules/mix-release.nix
+++ b/pkgs/development/beam-modules/mix-release.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, elixir, erlang, findutils, hex, rebar, rebar3, fetchMixDeps, makeWrapper, git, ripgrep }:
+{ stdenv, lib, elixir, erlang, findutils, hex, rebar, rebar3, fetchMixDeps, makeWrapper, git, ripgrep }@inputs:
 
 { pname
 , version
@@ -15,6 +15,8 @@
   # each dependency needs to have a setup hook to add the lib path to $ERL_LIBS
   # this is how mix will find dependencies
 , mixNixDeps ? { }
+, elixir ? inputs.elixir
+, hex ? inputs.hex.override { inherit elixir; }
 , ...
 }@attrs:
 let


### PR DESCRIPTION
###### Motivation for this change

The Elixir LS package in Nixpkgs by default used the latest Elixir
version available to compile and run Elixir LS. The user can build
a custom Elixir LS package with a different Elixir version:

    my-custom-elixir-ls = pkgs.elixir_ls.override {
      elixir = my-custom-elixir;
    };

But by doing so the user changes only the Elixir version used to
run Elixir LS; the Elixir version used to compile Elixir LS doesn't
change. As the result, the custom Elixir LS package uses a different
Elixir version at runtime than the Elixir version it was compiled with.

In order to be able to modify the Elixir version used at build time,
I changed `mixRelease` and `fetchMixDeps` to accept `elixir` and
`hex` as parameters (defaults to the latest Elixir and Hex packages).

Resolves #131815.
 
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
