### PR TITLE
lavalauncher: 2.0.0 -> 2.1.1, fix broken build

### DIFF
--- a/pkgs/applications/misc/lavalauncher/default.nix
+++ b/pkgs/applications/misc/lavalauncher/default.nix
@@ -7,24 +7,26 @@
 , scdoc
 , cairo
 , librsvg
+, libxkbcommon
 , wayland
 , wayland-protocols
 }:
 
 stdenv.mkDerivation rec {
   pname = "lavalauncher";
-  version = "2.0.0";
+  version = "2.1.1";
 
   src = fetchgit {
     url = "https://git.sr.ht/~leon_plickat/lavalauncher";
     rev = "v${version}";
-    sha256 = "MXREycR4ZetTe71ZwEqyozMJN9OLTDvU0W4J8qkTQAs=";
+    sha256 = "hobhZ6s9m2xCdAurdj0EF1BeS88j96133zu+2jb1FMM=";
   };
 
   nativeBuildInputs = [ meson ninja pkg-config scdoc ];
   buildInputs = [
     cairo
     librsvg
+    libxkbcommon
     wayland
     wayland-protocols
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Things done

Bumped version and added new dependency.
Before merging though, the reason it failed to build in the first place is because lavalauncher was using from a dependency a deprecated function, and `cc1: all warnings being treated as errors`. So I don't know if it might break again.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
