### PR TITLE
ocamlPackages.merlin: fix tests on darwin

### DIFF
--- a/pkgs/development/tools/ocaml/merlin/4.x.nix
+++ b/pkgs/development/tools/ocaml/merlin/4.x.nix
@@ -47,6 +47,9 @@ buildDunePackage {
       dot_merlin_reader = "${dot-merlin-reader}/bin/dot-merlin-reader";
       dune = "${dune_2}/bin/dune";
     })
+    # This fixes the test-suite on macOS
+    # See https://github.com/ocaml/merlin/pull/1399
+    ./test.patch
   ];
 
   useDune2 = true;

--- a/pkgs/development/tools/ocaml/merlin/test.patch
+++ b/pkgs/development/tools/ocaml/merlin/test.patch
@@ -1,0 +1,19 @@
+commit 282eed37f39ff216add8d53766fd59f3737eb87f
+Author: Vincent Laporte <Vincent.Laporte@gmail.com>
+Date:   Thu Nov 4 06:24:07 2021 +0100
+
+    Ignore dune stderr in tests
+
+diff --git a/tests/test-dirs/document/src-documentation.t/run.t b/tests/test-dirs/document/src-documentation.t/run.t
+index 2c9e1419..4f4c4327 100644
+--- a/tests/test-dirs/document/src-documentation.t/run.t
++++ b/tests/test-dirs/document/src-documentation.t/run.t
+@@ -42,7 +42,7 @@ documentation for the non-last defined value (in the same file) is show
+   > jq '.value'
+   " List reversal. "
+ 
+-  $ dune build --root=. ./doc.exe
++  $ dune build --root=. ./doc.exe 2> /dev/null
+   $ cat >.merlin <<EOF
+   > B _build/default/.doc.eobjs/byte
+   > S .


### PR DESCRIPTION
###### Motivation for this change

Tests spuriously fail.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
