### PR TITLE
python3Packages.threadpoolctl: disable test test_architecture

### DIFF
--- a/pkgs/development/python-modules/threadpoolctl/default.nix
+++ b/pkgs/development/python-modules/threadpoolctl/default.nix
@@ -23,6 +23,11 @@ buildPythonPackage rec {
   };
 
   checkInputs = [ pytestCheckHook numpy scipy ];
+  disabledTests = [
+    # accepts a limited set of cpu models based on project
+    # developers' hardware
+    "test_architecture"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/joblib/threadpoolctl";


### PR DESCRIPTION
###### Motivation for this change
Been annoying me for a while

This test will only pass on a limited set of cpu models. Notably it breaks on hydra's darwin machines.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
