### PR TITLE
ocamlPackages.eliom: 8.6.0 → 8.9.0

### DIFF
--- a/pkgs/development/ocaml-modules/eliom/default.nix
+++ b/pkgs/development/ocaml-modules/eliom/default.nix
@@ -1,8 +1,6 @@
 { stdenv, lib, fetchzip, which, ocsigen_server, ocaml,
   lwt_react,
   opaline, ppx_deriving, findlib
-, ocaml-migrate-parsetree
-, ppx_tools_versioned
 , js_of_ocaml-ocamlbuild, js_of_ocaml-ppx, js_of_ocaml-ppx_deriving_json
 , js_of_ocaml-lwt
 , js_of_ocaml-tyxml
@@ -13,17 +11,15 @@
 stdenv.mkDerivation rec
 {
   pname = "eliom";
-  version = "8.6.0";
+  version = "8.9.0";
 
   src = fetchzip {
     url = "https://github.com/ocsigen/eliom/archive/${version}.tar.gz";
-    sha256 = "0s1hpawwhqp4qcy8w1067n8c6zg8jcjpzplc39bjbb1ycqw667j9";
+    sha256 = "sha256:1b1vb3ilb54ffzb98mqa6zggqchsnjspbni8qxi6j42pbajp7p2l";
   };
 
   buildInputs = [ ocaml which findlib js_of_ocaml-ocamlbuild
-    ocaml-migrate-parsetree
     js_of_ocaml-ppx_deriving_json opaline
-    ppx_tools_versioned
     ocamlnet
   ];
 


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.13.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
