### PR TITLE
kotlin-native: remove `bin/kotlinc`

### DIFF
--- a/pkgs/development/compilers/kotlin/native.nix
+++ b/pkgs/development/compilers/kotlin/native.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
       standard library.
     '';
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ fabianhjr ];
     platforms = [ "x86_64-linux" ] ++ lib.platforms.darwin;
   };
 }

--- a/pkgs/development/compilers/kotlin/native.nix
+++ b/pkgs/development/compilers/kotlin/native.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation rec {
     runHook preInstall
 
     mkdir -p $out
+    rm bin/kotlinc
     mv * $out
 
     runHook postInstall


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is the only collision with the default kotlin distribution. (With this change both `kotlin` and `kotlin-native` can be added without problems on NixOS)

```
> kotlinc
NOTE: you are running "kotlinc" CLI tool from Kotlin/Native distribution,
it runs Kotlin/Native compiler that produces native binaries from Kotlin code.
If your intention was to compile Kotlin code to JVM bytecode instead, then you
need to use "kotlinc" from the main Kotlin distribution (e.g. it can be
downloaded as kotlin-compiler-X.Y.ZZ.zip archive from
https://github.com/JetBrains/kotlin/releases/latest, or installed using various
package managers).

WARNING: if your intention was to run Kotlin/Native compiler, then please use
"kotlinc-native" CLI tool instead of "kotlinc". "kotlinc" tool will be removed
from Kotlin/Native distribution, so it will stop clashing with "kotlinc" from
the main Kotlin distribution.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
