### PR TITLE
libmtp: 1.1.18 -> 1.1.19

### DIFF
--- a/pkgs/development/libraries/libmtp/default.nix
+++ b/pkgs/development/libraries/libmtp/default.nix
@@ -1,6 +1,13 @@
-{ lib, stdenv, fetchFromGitHub, autoconf, automake, gettext, libtool, pkg-config
-, libusb1
+{ stdenv
+, autoconf
+, automake
+, fetchFromGitHub
+, gettext
+, lib
 , libiconv
+, libtool
+, libusb1
+, pkg-config
 }:
 
 stdenv.mkDerivation rec {
@@ -24,30 +31,26 @@ stdenv.mkDerivation rec {
     pkg-config
   ];
 
-  buildInputs = [
-    libiconv
-  ];
+  buildInputs = [ libiconv ];
 
-  propagatedBuildInputs = [
-    libusb1
-  ];
+  propagatedBuildInputs = [ libusb1 ];
 
-  preConfigure = ''
-    ./autogen.sh
-  '';
+  preConfigure = "./autogen.sh";
 
-  # tried to install files to /lib/udev, hopefully OK
-  configureFlags = [ "--with-udev=$$bin/lib/udev" ];
+  configureFlags = [ "--with-udev=${placeholder "out"}/lib/udev" ];
+
+  enableParallelBuilding = true;
 
   meta = with lib; {
-    homepage = "http://libmtp.sourceforge.net";
+    homepage = "https://github.com/libmtp/libmtp";
     description = "An implementation of Microsoft's Media Transfer Protocol";
     longDescription = ''
       libmtp is an implementation of Microsoft's Media Transfer Protocol (MTP)
       in the form of a library suitable primarily for POSIX compliant operating
       systems. We implement MTP Basic, the stuff proposed for standardization.
-      '';
+    '';
     platforms = platforms.unix;
     license = licenses.lgpl21;
+    maintainers = with maintainers; [ lovesegfault ];
   };
 }

--- a/pkgs/development/libraries/libmtp/default.nix
+++ b/pkgs/development/libraries/libmtp/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libmtp";
-  version = "1.1.18";
+  version = "1.1.19";
 
   src = fetchFromGitHub {
     owner = "libmtp";
     repo = "libmtp";
     rev = "libmtp-${builtins.replaceStrings [ "." ] [ "-" ] version}";
-    sha256 = "0rya6dsb67a7ny2i1jzdicnday42qb8njqw6r902k712k5p7d1r9";
+    sha256 = "sha256-o8JKoKVNpU/nHTDnKJpa8FlXt37fZnTf45WBTCxLyTs=";
   };
 
   outputs = [ "bin" "dev" "out" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
