### PR TITLE
llvmPackages_*.clang-unwrapped: make scan-build work

### DIFF
--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -114,6 +114,11 @@ let
     '') + ''
       rm $out/bin/c-index-test
 
+      # TODO(@sternenseemann): support scan-build{,-py} properly in clang-tools
+      # scan-build expects these to be in ../libexec. These scripts use perl and
+      # are left with impure shebangs to avoid an 100MB closure size increase.
+      moveToOutput "libexec/c*-analyzer" "$out"
+
       # Move scan-build-py (!) and its dependencies to $python
       moveToOutput "bin/scan-build-py" "$python"
       moveToOutput "lib/libear" "$python"

--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -113,7 +113,15 @@ let
       mv $out/share/scan-view/*.py $python/share/scan-view
     '') + ''
       rm $out/bin/c-index-test
-      patchShebangs $python/bin
+
+      # Move scan-build-py (!) and its dependencies to $python
+      moveToOutput "bin/scan-build-py" "$python"
+      moveToOutput "lib/libear" "$python"
+      moveToOutput "lib/libscanbuild" "$python"
+      moveToOutput "libexec/analyze-c*" "$python"
+      moveToOutput "libexec/intercept-c*" "$python"
+
+      patchShebangs $python/bin $python/libexec
 
       mkdir -p $dev/bin
     '' + (if lib.versionOlder release_version "15" then ''


### PR DESCRIPTION
* scan-build and c*-analyzer are written in Perl, so we need to add it
  as a buildInput, so the interpreter is patched.

* For scan-build to discover c*-analyzer, the `bin` and `libexec`
  directories need to be in the same prefix. Since this is no big
  trouble for clang, we can just move the libexec directory from the
  `lib` to the `out` output.

To be tested how this interacts with bootstrapping for macOS and perhaps `pkgsLLVM`.
Additional perl dependency may be a problem in some cases?

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
