### PR TITLE
gcc: reenable LTO on i686

### DIFF
--- a/pkgs/applications/misc/curaengine/stable.nix
+++ b/pkgs/applications/misc/curaengine/stable.nix
@@ -13,8 +13,6 @@ stdenv.mkDerivation {
 
   postPatch = ''
     substituteInPlace Makefile --replace "--static" ""
-  '' + lib.optionalString stdenv.isi686 ''
-    substituteInPlace Makefile --replace "-flto" ""
   '';
 
   installPhase = ''

--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -30,10 +30,6 @@ edk2.mkDerivation projectDscPath {
 
   hardeningDisable = [ "format" "stackprotector" "pic" "fortify" ];
 
-  # Fails on i686 with:
-  # 'cc1: error: LTO support has not been enabled in this configuration'
-  NIX_CFLAGS_COMPILE = lib.optionals stdenv.isi686 [ "-fno-lto" ];
-
   buildFlags =
     lib.optionals secureBoot [ "-D SECURE_BOOT_ENABLE=TRUE" ]
     ++ lib.optionals csmSupport [ "-D CSM_ENABLE" "-D FD_SIZE_2MB" ]

--- a/pkgs/development/libraries/amdvlk/default.nix
+++ b/pkgs/development/libraries/amdvlk/default.nix
@@ -65,9 +65,6 @@ in stdenv.mkDerivation rec {
 
   cmakeDir = "../drivers/xgl";
 
-  # LTO is disabled in gcc for i686 as of #66528
-  cmakeFlags = lib.optionals stdenv.is32bit ["-DXGL_ENABLE_LTO=OFF"];
-
   installPhase = ''
     install -Dm755 -t $out/lib icd/amdvlk${suffix}.so
     install -Dm644 -t $out/share/vulkan/icd.d icd/amd_icd${suffix}.json

--- a/pkgs/servers/klipper/default.nix
+++ b/pkgs/servers/klipper/default.nix
@@ -15,12 +15,6 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-vUhP71vZ5XFG7MDkPFpAcCUL4kIdzHJ1hAkwqIi6ksQ=";
   };
 
-  # We have no LTO on i686 since commit 22284b0
-  postPatch = lib.optionalString stdenv.isi686 ''
-    substituteInPlace chelper/__init__.py \
-      --replace "-flto -fwhole-program " ""
-  '';
-
   sourceRoot = "source/klippy";
 
   # there is currently an attempt at moving it to Python 3, but it will remain

--- a/pkgs/tools/system/efibootmgr/default.nix
+++ b/pkgs/tools/system/efibootmgr/default.nix
@@ -22,8 +22,6 @@ stdenv.mkDerivation rec {
       sha256 = "1sbijvlpv4khkix3vix9mbhzffj8lp8zpnbxm9gnzjz8yssz9p5h";
     })
   ];
-  # We have no LTO here since commit 22284b07.
-  postPatch = if stdenv.isi686 then "sed '/^CFLAGS/s/-flto//' -i Make.defaults" else null;
 
   makeFlags = [ "EFIDIR=nixos" "PKG_CONFIG=${stdenv.cc.targetPrefix}pkg-config" ];
 

--- a/pkgs/tools/system/efivar/default.nix
+++ b/pkgs/tools/system/efivar/default.nix
@@ -39,9 +39,11 @@ stdenv.mkDerivation rec {
       sha256 = "1ajj11wwsvamfspq4naanvw08h63gr0g71q0dfbrrywrhc0jlmdw";
     })
   ];
-  # We have no LTO here since commit 22284b07.  With GCC 10 that triggers a warning.
-  postPatch = "sed '/^OPTIMIZE /s/-flto//' -i Make.defaults";
-  NIX_CFLAGS_COMPILE = "-Wno-error=stringop-truncation";
+
+  NIX_CFLAGS_COMPILE = [
+    "-Wno-error=stringop-truncation"
+    "-flto-partition=none"
+  ];
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ popt ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11702,8 +11702,6 @@ with pkgs;
     reproducibleBuild = true;
     profiledCompiler = false;
 
-    enableLTO = !stdenv.isi686;
-
     libcCross = if stdenv.targetPlatform != stdenv.buildPlatform then libcCross else null;
     threadsCross = if stdenv.targetPlatform != stdenv.buildPlatform then threadsCross else null;
 
@@ -11716,8 +11714,6 @@ with pkgs;
     reproducibleBuild = true;
     profiledCompiler = false;
 
-    enableLTO = !stdenv.isi686;
-
     libcCross = if stdenv.targetPlatform != stdenv.buildPlatform then libcCross else null;
     threadsCross = if stdenv.targetPlatform != stdenv.buildPlatform then threadsCross else null;
 
@@ -11729,8 +11725,6 @@ with pkgs;
 
     reproducibleBuild = true;
     profiledCompiler = false;
-
-    enableLTO = !stdenv.isi686;
 
     libcCross = if stdenv.targetPlatform != stdenv.buildPlatform then libcCross else null;
     threadsCross = if stdenv.targetPlatform != stdenv.buildPlatform then threadsCross else null;


### PR DESCRIPTION
This reverts https://github.com/NixOS/nixpkgs/commit/22284b07ef1ca082d14cde8205567b3af4fd27df, and cleans up the fallout from i686 not having LTO for a while.

I've tested on the full matrix of 32/64-bit linux native/cross, i.e.

* native 64-bit (pkgs)
* native 32-bit (pkgsi686Linux)
* 64 -> 32 cross (pkgsCross.gnu32)
* 32 -> 64 cross (pkgsi686Linux.pkgsCross.gnu64)

All the packages which now have LTO enabled have been tested on at least pkgsi686Linux, and have been cross-compiled as well when they support it.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Closes https://github.com/NixOS/nixpkgs/issues/143901

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
