### PR TITLE
autoPatchhelfHook: call addToDepCache recursive

### DIFF
--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -89,6 +89,7 @@ populateCacheForDep() {
 
             local soname="${found%.so*}"
             local foundso=
+            # TODO make this recursive?
             for foundso in "$rpathElem/$soname".so*; do
                 addToDepCache "$foundso"
             done
@@ -175,7 +176,7 @@ findDependency() {
 
     if [ $depCacheInitialised -eq 0 ]; then
         for lib in "${autoPatchelfLibs[@]}"; do
-            for so in "$lib/"*.so*; do addToDepCache "$so"; done
+            find "$lib" -not -type -d '(' -name '*.so' -or -name '*.so.*' ')' | while read so; do addToDepCache "$so"; done
         done
         depCacheInitialised=1
     fi

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -176,7 +176,7 @@ findDependency() {
 
     if [ $depCacheInitialised -eq 0 ]; then
         for lib in "${autoPatchelfLibs[@]}"; do
-            find "$lib" -not -type -d '(' -name '*.so' -or -name '*.so.*' ')' | while read so; do addToDepCache "$so"; done
+            find "$lib" -not -type d '(' -name '*.so' -or -name '*.so.*' ')' | while read so; do addToDepCache "$so"; done
         done
         depCacheInitialised=1
     fi


### PR DESCRIPTION
## Motivation for this change
make `autoPatchhelfHook` find `*.so` library files
not only in `$out/lib/library.so` but also in `$out/lib/path/to/library.so`

tested by patching the `findDependency` function, see [jesc-configurator/default.nix](https://github.com/milahu/random/blob/master/nixos/bugs/auto-patchelf-cannot-find-so-file/jesc-configurator/default.nix#L48)

related discourse [autoPatchhelfHook could not satisfy dependencies](https://discourse.nixos.org/t/autopatchhelfhook-could-not-satisfy-dependencies/13745)

<details>
<summary>PR merged: Bug in nwjs</summary>

there is also a bug in [nwjs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/nwjs/default.nix), PR in #144271

```
( cd /nix/store/fq45lf16xsdcz7ha7wr4wmwbwkb0imgr-nwjs-0.33.4/ && find . -name '*.so' )
./share/nwjs/lib/libnw.so
./share/nwjs/lib/libnode.so
./share/nwjs/lib/libffmpeg.so
./share/nwjs/swiftshader/libEGL.so
./share/nwjs/swiftshader/libGLESv2.so
```

at least `libnw.so` should be in `./lib/libnw.so` or `./lib/nwjs/libnw.so`

... assuming that we want to use library files only from `$out/lib`
and not from `$out/share` in this case

</details>

## Maybe Todo

### refactor find

we could pass multiple directories to `find` as in

https://github.com/NixOS/nixpkgs/blob/a8a57c90b3ad901bf868c217e58fe71251567594/pkgs/build-support/setup-hooks/auto-patchelf.sh#L299-L302

### recursive rpathElem

make this recursive?

```sh
            for foundso in "$rpathElem/$soname".so*; do
                addToDepCache "$foundso"
            done
```

```sh
            find "$rpathElem" '(' -name "${soname}.so" -or -name "${soname}.so.*" ')' | while read foundso; do
                addToDepCache "$foundso"
            done
```



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
