### PR TITLE
glog: 0.4.0 -> 0.5.0, also enable tests

### DIFF
--- a/pkgs/development/libraries/glog/default.nix
+++ b/pkgs/development/libraries/glog/default.nix
@@ -26,20 +26,16 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ gflags ];
 
-  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+    # Mak CMake place RPATHs such that tests will find the built libraries.
+    # See https://github.com/NixOS/nixpkgs/pull/144561#discussion_r742468811 and https://github.com/NixOS/nixpkgs/pull/108496
+    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
+  ];
 
   # TODO: Re-enable Darwin tests once we're on a release that has https://github.com/google/glog/issues/709#issuecomment-960381653 fixed
   doCheck = !stdenv.isDarwin;
   checkInputs = [ perl ];
-
-  # Add `build/` directory (`$PWD`) to LD_LIBRARY_PATH so that the built library
-  # can be loaded for the tests.
-  # Adding to LD_LIBRARY_PATH correctly is nontrivial:
-  #   https://jdhao.github.io/2021/07/03/ld_library_path_empty_item/
-  #   https://unix.stackexchange.com/questions/162891/append-to-path-like-variable-without-creating-leading-colon-if-unset
-  preCheck = ''
-    export LD_LIBRARY_PATH=''${LD_LIBRARY_PATH:+''${LD_LIBRARY_PATH}:}''$PWD
-  '';
 
   meta = with lib; {
     homepage = "https://github.com/google/glog";

--- a/pkgs/development/libraries/glog/default.nix
+++ b/pkgs/development/libraries/glog/default.nix
@@ -2,29 +2,25 @@
 
 stdenv.mkDerivation rec {
   pname = "glog";
-  version = "0.4.0";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "glog";
     rev = "v${version}";
-    sha256 = "1xd3maiipfbxmhc9rrblc5x52nxvkwxp14npg31y5njqvkvzax9b";
+    sha256 = "17014q25c99qyis6l3fwxidw6222bb269fdlr74gn7pzmzg4lvg3";
   };
 
-  patches = lib.optionals stdenv.hostPlatform.isMusl [
-    # TODO: Remove at next release that includes this commit.
+  patches = [
+    # Fix duplicate-concatenated nix store path in cmake file, see:
+    # https://github.com/NixOS/nixpkgs/pull/144561#issuecomment-960296043
+    # TODO: Remove when https://github.com/google/glog/pull/733 is merged and available.
     (fetchpatch {
-      name = "glog-Fix-symbolize_unittest-for-musl-builds.patch";
-      url = "https://github.com/google/glog/commit/834dd780bf1fe0704b8ed0350ca355a55f711a9f.patch";
-      sha256 = "0k4lanxg85anyvjsj3mh93bcgds8gizpiamcy2zvs3yyfjl40awn";
+      name = "glog-cmake-Fix-incorrect-relative-path-concatenation.patch";
+      url = "https://github.com/google/glog/pull/733/commits/57c636c02784f909e4b5d3c2f0ecbdbb47097266.patch";
+      sha256 = "1py93gkzmcyi2ypcwyj3nri210z8fmlaif51yflzmrrv507zd7bi";
     })
   ];
-
-  postPatch = lib.optionalString stdenv.isDarwin ''
-    # A path clash on case-insensitive file systems blocks creation of the build directory.
-    # The file in question is specific to bazel and does not influence the build result.
-    rm BUILD
-  '';
 
   nativeBuildInputs = [ cmake ];
 
@@ -32,8 +28,18 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
 
+  # TODO: Re-enable Darwin tests once we're on a release that has https://github.com/google/glog/issues/709#issuecomment-960381653 fixed
+  doCheck = !stdenv.isDarwin;
   checkInputs = [ perl ];
-  doCheck = false; # fails with "Mangled symbols (28 out of 380) found in demangle.dm"
+
+  # Add `build/` directory (`$PWD`) to LD_LIBRARY_PATH so that the built library
+  # can be loaded for the tests.
+  # Adding to LD_LIBRARY_PATH correctly is nontrivial:
+  #   https://jdhao.github.io/2021/07/03/ld_library_path_empty_item/
+  #   https://unix.stackexchange.com/questions/162891/append-to-path-like-variable-without-creating-leading-colon-if-unset
+  preCheck = ''
+    export LD_LIBRARY_PATH=''${LD_LIBRARY_PATH:+''${LD_LIBRARY_PATH}:}''$PWD
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/google/glog";

--- a/pkgs/development/libraries/glog/default.nix
+++ b/pkgs/development/libraries/glog/default.nix
@@ -40,5 +40,6 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     description = "Library for application-level logging";
     platforms = platforms.unix;
+    maintainers = with lib.maintainers; [ nh2 r-burns ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

https://github.com/google/glog/releases/tag/v0.5.0

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
