### PR TITLE
protoc-gen-go-vtproto: init at 0.2.0

### DIFF
--- a/pkgs/development/tools/protoc-gen-go-vtproto/default.nix
+++ b/pkgs/development/tools/protoc-gen-go-vtproto/default.nix
@@ -1,0 +1,26 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+}:
+buildGoModule rec {
+  pname = "protoc-gen-go-vtproto";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "planetscale";
+    repo = "vtprotobuf";
+    rev = "v${version}";
+    sha256 = "0kjjpfsiws4vi36ha1gajb97rwcggqw753mv2jqf09kdfszz9p63";
+  };
+
+  vendorSha256 = "01lxwlgh3y3gp22gk5qx7r60c1j63pnpi6jnri8gf2lmiiib8fdc";
+
+  excludedPackages = [ "conformance" ];
+
+  meta = with lib; {
+    description = "A Protocol Buffers compiler that generates optimized marshaling & unmarshaling Go code for ProtoBuf APIv2";
+    homepage = "https://github.com/planetscale/vtprotobuf";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.zane ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -337,6 +337,8 @@ with pkgs;
 
   protoc-gen-go-grpc = callPackage ../development/tools/protoc-gen-go-grpc { };
 
+  protoc-gen-go-vtproto = callPackage ../development/tools/protoc-gen-go-vtproto { };
+
   protoc-gen-grpc-web = callPackage ../development/tools/protoc-gen-grpc-web { };
 
   protoc-gen-twirp = callPackage ../development/tools/protoc-gen-twirp { };


### PR DESCRIPTION
###### Motivation for this change

Packaging.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
