### PR TITLE
stdenv/setup: tell libtool about library paths

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -986,7 +986,18 @@ patchPhase() {
 
 
 fixLibtool() {
-    sed -i -e 's^eval sys_lib_.*search_path=.*^^' "$1"
+    local search_path
+    for flag in $NIX_LDFLAGS; do
+        case $flag in
+            -L*)
+                search_path+=" ${flag#-L}"
+                ;;
+        esac
+    done
+
+    sed -i "$1" \
+        -e "s^eval \(sys_lib_search_path=\).*^\1'$search_path'^" \
+        -e 's^eval sys_lib_.+search_path=.*^^'
 }
 
 


### PR DESCRIPTION
Packages that use libtool run it as a wrapper around the linker. Before calling the linker, libtool will determine what libraries would be linked, and check if there's a corresponding libtool archive (libfoo.la) file in the same directory .  This file contains extra information about the library.  This is especially important for static linking, because static archives don't contain dependency information, so we need libtool to use the .la files to figure out which libraries actually need to be linked against.

But in Nixpkgs, this has never worked.  libtool isn't able to find any libraries, because only the compiler wrapper knows how to find them, and the compiler wrapper is opaque to libtool.  This is why pkgsStatic.util-linuxMinimal doesn't build prior to this patch — it depends on libpam, which depends on libaudit, and if libtool can't find the .la file, nothing will tell the linker to also link against libaudit when linking libpam.  (It was previously possible to build a static util-linux, because linux-pam only recently had the audit dependency added.)

There are a couple of ways we could fix this, so that libtool knows where to look for .la files.

 * Set `LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH`/whatever, which libtool will examine.  This would have major side effects though, because the dynamic linker looks at it too.

 * Inject libtool scripts with the appropriate information.  That's what I've done here.  It was the obvious choice because we're already finding and modifying the libtool scripts, to remove paths outside the Nix store that libtool might check in unsandboxed builds.  Instead of emptying out the system paths, we can repopulate it with our own library paths.

(We can't use a wrapper like we do for other tools in Nixpkgs, because libtool scripts are often distributed in source tarballs, so we can't just add a wrapped version of libtool as a dependency.  That's why there's already the fixLibtool function in stdenv.)

With this change, libtool is able to discover .la files, and pkgsStatic.util-linuxMinimal can build again, linking correctly against libpam and libaudit.
