### PR TITLE
nixos/google-compute-config: fix module

### DIFF
--- a/pkgs/tools/virtualization/google-compute-guest-agent/0001-oslogin-add-disable-toggle-in-conf-file.patch
+++ b/pkgs/tools/virtualization/google-compute-guest-agent/0001-oslogin-add-disable-toggle-in-conf-file.patch
@@ -1,0 +1,40 @@
+From f318f525149b06365e9f0c7f642f09f401c3e1c1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?F=C3=A9lix=20Baylac-Jacqu=C3=A9?= <felix@alternativebit.fr>
+Date: Fri, 5 Nov 2021 15:40:13 +0100
+Subject: [PATCH] oslogin: add disable toggle in conf file
+
+The guest agent is trying to imperatively alter the sshd authorized
+key config, inject some new NSS configuration, and update the PAM
+config. This won't work on NixOS. We already have a "legacy" support
+for the os-login feature that is more declarative, let's keep on using
+that.
+
+Sadly, the guest agent does not provide any way to disable the oslogin
+feature from its configuration file. The only way to prevent the
+daemon from trying to burn our ideal declarative world to the ground
+is to disable oslogin from the GCE metadata. This is obviously not a
+solution for us.
+
+Adding a new oslogin_daemon toggle to the conf file Daemons section
+allowing us to shut down the agent oslogin features.
+---
+ google_guest_agent/oslogin.go | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/google_guest_agent/oslogin.go b/google_guest_agent/oslogin.go
+index d05f733..d8a5151 100644
+--- a/google_guest_agent/oslogin.go
++++ b/google_guest_agent/oslogin.go
+@@ -76,7 +76,8 @@ func (o *osloginMgr) timeout() bool {
+ }
+ 
+ func (o *osloginMgr) disabled(os string) bool {
+-	return os == "windows"
++	return os == "windows" ||
++		!config.Section("Daemons").Key("oslogin_daemon").MustBool(true)
+ }
+ 
+ func (o *osloginMgr) set() error {
+-- 
+2.33.0
+

--- a/pkgs/tools/virtualization/google-compute-guest-agent/default.nix
+++ b/pkgs/tools/virtualization/google-compute-guest-agent/default.nix
@@ -1,0 +1,37 @@
+{ lib, fetchFromGitHub, buildGoModule, makeWrapper, google-compute-guest-configs }:
+
+let
+  version = "20211019.00";
+
+in buildGoModule {
+  inherit version;
+  pname = "guest-agent";
+
+  src = fetchFromGitHub {
+    owner = "GoogleCloudPlatform";
+    repo = "guest-agent";
+    rev = version;
+    sha256 = "sha256-DHpv6RIXV3Rn/8fuGUWS6nzsEqgyY5+zozsundX9ByM=";
+  };
+
+  patches = [ ./0001-oslogin-add-disable-toggle-in-conf-file.patch ];
+
+  vendorSha256 = "sha256-YcWKSiN715Z9lmNAQx+sHEgxWnhFhenCNXBS7gdMV4M=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  doCheck = false;
+
+  postFixup = ''
+    wrapProgram $out/bin/google_guest_agent \
+        --prefix PATH ":" "${lib.makeBinPath [ google-compute-guest-configs ]}"
+  '';
+
+  meta = with lib; {
+    description = "Guest Agent for Google Compute Engine";
+    homepage = "https://github.com/GoogleCloudPlatform/guest-agent";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mrkkrp ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/virtualization/google-compute-guest-configs/default.nix
+++ b/pkgs/tools/virtualization/google-compute-guest-configs/default.nix
@@ -1,0 +1,57 @@
+{ stdenv, lib, util-linux, fetchFromGitHub, bash, coreutils, ethtool, gnugrep, makeWrapper }:
+let
+  version = "20211028.00";
+in stdenv.mkDerivation {
+  inherit version;
+  pname = "guest-configs";
+
+  src = fetchFromGitHub {
+    owner = "GoogleCloudPlatform";
+    repo = "guest-configs";
+    rev = version;
+    sha256 = "sha256-0SRu6p/DsHNNI20mkXJitt/Ee5S2ooiy5hNmD+ndecM=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/udev $out/bin
+
+    # allows to install the package in `services.udev.packages` in NixOS
+    cp -r "src/lib/udev/rules.d" $out/lib/udev
+    cp "src/lib/udev/google_nvme_id" $out/bin
+    cp "src/usr/bin/google_set_multiqueue" $out/bin
+
+    # sysctl snippets will be used by google-compute-config.nix
+    cp -r "src/etc/sysctl.d" $out
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    wrapProgram $out/bin/google_set_multiqueue \
+        --prefix "PATH" ":" "${lib.makeBinPath [ coreutils ethtool gnugrep ]}"
+
+    for rules in $out/lib/udev/*.rules; do
+      substituteInPlace "$rules" \
+        --replace /bin/sh "${bash}/bin/bash" \
+        --replace /bin/umount "${util-linux}/bin/umount" \
+        --replace /usr/bin/logger "${util-linux}/bin/logger"
+    done
+
+    patchShebangs $out/bin/*
+  '';
+
+  meta = with lib; {
+    description = "Linux Guest Environment for Google Compute Engine";
+    homepage = "https://github.com/GoogleCloudPlatform/guest-configs";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mrkkrp ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5831,6 +5831,8 @@ with pkgs;
 
   google-compute-guest-agent = callPackage ../tools/virtualization/google-compute-guest-agent { };
 
+  google-compute-guest-configs = callPackage ../tools/virtualization/google-compute-guest-configs { };
+
   google-fonts = callPackage ../data/fonts/google-fonts { };
 
   google-clasp = callPackage ../development/misc/google-clasp { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5829,6 +5829,8 @@ with pkgs;
     with-gce = true;
   };
 
+  google-compute-guest-agent = callPackage ../tools/virtualization/google-compute-guest-agent { };
+
   google-fonts = callPackage ../data/fonts/google-fonts { };
 
   google-clasp = callPackage ../development/misc/google-clasp { };


### PR DESCRIPTION
###### Motivation for this change

We were relying on some google-provided python script to perform various actions on the GCE guests. These scripts have been decommissioned in favor of a Golang daemon: https://github.com/GoogleCloudPlatform/guest-agent. The https://github.com/NixOS/nixpkgs/pull/131761 bump broke the google-compute-config NixOS module: the Python script are not longer present in the `$out/bin` directory ([more info about that in the upstream commit](https://github.com/GoogleCloudPlatform/compute-image-packages/commit/276e520380816da1e03ad5eb38aa0aeec8c6431c#diff-267a2788071ee63df1443363c2ab882e7d321adc77ee53462a920229a962eabbL40)), hence breaking the NixOS module that was relying on those scripts.

Migrating to the new Golang daemon to perform what the scripts used to do. See more details in the individual commit messages.

This module is tightly coupled to GCE, it's sadly hard to write any VM test for it and prevent future similar breakages :( . We tested this PR manually on a GCE test deployment containing some oslogin and metadata scripts.

```
 google-guest-agent: init at 20211019.00

The guest agent is depending in some bash scripts contained in the
google-compute-guest-configs packages to setup the virtio multiqueue
support at runtime. We inject those through a wrapper.

The oslogin implementation of the guest agent won't work on NixOS as
it currently is. On top of that, it's enabled/disabled status
exclusively depends on the remote GCE deployment metadata, we can't
disable that through the conf file. We add a patch allowing us to
disable this feature via the conf file.
```

```
 nixos/google-compute-config: use the gce guest-agent

The python scripts we're using have been deprecated in favor of the
guest agent, see more infos at:
GoogleCloudPlatform/compute-image-packages@276e520#diff-267a2788071ee63df1443363c2ab882e7d321adc77ee53462a920229a962eabbL40

The guest agent onboard all the old python scripts as part of two new
go binaries: google_guest_agent and google_metadata_script_runner.
Both are using the same /etc/default-instance_configs.cfg
configuration file.

The configuration file we embed in this module mimicks the setup we
had with the python scripts. We'll have two services:

- The metadata script service: in charge of running the
  google compute startup/showdown scripts.
- The guest agent: in charge of syncing the guest clock with the host
  and setup the network interfaces on boot.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
