### PR TITLE
findimagedupes: init at 2.19.1

### DIFF
--- a/pkgs/development/perl-modules/findimagedupes/default.nix
+++ b/pkgs/development/perl-modules/findimagedupes/default.nix
@@ -1,0 +1,70 @@
+{ lib, stdenv, fetchurl, makeWrapper, perl, perlPackages, installShellFiles }:
+
+stdenv.mkDerivation rec {
+  pname = "findimagedupes";
+  version = "2.19.1";
+
+  # fetching this from GitHub does not contain the correct version number
+  src = fetchurl {
+    url = "http://www.jhnc.org/findimagedupes/findimagedupes-${version}.tar.gz";
+    sha256 = "sha256-5NBPoXNZays5wzpQYar4uZZb0P/zB7fdecE+SjkJjcI=";
+  };
+
+  # Work around the "unpacker appears to have produced no directories"
+  setSourceRoot = "sourceRoot=$(pwd)";
+
+  nativeBuildInputs = [ makeWrapper installShellFiles ];
+
+  buildInputs = [ perl ] ++ (with perlPackages; [
+    DBFile
+    FileMimeInfo
+    FileBaseDir
+    #GraphicsMagick
+    ImageMagick
+    Inline
+    InlineC
+    ParseRecDescent
+  ]);
+
+  # use /tmp as a storage
+  # replace GraphicsMagick with ImageMagick, because perl bindings are not yet available
+  postPatch = ''
+    substituteInPlace findimagedupes \
+      --replace "DIRECTORY => '/usr/local/lib/findimagedupes';" "DIRECTORY => '/tmp';" \
+      --replace "Graphics::Magick" "Image::Magick"
+  '';
+
+  buildPhase = "
+    runHook preBuild
+    ${perl}/bin/pod2man findimagedupes > findimagedupes.1
+    runHook postBuild
+  ";
+
+  installPhase = ''
+    runHook preInstall
+    install -D -m 755 findimagedupes $out/bin/findimagedupes
+    installManPage findimagedupes.1
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram "$out/bin/findimagedupes" \
+      --prefix PERL5LIB : "${with perlPackages; makePerlPath [
+        DBFile
+        FileMimeInfo
+        FileBaseDir
+        #GraphicsMagick
+        ImageMagick
+        Inline
+        InlineC
+        ParseRecDescent
+      ]}"
+  '';
+
+  meta = with lib; {
+    homepage = "http://www.jhnc.org/findimagedupes/";
+    description = "Finds visually similar or duplicate images";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ stunkymonkey ];
+  };
+}

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -8973,6 +8973,8 @@ let
     buildInputs = [ TestPod ];
   };
 
+  findimagedupes = callPackage ../development/perl-modules/findimagedupes { };
+
   FindLib = buildPerlPackage {
     pname = "Find-Lib";
     version = "1.04";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
the goal is to add the package `findimagedupes`. Therefore the `GraphicsMagick`-perl-bindings have to enabled.
<!--fixing #132587-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
