### PR TITLE
c3d: unstable-2020-10-05 -> unstable-2021-09-14

### DIFF
--- a/pkgs/applications/graphics/c3d/default.nix
+++ b/pkgs/applications/graphics/c3d/default.nix
@@ -1,19 +1,21 @@
-{ lib, stdenv, fetchFromGitHub, cmake, itk4, Cocoa }:
+{ lib, stdenv, fetchFromGitHub, cmake, itk, Cocoa }:
 
 stdenv.mkDerivation rec {
   pname   = "c3d";
-  version = "unstable-2020-10-05";
+  version = "unstable-2021-09-14";
 
   src = fetchFromGitHub {
     owner = "pyushkevich";
     repo = pname;
-    rev = "0a87e3972ea403babbe2d05ec6d50855e7c06465";
-    sha256 = "0wsmkifqrcfy13fnwvinmnq1m0lkqmpyg7bgbwnb37mbrlbq06wf";
+    rev = "cc06e6e2f04acd3d6faa3d8c9a66b499f02d4388";
+    sha256 = "sha256:1ql1y6694njsmdapywhppb54viyw8wdpaxxr1b3hm2rqhvwmhn52";
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ itk4 ]
+  buildInputs = [ itk ]
     ++ lib.optional stdenv.isDarwin Cocoa;
+
+  cmakeFlags = [ "-DCONVERT3D_USE_ITK_REMOTE_MODULES=OFF" ];
 
   meta = with lib; {
     homepage = "https://github.com/pyushkevich/c3d";
@@ -22,6 +24,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     license = licenses.gpl3;
     broken = stdenv.isAarch64;
-    # /build/git-3453f61/itkextras/OneDimensionalInPlaceAccumulateFilter.txx:311:10: fatal error: xmmintrin.h: No such file or directory
+    # /build/source/itkextras/OneDimensionalInPlaceAccumulateFilter.txx:312:10: fatal error: xmmintrin.h: No such file or directory
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update package and update ITK dependency

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [NA] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [NA] (Module updates) Added a release notes entry if the change is significant
  - [NA] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
