### PR TITLE
cloud-sql-proxy: 1.26.0 -> 1.27.0

### DIFF
--- a/pkgs/tools/misc/cloud-sql-proxy/default.nix
+++ b/pkgs/tools/misc/cloud-sql-proxy/default.nix
@@ -2,23 +2,27 @@
 
 buildGoModule rec {
   pname = "cloud-sql-proxy";
-  version = "1.26.0";
+  version = "1.27.0";
 
   src = fetchFromGitHub {
     owner = "GoogleCloudPlatform";
     repo = "cloudsql-proxy";
     rev = "v${version}";
-    sha256 = "sha256-Xgz8ku6szzbgL3cyiggHJYaj4aUhaqgIOUnwKUE1AeY=";
+    sha256 = "sha256-x44nG5M2ycBaf/Fbw5crmAV//yv/WtIYbTjJ7/6TnoI=";
   };
 
   subPackages = [ "cmd/cloud_sql_proxy" ];
 
-  vendorSha256 = "sha256-7KiLJoQ0xH35ae4NGODF4t1S9h86L0TJbCqFVm+bBmk=";
+  vendorSha256 = "sha256-Uw8YJ1qzLYlTkx6wR/FKeDRHGSwZm2za/c0f/OKHiE0=";
+
+  # Disables tests that require running fuse with a hardcoded path
+  doCheck = false;
 
   meta = with lib; {
     description = "An authenticating proxy for Second Generation Google Cloud SQL databases";
     homepage = "https://github.com/GoogleCloudPlatform/cloudsql-proxy";
     license = licenses.asl20;
     maintainers = with maintainers; [ nicknovitski ];
+    mainProgram = "cloud_sql_proxy";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Updates cloud-sql-proxy to 1.27.0

Disables check as tests added expect `fusermount` and `macfuse` in specific paths.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
