### PR TITLE
libdeflate: register static build as test (ref: #144207)

### DIFF
--- a/pkgs/development/libraries/libdeflate/default.nix
+++ b/pkgs/development/libraries/libdeflate/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, fixDarwinDylibNames, pkgsStatic }:
+{ stdenv, lib, fetchpatch, fetchFromGitHub, fixDarwinDylibNames, pkgsStatic }:
 
 stdenv.mkDerivation rec {
   pname = "libdeflate";
@@ -11,9 +11,18 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-P7YbuhP2/zJCpE9dxZev1yy5oda8WKAHY84ZLTL8gVs=";
   };
 
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/ebiggers/libdeflate/commit/ee4d18872bfe09a32cfd031c716b9069a04a50a0.diff";
+      sha256 = "0d2lllg60zbbbch0w0qrcqijrgski8xlsy5llg3i684d66ci538a";
+    })
+  ];
+
   postPatch = ''
     substituteInPlace Makefile --replace /usr/local $out
   '';
+
+  makeFlags = lib.optional stdenv.hostPlatform.isStatic [ "DISABLE_SHARED=1"];
 
   nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
 

--- a/pkgs/development/libraries/libdeflate/default.nix
+++ b/pkgs/development/libraries/libdeflate/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, fixDarwinDylibNames }:
+{ stdenv, lib, fetchFromGitHub, fixDarwinDylibNames, pkgsStatic }:
 
 stdenv.mkDerivation rec {
   pname = "libdeflate";
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  passthru.tests.static = pkgsStatic.libdeflate;
   meta = with lib; {
     description = "Fast DEFLATE/zlib/gzip compressor and decompressor";
     license = licenses.mit;

--- a/pkgs/development/libraries/libdeflate/default.nix
+++ b/pkgs/development/libraries/libdeflate/default.nix
@@ -38,6 +38,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     homepage = "https://github.com/ebiggers/libdeflate";
     platforms = platforms.unix;
-    maintainers = with maintainers; [ orivej ];
+    maintainers = with maintainers; [ orivej kaction ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Fix static build of libdeflate

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
