### PR TITLE
Package the (Pop!_OS) COSMIC Desktop Environment

### DIFF
--- a/pkgs/desktops/gnome/core/pop-control-center/default.nix
+++ b/pkgs/desktops/gnome/core/pop-control-center/default.nix
@@ -1,0 +1,44 @@
+{ lib, fetchFromGitHub, gnome, pop-desktop-widget, grilo }:
+
+gnome.gnome-control-center.overrideAttrs (old: rec {
+  pname = "pop-control-center";
+
+  src = fetchFromGitHub {
+    owner = "pop-os";
+    repo = "gnome-control-center";
+    # from branch `master_impish`
+    rev = "2dafb76ab69cf4c93e6dd8920c0e10b7cacf0d0f";
+    sha256 = "sha256-SSu3eaSB+4dZNQvsOiQiviHqM+eo4PQkNH97oG3xecc=";
+  };
+
+  buildInputs = old.buildInputs ++ [ grilo pop-desktop-widget ];
+
+  patches = let
+    patchDir = "${src}/debian/patches";
+  in old.patches ++ [
+    # "${patchDir}/pop/pop-allow-sound-above-100.patch"
+    "${patchDir}/pop/pop-mouse-accel.patch"
+    "${patchDir}/pop/pop-shop.patch"
+    # "${patchDir}/pop/pop-upgrade.patch"
+    # "${patchDir}/pop/pop-hidpi.patch"
+    # "${patchDir}/pop/system76-firmware.patch"
+    "${patchDir}/pop/pop-alert-sound.patch"
+    "${patchDir}/pop/remove-diagnostics.patch"
+    # "${patchDir}/pop/gsettings-desktop-schemas-version.patch"
+    "${patchDir}/pop/0001-mouse-Add-Disable-While-Typing-toggle-for-touchpad.patch"
+    "${patchDir}/pop/0001-Do-not-enforce-password-strength-requirements.patch"
+    "${patchDir}/pop/0002-users-Recreate-RunHandler-on-failure.patch"
+    "${patchDir}/pop/cc-search-locations-dialog.patch"
+    "${patchDir}/pop/0001-shell-Fix-bug-when-multiple-panels-use-custom-sideba.patch"
+    "${patchDir}/pop/pop-desktop-widget.patch"
+    "${patchDir}/pop/pop-no-search.patch"
+    "${patchDir}/pop/0001-keyboard-Pop-_OS-changes-with-support-for-multiple-b.patch"
+  ];
+
+  meta = with lib; {
+    description = "Modular IPC-based desktop launcher service for Pop!_OS";
+    maintainers = with maintainers; [ Enzime ];
+    license = licenses.gpl3;
+    homepage = "https://github.com/pop-os/gnome-control-center";
+  };
+})

--- a/pkgs/desktops/gnome/core/pop-desktop-widget/default.nix
+++ b/pkgs/desktops/gnome/core/pop-desktop-widget/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, rustPlatform, lib, pkg-config, glib, gst_all_1, gtk3, libhandy }:
+
+stdenv.mkDerivation rec {
+  pname = "pop-desktop-widget";
+  version = "unstable-2021-11-03";
+
+  src = fetchFromGitHub {
+    owner = "pop-os";
+    repo = "desktop-widget";
+    rev = "1652fc89aa16dcf652422c4c3dfe1095e6286b7d";
+    sha256 = "sha256-QBQBtBSj+J87yAQhYMOrJTUCee3ebJhVc4Y/7EyBDes=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-/Sa/eImZZ+XeeCJueZOEhAmz0MA9yjW58jbFmXk4HL0=";
+  };
+
+  nativeBuildInputs = [ pkg-config glib rustPlatform.cargoSetupHook rustPlatform.rust.cargo ];
+  buildInputs = [ gst_all_1.gstreamer gtk3 libhandy ];
+
+  installFlags = [ "prefix=$(out)" "DESTDIR=" ];
+
+  meta = with lib; {
+    description = "GTK desktop settings widget for Pop!_OS";
+    maintainers = with maintainers; [ Enzime ];
+    license = licenses.mit;
+    homepage = "https://github.com/pop-os/desktop-widget";
+  };
+}

--- a/pkgs/desktops/gnome/core/pop-launcher/custom-base-path.patch
+++ b/pkgs/desktops/gnome/core/pop-launcher/custom-base-path.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 433728e..065d328 100644
+--- a/Makefile
++++ b/Makefile
+@@ -2,7 +2,7 @@ TARGET = debug
+ DEBUG ?= 0
+ 
+ ifeq ($(DESTDIR),)
+-BASE_PATH = $(HOME)/.local
++BASE_PATH ?= $(HOME)/.local
+ LIB_PATH = $(BASE_PATH)/share
+ else
+ BASE_PATH = $(DESTDIR)/usr

--- a/pkgs/desktops/gnome/core/pop-launcher/default.nix
+++ b/pkgs/desktops/gnome/core/pop-launcher/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, rustPlatform, lib, pkg-config, openssl, gtk3 }:
+
+stdenv.mkDerivation rec {
+  pname = "pop-launcher";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "pop-os";
+    repo = "launcher";
+    rev = version;
+    sha256 = "sha256-eo/4ou9cW27IxS5C5l+KV6DU1gbe+Vbv9oVTTHPx0uI=";
+  };
+
+  patches = [ ./custom-base-path.patch ];
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-47s9tE2SImf8VhiKUXI4Kkk0ctamVktCKQsM8WpJOJM=";
+  };
+
+  nativeBuildInputs = [ pkg-config rustPlatform.cargoSetupHook rustPlatform.rust.cargo ];
+  buildInputs = [ openssl gtk3 ];
+
+  installFlags = [ "BASE_PATH=$(out)" ];
+
+  meta = with lib; {
+    description = "Modular IPC-based desktop launcher service for Pop!_OS";
+    maintainers = with maintainers; [ Enzime ];
+    license = licenses.mpl20;
+    homepage = "https://github.com/pop-os/launcher";
+  };
+}

--- a/pkgs/desktops/gnome/core/pop-shell-shortcuts/default.nix
+++ b/pkgs/desktops/gnome/core/pop-shell-shortcuts/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, fetchFromGitHub, rustPlatform, pkg-config, gtk3 }:
+
+stdenv.mkDerivation rec {
+  pname = "pop-shell-shortcuts";
+  version = "unstable-2021-10-02";
+
+  src = fetchFromGitHub {
+    owner = "pop-os";
+    repo = "shell-shortcuts";
+    rev = "005f76c8e59d924a7edb59a2d08030d439b7fd45";
+    sha256 = "sha256-/o6sQ/EieIbZrD7p1dwYOQ+uBsk+zf3vjnPXOcD890Q=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-SySh4/xjP+KnuL3x+IFQUyLgpI3hyshi3h8L5m5ZXOk=";
+  };
+
+  nativeBuildInputs = [ pkg-config rustPlatform.cargoSetupHook rustPlatform.rust.cargo ];
+  buildInputs = [ gtk3 ];
+
+  installFlags = [ "prefix=$(out)" "DESTDIR=" ];
+
+  meta = with lib; {
+    description = "Application for displaying and demoing Pop Shell shortcuts";
+    license = licenses.gpl3Only;
+    homepage = "https://github.com/pop-os/shell-shortcuts";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ Enzime ];
+  };
+}

--- a/pkgs/desktops/gnome/extensions/cosmic-dock/default.nix
+++ b/pkgs/desktops/gnome/extensions/cosmic-dock/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, fetchFromGitHub, glib, sassc }:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-extension-cosmic-dock";
+  version = "unstable-2021-11-03";
+
+  src = fetchFromGitHub {
+    owner = "pop-os";
+    repo = "cosmic-dock";
+    # from branch `master_impish`
+    rev = "acb33c1c25866655e11191a781055ac272acfdc3";
+    sha256 = "sha256-MM5E8T6xWamfi7ABgTgG8WmuX0bvdmZHu8bmys1og2k=";
+  };
+
+  nativeBuildInputs = [ glib sassc ];
+
+  makeFlags = [ "XDG_DATA_HOME=$(out)/share" ];
+
+  passthru = {
+    extensionUuid = "cosmic-dock@system76.com";
+    extensionPortalSlug = "cosmic-dock";
+  };
+
+  meta = with lib; {
+    description = "Cosmic Dock (Pop!_OS fork of Ubuntu Dock)";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ Enzime ];
+    homepage = "https://github.com/pop-os/cosmic-dock";
+  };
+}

--- a/pkgs/desktops/gnome/extensions/cosmic-workspaces/default.nix
+++ b/pkgs/desktops/gnome/extensions/cosmic-workspaces/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, fetchFromGitHub, glib }:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-extension-cosmic-workspaces";
+  version = "unstable-2021-11-03";
+
+  src = fetchFromGitHub {
+    owner = "pop-os";
+    repo = "cosmic-workspaces";
+    # from branch `master_impish`
+    rev = "678b34bdcdec14471665b87092ca16f6857dac66";
+    sha256 = "sha256-RhdNG9FQRat4mBNfB5G1VflzzyixXfdOUg4BfmPceCQ=";
+  };
+
+  nativeBuildInputs = [ glib ];
+
+  makeFlags = [ "XDG_DATA_HOME=$(out)/share" ];
+
+  passthru = {
+    extensionUuid = "cosmic-workspaces@system76.com";
+    extensionPortalSlug = "cosmic-workspaces";
+  };
+
+  meta = with lib; {
+    description = "Vertically stacked workspaces (Pop!_OS fork)";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ Enzime ];
+    homepage = "https://github.com/pop-os/cosmic-workspaces";
+  };
+}

--- a/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
+++ b/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
@@ -2,6 +2,7 @@
 {
   "arcmenu@arcmenu.com" = callPackage ./arcmenu { };
   "clock-override@gnomeshell.kryogenix.org" = callPackage ./clock-override { };
+  "cosmic-dock@system76.com" = callPackage ./cosmic-dock { };
   "dash-to-panel@jderose9.github.com" = callPackage ./dash-to-panel { };
   "drop-down-terminal@gs-extensions.zzrough.org" = callPackage ./drop-down-terminal { };
   "EasyScreenCast@iacopodeenosee.gmail.com" = callPackage ./EasyScreenCast { };

--- a/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
+++ b/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
@@ -16,6 +16,7 @@
   "no-title-bar@jonaspoehler.de" = callPackage ./no-title-bar { };
   "paperwm@hedning:matrix.org" = callPackage ./paperwm { };
   "pidgin@muffinmad" = callPackage ./pidgin-im-integration { };
+  "pop-cosmic@system76.com" = callPackage ./pop-cosmic { };
   "pop-shell@system76.com" = callPackage ./pop-shell { };
   "sound-output-device-chooser@kgshank.net" = callPackage ./sound-output-device-chooser { };
   "system-monitor@paradoxxx.zero.gmail.com" = callPackage ./system-monitor { };

--- a/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
+++ b/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
@@ -3,6 +3,7 @@
   "arcmenu@arcmenu.com" = callPackage ./arcmenu { };
   "clock-override@gnomeshell.kryogenix.org" = callPackage ./clock-override { };
   "cosmic-dock@system76.com" = callPackage ./cosmic-dock { };
+  "cosmic-workspaces@system76.com" = callPackage ./cosmic-workspaces { };
   "dash-to-panel@jderose9.github.com" = callPackage ./dash-to-panel { };
   "drop-down-terminal@gs-extensions.zzrough.org" = callPackage ./drop-down-terminal { };
   "EasyScreenCast@iacopodeenosee.gmail.com" = callPackage ./EasyScreenCast { };

--- a/pkgs/desktops/gnome/extensions/pop-cosmic/default.nix
+++ b/pkgs/desktops/gnome/extensions/pop-cosmic/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, fetchFromGitHub, glib }:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-extension-pop-cosmic";
+  version = "unstable-2021-11-03";
+
+  src = fetchFromGitHub {
+    owner = "pop-os";
+    repo = "cosmic";
+    # from branch `master_impish`
+    rev = "fbcaa2c071330a73e7b13b407e8b7fb0251eeace";
+    sha256 = "sha256-hgEbGG3ZQwSCeMvu8NiPA6SdO+Y2THD/nEoTzRRxdFs=";
+  };
+
+  nativeBuildInputs = [ glib ];
+
+  makeFlags = [ "XDG_DATA_HOME=$(out)/share" ];
+
+  passthru = {
+    extensionUuid = "pop-cosmic@system76.com";
+    extensionPortalSlug = "pop-cosmic";
+  };
+
+  meta = with lib; {
+    description = "Computer Operating System Main Interface Components";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ Enzime ];
+    homepage = "https://github.com/pop-os/cosmic";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31238,6 +31238,8 @@ with pkgs;
 
   pop-desktop-widget = callPackage ../desktops/gnome/core/pop-desktop-widget { };
 
+  pop-control-center = callPackage ../desktops/gnome/core/pop-control-center { };
+
   latte-dock = libsForQt5.callPackage ../applications/misc/latte-dock { };
 
   gnome-themes-extra = gnome.gnome-themes-extra;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31240,6 +31240,8 @@ with pkgs;
 
   pop-control-center = callPackage ../desktops/gnome/core/pop-control-center { };
 
+  pop-launcher = callPackage ../desktops/gnome/core/pop-launcher { };
+
   latte-dock = libsForQt5.callPackage ../applications/misc/latte-dock { };
 
   gnome-themes-extra = gnome.gnome-themes-extra;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31236,6 +31236,8 @@ with pkgs;
 
   redshift-plasma-applet = libsForQt5.callPackage ../applications/misc/redshift-plasma-applet { };
 
+  pop-desktop-widget = callPackage ../desktops/gnome/core/pop-desktop-widget { };
+
   latte-dock = libsForQt5.callPackage ../applications/misc/latte-dock { };
 
   gnome-themes-extra = gnome.gnome-themes-extra;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31242,6 +31242,8 @@ with pkgs;
 
   pop-launcher = callPackage ../desktops/gnome/core/pop-launcher { };
 
+  pop-shell-shortcuts = callPackage ../desktops/gnome/core/pop-shell-shortcuts { };
+
   latte-dock = libsForQt5.callPackage ../applications/misc/latte-dock { };
 
   gnome-themes-extra = gnome.gnome-themes-extra;


### PR DESCRIPTION
###### Motivation for this change

Currently not all the packages work on GNOME 41 so I've based this off 21.05 which has GNOME 40.

This is a combination of #104160 and #102150 and closes #92769.

Some inspiration from https://gitlab.manjaro.org/packages/community/gnome/cosmic :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
