### PR TITLE
pkgsMusl.dbus: enable systemd support

### DIFF
--- a/pkgs/development/libraries/dbus/default.nix
+++ b/pkgs/development/libraries/dbus/default.nix
@@ -3,7 +3,7 @@
 , fetchurl
 , pkg-config
 , expat
-, enableSystemd ? stdenv.isLinux && !stdenv.hostPlatform.isMusl
+, enableSystemd ? stdenv.isLinux && !stdenv.hostPlatform.isStatic
 , systemd
 , audit
 , libapparmor


### PR DESCRIPTION
We previously weren't able to build systemd for Musl, but now we can!  (But not statically.)  So there's no longer any reason to have systemd support in D-Bus disabled by default for pkgsMusl.
