### PR TITLE
dcpomatic: init at 2.15.171

### DIFF
--- a/pkgs/applications/video/dcpomatic/default.nix
+++ b/pkgs/applications/video/dcpomatic/default.nix
@@ -1,0 +1,134 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, wafHook
+, python3
+, pkg-config
+, boost
+, bzip2
+, cairomm
+, curl
+, ffmpeg
+, fontconfig
+, glib
+, gtk2
+, icu
+, leqm-nrt
+, libcxml
+, libdcp
+, libGLU
+, libpng
+, libsamplerate
+, libsndfile
+, libssh
+, libsub
+, libtool
+, libxmlxx
+, libzip
+, nanomsg
+, nettle
+, openssl
+, pangomm
+, rtaudio
+, wxGTK31
+, xmlsec
+, substitute
+}:
+
+let
+  openssl-cth = openssl.overrideAttrs (oldAttrs: {
+    version = "${oldAttrs.version}-dcpomatic";
+    patches = (oldAttrs.patches or []) ++ [
+      (fetchpatch {
+        url = "https://github.com/cth103/openssl/commit/752ff83f31327c91dfd45fbc6cb14e6d9c807e44.patch";
+        sha256 = "0xay54xxl0vjvigaxdfvgykrmlv9cgym6d2cc7acc5blggdzzlqf";
+      })
+    ];
+  });
+in stdenv.mkDerivation rec {
+  pname = "dcpomatic";
+  version = "2.15.183";
+
+  src = fetchFromGitHub {
+    owner = "cth103";
+    repo = "dcpomatic";
+    rev = "v${version}";
+    sha256 = "0srllj5vwnxhc3p3grvf92ymdvlg4z9lx5bbxrbx6l3prkyp2933";
+  };
+
+  patches = [
+    # libdcp's data files are not in a shared /share/ directory.
+    (substitute {
+      src = ./libdcp-path.patch;
+      replacements = [ "--replace" "@LIBDCP@" libdcp ];
+    })
+    # fixes to add correct headers
+    (fetchpatch {
+      url = "https://github.com/cth103/dcpomatic/pull/14/commits/cbcbbc1cf6f6faf18991e92f2e2917fc14a00116.patch";
+      sha256 = "0grdf5jdnbhnlw45f8v301z4gk3k64j3xqifdxfkakankgj3mxfw";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace wscript \
+      --replace "this_version = " "this_version = 'v${version}' #" \
+      --replace "last_version = " "last_version = 'v${version}' #"
+  '';
+
+  wafConfigureFlags = [
+    "--disable-tests"
+
+    # requires lwext4
+    # "--enable-disk"
+  ];
+
+  enableParallelBuilding = true;
+
+  buildInputs = [
+    boost
+    bzip2
+    cairomm
+    curl
+    ffmpeg
+    fontconfig
+    glib
+    gtk2
+    icu
+    leqm-nrt
+    libcxml
+    libdcp
+    libGLU
+    libpng
+    libsamplerate
+    libsndfile
+    libssh
+    libsub
+    libtool
+    libxmlxx
+    libzip
+    nanomsg
+    nettle
+    pangomm
+    rtaudio
+    wxGTK31
+    xmlsec
+  ];
+
+  nativeBuildInputs = [
+    wafHook
+    python3
+    pkg-config
+  ];
+
+  postInstall = ''
+    ln -s ${openssl-cth}/bin/openssl $out/bin/dcpomatic2_openssl
+  '';
+
+  meta = with lib; {
+    description = "Program for converting video, audio and subtitles to Digital Cinema Packages";
+    homepage = "https://dcpomatic.com";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ lukegb ];
+  };
+}

--- a/pkgs/applications/video/dcpomatic/libdcp-path.patch
+++ b/pkgs/applications/video/dcpomatic/libdcp-path.patch
@@ -1,0 +1,26 @@
+diff -r -u dcpomatic-2.15.171-orig/src/lib/cross_linux.cc dcpomatic-2.15.171/src/lib/cross_linux.cc
+--- dcpomatic-2.15.171-orig/src/lib/cross_linux.cc	2021-11-01 16:22:26.429450459 +0000
++++ dcpomatic-2.15.171/src/lib/cross_linux.cc	2021-11-01 16:23:49.198259057 +0000
+@@ -112,20 +112,14 @@
+ boost::filesystem::path
+ xsd_path ()
+ {
+-	if (auto appdir = getenv("APPDIR")) {
+-		return boost::filesystem::path(appdir) / "usr" / "share" / "libdcp" / "xsd";
+-	}
+-	return boost::filesystem::canonical(LINUX_SHARE_PREFIX) / "libdcp" / "xsd";
++	return boost::filesystem::path("@LIBDCP@") / "share" / "libdcp" / "xsd";
+ }
+ 
+ 
+ boost::filesystem::path
+ tags_path ()
+ {
+-	if (auto appdir = getenv("APPDIR")) {
+-		return boost::filesystem::path(appdir) / "usr" / "share" / "libdcp" / "tags";
+-	}
+-	return boost::filesystem::canonical(LINUX_SHARE_PREFIX) / "libdcp" / "tags";
++	return boost::filesystem::path("@LIBDCP@") / "share" / "libdcp" / "tags";
+ }
+ 
+ 

--- a/pkgs/development/libraries/asdcplib-carl/default.nix
+++ b/pkgs/development/libraries/asdcplib-carl/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, wafHook
+, python3
+, pkg-config
+, openssl
+, boost
+}:
+
+stdenv.mkDerivation rec {
+  pname = "asdcplib-carl";
+  version = "unstable-2021-10-28";
+
+  src = fetchFromGitHub {
+    owner = "cth103";
+    repo = "asdcplib";
+    rev = "8f23c6c904d17e468bf94397fee28e1242cb1651";
+    sha256 = "006ja8iclb4f3qx011p9qkjxza2ysxy060501rdz4q7a3fl3lvrz";
+  };
+
+  postPatch = ''
+    echo "0.1.6-${version}" > VERSION
+  '';
+
+  enableParallelBuilding = true;
+
+  propagatedBuildInputs = [
+    openssl
+  ];
+
+  buildInputs = [
+    boost
+  ];
+
+  nativeBuildInputs = [
+    wafHook
+    python3
+    pkg-config
+  ];
+
+  meta = with lib; {
+    description = "Open-source implementation of SMPTE and MXF Interop format";
+    homepage = "https://carlh.net/asdcplib";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ lukegb ];
+  };
+}

--- a/pkgs/development/libraries/asdcplib-carl/default.nix
+++ b/pkgs/development/libraries/asdcplib-carl/default.nix
@@ -6,6 +6,7 @@
 , pkg-config
 , openssl
 , boost
+, dcpomatic
 }:
 
 stdenv.mkDerivation rec {
@@ -38,6 +39,11 @@ stdenv.mkDerivation rec {
     python3
     pkg-config
   ];
+
+  passthru.tests = {
+    # Changes to asdcplib should basically always ensure dcpomatic continues to build.
+    inherit dcpomatic;
+  };
 
   meta = with lib; {
     description = "Open-source implementation of SMPTE and MXF Interop format";

--- a/pkgs/development/libraries/leqm-nrt/default.nix
+++ b/pkgs/development/libraries/leqm-nrt/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, wafHook
+, python3
+, pkg-config
+, ffmpeg
+, libsndfile
+}:
+
+stdenv.mkDerivation rec {
+  pname = "leqm-nrt";
+  version = "0.20-cth";
+
+  src = fetchFromGitHub {
+    owner = "cth103";
+    repo = "leqm-nrt";
+    rev = "93ae9e6e4319a792cbfe5302dddc1b7781c55c76";
+    sha256 = "08bsj2fp9waa3j11dqmn50w9lvhx960fmd5xcpjnxv3v0mkr7jsg";
+  };
+
+  postPatch = ''
+    substituteInPlace wscript \
+      --replace "this_version = " "this_version = 'v${version}' #" \
+      --replace "last_version = " "last_version = 'v${version}' #"
+  '';
+
+  buildInputs = [
+    ffmpeg
+    libsndfile
+  ];
+
+  nativeBuildInputs = [
+    wafHook
+    python3
+    pkg-config
+  ];
+
+  meta = with lib; {
+    description = "Implementation of Leq(M) measurement";
+    homepage = "https://github.com/lucat/leqm-nrt";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ lukegb ];
+  };
+}

--- a/pkgs/development/libraries/leqm-nrt/default.nix
+++ b/pkgs/development/libraries/leqm-nrt/default.nix
@@ -4,6 +4,7 @@
 , wafHook
 , python3
 , pkg-config
+, dcpomatic
 , ffmpeg
 , libsndfile
 }:
@@ -35,6 +36,11 @@ stdenv.mkDerivation rec {
     python3
     pkg-config
   ];
+
+  passthru.tests = {
+    # Changes to leqm-nrt should basically always ensure dcpomatic continues to build.
+    inherit dcpomatic;
+  };
 
   meta = with lib; {
     description = "Implementation of Leq(M) measurement";

--- a/pkgs/development/libraries/libcxml/default.nix
+++ b/pkgs/development/libraries/libcxml/default.nix
@@ -8,6 +8,7 @@
 , boost
 , libxmlxx
 , glibmm
+, dcpomatic
 }:
 
 stdenv.mkDerivation rec {
@@ -49,6 +50,11 @@ stdenv.mkDerivation rec {
     python3
     pkg-config
   ];
+
+  passthru.tests = {
+    # Changes to libcxml should basically always ensure dcpomatic continues to build.
+    inherit dcpomatic;
+  };
 
   meta = with lib; {
     description = "A slightly tidier C++ API for parsing XML.";

--- a/pkgs/development/libraries/libcxml/default.nix
+++ b/pkgs/development/libraries/libcxml/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, stdenv
+, fetchurl
+, fetchpatch
+, wafHook
+, python3
+, pkg-config
+, boost
+, libxmlxx
+, glibmm
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libcxml";
+  version = "0.17.2";
+
+  src = fetchurl {
+    url = "https://carlh.net/downloads/libcxml/libcxml-${version}.tar.bz2";
+    sha256 = "0zbl8msz7wvrnjvki1qj02dljj6g038yz7f707bm2cyazj2sn0d9";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/cth103/libcxml/pull/3/commits/dd0ca672a261d3e1d78e8d5cc5382c2e8df75a4e.patch";
+      sha256 = "0ki2nw4q84w8pabfifbqz9z7v5wsd4wvza7x6pppk97giji2960k";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace wscript \
+      --replace "this_version = " "this_version = 'v${version}' #" \
+      --replace "last_version = " "last_version = 'v${version}' #"
+  '';
+
+  enableParallelBuilding = true;
+
+  propagatedBuildInputs = [
+    libxmlxx
+    glibmm
+  ];
+
+  buildInputs = [
+    boost
+    libxmlxx
+  ];
+
+  nativeBuildInputs = [
+    wafHook
+    python3
+    pkg-config
+  ];
+
+  meta = with lib; {
+    description = "A slightly tidier C++ API for parsing XML.";
+    homepage = "https://carlh.net/libcxml";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ lukegb ];
+  };
+}

--- a/pkgs/development/libraries/libdcp/default.nix
+++ b/pkgs/development/libraries/libdcp/default.nix
@@ -1,0 +1,92 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, wafHook
+, python3
+, pkg-config
+, openssl
+, boost
+, libxmlxx
+, xmlsec
+, libxslt
+, graphicsmagick
+, libsndfile
+, openjpeg
+, asdcplib-carl
+, libcxml
+, xercesc
+, libtool
+, libsigcxx
+, llvmPackages
+}:
+
+let
+  openjpeg-patched = openjpeg.overrideAttrs (origAttrs: {
+    patches = (origAttrs.patches or [ ]) ++ [
+      (fetchpatch {
+        url = "https://github.com/cth103/openjpeg/commit/a1403c2e2e71c6252d97abf9ddca421ce925d456.patch";
+        sha256 = "1vc77rnw6yc3drksp6wzii9lw3jg0ykjw446s90ym2h52mhjr45x";
+      })
+    ];
+  });
+in
+stdenv.mkDerivation rec {
+  pname = "libdcp";
+  version = "unstable-20220116";
+
+  src = fetchFromGitHub {
+    owner = "cth103";
+    repo = "libdcp";
+    rev = "81c6fcba23f5c037f52c3324f4134e81d4f5d5c6";
+    sha256 = "1ay89xb99p5f74k9w8k9bil26a11vwyy1ap7jgv7mbgchdq0dy2l";
+  };
+
+  postPatch = ''
+    substituteInPlace wscript \
+      --replace "this_version = " "this_version = 'v${version}' #" \
+      --replace "last_version = " "last_version = 'v${version}' #"
+  '';
+
+  wafConfigureFlags = [
+    # Tests require private non-distributable data.
+    "--disable-tests"
+    "--disable-benchmarks"
+
+    "--enable-openmp"
+  ];
+
+  enableParallelBuilding = true;
+
+  propagatedBuildInputs = [
+    asdcplib-carl
+    openssl
+    xercesc
+    xmlsec
+    libxmlxx
+    libsigcxx
+    libxslt
+  ];
+
+  buildInputs = [
+    boost
+    graphicsmagick
+    libsndfile
+    openjpeg-patched
+    libcxml
+    libtool
+  ] ++ lib.optional stdenv.cc.isClang llvmPackages.openmp;
+
+  nativeBuildInputs = [
+    wafHook
+    python3
+    pkg-config
+  ];
+
+  meta = with lib; {
+    description = "Library to read and write Digital Cinema Packages using JPEG2000 and PCM data, including KDMs";
+    homepage = "https://carlh.net/libdcp";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ lukegb ];
+  };
+}

--- a/pkgs/development/libraries/libdcp/default.nix
+++ b/pkgs/development/libraries/libdcp/default.nix
@@ -19,6 +19,7 @@
 , libtool
 , libsigcxx
 , llvmPackages
+, dcpomatic
 }:
 
 let
@@ -82,6 +83,11 @@ stdenv.mkDerivation rec {
     python3
     pkg-config
   ];
+
+  passthru.tests = {
+    # Changes to libdcp should basically always ensure dcpomatic continues to build.
+    inherit dcpomatic;
+  };
 
   meta = with lib; {
     description = "Library to read and write Digital Cinema Packages using JPEG2000 and PCM data, including KDMs";

--- a/pkgs/development/libraries/libsub/default.nix
+++ b/pkgs/development/libraries/libsub/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, stdenv
+, fetchurl
+, wafHook
+, python3
+, pkg-config
+, openssl
+, boost
+, libdcp
+, libcxml
+, libtool
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libsub";
+  version = "1.6.5";
+
+  src = fetchurl {
+    url = "https://carlh.net/downloads/libsub/libsub-${version}.tar.bz2";
+    sha256 = "1r66cn9p83dlwhpppf17nkps246yfjalqv1lsdmydn2yhifcpxcx";
+  };
+
+  postPatch = ''
+    substituteInPlace wscript \
+      --replace "this_version = " "this_version = 'v${version}' #" \
+      --replace "last_version = " "last_version = 'v${version}' #"
+  '';
+
+  enableParallelBuilding = true;
+
+  buildInputs = [
+    openssl
+    boost
+    libdcp
+    libcxml
+    libtool
+  ];
+
+  nativeBuildInputs = [
+    wafHook
+    python3
+    pkg-config
+  ];
+
+  meta = with lib; {
+    description = "Library to read and write subtitles in STL/SubRip/DCP/SSA format";
+    homepage = "https://carlh.net/libsub";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ lukegb ];
+  };
+}

--- a/pkgs/development/libraries/libsub/default.nix
+++ b/pkgs/development/libraries/libsub/default.nix
@@ -9,6 +9,7 @@
 , libdcp
 , libcxml
 , libtool
+, dcpomatic
 }:
 
 stdenv.mkDerivation rec {
@@ -41,6 +42,11 @@ stdenv.mkDerivation rec {
     python3
     pkg-config
   ];
+
+  passthru.tests = {
+    # Changes to libsub should basically always ensure dcpomatic continues to build.
+    inherit dcpomatic;
+  };
 
   meta = with lib; {
     description = "Library to read and write subtitles in STL/SubRip/DCP/SSA format";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15797,6 +15797,8 @@ with pkgs;
 
   arsenal = callPackage ../tools/security/arsenal { };
 
+  asdcplib-carl = callPackage ../development/libraries/asdcplib-carl { };
+
   assimp = callPackage ../development/libraries/assimp { };
 
   asio_1_10 = callPackage ../development/libraries/asio/1.10.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17372,6 +17372,8 @@ with pkgs;
 
   lensfun = callPackage ../development/libraries/lensfun {};
 
+  leqm-nrt = callPackage ../development/libraries/leqm-nrt { };
+
   lesstif = callPackage ../development/libraries/lesstif { };
 
   leveldb = callPackage ../development/libraries/leveldb { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18081,6 +18081,8 @@ with pkgs;
 
   libspnav = callPackage ../development/libraries/libspnav { };
 
+  libsub = callPackage ../development/libraries/libsub { };
+
   libgsf = callPackage ../development/libraries/libgsf { };
 
   # GNU libc provides libiconv so systems with glibc don't need to build

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17607,6 +17607,8 @@ with pkgs;
 
   libcutl = callPackage ../development/libraries/libcutl { };
 
+  libcxml = callPackage ../development/libraries/libcxml { };
+
   libdaemon = callPackage ../development/libraries/libdaemon { };
 
   libdap = callPackage ../development/libraries/libdap { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17638,6 +17638,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };
 
+  libdcp = callPackage ../development/libraries/libdcp { };
+
   libde265 = callPackage ../development/libraries/libde265 {};
 
   libdeflate = callPackage ../development/libraries/libdeflate { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16202,6 +16202,8 @@ with pkgs;
       inherit suidHelper serviceDirectories apparmor;
     };
 
+  dcpomatic = callPackage ../applications/video/dcpomatic { };
+
   dee = callPackage ../development/libraries/dee {
     autoreconfHook = buildPackages.autoreconfHook269;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add https://dcpomatic.com/, a tool for producing Digital Cinema Packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
