### PR TITLE
makeWrapperAuto: init (declarative wrappers - RFC0075)

### DIFF
--- a/pkgs/applications/audio/clementine/default.nix
+++ b/pkgs/applications/audio/clementine/default.nix
@@ -33,7 +33,6 @@
 , sparsehash
 , config
 , makeWrapper
-, gst_plugins
 
 , util-linux
 , libunwind
@@ -91,6 +90,9 @@ let
     gettext
     glew
     gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-ugly
+    gst_all_1.gst-libav
     gst_all_1.gstreamer
     gvfs
     libechonest
@@ -126,10 +128,7 @@ let
   free = mkDerivation {
     pname = "clementine-free";
     inherit version;
-    inherit src patches nativeBuildInputs postPatch;
-
-    # gst_plugins needed for setup-hooks
-    buildInputs = buildInputs ++ gst_plugins;
+    inherit src patches buildInputs nativeBuildInputs postPatch;
 
     preConfigure = ''
       rm -rf ext/{,lib}clementine-spotifyblob

--- a/pkgs/build-support/setup-hooks/make-wrapper-auto/default.nix
+++ b/pkgs/build-support/setup-hooks/make-wrapper-auto/default.nix
@@ -4,17 +4,13 @@
 , jq
 }:
 
-{
-  # TODO: Will this work? How can I make the act of adding `makeWrapperAuto` to
-  # `nativeBuildInputs` add `./hook.sh`?
-  __functor = makeSetupHook {
-    deps = [ dieHook ];
-    substitutions = {
-      jq = "${lib.getBin jq}/bin/jq";
-    };
-  } ./hook.sh;
-
-  combineWrappersInfo = { envInfo
+(makeSetupHook {
+  deps = [ dieHook ];
+  substitutions = {
+    jq = "${lib.getBin jq}/bin/jq";
+  };
+} ./hook.sh).overrideAttrs(old: {
+  passthru.combineWrappersInfo = { envInfo
     , symlink ? {}
     , buildInputs ? []
     , propagatedBuildInputs ? []
@@ -42,4 +38,4 @@
     ${jq}/bin/jq "." ${envInfoFile} $inputs_wrap_info | sed "s#@out@#$out#g" > $dev/nix-support/wrappers.json
     ${jq}/bin/jq . $dev/nix-support/wrappers.json
   '';
-}
+})

--- a/pkgs/build-support/setup-hooks/make-wrapper-auto/default.nix
+++ b/pkgs/build-support/setup-hooks/make-wrapper-auto/default.nix
@@ -30,12 +30,17 @@
     for wrapInfo in ${inputsWrapInfo}; do
       if [[ -f "$wrapInfo" ]]; then
         inputs_wrap_info+=($wrapInfo)
-      else
-        echo did not find file $wrapInfo
       fi
     done
     # TODO: Is this the best way to substitute @out@ with $out?
-    ${jq}/bin/jq "." ${envInfoFile} $inputs_wrap_info | sed "s#@out@#$out#g" > $dev/nix-support/wrappers.json
+    # TODO: How to merge json files according to keys? See:
+    # https://stackoverflow.com/q/69862320/4935114
+    ${jq}/bin/jq "." ${envInfoFile} $inputs_wrap_info | sed \
+      -e "s,@out@,$out,g" \
+      -e "s,@bin@,$bin,g" \
+      -e "s,@lib@,$lib,g" \
+      > $dev/nix-support/wrappers.json
+    # Display the file
     ${jq}/bin/jq . $dev/nix-support/wrappers.json
   '';
 })

--- a/pkgs/build-support/setup-hooks/make-wrapper-auto/default.nix
+++ b/pkgs/build-support/setup-hooks/make-wrapper-auto/default.nix
@@ -17,7 +17,7 @@
   }: let
     inputsWrapInfo = lib.concatStringsSep " " (
       builtins.map (input: "${lib.getDev input}/nix-support/wrappers.json") (
-        buildInputs ++ propagatedBuildInputs
+        builtins.filter (x: !builtins.isNull x) (buildInputs ++ propagatedBuildInputs)
       )
     );
     envInfoFile = builtins.toFile "env-info.json" (builtins.toJSON envInfo);

--- a/pkgs/build-support/setup-hooks/make-wrapper-auto/default.nix
+++ b/pkgs/build-support/setup-hooks/make-wrapper-auto/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, dieHook
+, makeSetupHook
+, jq
+}:
+
+{
+  # TODO: Will this work? How can I make the act of adding `makeWrapperAuto` to
+  # `nativeBuildInputs` add `./hook.sh`?
+  __functor = makeSetupHook {
+    deps = [ dieHook ];
+    substitutions = {
+      jq = "${lib.getBin jq}/bin/jq";
+    };
+  } ./hook.sh;
+
+  combineWrappersInfo = { envInfo
+    , symlink ? {}
+    , buildInputs ? []
+    , propagatedBuildInputs ? []
+  }: let
+    inputsWrapInfo = lib.concatStringsSep " " (
+      builtins.map (input: "${lib.getDev input}/nix-support/wrappers.json") (
+        buildInputs ++ propagatedBuildInputs
+      )
+    );
+    envInfoFile = builtins.toFile "env-info.json" (builtins.toJSON envInfo);
+  in /* bash */ ''
+    # Make sure this evaluates if there are no multiple outputs.
+    mkdir -p $dev/nix-support
+    # TODO: Handle symlink requests
+    local wrapInfo
+    local -a inputs_wrap_info
+    for wrapInfo in ${inputsWrapInfo}; do
+      if [[ -f "$wrapInfo" ]]; then
+        inputs_wrap_info+=($wrapInfo)
+      else
+        echo did not find file $wrapInfo
+      fi
+    done
+    # TODO: Is this the best way to substitute @out@ with $out?
+    ${jq}/bin/jq "." ${envInfoFile} $inputs_wrap_info | sed "s#@out@#$out#g" > $dev/nix-support/wrappers.json
+    ${jq}/bin/jq . $dev/nix-support/wrappers.json
+  '';
+}

--- a/pkgs/build-support/setup-hooks/make-wrapper-auto/hook.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper-auto/hook.sh
@@ -1,0 +1,11 @@
+# Here we add wrapPhase to the standard fixup phase so that
+
+# I think this
+fixupOutputHooks+=(wrapAutoHook)
+
+# Read json files from $dev/nix-support/wrappers.json and generate a wrapper.
+# Should makeBinaryWrapper be used by default? see:
+# https://github.com/NixOS/nixpkgs/pull/124556
+wrapAutoHook(){
+
+}

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -305,6 +305,14 @@ stdenv.mkDerivation rec {
     patchShebangs \
       scripts/extract-release-date-from-doap-file.py
   '';
+  preConfigure = makeWrapperAuto.combineWrappersInfo {
+    inherit buildInputs propagatedBuildInputs;
+    envInfo = {
+      GST_PLUGIN_SYSTEM_PATH_1_0 = [
+        "@out@/lib/gstreamer-1.0"
+      ];
+    };
+  };
 
   # This package has some `_("string literal")` string formats
   # that trip up clang with format security enabled.

--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
     libjpeg
     tremor
     libGL
-  ] ++ lib.optional (!stdenv.isDarwin) [
+  ] ++ lib.optionals (!stdenv.isDarwin) [
     libvisual
   ] ++ lib.optionals stdenv.isDarwin [
     pango

--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , fetchurl
 , lib
+, makeWrapperAuto
 , pkg-config
 , meson
 , ninja
@@ -98,6 +99,14 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [
     gstreamer
   ];
+  preConfigure = makeWrapperAuto.combineWrappersInfo {
+    inherit buildInputs propagatedBuildInputs;
+    envInfo = {
+      GST_PLUGIN_SYSTEM_PATH_1_0 = [
+        "@out@/lib/gstreamer-1.0"
+      ];
+    };
+  };
 
   mesonFlags = [
     "-Dexamples=disabled" # requires many dependencies and probably not useful for our users

--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -94,10 +94,9 @@ stdenv.mkDerivation rec {
       scripts/extract-release-date-from-doap-file.py
   '';
 
-  # TODO: Replace this with some magic of makeWrapperAuto
-  wrapPrograms = [
-    "$dev/bin/*"
-  ];
+  # This can't be replaced with makeWrapperAuto, since wrapping needs to
+  # include paths in $NIX_PROFILES and that isn't yet supported in
+  # makeWrapperAuto.
   postInstall = ''
     for prog in "$dev/bin/"*; do
         # We can't use --suffix here due to quoting so we craft the export command by hand

--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -17,6 +17,7 @@
 , bash-completion
 , lib
 , CoreServices
+, makeWrapperAuto
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -94,6 +94,10 @@ stdenv.mkDerivation rec {
       scripts/extract-release-date-from-doap-file.py
   '';
 
+  # TODO: Replace this with some magic of makeWrapperAuto
+  wrapPrograms = [
+    "$dev/bin/*"
+  ];
   postInstall = ''
     for prog in "$dev/bin/"*; do
         # We can't use --suffix here due to quoting so we craft the export command by hand
@@ -104,6 +108,14 @@ stdenv.mkDerivation rec {
   preFixup = ''
     moveToOutput "share/bash-completion" "$dev"
   '';
+  preConfigure = makeWrapperAuto.combineWrappersInfo {
+    inherit buildInputs propagatedBuildInputs;
+    envInfo = {
+      GST_PLUGIN_SYSTEM_PATH_1_0 = [
+        "@out@/lib/gstreamer-1.0"
+      ];
+    };
+  };
 
   setupHook = ./setup-hook.sh;
 

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -116,6 +116,14 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals enableJack [
     libjack2
   ];
+  preConfigure = makeWrapperAuto.combineWrappersInfo {
+    inherit buildInputs propagatedBuildInputs;
+    envInfo = {
+      GST_PLUGIN_SYSTEM_PATH_1_0 = [
+        "@out@/lib/gstreamer-1.0"
+      ];
+    };
+  };
 
   mesonFlags = [
     "-Dexamples=disabled" # requires many dependencies and probably not useful for our users

--- a/pkgs/development/libraries/gstreamer/libav/default.nix
+++ b/pkgs/development/libraries/gstreamer/libav/default.nix
@@ -36,6 +36,14 @@ stdenv.mkDerivation rec {
     gst-plugins-base
     libav
   ];
+  preConfigure = makeWrapperAuto.combineWrappersInfo {
+    inherit buildInputs propagatedBuildInputs;
+    envInfo = {
+      GST_PLUGIN_SYSTEM_PATH_1_0 = [
+        "@out@/lib/gstreamer-1.0"
+      ];
+    };
+  };
 
   mesonFlags = [
     "-Ddoc=disabled" # `hotdoc` not packaged in nixpkgs as of writing

--- a/pkgs/development/libraries/gstreamer/ugly/default.nix
+++ b/pkgs/development/libraries/gstreamer/ugly/default.nix
@@ -56,6 +56,14 @@ stdenv.mkDerivation rec {
     CoreFoundation
     DiskArbitration
   ];
+  preConfigure = makeWrapperAuto.combineWrappersInfo {
+    inherit buildInputs propagatedBuildInputs;
+    envInfo = {
+      GST_PLUGIN_SYSTEM_PATH_1_0 = [
+        "@out@/lib/gstreamer-1.0"
+      ];
+    };
+  };
 
   mesonFlags = [
     "-Ddoc=disabled" # `hotdoc` not packaged in nixpkgs as of writing

--- a/pkgs/development/libraries/gstreamer/vaapi/default.nix
+++ b/pkgs/development/libraries/gstreamer/vaapi/default.nix
@@ -64,6 +64,14 @@ stdenv.mkDerivation rec {
     libvpx
     python3
   ];
+  preConfigure = makeWrapperAuto.combineWrappersInfo {
+    inherit buildInputs propagatedBuildInputs;
+    envInfo = {
+      GST_PLUGIN_SYSTEM_PATH_1_0 = [
+        "@out@/lib/gstreamer-1.0"
+      ];
+    };
+  };
 
   mesonFlags = [
     "-Dexamples=disabled" # requires many dependencies and probably not useful for our users

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -1,5 +1,6 @@
 { stdenv, lib
 , src, patches, version, qtCompatVersion
+, makeWrapperAuto
 
 , coreutils, bison, flex, gdb, gperf, lndir, perl, pkg-config, python3
 , which

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3933,7 +3933,7 @@ with pkgs;
 
   cksfv = callPackage ../tools/networking/cksfv { };
 
-  clementine = libsForQt514.callPackage ../applications/audio/clementine {
+  clementine = libsForQt5.callPackage ../applications/audio/clementine {
     protobuf = protobuf3_14;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3934,8 +3934,6 @@ with pkgs;
   cksfv = callPackage ../tools/networking/cksfv { };
 
   clementine = libsForQt514.callPackage ../applications/audio/clementine {
-    gst_plugins =
-      with gst_all_1; [ gst-plugins-base gst-plugins-good gst-plugins-ugly gst-libav ];
     protobuf = protobuf3_14;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -676,6 +676,8 @@ with pkgs;
   makeWrapper = makeSetupHook { deps = [ dieHook ]; substitutions = { shell = targetPackages.runtimeShell; }; }
                               ../build-support/setup-hooks/make-wrapper.sh;
 
+  makeWrapperAuto = callPackage ../build-support/setup-hooks/make-wrapper-auto { };
+
   makeModulesClosure = { kernel, firmware, rootModules, allowMissing ? false }:
     callPackage ../build-support/kernel/modules-closure.nix {
       inherit kernel firmware rootModules allowMissing;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Implement https://github.com/NixOS/rfcs/pull/75 .

###### Future work

Once `combineWrappersInfo` is ready, it should be added to builds of many core packages such as:

 - `gdk-pixbuf`
 - `gsettings-desktop-schemas`
 - `pango`
 - `gtk3`

And more... Afterwards it'd be easy to test the bash functions to be written in the setup-hook itself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
