### PR TITLE
php.packages.phpbench: init at 1.1.3

### DIFF
--- a/pkgs/development/php-packages/phpbench/default.nix
+++ b/pkgs/development/php-packages/phpbench/default.nix
@@ -1,0 +1,41 @@
+{ mkDerivation
+, fetchurl
+, makeWrapper
+, lib
+, php
+}:
+
+mkDerivation rec {
+  pname = "phpbench";
+  version = "1.1.3";
+
+  src = fetchurl {
+    url = "https://github.com/phpbench/phpbench/releases/download/${version}/phpbench.phar";
+    sha256 = "AsC9IORjTv7gryTUHJGcKAwIraxywod6PbDEs30P0h4=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin"
+    install -D "$src" "$out/libexec/phpbench/phpbench.phar"
+    makeWrapper "${php}/bin/php" "$out/bin/phpbench" \
+      --add-flags "$out/libexec/phpbench/phpbench.phar"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "PHP Benchmarking framework";
+    license = licenses.mit;
+    homepage = "https://github.com/phpbench/phpbench";
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -136,6 +136,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
     deployer = callPackage ../development/php-packages/deployer { };
 
+    phpbench = callPackage ../development/php-packages/phpbench { };
+
     php-cs-fixer = callPackage ../development/php-packages/php-cs-fixer { };
 
     php-parallel-lint = callPackage ../development/php-packages/php-parallel-lint { };


### PR DESCRIPTION
###### Motivation for this change
https://github.com/phpbench/phpbench

cc @NixOS/php

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
