### PR TITLE
tonelib-jam,zoom: fix meta.platforms

### DIFF
--- a/pkgs/applications/audio/tonelib-jam/default.nix
+++ b/pkgs/applications/audio/tonelib-jam/default.nix
@@ -56,6 +56,6 @@ stdenv.mkDerivation rec {
     homepage = "https://tonelib.net/";
     license = licenses.unfree;
     maintainers = with maintainers; [ dan4ik605743 ];
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/audio/tonelib-zoom/default.nix
+++ b/pkgs/applications/audio/tonelib-zoom/default.nix
@@ -1,12 +1,18 @@
-{ stdenv
-, dpkg
-, lib
-, autoPatchelfHook
+{ lib
+, stdenv
 , fetchurl
-, webkitgtk
-, libjack2
+, autoPatchelfHook
+, dpkg
 , alsa-lib
+, freetype
+, libglvnd
 , curl
+, libXcursor
+, libXinerama
+, libXrandr
+, libXrender
+, libjack2
+, webkitgtk
 }:
 
 stdenv.mkDerivation rec {
@@ -18,36 +24,40 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-4q2vM0/q7o/FracnO2xxnr27opqfVQoN7fsqTD9Tr/c=";
   };
 
-  buildInputs = [
-    dpkg
-    webkitgtk
-    libjack2
-    alsa-lib
-  ];
-
   nativeBuildInputs = [
     autoPatchelfHook
+    dpkg
   ];
 
-  unpackPhase = ''
-    mkdir -p $TMP/ $out/
-    dpkg -x $src $TMP
-  '';
+  buildInputs = [
+    stdenv.cc.cc.lib
+    alsa-lib
+    freetype
+    libglvnd
+    webkitgtk
+  ] ++ runtimeDependencies;
+
+  runtimeDependencies = map lib.getLib [
+    curl
+    libXcursor
+    libXinerama
+    libXrandr
+    libXrender
+    libjack2
+  ];
+
+  unpackCmd = "dpkg -x $curSrc source";
 
   installPhase = ''
-    cp -R $TMP/usr/* $out/
-    mv $out/bin/ToneLib-Zoom $out/bin/tonelib-zoom
+    mv usr $out
+    substituteInPlace $out/share/applications/ToneLib-Zoom.desktop --replace /usr/ $out/
   '';
-
-  runtimeDependencies = [
-    (lib.getLib curl)
-  ];
 
   meta = with lib; {
     description = "ToneLib Zoom – change and save all the settings in your Zoom(r) guitar pedal";
     homepage = "https://tonelib.net/";
     license = licenses.unfree;
     maintainers = with maintainers; [ dan4ik605743 ];
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
