### PR TITLE
[21.05] tonelib-jam: init at 4.7.0 && tonelib-zoom init at 4.3.1 && tonelib-gfx init at 4.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2219,6 +2219,12 @@
     githubId = 1298344;
     name = "Daniel Fullmer";
   };
+  dan4ik605743 = {
+    email = "6057430gu@gmail.com";
+    github = "dan4ik605743";
+    githubId = 86075850;
+    name = "Danil Danevich";
+  };
   das-g = {
     email = "nixpkgs@raphael.dasgupta.ch";
     github = "das-g";

--- a/pkgs/applications/audio/tonelib-gfx/default.nix
+++ b/pkgs/applications/audio/tonelib-gfx/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, dpkg
+, alsa-lib
+, freetype
+, libglvnd
+, curl
+, libXcursor
+, libXinerama
+, libXrandr
+, libXrender
+, libjack2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tonelib-gfx";
+  version = "4.7.0";
+
+  src = fetchurl {
+    url = "https://www.tonelib.net/download/0930/ToneLib-GFX-amd64.deb";
+    hash = "sha256-BcbX0dz94B4mj6QeQsnuZmwXAaXH+yJjnrUPgEYVqkU=";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook dpkg ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    alsa-lib
+    freetype
+    libglvnd
+  ] ++ runtimeDependencies;
+
+  runtimeDependencies = map lib.getLib [
+    curl
+    libXcursor
+    libXinerama
+    libXrandr
+    libXrender
+    libjack2
+  ];
+
+  unpackCmd = "dpkg -x $curSrc source";
+
+  installPhase = ''
+    mv usr $out
+    substituteInPlace $out/share/applications/ToneLib-GFX.desktop --replace /usr/ $out/
+ '';
+
+  meta = with lib; {
+    description = "Tonelib GFX is an amp and effects modeling software for electric guitar and bass.";
+    homepage = "https://tonelib.net/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ dan4ik605743 orivej ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/audio/tonelib-jam/default.nix
+++ b/pkgs/applications/audio/tonelib-jam/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, dpkg
+, alsa-lib
+, freetype
+, libglvnd
+, curl
+, libXcursor
+, libXinerama
+, libXrandr
+, libXrender
+, libjack2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tonelib-jam";
+  version = "4.7.0";
+
+  src = fetchurl {
+    url = "https://www.tonelib.net/download/0930/ToneLib-Jam-amd64.deb";
+    sha256 = "sha256-xyBDp3DQVC+nK2WGnvrfUfD+9GvwtbldXgExTMmCGw0=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+  ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    alsa-lib
+    freetype
+    libglvnd
+  ] ++ runtimeDependencies;
+
+  runtimeDependencies = map lib.getLib [
+    curl
+    libXcursor
+    libXinerama
+    libXrandr
+    libXrender
+    libjack2
+  ];
+
+  unpackCmd = "dpkg -x $curSrc source";
+
+  installPhase = ''
+    mv usr $out
+    substituteInPlace $out/share/applications/ToneLib-Jam.desktop --replace /usr/ $out/
+  '';
+
+  meta = with lib; {
+    description = "ToneLib Jam – the learning and practice software for guitar players";
+    homepage = "https://tonelib.net/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ dan4ik605743 ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/audio/tonelib-zoom/default.nix
+++ b/pkgs/applications/audio/tonelib-zoom/default.nix
@@ -1,0 +1,53 @@
+{ stdenv
+, dpkg
+, lib
+, autoPatchelfHook
+, fetchurl
+, webkitgtk
+, libjack2
+, alsa-lib
+, curl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tonelib-zoom";
+  version = "4.3.1";
+
+  src = fetchurl {
+    url = "https://www.tonelib.net/download/0129/ToneLib-Zoom-amd64.deb";
+    sha256 = "sha256-4q2vM0/q7o/FracnO2xxnr27opqfVQoN7fsqTD9Tr/c=";
+  };
+
+  buildInputs = [
+    dpkg
+    webkitgtk
+    libjack2
+    alsa-lib
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  unpackPhase = ''
+    mkdir -p $TMP/ $out/
+    dpkg -x $src $TMP
+  '';
+
+  installPhase = ''
+    cp -R $TMP/usr/* $out/
+    mv $out/bin/ToneLib-Zoom $out/bin/tonelib-zoom
+  '';
+
+  runtimeDependencies = [
+    (lib.getLib curl)
+  ];
+
+  meta = with lib; {
+    description = "ToneLib Zoom – change and save all the settings in your Zoom(r) guitar pedal";
+    homepage = "https://tonelib.net/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ dan4ik605743 ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -837,6 +837,8 @@ in
 
   aj-snapshot  = callPackage ../applications/audio/aj-snapshot { };
 
+  tonelib-jam = callPackage ../applications/audio/tonelib-jam { };
+ 
   ajour = callPackage ../tools/games/ajour {
     inherit (gnome) zenity;
     inherit (plasma5Packages) kdialog;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -838,7 +838,9 @@ in
   aj-snapshot  = callPackage ../applications/audio/aj-snapshot { };
 
   tonelib-jam = callPackage ../applications/audio/tonelib-jam { };
- 
+
+  tonelib-zoom = callPackage ../applications/audio/tonelib-zoom { };
+
   ajour = callPackage ../tools/games/ajour {
     inherit (gnome) zenity;
     inherit (plasma5Packages) kdialog;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -841,6 +841,8 @@ in
 
   tonelib-zoom = callPackage ../applications/audio/tonelib-zoom { };
 
+  tonelib-gfx = callPackage ../applications/audio/tonelib-gfx { };
+
   ajour = callPackage ../tools/games/ajour {
     inherit (gnome) zenity;
     inherit (plasma5Packages) kdialog;


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
