### PR TITLE
ocaml: consistent minimum OCaml variable

### DIFF
--- a/doc/languages-frameworks/ocaml.section.md
+++ b/doc/languages-frameworks/ocaml.section.md
@@ -6,7 +6,7 @@ Given that most of the OCaml ecosystem is now built with dune, nixpkgs includes 
 
 Here is a simple package example.
 
-- It defines an (optional) attribute `minimalOCamlVersion` that will be used to
+- It defines an (optional) attribute `minimumOcamlVersion` that will be used to
   throw a descriptive evaluation error if building with an older OCaml is
   attempted.
 
@@ -43,7 +43,7 @@ buildDunePackage rec {
   version = "0.15.0";
   useDune2 = true;
 
-  minimalOCamlVersion = "4.04";
+  minimumOcamlVersion = "4.04";
 
   src = fetchFromGitHub {
     owner  = "inhabitedtype";
@@ -76,7 +76,7 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  minimalOCamlVersion = "4.02";
+  minimumOcamlVersion = "4.02";
 
   src = fetchurl {
     url = "https://github.com/flowtype/ocaml-${pname}/releases/download/v${version}/${pname}-v${version}.tbz";

--- a/pkgs/build-support/ocaml/default.nix
+++ b/pkgs/build-support/ocaml/default.nix
@@ -1,20 +1,25 @@
 { lib, stdenv, writeText, ocaml, findlib, ocamlbuild, camlp4 }:
 
-{ name, version, nativeBuildInputs ? [],
-  createFindlibDestdir ?  true,
-  dontStrip ? true,
-  minimumSupportedOcamlVersion ? null,
-  hasSharedObjects ? false,
-  setupHook ? null,
-  meta ? {}, ...
+{ name
+, version
+, nativeBuildInputs ? [ ]
+, createFindlibDestdir ? true
+, dontStrip ? true
+, minimumOCamlVersion ? null
+, hasSharedObjects ? false
+, setupHook ? null
+, meta ? { }
+, ...
 }@args:
 let
   defaultMeta = {
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms or [ ];
   };
 in
-  assert minimumSupportedOcamlVersion != null ->
-          lib.versionOlder minimumSupportedOcamlVersion ocaml.version;
+
+if args ? minimumOCamlVersion && lib.versionOlder ocaml.version args.minimumOCamlVersion
+then throw "${name}-${version} is not available for OCaml ${ocaml.version}"
+else
 
 stdenv.mkDerivation (args // {
   name = "ocaml-${name}-${version}";

--- a/pkgs/build-support/ocaml/dune.nix
+++ b/pkgs/build-support/ocaml/dune.nix
@@ -1,11 +1,16 @@
 { lib, stdenv, ocaml, findlib, dune_1, dune_2 }:
 
-{ pname, version, nativeBuildInputs ? [], enableParallelBuilding ? true, ... }@args:
+{ pname
+, version
+, nativeBuildInputs ? [ ]
+, enableParallelBuilding ? true
+, minimumOCamlVersion ? null
+, ...
+}@args:
 
 let Dune = if args.useDune2 or false then dune_2 else dune_1; in
 
-if (args ? minimumOCamlVersion && ! lib.versionAtLeast ocaml.version args.minimumOCamlVersion) ||
-   (args ? minimalOCamlVersion && ! lib.versionAtLeast ocaml.version args.minimalOCamlVersion)
+if args ? minimumOCamlVersion && lib.versionOlder ocaml.version args.minimumOCamlVersion
 then throw "${pname}-${version} is not available for OCaml ${ocaml.version}"
 else
 
@@ -13,7 +18,7 @@ stdenv.mkDerivation ({
 
   inherit enableParallelBuilding;
   dontAddStaticConfigureFlags = true;
-  configurePlatforms = [];
+  configurePlatforms = [ ];
 
   buildPhase = ''
     runHook preBuild
@@ -37,6 +42,6 @@ stdenv.mkDerivation ({
 
   nativeBuildInputs = [ ocaml Dune findlib ] ++ nativeBuildInputs;
 
-  meta = (args.meta or {}) // { platforms = args.meta.platforms or ocaml.meta.platforms; };
+  meta = (args.meta or { }) // { platforms = args.meta.platforms or ocaml.meta.platforms; };
 
 })

--- a/pkgs/build-support/ocaml/oasis.nix
+++ b/pkgs/build-support/ocaml/oasis.nix
@@ -1,14 +1,16 @@
 { lib, stdenv, ocaml_oasis, ocaml, findlib, ocamlbuild }:
 
-{ pname, version, buildInputs ? [], meta ? { platforms = ocaml.meta.platforms or []; },
-  minimumOCamlVersion ? null,
-  createFindlibDestdir ? true,
-  dontStrip ? true,
-  ...
+{ pname
+, version
+, buildInputs ? [ ]
+, meta ? { platforms = ocaml.meta.platforms or [ ]; }
+, minimumOCamlVersion ? null
+, createFindlibDestdir ? true
+, dontStrip ? true
+, ...
 }@args:
 
-if args ? minimumOCamlVersion &&
-   ! lib.versionAtLeast ocaml.version args.minimumOCamlVersion
+if args ? minimumOCamlVersion && lib.versionOlder ocaml.version args.minimumOCamlVersion
 then throw "${pname}-${version} is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/bin_prot/default.nix
+++ b/pkgs/development/ocaml-modules/bin_prot/default.nix
@@ -8,7 +8,7 @@ buildOcaml rec {
   name = "bin_prot";
   version = "112.24.00";
 
-  minimumSupportedOcamlVersion = "4.00";
+  minimumOcamlVersion = "4.00";
 
   src = fetchurl {
     url = "https://github.com/janestreet/bin_prot/archive/${version}.tar.gz";

--- a/pkgs/development/ocaml-modules/bistro/default.nix
+++ b/pkgs/development/ocaml-modules/bistro/default.nix
@@ -36,7 +36,7 @@ buildDunePackage rec {
 
   propagatedBuildInputs = [ base64 bos core lwt_react ocamlgraph rresult tyxml ];
 
-  minimalOCamlVersion = "4.12";
+  minimumOcamlVersion = "4.12";
 
   meta = {
     inherit (src.meta) homepage;

--- a/pkgs/development/ocaml-modules/bls12-381/default.nix
+++ b/pkgs/development/ocaml-modules/bls12-381/default.nix
@@ -5,7 +5,7 @@ buildDunePackage rec {
 
   inherit (bls12-381-gen) version src useDune2 doCheck;
 
-  minimalOCamlVersion = "4.08";
+  minimumOcamlVersion = "4.08";
   propagatedBuildInputs = [
     ff-sig
     zarith

--- a/pkgs/development/ocaml-modules/bls12-381/gen.nix
+++ b/pkgs/development/ocaml-modules/bls12-381/gen.nix
@@ -12,7 +12,7 @@ buildDunePackage rec {
   };
   useDune2 = true;
 
-  minimalOCamlVersion = "4.08";
+  minimumOcamlVersion = "4.08";
 
   propagatedBuildInputs = [
     ff-sig

--- a/pkgs/development/ocaml-modules/cairo2/default.nix
+++ b/pkgs/development/ocaml-modules/cairo2/default.nix
@@ -9,7 +9,7 @@ buildDunePackage rec {
     sha256 = "sha256-a7P1kiVmIwT6Fhtwxs29ffgO4iexsulxUoc9cnJmEK4=";
   };
 
-  minimalOCamlVersion = "4.02";
+  minimumOcamlVersion = "4.02";
   useDune2 = true;
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/ocaml-modules/carton/default.nix
+++ b/pkgs/development/ocaml-modules/carton/default.nix
@@ -10,7 +10,7 @@ buildDunePackage rec {
   version = "0.4.3";
 
   useDune2 = true;
-  minimalOCamlVersion = "4.08";
+  minimumOcamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-git/releases/download/${pname}-v${version}/${pname}-${pname}-v${version}.tbz";

--- a/pkgs/development/ocaml-modules/coin/default.nix
+++ b/pkgs/development/ocaml-modules/coin/default.nix
@@ -10,7 +10,7 @@
 buildDunePackage rec {
   pname = "coin";
   version = "0.1.3";
-  minimalOCamlVersion = "4.03";
+  minimumOcamlVersion = "4.03";
 
   src = fetchzip {
     url = "https://github.com/mirage/coin/releases/download/v${version}/coin-v${version}.tbz";

--- a/pkgs/development/ocaml-modules/color/default.nix
+++ b/pkgs/development/ocaml-modules/color/default.nix
@@ -9,7 +9,7 @@ buildDunePackage rec {
   version = "0.2.0";
 
   useDune2 = true;
-  minimalOCamlVersion = "4.05";
+  minimumOcamlVersion = "4.05";
 
   src = fetchurl {
     url = "https://github.com/anuragsoni/color/releases/download/${version}/color-${version}.tbz";

--- a/pkgs/development/ocaml-modules/comparelib/default.nix
+++ b/pkgs/development/ocaml-modules/comparelib/default.nix
@@ -4,7 +4,7 @@ buildOcaml rec {
   name = "comparelib";
   version = "113.00.00";
 
-  minimumSupportedOcamlVersion = "4.00";
+  minimumOcamlVersion = "4.00";
 
   src = fetchurl {
     url = "https://github.com/janestreet/comparelib/archive/${version}.tar.gz";

--- a/pkgs/development/ocaml-modules/cstruct/ppx.nix
+++ b/pkgs/development/ocaml-modules/cstruct/ppx.nix
@@ -10,7 +10,7 @@ buildDunePackage {
   pname = "ppx_cstruct";
   inherit (cstruct) version src useDune2 meta;
 
-  minimalOCamlVersion = "4.08";
+  minimumOcamlVersion = "4.08";
 
   propagatedBuildInputs = [ cstruct ppxlib sexplib stdlib-shims ];
 

--- a/pkgs/development/ocaml-modules/csv/lwt.nix
+++ b/pkgs/development/ocaml-modules/csv/lwt.nix
@@ -1,12 +1,9 @@
 { lib, buildDunePackage, ocaml, csv, ocaml_lwt }:
 
-if !lib.versionAtLeast ocaml.version "4.02"
-then throw "csv-lwt is not available for OCaml ${ocaml.version}"
-else
-
 buildDunePackage {
   pname = "csv-lwt";
   inherit (csv) src version useDune2 meta;
+  minimumOCamlVersion = "4.02";
 
   propagatedBuildInputs = [ csv ocaml_lwt ];
 

--- a/pkgs/development/ocaml-modules/dolmen/default.nix
+++ b/pkgs/development/ocaml-modules/dolmen/default.nix
@@ -9,7 +9,7 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  minimalOCamlVersion = "4.08";
+  minimumOcamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/Gbury/dolmen/releases/download/v${version}/dolmen-v${version}.tbz";

--- a/pkgs/development/ocaml-modules/dose3/default.nix
+++ b/pkgs/development/ocaml-modules/dose3/default.nix
@@ -15,7 +15,7 @@ buildDunePackage rec {
     sha256 = "sha256-RFChY7VH2pVD4u5U1qng46h9aAv8I/3yXVaNmFDmKFI=";
   };
 
-  minimalOCamlVersion = "4.03";
+  minimumOcamlVersion = "4.03";
   useDune2 = true;
 
   buildInputs = [

--- a/pkgs/development/ocaml-modules/faillib/default.nix
+++ b/pkgs/development/ocaml-modules/faillib/default.nix
@@ -5,9 +5,10 @@ then throw "faillib-111.17.00 is not available for OCaml ${ocaml.version}"
 else
 
 buildOcaml rec {
-  minimumSupportedOcamlVersion = "4.00";
   name = "faillib";
   version = "111.17.00";
+
+  minimumOcamlVersion = "4.00";
 
   src = fetchurl {
     url = "https://github.com/janestreet/faillib/archive/${version}.tar.gz";

--- a/pkgs/development/ocaml-modules/ff/pbt.nix
+++ b/pkgs/development/ocaml-modules/ff/pbt.nix
@@ -4,7 +4,7 @@ buildDunePackage {
   pname = "ff-pbt";
   inherit (ff-sig) version src doCheck useDune2;
 
-  minimalOCamlVersion = "4.08";
+  minimumOcamlVersion = "4.08";
 
   checkInputs = [
     alcotest

--- a/pkgs/development/ocaml-modules/gluten/default.nix
+++ b/pkgs/development/ocaml-modules/gluten/default.nix
@@ -14,7 +14,7 @@ buildDunePackage rec {
     sha256 = "1pl0mpcprz8hmaiv28p7w51qfcx7s76zdkak0vm5cazbjl38nc46";
   };
 
-  minimalOCamlVersion = "4.06";
+  minimumOcamlVersion = "4.06";
 
   useDune2 = true;
 

--- a/pkgs/development/ocaml-modules/graphql_ppx/default.nix
+++ b/pkgs/development/ocaml-modules/graphql_ppx/default.nix
@@ -6,7 +6,7 @@ buildDunePackage rec {
   pname = "graphql_ppx";
   version = "1.2.0";
 
-  minimalOCamlVersion = "4.08";
+  minimumOcamlVersion = "4.08";
 
   src = fetchFromGitHub {
     owner = "reasonml-community";

--- a/pkgs/development/ocaml-modules/hacl-star/default.nix
+++ b/pkgs/development/ocaml-modules/hacl-star/default.nix
@@ -3,7 +3,7 @@
 buildDunePackage {
   pname = "hacl-star";
 
-  inherit (hacl-star-raw) version src meta doCheck minimalOCamlVersion;
+  inherit (hacl-star-raw) version src meta doCheck minimumOcamlVersion;
 
   useDune2 = true;
 

--- a/pkgs/development/ocaml-modules/hacl-star/raw.nix
+++ b/pkgs/development/ocaml-modules/hacl-star/raw.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "./source/raw";
 
-  minimalOCamlVersion = "4.05";
+  minimumOcamlVersion = "4.05";
 
   postPatch = ''
     patchShebangs ./

--- a/pkgs/development/ocaml-modules/herelib/default.nix
+++ b/pkgs/development/ocaml-modules/herelib/default.nix
@@ -4,7 +4,7 @@ buildOcaml rec {
   version = "112.35.00";
   name = "herelib";
 
-  minimumSupportedOcamlVersion = "4.00";
+  minimumOcamlVersion = "4.00";
 
   src = fetchurl {
     url = "https://github.com/janestreet/herelib/archive/${version}.tar.gz";

--- a/pkgs/development/ocaml-modules/hmap/default.nix
+++ b/pkgs/development/ocaml-modules/hmap/default.nix
@@ -8,9 +8,9 @@
 }:
 
 let
-  minimumSupportedOcamlVersion = "4.02.0";
+  minimumOcamlVersion = "4.02.0";
 in
-assert lib.versionOlder minimumSupportedOcamlVersion ocaml.version;
+assert lib.versionOlder minimumOcamlVersion ocaml.version;
 
 stdenv.mkDerivation rec {
   pname = "hmap";

--- a/pkgs/development/ocaml-modules/janestreet/bin_prot.nix
+++ b/pkgs/development/ocaml-modules/janestreet/bin_prot.nix
@@ -3,7 +3,7 @@
 buildOcamlJane {
   name = "bin_prot";
   version = "113.33.03";
-  minimumSupportedOcamlVersion = "4.02";
+  minimumOcamlVersion = "4.02";
   hash = "0jlarpfby755j0kikz6vnl1l6q0ga09b9zrlw6i84r22zchnqdsh";
 
   propagatedBuildInputs = [ type_conv ];

--- a/pkgs/development/ocaml-modules/janestreet/buildOcamlJane.nix
+++ b/pkgs/development/ocaml-modules/janestreet/buildOcamlJane.nix
@@ -2,11 +2,11 @@
 
 { name, version ? "113.33.03", buildInputs ? [],
   hash ? "",
-  minimumSupportedOcamlVersion ? "4.02", ...
+  minimumOcamlVersion ? "4.02", ...
 }@args:
 
 buildOcaml (args // {
-  inherit name version minimumSupportedOcamlVersion;
+  inherit name version minimumOcamlVersion;
   src = fetchurl {
     url = "https://github.com/janestreet/${name}/archive/${version}.tar.gz";
     sha256 = hash;

--- a/pkgs/development/ocaml-modules/janestreet/fieldslib.nix
+++ b/pkgs/development/ocaml-modules/janestreet/fieldslib.nix
@@ -4,7 +4,7 @@ buildOcamlJane {
   name = "fieldslib";
   version = "113.33.03";
 
-  minimumSupportedOcamlVersion = "4.02";
+  minimumOcamlVersion = "4.02";
 
   hash = "0mkbix32f8sq32q81hb10z2q31bw5f431jxv0jafbdrif0vr6xqd";
 

--- a/pkgs/development/ocaml-modules/janestreet/js-build-tools.nix
+++ b/pkgs/development/ocaml-modules/janestreet/js-build-tools.nix
@@ -4,7 +4,7 @@ buildOcaml rec {
   name = "js-build-tools";
   version = "113.33.06";
 
-  minimumSupportedOcamlVersion = "4.02";
+  minimumOcamlVersion = "4.02";
 
   src = fetchurl {
     url = "https://github.com/janestreet/${name}/archive/${version}.tar.gz";

--- a/pkgs/development/ocaml-modules/janestreet/ppx-bench.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-bench.nix
@@ -3,7 +3,7 @@
 
 buildOcamlJane {
   name = "ppx_bench";
-  minimumSupportedOcamlVersion = "4.02";
+  minimumOcamlVersion = "4.02";
   hash = "1l5jlwy1d1fqz70wa2fkf7izngp6nx3g4s9bmnd6ca4dx1x5bksk";
 
   hasSharedObjects = true;

--- a/pkgs/development/ocaml-modules/janestreet/sexplib.nix
+++ b/pkgs/development/ocaml-modules/janestreet/sexplib.nix
@@ -1,7 +1,7 @@
 {lib, buildOcamlJane, type_conv}:
 
 buildOcamlJane {
-  minimumSupportedOcamlVersion = "4.02";
+  minimumOcamlVersion = "4.02";
   name = "sexplib";
   version = "113.33.03";
 

--- a/pkgs/development/ocaml-modules/janestreet/typerep.nix
+++ b/pkgs/development/ocaml-modules/janestreet/typerep.nix
@@ -4,7 +4,7 @@ buildOcamlJane {
   name = "typerep";
   version = "113.33.03";
 
-  minimumSupportedOcamlVersion = "4.00";
+  minimumOcamlVersion = "4.00";
 
   hash = "1ss34nq20vfgx8hwi5sswpmn3my9lvrpdy5dkng746xchwi33ar7";
 

--- a/pkgs/development/ocaml-modules/janestreet/variantslib.nix
+++ b/pkgs/development/ocaml-modules/janestreet/variantslib.nix
@@ -4,7 +4,7 @@ buildOcamlJane {
   name = "variantslib";
   version = "113.33.03";
 
-  minimumSupportedOcamlVersion = "4.00";
+  minimumOcamlVersion = "4.00";
 
   hash = "1hv0f75msrryxsl6wfnbmhc0n8kf7qxs5f82ry3b8ldb44s3wigp";
 

--- a/pkgs/development/ocaml-modules/json-data-encoding/default.nix
+++ b/pkgs/development/ocaml-modules/json-data-encoding/default.nix
@@ -3,7 +3,7 @@
 buildDunePackage rec {
   pname = "json-data-encoding";
   version = "0.10";
-  minimalOCamlVersion = "4.10";
+  minimumOcamlVersion = "4.10";
   src = fetchFromGitLab {
     owner = "nomadic-labs";
     repo = "json-data-encoding";

--- a/pkgs/development/ocaml-modules/lambdasoup/default.nix
+++ b/pkgs/development/ocaml-modules/lambdasoup/default.nix
@@ -4,7 +4,7 @@ buildDunePackage rec {
   pname = "lambdasoup";
   version = "0.7.3";
 
-  minimalOCamlVersion = "4.02";
+  minimumOcamlVersion = "4.02";
 
   useDune2 = true;
 

--- a/pkgs/development/ocaml-modules/lens/default.nix
+++ b/pkgs/development/ocaml-modules/lens/default.nix
@@ -13,7 +13,7 @@ buildDunePackage rec {
     sha256 = "1k23n7pa945fk6nbaq6nlkag5kg97wsw045ghz4gqp8b9i2im3vn";
   };
 
-  minimalOCamlVersion = "4.10";
+  minimumOcamlVersion = "4.10";
   buildInputs = [ ppx_deriving ppxlib ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/lustre-v6/default.nix
+++ b/pkgs/development/ocaml-modules/lustre-v6/default.nix
@@ -6,7 +6,7 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  minimalOCamlVersion = "4.05";
+  minimumOcamlVersion = "4.05";
 
   src = fetchurl {
     url = "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/lustre-v6.6.103.3.tgz";

--- a/pkgs/development/ocaml-modules/lutils/default.nix
+++ b/pkgs/development/ocaml-modules/lutils/default.nix
@@ -6,7 +6,7 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  minimalOCamlVersion = "4.02";
+  minimumOcamlVersion = "4.02";
 
   src = fetchurl {
     url = "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/lutils.1.51.2.tgz";

--- a/pkgs/development/ocaml-modules/lwt-exit/default.nix
+++ b/pkgs/development/ocaml-modules/lwt-exit/default.nix
@@ -17,7 +17,7 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  minimalOCamlVersion = "4.08";
+  minimumOcamlVersion = "4.08";
 
   propagatedBuildInputs = [
     lwt

--- a/pkgs/development/ocaml-modules/magic-mime/default.nix
+++ b/pkgs/development/ocaml-modules/magic-mime/default.nix
@@ -9,7 +9,7 @@ buildDunePackage rec {
     sha256 = "1xqjs8bba567yzrzgnr88j5ck97d36zw68zr9v29liya37k6rcvz";
   };
 
-  minimalOCamlVersion = "4.03";
+  minimumOcamlVersion = "4.03";
   useDune2 = true;
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/2.x.nix
+++ b/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/2.x.nix
@@ -6,7 +6,7 @@ buildDunePackage rec {
 
    useDune2 = true;
 
-   minimalOCamlVersion = "4.02";
+   minimumOcamlVersion = "4.02";
 
    src = fetchurl {
      url = "https://github.com/ocaml-ppx/${pname}/releases/download/v${version}/${pname}-v${version}.tbz";

--- a/pkgs/development/ocaml-modules/ocamlgraph/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlgraph/default.nix
@@ -9,7 +9,7 @@ buildDunePackage rec {
     sha256 = "029692bvdz3hxpva9a2jg5w5381fkcw55ysdi8424lyyjxvjdzi0";
   };
 
-  minimalOCamlVersion = "4.03";
+  minimumOcamlVersion = "4.03";
   useDune2 = true;
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/ocsigen-server/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-server/default.nix
@@ -21,7 +21,7 @@ buildDunePackage rec {
   pname = "ocsigenserver";
 
   useDune2 = true;
-  minimalOCamlVersion = "4.08";
+  minimumOcamlVersion = "4.08";
 
   src = fetchFromGitHub {
     owner = "ocsigen";

--- a/pkgs/development/ocaml-modules/otoml/default.nix
+++ b/pkgs/development/ocaml-modules/otoml/default.nix
@@ -10,7 +10,7 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  minimalOCamlVersion = "4.08";
+  minimumOcamlVersion = "4.08";
 
   src = fetchFromGitHub {
     owner = "dmbaturin";

--- a/pkgs/development/ocaml-modules/pa_bench/default.nix
+++ b/pkgs/development/ocaml-modules/pa_bench/default.nix
@@ -4,7 +4,7 @@ buildOcaml rec {
   name = "pa_bench";
   version = "113.00.00";
 
-  minimumSupportedOcamlVersion = "4.00";
+  minimumOcamlVersion = "4.00";
 
   src = fetchurl {
     url = "https://github.com/janestreet/pa_bench/archive/${version}.tar.gz";

--- a/pkgs/development/ocaml-modules/parmap/default.nix
+++ b/pkgs/development/ocaml-modules/parmap/default.nix
@@ -9,7 +9,7 @@ buildDunePackage rec {
     sha256 = "1wg81slp453jci0gi0rzvdjx74110mlf1n5qpsmxic6fqsyz9d2v";
   };
 
-  minimalOCamlVersion = "4.03";
+  minimumOcamlVersion = "4.03";
   useDune2 = true;
 
   buildInputs = [

--- a/pkgs/development/ocaml-modules/pcre/default.nix
+++ b/pkgs/development/ocaml-modules/pcre/default.nix
@@ -6,7 +6,7 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  minimalOCamlVersion = "4.08";
+  minimumOcamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/mmottl/pcre-ocaml/releases/download/${version}/pcre-${version}.tbz";

--- a/pkgs/development/ocaml-modules/pipebang/default.nix
+++ b/pkgs/development/ocaml-modules/pipebang/default.nix
@@ -4,7 +4,7 @@ buildOcaml rec {
   name = "pipebang";
   version = "113.00.00";
 
-  minimumSupportedOcamlVersion = "4.00";
+  minimumOcamlVersion = "4.00";
 
   src = fetchurl {
     url = "https://github.com/janestreet/pipebang/archive/${version}.tar.gz";

--- a/pkgs/development/ocaml-modules/pp/default.nix
+++ b/pkgs/development/ocaml-modules/pp/default.nix
@@ -14,7 +14,7 @@ buildDunePackage rec {
   };
 
   useDune2 = true;
-  minimalOCamlVersion = "4.08";
+  minimumOcamlVersion = "4.08";
 
   checkInputs = [ ppx_expect ];
   doCheck = true;

--- a/pkgs/development/ocaml-modules/ppx_deriving_yaml/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_yaml/default.nix
@@ -8,7 +8,7 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  minimalOCamlVersion = "4.08";
+  minimumOcamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/patricoferris/ppx_deriving_yaml/releases/download/v${version}/ppx_deriving_yaml-v${version}.tbz";

--- a/pkgs/development/ocaml-modules/qcheck/core.nix
+++ b/pkgs/development/ocaml-modules/qcheck/core.nix
@@ -6,7 +6,7 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  minimalOCamlVersion = "4.08";
+  minimumOcamlVersion = "4.08";
 
   src = fetchFromGitHub {
     owner = "c-cube";

--- a/pkgs/development/ocaml-modules/rdbg/default.nix
+++ b/pkgs/development/ocaml-modules/rdbg/default.nix
@@ -6,7 +6,7 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  minimalOCamlVersion = "4.07";
+  minimumOcamlVersion = "4.07";
 
   src = fetchurl {
     url = "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/rdbg.1.196.12.tgz";

--- a/pkgs/development/ocaml-modules/reason-native/pastel.nix
+++ b/pkgs/development/ocaml-modules/reason-native/pastel.nix
@@ -3,7 +3,7 @@
 {
   pname = "pastel";
 
-  minimalOCamlVersion = "4.05";
+  minimumOcamlVersion = "4.05";
 
   buildInputs = [
     reason

--- a/pkgs/development/ocaml-modules/resto/acl.nix
+++ b/pkgs/development/ocaml-modules/resto/acl.nix
@@ -4,7 +4,7 @@ buildDunePackage {
   pname = "resto-acl";
   inherit (resto) src version meta useDune2 doCheck;
 
-    minimalOCamlVersion = "4.05";
+    minimumOcamlVersion = "4.05";
 
   propagatedBuildInputs = [
     resto

--- a/pkgs/development/ocaml-modules/ringo/default.nix
+++ b/pkgs/development/ocaml-modules/ringo/default.nix
@@ -11,7 +11,7 @@ buildDunePackage rec {
     sha256 = "1zwha0ycv3rm3qnw7nkg2m08ibx39yxnx5fan4lnn82b0pdasjag";
   };
 
-  minimalOCamlVersion = "4.05";
+  minimumOcamlVersion = "4.05";
 
   useDune2 = true;
 

--- a/pkgs/development/ocaml-modules/ringo/lwt.nix
+++ b/pkgs/development/ocaml-modules/ringo/lwt.nix
@@ -4,7 +4,7 @@ buildDunePackage {
   pname = "ringo-lwt";
   inherit (ringo) version src doCheck useDune2;
 
-  minimalOCamlVersion = "4.08";
+  minimumOcamlVersion = "4.08";
 
   propagatedBuildInputs = [
     ringo

--- a/pkgs/development/ocaml-modules/routes/default.nix
+++ b/pkgs/development/ocaml-modules/routes/default.nix
@@ -5,7 +5,7 @@ buildDunePackage rec {
   version = "0.9.1";
 
   useDune2 = true;
-  minimalOCamlVersion = "4.05";
+  minimumOcamlVersion = "4.05";
 
   src = fetchurl {
     url = "https://github.com/anuragsoni/routes/releases/download/${version}/routes-${version}.tbz";

--- a/pkgs/development/ocaml-modules/secp256k1-internal/default.nix
+++ b/pkgs/development/ocaml-modules/secp256k1-internal/default.nix
@@ -21,7 +21,7 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  minimalOCamlVersion = "4.08";
+  minimumOcamlVersion = "4.08";
 
   propagatedBuildInputs = [
     gmp

--- a/pkgs/development/ocaml-modules/tezos/protocol-compiler.nix
+++ b/pkgs/development/ocaml-modules/tezos/protocol-compiler.nix
@@ -17,7 +17,7 @@ buildDunePackage {
   inherit (tezos-stdlib) version useDune2;
   src = "${tezos-stdlib.base_src}/src/lib_protocol_compiler";
 
-  minimalOCamlVersion = "4.10";
+  minimumOcamlVersion = "4.10";
 
   propagatedBuildInputs = [
     tezos-protocol-environment

--- a/pkgs/development/ocaml-modules/tezos/protocol-environment-packer.nix
+++ b/pkgs/development/ocaml-modules/tezos/protocol-environment-packer.nix
@@ -8,7 +8,7 @@ buildDunePackage {
   inherit (tezos-stdlib) version useDune2;
   src = "${tezos-stdlib.base_src}/src/lib_protocol_environment";
 
-  minimalOCamlVersion = "4.03";
+  minimumOcamlVersion = "4.03";
 
   doCheck = true;
 

--- a/pkgs/development/ocaml-modules/tezos/stdlib.nix
+++ b/pkgs/development/ocaml-modules/tezos/stdlib.nix
@@ -26,7 +26,7 @@ buildDunePackage rec {
 
   src = "${base_src}/src/lib_stdlib";
 
-  minimalOCamlVersion = "4.10.0";
+  minimumOcamlVersion = "4.10.0";
 
   useDune2 = true;
 

--- a/pkgs/development/ocaml-modules/torch/default.nix
+++ b/pkgs/development/ocaml-modules/torch/default.nix
@@ -21,7 +21,7 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  minimalOCamlVersion = "4.08";
+  minimumOcamlVersion = "4.08";
 
   src = fetchFromGitHub {
     owner = "LaurentMazare";

--- a/pkgs/development/ocaml-modules/type_conv/112.01.01.nix
+++ b/pkgs/development/ocaml-modules/type_conv/112.01.01.nix
@@ -1,7 +1,7 @@
 { lib, fetchurl, buildOcaml}:
 
 buildOcaml rec {
-  minimumSupportedOcamlVersion = "4.02";
+  minimumOcamlVersion = "4.02";
 
   name = "type_conv";
   version = "113.00.02";

--- a/pkgs/development/ocaml-modules/typerep/default.nix
+++ b/pkgs/development/ocaml-modules/typerep/default.nix
@@ -4,7 +4,7 @@ buildOcaml rec {
   name = "typerep";
   version = "112.24.00";
 
-  minimumSupportedOcamlVersion = "4.00";
+  minimumOcamlVersion = "4.00";
 
   src = fetchFromGitHub {
     owner = "janestreet";

--- a/pkgs/development/ocaml-modules/uri/sexp.nix
+++ b/pkgs/development/ocaml-modules/uri/sexp.nix
@@ -1,12 +1,9 @@
 { lib, ocaml, buildDunePackage, uri, ounit, ppx_sexp_conv, sexplib0 }:
 
-if !lib.versionAtLeast ocaml.version "4.04"
-then throw "uri-sexp is not available for OCaml ${ocaml.version}"
-else
-
 buildDunePackage {
   pname = "uri-sexp";
   inherit (uri) version useDune2 src meta;
+  minimumOCamlVersion = "4.04";
 
   checkInputs = [ ounit ];
   propagatedBuildInputs = [ ppx_sexp_conv sexplib0 uri ];

--- a/pkgs/development/ocaml-modules/variantslib/default.nix
+++ b/pkgs/development/ocaml-modules/variantslib/default.nix
@@ -8,7 +8,7 @@ buildOcaml rec {
   name = "variantslib";
   version = "109.15.03";
 
-  minimumSupportedOcamlVersion = "4.00";
+  minimumOcamlVersion = "4.00";
 
   src = fetchFromGitHub {
     owner = "janestreet";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
in #143870 it cam up, that the naming of the minimum required OCaml version is done differently for each OCaml package-type. I believe, that a single name should be chosen.

I think more work has to be done on documenting the change, but maybe someone could guide me.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
