### PR TITLE
 sanic: 21.3.4 -> 21.9.1,   sanic-routing: 0.6.2 -> 0.7.2

### DIFF
--- a/pkgs/development/python-modules/pytest-sanic/default.nix
+++ b/pkgs/development/python-modules/pytest-sanic/default.nix
@@ -47,5 +47,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/yunstanford/pytest-sanic/";
     license = licenses.asl20;
     maintainers = with maintainers; [ costrouc ];
+    broken = true; # 2021-11-04
   };
 }

--- a/pkgs/development/python-modules/sanic-routing/default.nix
+++ b/pkgs/development/python-modules/sanic-routing/default.nix
@@ -7,13 +7,13 @@
 
 buildPythonPackage rec {
   pname = "sanic-routing";
-  version = "0.6.2";
+  version = "0.7.2";
 
   src = fetchFromGitHub {
     owner = "sanic-org";
     repo = "sanic-routing";
     rev = "v${version}";
-    hash = "sha256-ZMl8PB9E401pUfUJ4tW7nBx1TgPQQtx9erVni3zP+lo=";
+    hash = "sha256-MN6A8CtDVxj34eehr3UIwCT09VOfcruVX+/iImr1MgY=";
   };
 
   checkInputs = [ pytestCheckHook pytest-asyncio ];

--- a/pkgs/development/python-modules/sanic/default.nix
+++ b/pkgs/development/python-modules/sanic/default.nix
@@ -10,7 +10,6 @@
 , multidict
 , pytest-asyncio
 , pytest-benchmark
-, pytest-sanic
 , pytest-sugar
 , pytestCheckHook
 , sanic-routing
@@ -23,28 +22,19 @@
 
 buildPythonPackage rec {
   pname = "sanic";
-  version = "21.3.4";
+  version = "21.9.1";
 
   src = fetchFromGitHub {
     owner = "sanic-org";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0vldlic8gqcf56fqb31igycqf11syd9csk66v34w6dim54lcny2b";
+    sha256 = "sha256-TRrJr/L8AXLAARPjhBi2FxNh+jvxxdeMN24cT1njmqY=";
   };
-
-  patches = [
-    # Allow later websockets release, https://github.com/sanic-org/sanic/pull/2154
-    (fetchpatch {
-      name = "later-websockets.patch";
-      url = "https://github.com/sanic-org/sanic/commit/5fb820b5c1ce395e86a1ee11996790c65ec7bc65.patch";
-      sha256 = "1glvq23pf1sxqjnrz0w8rr7nsnyz82k1479b3rm8szfkjg9q5d1w";
-    })
-  ];
 
   postPatch = ''
     # Loosen dependency requirements.
     substituteInPlace setup.py \
-      --replace '"pytest==5.2.1"' '"pytest"' \
+      --replace '"pytest==6.2.5"' '"pytest"' \
       --replace '"gunicorn==20.0.4"' '"gunicorn"' \
       --replace '"pytest-sanic",' "" \
     # Patch a request headers test to allow brotli encoding
@@ -68,7 +58,6 @@ buildPythonPackage rec {
     gunicorn
     pytest-asyncio
     pytest-benchmark
-    pytest-sanic
     pytest-sugar
     pytestCheckHook
     sanic-testing
@@ -77,6 +66,11 @@ buildPythonPackage rec {
 
   inherit doCheck;
 
+  preCheck = ''
+    # Some tests depends on executables on PATH
+    PATH="$out/bin:${gunicorn}/bin:$PATH"
+  '';
+
   disabledTests = [
     # Tests are flaky
     "test_keep_alive_client_timeout"
@@ -84,6 +78,11 @@ buildPythonPackage rec {
     "test_check_timeouts_response_timeout"
     "test_reloader_live"
     "test_zero_downtime"
+    # Not working from 21.9.1
+    "test_create_server_main"
+    "test_create_server_main_convenience"
+    "test_debug"
+    "test_auto_reload"
   ];
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/python-modules/sanic/default.nix
+++ b/pkgs/development/python-modules/sanic/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , aiofiles
 , beautifulsoup4
 , buildPythonPackage
@@ -83,8 +84,13 @@ buildPythonPackage rec {
     "test_create_server_main_convenience"
     "test_debug"
     "test_auto_reload"
+  ] ++ lib.optionals stdenv.isDarwin [
+    # https://github.com/sanic-org/sanic/issues/2298
+    "test_no_exceptions_when_cancel_pending_request"
   ];
 
+  # avoid usage of nixpkgs-review in darwin since tests will compete usage
+  # for the same local port
   __darwinAllowLocalNetworking = true;
 
   pythonImportsCheck = [ "sanic" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF: https://github.com/NixOS/nixpkgs/issues/144627

- Mark `pytest-sanic` as broken. It doesn't build with newer versions of `sanic`, since `sanic.websocket` was removed.
- Disable some tests that don't work. ~~Most of them are related to the lack of `sanic` on `PATH`, so it should be safe.~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
