### PR TITLE
pantheon-tweaks: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/applications/system/pantheon-tweaks/default.nix
+++ b/pkgs/applications/system/pantheon-tweaks/default.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "pantheon-tweaks";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "pantheon-tweaks";
     repo = pname;
     rev = version;
-    sha256 = "sha256-tAfDxX/RD7pO5PN/LaZ92Cj/iZtBI/EHb0+pORfYnPM=";
+    sha256 = "sha256-2spZ6RQ5PhBNrv/xG1TNbYsJrmuRpaZ72CeH2s8+P8g=";
   };
 
   patches = [
@@ -38,9 +38,12 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gtk3
     libgee
-    pantheon.granite
-    pantheon.switchboard
-  ];
+  ] ++ (with pantheon; [
+    elementary-files # settings schemas
+    elementary-terminal # settings schemas
+    granite
+    switchboard
+  ]);
 
   postPatch = ''
     chmod +x meson/post_install.py


### PR DESCRIPTION
###### Motivation for this change

https://github.com/pantheon-tweaks/pantheon-tweaks/releases/tag/1.0.2
https://github.com/pantheon-tweaks/pantheon-tweaks/compare/1.0.1...1.0.2

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] ~~Tested execution of all binary files (usually in `./result/bin/`)~~ Tested with switchboard
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
