### PR TITLE
eztrace: 1-1-7 -> 1.1-11, fix build, switch to fetchFromGitLab, refactor

### DIFF
--- a/pkgs/development/tools/profiling/EZTrace/default.nix
+++ b/pkgs/development/tools/profiling/EZTrace/default.nix
@@ -1,31 +1,33 @@
-{ lib, stdenv
-, fetchurl, autoconf, gfortran
-, libelf, libiberty, zlib, libbfd, libopcodes
-, buildPackages
+{ lib,
+  stdenv,
+  fetchFromGitLab,
+  gfortran,
+  libelf,
+  libiberty,
+  zlib,
+  libbfd,
+  libopcodes,
+  buildPackages,
+  autoreconfHook
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.1-7";
   pname = "EZTrace";
+  version = "1.1-11";
 
-  src = fetchurl {
-    url = "https://gforge.inria.fr/frs/download.php/file/37155/eztrace-${version}.tar.gz";
-    sha256 = "0cr2d4fdv4ljvag55dsz3rpha1jan2gc3jhr06ycyk43450pl58p";
+  src = fetchFromGitLab {
+    owner = "eztrace";
+    repo = "eztrace";
+    rev = "eztrace-${version}";
+    sha256 = "sha256-A6HMr4ib5Ka1lTbbTQOdq3kIdCoN/CwAKRdXdv9wpfU=";
   };
 
-  # Goes past the rpl_malloc linking failure; fixes silent file breakage
-  preConfigure = ''
-    export ac_cv_func_malloc_0_nonnull=yes
-    substituteInPlace ./configure \
-      --replace "/usr/bin/file" "${buildPackages.file}/bin/file"
-  '';
-
-  nativeBuildInputs = [ autoconf gfortran ];
+  nativeBuildInputs = [ gfortran autoreconfHook ];
   buildInputs = [ libelf libiberty zlib libbfd libopcodes ];
 
-  meta = {
+  meta = with lib; {
     description = "Tool that aims at generating automatically execution trace from HPC programs";
-    license = lib.licenses.cecill-b;
-    maintainers = with lib.maintainers; [ ];
+    license = licenses.cecill-b;
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
ZHF: https://github.com/NixOS/nixpkgs/issues/144627
https://hydra.nixos.org/build/157349557

I do realize that release tarballs are preferred over source tarballs of the release - but having to patch the resulting configure script feels unnecessary, when we can generate the makefile and configure script ourselves.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
