### PR TITLE
fix replaceStdenv evaluation: avoid infinite recursion

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -842,13 +842,35 @@ with pkgs;
         openssl = buildPackages.openssl.override {
           fetchurl = stdenv.fetchurlBoot;
           buildPackages = {
-            coreutils = buildPackages.coreutils.override {
+            coreutils = buildPackages.coreutils.override rec {
               fetchurl = stdenv.fetchurlBoot;
               inherit perl;
               xz = buildPackages.xz.override { fetchurl = stdenv.fetchurlBoot; };
               gmp = null;
               aclSupport = false;
               attrSupport = false;
+              autoreconfHook = buildPackages.autoreconfHook.override rec {
+                autoconf = buildPackages.autoconf.override {
+                  fetchurl = stdenv.fetchurlBoot;
+                  m4 = buildPackages.gnum4.override { fetchurl = stdenv.fetchurlBoot; };
+                  inherit perl;
+                };
+                automake = buildPackages.automake.override {
+                  fetchurl = stdenv.fetchurlBoot;
+                  inherit autoconf perl;
+                };
+                libtool = buildPackages.libtool_1_5.override {
+                  fetchurl = stdenv.fetchurlBoot;
+                  inherit perl;
+                  m4 = buildPackages.m4.override { fetchurl = stdenv.fetchurlBoot; };
+                };
+                gettext = buildPackages.gettext.override {
+                  fetchurl = stdenv.fetchurlBoot;
+                  xz = buildPackages.xz.override { fetchurl = stdenv.fetchurlBoot; };
+                  libiconv = null;
+                };
+              };
+              texinfo = null;
             };
             inherit perl;
           };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -838,7 +838,7 @@ with pkgs;
             fetchurl = stdenv.fetchurlBoot;
           };
         });
-        perl = buildPackages.perl.override { fetchurl = stdenv.fetchurlBoot; };
+        perl = buildPackages.perl.override { fetchurl = stdenv.fetchurlBoot; inherit zlib; };
         openssl = buildPackages.openssl.override {
           fetchurl = stdenv.fetchurlBoot;
           buildPackages = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21115,6 +21115,7 @@ with pkgs;
     perl = buildPackages.perl.override {
       enableCrypt = false;
       fetchurl = stdenv.fetchurlBoot;
+      zlib = buildPackages.zlib.override { fetchurl = stdenv.fetchurlBoot; };
     };
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -842,36 +842,18 @@ with pkgs;
         openssl = buildPackages.openssl.override {
           fetchurl = stdenv.fetchurlBoot;
           buildPackages = {
-            coreutils = buildPackages.coreutils.override rec {
+            coreutils = (buildPackages.coreutils.override rec {
               fetchurl = stdenv.fetchurlBoot;
               inherit perl;
               xz = buildPackages.xz.override { fetchurl = stdenv.fetchurlBoot; };
               gmp = null;
               aclSupport = false;
               attrSupport = false;
-              autoreconfHook = buildPackages.autoreconfHook.override rec {
-                autoconf = buildPackages.autoconf.override {
-                  fetchurl = stdenv.fetchurlBoot;
-                  m4 = buildPackages.gnum4.override { fetchurl = stdenv.fetchurlBoot; };
-                  inherit perl;
-                };
-                automake = buildPackages.automake.override {
-                  fetchurl = stdenv.fetchurlBoot;
-                  inherit autoconf perl;
-                };
-                libtool = buildPackages.libtool_1_5.override {
-                  fetchurl = stdenv.fetchurlBoot;
-                  inherit perl;
-                  m4 = buildPackages.m4.override { fetchurl = stdenv.fetchurlBoot; };
-                };
-                gettext = buildPackages.gettext.override {
-                  fetchurl = stdenv.fetchurlBoot;
-                  xz = buildPackages.xz.override { fetchurl = stdenv.fetchurlBoot; };
-                  libiconv = null;
-                };
-              };
+              autoreconfHook = null;
               texinfo = null;
-            };
+            }).overrideAttrs (_: {
+              preBuild = "touch Makefile.in"; # avoid automake
+            });
             inherit perl;
           };
           inherit perl;


### PR DESCRIPTION
This avoids infinite recursion when using config.replaceStdenv

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
