### PR TITLE
ouch: 0.2.0 -> 0.3.1

### DIFF
--- a/pkgs/tools/compression/ouch/default.nix
+++ b/pkgs/tools/compression/ouch/default.nix
@@ -1,22 +1,34 @@
-{ lib, rustPlatform, fetchFromGitHub }:
+{ lib, rustPlatform, fetchFromGitHub, help2man, installShellFiles }:
 
 rustPlatform.buildRustPackage rec {
   pname = "ouch";
-  version = "0.2.0";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "ouch-org";
     repo = pname;
     rev = version;
-    sha256 = "sha256-OhEr/HvwgDkB8h3cpayOlnrs6OXiwAsQUH9XGqi5rpc=";
+    sha256 = "sha256-I9CgkYxcK+Ih9UlcYBa8QAZZsPvzPUK5ZUYKPxzgs38=";
   };
 
-  cargoSha256 = "sha256-lKsB75Lb9IYS80qu4jaIpnbEOr4Ow9M5S45Kk03An2o=";
+  cargoSha256 = "sha256-jEprWtIl5LihD9fOMYHGGlk0+h4woUlwUWNfSkd2t10=";
+
+  nativeBuildInputs = [ help2man installShellFiles ];
+
+  postInstall = ''
+    help2man $out/bin/ouch > ouch.1
+    installManPage ouch.1
+
+    completions=($releaseDir/build/ouch-*/out/completions)
+    installShellCompletion $completions/ouch.{bash,fish} --zsh $completions/_ouch
+  '';
+
+  GEN_COMPLETIONS = 1;
 
   meta = with lib; {
     description = "A command-line utility for easily compressing and decompressing files and directories";
     homepage = "https://github.com/ouch-org/ouch";
     license = licenses.mit;
-    maintainers = [ maintainers.psibi ];
+    maintainers = with maintainers; [ figsoda psibi ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Also adds me as a maintainer

https://github.com/ouch-org/ouch/releases
https://github.com/ouch-org/ouch/compare/0.2.0...0.3.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
