### PR TITLE
openmw: 0.46 -> 0.47

### DIFF
--- a/pkgs/development/libraries/collada-dom/default.nix
+++ b/pkgs/development/libraries/collada-dom/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib, fetchFromGitHub, cmake, boost, libxml2, minizip, readline }:
+
+stdenv.mkDerivation {
+  pname = "collada-dom";
+  version = "unstable-2020-01-03";
+
+  src = fetchFromGitHub {
+    owner = "rdiankov";
+    repo = "collada-dom";
+    rev = "c1e20b7d6ff806237030fe82f126cb86d661f063";
+    sha256 = "sha256-A1ne/D6S0shwCzb9spd1MoSt/238HWA8dvgd+DC9cXc=";
+  };
+
+  postInstall = ''
+    chmod +w -R $out
+    ln -s $out/include/*/* $out/include
+  '';
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    boost
+    libxml2
+    minizip
+    readline
+  ];
+
+  meta = with lib; {
+    description = "Lightweight version of collada-dom, with only the parser.";
+    homepage = "https://github.com/rdiankov/collada-dom";
+    license = licenses.mit;
+    maintainers = with maintainers; [ marius851000 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/openscenegraph/default.nix
+++ b/pkgs/development/libraries/openscenegraph/default.nix
@@ -2,6 +2,7 @@
   libX11, libXinerama, libXrandr, libGLU, libGL,
   glib, ilmbase, libxml2, pcre, zlib,
   AGL, Carbon, Cocoa, Foundation,
+  boost,
   jpegSupport ? true, libjpeg,
   exrSupport ? false, openexr,
   gifSupport ? true, giflib,
@@ -9,7 +10,7 @@
   tiffSupport ? true, libtiff,
   gdalSupport ? false, gdal,
   curlSupport ? true, curl,
-  colladaSupport ? false, opencollada,
+  colladaSupport ? false, collada-dom,
   opencascadeSupport ? false, opencascade,
   ffmpegSupport ? false, ffmpeg,
   nvttSupport ? false, nvidia-texture-tools,
@@ -20,7 +21,7 @@
   lasSupport ? false, libLAS,
   luaSupport ? false, lua,
   sdlSupport ? false, SDL2,
-  restSupport ? false, asio, boost,
+  restSupport ? false, asio,
   withApps ? false,
   withExamples ? false, fltk, wxGTK,
 }:
@@ -48,7 +49,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional tiffSupport libtiff
     ++ lib.optional gdalSupport gdal
     ++ lib.optional curlSupport curl
-    ++ lib.optional colladaSupport opencollada
+    ++ lib.optional colladaSupport collada-dom
     ++ lib.optional opencascadeSupport opencascade
     ++ lib.optional ffmpegSupport ffmpeg
     ++ lib.optional nvttSupport nvidia-texture-tools
@@ -59,9 +60,10 @@ stdenv.mkDerivation rec {
     ++ lib.optional lasSupport libLAS
     ++ lib.optional luaSupport lua
     ++ lib.optional sdlSupport SDL2
-    ++ lib.optionals restSupport [ asio boost ]
+    ++ lib.optional restSupport asio
     ++ lib.optionals withExamples [ fltk wxGTK ]
     ++ lib.optionals stdenv.isDarwin [ AGL Carbon Cocoa Foundation ]
+    ++ lib.optional (restSupport || colladaSupport) boost
   ;
 
   cmakeFlags = lib.optional (!withApps) "-DBUILD_OSG_APPLICATIONS=OFF" ++ lib.optional withExamples "-DBUILD_OSG_EXAMPLES=ON";

--- a/pkgs/development/libraries/recastnavigation/default.nix
+++ b/pkgs/development/libraries/recastnavigation/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, lib, fetchFromGitHub, cmake, libGL, SDL2, libGLU }:
+
+stdenv.mkDerivation rec {
+  pname = "recastai";
+  # use latest revision for the CMake build process and OpenMW
+  # OpenMW use e75adf86f91eb3082220085e42dda62679f9a3ea
+  version = "unstable-2021-03-05";
+
+  src = fetchFromGitHub {
+    owner = "recastnavigation";
+    repo = "recastnavigation";
+    rev = "c5cbd53024c8a9d8d097a4371215e3342d2fdc87";
+    sha256 = "sha256-QP3lMMFR6fiKQTksAkRL6X9yaoVz2xt4QSIP9g6piww=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ libGL SDL2 libGLU ];
+
+  meta = with lib; {
+    homepage = "https://github.com/recastnavigation/recastnavigation";
+    description = "Navigation-mesh Toolset for Games";
+    license = licenses.zlib;
+    maintainers = with maintainers; [ marius851000 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/games/openmw/tes3mp.nix
+++ b/pkgs/games/openmw/tes3mp.nix
@@ -9,6 +9,7 @@
 , symlinkJoin
 , mygui
 , crudini
+, bullet
 }:
 
 # revisions are taken from https://github.com/GrimKriegor/TES3MP-deploy
@@ -70,7 +71,8 @@ let
 
     nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [ makeWrapper ];
 
-    buildInputs = oldAttrs.buildInputs ++ [ luajit ];
+    buildInputs = (builtins.map (x: if x.pname or "" == "bullet" then bullet else x) oldAttrs.buildInputs)
+      ++ [ luajit ];
 
     cmakeFlags = oldAttrs.cmakeFlags ++ [
       "-DBUILD_OPENCS=OFF"
@@ -78,6 +80,11 @@ let
       "-DRakNet_LIBRARY_RELEASE=${raknet}/lib/libRakNetLibStatic.a"
       "-DRakNet_LIBRARY_DEBUG=${raknet}/lib/libRakNetLibStatic.a"
     ];
+
+    prePatch = ''
+      substituteInPlace components/process/processinvoker.cpp \
+        --replace "\"./\"" "\"$out/bin/\""
+    '';
 
     # https://github.com/TES3MP/openmw-tes3mp/issues/552
     patches = [ ./tes3mp.patch ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15818,6 +15818,8 @@ with pkgs;
 
   cointop = callPackage ../applications/misc/cointop { };
 
+  collada-dom = callPackage ../development/libraries/collada-dom { };
+
   cog = callPackage ../development/web/cog { };
 
   cosmopolitan = callPackage ../development/libraries/cosmopolitan { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19200,6 +19200,8 @@ with pkgs;
 
   readosm = callPackage ../development/libraries/readosm { };
 
+  recastnavigation = callPackage ../development/libraries/recastnavigation { };
+
   rinutils = callPackage ../development/libraries/rinutils { };
 
   kissfft = callPackage ../development/libraries/kissfft { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

OpenMW version 0.47 was released, with some really interesting new feature (was using a nightly version compiled via Nix previously, on which this commit is based)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


note : 
openmw dropped support for Qt4 (so removed the compilation flag)
it add two dependancies, a direct one on recastnavigation, and an indirect on OSG with collada (adding some support for collada format)
The optional opencollada depencie of OSG was broken. I repeared it, using the code referenced in the OpenMW CI.
Added myself to OpenMW maintainers.