### PR TITLE
mattermost-desktop: 4.6.2 -> 5.0.3

### DIFF
--- a/pkgs/applications/networking/instant-messengers/mattermost-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/mattermost-desktop/default.nix
@@ -1,8 +1,41 @@
-{ lib, stdenv, fetchurl, gnome2, gtk3, pango, atk, cairo, gdk-pixbuf, glib,
-freetype, fontconfig, dbus, libX11, xorg, libXi, libXcursor, libXdamage,
-libXrandr, libXcomposite, libXext, libXfixes, libXrender, libXtst,
-libXScrnSaver, nss, nspr, alsa-lib, cups, expat, udev, wrapGAppsHook,
-hicolor-icon-theme, libuuid, at-spi2-core, at-spi2-atk, libappindicator-gtk3 }:
+{ lib
+, stdenv
+, fetchurl
+, gnome2
+, gtk3
+, pango
+, atk
+, cairo
+, gdk-pixbuf
+, glib
+, freetype
+, fontconfig
+, dbus
+, libX11
+, xorg
+, libXi
+, libXcursor
+, libXdamage
+, libXrandr
+, libXcomposite
+, libXext
+, libXfixes
+, libXrender
+, libXtst
+, libXScrnSaver
+, nss
+, nspr
+, alsa-lib
+, cups
+, expat
+, udev
+, wrapGAppsHook
+, hicolor-icon-theme
+, libuuid
+, at-spi2-core
+, at-spi2-atk
+, libappindicator-gtk3
+}:
 
 let
   rpath = lib.makeLibraryPath [
@@ -42,64 +75,66 @@ let
   ];
 
 in
-  stdenv.mkDerivation rec {
-    pname = "mattermost-desktop";
-    version = "4.6.2";
+stdenv.mkDerivation rec {
+  pname = "mattermost-desktop";
+  version = "4.6.2";
 
-    src =
-      if stdenv.hostPlatform.system == "x86_64-linux" then
-        fetchurl {
+  src =
+    if stdenv.hostPlatform.system == "x86_64-linux" then
+      fetchurl
+        {
           url = "https://releases.mattermost.com/desktop/${version}/${pname}-${version}-linux-x64.tar.gz";
           sha256 = "0i836bc0gx375a9fm2cdxg84k03zhpx1z6jqxndf2m8pkfsblc3x";
         }
-      else if stdenv.hostPlatform.system == "i686-linux" then
-        fetchurl {
+    else if stdenv.hostPlatform.system == "i686-linux" then
+      fetchurl
+        {
           url = "https://releases.mattermost.com/desktop/${version}/${pname}-${version}-linux-ia32.tar.gz";
           sha256 = "04jv9hkmkh0jipv0fjdprnp5kmkjvf3c0fah6ysi21wmnmp5ab3m";
         }
-      else
-        throw "Mattermost-Desktop is not currently supported on ${stdenv.hostPlatform.system}";
+    else
+      throw "Mattermost-Desktop is not currently supported on ${stdenv.hostPlatform.system}";
 
-    dontBuild = true;
-    dontConfigure = true;
-    dontPatchELF = true;
+  dontBuild = true;
+  dontConfigure = true;
+  dontPatchELF = true;
 
-    nativeBuildInputs = [ wrapGAppsHook ];
+  nativeBuildInputs = [ wrapGAppsHook ];
 
-    buildInputs = [ gtk3 hicolor-icon-theme ];
+  buildInputs = [ gtk3 hicolor-icon-theme ];
 
-    installPhase = ''
-      runHook preInstall
+  installPhase = ''
+    runHook preInstall
 
-      mkdir -p $out/share/mattermost-desktop
-      cp -R . $out/share/mattermost-desktop
+    mkdir -p $out/share/mattermost-desktop
+    cp -R . $out/share/mattermost-desktop
 
-      mkdir -p "$out/bin"
-      ln -s $out/share/mattermost-desktop/mattermost-desktop \
-        $out/bin/mattermost-desktop
+    mkdir -p "$out/bin"
+    ln -s $out/share/mattermost-desktop/mattermost-desktop \
+      $out/bin/mattermost-desktop
 
-      patchShebangs $out/share/mattermost-desktop/create_desktop_file.sh
-      $out/share/mattermost-desktop/create_desktop_file.sh
-      rm $out/share/mattermost-desktop/create_desktop_file.sh
-      mkdir -p $out/share/applications
-      mv Mattermost.desktop $out/share/applications/Mattermost.desktop
-      substituteInPlace \
-        $out/share/applications/Mattermost.desktop \
-        --replace /share/mattermost-desktop/mattermost-desktop /bin/mattermost-desktop
+    patchShebangs $out/share/mattermost-desktop/create_desktop_file.sh
+    $out/share/mattermost-desktop/create_desktop_file.sh
+    rm $out/share/mattermost-desktop/create_desktop_file.sh
+    mkdir -p $out/share/applications
+    mv Mattermost.desktop $out/share/applications/Mattermost.desktop
+    substituteInPlace \
+      $out/share/applications/Mattermost.desktop \
+      --replace /share/mattermost-desktop/mattermost-desktop /bin/mattermost-desktop
 
-      patchelf \
-        --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-        --set-rpath "${rpath}:$out/share/mattermost-desktop" \
-        $out/share/mattermost-desktop/mattermost-desktop
+    patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${rpath}:$out/share/mattermost-desktop" \
+      $out/share/mattermost-desktop/mattermost-desktop
 
-      runHook postInstall
-    '';
+    runHook postInstall
+  '';
 
-    meta = with lib; {
-      description = "Mattermost Desktop client";
-      homepage    = "https://about.mattermost.com/";
-      license     = licenses.asl20;
-      platforms   = [ "x86_64-linux" "i686-linux" ];
-      maintainers = [ maintainers.joko ];
-    };
-  }
+  meta = with lib; {
+    description = "Mattermost Desktop client";
+    homepage = "https://about.mattermost.com/";
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+    maintainers = [ maintainers.joko ];
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/mattermost-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/mattermost-desktop/default.nix
@@ -1,131 +1,82 @@
 { lib
 , stdenv
 , fetchurl
-, gnome2
-, gtk3
-, pango
-, atk
-, cairo
-, gdk-pixbuf
-, glib
-, freetype
-, fontconfig
-, dbus
-, libX11
-, xorg
-, libXi
-, libXcursor
-, libXdamage
-, libXrandr
-, libXcomposite
-, libXext
-, libXfixes
-, libXrender
-, libXtst
-, libXScrnSaver
-, nss
-, nspr
-, alsa-lib
-, cups
-, expat
-, udev
-, wrapGAppsHook
-, hicolor-icon-theme
-, libuuid
-, at-spi2-core
-, at-spi2-atk
+, atomEnv
+, systemd
+, pulseaudio
+, libxshmfence
+, libnotify
 , libappindicator-gtk3
+, wrapGAppsHook
+, autoPatchelfHook
 }:
 
 let
-  rpath = lib.makeLibraryPath [
-    alsa-lib
-    at-spi2-atk
-    at-spi2-core
-    atk
-    cairo
-    cups
-    dbus
-    expat
-    fontconfig
-    freetype
-    gdk-pixbuf
-    glib
-    gnome2.GConf
-    gtk3
-    pango
-    libappindicator-gtk3
-    libuuid
-    libX11
-    libXScrnSaver
-    libXcomposite
-    libXcursor
-    libXdamage
-    libXext
-    libXfixes
-    libXi
-    libXrandr
-    libXrender
-    libXtst
-    nspr
-    nss
-    stdenv.cc.cc
-    udev
-    xorg.libxcb
-  ];
+
+  pname = "mattermost-desktop";
+  version = "5.0.3";
+
+  srcs = {
+    "x86_64-linux" = {
+      url = "https://releases.mattermost.com/desktop/${version}/${pname}-${version}-linux-x64.tar.gz";
+      hash = "sha256-KLSWJpNSMGmfugbkFIJLDnxcZtrtBZOGjLlR+kAoMTA=";
+    };
+
+    "i686-linux" = {
+      url = "https://releases.mattermost.com/desktop/${version}/${pname}-${version}-linux-ia32.tar.gz";
+      hash = "sha256-4ofjOsfGbgO1PSqQpigNp90JsvlGP1kGexVAR/h3/88=";
+    };
+  };
+
+  inherit (stdenv.hostPlatform) system;
 
 in
-stdenv.mkDerivation rec {
-  pname = "mattermost-desktop";
-  version = "4.6.2";
 
-  src =
-    if stdenv.hostPlatform.system == "x86_64-linux" then
-      fetchurl
-        {
-          url = "https://releases.mattermost.com/desktop/${version}/${pname}-${version}-linux-x64.tar.gz";
-          sha256 = "0i836bc0gx375a9fm2cdxg84k03zhpx1z6jqxndf2m8pkfsblc3x";
-        }
-    else if stdenv.hostPlatform.system == "i686-linux" then
-      fetchurl
-        {
-          url = "https://releases.mattermost.com/desktop/${version}/${pname}-${version}-linux-ia32.tar.gz";
-          sha256 = "04jv9hkmkh0jipv0fjdprnp5kmkjvf3c0fah6ysi21wmnmp5ab3m";
-        }
-    else
-      throw "Mattermost-Desktop is not currently supported on ${stdenv.hostPlatform.system}";
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchurl (srcs."${system}" or (throw "Unsupported system ${system}"));
 
   dontBuild = true;
   dontConfigure = true;
-  dontPatchELF = true;
+  dontStrip = true;
 
-  nativeBuildInputs = [ wrapGAppsHook ];
+  nativeBuildInputs = [ wrapGAppsHook autoPatchelfHook ];
 
-  buildInputs = [ gtk3 hicolor-icon-theme ];
+  buildInputs = atomEnv.packages ++ [
+    libxshmfence
+  ];
+
+  runtimeDependencies = [
+    (lib.getLib systemd)
+    pulseaudio
+    libnotify
+    libappindicator-gtk3
+  ];
 
   installPhase = ''
     runHook preInstall
+
+    # Mattermost tarball comes with executable bit set for everything.
+    # We’ll apply it only to files that need it.
+    find . -type f -print0 | xargs -0 chmod -x
+    find . -type f \( -name '*.so.*' -o -name '*.s[oh]' \) -print0 | xargs -0 chmod +x
+    chmod +x mattermost-desktop chrome-sandbox
 
     mkdir -p $out/share/mattermost-desktop
     cp -R . $out/share/mattermost-desktop
 
     mkdir -p "$out/bin"
-    ln -s $out/share/mattermost-desktop/mattermost-desktop \
-      $out/bin/mattermost-desktop
+    ln -s $out/share/mattermost-desktop/mattermost-desktop $out/bin/mattermost-desktop
 
     patchShebangs $out/share/mattermost-desktop/create_desktop_file.sh
     $out/share/mattermost-desktop/create_desktop_file.sh
     rm $out/share/mattermost-desktop/create_desktop_file.sh
     mkdir -p $out/share/applications
+    chmod -x Mattermost.desktop
     mv Mattermost.desktop $out/share/applications/Mattermost.desktop
-    substituteInPlace \
-      $out/share/applications/Mattermost.desktop \
+    substituteInPlace $out/share/applications/Mattermost.desktop \
       --replace /share/mattermost-desktop/mattermost-desktop /bin/mattermost-desktop
-
-    patchelf \
-      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath "${rpath}:$out/share/mattermost-desktop" \
-      $out/share/mattermost-desktop/mattermost-desktop
 
     runHook postInstall
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New [major release of the desktop app](https://docs.mattermost.com/install/desktop-app-changelog.html).

While at it I formatted the source with `nixpkgs-fmt` and changed to use `atomEnv` since it’s an Electron app.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
