### PR TITLE
nilfs-utils: 2.2.7 -> 2.2.8

### DIFF
--- a/pkgs/tools/filesystems/nilfs-utils/default.nix
+++ b/pkgs/tools/filesystems/nilfs-utils/default.nix
@@ -1,46 +1,23 @@
-{ lib, stdenv, fetchurl, fetchpatch, libuuid, libselinux }:
-let
-  sourceInfo = rec {
-    version = "2.2.7";
-    url = "http://nilfs.sourceforge.net/download/nilfs-utils-${version}.tar.bz2";
-    sha256 = "01f09bvjk2crx65pxmxiw362wkkl3v2v144dfn3i7bk5gz253xic";
-    baseName = "nilfs-utils";
-    name = "${baseName}-${version}";
-  };
-in
-stdenv.mkDerivation {
-  src = fetchurl {
-    url = sourceInfo.url;
-    sha256 = sourceInfo.sha256;
+{ lib, stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, libuuid, libselinux }:
+
+stdenv.mkDerivation rec {
+  pname = "nilfs-utils";
+  version = "2.2.8";
+
+  src = fetchFromGitHub {
+    owner = "nilfs-dev";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "094mw7dsyppyiyzfdnf3f5hlkrh4bidk1kvvpn1kcvw5vn2xpfk7";
   };
 
-  inherit (sourceInfo) name version;
-  buildInputs = [libuuid libselinux];
+  nativeBuildInputs = [ autoreconfHook ];
 
-  preConfigure = ''
-    sed -e '/sysconfdir=\/etc/d; ' -i configure
-    sed -e "s@sbindir=/sbin@sbindir=$out/sbin@" -i configure
-    sed -e 's@/sbin/@'"$out"'/sbin/@' -i ./lib/cleaner*.c
-  '';
+  buildInputs = [ libuuid libselinux ];
 
-  patches = [
-    # Fix w/musl
-    (fetchpatch {
-      url = "https://github.com/nilfs-dev/nilfs-utils/commit/115fe4b976858c487cf83065f513d8626089579a.patch";
-      sha256 = "0h89jz9l5d4rqj647ljbnv451l4ncqpsvzj0v70mn5391hfwsjlv";
-    })
-    (fetchpatch {
-      url =  "https://github.com/nilfs-dev/nilfs-utils/commit/51b32c614be9e98c32de7f531ee600ca0740946f.patch";
-      sha256 = "1ycq83c6jjy74aif47v075k5y2szzwhq6mbcrpd1z4b4i1x6yhpn";
-    })
-  ];
-
-  configureFlags = [
-    "--with-libmount"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-    # AC_FUNC_MALLOC is broken on cross builds.
-    "ac_cv_func_malloc_0_nonnull=yes"
-    "ac_cv_func_realloc_0_nonnull=yes"
+  installFlags = [
+    "sysconfdir=${placeholder "out"}/etc"
+    "root_sbindir=${placeholder "out"}/sbin"
   ];
 
   # FIXME: https://github.com/NixOS/patchelf/pull/98 is in, but stdenv
@@ -49,7 +26,7 @@ stdenv.mkDerivation {
   # To make sure patchelf doesn't mistakenly keep the reference via
   # build directory
   postInstall = ''
-    find . -name .libs | xargs rm -rf
+    find . -name .libs -exec rm -rf -- {} +
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Updates nilfs-utils to the latest version.

###### Things done
Built and tested on my own machine.
Tested cross-compilation, using `nix-build -A pkgsCross.armv7l-hf-multiplatform.nilfs-utils`.
Refactored the expression to use `autoreconfHook`.
Changed the source from sourceforge to GitHub.

@Atemu I noticed that cross-compilation of the NixOS SD image is important to you. I would appreciate if you could test if my changes do not break that. I assume testing cross-compilation as I did is good enough but I am not sure.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
