### PR TITLE
clojure-lsp: 2021.09.30-15.28.01 -> 2021.11.02-15.24.47

### DIFF
--- a/pkgs/development/tools/misc/clojure-lsp/default.nix
+++ b/pkgs/development/tools/misc/clojure-lsp/default.nix
@@ -2,33 +2,37 @@
 
 stdenv.mkDerivation rec {
   pname = "clojure-lsp";
-  version = "2021.09.30-15.28.01";
+  version = "2021.11.02-15.24.47";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "i7HCVcQa35pRnk7uXf+8PQ4IMpdSVrT7FKvguvzOvj4=";
+    sha256 = "sha256-PBbo8yx4g4SsViUA1jnwqF8q9Dfn3lrgK2CP026Bm4Q=";
   };
 
   jar = fetchurl {
     url = "https://github.com/clojure-lsp/clojure-lsp/releases/download/${version}/clojure-lsp.jar";
-    sha256 = "27a1ca0ca96cf0b5177a76679c6b7d09e6e02dca4c85fd252f7b2c43ef39b89a";
+    sha256 = "sha256-k0mzibcLAspklCPE6f2qsUm9bwSvcJRgWecMBq7mpF0=";
   };
 
   GRAALVM_HOME = graalvm11-ce;
   CLOJURE_LSP_JAR = jar;
-  CLOJURE_LSP_XMX = "-J-Xmx4g";
+  CLOJURE_LSP_XMX = "-J-Xmx6g";
 
   buildInputs = [ graalvm11-ce clojure ];
 
   buildPhase = with lib; ''
     runHook preBuild
 
-    # https://github.com/clojure-lsp/clojure-lsp/blob/2021.09.30-15.28.01/graalvm/native-unix-compile.sh#L19-L24
+    # https://github.com/clojure-lsp/clojure-lsp/blob/2021.11.02-15.24.47/graalvm/native-unix-compile.sh#L18-L27
+    DTLV_LIB_EXTRACT_DIR=$(mktemp -d)
+    export DTLV_LIB_EXTRACT_DIR=$DTLV_LIB_EXTRACT_DIR
+
     args=("-jar" "$CLOJURE_LSP_JAR"
-          "-H:CLibraryPath=${graalvm11-ce.lib}/lib"
           "-H:+ReportExceptionStackTraces"
+          "-H:CLibraryPath=${graalvm11-ce.lib}/lib"
+          "-H:CLibraryPath=$DTLV_LIB_EXTRACT_DIR"
           "--verbose"
           "--no-fallback"
           "--native-image-info"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- Fix graalvm build for recent versions
- Bump clojure-lsp

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
