### PR TITLE
lagrange: 1.7.3 → 1.9.0

### DIFF
--- a/pkgs/applications/networking/browsers/lagrange/default.nix
+++ b/pkgs/applications/networking/browsers/lagrange/default.nix
@@ -13,18 +13,19 @@
 , pcre
 , SDL2
 , AppKit
+, zip
 , zlib
 }:
 
 stdenv.mkDerivation rec {
   pname = "lagrange";
-  version = "1.7.3";
+  version = "1.9.0";
 
   src = fetchFromGitHub {
     owner = "skyjake";
     repo = "lagrange";
     rev = "v${version}";
-    sha256 = "sha256-peBdmz/aucrKO5Vsj8WkHkpGpLm4inQHee133Zph3MM=";
+    sha256 = "sha256-T4LZcdQHqykcv1HnTHMt5LE/1gwKPjN3f0ZmqSCID/A=";
     fetchSubmodules = true;
   };
 
@@ -32,17 +33,12 @@ stdenv.mkDerivation rec {
     rm -r lib/fribidi lib/harfbuzz
   '';
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  nativeBuildInputs = [ cmake pkg-config zip ];
 
   buildInputs = [ fribidi harfbuzz libunistring libwebp mpg123 openssl pcre SDL2 zlib ]
     ++ lib.optional stdenv.isDarwin AppKit;
 
   hardeningDisable = lib.optional (!stdenv.cc.isClang) "format";
-
-  cmakeFlags = [
-    "-DENABLE_HARFBUZZ_MINIMAL:BOOL=OFF"
-    "-DENABLE_FRIBIDI_BUILD:BOOL=OFF"
-  ];
 
   installPhase = lib.optionalString stdenv.isDarwin ''
     mkdir -p $out/Applications


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/skyjake/lagrange/releases)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).