### PR TITLE
btcpayserver: 1.3.2 -> 1.3.3

### DIFF
--- a/pkgs/applications/blockchains/btcpayserver/default.nix
+++ b/pkgs/applications/blockchains/btcpayserver/default.nix
@@ -3,13 +3,13 @@
 
 buildDotnetModule rec {
   pname = "btcpayserver";
-  version = "1.3.2";
+  version = "1.3.3";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-TAngdQz3FupoqPrqskjSQ9xSDbZV4/6+j7C4NjBFcFw=";
+    sha256 = "sha256-IBdQlVZx7Bt4y7B7FvHJihHUWO15a89hs+SGwcobDqY=";
   };
 
   projectFile = "BTCPayServer/BTCPayServer.csproj";


### PR DESCRIPTION
Things done:
- Tested with the [nix-bitcoin VM test](https://gist.github.com/dcaf04ce9367c5779f8bf41b5507a3ba).

Notes for reviewers:
You can verify with GPG signatures with `refetch=1 pkgs/applications/blockchains/btcpayserver/update.sh`.

cc @prusnak @nixbitcoin