### PR TITLE
bitwarden: 1.28.1 -> 1.29.1

### DIFF
--- a/pkgs/tools/security/bitwarden/default.nix
+++ b/pkgs/tools/security/bitwarden/default.nix
@@ -4,6 +4,7 @@
 , fetchurl
 , lib
 , libsecret
+, libxshmfence
 , makeDesktopItem
 , makeWrapper
 , stdenv
@@ -11,18 +12,55 @@
 , wrapGAppsHook
 }:
 
-let
-  inherit (stdenv.hostPlatform) system;
-
+stdenv.mkDerivation rec {
   pname = "bitwarden";
+  version = "1.29.1";
 
-  version = {
-    x86_64-linux = "1.28.1";
-  }.${system} or "";
+  src = fetchurl {
+    url = "https://github.com/bitwarden/desktop/releases/download/v${version}/Bitwarden-${version}-amd64.deb";
+    sha256 = "0rxy19bazi7a6m2bpx6wadg5d9p0k324h369vgr5ppmxb69d6zp8";
+  };
 
-  sha256 = {
-    x86_64-linux = "sha256-vyEbISZDTN+CHqSEtElzfg4M4i+2RjUux5vzwJw8/dc=";
-  }.${system} or "";
+  desktopItem = makeDesktopItem {
+    name = "bitwarden";
+    exec = "bitwarden %U";
+    icon = "bitwarden";
+    comment = "A secure and free password manager for all of your devices";
+    desktopName = "Bitwarden";
+    categories = "Utility";
+  };
+
+  dontBuild = true;
+  dontConfigure = true;
+  dontPatchELF = true;
+  dontWrapGApps = true;
+
+  nativeBuildInputs = [ dpkg makeWrapper autoPatchelfHook wrapGAppsHook ];
+
+  buildInputs = [ libsecret libxshmfence ] ++ atomEnv.packages;
+
+  unpackPhase = "dpkg-deb -x $src .";
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    cp -R "opt" "$out"
+    cp -R "usr/share" "$out/share"
+    chmod -R g-w "$out"
+
+    # Desktop file
+    mkdir -p "$out/share/applications"
+    cp "${desktopItem}/share/applications/"* "$out/share/applications"
+  '';
+
+  runtimeDependencies = [
+    (lib.getLib udev)
+  ];
+
+  postFixup = ''
+    makeWrapper $out/opt/Bitwarden/bitwarden $out/bin/bitwarden \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libsecret stdenv.cc.cc ] }" \
+      "''${gappsWrapperArgs[@]}"
+  '';
 
   meta = with lib; {
     description = "A secure and free password manager for all of your devices";
@@ -31,58 +69,4 @@ let
     maintainers = with maintainers; [ kiwi ];
     platforms = [ "x86_64-linux" ];
   };
-
-  linux = stdenv.mkDerivation rec {
-    inherit pname version meta;
-
-    src = fetchurl {
-      url = "https://github.com/bitwarden/desktop/releases/download/"
-      + "v${version}/Bitwarden-${version}-amd64.deb";
-      inherit sha256;
-    };
-
-    desktopItem = makeDesktopItem {
-      name = "bitwarden";
-      exec = "bitwarden %U";
-      icon = "bitwarden";
-      comment = "A secure and free password manager for all of your devices";
-      desktopName = "Bitwarden";
-      categories = "Utility";
-    };
-
-    dontBuild = true;
-    dontConfigure = true;
-    dontPatchELF = true;
-    dontWrapGApps = true;
-
-    buildInputs = [ libsecret ] ++ atomEnv.packages;
-
-    nativeBuildInputs = [ dpkg makeWrapper autoPatchelfHook wrapGAppsHook ];
-
-    unpackPhase = "dpkg-deb -x $src .";
-
-    installPhase = ''
-      mkdir -p "$out/bin"
-      cp -R "opt" "$out"
-      cp -R "usr/share" "$out/share"
-      chmod -R g-w "$out"
-
-      # Desktop file
-      mkdir -p "$out/share/applications"
-      cp "${desktopItem}/share/applications/"* "$out/share/applications"
-    '';
-
-    runtimeDependencies = [
-      (lib.getLib udev)
-    ];
-
-    postFixup = ''
-      makeWrapper $out/opt/Bitwarden/bitwarden $out/bin/bitwarden \
-        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libsecret stdenv.cc.cc ] }" \
-        "''${gappsWrapperArgs[@]}"
-    '';
-  };
-
-in if stdenv.isDarwin
-then throw "Bitwarden has not been packaged for macOS yet"
-else linux
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- version update
- fixes https://github.com/NixOS/nixpkgs/issues/144497

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
