### PR TITLE
pkgsMusl.cups: enable systemd support

### DIFF
--- a/pkgs/misc/cups/default.nix
+++ b/pkgs/misc/cups/default.nix
@@ -8,7 +8,7 @@
 , libtiff
 , pam
 , dbus
-, enableSystemd ? stdenv.isLinux && !stdenv.hostPlatform.isMusl
+, enableSystemd ? stdenv.isLinux
 , systemd
 , acl
 , gmp


### PR DESCRIPTION
We previously weren't able to build systemd for Musl, but now we can!  (But not statically.)  So there's no longer any reason to have systemd support in CUPS disabled by default for pkgsMusl.
