### PR TITLE
firefly-desktop: init at 1.2.0

### DIFF
--- a/pkgs/applications/misc/firefly-desktop/default.nix
+++ b/pkgs/applications/misc/firefly-desktop/default.nix
@@ -1,0 +1,34 @@
+{ lib, fetchurl, appimageTools }:
+
+let
+  pname = "firefly-desktop";
+  version = "1.2.0";
+  src = fetchurl {
+    url = "https://github.com/iotaledger/firefly/releases/download/desktop-${version}/${pname}-${version}.AppImage";
+    sha256 = "f3162efcf0407614fd1351af50e95ef180400b747a5cc6b82bc840828a15548d";
+  };
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+
+in appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraPkgs = pkgs: (appimageTools.defaultFhsEnvArgs.multiPkgs pkgs) ++ [ pkgs.libsecret ];
+
+  extraInstallCommands = ''
+    mkdir -p $out/share/applications $out/share/pixmaps
+    mv $out/bin/${pname}-${version} $out/bin/firefly-desktop
+    cp ${appimageContents}/desktop.desktop $out/share/applications/firefly-desktop.desktop
+    substituteInPlace $out/share/applications/firefly-desktop.desktop \
+      --replace 'Exec=AppRun' 'Exec=firefly-desktop' \
+      --replace 'Icon=desktop' 'Icon=firefly-desktop'
+    cp ${appimageContents}/desktop.png $out/share/pixmaps/firefly-desktop.png
+  '';
+
+  meta = with lib; {
+    description = "IOTA's New Wallet";
+    homepage = "https://firefly.iota.org";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ wolfangaukang ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -305,6 +305,8 @@ with pkgs;
 
   evans = callPackage ../development/tools/evans { };
 
+  firefly-desktop = callPackage ../applications/misc/firefly-desktop { };
+
   frugal = callPackage ../development/tools/frugal { };
 
   glade = callPackage ../development/tools/glade { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#143855

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
