### PR TITLE
gomobile: make providing Android SDK optional

### DIFF
--- a/pkgs/development/mobile/gomobile/default.nix
+++ b/pkgs/development/mobile/gomobile/default.nix
@@ -1,6 +1,7 @@
 { stdenv, lib, fetchgit, buildGoModule, zlib, makeWrapper, xcodeenv, androidenv
 , xcodeWrapperArgs ? { }
 , xcodeWrapper ? xcodeenv.composeXcodeWrapper xcodeWrapperArgs
+, withAndroidPkgs ? true
 , androidPkgs ? androidenv.composeAndroidPackages {
     includeNDK = true;
     ndkVersion = "22.1.7171670";
@@ -43,10 +44,12 @@ buildGoModule {
     mkdir -p $out/src/golang.org/x
     ln -s $src $out/src/golang.org/x/mobile
     wrapProgram $out/bin/gomobile \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ zlib ]}" \
+  '' + lib.optionalString withAndroidPkgs ''
       --prefix PATH : "${androidPkgs.androidsdk}/bin" \
       --set ANDROID_NDK_HOME "${androidPkgs.androidsdk}/libexec/android-sdk/ndk-bundle" \
-      --set ANDROID_HOME "${androidPkgs.androidsdk}/libexec/android-sdk"
+      --set ANDROID_HOME "${androidPkgs.androidsdk}/libexec/android-sdk" \
+  '' + ''
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ zlib ]}"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Currently there are no `aarch64-darwin` builds of Android SDK available.
For this reason attempts to build `gomobile` on that platform fail with:
```
No Android SDK tarballs are available for system architecture: aarch64-darwin
```
Tested in: https://github.com/status-im/status-react/pull/12797

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
