### PR TITLE
openafs: Add upstream patches for Linux kernel 5.15

### DIFF
--- a/pkgs/servers/openafs/1.8/module.nix
+++ b/pkgs/servers/openafs/1.8/module.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, which, autoconf, automake, flex, bison
-, kernel, glibc, perl, libtool_2, libkrb5 }:
+, kernel, glibc, perl, libtool_2, libkrb5, fetchpatch }:
 
 with (import ./srcs.nix {
   inherit fetchurl;
@@ -17,6 +17,23 @@ in stdenv.mkDerivation {
     ++ kernel.moduleBuildDependencies;
 
   buildInputs = [ libkrb5 ];
+
+  patches = [
+    # LINUX 5.14: explicitly set set_page_dirty to default
+    ((fetchpatch {
+      url = "https://gerrit.openafs.org/changes/14830/revisions/20b8a37950b3718b85a4a3d21b23469a5176eb6a/patch";
+      sha256 = "1mkfwq0pbwvfjspsy2lxhi0f09hljgc6xyn3y97sai0dyivn05jp";
+    }).overrideAttrs (o: {
+      postFetch = "mv $out p; base64 -d p > $out; " + o.postFetch;
+    }))
+    # Linux 5.15: Convert osi_Msg macro to a function
+    ((fetchpatch {
+      url = "https://gerrit.openafs.org/changes/14831/revisions/6cfa9046229d90c0625687e3fddb7877f21fbcff/patch";
+      sha256 = "18rip9a1krxf47fizf3f12ddq55apzb2w3wjj5qs7n3sh2nwks7g";
+    }).overrideAttrs (o: {
+      postFetch = "mv $out p; base64 -d p > $out; " + o.postFetch;
+    }))
+  ];
 
   hardeningDisable = [ "pic" ];
 
@@ -56,6 +73,6 @@ in stdenv.mkDerivation {
     license = licenses.ipl10;
     platforms = platforms.linux;
     maintainers = with maintainers; [ maggesi spacefrogg ];
-    broken = versionOlder kernel.version "3.18" || kernel.kernelAtLeast "5.15" || kernel.isHardened;
+    broken = versionOlder kernel.version "3.18" || kernel.isHardened;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Without these patches, the OpenAFS kernel module no longer compiles with kernel 5.15 (#144079).

Since these patches have not yet been merged to the upstream `openafs-stable-1_8_x` branch, and the patches from the upstream `master` branch don’t apply cleanly, we need to download them from Gerrit and awkwardly base64-decode them because Gerrit is weird.

https://gerrit.openafs.org/14830
https://gerrit.openafs.org/14831

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
