### PR TITLE
alfis: Add support for GUI dialogs

### DIFF
--- a/pkgs/applications/blockchains/alfis/default.nix
+++ b/pkgs/applications/blockchains/alfis/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, rustPlatform, pkg-config, withGui ? true
-, webkitgtk, Cocoa, WebKit, dialog, makeWrapper }:
+, webkitgtk, Cocoa, WebKit, zenity, makeWrapper }:
 
 rustPlatform.buildRustPackage rec {
   pname = "alfis";
@@ -31,9 +31,8 @@ rustPlatform.buildRustPackage rec {
     ++ lib.optionals (withGui && stdenv.isDarwin) [ Cocoa WebKit ];
 
   postInstall = lib.optionalString (withGui && stdenv.isLinux) ''
-    cp $out/bin/alfis{,_unwrapped}
-    makeWrapper $out/bin/alfis{_unwrapped,} \
-      --prefix PATH : ${lib.makeBinPath [ dialog ]}
+    wrapProgram $out/bin/alfis \
+      --prefix PATH : ${lib.makeBinPath [ zenity ]}
   '';
 
   meta = with lib; {

--- a/pkgs/applications/blockchains/alfis/default.nix
+++ b/pkgs/applications/blockchains/alfis/default.nix
@@ -1,6 +1,5 @@
-{ stdenv, lib, fetchFromGitHub, rustPlatform, pkg-config
-, withGui ? true, webkitgtk, Cocoa, WebKit
-}:
+{ stdenv, lib, fetchFromGitHub, rustPlatform, pkg-config, withGui ? true
+, webkitgtk, Cocoa, WebKit, dialog, makeWrapper }:
 
 rustPlatform.buildRustPackage rec {
   pname = "alfis";
@@ -27,9 +26,15 @@ rustPlatform.buildRustPackage rec {
     "--skip=dns::client::tests::test_udp_client"
   ];
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config makeWrapper ];
   buildInputs = lib.optional (withGui && stdenv.isLinux) webkitgtk
     ++ lib.optionals (withGui && stdenv.isDarwin) [ Cocoa WebKit ];
+
+  postInstall = lib.optionalString (withGui && stdenv.isLinux) ''
+    cp $out/bin/alfis{,_unwrapped}
+    makeWrapper $out/bin/alfis{_unwrapped,} \
+      --prefix PATH : ${lib.makeBinPath [ dialog ]}
+  '';
 
   meta = with lib; {
     description = "Alternative Free Identity System";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28669,7 +28669,7 @@ with pkgs;
 
   alfis = callPackage ../applications/blockchains/alfis {
     inherit (darwin.apple_sdk.frameworks) Cocoa WebKit;
-    dialog = gnome.zenity;
+    inherit (gnome) zenity;
   };
   alfis-nogui = alfis.override {
     withGui = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28669,6 +28669,7 @@ with pkgs;
 
   alfis = callPackage ../applications/blockchains/alfis {
     inherit (darwin.apple_sdk.frameworks) Cocoa WebKit;
+    dialog = gnome.zenity;
   };
   alfis-nogui = alfis.override {
     withGui = false;


### PR DESCRIPTION
###### Motivation for this change

Alfis requires GUI dialog provider to save/load keys with GUI.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
