### PR TITLE
deluge: fix test

### DIFF
--- a/nixos/tests/deluge.nix
+++ b/nixos/tests/deluge.nix
@@ -5,7 +5,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
   };
 
   nodes = {
-    simple2 = {
+    simple = {
       services.deluge = {
         enable = true;
         package = pkgs.deluge-2_x;
@@ -16,7 +16,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
       };
     };
 
-    declarative2 = {
+    declarative = {
       services.deluge = {
         enable = true;
         package = pkgs.deluge-2_x;
@@ -45,27 +45,16 @@ import ./make-test-python.nix ({ pkgs, ...} : {
   testScript = ''
     start_all()
 
-    simple1.wait_for_unit("deluged")
-    simple2.wait_for_unit("deluged")
-    simple1.wait_for_unit("delugeweb")
-    simple2.wait_for_unit("delugeweb")
-    simple1.wait_for_open_port("8112")
-    simple2.wait_for_open_port("8112")
-    declarative1.wait_for_unit("network.target")
-    declarative2.wait_for_unit("network.target")
-    declarative1.wait_until_succeeds("curl --fail http://simple1:8112")
-    declarative2.wait_until_succeeds("curl --fail http://simple2:8112")
+    simple.wait_for_unit("deluged")
+    simple.wait_for_unit("delugeweb")
+    simple.wait_for_open_port("8112")
+    declarative.wait_for_unit("network.target")
+    declarative.wait_until_succeeds("curl --fail http://simple:8112")
 
-    declarative1.wait_for_unit("deluged")
-    declarative2.wait_for_unit("deluged")
-    declarative1.wait_for_unit("delugeweb")
-    declarative2.wait_for_unit("delugeweb")
-    declarative1.wait_until_succeeds("curl --fail http://declarative1:3142")
-    declarative2.wait_until_succeeds("curl --fail http://declarative2:3142")
-    declarative1.succeed(
-        "deluge-console 'connect 127.0.0.1:58846 andrew password; help' | grep -q 'rm.*Remove a torrent'"
-    )
-    declarative2.succeed(
+    declarative.wait_for_unit("deluged")
+    declarative.wait_for_unit("delugeweb")
+    declarative.wait_until_succeeds("curl --fail http://declarative:3142")
+    declarative.succeed(
         "deluge-console 'connect 127.0.0.1:58846 andrew password; help' | grep -q 'rm.*Remove a torrent'"
     )
   '';


### PR DESCRIPTION
In 780135ad5ce54a6b3e7dfb35e3b596757e2ea6f8 the nodes for testing Deluge
1.x were removed, but the test script still referred to it.

This removes the references in the test script and also renames the
nodes to drop the `2` suffix.

###### Motivation for this change

ZHF: #144627

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).