### PR TITLE
percona: add some tools and new versions

### DIFF
--- a/pkgs/servers/sql/percona/5.7.nix
+++ b/pkgs/servers/sql/percona/5.7.nix
@@ -1,0 +1,84 @@
+{ lib, stdenv, fetchurl, cmake, curl, boost, bison, ncurses, libaio
+, pkg-config, openssl, readline, zlib, perl, libtirpc, rpcsvc-proto }:
+
+# Note: zlib is not required; MySQL can use an internal zlib.
+
+stdenv.mkDerivation rec {
+  pname = "percona";
+  version = "5.7.33-36";
+
+  src = fetchurl {
+    url = "https://www.percona.com/downloads/Percona-Server-5.7/Percona-Server-${version}/source/tarball/percona-server-${version}.tar.gz";
+    sha256 = "0nzxxmdm9zl57rnaxnfbyf79srcy9z9d50dy4qg44dg2l7s34kln";
+  };
+
+  preConfigure = lib.optional stdenv.isDarwin ''
+    ln -s /bin/ps $TMPDIR/ps
+    export PATH=$PATH:$TMPDIR
+  '';
+
+  nativeBuildInputs = [ bison cmake pkg-config ]
+    ++ lib.optionals (!stdenv.isDarwin) [ rpcsvc-proto ];
+
+  buildInputs = [
+      curl ncurses openssl readline zlib boost libaio libtirpc
+    ] ++ lib.optional stdenv.isDarwin perl;
+
+  enableParallelBuilding = true;
+
+  cmakeFlags = [
+    "-DCMAKE_SKIP_BUILD_RPATH=OFF" # To run libmysql/libmysql_api_test during build.
+    "-DBUILD_CONFIG=mysql_release"
+    "-DWITH_SSL=system"
+    "-DWITH_EMBEDDED_SERVER=no"
+    "-DWITH_ZLIB=system"
+    "-DWITH_EDITLINE=bundled"
+    "-DHAVE_IPV6=yes"
+    "-DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock"
+    "-DMYSQL_DATADIR=/var/lib/mysql"
+    "-DINSTALL_SYSCONFDIR=etc/mysql"
+    "-DINSTALL_INFODIR=share/mysql/docs"
+    "-DINSTALL_MANDIR=share/man"
+    "-DINSTALL_PLUGINDIR=lib/mysql/plugin"
+    "-DINSTALL_SCRIPTDIR=bin"
+    "-DINSTALL_INCLUDEDIR=include/mysql"
+    "-DINSTALL_DOCREADMEDIR=share/mysql"
+    "-DINSTALL_SUPPORTFILESDIR=share/mysql"
+    "-DINSTALL_MYSQLSHAREDIR=share/mysql"
+    "-DINSTALL_DOCDIR=share/mysql/docs"
+    "-DINSTALL_SHAREDIR=share/mysql"
+  ];
+
+  NIX_LDFLAGS = lib.optionalString stdenv.isLinux "-lgcc_s";
+
+  prePatch = ''
+    sed -i -e "s|/usr/bin/libtool|libtool|" cmake/libutils.cmake
+
+    patchShebangs .
+
+    sed -i "s|COMMAND env -i |COMMAND env -i PATH=$PATH |" \
+      storage/rocksdb/CMakeLists.txt
+
+    # Disable ABI check. See case #108154
+    sed -i "s/SET(RUN_ABI_CHECK 1)/SET(RUN_ABI_CHECK 0)/" cmake/abi_check.cmake
+
+  '';
+  postInstall = ''
+    sed -i -e "s|basedir=\"\"|basedir=\"$out\"|" $out/bin/mysql_install_db
+    rm -r $out/mysql-test $out/lib/*.a
+  '';
+
+  preBuild = ''
+    export LD_LIBRARY_PATH=$(pwd)/library_output_directory
+  '';
+
+  passthru.mysqlVersion = "5.7";
+
+  meta = with lib; {
+    homepage = "https://www.percona.com";
+    description = "a free, fully compatible, enhanced, open source drop-in replacement for MySQL that provides superior performance, scalability and instrumentation";
+    platforms = platforms.linux;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/servers/sql/percona/8.0.nix
+++ b/pkgs/servers/sql/percona/8.0.nix
@@ -1,0 +1,97 @@
+{ lib, stdenv, fetchurl, fetchFromGitHub, cmake, pkg-config, ncurses, zlib, xz
+, lzo, lz4, bzip2, snappy
+, libiconv, openssl, pcre, boost, judy, bison, libxml2
+, libaio, jemalloc, cracklib, systemd, numactl
+, asio, buildEnv, check, scons, curl, perl, openldap, libtirpc, rpcsvc-proto
+}:
+
+stdenv.mkDerivation rec {
+  pname = "percona";
+  version = "8.0.22-13";
+
+  src = fetchurl {
+    url = "https://www.percona.com/downloads/Percona-Server-8.0/Percona-Server-${version}/source/tarball/percona-server-${version}.tar.gz";
+    sha256 = "16ncjy3hwzm10hi6c3smk275pv775d4j1nrgyamjrs4hfzf4jhk1";
+  };
+
+  preConfigure = lib.optional stdenv.isDarwin ''
+    ln -s /bin/ps $TMPDIR/ps
+    export PATH=$PATH:$TMPDIR
+  '';
+
+  nativeBuildInputs = [ bison cmake pkg-config ]
+    ++ lib.optionals (!stdenv.isDarwin) [ rpcsvc-proto ];
+
+  buildInputs = [
+    ncurses openssl zlib pcre jemalloc libiconv libaio systemd boost
+    curl perl openldap.dev libtirpc
+  ];
+
+  enableParallelBuilding = true;
+
+  cmakeFlags = [
+
+    "-DBUILD_CONFIG=mysql_release"
+    "-DDEFAULT_CHARSET=utf8mb4"
+    "-DDEFAULT_COLLATION=utf8mb4_unicode_ci"
+
+    "-DWITH_ZLIB=system"
+    "-DWITH_SSL=system"
+    "-DWITH_EDITLINE=bundled"
+
+    # https://www.percona.com/blog/2013/03/08/mysql-performance-impact-of-memory-allocators-part-2/
+    "-DWITH_JEMALLOC=1"
+    "-DWITH_SYSTEMD=1"
+
+    "-DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock"
+    "-DMYSQL_DATADIR=/var/lib/mysql"
+    "-DINSTALL_INFODIR=share/mysql/docs"
+    "-DINSTALL_MANDIR=share/man"
+    "-DINSTALL_PLUGINDIR=lib/mysql/plugin"
+    "-DINSTALL_INCLUDEDIR=include/mysql"
+    "-DINSTALL_DOCREADMEDIR=share/mysql"
+    "-DINSTALL_SUPPORTFILESDIR=share/mysql"
+    "-DINSTALL_MYSQLSHAREDIR=share/mysql"
+    "-DINSTALL_DOCDIR=share/mysql/docs"
+    "-DINSTALL_SHAREDIR=share/mysql"
+
+    "-DENABLED_LOCAL_INFILE=ON"
+    "-DWITH_ARCHIVE_STORAGE_ENGINE=1"
+    "-DWITH_BLACKHOLE_STORAGE_ENGINE=1"
+    "-DWITH_INNOBASE_STORAGE_ENGINE=1"
+    "-DWITHOUT_EXAMPLE_STORAGE_ENGINE=1"
+  ];
+
+  NIX_LDFLAGS = lib.optionalString stdenv.isLinux "-lgcc_s";
+  CXXFLAGS = lib.optionalString stdenv.isi686 "-fpermissive";
+
+  prePatch = ''
+    sed -i -e "s|/usr/bin/libtool|libtool|" cmake/libutils.cmake
+    patchShebangs .
+    sed -i "s|COMMAND env -i |COMMAND env -i PATH=$PATH |" \
+      storage/rocksdb/CMakeLists.txt
+
+    # Disable ABI check. See case #108154
+    sed -i "s/SET(RUN_ABI_CHECK 1)/SET(RUN_ABI_CHECK 0)/" cmake/abi_check.cmake
+
+  '';
+
+  preBuild = ''
+    export LD_LIBRARY_PATH=$(pwd)/library_output_directory
+  '';
+
+  postInstall = ''
+    rm -r $out/mysql-test
+    chmod g-w $out
+  '';
+
+  passthru.mysqlVersion = "8.0";
+
+  meta = with lib; {
+    homepage = "https://www.percona.com";
+    description = "a free, fully compatible, enhanced, open source drop-in replacement for MySQL that provides superior performance, scalability and instrumentation";
+    platforms = platforms.linux;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/tools/admin/innotop/default.nix
+++ b/pkgs/tools/admin/innotop/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, fetchFromGitHub
+, buildPerlPackage
+, perlPackages
+}:
+
+buildPerlPackage rec {
+  pname = "innotop";
+  version = "1.13.0";
+
+  src = fetchFromGitHub {
+    owner = "innotop";
+    repo = "innotop";
+    rev = "v${version}";
+    sha256 = "6XA+3FwLtlj03so0z54NpOb9GqR5Yi0ZKd7l2ZlHwek=";
+  };
+
+  patches = [ ./innotop.patch ];
+
+  outputs = [ "out" ];
+
+  # The script uses usr/bin/env perl and the Perl builder adds PERL5LIB to it.
+  # This doesn't work. Looks like a bug in Nixpkgs.
+  # Replacing the interpreter path before the Perl builder touches it fixes this.
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  propagatedBuildInputs = with perlPackages; [ DBI DBDmysql TermReadKey ];
+
+  meta = with lib; {
+    homepage = "https://github.com/innotop/innotop";
+    description = "'top' clone for MySQL with many features and flexibility";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/tools/admin/innotop/innotop.patch
+++ b/pkgs/tools/admin/innotop/innotop.patch
@@ -1,0 +1,13 @@
+diff --git a/innotop.spec b/innotop.spec
+index 61155bc..8bcdf4c 100644
+--- a/innotop.spec
++++ b/innotop.spec
+@@ -99,7 +99,7 @@ find %{buildroot}%{_prefix}             \
+         $d = $_;
+         /\Q$d\E/ && return for reverse sort @INC;
+         $d =~ /\Q$_\E/ && return
+-            for qw|/etc %_prefix/man %_prefix/bin %_prefix/share|;
++            for qw|/etc %_prefix/man1 %_prefix/bin %_prefix/share|;
+
+         $dirs[@dirs] = $_;
+         }

--- a/pkgs/tools/backup/percona-xtrabackup/8_0.nix
+++ b/pkgs/tools/backup/percona-xtrabackup/8_0.nix
@@ -1,8 +1,10 @@
-{ callPackage, ... } @ args:
+{ callPackage, boost173, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  version = "8.0.13";
-  sha256 = "0cj0fnjimv22ykfl0yk6w29wcjvqp8y8j2g1c6gcml65qazrswyr";
+  version = "8.0.26-18";
+  sha256 = "sha256-wluNdX++SP07BPei2rxWS6ATIxc+W4TZLY4TkXtg57c=";
+
+  boost = boost173;
 
   extraPatches = [
     ./../../../servers/sql/mysql/abi-check.patch

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21042,6 +21042,7 @@ with pkgs;
 
   percona-server56 = callPackage ../servers/sql/percona/5.6.x.nix { };
   percona-server57 = callPackage ../servers/sql/percona/5.7.x.nix { };
+  percona-server80 = callPackage ../servers/sql/percona/8.0.x.nix { };
   percona-server = percona-server56;
 
   riak = callPackage ../servers/nosql/riak/2.2.0.nix {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21857,6 +21857,8 @@ with pkgs;
 
   iomelt = callPackage ../os-specific/linux/iomelt { };
 
+  innotop = callPackage ../tools/admin/innotop { };
+
   iotop = callPackage ../os-specific/linux/iotop { };
   iotop-c = callPackage ../os-specific/linux/iotop-c { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21041,6 +21041,7 @@ with pkgs;
   nginx-sso = callPackage ../servers/nginx-sso { };
 
   percona-server56 = callPackage ../servers/sql/percona/5.6.x.nix { };
+  percona-server57 = callPackage ../servers/sql/percona/5.7.x.nix { };
   percona-server = percona-server56;
 
   riak = callPackage ../servers/nosql/riak/2.2.0.nix {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add some tools and new versions of percona SQL server

// cc @dpausp 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
