### PR TITLE
bastet: fix build against upcoming ncurses-6.3

### DIFF
--- a/pkgs/games/bastet/default.nix
+++ b/pkgs/games/bastet/default.nix
@@ -18,6 +18,14 @@ stdenv.mkDerivation rec {
       url = "https://github.com/fph/bastet/commit/0e03f8d4d6bc6949cf1c447e632ce0d1b98c4be1.patch";
       sha256 = "1475hisbm44jirsrhdlnddppsyn83xmvcx09gfkm9drcix05alzj";
     })
+
+    # Fix pending upstream inclusion for ncurses-6.3:
+    #  https://github.com/fph/bastet/pull/21
+    (fetchpatch {
+      name = "ncurses-6.3";
+      url = "https://github.com/fph/bastet/commit/54a6d127351ea2c62f50efafe97c5b02e23e86a7.patch";
+      sha256 = "14v95b0m16m6ycd82i3wpp81kbmj6qz029b1m5483dkk6mwz98iy";
+    })
   ];
 
   installPhase = ''

--- a/pkgs/games/bastet/default.nix
+++ b/pkgs/games/bastet/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     # Fix pending upstream inclusion for ncurses-6.3:
     #  https://github.com/fph/bastet/pull/21
     (fetchpatch {
-      name = "ncurses-6.3";
+      name = "ncurses-6.3.patch";
       url = "https://github.com/fph/bastet/commit/54a6d127351ea2c62f50efafe97c5b02e23e86a7.patch";
       sha256 = "14v95b0m16m6ycd82i3wpp81kbmj6qz029b1m5483dkk6mwz98iy";
     })


### PR DESCRIPTION
On ncurses-6.3 with extra printf() annotations gcc now detects
use of user input in place of format strings:

    Ui.cpp:293:16: error: format not a string literal and no format arguments [-Werror=format-security]
      293 |       mvwprintw(w,0,0,msg.c_str());
          |       ~~~~~~~~~^~~~~~~~~~~~~~~~~~~
