### PR TITLE
lib: fix escapeXML example in documentation

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -369,7 +369,7 @@ rec {
 
      Example:
        escapeXML ''"test" 'test' < & >''
-       => "\\[\\^a-z]\\*"
+       => "&quot;test&quot; &apos;test&apos; &lt; &amp; &gt;"
   */
   escapeXML = builtins.replaceStrings
     ["\"" "'" "<" ">" "&"]


### PR DESCRIPTION
###### Motivation for this change

The previous example output was forgotten copy-paste from some other function.

###### Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).