### PR TITLE
zerobin: fix build

### DIFF
--- a/pkgs/applications/networking/zerobin/default.nix
+++ b/pkgs/applications/networking/zerobin/default.nix
@@ -40,7 +40,7 @@ python3Packages.buildPythonApplication rec {
     # relax version constraints of some dependencies
     substituteInPlace setup.cfg \
       --replace "clize==4.1.1" "clize" \
-      --replace "bleach==3.1.5" "bleach>=3.1.5,<4" \
+      --replace "bleach==3.1.5" "bleach>=3.1.5,<5" \
       --replace "bottle==0.12.18" "bottle>=0.12.18,<1" \
       --replace "Paste==3.4.3" "Paste>=3.4.3,<4"
   '';


### PR DESCRIPTION
###### Motivation for this change
ZHF: #144627

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
