### PR TITLE
prl-tools: use undmg without redirection

### DIFF
--- a/pkgs/os-specific/linux/prl-tools/default.nix
+++ b/pkgs/os-specific/linux/prl-tools/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   inherit libsOnly;
 
   unpackPhase = ''
-    undmg < "${src}"
+    undmg "${src}"
 
     export sourceRoot=prl-tools-build
     7z x "Parallels Desktop.app/Contents/Resources/Tools/prl-tools-lin.iso" -o$sourceRoot


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`undmg` has an issue with some DMG files that causes a segfault when read via stdin but not when the filename is provided as a parameter [1]. The author of `undmg` is removing the ability to read from stdin [2]. All other uses of `undmg` in nixpkgs are with the file as a parameter.

[1] https://github.com/matthewbauer/undmg/issues/8
[2] https://github.com/matthewbauer/undmg/commit/97f07e8b1e17b0b7a4eb7bda640d3e7482265e6e

###### Things done

It appears `prl-tools` involves compiling multiple versions of the kernel and my ancient system is not up to the task.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
