### PR TITLE
arrow-cpp: add flight feature flag

### DIFF
--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -159,15 +159,15 @@ stdenv.mkDerivation rec {
   ARROW_TEST_DATA = lib.optionalString doInstallCheck "${arrow-testing}/data";
   PARQUET_TEST_DATA = lib.optionalString doInstallCheck "${parquet-testing}/data";
   GTEST_FILTER =
-      let
-        # Upstream Issue: https://issues.apache.org/jira/browse/ARROW-11398
-        filteredTests = lib.optionals stdenv.hostPlatform.isAarch64 [
-          "TestFilterKernelWithNumeric/3.CompareArrayAndFilterRandomNumeric"
-          "TestFilterKernelWithNumeric/7.CompareArrayAndFilterRandomNumeric"
-          "TestCompareKernel.PrimitiveRandomTests"
-        ];
-      in
-      lib.optionalString doInstallCheck "-${builtins.concatStringsSep ":" filteredTests}";
+    let
+      # Upstream Issue: https://issues.apache.org/jira/browse/ARROW-11398
+      filteredTests = lib.optionals stdenv.hostPlatform.isAarch64 [
+        "TestFilterKernelWithNumeric/3.CompareArrayAndFilterRandomNumeric"
+        "TestFilterKernelWithNumeric/7.CompareArrayAndFilterRandomNumeric"
+        "TestCompareKernel.PrimitiveRandomTests"
+      ];
+    in
+    lib.optionalString doInstallCheck "-${builtins.concatStringsSep ":" filteredTests}";
   installCheckInputs = [ perl which ];
   installCheckPhase =
     let

--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -1,8 +1,36 @@
-{ stdenv, lib, fetchurl, fetchFromGitHub, fixDarwinDylibNames
-, autoconf, boost, brotli, cmake, flatbuffers, gflags, glog, gtest, jemalloc
-, lz4, perl, python3, rapidjson, re2, snappy, thrift, tzdata , utf8proc, which
-, zlib, zstd
+{ stdenv
+, lib
+, fetchurl
+, fetchFromGitHub
+, fixDarwinDylibNames
+, autoconf
+, boost
+, brotli
+, c-ares
+, cmake
+, flatbuffers
+, gflags
+, glog
+, grpc
+, gtest
+, jemalloc
+, libnsl
+, lz4
+, openssl
+, perl
+, protobuf
+, python3
+, rapidjson
+, re2
+, snappy
+, thrift
+, tzdata
+, utf8proc
+, which
+, zlib
+, zstd
 , enableShared ? !stdenv.hostPlatform.isStatic
+, enableFlight ? !stdenv.isDarwin # libnsl is not supported on darwin
 }:
 
 let
@@ -20,7 +48,8 @@ let
     hash = "sha256-GmOAS8gGhzDI0WzORMkWHRRUl/XBwmNen2d3VefZxxc=";
   };
 
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "arrow-cpp";
   version = "6.0.0";
 
@@ -78,6 +107,11 @@ in stdenv.mkDerivation rec {
   ] ++ lib.optionals enableShared [
     python3.pkgs.python
     python3.pkgs.numpy
+  ] ++ lib.optionals enableFlight [
+    grpc
+    libnsl
+    openssl
+    protobuf
   ];
 
   preConfigure = ''
@@ -113,6 +147,7 @@ in stdenv.mkDerivation rec {
     # Parquet options:
     "-DARROW_PARQUET=ON"
     "-DPARQUET_BUILD_EXECUTABLES=ON"
+    "-DARROW_FLIGHT=${if enableFlight then "ON" else "OFF"}"
   ] ++ lib.optionals (!enableShared) [
     "-DARROW_TEST_LINKAGE=static"
   ] ++ lib.optionals stdenv.isDarwin [
@@ -126,27 +161,30 @@ in stdenv.mkDerivation rec {
   PARQUET_TEST_DATA =
     if doInstallCheck then "${parquet-testing}/data" else null;
   GTEST_FILTER =
-    if doInstallCheck then let
-      # Upstream Issue: https://issues.apache.org/jira/browse/ARROW-11398
-      filteredTests = lib.optionals stdenv.hostPlatform.isAarch64 [
-        "TestFilterKernelWithNumeric/3.CompareArrayAndFilterRandomNumeric"
-        "TestFilterKernelWithNumeric/7.CompareArrayAndFilterRandomNumeric"
-        "TestCompareKernel.PrimitiveRandomTests"
-      ];
-    in "-${builtins.concatStringsSep ":" filteredTests}" else null;
+    if doInstallCheck then
+      let
+        # Upstream Issue: https://issues.apache.org/jira/browse/ARROW-11398
+        filteredTests = lib.optionals stdenv.hostPlatform.isAarch64 [
+          "TestFilterKernelWithNumeric/3.CompareArrayAndFilterRandomNumeric"
+          "TestFilterKernelWithNumeric/7.CompareArrayAndFilterRandomNumeric"
+          "TestCompareKernel.PrimitiveRandomTests"
+        ];
+      in
+      "-${builtins.concatStringsSep ":" filteredTests}" else null;
   installCheckInputs = [ perl which ];
   installCheckPhase =
-  let
-    excludedTests = lib.optionals stdenv.isDarwin [
-      # Some plasma tests need to be patched to use a shorter AF_UNIX socket
-      # path on Darwin. See https://github.com/NixOS/nix/pull/1085
-      "plasma-external-store-tests"
-      "plasma-client-tests"
-    ];
-  in ''
-    ctest -L unittest -V \
-      --exclude-regex '^(${builtins.concatStringsSep "|" excludedTests})$'
-  '';
+    let
+      excludedTests = lib.optionals stdenv.isDarwin [
+        # Some plasma tests need to be patched to use a shorter AF_UNIX socket
+        # path on Darwin. See https://github.com/NixOS/nix/pull/1085
+        "plasma-external-store-tests"
+        "plasma-client-tests"
+      ];
+    in
+    ''
+      ctest -L unittest -V \
+        --exclude-regex '^(${builtins.concatStringsSep "|" excludedTests})$'
+    '';
 
   meta = with lib; {
     description = "A cross-language development platform for in-memory data";

--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -156,12 +156,9 @@ stdenv.mkDerivation rec {
   ] ++ lib.optional (!stdenv.isx86_64) "-DARROW_USE_SIMD=OFF";
 
   doInstallCheck = true;
-  ARROW_TEST_DATA =
-    if doInstallCheck then "${arrow-testing}/data" else null;
-  PARQUET_TEST_DATA =
-    if doInstallCheck then "${parquet-testing}/data" else null;
+  ARROW_TEST_DATA = lib.optionalString doInstallCheck "${arrow-testing}/data";
+  PARQUET_TEST_DATA = lib.optionalString doInstallCheck "${parquet-testing}/data";
   GTEST_FILTER =
-    if doInstallCheck then
       let
         # Upstream Issue: https://issues.apache.org/jira/browse/ARROW-11398
         filteredTests = lib.optionals stdenv.hostPlatform.isAarch64 [
@@ -170,7 +167,7 @@ stdenv.mkDerivation rec {
           "TestCompareKernel.PrimitiveRandomTests"
         ];
       in
-      "-${builtins.concatStringsSep ":" filteredTests}" else null;
+      lib.optionalString doInstallCheck "-${builtins.concatStringsSep ":" filteredTests}";
   installCheckInputs = [ perl which ];
   installCheckPhase =
     let

--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -179,8 +179,12 @@ stdenv.mkDerivation rec {
       ];
     in
     ''
+      runHook preInstallCheck
+
       ctest -L unittest -V \
         --exclude-regex '^(${builtins.concatStringsSep "|" excludedTests})$'
+
+      runHook postInstallCheck
     '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add the option of building `arrow-cpp` with Flight enabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
