### PR TITLE
jami-client-gnome: unset CLUTTER_BACKEND

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jami/client-gnome.nix
+++ b/pkgs/applications/networking/instant-messengers/jami/client-gnome.nix
@@ -39,6 +39,10 @@ stdenv.mkDerivation {
   dontWrapGApps = true;
   preFixup = ''
     qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
+    # Users that set CLUTTER_BACKEND=wayland in their default environment will
+    # encounter a segfault due to:
+    # https://git.jami.net/savoirfairelinux/jami-client-gnome/-/issues/1100 .
+    qtWrapperArgs+=("--unset" "CLUTTER_BACKEND")
   '';
 
   buildInputs = [

--- a/pkgs/applications/networking/instant-messengers/jami/daemon.nix
+++ b/pkgs/applications/networking/instant-messengers/jami/daemon.nix
@@ -49,6 +49,10 @@ let
         ++ lib.optionals stdenv.isLinux (readLinesToList ./config/ffmpeg_args_linux)
         ++ lib.optionals (stdenv.isx86_32 || stdenv.isx86_64) (readLinesToList ./config/ffmpeg_args_x86);
       outputs = [ "out" "doc" ];
+      meta = old.meta // {
+        # undefined reference to `ff_nlmeans_init_aarch64'
+        broken = stdenv.isAarch64;
+      };
     });
 
   pjsip-jami = pjsip.overrideAttrs (old:


### PR DESCRIPTION
###### Motivation for this change

Users that set `CLUTTER_BACKEND=wayland` in their default environment will encounter a segfault due to: https://git.jami.net/savoirfairelinux/jami-client-gnome/-/issues/1100 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
