### PR TITLE
[21.05] firefox: 93.0 -> 94.0; firefox-esr-91: 91.2.0esr -> 91.3.0esr; firefox-esr-78: mark insecure; firefox-esr: redirect to firefox-esr-91]

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -9,7 +9,7 @@
 , hunspell, libevent, libstartup_notification
 , libvpx_1_8
 , icu69, libpng, jemalloc, glib, pciutils
-, autoconf213, which, gnused, rustPackages, rustPackages_1_45
+, autoconf213, which, gnused, rustPackages_1_45, rustPackages_1_55
 , rust-cbindgen, nodejs, nasm, fetchpatch
 , gnum4
 , gtk2, gtk3, wrapGAppsHook
@@ -99,18 +99,18 @@ let
   rust-cbindgen_pkg = if lib.versionAtLeast ffversion "89" then rust-cbindgen_latest else rust-cbindgen;
 
   # 78 ESR won't build with rustc 1.47
-  inherit (if lib.versionAtLeast ffversion "82" then rustPackages else rustPackages_1_45)
+  inherit (if lib.versionAtLeast ffversion "91" then rustPackages_1_55 else rustPackages_1_45)
     rustc cargo;
 
   # Darwin's stdenv provides the default llvmPackages version, match that since
   # clang LTO on Darwin is broken so the stdenv is not being changed.
   # Target the LLVM version that rustc -Vv reports it is built with for LTO.
-  # rustPackages_1_45 -> LLVM 10, rustPackages -> LLVM 11
+  # rustPackages_1_45 -> LLVM 10, rustPackages_1_55 -> LLVM 12
   llvmPackages0 =
     /**/ if stdenv.isDarwin
       then buildPackages.llvmPackages
-    else if lib.versionAtLeast rustc.llvm.version "11"
-      then buildPackages.llvmPackages_11
+    else if lib.versionAtLeast rustc.llvm.version "12"
+      then buildPackages.llvmPackages_12
     else buildPackages.llvmPackages_10;
   # Force the use of lld and other llvm tools for LTO
   llvmPackages = llvmPackages0.override {

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -7,10 +7,10 @@ in
 rec {
   firefox = common rec {
     pname = "firefox";
-    ffversion = "93.0";
+    ffversion = "94.0";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "b29890e331819d47201b599b9feaaa7eaa0b02088fcbf980efc4f289d43da4f73970bf35ba2f763a2a892fd5318deb68cb9a66e71e9bc0c603642434c7e32e91";
+      sha512 = "5eb65450a0f1842d28d73235f3ef95fa1dbf8cf1467c354f13df51313bd227aaf5a48b741ee49b13378aaaf054bff52004c1dd5a274eddef4a3cf1b913ef7071";
     };
 
     meta = {

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -33,10 +33,10 @@ rec {
 
   firefox-esr-91 = common rec {
     pname = "firefox-esr";
-    ffversion = "91.2.0esr";
+    ffversion = "91.3.0esr";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "f4cff7e43ff9927cbab3f02d37d360ee8bb0dbe988e280cb0638ee67bfe3c76e3a0469336de1b212fba66c958d58594b1739aafee1ebb84695d098c1e5c77b9d";
+      sha512 = "7cf6efd165acc134bf576715580c103a2fc10ab928ede4c18f69908c62a04eb0f60affa8ceafd5883b393c31b85cae6821d0ae063c9e78117456d475947deaa9";
     };
 
     meta = {

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -73,6 +73,9 @@ rec {
       badPlatforms = lib.platforms.darwin;
       broken = stdenv.buildPlatform.is32bit; # since Firefox 60, build on 32-bit platforms fails with "out of memory".
                                              # not in `badPlatforms` because cross-compilation on 64-bit machine might work.
+      knownVulnerabilities = [
+        "Firefox ESR 78 has reached its end of life. Migrate to Firefox ESR 91 (`firefox-esr` or `firefox-esr-91`)."
+      ];
       license = lib.licenses.mpl20;
     };
     tests = [ nixosTests.firefox-esr-78 ];

--- a/pkgs/development/compilers/rust/1_55.nix
+++ b/pkgs/development/compilers/rust/1_55.nix
@@ -1,0 +1,60 @@
+# New rust versions should first go to staging.
+# Things to check after updating:
+# 1. Rustc should produce rust binaries on x86_64-linux, aarch64-linux and x86_64-darwin:
+#    i.e. nix-shell -p fd or @GrahamcOfBorg build fd on github
+#    This testing can be also done by other volunteers as part of the pull
+#    request review, in case platforms cannot be covered.
+# 2. The LLVM version used for building should match with rust upstream.
+#    Check the version number in the src/llvm-project git submodule in:
+#    https://github.com/rust-lang/rust/blob/<version-tag>/.gitmodules
+# 3. Firefox and Thunderbird should still build on x86_64-linux.
+
+{ stdenv, lib
+, buildPackages
+, newScope, callPackage
+, CoreFoundation, Security
+, pkgsBuildTarget, pkgsBuildBuild, pkgsBuildHost
+, makeRustPlatform
+, llvmPackages_11
+, llvmPackages_12, llvm_12
+} @ args:
+
+import ./default.nix {
+  rustcVersion = "1.55.0";
+  rustcSha256 = "07l28f7grdmi65naq71pbmvdd61hwcpi40ry7kp7dy7m233rldxj";
+
+  llvmSharedForBuild = pkgsBuildBuild.llvmPackages_12.libllvm.override { enableSharedLibraries = true; };
+  llvmSharedForHost = pkgsBuildHost.llvmPackages_12.libllvm.override { enableSharedLibraries = true; };
+  llvmSharedForTarget = pkgsBuildTarget.llvmPackages_12.libllvm.override { enableSharedLibraries = true; };
+
+  llvmBootstrapForDarwin = llvmPackages_11;
+
+  # For use at runtime
+  llvmShared = llvm_12.override { enableSharedLibraries = true; };
+
+  # Note: the version MUST be one version prior to the version we're
+  # building
+  bootstrapVersion = "1.54.0";
+
+  # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
+  bootstrapHashes = {
+    i686-unknown-linux-gnu = "1cd06090463711d50d98374ef52c1a84b9f4e3e35febaaef4890fb10536ceb3a";
+    x86_64-unknown-linux-gnu = "350354495b1d4b6dd2ec7cf96aa9bc61d031951cf667a31e8cf401dc508639e6";
+    x86_64-unknown-linux-musl = "3571db0018fcd32f3b579a32b2301826dbd1cce44b373aed8e8a31c2a6f52fe8";
+    arm-unknown-linux-gnueabihf = "77f4e4c2195f75466c6de0b1d8fd7fb8cef3d12666e3aae777dcfd0d71d080ca";
+    armv7-unknown-linux-gnueabihf = "dd01ccb6a53d5e895a6755a78c213ae601a347366688941d5c543b5af5835d6d";
+    aarch64-unknown-linux-gnu = "33a50c5366a57aaab43c1c19e4a49ab7d8ffcd99a72925c315fb1f9389139e6f";
+    aarch64-unknown-linux-musl = "49d94116a357ea13f5a3231de2472f59210028c3cf81f158b8a367c3155ac544";
+    x86_64-apple-darwin = "5eb27a4f5f7a4699bc70cf1848e340ddd74e151488bfcb26853fd584958e3d33";
+    aarch64-apple-darwin = "801b3b15b992b0321261de8b8ea2728e9a74822c6cb99bf978b34e217c7825ba";
+    powerpc64le-unknown-linux-gnu = "67cadf7ac5bd2e3d5fb4baede69846059f17c4e099f771329b266d08b875ed71";
+    riscv64gc-unknown-linux-gnu = "6113a6cce3500033d0dc0d170b54c5f22562ef3025fd58d804c822a2499c74d7";
+  };
+
+  selectRustPackage = pkgs: pkgs.rust_1_55;
+
+  rustcPatches = [
+  ];
+}
+
+(builtins.removeAttrs args [ "fetchpatch" "pkgsBuildHost" "llvmPackages_11" "llvmPackages_12" "llvm_12"])

--- a/pkgs/development/libraries/nss/latest.nix
+++ b/pkgs/development/libraries/nss/latest.nix
@@ -18,7 +18,7 @@ let
   #       It will rebuild itself using the version of this package (NSS) and if
   #       an update is required do the required changes to the expression.
   #       Example: nix-shell ./maintainers/scripts/update.nix --argstr package cacert
-  version = "3.70";
+  version = "3.71";
   underscoreVersion = builtins.replaceStrings ["."] ["_"] version;
 
 in stdenv.mkDerivation rec {
@@ -27,7 +27,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://mozilla/security/nss/releases/NSS_${underscoreVersion}_RTM/src/${pname}-${version}.tar.gz";
-    sha256 = "sha256-K4mruGAe5AW+isW1cD1x8fs4pRw6ZKPYNDh/eLMlURs=";
+    sha256 = "0ly2l3dv6z5hlxs72h5x6796ni3x1bq60saavaf42ddgv4ax7b4r";
   };
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23704,7 +23704,7 @@ in
   firefox-esr-wayland = wrapFirefox firefox-esr-91-unwrapped { forceWayland = true; };
   firefox-esr-78 = wrapFirefox firefox-esr-78-unwrapped { };
   firefox-esr-91 = wrapFirefox firefox-esr-91-unwrapped { };
-  firefox-esr = firefox-esr-78;
+  firefox-esr = firefox-esr-91;
 
   firefox-bin-unwrapped = callPackage ../applications/networking/browsers/firefox-bin {
     channel = "release";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11654,6 +11654,10 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
     llvm_12 = llvmPackages_12.libllvm;
   };
+  rust_1_55 = callPackage ../development/compilers/rust/1_55.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+    llvm_12 = llvmPackages_12.libllvm;
+  };
   rust = rust_1_52;
 
   mrustc = callPackage ../development/compilers/mrustc { };
@@ -11662,6 +11666,7 @@ in
 
   rustPackages_1_45 = rust_1_45.packages.stable;
   rustPackages_1_52 = rust_1_52.packages.stable;
+  rustPackages_1_55 = rust_1_55.packages.stable;
   rustPackages = rustPackages_1_52;
 
   inherit (rustPackages) cargo clippy rustc rustPlatform;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Backport #144219 

78 ESR is EOL, redirect everyone to 91 ESR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
