### PR TITLE
php: Implement overrideAttrs that composes with buildEnv/withExtensions

### DIFF
--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -37,6 +37,8 @@ with pkgs;
 
   cross = callPackage ./cross {};
 
+  php = recurseIntoAttrs (callPackages ./php {});
+
   rustCustomSysroot = callPackage ./rust-sysroot {};
   buildRustCrate = callPackage ../build-support/rust/build-rust-crate/test { };
   importCargoLock = callPackage ../build-support/rust/test/import-cargo-lock { };

--- a/pkgs/test/php/default.nix
+++ b/pkgs/test/php/default.nix
@@ -1,0 +1,116 @@
+{ lib
+, php
+, runCommand
+}:
+
+let
+  runTest = name: body: runCommand name { } ''
+    testFailed=
+    checking() {
+      echo -n "Checking $1... " > /dev/stderr
+    }
+    ok() {
+      echo ok > /dev/stderr
+    }
+    nok() {
+      echo fail > /dev/stderr
+      testFailed=1
+    }
+
+    ${body}
+
+    if test -n "$testFailed"; then
+      exit 1
+    fi
+
+    touch $out
+  '';
+
+  check = cond: if cond then "ok" else "nok";
+in
+{
+  withExtensions-enables-previously-disabled-extensions = runTest "php-test-withExtensions-enables-previously-disabled-extensions" ''
+    php="${php}"
+
+    checking "that imagick is not present by default"
+    $php/bin/php -r 'exit(extension_loaded("imagick") ? 1 : 0);' && ok || nok
+
+    phpWithImagick="${php.withExtensions ({ all, ... }: [ all.imagick ])}"
+    checking "that imagick extension is present when enabled"
+    $phpWithImagick/bin/php -r 'exit(extension_loaded("imagick") ? 0 : 1);' && ok || nok
+  '';
+
+  overrideAttrs-preserves-enabled-extensions =
+    let
+      customPhp =
+        (php.withExtensions ({ all, ... }: [ all.imagick ])).overrideAttrs (attrs: {
+          postInstall = attrs.postInstall or "" + ''
+            touch "$out/oApee-was-here"
+          '';
+        });
+    in
+    runTest "php-test-overrideAttrs-preserves-enabled-extensions" ''
+      php="${customPhp}"
+      phpUnwrapped="${customPhp.unwrapped}"
+
+      checking "if overrides took hold"
+      test -f "$phpUnwrapped/oApee-was-here" && ok || nok
+
+      checking "if imagick extension is still present"
+      $php/bin/php -r 'exit(extension_loaded("imagick") ? 0 : 1);' && ok || nok
+
+      checking "if imagick extension is linked against the overridden PHP"
+      echo $php
+      $php/bin/php -r 'exit(extension_loaded("imagick") ? 0 : 1);' && ok || nok
+    '';
+
+  unwrapped-overrideAttrs-stacks =
+    let
+      customPhp =
+        lib.pipe php.unwrapped [
+          (pkg: pkg.overrideAttrs (attrs: {
+            postInstall = attrs.postInstall or "" + ''
+              touch "$out/oAs-first"
+            '';
+          }))
+
+          (pkg: pkg.overrideAttrs (attrs: {
+            postInstall = attrs.postInstall or "" + ''
+              touch "$out/oAs-second"
+            '';
+          }))
+        ];
+    in
+    runTest "php-test-unwrapped-overrideAttrs-stacks" ''
+      checking "if first override remained"
+      ${check (builtins.match ".*oAs-first.*" customPhp.postInstall != null)}
+
+      checking "if second override is there"
+      ${check (builtins.match ".*oAs-second.*" customPhp.postInstall != null)}
+    '';
+
+  wrapped-overrideAttrs-stacks =
+    let
+      customPhp =
+        lib.pipe php [
+          (pkg: pkg.overrideAttrs (attrs: {
+            postInstall = attrs.postInstall or "" + ''
+              touch "$out/oAs-first"
+            '';
+          }))
+
+          (pkg: pkg.overrideAttrs (attrs: {
+            postInstall = attrs.postInstall or "" + ''
+              touch "$out/oAs-second"
+            '';
+          }))
+        ];
+    in
+    runTest "php-test-wrapped-overrideAttrs-stacks" ''
+      checking "if first override remained"
+      ${check (builtins.match ".*oAs-first.*" customPhp.unwrapped.postInstall != null)}
+
+      checking "if second override is there"
+      ${check (builtins.match ".*oAs-second.*" customPhp.unwrapped.postInstall != null)}
+    '';
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Hopefully.

Also add a couple of tests to check that.

----

I need this so I can add configure flags to fix https://github.com/fossar/nix-phps/pull/47

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
