### PR TITLE
scikit-learn: 0.24.1 -> 1.0.1

### DIFF
--- a/pkgs/development/python-modules/scikit-learn/default.nix
+++ b/pkgs/development/python-modules/scikit-learn/default.nix
@@ -2,7 +2,6 @@
 , lib
 , buildPythonPackage
 , fetchPypi
-, fetchpatch
 , gfortran
 , glibcLocales
 , numpy
@@ -19,22 +18,13 @@
 
 buildPythonPackage rec {
   pname = "scikit-learn";
-  version = "0.24.1";
+  version = "1.0.1";
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "oDNKGALmTWVgIsO/q1anP71r9LEpg0PzaIryFRgQu98=";
+    sha256 = "rCyp27dU1hz+HIO6hINJjvlR0puT7AnW8AKEfyEKmdo=";
   };
-
-  patches = [
-    # This patch fixes compatibility with numpy 1.20. It was merged before 0.24.1 was released,
-    # but for some reason was not included in the 0.24.1 release tarball.
-    (fetchpatch {
-      url = "https://github.com/scikit-learn/scikit-learn/commit/e7ef22c3ba2334cb3b476e95d7c083cf6b48ce56.patch";
-      sha256 = "174554k1pbf92bj7wgq0xjj16bkib32ailyhwavdxaknh4bd9nmv";
-    })
-  ];
 
   buildInputs = [
     pillow


### PR DESCRIPTION
###### Motivation for this change
Updates to the stable branch of scikit-learn.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
