### PR TITLE
Update Raspberry Pi packages

### DIFF
--- a/pkgs/development/libraries/libraspberrypi/default.nix
+++ b/pkgs/development/libraries/libraspberrypi/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libraspberrypi";
-  version = "unstable-2021-06-23";
+  version = "unstable-2021-10-25";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "userland";
-    rev = "97bc8180ad682b004ea224d1db7b8e108eda4397";
-    sha256 = "0cnjc7w8ynayj90vlpl13xzm9izd8m5b4cvrq52si9vc6wlm4in5";
+    rev = "0093675e4aa6e152a3ffc318b51a124e96eb287b";
+    sha256 = "qpooQy9k2UZ94KaqlFwurV+tt0GrBSRffGdlvMcn1XU=";
   };
 
   patches = [

--- a/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation {
   pname = "raspberrypi-wireless-firmware";
-  version = "2021-06-28";
+  version = "2021-11-02";
 
   srcs = [
     (fetchFromGitHub {
@@ -16,8 +16,8 @@ stdenv.mkDerivation {
       name = "firmware-nonfree";
       owner = "RPi-Distro";
       repo = "firmware-nonfree";
-      rev = "00de3194a96397c913786945ac0af1fd6fbec45b";
-      sha256 = "1xnr364dkiq6gmr21lcrj23hwc0g9y5qad8dm2maij647bgzp07r";
+      rev = "54ffdd6e2ea6055d46656b78e148fe7def3ec9d8";
+      sha256 = "4WTrs/tUyOugufRrrh0qsEmhPclQD64ypYysxsnOyS8=";
     })
   ];
 
@@ -32,7 +32,8 @@ stdenv.mkDerivation {
     mkdir -p "$out/lib/firmware/brcm"
 
     # Wifi firmware
-    for filename in firmware-nonfree/brcm/brcmfmac434??-sdio.*; do
+    shopt -s extglob
+    for filename in firmware-nonfree/brcm/brcmfmac434??{,s}-sdio.*; do
       cp "$filename" "$out/lib/firmware/brcm"
     done
 
@@ -43,7 +44,7 @@ stdenv.mkDerivation {
 
   outputHashMode = "recursive";
   outputHashAlgo = "sha256";
-  outputHash = "0a54gyrq6jfxxvimaa4yjfiyfwf7wv58v0a32l74yrzyarr3ldby";
+  outputHash = "l+7VOq7CV5QA8/FWjMBGDcxq8Qe7NFf6E2Y42htZEgE=";
 
   meta = with lib; {
     description = "Firmware for builtin Wifi/Bluetooth devices in the Raspberry Pi 3+ and Zero W";

--- a/pkgs/os-specific/linux/firmware/raspberrypi/armstubs.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/armstubs.nix
@@ -5,13 +5,13 @@ let
 in
 stdenv.mkDerivation {
   pname = "raspberrypi-armstubs";
-  version = "2021-07-05";
+  version = "2021-11-01";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "tools";
-    rev = "2e59fc67d465510179155973d2b959e50a440e47";
-    sha256 = "1ysdl4qldy6ldf8cm1igxjisi14xl3s2pi6cnqzpxb38sgihb1vy";
+    rev = "13474ee775d0c5ec8a7da4fb0a9fa84187abfc87";
+    sha256 = "s/RPMIpQSznoQfchAP9gpO7I2uuTsOV0Ep4vVz7i2o4=";
   };
 
   NIX_CFLAGS_COMPILE = [

--- a/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
@@ -3,13 +3,13 @@
 stdenvNoCC.mkDerivation rec {
   # NOTE: this should be updated with linux_rpi
   pname = "raspberrypi-firmware";
-  version = "1.20210805";
+  version = "1.20211029";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "firmware";
     rev = version;
-    sha256 = "1nndhjv4il42yw3pq8ni3r4nlp1m0r229fadrf4f9v51mgcg11i1";
+    sha256 = "J527tS1ky36TSPn6isBGWqZBDXGyuqvWV9hxP1aJlL8=";
   };
 
   installPhase = ''

--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -3,7 +3,8 @@
 let
   # NOTE: raspberrypifw & raspberryPiWirelessFirmware should be updated with this
   modDirVersion = "5.10.52";
-  tag = "1.20210805";
+  tag = "1.20211029"; # commit seems to be wrong, same as 1.20211007 and doesn't match firmware
+  rev = "84dc624be6ae704fdb3c413b7d86315cf49fbb0b";
 in
 lib.overrideDerivation (buildLinux (args // {
   version = "${modDirVersion}-${tag}";
@@ -12,7 +13,7 @@ lib.overrideDerivation (buildLinux (args // {
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "linux";
-    rev = tag;
+    inherit rev;
     sha256 = "1j71xblflslfi4c3zx2srw6fahnhp3bjx4yjfqrp39kzaa41ij0b";
   };
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -455,6 +455,8 @@ mapAliases ({
   links = links2; # added 2016-01-31
   linux_rpi0 = linuxKernel.kernels.linux_rpi1;
   linuxPackages_rpi0 = linuxKernel.packages.linux_rpi1;
+  linux_rpi02w = linuxKernel.kernels.linux_rpi3;
+  linuxPackages_rpi02w = linuxKernel.packages.linux_rpi3;
   linuxPackages_rt_5_4 = linuxKernel.packages.linux_rt_5_4;
   linuxPackages_rt_5_10 = linuxKernel.packages.linux_rt_5_10;
   linuxPackages_rt_5_11 = linuxKernel.packages.linux_rt_5_11;


### PR DESCRIPTION
###### Motivation for this change
The primary impetus was for Raspberry Pi Zero 2 W support, but there are minor changes affecting all hardware.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (`pkgsCross.aarch64-multiplatform`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
