### PR TITLE
arduino: use buildFHSUserEnv to support compilation of boards

### DIFF
--- a/pkgs/development/embedded/arduino/arduino-core/chrootenv.nix
+++ b/pkgs/development/embedded/arduino/arduino-core/chrootenv.nix
@@ -1,0 +1,36 @@
+{ lib, buildFHSUserEnv, arduino-core-unwrapped, withGui ? false, withTeensyduino ? false }:
+let
+  arduino-unwrapped = arduino-core-unwrapped.override { inherit withGui withTeensyduino; };
+in
+buildFHSUserEnv {
+  name = "arduino";
+
+  targetPkgs =
+    pkgs: (with pkgs; [
+      ncurses
+      arduino-unwrapped
+      zlib
+      (python3.withPackages (p: with p; [
+        pyserial
+      ]))
+    ]);
+  multiPkgs = null;
+
+  extraInstallCommands = ''
+    ${lib.optionalString withGui ''
+      # desktop file
+      mkdir -p $out/share/applications
+      cp ${arduino-core-unwrapped.src}/build/linux/dist/desktop.template $out/share/applications/arduino.desktop
+      substituteInPlace $out/share/applications/arduino.desktop \
+        --replace '<BINARY_LOCATION>' "$out/bin/arduino" \
+        --replace '<ICON_NAME>' "$out/share/arduino/icons/128x128/apps/arduino.png"
+      # icon file
+      mkdir -p $out/share/arduino
+      cp -r ${arduino-core-unwrapped.src}/build/shared/icons $out/share/arduino
+    ''}
+  '';
+
+  runScript = "arduino";
+
+  meta = arduino-core-unwrapped.meta;
+}

--- a/pkgs/development/embedded/arduino/arduino-core/default.nix
+++ b/pkgs/development/embedded/arduino/arduino-core/default.nix
@@ -69,17 +69,16 @@ let
     xorg.libXxf86vm
     zlib
   ];
-  teensy_architecture = if stdenv.hostPlatform.isx86_32 then "linux32"
-                        else if stdenv.hostPlatform.isx86_64 then "linux64"
-                        else if stdenv.hostPlatform.isAarch64 then "linuxaarch64"
-                        else if stdenv.hostPlatform.isAarch32 then "linuxarm"
-                        else throw "${stdenv.hostPlatform.system} is not supported in teensy";
+  teensy_architecture =
+    if stdenv.hostPlatform.isx86_32 then "linux32"
+    else if stdenv.hostPlatform.isx86_64 then "linux64"
+    else if stdenv.hostPlatform.isAarch64 then "linuxaarch64"
+    else if stdenv.hostPlatform.isAarch32 then "linuxarm"
+    else throw "${stdenv.hostPlatform.system} is not supported in teensy";
 
-  pname = (if withTeensyduino then "teensyduino" else "arduino")
-             + lib.optionalString (!withGui) "-core";
 in
 stdenv.mkDerivation rec {
-  inherit pname;
+  pname = (if withTeensyduino then "teensyduino" else "arduino") + lib.optionalString (!withGui) "-core";
   version = "1.8.16";
 
   src = fetchFromGitHub {
@@ -195,8 +194,8 @@ stdenv.mkDerivation rec {
       chmod +w ./TeensyduinoInstall.${teensy_architecture}
       upx -d ./TeensyduinoInstall.${teensy_architecture}
       patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-          --set-rpath "${teensy_libpath}" \
-          ./TeensyduinoInstall.${teensy_architecture}
+        --set-rpath "${teensy_libpath}" \
+        ./TeensyduinoInstall.${teensy_architecture}
       chmod +x ./TeensyduinoInstall.${teensy_architecture}
       ./TeensyduinoInstall.${teensy_architecture} --dir=$out/share/arduino
       # Check for successful installation
@@ -213,8 +212,8 @@ stdenv.mkDerivation rec {
 
   preFixup = ''
     for file in $(find $out -type f \( -perm /0111 -o -name \*.so\* \) ); do
-        patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$file" || true
-        patchelf --set-rpath ${rpath}:$out/lib $file || true
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$file" || true
+      patchelf --set-rpath ${rpath}:$out/lib $file || true
     done
 
     ${lib.concatMapStringsSep "\n"
@@ -235,15 +234,15 @@ stdenv.mkDerivation rec {
     ${lib.optionalString withTeensyduino ''
       # Patch the Teensy loader binary
       patchelf --debug \
-          --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-          --set-rpath "${teensy_libpath}" \
-          $out/share/arduino/hardware/tools/teensy{,_ports,_reboot,_restart,_serialmon}
+        --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+        --set-rpath "${teensy_libpath}" \
+        $out/share/arduino/hardware/tools/teensy{,_ports,_reboot,_restart,_serialmon}
     ''}
   '';
 
   meta = with lib; {
     description = "Open-source electronics prototyping platform";
-    homepage = "http://arduino.cc/";
+    homepage = "https://www.arduino.cc/";
     license = if withTeensyduino then licenses.unfreeRedistributable else licenses.gpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ antono auntie robberer bjornfor bergey ];

--- a/pkgs/development/octave-modules/arduino/default.nix
+++ b/pkgs/development/octave-modules/arduino/default.nix
@@ -2,7 +2,7 @@
 , lib
 , fetchurl
 , instrument-control
-, arduino
+, arduino-core-unwrapped
 }:
 
 buildOctavePackage rec {
@@ -18,9 +18,8 @@ buildOctavePackage rec {
     instrument-control
   ];
 
-  # Might be able to use pkgs.arduino-core
   propagatedBuildInputs = [
-    arduino
+    arduino-core-unwrapped
   ];
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1271,7 +1271,8 @@ with pkgs;
 
   arduino-cli = callPackage ../development/embedded/arduino/arduino-cli { };
 
-  arduino-core = callPackage ../development/embedded/arduino/arduino-core { };
+  arduino-core = callPackage ../development/embedded/arduino/arduino-core/chrootenv.nix { };
+  arduino-core-unwrapped = callPackage ../development/embedded/arduino/arduino-core { };
 
   arduino-mk = callPackage ../development/embedded/arduino/arduino-mk {};
 

--- a/pkgs/top-level/octave-packages.nix
+++ b/pkgs/top-level/octave-packages.nix
@@ -54,7 +54,7 @@ makeScope newScope (self:
       writeRequiredOctavePackagesHook;
 
     arduino = callPackage ../development/octave-modules/arduino {
-      inherit (pkgs) arduino;
+      inherit (pkgs) arduino-core-unwrapped;
     };
 
     audio = callPackage ../development/octave-modules/audio { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
fixes #73965
currently it enables compilation of other board. I tested it with ESP32.
@veprbl any comments?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
