### PR TITLE
[21.05] qemu: patch CVE-2021-3544

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -107,6 +107,31 @@ stdenv.mkDerivation rec {
       sha256 = "1qakkb7i4gx3x4rrp7500yxqrcnvc2h6a8g916csynscbprlvl97";
     })
     (fetchpatch {
+      name = "CVE-2021-3544-patch1.patch";
+      url = "https://gitlab.com/qemu-project/qemu/-/commit/86dd8fac2acc366930a5dc08d3fb1b1e816f4e1e.patch";
+      sha256 = "0kl0jfs7681fymz2b46a8anyzbmp9lv6k43bkscq7nsh8972b7s1";
+    })
+    (fetchpatch {
+      name = "CVE-2021-3544-patch2.patch";
+      url = "https://gitlab.com/qemu-project/qemu/-/commit/b9f79858a614d95f5de875d0ca31096eaab72c3b.patch";
+      sha256 = "1wxd4q5q24lr8yhjxjayxli6kpkq4cd3q953kk4sw793wywivsb3";
+    })
+    (fetchpatch {
+      name = "CVE-2021-3544-patch3.patch";
+      url = "https://gitlab.com/qemu-project/qemu/-/commit/b7afebcf9e6ecf3cf9b5a9b9b731ed04bca6aa3e.patch";
+      sha256 = "05yg9a4khan7hmxv2ssv4l6rvvw4vxf9l225g0kc7a947giwmqjy";
+    })
+    (fetchpatch {
+      name = "CVE-2021-3544-patch4.patch";
+      url = "https://gitlab.com/qemu-project/qemu/-/commit/f6091d86ba9ea05f4e111b9b42ee0005c37a6779.patch";
+      sha256 = "1xxjd1fz21p88x0fp1bk4pd15w873cxm13av45i2xv7j9v510vsj";
+    })
+    (fetchpatch {
+      name = "CVE-2021-3544-patch5.patch";
+      url = "https://gitlab.com/qemu-project/qemu/-/commit/63736af5a6571d9def93769431e0d7e38c6677bf.patch";
+      sha256 = "1h4hij602fsplgmppvgv51rghhkchq14akd8x7jb3w4hv241rsz1";
+    })
+    (fetchpatch {
       name = "CVE-2021-3682.patch";
       url = "https://gitlab.com/qemu-project/qemu/-/commit/5e796671e6b8d5de4b0b423dce1b3eba144a92c9.patch";
       sha256 = "0g87arqvjff1vzgzb87h67ws51y033slhzlqx1yy4fw9dzkszj9k";


### PR DESCRIPTION
This is a 5-part patch series for a series of related memory leaks,
backported from qemu 6.1.0.

https://gitlab.com/qemu-project/qemu/-/commit/86dd8fac2acc366930a5dc08d3fb1b1e816f4e1e
https://gitlab.com/qemu-project/qemu/-/commit/b9f79858a614d95f5de875d0ca31096eaab72c3b
https://gitlab.com/qemu-project/qemu/-/commit/b7afebcf9e6ecf3cf9b5a9b9b731ed04bca6aa3e
https://gitlab.com/qemu-project/qemu/-/commit/f6091d86ba9ea05f4e111b9b42ee0005c37a6779
https://gitlab.com/qemu-project/qemu/-/commit/63736af5a6571d9def93769431e0d7e38c6677bf

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/128419
https://github.com/NixOS/nixpkgs/issues/128420

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
