### PR TITLE
linux: enable TCP_CONG_ADVANCED

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -129,6 +129,7 @@ let
       XDP_SOCKETS        = whenAtLeast "4.19" yes;
       XDP_SOCKETS_DIAG   = whenAtLeast "5.1" yes;
       WAN                = yes;
+      TCP_CONG_ADVANCED  = yes;
       TCP_CONG_CUBIC     = yes; # This is the default congestion control algorithm since 2.6.19
       # Required by systemd per-cgroup firewalling
       CGROUP_BPF                  = option yes;


### PR DESCRIPTION
###### Motivation for this change

[TCP_CONG_ADVANCED][0] is enabled by default on [x86_64][1] in the upstream.
Although it is not the case for [aarch64][2], many distributions, such as
[Debian][3], [Fedora][4] and [Gentoo][5], choose to enable it in their
distribution kernel.

With this patch, aarch64 users can choose many other TCP congestion
algorithms, which may improve their network performance.

I have tested the 5.10.76 kernel and it builds and runs well.

I also run several `iperf` tests. The fastest speed I get using the default value (`cubic`) of net.ipv4.tcp_congestion_control is 38Mbps, while it is 268Mbps using `bbr`, which needs this patch to be applied.

This PR fixes https://github.com/NixOS/nixpkgs/issues/141051.

[0]: https://cateee.net/lkddb/web-lkddb/TCP_CONG_ADVANCED.html
[1]: https://github.com/torvalds/linux/blob/7ddb58cb0ecae8e8b6181d736a87667cc9ab8389/arch/x86/configs/x86_64_defconfig#L71
[2]: https://github.com/torvalds/linux/blob/7ddb58cb0ecae8e8b6181d736a87667cc9ab8389/arch/arm64/configs/defconfig
[3]: https://salsa.debian.org/kernel-team/linux/-/blob/e2d14375d74cdcb2cfed6518d7a5ad784c30df1a/debian/config/config#L7063
[4]: https://src.fedoraproject.org/rpms/kernel/raw/836165dd2dff34e4f2c47ca8f9c803002c1e6530/f/kernel-aarch64-fedora.config
[5]: https://github.com/gentoo/gentoo/blob/5808eb2f066ea2ece19c35a1978b7f79077a467b/sys-kernel/gentoo-kernel/gentoo-kernel-5.10.77.ebuild#L27

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
