### PR TITLE
lingua-franca: init with 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9588,6 +9588,16 @@
     githubId = 500703;
     name = "Tadas Barzdžius";
   };
+  revol-xut = {
+    email = "revol-xut@protonmail.com";
+    name = "Tassilo Tanneberger";
+    github = "revol-xut";
+    githubId = 32239737;
+    keys = [{
+      longkeyid = "rsa4096/B966009D57E69CC6";
+      fingerprint = "91EB E870 1639 1323 642A  6803 B966 009D 57E6 9CC6";
+    }];
+  };
   rexim = {
     email = "reximkut@gmail.com";
     github = "rexim";

--- a/pkgs/development/compilers/lingua-franca/default.nix
+++ b/pkgs/development/compilers/lingua-franca/default.nix
@@ -1,0 +1,39 @@
+{ lib, pkgs, stdenv, jdk11_headless }:
+stdenv.mkDerivation {
+  name = "lfc";
+  version = "0.1.0";
+
+  src = fetchGit {
+    url = "https://github.com/revol-xut/lingua-franca-nix-releases.git";
+    rev = "11c6d5297cd63bf0b365a68c5ca31ec80083bd05";
+    ref = "master";
+  };
+
+  buildInputs = [ jdk11_headless ];
+
+  _JAVA_HOME = "${jdk11_headless}/";
+
+  postPatch = ''
+    substituteInPlace bin/lfc \
+      --replace 'base=`dirname $(dirname ''${abs_path})`' "base='$out'" \
+      --replace "run_lfc_with_args" "${jdk11_headless}/bin/java -jar $out/lib/jars/org.lflang.lfc-${version}-SNAPSHOT-all.jar"
+  '';
+
+  installPhase = ''
+    cp -r ./ $out/
+    chmod +x $out/bin/lfc
+  '';
+
+  meta = with lib; {
+    description = "Polyglot coordination language";
+    longDescription = ''
+      Lingua Franca (LF) is a polyglot coordination language for concurrent
+      and possibly time-sensitive applications ranging from low-level
+      embedded code to distributed cloud and edge applications.
+    '';
+    homepage = "https://github.com/lf-lang/lingua-franca";
+    license = licenses.bsd2;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ revol-xut ];
+  };
+}

--- a/pkgs/development/compilers/lingua-franca/default.nix
+++ b/pkgs/development/compilers/lingua-franca/default.nix
@@ -1,12 +1,14 @@
-{ lib, pkgs, stdenv, jdk11_headless }:
+{ lib, pkgs, stdenv, fetchFromGitHub, jdk11_headless }:
+
 stdenv.mkDerivation {
-  name = "lfc";
+  pname = "lfc";
   version = "0.1.0";
 
-  src = fetchGit {
-    url = "https://github.com/revol-xut/lingua-franca-nix-releases.git";
+  src = fetchFromGitHub {
+    owner = "revol-xut";
+    repo = "lingua-franca-nix-releases";
     rev = "11c6d5297cd63bf0b365a68c5ca31ec80083bd05";
-    ref = "master";
+    sha256 = "DgxunzC8Ep0WdwChDHWgG5QJbJZ8UgQRXtP1HZqL9Jg=";
   };
 
   buildInputs = [ jdk11_headless ];
@@ -16,7 +18,7 @@ stdenv.mkDerivation {
   postPatch = ''
     substituteInPlace bin/lfc \
       --replace 'base=`dirname $(dirname ''${abs_path})`' "base='$out'" \
-      --replace "run_lfc_with_args" "${jdk11_headless}/bin/java -jar $out/lib/jars/org.lflang.lfc-${version}-SNAPSHOT-all.jar"
+      --replace "run_lfc_with_args" "${jdk11_headless}/bin/java -jar $out/lib/jars/org.lflang.lfc-0.1.0-SNAPSHOT-all.jar"
   '';
 
   installPhase = ''
@@ -33,7 +35,7 @@ stdenv.mkDerivation {
     '';
     homepage = "https://github.com/lf-lang/lingua-franca";
     license = licenses.bsd2;
-    platforms = platforms.all;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ revol-xut ];
   };
 }


### PR DESCRIPTION
## Lingua Franca
A polyglot coordination language.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
