### PR TITLE
Add UHK agent v1.5.16

### DIFF
--- a/pkgs/tools/misc/uhk-agent/default.nix
+++ b/pkgs/tools/misc/uhk-agent/default.nix
@@ -1,0 +1,44 @@
+{ lib, stdenv, bash, appimage-run }:
+let
+  uhk-agent-bin = stdenv.mkDerivation rec {
+    pname = "uhk-agent-bin";
+    version = "1.5.16";
+    src = builtins.fetchurl {
+      url = "https://github.com/UltimateHackingKeyboard/agent/releases/download/v1.5.16/UHK.Agent-1.5.16-linux-x86_64.AppImage";
+      sha256 = "sha256:02569smxbn3fr1nhbj7sg79mwc1zs2y2y3jlzbpbkngdc635z74w";
+    };
+    phases = [ "installPhase" "patchPhase" ];
+    installPhase = ''
+      mkdir -p $out/bin
+      cp $src $out/bin/uhk-agent
+      chmod +x $out/bin/uhk-agent
+    '';
+  };
+
+  script = ''
+    #!${bash}/bin/bash
+
+    ${appimage-run}/bin/appimage-run ${uhk-agent-bin}/bin/uhk-agent
+  '';
+in
+stdenv.mkDerivation rec {
+  pname = "uhk-agent";
+  version = "1.5.16";
+  buildInputs = [
+    bash
+    uhk-agent-bin
+    appimage-run
+  ];
+
+  phases = [ "buildPhase" "installPhase" "patchPhase" ];
+
+  buildPhase = ''
+    echo "${script}" >> uhk-agent
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp uhk-agent $out/bin/uhk-agent
+    chmod +x $out/bin/uhk-agent
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4045,6 +4045,8 @@ with pkgs;
 
   usbsdmux = callPackage ../development/tools/misc/usbsdmux { };
 
+  uhk-agent = callPackage ../tools/misc/uhk-agent { };
+
   usbview = callPackage ../tools/misc/usbview { };
 
   uwuify = callPackage ../tools/misc/uwuify { };


### PR DESCRIPTION
###### Motivation for this change

[UHK-agent](https://github.com/UltimateHackingKeyboard/agent/tree/master) is the configuration application of the Ultimate Hacking Keyboard.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
