### PR TITLE
treewide: set meta.mainProgram for packages teams.pantheon.members maintain

### DIFF
--- a/pkgs/applications/audio/vocal/default.nix
+++ b/pkgs/applications/audio/vocal/default.nix
@@ -88,5 +88,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ ] ++ teams.pantheon.members;
     platforms = platforms.linux;
+    mainProgram = "com.github.needleandthread.vocal";
   };
 }

--- a/pkgs/applications/graphics/akira/default.nix
+++ b/pkgs/applications/graphics/akira/default.nix
@@ -71,5 +71,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ Br1ght0ne neonfuz ] ++ teams.pantheon.members;
     platforms = platforms.linux;
+    mainProgram = "com.github.akiraux.akira";
   };
 }

--- a/pkgs/applications/graphics/fondo/default.nix
+++ b/pkgs/applications/graphics/fondo/default.nix
@@ -58,15 +58,16 @@ stdenv.mkDerivation rec {
     patchShebangs meson/post_install.py
   '';
 
+  passthru.updateScript = nix-update-script {
+    attrPath = pname;
+  };
+
   meta = with lib; {
     homepage = "https://github.com/calo001/fondo";
     description = "Find the most beautiful wallpapers for your desktop";
     license = licenses.agpl3Plus;
     maintainers = with maintainers; [ AndersonTorres ] ++ teams.pantheon.members;
     platforms = platforms.linux;
-  };
-
-  passthru.updateScript = nix-update-script {
-    attrPath = pname;
+    mainProgram = "com.github.calo001.fondo";
   };
 }

--- a/pkgs/applications/graphics/ideogram/default.nix
+++ b/pkgs/applications/graphics/ideogram/default.nix
@@ -63,6 +63,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     maintainers = teams.pantheon.members;
     platforms = platforms.linux;
+    mainProgram = "com.github.cassidyjames.ideogram";
   };
 
 }

--- a/pkgs/applications/misc/appeditor/default.nix
+++ b/pkgs/applications/misc/appeditor/default.nix
@@ -59,5 +59,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ xiorcale ] ++ teams.pantheon.members;
     platforms = platforms.linux;
     license = licenses.gpl3Plus;
+    mainProgram = "com.github.donadigo.appeditor";
   };
 }

--- a/pkgs/applications/misc/cipher/default.nix
+++ b/pkgs/applications/misc/cipher/default.nix
@@ -60,5 +60,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ xiorcale ] ++ teams.pantheon.members;
     platforms = platforms.linux;
     license = licenses.gpl3Plus;
+    mainProgram = "com.github.arshubham.cipher";
   };
 }

--- a/pkgs/applications/misc/formatter/default.nix
+++ b/pkgs/applications/misc/formatter/default.nix
@@ -74,5 +74,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ xiorcale ] ++ teams.pantheon.members;
     platforms = platforms.linux;
     license = licenses.lgpl2Plus;
+    mainProgram = "com.github.djaler.formatter";
   };
 }

--- a/pkgs/applications/misc/minder/default.nix
+++ b/pkgs/applications/misc/minder/default.nix
@@ -75,5 +75,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ dtzWill ] ++ teams.pantheon.members;
+    mainProgram = "com.github.phase1geo.minder";
   };
 }

--- a/pkgs/applications/misc/notejot/default.nix
+++ b/pkgs/applications/misc/notejot/default.nix
@@ -64,5 +64,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ AndersonTorres ] ++ teams.pantheon.members;
     platforms = platforms.linux;
+    mainProgram = "io.github.lainsce.Notejot";
   };
 }

--- a/pkgs/applications/misc/sequeler/default.nix
+++ b/pkgs/applications/misc/sequeler/default.nix
@@ -47,5 +47,6 @@ in stdenv.mkDerivation rec {
     license = licenses.gpl3;
     maintainers = with maintainers; [ etu ] ++ teams.pantheon.members;
     platforms = platforms.linux;
+    mainProgram = "com.github.alecaddd.sequeler";
   };
 }

--- a/pkgs/applications/networking/browsers/ephemeral/default.nix
+++ b/pkgs/applications/networking/browsers/ephemeral/default.nix
@@ -67,5 +67,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ xiorcale ] ++ teams.pantheon.members;
     platforms = platforms.linux;
     license = licenses.gpl3;
+    mainProgram = "com.github.cassidyjames.ephemeral";
   };
 }

--- a/pkgs/applications/networking/ftp/taxi/default.nix
+++ b/pkgs/applications/networking/ftp/taxi/default.nix
@@ -52,15 +52,16 @@ stdenv.mkDerivation rec {
     patchShebangs meson/post_install.py
   '';
 
+  passthru.updateScript = nix-update-script {
+    attrPath = pname;
+  };
+
   meta = with lib; {
     homepage = "https://github.com/Alecaddd/taxi";
     description = "The FTP Client that drives you anywhere";
     license = licenses.lgpl3Plus;
     maintainers = with maintainers; [ AndersonTorres ] ++ teams.pantheon.members;
     platforms = platforms.linux;
-  };
-
-  passthru.updateScript = nix-update-script {
-    attrPath = pname;
+    mainProgram = "com.github.alecaddd.taxi";
   };
 }

--- a/pkgs/applications/networking/p2p/torrential/default.nix
+++ b/pkgs/applications/networking/p2p/torrential/default.nix
@@ -77,5 +77,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ xiorcale ] ++ teams.pantheon.members;
     platforms = platforms.linux;
     license = licenses.gpl2Plus;
+    mainProgram = "com.github.davidmhewitt.torrential";
   };
 }

--- a/pkgs/applications/networking/ping/default.nix
+++ b/pkgs/applications/networking/ping/default.nix
@@ -64,5 +64,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ xiorcale ] ++ teams.pantheon.members;
     platforms = platforms.linux;
     license = licenses.gpl3;
+    mainProgram = "com.github.jeremyvaartjes.ping";
   };
 }

--- a/pkgs/applications/office/agenda/default.nix
+++ b/pkgs/applications/office/agenda/default.nix
@@ -62,6 +62,7 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ xiorcale ] ++ teams.pantheon.members;
     platforms = platforms.linux;
     license = licenses.gpl3;
+    mainProgram = "com.github.dahenson.agenda";
   };
 }
 

--- a/pkgs/applications/office/elementary-planner/default.nix
+++ b/pkgs/applications/office/elementary-planner/default.nix
@@ -85,6 +85,8 @@ stdenv.mkDerivation rec {
     homepage = "https://planner-todo.web.app";
     license = licenses.gpl3;
     maintainers = with maintainers; [ dtzWill ] ++ teams.pantheon.members;
+    platforms = platforms.linux;
+    mainProgram = "com.github.alainm23.planner";
   };
 }
 

--- a/pkgs/applications/office/notes-up/default.nix
+++ b/pkgs/applications/office/notes-up/default.nix
@@ -68,5 +68,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ ] ++ teams.pantheon.members;
     platforms = platforms.linux;
+    mainProgram = "com.github.philip-scott.notes-up";
   };
 }

--- a/pkgs/applications/office/spice-up/default.nix
+++ b/pkgs/applications/office/spice-up/default.nix
@@ -74,5 +74,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     # The COPYING file has GPLv3; some files have GPLv2+ and some have GPLv3+
     license = licenses.gpl3Plus;
+    mainProgram = "com.github.philip-scott.spice-up";
   };
 }

--- a/pkgs/applications/science/math/nasc/default.nix
+++ b/pkgs/applications/science/math/nasc/default.nix
@@ -83,5 +83,6 @@ stdenv.mkDerivation rec {
     maintainers = teams.pantheon.members;
     platforms = platforms.linux;
     license = licenses.gpl3Plus;
+    mainProgram = "com.github.parnold_x.nasc";
   };
 }

--- a/pkgs/tools/misc/hashit/default.nix
+++ b/pkgs/tools/misc/hashit/default.nix
@@ -45,5 +45,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     maintainers = teams.pantheon.members;
     platforms = platforms.linux;
+    mainProgram = "com.github.artemanufrij.hashit";
   };
 }

--- a/pkgs/tools/text/snippetpixie/default.nix
+++ b/pkgs/tools/text/snippetpixie/default.nix
@@ -88,5 +88,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ ianmjones ] ++ teams.pantheon.members;
     platforms = platforms.linux;
+    mainProgram = "com.github.bytepixie.snippetpixie";
   };
 }


### PR DESCRIPTION
This is a follow-up of https://github.com/NixOS/nixpkgs/pull/143285

###### Motivation for this change

Make `nix run` work (Almost all Pantheon related packages follow RDNN scheme for executable name).

###### Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
