### PR TITLE
tty-solitaire: fix build against upcoming ncurses-6.3

### DIFF
--- a/pkgs/applications/misc/tty-solitaire/default.nix
+++ b/pkgs/applications/misc/tty-solitaire/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, ncurses }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, ncurses }:
 
 stdenv.mkDerivation rec {
   pname = "tty-solitaire";
@@ -11,9 +11,21 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-zMLNWJieHxHALFQoSkdAxGbUBGuZnznLX86lI3P21F0=";
   };
 
-  buildInputs = [ ncurses ];
+  patches = [
+    # Patch pending upstream inclusion to support ncurses-6.3:
+    #  https://github.com/mpereira/tty-solitaire/pull/61
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/mpereira/tty-solitaire/commit/4d066c564d086ce272b78cb8f80717a7fb83c261.patch";
+      sha256 = "sha256-E1XVG0be6JH3K1y7UPap93s8xk8Nk0dKLdKHcJ7mA8E=";
+    })
+  ];
 
-  patchPhase = "sed -i -e '/^CFLAGS *?= *-g *$/d' Makefile";
+  postPatch = ''
+    sed -i -e '/^CFLAGS *?= *-g *$/d' Makefile
+  '';
+
+  buildInputs = [ ncurses ];
 
   makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" "PREFIX=${placeholder "out"}" ];
 


### PR DESCRIPTION
On ncurses-6.3 with extra printf() annotations gcc now detects
use of user input in place of format strings:

    src/gui.c:48:13: error: format not a string literal and no format arguments [-Werror=format-security]
       48 |             card_suits[card->suit]);
          |             ^~~~~~~~~~
