### PR TITLE
jpsxdec: init at 1.05

### DIFF
--- a/pkgs/tools/games/jpsxdec/0001-jpsxdec-hackfix-build-with-newer-JDKs.patch
+++ b/pkgs/tools/games/jpsxdec/0001-jpsxdec-hackfix-build-with-newer-JDKs.patch
@@ -1,0 +1,43 @@
+From 52662c71f7b043f374d4062d07a28b59ef010cbe Mon Sep 17 00:00:00 2001
+From: Zane van Iperen <zane@zanevaniperen.com>
+Date: Wed, 22 Sep 2021 18:41:36 +1000
+Subject: [PATCH] jpsxdec: hackfix build with newer JDKs
+
+---
+ jpsxdec/build.xml | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/jpsxdec/build.xml b/jpsxdec/build.xml
+index 713941c..f5aa902 100644
+--- a/jpsxdec/build.xml
++++ b/jpsxdec/build.xml
+@@ -43,8 +43,8 @@
+     <property name="build-lgpl.dir" location="${working.dir}/build-lgpl"/>
+     <property name="testbuild.dir"  location="${working.dir}/build-test"/>
+ 
+-    <property name="javac.target.ver" value="1.6"/>
+-    <property name="javac.source.ver" value="1.6" />
++    <property name="javac.target.ver" value="1.8"/>
++    <property name="javac.source.ver" value="1.8" />
+ 
+     <!-- output -->
+     <property name="release.dir"       location="${working.dir}/release"/>
+@@ -76,7 +76,6 @@
+             <compilerarg value="-Xlint:static"/>
+             <compilerarg value="-Xlint:unchecked"/>
+             <compilerarg value="-Xlint:varargs"/>
+-            <compilerarg value="-Werror"/>
+         </javac>
+ 
+         <!-- Copy over resources -->
+@@ -109,7 +108,6 @@
+             <compilerarg value="-Xlint:static"/>
+             <compilerarg value="-Xlint:unchecked"/>
+             <compilerarg value="-Xlint:varargs"/>
+-            <compilerarg value="-Werror"/>
+         </javac>
+             
+         <!-- Copy over resources -->
+-- 
+2.31.1
+

--- a/pkgs/tools/games/jpsxdec/default.nix
+++ b/pkgs/tools/games/jpsxdec/default.nix
@@ -1,0 +1,84 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, jdk
+/*
+ * jPSXdec needs to be built with no later than JDK8, but
+ * should be run with the latest to get HiDPI fixes, etc.
+ */
+, jre ? jdk
+, ant
+, unoconv
+, makeWrapper
+, makeDesktopItem
+}:
+let
+  pname = "jpsxdec";
+  version = "1.05";
+
+  description = "Cross-platform PlayStation 1 audio and video converter";
+
+  desktopItem = makeDesktopItem {
+    name = pname;
+    exec = pname;
+    icon = pname;
+    comment = description;
+    desktopName = "jPSXdec";
+    categories = "AudioVideo;Utility;";
+  };
+in
+stdenv.mkDerivation rec {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "m35";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0wnfvvcyldf699b08lzlc0gshl7rn09a6q4i7jmr41izlcdszdbz";
+  };
+
+  nativeBuildInputs = [ ant jdk unoconv makeWrapper ];
+  buildInputs = [ jre ];
+
+  patches = [
+    ./0001-jpsxdec-hackfix-build-with-newer-JDKs.patch
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    cd jpsxdec
+    mkdir -p _ant/release/doc/
+    unoconv -d document -f pdf -o _ant/release/doc/jPSXdec-manual.pdf doc/jPSXdec-manual.odt
+
+    ant release
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share/pixmaps}
+    mv _ant/release $out/jpsxdec
+
+    makeWrapper ${jre}/bin/java $out/bin/jpsxdec \
+      --add-flags "-jar $out/jpsxdec/jpsxdec.jar"
+
+    cp ${src}/jpsxdec/src/jpsxdec/gui/icon48.png $out/share/pixmaps/${pname}.png
+    ln -s ${desktopItem}/share/applications $out/share
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    inherit description;
+    homepage = "https://jpsxdec.blogspot.com/";
+    platforms = platforms.all;
+    license = {
+      url = "https://raw.githubusercontent.com/m35/jpsxdec/readme/.github/LICENSE.md";
+      free = true;
+    };
+    maintainers = with maintainers; [ zane ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27511,6 +27511,10 @@ with pkgs;
     wxGTK = wxGTK30-gtk3;
   };
 
+  jpsxdec = callPackage ../tools/games/jpsxdec {
+    jdk = openjdk8;
+  };
+
   pdfslicer = callPackage ../applications/misc/pdfslicer { };
 
   pekwm = callPackage ../applications/window-managers/pekwm { };


### PR DESCRIPTION
###### Motivation for this change

Packaging.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
