### PR TITLE
geopandas: 0.9.0 -> 0.10.2; fix check

### DIFF
--- a/pkgs/development/python-modules/geopandas/default.nix
+++ b/pkgs/development/python-modules/geopandas/default.nix
@@ -1,31 +1,18 @@
-{ lib, stdenv, buildPythonPackage, fetchFromGitHub, fetchpatch, pythonOlder
+{ lib, stdenv, buildPythonPackage, fetchFromGitHub, pythonOlder
 , pandas, shapely, fiona, pyproj
 , pytestCheckHook, Rtree }:
 
 buildPythonPackage rec {
   pname = "geopandas";
-  version = "0.9.0";
+  version = "0.10.2";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "geopandas";
     repo = "geopandas";
     rev = "v${version}";
-    sha256 = "sha256-58X562OkRzZ4UTNMTwXW4U5czoa5tbSMBCcE90DqbaE=";
+    sha256 = "14azl3gppqn90k8h4hpjilsivj92k6p1jh7mdr6p4grbww1b7sdq";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "skip-pandas-master-fillna-test.patch";
-      url = "https://github.com/geopandas/geopandas/pull/1878.patch";
-      sha256 = "1yw3i4dbhaq7f02n329b9y2cqxbwlz9db81mhgrfc7af3whwysdb";
-    })
-    (fetchpatch {
-      name = "fix-proj4strings-test.patch";
-      url = "https://github.com/geopandas/geopandas/pull/1958.patch";
-      sha256 = "0kzmpq5ry87yvhqr6gnh9p2606b06d3ynzjvw0hpp9fncczpc2yn";
-    })
-  ];
 
   propagatedBuildInputs = [
     pandas
@@ -35,6 +22,10 @@ buildPythonPackage rec {
   ];
 
   doCheck = !stdenv.isDarwin;
+  preCheck = ''
+    # Wants to write test files into $HOME.
+    export HOME="$TMPDIR"
+  '';
   checkInputs = [ pytestCheckHook Rtree ];
   disabledTests = [
     # requires network access


### PR DESCRIPTION
ZHF: #144627

@NixOS/nixos-release-managers

Patches are both now applied upstream.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
