### PR TITLE
synology-drive-client: init at 3.0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5197,6 +5197,16 @@
     githubId = 938744;
     name = "John Chadwick";
   };
+  jcouyang = {
+    email = "oyanglulu@gmail.com";
+    github = "jcouyang";
+    githubId = 1235045;
+    name = "Jichao Ouyang";
+    keys = [{
+      longkeyid = "rsa2048/0xDA8B833B52604E63";
+      fingerprint = "A506 C38D 5CC8 47D0 DF01  134A DA8B 833B 5260 4E63";
+    }];
+  };
   jcumming = {
     email = "jack@mudshark.org";
     github = "jcumming";

--- a/pkgs/applications/networking/synology-drive-client/default.nix
+++ b/pkgs/applications/networking/synology-drive-client/default.nix
@@ -3,7 +3,7 @@ let
   pname = "synology-drive-client";
   buildNumber = "12682";
   version = "3.0.2";
-  baseUrl = "https://global.download.synology.com/download/Utility/SynologyDriveClient";    
+  baseUrl = "https://global.download.synology.com/download/Utility/SynologyDriveClient";
   meta = with lib; {
     description = "Desktop application to synchronize files and folders between the computer and the Synology Drive server.";
     homepage = "https://www.synology.com/en-global/dsm/feature/drive";
@@ -44,7 +44,7 @@ let
 
   darwin = stdenv.mkDerivation {
     inherit pname version;
-    
+
     src = fetchurl {
       url = "${baseUrl}/${version}-${buildNumber}/Mac/Installer/synology-drive-client-${buildNumber}.dmg";
       sha256 = "1mlv8gxzivgxm59mw1pd63yq9d7as79ihm7166qyy0h0b0m04q2m";

--- a/pkgs/applications/networking/synology-drive-client/default.nix
+++ b/pkgs/applications/networking/synology-drive-client/default.nix
@@ -1,74 +1,52 @@
-{ pkgs }:
-with pkgs;
+{ stdenv, lib, qt5, fetchurl, autoPatchelfHook, dpkg, glibc, cpio, xar, undmg, gtk3, pango }:
 let
   pname = "synology-drive-client";
   buildNumber = "12682";
   version = "3.0.2";
-  baseUrl =
-    "https://global.download.synology.com/download/Utility/SynologyDriveClient";
-  dmgImage =
-    "${baseUrl}/${version}-${buildNumber}/Mac/Installer/synology-drive-client-${buildNumber}.dmg";
-  debImage =
-    "${baseUrl}/${version}-${buildNumber}/Ubuntu/Installer/x86_64/synology-drive-client-${buildNumber}.x86_64.deb";
+  baseUrl = "https://global.download.synology.com/download/Utility/SynologyDriveClient";    
   meta = with lib; {
-    description =
-      "Desktop application to synchronize files and folders between the computer and the Synology Drive server.";
+    description = "Desktop application to synchronize files and folders between the computer and the Synology Drive server.";
     homepage = "https://www.synology.com/en-global/dsm/feature/drive";
     license = licenses.unfree;
     maintainers = with maintainers; [ jcouyang ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
   };
-  linux = stdenv.mkDerivation {
 
+  linux = qt5.mkDerivation {
     inherit pname version;
 
     src = fetchurl {
-      url = debImage;
+      url = "${baseUrl}/${version}-${buildNumber}/Ubuntu/Installer/x86_64/synology-drive-client-${buildNumber}.x86_64.deb";
       sha256 = "19fd2r39lb7bb6vkxfxyq0gp3l7pk5wy9fl0r7qwhym2jpi8yv6l";
     };
 
     nativeBuildInputs = [ autoPatchelfHook dpkg ];
 
-    buildInputs = [
-      xorg.libX11
-      glib
-      freetype
-      libxkbcommon
-      xorg.libICE
-      xorg.libXrender
-      xorg.libSM
-      fontconfig
-      pango
-      gtk3
-      dbus_libs
-      qt5.qtbase
-      qt5.qtx11extras
-    ];
+    buildInputs = [ glibc gtk3 pango ];
 
-    unpackPhase = "true";
-
-    installPhase = ''
+    unpackPhase = ''
       mkdir -p $out
       dpkg -x $src $out
       rm -rf $out/usr/lib/nautilus
       rm -rf $out/opt/Synology/SynologyDrive/package/cloudstation/icon-overlay
-      cp -r $out/usr/bin $out/bin
+    '';
+
+    installPhase = ''
+      cp -av $out/usr/* $out
+      rm -rf $out/usr
       runHook postInstall
     '';
 
     postInstall = ''
-      substituteInPlace $out/bin/synology-drive \
-        --replace /opt/Synology/SynologyDrive $out/opt/Synology/SynologyDrive \
-        --replace /opt/apps/com.synology.drive/files/Synology/SynologyDrive $out/opt/Synology/SynologyDrive
+      substituteInPlace $out/bin/synology-drive --replace /opt $out/opt
     '';
-
-    dontWrapQtApps = true;
-
   };
+
   darwin = stdenv.mkDerivation {
     inherit pname version;
+    
     src = fetchurl {
-      url = dmgImage;
+      url = "${baseUrl}/${version}-${buildNumber}/Mac/Installer/synology-drive-client-${buildNumber}.dmg";
       sha256 = "1mlv8gxzivgxm59mw1pd63yq9d7as79ihm7166qyy0h0b0m04q2m";
     };
 
@@ -86,6 +64,5 @@ let
       mkdir -p $out/Applications/
       cp -R 'Synology Drive Client.app' $out/Applications/
     '';
-
   };
 in if stdenv.isDarwin then darwin else linux

--- a/pkgs/applications/networking/synology/drive.nix
+++ b/pkgs/applications/networking/synology/drive.nix
@@ -4,7 +4,8 @@ let
   pname = "synology-drive-client";
   buildNumber = "12682";
   version = "3.0.2";
-  baseUrl = "https://global.download.synology.com/download/Utility/SynologyDriveClient";
+  baseUrl =
+    "https://global.download.synology.com/download/Utility/SynologyDriveClient";
   dmgImage =
     "${baseUrl}/${version}-${buildNumber}/Mac/Installer/synology-drive-client-${buildNumber}.dmg";
   debImage =
@@ -22,9 +23,9 @@ let
     inherit pname version;
 
     src = fetchurl {
-        url = debImage;
-        sha256 = "19fd2r39lb7bb6vkxfxyq0gp3l7pk5wy9fl0r7qwhym2jpi8yv6l";
-      };
+      url = debImage;
+      sha256 = "19fd2r39lb7bb6vkxfxyq0gp3l7pk5wy9fl0r7qwhym2jpi8yv6l";
+    };
 
     nativeBuildInputs = [ autoPatchelfHook dpkg ];
 
@@ -54,12 +55,13 @@ let
       cp -r $out/usr/bin $out/bin
       runHook postInstall
     '';
-    
+
     postInstall = ''
       substituteInPlace $out/bin/synology-drive \
-        --replace /opt/Synology/SynologyDrive $out/opt/Synology/SynologyDrive
+        --replace /opt/Synology/SynologyDrive $out/opt/Synology/SynologyDrive \
+        --replace /opt/apps/com.synology.drive/files/Synology/SynologyDrive $out/opt/Synology/SynologyDrive
     '';
-    
+
     dontWrapQtApps = true;
 
   };

--- a/pkgs/applications/networking/synology/drive.nix
+++ b/pkgs/applications/networking/synology/drive.nix
@@ -1,0 +1,89 @@
+{ pkgs }:
+with pkgs;
+let
+  pname = "synology-drive-client";
+  buildNumber = "12682";
+  version = "3.0.2";
+  baseUrl = "https://global.download.synology.com/download/Utility/SynologyDriveClient";
+  dmgImage =
+    "${baseUrl}/${version}-${buildNumber}/Mac/Installer/synology-drive-client-${buildNumber}.dmg";
+  debImage =
+    "${baseUrl}/${version}-${buildNumber}/Ubuntu/Installer/x86_64/synology-drive-client-${buildNumber}.x86_64.deb";
+  meta = with lib; {
+    description =
+      "Desktop application to synchronize files and folders between the computer and the Synology Drive server.";
+    homepage = "https://www.synology.com/en-global/dsm/feature/drive";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ jcouyang ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+  };
+  linux = stdenv.mkDerivation {
+
+    inherit pname version;
+
+    src = fetchurl {
+        url = debImage;
+        sha256 = "19fd2r39lb7bb6vkxfxyq0gp3l7pk5wy9fl0r7qwhym2jpi8yv6l";
+      };
+
+    nativeBuildInputs = [ autoPatchelfHook dpkg ];
+
+    buildInputs = [
+      xorg.libX11
+      glib
+      freetype
+      libxkbcommon
+      xorg.libICE
+      xorg.libXrender
+      xorg.libSM
+      fontconfig
+      pango
+      gtk3
+      dbus_libs
+      qt5.qtbase
+      qt5.qtx11extras
+    ];
+
+    unpackPhase = "true";
+
+    installPhase = ''
+      mkdir -p $out
+      dpkg -x $src $out
+      rm -rf $out/usr/lib/nautilus
+      rm -rf $out/opt/Synology/SynologyDrive/package/cloudstation/icon-overlay
+      cp -r $out/usr/bin $out/bin
+      runHook postInstall
+    '';
+    
+    postInstall = ''
+      substituteInPlace $out/bin/synology-drive \
+        --replace /opt/Synology/SynologyDrive $out/opt/Synology/SynologyDrive
+    '';
+    
+    dontWrapQtApps = true;
+
+  };
+  darwin = stdenv.mkDerivation {
+    inherit pname version;
+    src = fetchurl {
+      url = dmgImage;
+      sha256 = "1mlv8gxzivgxm59mw1pd63yq9d7as79ihm7166qyy0h0b0m04q2m";
+    };
+
+    nativeBuildInputs = [ cpio xar undmg ];
+
+    postUnpack = ''
+      xar -xf 'Install Synology Drive Client.pkg'
+      cd synology-drive.installer.pkg
+      gunzip -dc Payload | cpio -i
+    '';
+
+    sourceRoot = ".";
+
+    installPhase = ''
+      mkdir -p $out/Applications/
+      cp -R 'Synology Drive Client.app' $out/Applications/
+    '';
+
+  };
+in if stdenv.isDarwin then darwin else linux

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27924,7 +27924,7 @@ with pkgs;
 
   dropbox-cli = callPackage ../applications/networking/dropbox/cli.nix { };
 
-  synology-drive-client = callPackage ../applications/networking/synology/drive.nix { };
+  synology-drive-client = callPackage ../applications/networking/synology-drive-client { };
 
   maestral = with python3Packages; toPythonApplication maestral;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27924,6 +27924,8 @@ with pkgs;
 
   dropbox-cli = callPackage ../applications/networking/dropbox/cli.nix { };
 
+  synology-drive-client = callPackage ../applications/networking/synology/drive.nix { };
+
   maestral = with python3Packages; toPythonApplication maestral;
 
   maestral-gui = libsForQt5.callPackage ../applications/networking/maestral-qt { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
