### PR TITLE
git-aggregator: 1.8.1 -> 2.10, fix build

### DIFF
--- a/pkgs/development/tools/git-aggregator/default.nix
+++ b/pkgs/development/tools/git-aggregator/default.nix
@@ -1,17 +1,18 @@
-{ git, lib, python3Packages }:
+{ lib, git, python3Packages }:
 
 python3Packages.buildPythonApplication rec {
   pname = "git-aggregator";
-  version = "1.8.1";
+  version = "2.1.0";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    hash = "sha256-LLsyhyhPmOOvPzwEEJwkhrDfBMFueA7kuDlnrqwr08k=";
+    sha256 = "sha256-79xNPzYP1j71sU5wZM5e2xTqQExqQEdxXPxbk4T/Scw=";
   };
 
   nativeBuildInputs = with python3Packages; [
     setuptools-scm
   ];
+
   propagatedBuildInputs = with python3Packages; [
     argcomplete
     colorama
@@ -25,13 +26,15 @@ python3Packages.buildPythonApplication rec {
   ];
 
   preCheck = ''
-    export HOME=`mktemp -d`
+    export HOME="$(mktemp -d)"
     git config --global user.name John
     git config --global user.email john@localhost
+    git config --global init.defaultBranch master
+    git config --global pull.rebase false
   '';
 
   meta = with lib; {
-    description = "Manage the aggregation of git branches from different remotes to build a consolidated one.";
+    description = "Manage the aggregation of git branches from different remotes to build a consolidated one";
     homepage = "https://github.com/acsone/git-aggregator";
     license = licenses.agpl3Plus;
     maintainers = with maintainers; [ lourkeur ];


### PR DESCRIPTION
##### Motivation for this change
ZHF: #144627

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
