### PR TITLE
proverif: 2.02pl1 → 2.03

### DIFF
--- a/pkgs/applications/science/logic/proverif/default.nix
+++ b/pkgs/applications/science/logic/proverif/default.nix
@@ -2,28 +2,28 @@
 
 stdenv.mkDerivation rec {
   pname = "proverif";
-  version = "2.02pl1";
+  version = "2.03";
 
   src = fetchurl {
-    url    = "http://prosecco.gforge.inria.fr/personal/bblanche/proverif/proverif${version}.tar.gz";
-    sha256 = "1jmzfpx0hdgfmkq0jp6i3k5av9xxgndjaj743wfy37svn0ga4jjx";
+    url    = "https://bblanche.gitlabpages.inria.fr/proverif/proverif${version}.tar.gz";
+    sha256 = "sha256:1q5mp9il09jylimcaqczb3kh34gb5px88js127gxv0jj5b4bqfc7";
   };
 
-  buildInputs = with ocamlPackages; [ ocaml findlib lablgtk ];
+  buildInputs = with ocamlPackages; [ ocaml findlib ];
 
-  buildPhase = "./build";
+  buildPhase = "./build -nointeract";
   installPhase = ''
-    mkdir -p $out/bin
-    cp ./proverif      $out/bin
-    cp ./proveriftotex $out/bin
+    runHook preInstall
+    install -D -t $out/bin proverif proveriftotex
     install -D -t $out/share/emacs/site-lisp/ emacs/proverif.el
+    runHook postInstall
   '';
 
   meta = {
-    description = "Cryptographic protocol verifier in the Dolev-Yao model";
-    homepage    = "https://prosecco.gforge.inria.fr/personal/bblanche/proverif/";
+    description = "Cryptographic protocol verifier in the formal model";
+    homepage    = "https://bblanche.gitlabpages.inria.fr/proverif/";
     license     = lib.licenses.gpl2;
     platforms   = lib.platforms.unix;
-    maintainers = [ lib.maintainers.thoughtpolice ];
+    maintainers = with lib.maintainers; [ thoughtpolice vbgl ];
   };
 }


### PR DESCRIPTION
Do not build `proverif_interact` (that was not installed).

###### Motivation for this change

Fixes & improvements: https://gitlab.inria.fr/bblanche/proverif/-/blob/41f28668fe045fd535309d57633a61aaa2fdc722/proverif/CHANGES#L4-40

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc maintainer @thoughtpolice 