### PR TITLE
mdbook-plantuml: init at 0.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5197,6 +5197,16 @@
     githubId = 938744;
     name = "John Chadwick";
   };
+  jcouyang = {
+    email = "oyanglulu@gmail.com";
+    github = "jcouyang";
+    githubId = 1235045;
+    name = "Jichao Ouyang";
+    keys = [{
+      longkeyid = "rsa2048/0xDA8B833B52604E63";
+      fingerprint = "A506 C38D 5CC8 47D0 DF01  134A DA8B 833B 5260 4E63";
+    }];
+  };
   jcumming = {
     email = "jack@mudshark.org";
     github = "jcumming";

--- a/pkgs/tools/text/mdbook-plantuml/default.nix
+++ b/pkgs/tools/text/mdbook-plantuml/default.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ openssl.dev ]
+  buildInputs = [ openssl ]
     ++ lib.optionals stdenv.isDarwin [ CoreServices ];
 
   meta = with lib; {

--- a/pkgs/tools/text/mdbook-plantuml/default.nix
+++ b/pkgs/tools/text/mdbook-plantuml/default.nix
@@ -1,4 +1,5 @@
-{ lib, fetchFromGitHub, stdenv, rustPlatform, darwin, pkg-config, openssl, libiconv }:
+{ lib, fetchFromGitHub, stdenv, rustPlatform, darwin, pkg-config, openssl
+, libiconv, CoreServices }:
 
 rustPlatform.buildRustPackage rec {
   pname = "mdbook-plantuml";
@@ -16,11 +17,11 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ openssl.dev ]
-    ++ (lib.optionals stdenv.isDarwin
-      [ darwin.apple_sdk.frameworks.CoreServices ]);
+    ++ lib.optionals stdenv.isDarwin [ CoreServices ];
 
   meta = with lib; {
-    description = "mdBook preprocessor to render PlantUML diagrams to png images in the book output directory.";
+    description =
+      "mdBook preprocessor to render PlantUML diagrams to png images in the book output directory.";
     homepage = "https://github.com/sytsereitsma/mdbook-plantuml";
     license = [ licenses.mit ];
     maintainers = with maintainers; [ jcouyang ];

--- a/pkgs/tools/text/mdbook-plantuml/default.nix
+++ b/pkgs/tools/text/mdbook-plantuml/default.nix
@@ -20,8 +20,7 @@ rustPlatform.buildRustPackage rec {
     ++ lib.optionals stdenv.isDarwin [ CoreServices ];
 
   meta = with lib; {
-    description =
-      "mdBook preprocessor to render PlantUML diagrams to png images in the book output directory.";
+    description = "mdBook preprocessor to render PlantUML diagrams to png images in the book output directory";
     homepage = "https://github.com/sytsereitsma/mdbook-plantuml";
     license = [ licenses.mit ];
     maintainers = with maintainers; [ jcouyang ];

--- a/pkgs/tools/text/mdbook-plantuml/default.nix
+++ b/pkgs/tools/text/mdbook-plantuml/default.nix
@@ -1,0 +1,28 @@
+{ lib, fetchFromGitHub, stdenv, rustPlatform, darwin, pkg-config, openssl, libiconv }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "mdbook-plantuml";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "sytsereitsma";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1m53sp3k387injn6mwk2c6rkzw16b12m4j7q0p69fdb3fiqbkign";
+  };
+
+  cargoSha256 = "0xi14k86ym3rfz6901lmj444y814m7vp90bwsyjmcph3hdv6mjp0";
+
+  nativeBuildInputs = [ pkg-config ];
+  
+  buildInputs = [ openssl openssl.dev libiconv ]
+    ++ (lib.optionals stdenv.isDarwin
+      [ darwin.apple_sdk.frameworks.CoreServices ]);
+
+  meta = with lib; {
+    description = "mdBook preprocessor to render PlantUML diagrams to png images in the book output directory.";
+    homepage = "https://github.com/sytsereitsma/mdbook-plantuml";
+    license = [ licenses.mit ];
+    maintainers = with maintainers; [ jcouyang ];
+  };
+}

--- a/pkgs/tools/text/mdbook-plantuml/default.nix
+++ b/pkgs/tools/text/mdbook-plantuml/default.nix
@@ -14,8 +14,8 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "0xi14k86ym3rfz6901lmj444y814m7vp90bwsyjmcph3hdv6mjp0";
 
   nativeBuildInputs = [ pkg-config ];
-  
-  buildInputs = [ openssl openssl.dev libiconv ]
+
+  buildInputs = [ openssl.dev ]
     ++ (lib.optionals stdenv.isDarwin
       [ darwin.apple_sdk.frameworks.CoreServices ]);
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6956,7 +6956,9 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };
 
-  mdbook-plantuml = callPackage ../tools/text/mdbook-plantuml { };
+  mdbook-plantuml = callPackage ../tools/text/mdbook-plantuml {
+    inherit (darwin.apple_sdk.frameworks) CoreServices;
+  };
 
   mdcat = callPackage ../tools/text/mdcat {
     inherit (darwin.apple_sdk.frameworks) Security;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6956,6 +6956,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };
 
+  mdbook-plantuml = callPackage ../tools/text/mdbook-plantuml { };
+
   mdcat = callPackage ../tools/text/mdcat {
     inherit (darwin.apple_sdk.frameworks) Security;
     inherit (python3Packages) ansi2html;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
