### PR TITLE
[21.05] tonelib-gfx: init at 4.7.0

### DIFF
--- a/pkgs/applications/audio/tonelib-gfx/default.nix
+++ b/pkgs/applications/audio/tonelib-gfx/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, dpkg
+, alsa-lib
+, freetype
+, libglvnd
+, curl
+, libXcursor
+, libXinerama
+, libXrandr
+, libXrender
+, libjack2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tonelib-gfx";
+  version = "4.7.0";
+
+  src = fetchurl {
+    url = "https://www.tonelib.net/download/0930/ToneLib-GFX-amd64.deb";
+    hash = "sha256-BcbX0dz94B4mj6QeQsnuZmwXAaXH+yJjnrUPgEYVqkU=";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook dpkg ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    alsa-lib
+    freetype
+    libglvnd
+  ] ++ runtimeDependencies;
+
+  runtimeDependencies = map lib.getLib [
+    curl
+    libXcursor
+    libXinerama
+    libXrandr
+    libXrender
+    libjack2
+  ];
+
+  unpackCmd = "dpkg -x $curSrc source";
+
+  installPhase = ''
+    mv usr $out
+    substituteInPlace $out/share/applications/ToneLib-GFX.desktop --replace /usr/ $out/
+ '';
+
+  meta = with lib; {
+    description = "Tonelib GFX is an amp and effects modeling software for electric guitar and bass.";
+    homepage = "https://tonelib.net/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ dan4ik605743 orivej ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -755,6 +755,8 @@ in
 
   adlplug = callPackage ../applications/audio/adlplug { };
 
+  tonelib-gfx = callPackage ../applications/audio/tonelib-gfx { };
+
   arc_unpacker = callPackage ../tools/archivers/arc_unpacker { };
 
   opnplug = callPackage ../applications/audio/adlplug {


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
