### PR TITLE
libsForQt5.applet-window-buttons: 0.9.0 -> 0.10.1

### DIFF
--- a/pkgs/development/libraries/applet-window-buttons/default.nix
+++ b/pkgs/development/libraries/applet-window-buttons/default.nix
@@ -11,13 +11,13 @@
 
 mkDerivation rec {
   pname = "applet-window-buttons";
-  version = "0.9.0";
+  version = "0.10.1";
 
   src = fetchFromGitHub {
     owner = "psifidotos";
     repo = "applet-window-buttons";
     rev = version;
-    sha256 = "sha256-ikgUE8GaiTpNjwrz7SbNQ3+b8KiigDgMREQ7J2b+EEs=";
+    sha256 = "18h2g3jqzr88wkmws2iz71sgrz633zwkqvhn32sdi32sxxbrksgd";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
ZHF: #144627

@NixOS/nixos-release-managers

This fixes the build, which was previously failing with:

	In file included from /build/source/build/libappletdecoration/appletdecorationplugin_autogen/EWIEGA46WW/moc_previewbridge.cpp:10,
	                 from /build/source/build/libappletdecoration/appletdecorationplugin_autogen/mocs_compilation.cpp:9:
	/build/source/build/libappletdecoration/appletdecorationplugin_autogen/EWIEGA46WW/../../../../libappletdecoration/previewbridge.h:53:10: error: 'void Decoration::Applet::PreviewBridge::update(KDecoration2::Decoration*, const QRect&)' marked 'override', but does not override
	   53 |     void update(KDecoration2::Decoration *decoration, const QRect &geometry) override;
	      |          ^~~~~~

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
