### PR TITLE
thefuck: fix build on darwin

### DIFF
--- a/pkgs/tools/misc/thefuck/default.nix
+++ b/pkgs/tools/misc/thefuck/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildPythonApplication
+{ lib, stdenv, fetchFromGitHub, buildPythonApplication
 , colorama, decorator, psutil, pyte, six
 , go, mock, pytestCheckHook, pytest-mock
 }:
@@ -17,6 +17,23 @@ buildPythonApplication rec {
   propagatedBuildInputs = [ colorama decorator psutil pyte six ];
 
   checkInputs = [ go mock pytestCheckHook pytest-mock ];
+
+  disabledTests = lib.optional stdenv.isDarwin [
+    "test_settings_defaults"
+    "test_from_file"
+    "test_from_env"
+    "test_settings_from_args"
+    "test_get_all_executables_exclude_paths"
+    "test_with_blank_cache"
+    "test_with_filled_cache"
+    "test_when_etag_changed"
+    "test_for_generic_shell"
+    "test_on_first_run"
+    "test_on_run_after_other_commands"
+    "test_when_cant_configure_automatically"
+    "test_when_already_configured"
+    "test_when_successfully_configured"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/nvbn/thefuck";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`thefuck` isn't currently building on Darwin systems due to some tests failing. This PR disables the relevant tests.

I could imagine that it's possible to change the derivation in some way to enable those tests to run successfully, but I don't know enough to do that myself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


ZHF: #144627 
cc: @NixOS/nixos-release-managers 
