### PR TITLE
pythonPackages.pytest-dotenv: init at 0.5.2

### DIFF
--- a/pkgs/development/python-modules/pytest-dotenv/default.nix
+++ b/pkgs/development/python-modules/pytest-dotenv/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, pytest, python-dotenv }:
+
+buildPythonPackage rec {
+  pname = "pytest-dotenv";
+  version = "0.5.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "LcbDrG2HZMccbSgE6QLQ/4EPoZaS6V/hOK78mxqnNzI=";
+  };
+
+  buildInputs = [ pytest ];
+  propagatedBuildInputs = [ python-dotenv ];
+
+  checkInputs = [ pytest ];
+
+  meta = with lib; {
+    description = "A pytest plugin that parses environment files before running tests";
+    homepage = "https://github.com/quiqua/pytest-dotenv";
+    license = licenses.mit;
+    maintainers = with maintainers; [ cleeyv ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7256,6 +7256,8 @@ in {
 
   pytest-doctestplus = callPackage ../development/python-modules/pytest-doctestplus { };
 
+  pytest-dotenv = callPackage ../development/python-modules/pytest-dotenv { };
+
   pytest-env = callPackage ../development/python-modules/pytest-env { };
 
   pytest-error-for-skips = callPackage ../development/python-modules/pytest-error-for-skips { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The pytest plugin pytest-dotenv is a dependency of the tests for LiberaForms which I packaged as a flake and module for Summer of Nix:  https://github.com/ngi-nix/liberaforms

###### Things done

I have tested that this package works by using it in the flake.nix for LiberaForms and successfully running all of the tests with `nix flake check`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
