### PR TITLE
zrythm: init at 1.0.0-alpha.26.0.13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11635,6 +11635,12 @@
     githubId = 1568873;
     name = "Torsten Scholak";
   };
+  tshaynik = {
+    email = "tshaynik@protonmail.com";
+    github = "tshaynik";
+    githubId = 15064765;
+    name = "tshaynik";
+  };
   tstrobel = {
     email = "4ZKTUB6TEP74PYJOPWIR013S2AV29YUBW5F9ZH2F4D5UMJUJ6S@hash.domains";
     name = "Thomas Strobel";

--- a/pkgs/applications/audio/zrythm/default.nix
+++ b/pkgs/applications/audio/zrythm/default.nix
@@ -1,0 +1,169 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, SDL2
+, alsa-lib
+, libaudec
+, bash
+, bash-completion
+, breeze-icons
+, carla
+, chromaprint
+, cmake
+, curl
+, dconf
+, epoxy
+, ffmpeg
+, fftw
+, fftwFloat
+, flex
+, glib
+, gtk3
+, gtksourceview3
+, guile
+, graphviz
+, help2man
+, json-glib
+, jq
+, libbacktrace
+, libcyaml
+, libgtop
+, libjack2
+, libpulseaudio
+, libsamplerate
+, libsndfile
+, libsoundio
+, libxml2
+, libyaml
+, lilv
+, lv2
+, meson
+, ninja
+, pandoc
+, pcre
+, pcre2
+, pkg-config
+, python3
+, reproc
+, rtaudio
+, rtmidi
+, rubberband
+, serd
+, sord
+, sratom
+, texi2html
+, wrapGAppsHook
+, xdg-utils
+, xxHash
+, vamp-plugin-sdk
+, zstd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "zrythm";
+  version = "1.0.0-alpha.26.0.13";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-dkXlkJ+qlfxV9Bv2UvZZa2iRVm8tgpK4JxkWL2Jeq48=";
+  };
+
+  nativeBuildInputs = [
+    help2man
+    jq
+    libaudec
+    libxml2
+    meson
+    ninja
+    pandoc
+    pkg-config
+    python3
+    python3.pkgs.sphinx
+    texi2html
+    wrapGAppsHook
+    cmake
+  ];
+
+  buildInputs = [
+    SDL2
+    alsa-lib
+    bash-completion
+    carla
+    chromaprint
+    curl
+    dconf
+    epoxy
+    ffmpeg
+    fftw
+    fftwFloat
+    flex
+    breeze-icons
+    glib
+    gtk3
+    gtksourceview3
+    graphviz
+    guile
+    json-glib
+    libbacktrace
+    libcyaml
+    libgtop
+    libjack2
+    libpulseaudio
+    libsamplerate
+    libsndfile
+    libsoundio
+    libyaml
+    lilv
+    lv2
+    pcre
+    pcre2
+    reproc
+    rtaudio
+    rtmidi
+    rubberband
+    serd
+    sord
+    sratom
+    vamp-plugin-sdk
+    xdg-utils
+    xxHash
+    zstd
+  ];
+
+  mesonFlags = [
+    "-Denable_ffmpeg=true"
+    "-Denable_rtmidi=true"
+    "-Denable_rtaudio=true"
+    "-Denable_sdl=true"
+    "-Dmanpage=true"
+    # "-Duser_manual=true" # needs sphinx-intl
+    "-Dlsp_dsp=disabled"
+    "-Db_lto=false"
+  ];
+
+  NIX_LDFLAGS = ''
+    -lfftw3_threads -lfftw3f_threads
+  '';
+
+  postPatch = ''
+    chmod +x scripts/meson-post-install.sh
+    patchShebangs ext/sh-manpage-completions/run.sh scripts/generic_guile_wrap.sh \
+      scripts/meson-post-install.sh tools/check_have_unlimited_memlock.sh
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix GSETTINGS_SCHEMA_DIR : "$out/share/gsettings-schemas/${pname}-${version}/glib-2.0/schemas/"
+    )
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.zrythm.org";
+    description = "Highly automated and intuitive digital audio workstation";
+    maintainers = with maintainers; [ tshaynik magnetophon ];
+    platforms = platforms.linux;
+    license = licenses.agpl3Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33563,5 +33563,9 @@ with pkgs;
 
   zktree = callPackage ../applications/misc/zktree {};
 
+  zrythm = callPackage ../applications/audio/zrythm {
+    inherit (plasma5Packages) breeze-icons;
+  };
+
   zthrottle = callPackage ../tools/misc/zthrottle { };
 }


### PR DESCRIPTION
Add a package for the zrythm Digital Audio Workstation.

Closes #98871

Built on work done by @andreasfelix on #129457 but adds additional
missing dependencies, uses the latest zrythm
version, makes use of dependencies that have since been added to
nixpkgs, and resolves the issue of the crash on start that previous
packaging attempt was encountering.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add a package for the zrythm Digital Audio Workstation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
