### PR TITLE
python3Packages.parfive: disable network test

### DIFF
--- a/pkgs/development/python-modules/parfive/default.nix
+++ b/pkgs/development/python-modules/parfive/default.nix
@@ -3,7 +3,7 @@
 , fetchPypi
 , tqdm
 , aiohttp
-, pytest
+, pytestCheckHook
 , setuptools-scm
 , pytest-localserver
 , pytest-socket
@@ -31,16 +31,17 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    pytest
+    pytestCheckHook
     pytest-localserver
     pytest-socket
     pytest-asyncio
   ];
 
-  checkPhase = ''
-    # these two tests require network connection
-    pytest parfive -k "not test_ftp and not test_ftp_http"
-  '';
+  disabledTests = [
+    # no network access
+    "test_ftp"
+    "aiofiles"
+  ];
 
   meta = with lib; {
     description = "A HTTP and FTP parallel file downloader";


### PR DESCRIPTION
###### Motivation for this change

Disable network test, and tests which require another aio plugin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
