### PR TITLE
vagrant: add vagrant-aws plugin

### DIFF
--- a/pkgs/development/tools/vagrant/gemset_aws.nix
+++ b/pkgs/development/tools/vagrant/gemset_aws.nix
@@ -1,0 +1,836 @@
+{
+  activesupport = {
+    dependencies = ["concurrent-ruby" "i18n" "minitest" "tzinfo" "zeitwerk"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "19gx1jcq46x9d1pi1w8xq0bgvvfw239y4lalr8asm291gj3q3ds4";
+      type = "gem";
+    };
+    version = "6.1.4.1";
+  };
+  aliyun-sdk = {
+    dependencies = ["nokogiri" "rest-client"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "17avsza5r4f6d0f2ajgy6clmasrxs7jd16hz7ljq502jkczmv4b5";
+      type = "gem";
+    };
+    version = "0.8.0";
+  };
+  builder = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "045wzckxpwcqzrjr353cxnyaxgf0qg22jh00dcx7z38cys5g1jlr";
+      type = "gem";
+    };
+    version = "3.2.4";
+  };
+  CFPropertyList = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0hadm41xr1fq3qp74jd9l5q8l0j9083rgklgzsilllwaav7qrrid";
+      type = "gem";
+    };
+    version = "2.3.6";
+  };
+  concurrent-ruby = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0nwad3211p7yv9sda31jmbyw6sdafzmdi2i2niaz6f0wk5nq9h0f";
+      type = "gem";
+    };
+    version = "1.1.9";
+  };
+  diff-lcs = {
+    groups = ["default" "development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0m925b8xc6kbpnif9dldna24q1szg4mk0fvszrki837pfn46afmz";
+      type = "gem";
+    };
+    version = "1.4.4";
+  };
+  domain_name = {
+    dependencies = ["unf"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0lcqjsmixjp52bnlgzh4lg9ppsk52x9hpwdjd53k8jnbah2602h0";
+      type = "gem";
+    };
+    version = "0.5.20190701";
+  };
+  dry-inflector = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0mhzq07hi4v8g3b90z9sqv41vb9hqalbqrnpvxjln7djq8gr4n5l";
+      type = "gem";
+    };
+    version = "0.2.1";
+  };
+  excon = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "15yrwawhvkjvfg0dsf8z81876ddj6161q0wh5s7pw4sim8z8pspr";
+      type = "gem";
+    };
+    version = "0.88.0";
+  };
+  fission = {
+    dependencies = ["CFPropertyList"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "09pmp1j1rr8r3pcmbn2na2ls7s1j9ijbxj99xi3a8r6v5xhjdjzh";
+      type = "gem";
+    };
+    version = "0.5.0";
+  };
+  fog = {
+    dependencies = ["fog-aliyun" "fog-atmos" "fog-aws" "fog-brightbox" "fog-cloudatcost" "fog-core" "fog-digitalocean" "fog-dnsimple" "fog-dynect" "fog-ecloud" "fog-google" "fog-internet-archive" "fog-joyent" "fog-json" "fog-local" "fog-openstack" "fog-ovirt" "fog-powerdns" "fog-profitbricks" "fog-rackspace" "fog-radosgw" "fog-riakcs" "fog-sakuracloud" "fog-serverlove" "fog-softlayer" "fog-storm_on_demand" "fog-terremark" "fog-vmfusion" "fog-voxel" "fog-vsphere" "fog-xenserver" "fog-xml" "ipaddress" "json"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bzmxqppksdirx5fp9b2sr80kkb8w78zzkfbm0pnql7pbh21rvgl";
+      type = "gem";
+    };
+    version = "1.42.1";
+  };
+  fog-aliyun = {
+    dependencies = ["aliyun-sdk" "fog-core" "fog-json" "ipaddress" "xml-simple"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "09fqw4l574am2rbliw3ncnys556hbgpl9c0pr89619sm8q8w51bb";
+      type = "gem";
+    };
+    version = "0.3.19";
+  };
+  fog-atmos = {
+    dependencies = ["fog-core" "fog-xml"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1aaxgnw9zy96gsh4h73kszypc32sx497s6bslvhfqh32q9d1y8c9";
+      type = "gem";
+    };
+    version = "0.1.0";
+  };
+  fog-aws = {
+    dependencies = ["fog-core" "fog-json" "fog-xml" "ipaddress"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "00skbbgvhqzq6gpgzmw0957n0wf1y3vjgrdyq3sib0ghpyfgmig3";
+      type = "gem";
+    };
+    version = "2.0.1";
+  };
+  fog-brightbox = {
+    dependencies = ["dry-inflector" "fog-core" "fog-json" "mime-types"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0z0azs8119v4v3xrds822pyv7137cy8kgsmbjmf96l717qzr4b4p";
+      type = "gem";
+    };
+    version = "0.16.1";
+  };
+  fog-cloudatcost = {
+    dependencies = ["fog-core" "fog-json" "fog-xml" "ipaddress"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1320ax5x8gxdnaxkgzhmy751nip771ax7nyljfgqblw6l4m0gigy";
+      type = "gem";
+    };
+    version = "0.1.2";
+  };
+  fog-core = {
+    dependencies = ["builder" "excon" "formatador"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "02449kh2x3zj9xxszm02vy8zpbsrykvjrg5gj3kqcy2yizy2bhp3";
+      type = "gem";
+    };
+    version = "1.45.0";
+  };
+  fog-digitalocean = {
+    dependencies = ["fog-core" "fog-json" "fog-xml" "ipaddress"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "03wbwp6fcl9ic38w99wv4iab96zzccl2ykmddcp6jvlwyp3x88d9";
+      type = "gem";
+    };
+    version = "0.4.0";
+  };
+  fog-dnsimple = {
+    dependencies = ["fog-core" "fog-json"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0vkx74hgwaymgiw1swqcf2ik65jiznxhf3z50434dgvvn5zk65sw";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  fog-dynect = {
+    dependencies = ["fog-core" "fog-json" "fog-xml"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bmv12zjfbbcl33vg664bd6fp3q7rp0xi8n53i3707bi9zvf7d98";
+      type = "gem";
+    };
+    version = "0.0.3";
+  };
+  fog-ecloud = {
+    dependencies = ["fog-core" "fog-xml"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "18rb4qjad9xwwqvvpj8r2h0hi9svy71pm4d3fc28cdcnfarmdi06";
+      type = "gem";
+    };
+    version = "0.3.0";
+  };
+  fog-google = {
+    dependencies = ["fog-core" "fog-json" "fog-xml"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0z4vmswpqwph04c0wqzrscns1d1wdm8kbxx457bv156mawzrhfj3";
+      type = "gem";
+    };
+    version = "0.1.0";
+  };
+  fog-internet-archive = {
+    dependencies = ["fog-core" "fog-json" "fog-xml"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1z9w23k9578jb95zilikdzjlv6hjssz7q9qyg2n18irnm52ayh72";
+      type = "gem";
+    };
+    version = "0.0.2";
+  };
+  fog-joyent = {
+    dependencies = ["fog-core" "fog-json"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "01aihain51b253pvf0al329305vq5w6ndfp18a6hcdqiybzizvb0";
+      type = "gem";
+    };
+    version = "0.0.1";
+  };
+  fog-json = {
+    dependencies = ["fog-core" "multi_json"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1zj8llzc119zafbmfa4ai3z5s7c4vp9akfs0f9l2piyvcarmlkyx";
+      type = "gem";
+    };
+    version = "1.2.0";
+  };
+  fog-local = {
+    dependencies = ["fog-core"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0fxzr702hm2i0ivfh2hwd636lk7hdjynkync1rdiyhhlfk3pwyng";
+      type = "gem";
+    };
+    version = "0.7.0";
+  };
+  fog-openstack = {
+    dependencies = ["fog-core" "fog-json" "ipaddress"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "11j18h61d3p0pcp9k5346lbj1lahab1dqybkrx9338932lmjn7ap";
+      type = "gem";
+    };
+    version = "0.3.10";
+  };
+  fog-ovirt = {
+    dependencies = ["activesupport" "fog-core" "fog-json" "fog-xml" "ovirt-engine-sdk"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0vgpxq9p88isgmqqk9f0minkkxkqxllcq6lhmgznj8zzwllppmmp";
+      type = "gem";
+    };
+    version = "2.0.1";
+  };
+  fog-powerdns = {
+    dependencies = ["fog-core" "fog-json" "fog-xml"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0y531ag9qcbyb9mq7lxv77rvdz9bc1igaplgv850z4krg9f7pq7m";
+      type = "gem";
+    };
+    version = "0.2.0";
+  };
+  fog-profitbricks = {
+    dependencies = ["fog-core" "fog-json"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0879dfgdd9xby0l41a0rq0nzj9sj24l34knkjf48rdihvi7pbcl4";
+      type = "gem";
+    };
+    version = "4.1.1";
+  };
+  fog-rackspace = {
+    dependencies = ["fog-core" "fog-json" "fog-xml" "ipaddress"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "15hqiv60skk4c0gw8ihn4v8vdl0ipbw4yb8zbaq6nyyvg59wfcfm";
+      type = "gem";
+    };
+    version = "0.1.6";
+  };
+  fog-radosgw = {
+    dependencies = ["fog-core" "fog-json" "fog-xml"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0nslgv8yp5qkiryj3zsm91gs7s6i626igj61kwxjjwk2yv6swyr6";
+      type = "gem";
+    };
+    version = "0.0.5";
+  };
+  fog-riakcs = {
+    dependencies = ["fog-core" "fog-json" "fog-xml"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1nbxc4dky3agfwrmgm1aqmi59p6vnvfnfbhhg7xpg4c2cf41whxm";
+      type = "gem";
+    };
+    version = "0.1.0";
+  };
+  fog-sakuracloud = {
+    dependencies = ["fog-core" "fog-json"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "08krsn9sk5sx0aza812g31r169bd0zanb8pq5am3a64j6azarimd";
+      type = "gem";
+    };
+    version = "1.7.5";
+  };
+  fog-serverlove = {
+    dependencies = ["fog-core" "fog-json"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0hxgmwzygrw25rbsy05i6nzsyr0xl7xj5j2sjpkb9n9wli5sagci";
+      type = "gem";
+    };
+    version = "0.1.2";
+  };
+  fog-softlayer = {
+    dependencies = ["fog-core" "fog-json"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0f2crz9g3s6m6casr3bsdqc7lp55gd22iq99r63zi80fx37c1pzf";
+      type = "gem";
+    };
+    version = "1.1.4";
+  };
+  fog-storm_on_demand = {
+    dependencies = ["fog-core" "fog-json"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0fif1x8ci095b2yyilf65n7x6iyvn448azrsnmwsdkriy8vxxv3y";
+      type = "gem";
+    };
+    version = "0.1.1";
+  };
+  fog-terremark = {
+    dependencies = ["fog-core" "fog-xml"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "01lfkh9jppj0iknlklmwyb7ym3bfhkq58m3absb6rf5a5mcwi3lf";
+      type = "gem";
+    };
+    version = "0.1.0";
+  };
+  fog-vmfusion = {
+    dependencies = ["fission" "fog-core"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0g0l0k9ylxk1h9pzqr6h2ba98fl47lpp3j19lqv4jxw0iw1rqxn4";
+      type = "gem";
+    };
+    version = "0.1.0";
+  };
+  fog-voxel = {
+    dependencies = ["fog-core" "fog-xml"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "10skdnj59yf4jpvq769njjrvh2l0wzaa7liva8n78qq003mvmfgx";
+      type = "gem";
+    };
+    version = "0.1.0";
+  };
+  fog-vsphere = {
+    dependencies = ["fog-core" "rbvmomi"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1y1j1v8w8vd5qgajrd32x8bg93k5lwhdcz2jfr4npi67vnhp31rp";
+      type = "gem";
+    };
+    version = "3.5.0";
+  };
+  fog-xenserver = {
+    dependencies = ["fog-core" "fog-xml" "xmlrpc"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0maqa0hchk5pyasn0yjbh3ackb071128s0102adzijhga0k6vvhz";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  fog-xml = {
+    dependencies = ["fog-core" "nokogiri"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1vyyb2429xqzys39xyk2r3fal80qqn397aj2kqsjrgg2y6m59i41";
+      type = "gem";
+    };
+    version = "0.1.4";
+  };
+  formatador = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0mprf1dwznz5ld0q1jpbyl59fwnwk6azspnd0am7zz7kfg3pxhv5";
+      type = "gem";
+    };
+    version = "0.3.0";
+  };
+  http-accept = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "09m1facypsdjynfwrcv19xcb1mqg8z6kk31g8r33pfxzh838c9n6";
+      type = "gem";
+    };
+    version = "1.7.0";
+  };
+  http-cookie = {
+    dependencies = ["domain_name"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "19370bc97gsy2j4hanij246hv1ddc85hw0xjb6sj7n1ykqdlx9l9";
+      type = "gem";
+    };
+    version = "1.0.4";
+  };
+  i18n = {
+    dependencies = ["concurrent-ruby"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0vdd1kii40qhbr9n8qx71k2gskq6rkl8ygy8hw5hfj8bb5a364xf";
+      type = "gem";
+    };
+    version = "1.8.11";
+  };
+  iniparse = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1wb1qy4i2xrrd92dc34pi7q7ibrjpapzk9y465v0n9caiplnb89n";
+      type = "gem";
+    };
+    version = "1.5.0";
+  };
+  ipaddress = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1x86s0s11w202j6ka40jbmywkrx8fhq8xiy8mwvnkhllj57hqr45";
+      type = "gem";
+    };
+    version = "0.8.3";
+  };
+  json = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1z9grvjyfz16ag55hg522d3q4dh07hf391sf9s96npc0vfi85xkz";
+      type = "gem";
+    };
+    version = "2.6.1";
+  };
+  mime-types = {
+    dependencies = ["mime-types-data"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1zj12l9qk62anvk9bjvandpa6vy4xslil15wl6wlivyf51z773vh";
+      type = "gem";
+    };
+    version = "3.3.1";
+  };
+  mime-types-data = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1z5wvk6qi4ws1kjh7xn1rfirqw5m72bwvqacck1fjpbh33pcrwxv";
+      type = "gem";
+    };
+    version = "3.2021.0901";
+  };
+  mini_portile2 = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1lvxm91hi0pabnkkg47wh1siv56s6slm2mdq1idfm86dyfidfprq";
+      type = "gem";
+    };
+    version = "2.6.1";
+  };
+  minitest = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "19z7wkhg59y8abginfrm2wzplz7py3va8fyngiigngqvsws6cwgl";
+      type = "gem";
+    };
+    version = "5.14.4";
+  };
+  multi_json = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0pb1g1y3dsiahavspyzkdy39j4q377009f6ix0bh1ag4nqw43l0z";
+      type = "gem";
+    };
+    version = "1.15.0";
+  };
+  netrc = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0gzfmcywp1da8nzfqsql2zqi648mfnx6qwkig3cv36n9m0yy676y";
+      type = "gem";
+    };
+    version = "0.11.0";
+  };
+  nokogiri = {
+    dependencies = ["mini_portile2" "racc"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1v02g7k7cxiwdcahvlxrmizn3avj2q6nsjccgilq1idc89cr081b";
+      type = "gem";
+    };
+    version = "1.12.5";
+  };
+  optimist = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1vg2chy1cfmdj6c1gryl8zvjhhmb3plwgyh1jfnpq4fnfqv7asrk";
+      type = "gem";
+    };
+    version = "3.0.1";
+  };
+  ovirt-engine-sdk = {
+    dependencies = ["json"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0m2acfd6l6k9xvqxvwivcnwji9974ac7498znydxh69z1x3rr8nm";
+      type = "gem";
+    };
+    version = "4.4.1";
+  };
+  racc = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0la56m0z26j3mfn1a9lf2l03qx1xifanndf9p3vx1azf6sqy7v9d";
+      type = "gem";
+    };
+    version = "1.6.0";
+  };
+  rake = {
+    groups = ["development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "15whn7p9nrkxangbs9hh75q585yfn66lv0v2mhj6q6dl6x8bzr2w";
+      type = "gem";
+    };
+    version = "13.0.6";
+  };
+  rbvmomi = {
+    dependencies = ["builder" "json" "nokogiri" "optimist"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "12gsnkrhk03qkxr8zrfq3vkpg8qcylvayja2qavkwalwg8iry3sc";
+      type = "gem";
+    };
+    version = "2.4.1";
+  };
+  rest-client = {
+    dependencies = ["http-accept" "http-cookie" "mime-types" "netrc"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1qs74yzl58agzx9dgjhcpgmzfn61fqkk33k1js2y5yhlvc5l19im";
+      type = "gem";
+    };
+    version = "2.1.0";
+  };
+  rexml = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "08ximcyfjy94pm1rhcx04ny1vx2sk0x4y185gzn86yfsbzwkng53";
+      type = "gem";
+    };
+    version = "3.2.5";
+  };
+  rspec = {
+    dependencies = ["rspec-core" "rspec-expectations" "rspec-mocks"];
+    groups = ["development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1dwai7jnwmdmd7ajbi2q0k0lx1dh88knv5wl7c34wjmf94yv8w5q";
+      type = "gem";
+    };
+    version = "3.10.0";
+  };
+  rspec-core = {
+    dependencies = ["rspec-support"];
+    groups = ["default" "development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0wwnfhxxvrlxlk1a3yxlb82k2f9lm0yn0598x7lk8fksaz4vv6mc";
+      type = "gem";
+    };
+    version = "3.10.1";
+  };
+  rspec-expectations = {
+    dependencies = ["diff-lcs" "rspec-support"];
+    groups = ["default" "development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1sz9bj4ri28adsklnh257pnbq4r5ayziw02qf67wry0kvzazbb17";
+      type = "gem";
+    };
+    version = "3.10.1";
+  };
+  rspec-its = {
+    dependencies = ["rspec-core" "rspec-expectations"];
+    groups = ["development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "15zafd70gxly5i0s00nky14sj2n92dnj3xpj83ysl3c2wx0119ad";
+      type = "gem";
+    };
+    version = "1.3.0";
+  };
+  rspec-mocks = {
+    dependencies = ["diff-lcs" "rspec-support"];
+    groups = ["default" "development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1d13g6kipqqc9lmwz5b244pdwc97z15vcbnbq6n9rlf32bipdz4k";
+      type = "gem";
+    };
+    version = "3.10.2";
+  };
+  rspec-support = {
+    groups = ["default" "development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0pjckrh8q6sqxy38xw7f4ziylq1983k84xh927s6352pps68zj35";
+      type = "gem";
+    };
+    version = "3.10.3";
+  };
+  tzinfo = {
+    dependencies = ["concurrent-ruby"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "10qp5x7f9hvlc0psv9gsfbxg4a7s0485wsbq1kljkxq94in91l4z";
+      type = "gem";
+    };
+    version = "2.0.4";
+  };
+  unf = {
+    dependencies = ["unf_ext"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bh2cf73i2ffh4fcpdn9ir4mhq8zi50ik0zqa1braahzadx536a9";
+      type = "gem";
+    };
+    version = "0.1.4";
+  };
+  unf_ext = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0jmbimpnpjdzz8hlrppgl9spm99qh3qzbx0b81k3gkgwba8nk3yd";
+      type = "gem";
+    };
+    version = "0.0.8";
+  };
+  webrick = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1d4cvgmxhfczxiq5fr534lmizkhigd15bsx5719r5ds7k7ivisc7";
+      type = "gem";
+    };
+    version = "1.7.0";
+  };
+  xml-simple = {
+    dependencies = ["rexml"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0pb9plyl71mdbjr4kllfy53qx6g68ryxblmnq9dilvy837jk24fj";
+      type = "gem";
+    };
+    version = "1.1.9";
+  };
+  xmlrpc = {
+    dependencies = ["webrick"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1xa79ry3976ylap38cr5g6q3m81plm611flqd3dwgnmgbkycb6jp";
+      type = "gem";
+    };
+    version = "0.3.2";
+  };
+  zeitwerk = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "18l4r6layck0d80ydc692mv1lxak5xbf6w2paj1x7m2ggbggzxgj";
+      type = "gem";
+    };
+    version = "2.5.1";
+  };
+  vagrant-aws = {
+    dependencies = ["fog" "iniparse"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0nkvw6779fbq8gn6kg29kbwvm247d52xp6x8w6l18jy2c7s1r446";
+      type = "gem";
+    };
+    version = "0.7.2";
+  };
+}

--- a/pkgs/development/tools/vagrant/vagrant-plugin.json.in
+++ b/pkgs/development/tools/vagrant/vagrant-plugin.json.in
@@ -1,5 +1,5 @@
 {
-  "vagrant-libvirt": {
+  "vagrant-@pname@": {
     "ruby_version":"@ruby_version@",
     "vagrant_version":"@vagrant_version@",
     "gem_version":"",


### PR DESCRIPTION
###### Motivation for this change
Got frustrated trying to get the `vagrant-aws` plugin working the "normal" way and so created a package for it. Generating the `gemset_aws.nix` for it was ugly, let's not go into it. Tried to essentially follow the pattern of the `libvirt` plugin. I realize this isn't the most extensible pattern, but it does the job for now.

Unfortunately the dependencies of `vagrant-aws` conflict with those of `vagrant-libvirt` so I've disabled it by default and added an assertion to alert anyone trying to enable both together. I realize this isn't great, but it solves the problem for me.

Package was requested in #121161.

Edit(@tomodachi94): Fixes #121161.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
