### PR TITLE
python3Packages.aws-sam-cli: 1.29.0 -> 1.35.0, fix build

### DIFF
--- a/pkgs/development/python-modules/aws-sam-translator/default.nix
+++ b/pkgs/development/python-modules/aws-sam-translator/default.nix
@@ -14,13 +14,13 @@
 
 buildPythonPackage rec {
   pname = "aws-sam-translator";
-  version = "1.39.0";
+  version = "1.40.0";
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = "serverless-application-model";
     rev = "v${version}";
-    sha256 = "1a9m7zyqc414adw1i0sr2n9nlnmry0gi1ah1qna3yv9dx4ql9v9c";
+    sha256 = "sha256-jVJVoS7rc1RebBvihzmv6LvufMf/VvXOwj0TYkXBdmo=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/tools/aws-sam-cli/default.nix
+++ b/pkgs/development/tools/aws-sam-cli/default.nix
@@ -5,11 +5,11 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "aws-sam-cli";
-  version = "1.29.0";
+  version = "1.35.0";
 
   src = python3.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "sha256-JXphjERqY5Vj8j2F4Z7FrFJJEpBgK/5236pYfQRVdco=";
+    sha256 = "sha256-ojJoC8UuZDVm6CDmYbPoO0e+1QAYa0UcekYEd/MGFRM=";
   };
 
   # Tests are not included in the PyPI package
@@ -30,6 +30,8 @@ python3.pkgs.buildPythonApplication rec {
     serverlessrepo
     tomlkit
     watchdog
+    typing-extensions
+    regex
   ];
 
   postFixup = if enableTelemetry then "echo aws-sam-cli TELEMETRY IS ENABLED" else ''
@@ -42,10 +44,14 @@ python3.pkgs.buildPythonApplication rec {
     substituteInPlace requirements/base.txt \
       --replace "click~=7.1" "click~=8.0" \
       --replace "Flask~=1.1.2" "Flask~=2.0" \
-      --replace "dateparser~=0.7" "dateparser>=0.7" \
+      --replace "dateparser~=1.0" "dateparser>=0.7" \
       --replace "docker~=4.2.0" "docker>=4.2.0" \
       --replace "requests==" "requests #" \
-      --replace "watchdog==" "watchdog #"
+      --replace "watchdog==" "watchdog #" \
+      --replace "aws_lambda_builders==" "aws-lambda-builders #" \
+      --replace "typing_extensions==" "typing-extensions #" \
+      --replace "regex==" "regex #" \
+      --replace "tzlocal==3.0" "tzlocal==2.*"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
ZHF: #144627
Haven't tested it, but it compiles
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
