### PR TITLE
PyTorch: Reduce closure size by ~500MB

### DIFF
--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -6,7 +6,7 @@
   cudaArchList ? null,
 
   # Native build inputs
-  cmake, util-linux, linkFarm, symlinkJoin, which, pybind11,
+  cmake, util-linux, linkFarm, symlinkJoin, which, pybind11, removeReferencesTo,
 
   # Build inputs
   numactl,
@@ -220,6 +220,7 @@ in buildPythonPackage rec {
     which
     ninja
     pybind11
+    removeReferencesTo
   ] ++ lib.optionals cudaSupport [ cudatoolkit_joined ];
 
   buildInputs = [ blas blas.provider ]
@@ -259,6 +260,8 @@ in buildPythonPackage rec {
     ])
   ];
   postInstall = ''
+    find "$out/${python.sitePackages}/torch/include" "$out/${python.sitePackages}/torch/lib" -type f -exec remove-references-to -t ${stdenv.cc} '{}' +
+
     mkdir $dev
     cp -r $out/${python.sitePackages}/torch/include $dev/include
     cp -r $out/${python.sitePackages}/torch/share   $dev/share

--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -276,7 +276,8 @@ in buildPythonPackage rec {
       --replace \''${_IMPORT_PREFIX}/lib "$lib/lib"
 
     mkdir $lib
-    cp -r $out/${python.sitePackages}/torch/lib     $lib/lib
+    mv $out/${python.sitePackages}/torch/lib     $lib/lib
+    ln -s $lib/lib $out/${python.sitePackages}/torch/lib
   '';
 
   postFixup = lib.optionalString stdenv.isDarwin ''


### PR DESCRIPTION
###### Motivation for this change

PyTorch has a very large closure size (1.0GB before this change), about half of which turns out to be unnecessary (reduced to 537M with this change):
  * Removed ~300MB from the outputs by symlinking instead of copying libraries duplicated between the $lib and $out outputs
  * Removed ~200MB from the closure by using `removeReferencesTo` to make the output not depend on gcc
  * ~~Added an argument to make `tensorboard` dependencies optional - small, but removes dozens of Python dependencies when `tensorboard` is not needed (still enabled by default)~~ (deferred to a later PR)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
