### PR TITLE
gst: 5.0.4 -> 5.0.5

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/gst/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gst/default.nix
@@ -7,13 +7,13 @@
 
 buildGoModule rec {
   pname = "gst";
-  version = "5.0.4";
+  version = "5.0.5";
 
   src = fetchFromGitHub {
     owner = "uetchy";
     repo = "gst";
     rev = "v${version}";
-    sha256 = "0fqgkmhn84402hidxv4niy9himcdwm1h80prkfk9vghwcyynrbsj";
+    sha256 = "07cixz5wlzzb4cwcrncg2mz502wlhd3awql5js1glw9f6qfwc5in";
   };
 
   vendorSha256 = "0k5xl55vzpl64gwsgaff92jismpx6y7l2ia0kx7gamd1vklf0qwh";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Upgrade to [5.0.5](https://github.com/uetchy/gst/releases/tag/v5.0.5) incorporating these [changes](https://github.com/uetchy/gst/compare/v5.0.4...v5.0.5).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
