### PR TITLE
treewide: Fix unsafe concatenation of $LD_LIBRARY_PATH, round 2

### DIFF
--- a/doc/using/overlays.chapter.md
+++ b/doc/using/overlays.chapter.md
@@ -112,7 +112,7 @@ self: super:
 This overlay uses Intel's MKL library for both BLAS and LAPACK interfaces. Note that the same can be accomplished at runtime using `LD_LIBRARY_PATH` of `libblas.so.3` and `liblapack.so.3`. For instance:
 
 ```ShellSession
-$ LD_LIBRARY_PATH=$(nix-build -A mkl)/lib:$LD_LIBRARY_PATH nix-shell -p octave --run octave
+$ LD_LIBRARY_PATH=$(nix-build -A mkl)/lib${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH nix-shell -p octave --run octave
 ```
 
 Intel MKL requires an `openmp` implementation when running with multiple processors. By default, `mkl` will use Intel's `iomp` implementation if no other is specified, but this is a runtime-only dependency and binary compatible with the LLVM implementation. To use that one instead, Intel recommends users set it with `LD_PRELOAD`. Note that `mkl` is only available on `x86_64-linux` and `x86_64-darwin`. Moreover, Hydra is not building and distributing pre-compiled binaries using it.

--- a/pkgs/applications/office/jabref/default.nix
+++ b/pkgs/applications/office/jabref/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
 
     makeWrapper $out/lib/runtime/bin/java $out/bin/jabref \
       --add-flags '-Djava.library.path=${systemLibPaths}' --add-flags "-p $out/lib/app -m org.jabref/org.jabref.JabRefLauncher" \
-      --run 'export LD_LIBRARY_PATH=${systemLibPaths}:$LD_LIBRARY_PATH'
+      --prefix LD_LIBRARY_PATH : '${systemLibPaths}'
 
     cp -r ${desktopItem}/share/applications $out/share/
 

--- a/pkgs/development/compilers/llvm/rocm/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/rocm/llvm/default.nix
@@ -74,7 +74,7 @@ in stdenv.mkDerivation rec {
   '';
 
   preCheck = ''
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$PWD/lib
   '';
 
   postInstall = ''

--- a/pkgs/development/libraries/spdlog/default.nix
+++ b/pkgs/development/libraries/spdlog/default.nix
@@ -36,7 +36,7 @@ let
       '';
 
       doCheck = true;
-      preCheck = "export LD_LIBRARY_PATH=$(pwd):$LD_LIBRARY_PATH";
+      preCheck = "export LD_LIBRARY_PATH=$(pwd)\${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH";
 
       meta = with lib; {
         description    = "Very fast, header only, C++ logging library";

--- a/pkgs/development/python-modules/openbabel-bindings/default.nix
+++ b/pkgs/development/python-modules/openbabel-bindings/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   # some functionality to work (inparticular, pybel).
   # see https://openbabel.org/docs/dev/Installation/install.html
   BABEL_LIBDIR = "${openbabel}/lib/openbabel/3.1.0";
-  LD_LIBRARY_PATH = "$LD_LIBRARY_PATH:${openbabel}/lib";
+  LD_LIBRARY_PATH = "${openbabel}/lib";
 
   doCheck = false;
   pythonImportsCheck = [ "openbabel" ];

--- a/pkgs/development/tools/poetry2nix/poetry2nix/overrides.nix
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/overrides.nix
@@ -1700,7 +1700,7 @@ self: super:
           if (!enableCuda) then ''
             export USE_CUDA=0
           '' else ''
-            export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${cudatoolkit}/targets/x86_64-linux/lib"
+            export LD_LIBRARY_PATH="$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}${cudatoolkit}/targets/x86_64-linux/lib"
           '';
         preFixup = lib.optionalString (!enableCuda) ''
           # For some reason pytorch retains a reference to libcuda even if it
@@ -1739,9 +1739,9 @@ self: super:
       ];
       preConfigure =
         if (enableCuda) then ''
-          export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${self.torch}/${self.python.sitePackages}/torch/lib:${lib.makeLibraryPath [ cudatoolkit "${cudatoolkit}" ]}"
+          export LD_LIBRARY_PATH="$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}${self.torch}/${self.python.sitePackages}/torch/lib:${lib.makeLibraryPath [ cudatoolkit "${cudatoolkit}" ]}"
         '' else ''
-          export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${self.torch}/${self.python.sitePackages}/torch/lib"
+          export LD_LIBRARY_PATH="$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}${self.torch}/${self.python.sitePackages}/torch/lib"
         '';
     }))
     { };

--- a/pkgs/tools/games/gamemode/preload-nix-workaround.patch
+++ b/pkgs/tools/games/gamemode/preload-nix-workaround.patch
@@ -6,7 +6,7 @@ index 573b3e4..6f2799e 100755
  
  # ld will find the right path to load the library, including for 32-bit apps.
  LD_PRELOAD="${GAMEMODEAUTO_NAME}${LD_PRELOAD:+:$LD_PRELOAD}"
-+LD_LIBRARY_PATH="@libraryPath@${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
++LD_LIBRARY_PATH="@libraryPath@${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
  
 -exec env LD_PRELOAD="${LD_PRELOAD}" $GAMEMODERUNEXEC "$@"
 +exec env LD_PRELOAD="${LD_PRELOAD}" LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" $GAMEMODERUNEXEC "$@"


### PR DESCRIPTION
###### Motivation for this change

Naive concatenation of `$LD_LIBRARY_PATH` can result in an empty colon-delimited segment; this tells glibc to load libraries from the current directory, which is definitely wrong, and may be a security vulnerability if the current directory is untrusted.  (See #67234, for example.)  Fix this throughout the tree.

Followup to #76804.  Fixes #144646.

Cc @fricklerhandwerk @wamserma @danieldk @drewrisinger @danielbarter @adisbladis @kira-bruneau @nh2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
