### PR TITLE
pkgsMusl.redis: enable systemd support

### DIFF
--- a/pkgs/servers/nosql/redis/default.nix
+++ b/pkgs/servers/nosql/redis/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, lua, pkg-config, nixosTests
-, withSystemd ? stdenv.isLinux && !stdenv.hostPlatform.isMusl, systemd
+, withSystemd ? stdenv.isLinux && !stdenv.hostPlatform.isStatic, systemd
 # dependency ordering is broken at the moment when building with openssl
 , tlsSupport ? !stdenv.hostPlatform.isStatic, openssl
 }:


### PR DESCRIPTION
We previously weren't able to build systemd for Musl, but now we can!  (But not statically.)  So there's no longer any reason to have systemd support in Redis disabled by default for pkgsMusl.
