### PR TITLE
tox-node: fix build

### DIFF
--- a/pkgs/tools/networking/tox-node/default.nix
+++ b/pkgs/tools/networking/tox-node/default.nix
@@ -39,6 +39,6 @@ buildRustPackage rec {
     homepage = "https://github.com/tox-rs/tox-node";
     license = [ licenses.gpl3Plus ];
     platforms = platforms.linux;
-    maintainers = with maintainers; [ suhr ];
+    maintainers = with maintainers; [ suhr kurnevsky ];
   };
 }

--- a/pkgs/tools/networking/tox-node/default.nix
+++ b/pkgs/tools/networking/tox-node/default.nix
@@ -1,6 +1,7 @@
 { lib, rustPlatform, fetchFromGitHub
 , libsodium, openssl
 , pkg-config
+, fetchpatch
 }:
 
 with rustPlatform;
@@ -16,6 +17,14 @@ buildRustPackage rec {
     sha256 = "sha256-tB6v2NEBdTNHf89USdQOr/pV0mbxxb8ftOYPPJMvz5Y=";
   };
 
+  cargoPatches = [
+    # update cargo lock
+    (fetchpatch {
+      url = "https://github.com/tox-rs/tox-node/commit/63712d49d84e55df7bba9710e129780bbc636de3.patch";
+      sha256 = "sha256-jI6b5IHsAuGuM+7sPCdFnOOuV6K9rBmc5QqU5x72Fl0=";
+    })
+  ];
+
   buildInputs = [ libsodium openssl ];
   nativeBuildInputs = [ pkg-config ];
 
@@ -23,7 +32,7 @@ buildRustPackage rec {
 
   doCheck = false;
 
-  cargoSha256 = "sha256-J/0KO33vZmOvm6V7qCXInuAJTbRqyy5/qj6p6dEmoas=";
+  cargoSha256 = "sha256-yHsYjKJJNjepvcNszj4XQ0DbOY3AEJMZOnz0cAiwO1A=";
 
   meta = with lib; {
     description = "A server application to run tox node written in pure Rust";


### PR DESCRIPTION
###### Motivation for this change
ZHF: #144627 
Also added myself to maintainers as I'm one of tox-node developers.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
