### PR TITLE
rbw: Install git credential helper without an option

### DIFF
--- a/pkgs/tools/security/rbw/default.nix
+++ b/pkgs/tools/security/rbw/default.nix
@@ -22,9 +22,6 @@
   # pass-import
 , withPass ? false
 , pass
-
-  # git-credential-helper
-, withGitCredential ? false
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -47,7 +44,11 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = lib.optionals stdenv.isDarwin [ Security libiconv ];
 
-  postPatch = lib.optionalString withFzf ''
+  postPatch = ''
+    patchShebangs bin/git-credential-rbw
+    substituteInPlace bin/git-credential-rbw \
+        --replace rbw $out/bin/rbw
+  '' + lib.optionalString withFzf ''
     patchShebangs bin/rbw-fzf
     substituteInPlace bin/rbw-fzf \
         --replace fzf ${fzf}/bin/fzf \
@@ -61,10 +62,6 @@ rustPlatform.buildRustPackage rec {
     patchShebangs bin/pass-import
     substituteInPlace bin/pass-import \
         --replace pass ${pass}/bin/pass
-  '' + lib.optionalString withGitCredential ''
-    patchShebangs bin/git-credential-rbw
-    substituteInPlace bin/git-credential-rbw \
-        --replace rbw $out/bin/rbw
   '';
 
   preConfigure = ''
@@ -77,14 +74,14 @@ rustPlatform.buildRustPackage rec {
       $out/bin/rbw gen-completions $shell > rbw.$shell
       installShellCompletion rbw.$shell
     done
+  '' + ''
+    cp bin/git-credential-rbw $out/bin
   '' + lib.optionalString withFzf ''
     cp bin/rbw-fzf $out/bin
   '' + lib.optionalString withRofi ''
     cp bin/rbw-rofi $out/bin
   '' + lib.optionalString withPass ''
     cp bin/pass-import $out/bin
-  '' + lib.optionalString withGitCredential ''
-    cp bin/git-credential-rbw $out/bin
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
