### PR TITLE
kodi.packages.keymap: init at 1.1.3+matrix.1

### DIFF
--- a/pkgs/applications/video/kodi-packages/defusedxml/default.nix
+++ b/pkgs/applications/video/kodi-packages/defusedxml/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildKodiAddon, fetchzip, addonUpdateScript }:
+
+buildKodiAddon rec {
+  pname = "defusedxml";
+  namespace = "script.module.defusedxml";
+  version = "0.6.0+matrix.1";
+
+  src = fetchzip {
+    url = "https://mirrors.kodi.tv/addons/matrix/${namespace}/${namespace}-${version}.zip";
+    sha256 = "026i5rx9rmxcc18ixp6qhbryqdl4pn7cbwqicrishivan6apnacd";
+  };
+
+  passthru = {
+    pythonPath = "lib";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.defusedxml";
+    };
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/tiran/defusedxml";
+    description = "defusing XML bombs and other exploits";
+    license = licenses.psfl;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/applications/video/kodi-packages/keymap/default.nix
+++ b/pkgs/applications/video/kodi-packages/keymap/default.nix
@@ -1,0 +1,24 @@
+{ lib, addonDir, buildKodiAddon, fetchzip, defusedxml, kodi-six }:
+
+buildKodiAddon rec {
+  pname = "keymap";
+  namespace = "script.keymap";
+  version = "1.1.3+matrix.1";
+
+  src = fetchzip {
+    url = "https://mirrors.kodi.tv/addons/matrix/${namespace}/${namespace}-${version}.zip";
+    sha256 = "1icrailzpf60nw62xd0khqdp66dnr473m2aa9wzpmkk3qj1ay6jv";
+  };
+
+  propagatedBuildInputs = [
+    defusedxml
+    kodi-six
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/tamland/xbmc-keymap-editor";
+    description = "A GUI for configuring mappings for remotes, keyboard and other inputs supported by Kodi";
+    license = licenses.gpl3Plus;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -72,6 +72,8 @@ let self = rec {
 
   joystick = callPackage ../applications/video/kodi-packages/joystick { };
 
+  keymap = callPackage ../applications/video/kodi-packages/keymap { };
+
   netflix = callPackage ../applications/video/kodi-packages/netflix { };
 
   svtplay = callPackage ../applications/video/kodi-packages/svtplay { };

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -106,6 +106,8 @@ let self = rec {
 
   dateutil = callPackage ../applications/video/kodi-packages/dateutil { };
 
+  defusedxml = callPackage ../applications/video/kodi-packages/defusedxml { };
+
   idna = callPackage ../applications/video/kodi-packages/idna { };
 
   inputstream-adaptive = callPackage ../applications/video/kodi-packages/inputstream-adaptive { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
recently this plugin came to my attention and solved some problems for me - i would love to deploy this to all my htpc setups

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
