### PR TITLE
xmedcon: 0.21.0 -> 0.21.2, fix meta.platforms

### DIFF
--- a/pkgs/applications/science/medicine/xmedcon/default.nix
+++ b/pkgs/applications/science/medicine/xmedcon/default.nix
@@ -31,6 +31,6 @@ stdenv.mkDerivation rec {
     homepage = "https://xmedcon.sourceforge.io/Main/HomePage";
     license = licenses.lgpl2Plus;
     maintainers = with maintainers; [ arianvp flokli ];
-    platforms = with platforms; [ darwin linux ];
+    platforms = platforms.darwin ++ platforms.linux;
   };
 }

--- a/pkgs/applications/science/medicine/xmedcon/default.nix
+++ b/pkgs/applications/science/medicine/xmedcon/default.nix
@@ -10,11 +10,11 @@
 
 stdenv.mkDerivation rec {
   pname = "xmedcon";
-  version = "0.21.0";
+  version = "0.21.2";
 
   src = fetchurl {
     url = "https://prdownloads.sourceforge.net/${pname}/${pname}-${version}.tar.bz2";
-    sha256 = "0yfnbrcil5i76z1wbg308pb1mnjbcxy6nih46qpqs038v1lhh4q8";
+    sha256 = "0svff8rc3j2p47snaq1hx9mv4ydmxawpb0hf3d165g1ccjwvmm6m";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change
There's a new release, and due to the wrong usage of `meta.platforms`, it appeared as unsupported.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
