### PR TITLE
toxic: fix build against upcoming ncurses-6.3

### DIFF
--- a/pkgs/applications/networking/instant-messengers/toxic/default.nix
+++ b/pkgs/applications/networking/instant-messengers/toxic/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, libsodium, ncurses, curl
+{ lib, stdenv, fetchFromGitHub, fetchpatch, libsodium, ncurses, curl
 , libtoxcore, openal, libvpx, freealut, libconfig, pkg-config, libopus
 , qrencode, gdk-pixbuf, libnotify }:
 
@@ -12,6 +12,15 @@ stdenv.mkDerivation rec {
     rev    = "v${version}";
     sha256 = "sha256-5jLXXI+IMrYa7ZtdMjJrah1zB5TJ3GdHfvcMd1TYE4E=";
   };
+
+  patches = [
+    # Pending for upstream inclusion fix for ncurses-6.3 compatibility.
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/JFreegman/toxic/commit/41e93adbdbd56db065166af5a6676a7996e9e451.patch";
+      sha256 = "sha256-LYEseB5FmXFNifa1RZUxhkXeWlkEEMm3ASD55IoUPa0=";
+    })
+  ];
 
   makeFlags = [ "PREFIX=$(out)"];
   installFlags = [ "PREFIX=$(out)"];


### PR DESCRIPTION
On ncurses-6.3 with extra printf() annotations gcc now detects
use of user input in place of format strings:

    toxic/src/game_chess.c:1633:63: error:
      format not a string literal and no format arguments [-Werror=format-security]
     1633 |         mvwprintw(win, board->y_bottom_bound + 2, x_mid, state->status_message);
          |                                                          ~~~~~^~~~~~~~~~~~~~~~
