### PR TITLE
wg-friendly-peer-names: init at unstable-2021-11-08

### DIFF
--- a/pkgs/tools/networking/wg-friendly-peer-names/default.nix
+++ b/pkgs/tools/networking/wg-friendly-peer-names/default.nix
@@ -1,0 +1,29 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, wireguard-tools
+}:
+
+stdenv.mkDerivation {
+  pname = "wg-friendly-peer-names";
+  version = "unstable-2021-11-08";
+
+  src = fetchFromGitHub {
+    owner = "FlyveHest";
+    repo = "wg-friendly-peer-names";
+    rev = "66b9b6b74ec77b9fec69b2a58296635321d4f5f1";
+    sha256 = "pH/b5rCHIqLxz/Fnx+Dm0m005qAUWBsczSU9vGEQ2RQ=";
+  };
+
+  installPhase = ''
+    install -D wgg.sh $out/bin/wgg
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/FlyveHest/wg-friendly-peer-names";
+    description = "Small shellscript that makes it possible to give peers a friendlier and more readable name in the `wg` peer list";
+    license = licenses.mit;
+    platforms = wireguard-tools.meta.platforms;
+    maintainers = with maintainers; [ mkg20001 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10468,6 +10468,8 @@ with pkgs;
 
   wireguard-tools = callPackage ../tools/networking/wireguard-tools { };
 
+  wg-friendly-peer-names = callPackage ../tools/networking/wg-friendly-peer-names { };
+
   woff2 = callPackage ../development/web/woff2 { };
 
   woof = callPackage ../tools/misc/woof { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
