### PR TITLE
python3Packages.pytest-astropy: fix build, add missing dep

### DIFF
--- a/pkgs/development/python-modules/pytest-astropy/default.nix
+++ b/pkgs/development/python-modules/pytest-astropy/default.nix
@@ -3,12 +3,13 @@
 , fetchPypi
 , hypothesis
 , pytest
+, pytest-arraydiff
 , pytest-astropy-header
 , pytest-doctestplus
 , pytest-filter-subpackage
-, pytest-remotedata
+, pytest-mock
 , pytest-openfiles
-, pytest-arraydiff
+, pytest-remotedata
 , setuptools-scm
 , pythonOlder
 }:
@@ -33,12 +34,13 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     hypothesis
+    pytest-arraydiff
     pytest-astropy-header
     pytest-doctestplus
     pytest-filter-subpackage
-    pytest-remotedata
+    pytest-mock
     pytest-openfiles
-    pytest-arraydiff
+    pytest-remotedata
   ];
 
   # pytest-astropy is a meta package and has no tests


### PR DESCRIPTION
###### Motivation for this change
Was getting:

```
       > ERROR: Could not find a version that satisfies the requirement pytest-mock>=2.0 (from pytest-astropy) (from versions: none)
       > ERROR: No matching distribution found for pytest-mock>=2.0
       For full logs, run 'nix log /nix/store/40yd5mq1826z7d3si62cvc1wk2mqx61q-python3.8-pytest-astropy-0.9.0.drv'.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
