### PR TITLE
[staging-next] kexec-tools: 2.0.22 → 2.0.23

### DIFF
--- a/pkgs/os-specific/linux/kexec-tools/default.nix
+++ b/pkgs/os-specific/linux/kexec-tools/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "kexec-tools";
-  version = "2.0.22";
+  version = "2.0.23";
 
   src = fetchurl {
     urls = [
       "mirror://kernel/linux/utils/kernel/kexec/${pname}-${version}.tar.xz"
       "http://horms.net/projects/kexec/kexec-tools/${pname}-${version}.tar.xz"
     ];
-    sha256 = "1j7qlhxk1rbv9jbj8wd6hb7zl8p2mp29ymrmccgmsi0m0dzhgn6s";
+    sha256 = "qmPNbH3ZWwbOumJAp/3GeSeJytp1plXmcUmHF1IkJBs=";
   };
 
   hardeningDisable = [ "format" "pic" "relro" "pie" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Unbreaks staging-next recently rebased on the main branch on Linux x86_64

Targetting: #144730

Currently noticing the following build error on a local `nixos-rebuild` of `staging-next`:

```
gcc -g -O2 -fno-strict-aliasing -Wall -Wstrict-prototypes -I./include -I./util_lib/include -Iinclude/  -I./kexec/arch/i386/include  -c -MD -o kexec/arch/i386/kexec-x86.o kexec/arch/i386/kexec-x86.c
checking whether to add -D_FORTIFY_SOURCE=2 to CFLAGS... yes
kexec/arch/i386/kexec-x86.c:39:22: error: 'multiboot2_x86_probe' undeclared here (not in a function); did you mean 'multiboot_x86_probe'?
   39 |  { "multiboot2-x86", multiboot2_x86_probe, multiboot2_x86_load,
      |                      ^~~~~~~~~~~~~~~~~~~~
      |                      multiboot_x86_probe
kexec/arch/i386/kexec-x86.c:39:44: error: 'multiboot2_x86_load' undeclared here (not in a function); did you mean 'multiboot_x86_load'?
   39 |  { "multiboot2-x86", multiboot2_x86_probe, multiboot2_x86_load,
      |                                            ^~~~~~~~~~~~~~~~~~~
      |                                            multiboot_x86_load
kexec/arch/i386/kexec-x86.c:40:4: error: 'multiboot2_x86_usage' undeclared here (not in a function); did you mean 'multiboot_x86_usage'?
   40 |    multiboot2_x86_usage },
      |    ^~~~~~~~~~~~~~~~~~~~
      |    multiboot_x86_usage
make: *** [Makefile:114: kexec/arch/i386/kexec-x86.o] Error 1
error: builder for '/nix/store/xh5fw8sllifl4sgfzc4qn98mcfn0sawr-kexec-tools-2.0.22.drv' failed with exit code 2
error: 1 dependencies of derivation '/nix/store/63rj3mh767bj8dab5ws5frrisvp579s9-systemd-249.5.drv' failed to build
```

This version bump fixes the issue and I was able to rebuild my NixOS configuration.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
