### PR TITLE
wiki-tui: 0.3.4 -> 0.4.1, fix build on darwin

### DIFF
--- a/pkgs/misc/wiki-tui/default.nix
+++ b/pkgs/misc/wiki-tui/default.nix
@@ -1,19 +1,25 @@
-{ lib, rustPlatform, fetchCrate, ncurses, openssl, pkg-config }:
+{ lib, rustPlatform, fetchFromGitHub, ncurses, openssl, pkg-config, nix-update-script }:
 
 rustPlatform.buildRustPackage rec {
   pname = "wiki-tui";
-  version = "0.3.4";
+  version = "0.4.1";
 
-  src = fetchCrate {
-    inherit pname version;
-    sha256 = "sha256-H+C1AbZ2zUhw6TNlSPaNaNuY5iNf39JW4q2g6uolevM=";
+  src = fetchFromGitHub {
+    owner = "Builditluc";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-aCfYb5UvlWbBvBlwNjVIbOJlEV2b3+FD0qKO+9h5Nos=";
   };
 
   buildInputs = [ ncurses openssl ];
 
   nativeBuildInputs = [ pkg-config ];
 
-  cargoSha256 = "sha256-PIt592nGtNEREQMukqRl/6KSJ/P32fWucHEMyOOc7BA=";
+  cargoSha256 = "sha256-dD8iC/b6KwElmq0RNdnHHC/jMWh7Q0/kMM+/zityHqQ=";
+
+  passthru.updateScript = nix-update-script {
+    attrPath = pname;
+  };
 
   meta = with lib; {
     description = "A simple and easy to use Wikipedia Text User Interface";

--- a/pkgs/misc/wiki-tui/default.nix
+++ b/pkgs/misc/wiki-tui/default.nix
@@ -1,4 +1,4 @@
-{ lib, rustPlatform, fetchFromGitHub, ncurses, openssl, pkg-config, nix-update-script }:
+{ lib, rustPlatform, fetchFromGitHub, ncurses, openssl, pkg-config, stdenv, nix-update-script, Security }:
 
 rustPlatform.buildRustPackage rec {
   pname = "wiki-tui";
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-aCfYb5UvlWbBvBlwNjVIbOJlEV2b3+FD0qKO+9h5Nos=";
   };
 
-  buildInputs = [ ncurses openssl ];
+  buildInputs = [ ncurses openssl ] ++ lib.optional stdenv.isDarwin Security;
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32438,7 +32438,9 @@ with pkgs;
 
   wiki-js = callPackage ../servers/web-apps/wiki-js { };
 
-  wiki-tui = callPackage ../misc/wiki-tui { };
+  wiki-tui = callPackage ../misc/wiki-tui {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
 
   winePackagesFor = wineBuild: lib.makeExtensible (self: with self; {
     callPackage = newScope self;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
