### PR TITLE
kwin: add optional dependency libqaccessibilityclient

### DIFF
--- a/pkgs/desktops/plasma-5/kwin/default.nix
+++ b/pkgs/desktops/plasma-5/kwin/default.nix
@@ -12,7 +12,7 @@
   kcoreaddons, kcrash, kdeclarative, kdecoration, kglobalaccel, ki18n,
   kiconthemes, kidletime, kinit, kio, knewstuff, knotifications, kpackage,
   krunner, kscreenlocker, kservice, kwayland, kwayland-server, kwidgetsaddons,
-  kwindowsystem, kxmlgui, plasma-framework,
+  kwindowsystem, kxmlgui, plasma-framework, libqaccessibilityclient,
 }:
 
 # TODO (ttuegel): investigate qmlplugindump failure
@@ -31,7 +31,7 @@ mkDerivation {
     kcoreaddons kcrash kdeclarative kdecoration kglobalaccel ki18n kiconthemes
     kidletime kinit kio knewstuff knotifications kpackage krunner kscreenlocker
     kservice kwayland kwayland-server kwidgetsaddons kwindowsystem kxmlgui
-    plasma-framework
+    plasma-framework libqaccessibilityclient
 
   ];
   outputs = [ "dev" "out" ];

--- a/pkgs/development/libraries/libqaccessibilityclient/default.nix
+++ b/pkgs/development/libraries/libqaccessibilityclient/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, fetchurl, cmake, qtbase, extra-cmake-modules }:
+
+stdenv.mkDerivation rec {
+  pname = "libqaccessibilityclient";
+  version = "0.4.1";
+
+  src = fetchurl {
+    url = "mirror://kde/stable/libqaccessibilityclient/libqaccessibilityclient-${version}.tar.xz";
+    sha256 = "sha256-HHaLT0MU/K4qB8t958sq4FIrXwK0Fzrz7ti/sqTYNCk=";
+  };
+
+  nativeBuildInputs = [ cmake extra-cmake-modules ];
+  buildInputs = [ qtbase ];
+
+  outputs = [ "out" "dev" ];
+
+  dontWrapQtApps = true;
+
+  meta = with lib; {
+    description = "Accessibilty tools helper library, used e.g. by screen readers";
+    homepage = "https://github.com/KDE/libqaccessibilityclient";
+    maintainers = with maintainers; [ artturin ];
+    license = with licenses; [ lgpl3Only /* or */ lgpl21Only ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -136,6 +136,8 @@ in (kdeFrameworks // plasmaMobileGear // plasma5 // plasma5.thirdParty // kdeGea
 
   libqtav = callPackage ../development/libraries/libqtav { };
 
+  libqaccessibilityclient = callPackage ../development/libraries/libqaccessibilityclient { };
+
   kpmcore = callPackage ../development/libraries/kpmcore { };
 
   mapbox-gl-native = libsForQt5.callPackage ../development/libraries/mapbox-gl-native { };


### PR DESCRIPTION
fixes
-- The following OPTIONAL packages have not been found:
 * QAccessibilityClient, KDE client-side accessibility library, <kde.org>
   Required to enable accessibility features
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


Should i remove the lib prefix?

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
