### PR TITLE
treewide: use mirror URLs where available

### DIFF
--- a/pkgs/applications/misc/mkgmap/deps.nix
+++ b/pkgs/applications/misc/mkgmap/deps.nix
@@ -9,23 +9,23 @@
     sha256 = "0zb4pqkwly5z30ww66qhhasdhdrzwmrw00347yrbgyk2ii4wjad3";
   };
   protobuf = fetchurl {
-    url = "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/2.5.0/protobuf-java-2.5.0.jar";
+    url = "mirror://maven/com/google/protobuf/protobuf-java/2.5.0/protobuf-java-2.5.0.jar";
     sha256 = "0x6c4pbsizvk3lm6nxcgi1g2iqgrxcna1ip74lbn01f0fm2wdhg0";
   };
   xpp3 = fetchurl {
-    url = "https://repo1.maven.org/maven2/xpp3/xpp3/1.1.4c/xpp3-1.1.4c.jar";
+    url = "mirror://maven/xpp3/xpp3/1.1.4c/xpp3-1.1.4c.jar";
     sha256 = "1f9ifnxxj295xb1494jycbfm76476xm5l52p7608gf0v91d3jh83";
   };
   jaxb-api = fetchurl {
-    url = "https://repo1.maven.org/maven2/javax/xml/bind/jaxb-api/2.3.0/jaxb-api-2.3.0.jar";
+    url = "mirror://maven/javax/xml/bind/jaxb-api/2.3.0/jaxb-api-2.3.0.jar";
     sha256 = "00rxpc0m30d3jc572ni01ryxq8gcbnr955xsabrijg9pknc0fc48";
   };
   junit = fetchurl {
-    url = "https://repo1.maven.org/maven2/junit/junit/4.11/junit-4.11.jar";
+    url = "mirror://maven/junit/junit/4.11/junit-4.11.jar";
     sha256 = "1zh6klzv8w30dx7jg6pkhllk4587av4znflzhxz8x97c7rhf3a4h";
   };
   hamcrest-core = fetchurl {
-    url = "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar";
+    url = "mirror://maven/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar";
     sha256 = "1sfqqi8p5957hs9yik44an3lwpv8ln2a6sh9gbgli4vkx68yzzb6";
   };
 }

--- a/pkgs/applications/science/medicine/xmedcon/default.nix
+++ b/pkgs/applications/science/medicine/xmedcon/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   version = "0.21.2";
 
   src = fetchurl {
-    url = "https://prdownloads.sourceforge.net/${pname}/${pname}-${version}.tar.bz2";
+    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.bz2";
     sha256 = "0svff8rc3j2p47snaq1hx9mv4ydmxawpb0hf3d165g1ccjwvmm6m";
   };
 

--- a/pkgs/applications/window-managers/oroborus/default.nix
+++ b/pkgs/applications/window-managers/oroborus/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
                   libXft libXpm libXrandr libXrender xorgproto libXinerama ];
 
   src = fetchurl {
-    url = "http://ftp.debian.org/debian/pool/main/o/oroborus/oroborus_${version}.tar.gz";
+    url = "mirror://debian/pool/main/o/oroborus/oroborus_${version}.tar.gz";
     sha256 = "12bvk8x8rfnymbfbwmdcrd9g8m1zxbcq7rgvfdkjr0gnpi0aa82j";
   };
 

--- a/pkgs/data/fonts/arphic/default.nix
+++ b/pkgs/data/fonts/arphic/default.nix
@@ -6,7 +6,7 @@ in {
   arphic-ukai = fetchzip {
     name = "arphic-ukai-${version}";
 
-    url = "http://archive.ubuntu.com/ubuntu/pool/main/f/fonts-arphic-ukai/fonts-arphic-ukai_${version}.orig.tar.bz2";
+    url = "mirror://ubuntu/pool/main/f/fonts-arphic-ukai/fonts-arphic-ukai_${version}.orig.tar.bz2";
 
     postFetch = ''
       tar -xjvf $downloadedFile --strip-components=1
@@ -31,7 +31,7 @@ in {
   arphic-uming = fetchzip {
     name = "arphic-uming-${version}";
 
-    url = "http://archive.ubuntu.com/ubuntu/pool/main/f/fonts-arphic-uming/fonts-arphic-uming_${version}.orig.tar.bz2";
+    url = "mirror://ubuntu/pool/main/f/fonts-arphic-uming/fonts-arphic-uming_${version}.orig.tar.bz2";
 
     postFetch = ''
       tar -xjvf $downloadedFile --strip-components=1

--- a/pkgs/development/compilers/apache-flex-sdk/default.nix
+++ b/pkgs/development/compilers/apache-flex-sdk/default.nix
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   version = "4.16.1";
 
   src = fetchurl {
-    url = "https://www.apache.org/dist/flex/${version}/binaries/${pname}-${version}-bin.tar.gz";
+    url = "mirror://apache/flex/${version}/binaries/${pname}-${version}-bin.tar.gz";
     sha256 = "13iq16dqvgcpb0p35x66hzxsq5pkbr2lbwr766nnqiryinnagz8p";
   };
 

--- a/pkgs/development/compilers/closure/default.nix
+++ b/pkgs/development/compilers/closure/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "20210808";
 
   src = fetchurl {
-    url = "https://repo1.maven.org/maven2/com/google/javascript/closure-compiler/v${version}/closure-compiler-v${version}.jar";
+    url = "mirror://maven/com/google/javascript/closure-compiler/v${version}/closure-compiler-v${version}.jar";
     sha256 = "1cvibvm8l4mp64ml6lpsh3w62bgbr42pi3i7ga8ss0prhr0dsk3y";
   };
 

--- a/pkgs/development/libraries/libopus/default.nix
+++ b/pkgs/development/libraries/libopus/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "1.3.1";
 
   src = fetchurl {
-    url = "https://archive.mozilla.org/pub/opus/opus-${version}.tar.gz";
+    url = "mirror://mozilla/opus/opus-${version}.tar.gz";
     sha256 = "17gz8kxs4i7icsc1gj713gadiapyklynlwqlf0ai98dj4lg8xdb5";
   };
 

--- a/pkgs/development/libraries/libopusenc/default.nix
+++ b/pkgs/development/libraries/libopusenc/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.2.1";
 
   src = fetchurl {
-    url = "https://archive.mozilla.org/pub/opus/libopusenc-${version}.tar.gz";
+    url = "mirror://mozilla/opus/libopusenc-${version}.tar.gz";
     sha256 = "1ffb0vhlymlsq70pxsjj0ksz77yfm2x0a1x8q50kxmnkm1hxp642";
   };
 

--- a/pkgs/development/libraries/libutempter/default.nix
+++ b/pkgs/development/libraries/libutempter/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   version = "1.1.6";
 
   src = fetchurl {
-    url = "http://archive.ubuntu.com/ubuntu/pool/main/libu/libutempter/libutempter_${version}.orig.tar.bz2";
+    url = "mirror://ubuntu/pool/main/libu/libutempter/libutempter_${version}.orig.tar.bz2";
     sha256 = "15y3xbgznjxnfmix4xg3bwmqdvghdw7slbhazb0ybmyf65gmd65q";
   };
 

--- a/pkgs/development/libraries/plplot/default.nix
+++ b/pkgs/development/libraries/plplot/default.nix
@@ -15,7 +15,7 @@ in stdenv.mkDerivation rec {
   version = "5.15.0";
 
   src = fetchurl {
-    url = "https://downloads.sourceforge.net/project/${pname}/${pname}/${version}%20Source/${pname}-${version}.tar.gz";
+    url = "mirror://sourceforge/project/${pname}/${pname}/${version}%20Source/${pname}-${version}.tar.gz";
     sha256 = "0ywccb6bs1389zjfmc9zwdvdsvlpm7vg957whh6b5a96yvcf8bdr";
   };
 

--- a/pkgs/development/libraries/serf/default.nix
+++ b/pkgs/development/libraries/serf/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "1.3.9";
 
   src = fetchurl {
-    url = "https://www.apache.org/dist/serf/${pname}-${version}.tar.bz2";
+    url = "mirror://apache/serf/${pname}-${version}.tar.bz2";
     sha256 = "1k47gbgpp52049andr28y28nbwh9m36bbb0g8p0aka3pqlhjv72l";
   };
 

--- a/pkgs/development/libraries/unixODBCDrivers/default.nix
+++ b/pkgs/development/libraries/unixODBCDrivers/default.nix
@@ -8,7 +8,7 @@
     version = "10.01.0000";
 
     src = fetchurl {
-      url = "http://ftp.postgresql.org/pub/odbc/versions/src/${pname}-${version}.tar.gz";
+      url = "mirror://postgresql/odbc/versions/src/${pname}-${version}.tar.gz";
       sha256 = "1cyams7157f3gry86x64xrplqi2vyqrq3rqka59gv4lb4rpl7jl7";
     };
 

--- a/pkgs/development/libraries/xalanc/default.nix
+++ b/pkgs/development/libraries/xalanc/default.nix
@@ -9,7 +9,7 @@ in stdenv.mkDerivation rec {
   version = "1.11";
 
   src = fetchurl {
-    url = "http://www.eu.apache.org/dist/xalan/xalan-c/sources/xalan_c-${version}-src.tar.gz";
+    url = "mirror://apache/xalan/xalan-c/sources/xalan_c-${version}-src.tar.gz";
     sha256 = "0a3a2b15vpacnqgpp6fiy1pwyc8q6ywzvyb5445f6wixfdspypjg";
   };
 

--- a/pkgs/development/libraries/xml-security-c/default.nix
+++ b/pkgs/development/libraries/xml-security-c/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "2.0.2";
 
   src = fetchurl {
-    url = "https://www.apache.org/dist/santuario/c-library/${pname}-${version}.tar.gz";
+    url = "mirror://apache/santuario/c-library/${pname}-${version}.tar.gz";
     sha256 = "1prh5sxzipkqglpsh53iblbr7rxi54wbijxdjiahzjmrijqa40y3";
   };
 

--- a/pkgs/development/mobile/titaniumenv/titaniumsdk-7.5.nix
+++ b/pkgs/development/mobile/titaniumenv/titaniumsdk-7.5.nix
@@ -15,23 +15,23 @@ let
   proguardVersion = "5.3.3";
 
   proguardGradlePOM = fetchurl {
-    url = "https://repo1.maven.org/maven2/net/sf/proguard/proguard-gradle/${proguardVersion}/proguard-gradle-${proguardVersion}.pom";
+    url = "mirror://maven/net/sf/proguard/proguard-gradle/${proguardVersion}/proguard-gradle-${proguardVersion}.pom";
     sha256 = "03v9zm3ykfkyb5cs5ald07ph103fh68d5c33rv070r29p71dwszj";
   };
   proguardGradleJAR = fetchurl {
-    url = "https://repo1.maven.org/maven2/net/sf/proguard/proguard-gradle/${proguardVersion}/proguard-gradle-${proguardVersion}.jar";
+    url = "mirror://maven/net/sf/proguard/proguard-gradle/${proguardVersion}/proguard-gradle-${proguardVersion}.jar";
     sha256 = "0shhpsjfc5gam15jnv1hk718v5c7vi7dwdc3gvmnid6dc85kljzk";
   };
   proguardParentPOM = fetchurl {
-    url = "https://repo1.maven.org/maven2/net/sf/proguard/proguard-parent/${proguardVersion}/proguard-parent-${proguardVersion}.pom";
+    url = "mirror://maven/net/sf/proguard/proguard-parent/${proguardVersion}/proguard-parent-${proguardVersion}.pom";
     sha256 = "0mv0zbwyw8xa4mkc5kw69y5xqashkz9gp123akfvh9f6152l3202";
   };
   proguardBasePOM = fetchurl {
-    url = "https://repo1.maven.org/maven2/net/sf/proguard/proguard-base/${proguardVersion}/proguard-base-${proguardVersion}.pom";
+    url = "mirror://maven/net/sf/proguard/proguard-base/${proguardVersion}/proguard-base-${proguardVersion}.pom";
     sha256 = "1jnr6zsxfimb8wglqlwa6rrdc3g3nqf1dyw0k2dq9cj0q4pgn7p5";
   };
   proguardBaseJAR = fetchurl {
-    url = "https://repo1.maven.org/maven2/net/sf/proguard/proguard-base/${proguardVersion}/proguard-base-${proguardVersion}.jar";
+    url = "mirror://maven/net/sf/proguard/proguard-base/${proguardVersion}/proguard-base-${proguardVersion}.jar";
     sha256 = "11nwdb9y84cghcx319nsjjf9m035s4s1184zrhzpvaxq2wvqhbhx";
   };
 

--- a/pkgs/development/mobile/titaniumenv/titaniumsdk-8.2.nix
+++ b/pkgs/development/mobile/titaniumenv/titaniumsdk-8.2.nix
@@ -15,23 +15,23 @@ let
   proguardVersion = "5.3.3";
 
   proguardGradlePOM = fetchurl {
-    url = "https://repo1.maven.org/maven2/net/sf/proguard/proguard-gradle/${proguardVersion}/proguard-gradle-${proguardVersion}.pom";
+    url = "mirror://maven/net/sf/proguard/proguard-gradle/${proguardVersion}/proguard-gradle-${proguardVersion}.pom";
     sha256 = "03v9zm3ykfkyb5cs5ald07ph103fh68d5c33rv070r29p71dwszj";
   };
   proguardGradleJAR = fetchurl {
-    url = "https://repo1.maven.org/maven2/net/sf/proguard/proguard-gradle/${proguardVersion}/proguard-gradle-${proguardVersion}.jar";
+    url = "mirror://maven/net/sf/proguard/proguard-gradle/${proguardVersion}/proguard-gradle-${proguardVersion}.jar";
     sha256 = "0shhpsjfc5gam15jnv1hk718v5c7vi7dwdc3gvmnid6dc85kljzk";
   };
   proguardParentPOM = fetchurl {
-    url = "https://repo1.maven.org/maven2/net/sf/proguard/proguard-parent/${proguardVersion}/proguard-parent-${proguardVersion}.pom";
+    url = "mirror://maven/net/sf/proguard/proguard-parent/${proguardVersion}/proguard-parent-${proguardVersion}.pom";
     sha256 = "0mv0zbwyw8xa4mkc5kw69y5xqashkz9gp123akfvh9f6152l3202";
   };
   proguardBasePOM = fetchurl {
-    url = "https://repo1.maven.org/maven2/net/sf/proguard/proguard-base/${proguardVersion}/proguard-base-${proguardVersion}.pom";
+    url = "mirror://maven/net/sf/proguard/proguard-base/${proguardVersion}/proguard-base-${proguardVersion}.pom";
     sha256 = "1jnr6zsxfimb8wglqlwa6rrdc3g3nqf1dyw0k2dq9cj0q4pgn7p5";
   };
   proguardBaseJAR = fetchurl {
-    url = "https://repo1.maven.org/maven2/net/sf/proguard/proguard-base/${proguardVersion}/proguard-base-${proguardVersion}.jar";
+    url = "mirror://maven/net/sf/proguard/proguard-base/${proguardVersion}/proguard-base-${proguardVersion}.jar";
     sha256 = "11nwdb9y84cghcx319nsjjf9m035s4s1184zrhzpvaxq2wvqhbhx";
   };
 

--- a/pkgs/development/mobile/titaniumenv/titaniumsdk-8.3.nix
+++ b/pkgs/development/mobile/titaniumenv/titaniumsdk-8.3.nix
@@ -15,23 +15,23 @@ let
   proguardVersion = "5.3.3";
 
   proguardGradlePOM = fetchurl {
-    url = "https://repo1.maven.org/maven2/net/sf/proguard/proguard-gradle/${proguardVersion}/proguard-gradle-${proguardVersion}.pom";
+    url = "mirror://maven/net/sf/proguard/proguard-gradle/${proguardVersion}/proguard-gradle-${proguardVersion}.pom";
     sha256 = "03v9zm3ykfkyb5cs5ald07ph103fh68d5c33rv070r29p71dwszj";
   };
   proguardGradleJAR = fetchurl {
-    url = "https://repo1.maven.org/maven2/net/sf/proguard/proguard-gradle/${proguardVersion}/proguard-gradle-${proguardVersion}.jar";
+    url = "mirror://maven/net/sf/proguard/proguard-gradle/${proguardVersion}/proguard-gradle-${proguardVersion}.jar";
     sha256 = "0shhpsjfc5gam15jnv1hk718v5c7vi7dwdc3gvmnid6dc85kljzk";
   };
   proguardParentPOM = fetchurl {
-    url = "https://repo1.maven.org/maven2/net/sf/proguard/proguard-parent/${proguardVersion}/proguard-parent-${proguardVersion}.pom";
+    url = "mirror://maven/net/sf/proguard/proguard-parent/${proguardVersion}/proguard-parent-${proguardVersion}.pom";
     sha256 = "0mv0zbwyw8xa4mkc5kw69y5xqashkz9gp123akfvh9f6152l3202";
   };
   proguardBasePOM = fetchurl {
-    url = "https://repo1.maven.org/maven2/net/sf/proguard/proguard-base/${proguardVersion}/proguard-base-${proguardVersion}.pom";
+    url = "mirror://maven/net/sf/proguard/proguard-base/${proguardVersion}/proguard-base-${proguardVersion}.pom";
     sha256 = "1jnr6zsxfimb8wglqlwa6rrdc3g3nqf1dyw0k2dq9cj0q4pgn7p5";
   };
   proguardBaseJAR = fetchurl {
-    url = "https://repo1.maven.org/maven2/net/sf/proguard/proguard-base/${proguardVersion}/proguard-base-${proguardVersion}.jar";
+    url = "mirror://maven/net/sf/proguard/proguard-base/${proguardVersion}/proguard-base-${proguardVersion}.jar";
     sha256 = "11nwdb9y84cghcx319nsjjf9m035s4s1184zrhzpvaxq2wvqhbhx";
   };
 

--- a/pkgs/development/ocaml-modules/inifiles/default.nix
+++ b/pkgs/development/ocaml-modules/inifiles/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   name = "ocaml${ocaml.version}-inifiles-1.2";
 
   src = fetchurl {
-    url = "http://archive.ubuntu.com/ubuntu/pool/universe/o/ocaml-inifiles/ocaml-inifiles_1.2.orig.tar.gz";
+    url = "mirror://ubuntu/pool/universe/o/ocaml-inifiles/ocaml-inifiles_1.2.orig.tar.gz";
     sha256 = "0jhzgiypmh6hwsv1zpiq77fi0cvcmwbiy5x0yg7mz6p3dh1dmkns";
   };
 

--- a/pkgs/development/tools/avro-tools/default.nix
+++ b/pkgs/development/tools/avro-tools/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url =
-    "https://repo1.maven.org/maven2/org/apache/avro/avro-tools/${version}/${pname}-${version}.jar";
+    "mirror://maven/org/apache/avro/avro-tools/${version}/${pname}-${version}.jar";
     sha256 = "169cv4fjsj69fa2s87gh1i7wk0xzh3l7sx5yyz3cgyjalg4a12n1";
   };
 

--- a/pkgs/development/tools/flyway/default.nix
+++ b/pkgs/development/tools/flyway/default.nix
@@ -3,7 +3,7 @@ stdenv.mkDerivation rec{
   pname = "flyway";
   version = "7.13.0";
   src = fetchurl {
-    url = "https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${version}/flyway-commandline-${version}.tar.gz";
+    url = "mirror://maven/org/flywaydb/flyway-commandline/${version}/flyway-commandline-${version}.tar.gz";
     sha256 = "sha256-rZUVxswJdCFKwuXlzko+t+ZO1plRgH2VcZFJ5kkiM2s=";
   };
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/misc/drivers/epson-alc1100/default.nix
+++ b/pkgs/misc/drivers/epson-alc1100/default.nix
@@ -4,7 +4,7 @@ let
   version = "1.2-0";
 
   libstdcpp5 = fetchurl {
-    url = "http://old-releases.ubuntu.com/ubuntu/pool/universe/g/gcc-3.3/libstdc++5_3.3.6-17ubuntu1_i386.deb";
+    url = "mirror://ubuntu/pool/universe/g/gcc-3.3/libstdc++5_3.3.6-17ubuntu1_i386.deb";
     sha256 = "10f8zcmqaa7skvg2bz94mnlgqpan4iscvi8913r6iawjh7hiisjy";
   };
 in

--- a/pkgs/os-specific/linux/pax-utils/default.nix
+++ b/pkgs/os-specific/linux/pax-utils/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.3.3";
 
   src = fetchurl {
-    url = "http://distfiles.gentoo.org/distfiles/${pname}-${version}.tar.xz";
+    url = "mirror://gentoo/distfiles/${pname}-${version}.tar.xz";
     sha256 = "sha256-7sp/vZi8Zr6tSncADCAl2fF+qCAbhCRYgkBs4AubaxQ=";
   };
 

--- a/pkgs/servers/fingerd/bsd-fingerd/default.nix
+++ b/pkgs/servers/fingerd/bsd-fingerd/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   version = "0.17";
 
   src = fetchurl {
-    url = "ftp://ftp.metalab.unc.edu/pub/linux/system/network/finger/bsd-finger-${version}.tar.gz";
+    url = "mirror://metalab/system/network/finger/bsd-finger-${version}.tar.gz";
     sha256 = "1yhkiv0in588il7f84k2xiy78g9lv12ll0y7047gazhiimk5v244";
   };
 

--- a/pkgs/servers/http/jetty/default.nix
+++ b/pkgs/servers/http/jetty/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   pname = "jetty";
   version = "9.4.43.v20210629";
   src = fetchurl {
-    url = "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/${version}/jetty-distribution-${version}.tar.gz";
+    url = "mirror://maven/org/eclipse/jetty/jetty-distribution/${version}/jetty-distribution-${version}.tar.gz";
     sha256 = "sha256-AfrmVLCZMuRGAZqoWeevbgXifbreErVM17rjJJ/HI9k=";
   };
 

--- a/pkgs/tools/cd-dvd/brasero/default.nix
+++ b/pkgs/tools/cd-dvd/brasero/default.nix
@@ -12,7 +12,7 @@ in stdenv.mkDerivation rec {
   pname = "brasero";
 
   src = fetchurl {
-    url = "http://download.gnome.org/sources/brasero/${major}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/brasero/${major}/${pname}-${version}.tar.xz";
     sha256 = "0h90y674j26rvjahb8cc0w79zx477rb6zaqcj26wzvq8kmpic8k8";
   };
 

--- a/pkgs/tools/networking/bsd-finger/default.nix
+++ b/pkgs/tools/networking/bsd-finger/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   version = "0.17";
 
   src = fetchurl {
-    url = "ftp://ftp.metalab.unc.edu/pub/linux/system/network/finger/bsd-finger-${version}.tar.gz";
+    url = "mirror://metalab/system/network/finger/bsd-finger-${version}.tar.gz";
     sha256 = "1yhkiv0in588il7f84k2xiy78g9lv12ll0y7047gazhiimk5v244";
   };
 

--- a/pkgs/tools/networking/dhcpdump/default.nix
+++ b/pkgs/tools/networking/dhcpdump/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.8";
 
   src = fetchurl {
-    url = "http://archive.ubuntu.com/ubuntu/pool/universe/d/dhcpdump/dhcpdump_${version}.orig.tar.gz";
+    url = "mirror://ubuntu/pool/universe/d/dhcpdump/dhcpdump_${version}.orig.tar.gz";
     sha256 = "143iyzkqvhj4dscwqs75jvfr4wvzrs11ck3fqn5p7yv2h50vjpkd";
   };
 

--- a/pkgs/tools/networking/sshoogr/default.nix
+++ b/pkgs/tools/networking/sshoogr/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.9.26";
 
   src = fetchzip {
-    url = "https://repo1.maven.org/maven2/com/aestasit/infrastructure/${pname}/${pname}/${version}/${pname}-${version}.zip";
+    url = "mirror://maven/com/aestasit/infrastructure/${pname}/${pname}/${version}/${pname}-${version}.zip";
     sha256 = "134qlx90y82g1rfxhyn12z9r2imm1l3fz09hrrn3pgcdcq5jz2s1";
   };
 

--- a/pkgs/tools/networking/swagger-codegen/default.nix
+++ b/pkgs/tools/networking/swagger-codegen/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   ];
 
   src = fetchurl {
-    url = "https://repo1.maven.org/maven2/io/swagger/${pname}-cli/${version}/${jarfilename}";
+    url = "mirror://maven/io/swagger/${pname}-cli/${version}/${jarfilename}";
     sha256 = "04wl5k8k1ziqz7k5w0g7i6zdfn41pbh3k0m8vq434k1886inf8yn";
   };
 

--- a/pkgs/tools/networking/swagger-codegen3/default.nix
+++ b/pkgs/tools/networking/swagger-codegen3/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   ];
 
   src = fetchurl {
-    url = "https://repo1.maven.org/maven2/io/swagger/codegen/v3/${pname}-cli/${version}/${jarfilename}";
+    url = "mirror://maven/io/swagger/codegen/v3/${pname}-cli/${version}/${jarfilename}";
     sha256 = "sha256-sEwqUmtWaoBV0QmdP8ibm3neqWHk7+tWLAuO2FaCUtQ=";
   };
 

--- a/pkgs/tools/text/dirdiff/default.nix
+++ b/pkgs/tools/text/dirdiff/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "2.1";
 
   src = fetchurl {
-    url = "https://www.samba.org/ftp/paulus/${pname}-${version}.tar.gz";
+    url = "mirror://samba/paulus/${pname}-${version}.tar.gz";
     sha256 = "0lljd8av68j70733yshzzhxjr1lm0vgmbqsm8f02g03qsma3cdyb";
   };
 

--- a/pkgs/tools/text/sgml/jade/default.nix
+++ b/pkgs/tools/text/sgml/jade/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   patchsrc =  fetchurl {
-    url = "http://ftp.debian.org/debian/pool/main/j/jade/jade_${version}-${debpatch}.diff.gz";
+    url = "mirror://debian/pool/main/j/jade/jade_${version}-${debpatch}.diff.gz";
     sha256 = "8e94486898e3503308805f856a65ba5b499a6f21994151270aa743de48305464";
   };
 


### PR DESCRIPTION
Candidates identified with

	git grep -F "$(grep -v '#' pkgs/build-support/fetchurl/mirrors.nix |
		grep -v nixos.org | grep :// | cut -d '"' -f 2)"

and then manually reviewed and tested.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
