### PR TITLE
rustracer: 2.1.46 -> 2.1.48, mark as broken

### DIFF
--- a/pkgs/development/tools/rust/racer/default.nix
+++ b/pkgs/development/tools/rust/racer/default.nix
@@ -1,17 +1,15 @@
-{ lib, stdenv, fetchFromGitHub, rustPlatform, makeWrapper, substituteAll, Security }:
+{ lib, rustPlatform, fetchCrate, makeWrapper, stdenv, Security }:
 
 rustPlatform.buildRustPackage rec {
   pname = "racer";
-  version = "2.1.46";
+  version = "2.1.48";
 
-  src = fetchFromGitHub {
-    owner = "racer-rust";
-    repo = "racer";
-    rev = "v${version}";
-    sha256 = "sha256-7h1w5Yyt5VN6+pYuTTbdM1Nrd8aDEhPLusxuIsdS+mQ=";
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-lat5s9+AMFI3VXiWqjLESZrtq3IwOZhlt+5BhYoonfA=";
   };
 
-  cargoSha256 = "sha256-fllhB+so6H36b+joW0l+NBtz3PefOKdj6C8qKQPuJpk=";
+  cargoSha256 = "sha256-jGsvCmrPGVzWdx7V3J4bBK+SF2o+icORmVKuwqYxdh4=";
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = lib.optional stdenv.isDarwin Security;
@@ -44,5 +42,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/racer-rust/racer";
     license = licenses.mit;
     maintainers = with maintainers; [ jagajaga ];
+    # error[E0199]: implementing the trait `Step` is not unsafe
+    broken = true;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF: #144627

hydra builds are already failing: https://hydra.nixos.org/eval/1719259?filter=rustracer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
