### PR TITLE
chia: 1.2.10 -> 1.2.11

### DIFF
--- a/pkgs/applications/blockchains/chia/default.nix
+++ b/pkgs/applications/blockchains/chia/default.nix
@@ -6,14 +6,14 @@
 
 let chia = python3Packages.buildPythonApplication rec {
   pname = "chia";
-  version = "1.2.10";
+  version = "1.2.11";
 
   src = fetchFromGitHub {
     owner = "Chia-Network";
     repo = "chia-blockchain";
     rev = version;
     fetchSubmodules = true;
-    sha256 = "sha256-TzSBGjgaE0IWaqJcCIoO/u+gDh17NtAqhE8ldbbjNIE=";
+    sha256 = "sha256-hRpZce8ydEsyq7htNfzlRSKPwMAOUurC3uiQpX6WiB8=";
   };
 
   postPatch = ''
@@ -46,7 +46,7 @@ let chia = python3Packages.buildPythonApplication rec {
     colorlog
     concurrent-log-handler
     cryptography
-    dnspython
+    dnspythonchia
     fasteners
     keyrings-cryptfile
     pyyaml

--- a/pkgs/development/python-modules/chiapos/default.nix
+++ b/pkgs/development/python-modules/chiapos/default.nix
@@ -6,6 +6,7 @@
 , cxxopts
 , ghc_filesystem
 , pybind11
+, pytestCheckHook
 , pythonOlder
 , psutil
 , setuptools-scm
@@ -13,12 +14,12 @@
 
 buildPythonPackage rec {
   pname = "chiapos";
-  version = "1.0.4";
+  version = "1.0.6";
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-flI1vwtD0H28UDMcEEELECewkXZ6vf/XEYMqRKy5R6w=";
+    sha256 = "sha256-Zh5AULPgbG0oYPcBZMp/vm94MPyfdtYn4P5V+1LeMqA=";
   };
 
   patches = [
@@ -34,7 +35,11 @@ buildPythonPackage rec {
 
   buildInputs = [ pybind11 ];
 
-  checkInputs = [ psutil ];
+  checkInputs = [
+    psutil
+    pytestCheckHook
+  ];
+
 
   # CMake needs to be run by setuptools rather than by its hook
   dontConfigure = true;

--- a/pkgs/development/python-modules/chiapos/dont_fetch_dependencies.patch
+++ b/pkgs/development/python-modules/chiapos/dont_fetch_dependencies.patch
@@ -1,13 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 9b4a2f5..86f849c 100644
+index b757b70..fcce055 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -18,22 +18,19 @@ include(FetchContent)
- else() 
+@@ -21,23 +21,20 @@ include(${CMAKE_INSTALL_PREFIX}/share/cmake/pybind11/pybind11Config.cmake)
+ else()
  FetchContent_Declare(
    pybind11-src
 -  GIT_REPOSITORY https://github.com/pybind/pybind11.git
--  GIT_TAG        v2.6.2
+-  GIT_TAG        v2.7.1
 +  SOURCE_DIR @pybind11_src@
  )
  FetchContent_MakeAvailable(pybind11-src)
@@ -29,4 +29,3 @@ index 9b4a2f5..86f849c 100644
  )
  FetchContent_MakeAvailable(gulrak)
  
-

--- a/pkgs/development/python-modules/clvm-rs/bump-cargo-lock.patch
+++ b/pkgs/development/python-modules/clvm-rs/bump-cargo-lock.patch
@@ -1,0 +1,11 @@
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -80,7 +80,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+ 
+ [[package]]
+ name = "clvm_rs"
+-version = "0.1.14"
++version = "0.1.15"
+ dependencies = [
+  "bls12_381",
+  "hex",

--- a/pkgs/development/python-modules/clvm-rs/default.nix
+++ b/pkgs/development/python-modules/clvm-rs/default.nix
@@ -9,20 +9,25 @@
 
 buildPythonPackage rec {
   pname = "clvm_rs";
-  version = "0.1.14";
+  version = "0.1.15";
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "Chia-Network";
     repo = "clvm_rs";
     rev = version;
-    sha256 = "sha256-sQ+jzBiIZYVQj2rb170wLFEx2NzOj7kEL0k0gx/JOAc=";
+    sha256 = "sha256-4QFreQlRjKqGhPvuXU/pZpxMfF8LkIf6X7C3K2q77MI=";
   };
 
+  patches = [
+    # upstream forgot to refresh the lock file
+    ./bump-cargo-lock.patch
+  ];
+
   cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit src;
+    inherit src patches;
     name = "${pname}-${version}";
-    sha256 = "sha256-ZSu3bu0MfxZEFqBwdHH/RM4WTF/yx9ju1IqSVfu+Upo=";
+    sha256 = "sha256-jPNU+P6JgxTPL1GYUBE4VPU3p6cgL8u/+AIELr7r5Mk=";
   };
 
   format = "pyproject";

--- a/pkgs/development/python-modules/dnspythonchia/default.nix
+++ b/pkgs/development/python-modules/dnspythonchia/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "dnspythonchia";
+  version = "2.2.0";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-iYaPYqOZ33R2DUXgIHxsewLi79iB5ja0WHOGkamffZk=";
+  };
+
+  nativeBuildInputs = [ setuptools-scm ];
+
+  # needs networking for some tests
+  doCheck = false;
+  pythonImportsCheck = [ "dns" ];
+
+  meta = with lib; {
+    description = "A DNS toolkit for Python (Chia Network fork)";
+    homepage = "https://www.chia.net/";
+    license = with licenses; [ isc ];
+    maintainers = teams.chia.members;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2251,6 +2251,8 @@ in {
 
   dnspython = callPackage ../development/python-modules/dnspython { };
 
+  dnspythonchia = callPackage ../development/python-modules/dnspythonchia { };
+
   doc8 = callPackage ../development/python-modules/doc8 { };
 
   docker = callPackage ../development/python-modules/docker { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/Chia-Network/chia-blockchain/releases/tag/1.2.11

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
