### PR TITLE
nixos/systemd: add {pre,post}StartElevated

### DIFF
--- a/nixos/modules/system/boot/systemd-unit-options.nix
+++ b/nixos/modules/system/boot/systemd-unit-options.nix
@@ -286,12 +286,30 @@ in rec {
       '';
     };
 
+    preStartElevated = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether or not the preStart script should be executed with elevated privileges.
+        Equivalent to adding + to ExecPreStart.
+      '';
+    };
+
     postStart = mkOption {
       type = types.lines;
       default = "";
       description = ''
         Shell commands executed after the service's main process
         is started.
+      '';
+    };
+
+    postStartElevated = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether or not the postStart script should be executed with elevated privileges.
+        Equivalent to adding + to ExecPostStart.
       '';
     };
 

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -274,7 +274,7 @@ let
         }
         (mkIf (config.preStart != "")
           { serviceConfig.ExecStartPre =
-              [ (makeJobScript "${name}-pre-start" config.preStart) ];
+              [ ((optionalString config.preStartElevated "+") + (makeJobScript "${name}-pre-start" config.preStart)) ];
           })
         (mkIf (config.script != "")
           { serviceConfig.ExecStart =
@@ -282,7 +282,7 @@ let
           })
         (mkIf (config.postStart != "")
           { serviceConfig.ExecStartPost =
-              [ (makeJobScript "${name}-post-start" config.postStart) ];
+              [ ((optionalString config.postStartElevated "+") + (makeJobScript "${name}-post-start" config.postStart)) ];
           })
         (mkIf (config.reload != "")
           { serviceConfig.ExecReload =


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Convenience option for the lazy

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
