### PR TITLE
ansible-lint: Fix build when home dir of build user is not writable

### DIFF
--- a/pkgs/development/python-modules/ansible-lint/default.nix
+++ b/pkgs/development/python-modules/ansible-lint/default.nix
@@ -27,6 +27,8 @@ buildPythonPackage rec {
     sha256 = "sha256-1krKWcjYllQdN5uSBbISa4UQiKqwosLKsZ/3SxhM3xw=";
   };
 
+  patches = [ ./safe-env-vars.patch ];
+
   nativeBuildInputs = [
     setuptools-scm
   ];

--- a/pkgs/development/python-modules/ansible-lint/safe-env-vars.patch
+++ b/pkgs/development/python-modules/ansible-lint/safe-env-vars.patch
@@ -1,0 +1,12 @@
+diff --git a/src/ansiblelint/testing/__init__.py b/src/ansiblelint/testing/__init__.py
+index aa1ae1d..8c944e9 100644
+--- a/src/ansiblelint/testing/__init__.py
++++ b/src/ansiblelint/testing/__init__.py
+@@ -87,6 +87,7 @@ def run_ansible_lint(
+     # pollute the env, causing weird behaviors, so we pass only a safe list of
+     # vars.
+     safe_list = [
++        'HOME',
+         'LANG',
+         'LC_ALL',
+         'LC_CTYPE',


### PR DESCRIPTION
The modified HOME env var by `preCheck` get cleared by upstream test code, when the
original home dir of build user is not writable, some tests fail.

See https://hydra.nixos.org/build/157038092/nixlog/1 for failed log.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
