### PR TITLE
picoscope: 6.14.44 -> 7.0.83

### DIFF
--- a/pkgs/applications/science/electronics/picoscope/sources.json
+++ b/pkgs/applications/science/electronics/picoscope/sources.json
@@ -1,146 +1,69 @@
 {
-  "armv7l-linux": {
-    "libpl1000": {
-      "sha256": "10827029023fb1fd8085f216fc75e09010acb081fdaa4a65f81cfd7436bed84b",
-      "url": "https://labs.picotech.com/debian/pool/main/libp/libpl1000/libpl1000_2.0.61-1r2597_armhf.deb",
-      "version": "2.0.61-1r2597"
-    },
-    "libps2000": {
-      "sha256": "21d09b8a792ad7c6cd90dc51ba073c21c7dbd17ec6e5c88752b7c2c5a15be73f",
-      "url": "https://labs.picotech.com/debian/pool/main/libp/libps2000/libps2000_3.0.63-3r2621_armhf.deb",
-      "version": "3.0.63-3r2621"
-    },
-    "libps2000a": {
-      "sha256": "8293fe86d6d0f12dcefc67d3bf694ec7922dd28c80baab8aa6bc5a01a152e0a9",
-      "url": "https://labs.picotech.com/debian/pool/main/libp/libps2000a/libps2000a_2.1.61-5r2597_armhf.deb",
-      "version": "2.1.61-5r2597"
-    },
-    "libps3000": {
-      "sha256": "3289ad3671767ab767f9308106d664a57a09578142a82fc62ec4b68df23e8ef1",
-      "url": "https://labs.picotech.com/debian/pool/main/libp/libps3000/libps3000_4.0.63-3r2621_armhf.deb",
-      "version": "4.0.63-3r2621"
-    },
-    "libps3000a": {
-      "sha256": "e5c8c1dc94cc9924ec08a821fd92351c8ef05df8bb53bd2855e59d81358a33d6",
-      "url": "https://labs.picotech.com/debian/pool/main/libp/libps3000a/libps3000a_2.1.61-6r2597_armhf.deb",
-      "version": "2.1.61-6r2597"
-    },
-    "libps4000": {
-      "sha256": "5c2abeb819964c2902e5a17b22ecf184d5fb78cd399cf56b3d0301428f7e4631",
-      "url": "https://labs.picotech.com/debian/pool/main/libp/libps4000/libps4000_2.1.61-2r2597_armhf.deb",
-      "version": "2.1.61-2r2597"
-    },
-    "libps4000a": {
-      "sha256": "fd3a37c9d22137bed5c7a7013e0afc408e7dc9abac759b900ac23733fcd736e8",
-      "url": "https://labs.picotech.com/debian/pool/main/libp/libps4000a/libps4000a_2.1.61-2r2597_armhf.deb",
-      "version": "2.1.61-2r2597"
-    },
-    "libps5000": {
-      "sha256": "5554829e24778b77da4a4ea30d074859bec30b56c1400aa4771429961050a7d6",
-      "url": "https://labs.picotech.com/debian/pool/main/libp/libps5000/libps5000_2.1.61-3r2597_armhf.deb",
-      "version": "2.1.61-3r2597"
-    },
-    "libps5000a": {
-      "sha256": "ee88e0c5f4f1f398c62b9672c30a08a94b14e1402d4769b66ed90c3dd9368d38",
-      "url": "https://labs.picotech.com/debian/pool/main/libp/libps5000a/libps5000a_2.1.61-5r2597_armhf.deb",
-      "version": "2.1.61-5r2597"
-    },
-    "libps6000": {
-      "sha256": "1470ca16d2b48141d0385e903d5aab883164fa6c9f29abd79713b52abc532442",
-      "url": "https://labs.picotech.com/debian/pool/main/libp/libps6000/libps6000_2.1.61-6r2597_armhf.deb",
-      "version": "2.1.61-6r2597"
-    },
-    "libps6000a": {
-      "sha256": "7eb5668fe22c6f042a63a218e1b2eed983d8d9d92bfc525a98bd95a37f3de3ef",
-      "url": "https://labs.picotech.com/debian/pool/main/libp/libps6000a/libps6000a_1.0.61-0r2608_armhf.deb",
-      "version": "1.0.61-0r2608"
-    },
-    "libusbdrdaq": {
-      "sha256": "3dc7c4ea506eb0384d2b81214c00f39951bfaf196988ccf373a3e3e2dd342c41",
-      "url": "https://labs.picotech.com/debian/pool/main/libu/libusbdrdaq/libusbdrdaq_2.0.61-1r2597_armhf.deb",
-      "version": "2.0.61-1r2597"
-    },
-    "picoscope": {
-      "sha256": "448cfebcb20b18e7b27c05b0af4f44779d087b2d6046ad99d98c773321fb3e17",
-      "url": "https://labs.picotech.com/debian/pool/main/p/picoscope/picoscope_6.14.44-4r5870_all.deb",
-      "version": "6.14.44-4r5870"
-    }
-  },
   "x86_64-linux": {
-    "libpicoipp": {
-      "sha256": "c7c052d2214f1fc54c07dbe20b6cf650e9b1d658aa7b989acdaeb7c1639ba761",
-      "url": "https://labs.picotech.com/debian/pool/main/libp/libpicoipp/libpicoipp_1.3.0-4r78_amd64.deb",
-      "version": "1.3.0-4r78"
+    "libpicocv": {
+      "sha256": "c2e74c2b0679df0226993d063b38d0eda5b05ff59f29bbfa12ded5226df37024",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libpicocv/libpicocv_1.1.27-1r153_amd64.deb",
+      "version": "1.1.27-1r153"
     },
-    "libpl1000": {
-      "sha256": "c6b7bb916129a7cf821c2e28e42914b9ac1a23cc1521fb78dec5aa59283790ac",
-      "url": "https://labs.picotech.com/debian/pool/main/libp/libpl1000/libpl1000_2.0.61-1r2597_amd64.deb",
-      "version": "2.0.61-1r2597"
+    "libpicoipp": {
+      "sha256": "87ae49cd5e8dda4a73a835b95ea13e4c3fc4d1c4c9d6495c9affdf6fa6b1b4aa",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libpicoipp/libpicoipp_1.3.0-4r121_amd64.deb",
+      "version": "1.3.0-4r121"
     },
     "libps2000": {
-      "sha256": "9b4af7a07f53d8cc056386e036ecd3731519d4ebf8f62a02def5c022509255ac",
-      "url": "https://labs.picotech.com/debian/pool/main/libp/libps2000/libps2000_3.0.63-3r2621_amd64.deb",
-      "version": "3.0.63-3r2621"
+      "sha256": "792e506c08cebbd617e833e1547d3e5a13a186f93cea3f84608b7ed9451fb077",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps2000/libps2000_3.0.75-3r2957_amd64.deb",
+      "version": "3.0.75-3r2957"
     },
     "libps2000a": {
-      "sha256": "cfecbf6c04330a4439e8609c9973192f7a249a3b2853e6df1d63ab24a4d0ef89",
-      "url": "https://labs.picotech.com/debian/pool/main/libp/libps2000a/libps2000a_2.1.61-5r2597_amd64.deb",
-      "version": "2.1.61-5r2597"
+      "sha256": "f31b3a8e9c6af14a59e348e4b302f12f582cdb08a47a3c04d8a6a612b4630305",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps2000a/libps2000a_2.1.75-5r2957_amd64.deb",
+      "version": "2.1.75-5r2957"
     },
     "libps3000": {
-      "sha256": "7052b872463e95c78f118f494d546c2b0758e1505297e9eaa3916dba5e24d85e",
-      "url": "https://labs.picotech.com/debian/pool/main/libp/libps3000/libps3000_4.0.63-3r2621_amd64.deb",
-      "version": "4.0.63-3r2621"
+      "sha256": "27dce3c924bb0169768a4964ce567b4a18ce74079537ca1fcba61e9234691580",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps3000/libps3000_4.0.75-3r2957_amd64.deb",
+      "version": "4.0.75-3r2957"
     },
     "libps3000a": {
-      "sha256": "fbc64876731c6a8b7e1dc5b95113568819e7122acebc84dcabe102b900dfbb0d",
-      "url": "https://labs.picotech.com/debian/pool/main/libp/libps3000a/libps3000a_2.1.61-6r2597_amd64.deb",
-      "version": "2.1.61-6r2597"
+      "sha256": "31cf00ce136526af6e8b211a44a56b221d137de6eaec4d6fd7f31593b4245d62",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps3000a/libps3000a_2.1.75-6r2957_amd64.deb",
+      "version": "2.1.75-6r2957"
     },
     "libps4000": {
-      "sha256": "84cc299e05d2ff73ef11d5f36e1f944e1cc8a93a19541a17db30d3cd45b383c1",
-      "url": "https://labs.picotech.com/debian/pool/main/libp/libps4000/libps4000_2.1.61-2r2597_amd64.deb",
-      "version": "2.1.61-2r2597"
+      "sha256": "c976f09647f1fd2c980aafd1efe7f557bfc7c283fb9c135725c38dd59cc297e9",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps4000/libps4000_2.1.75-2r2957_amd64.deb",
+      "version": "2.1.75-2r2957"
     },
     "libps4000a": {
-      "sha256": "1839d654407dee76435f918c4df35d78edebcc45f442649fc964ee0470fcee30",
-      "url": "https://labs.picotech.com/debian/pool/main/libp/libps4000a/libps4000a_2.1.61-2r2597_amd64.deb",
-      "version": "2.1.61-2r2597"
+      "sha256": "727f24fa74759385902d41d52a26a4636b3e3f08a8743901d15cc49622207b97",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps4000a/libps4000a_2.1.75-2r2957_amd64.deb",
+      "version": "2.1.75-2r2957"
     },
     "libps5000": {
-      "sha256": "ed2bd627f08fd98e93a22f824b8e81fc7ff7342dabd9fae748e12a10ec95d08a",
-      "url": "https://labs.picotech.com/debian/pool/main/libp/libps5000/libps5000_2.1.61-3r2597_amd64.deb",
-      "version": "2.1.61-3r2597"
+      "sha256": "3237c1dfdb384079b7039d2b4a8e0b0126e804830b29d60e89ae018182667edb",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps5000/libps5000_2.1.75-3r2957_amd64.deb",
+      "version": "2.1.75-3r2957"
     },
     "libps5000a": {
-      "sha256": "78fd28bbc7817098f57ba886e847fe76e65e0321c1bf0880b0b3066499626c5e",
-      "url": "https://labs.picotech.com/debian/pool/main/libp/libps5000a/libps5000a_2.1.61-5r2597_amd64.deb",
-      "version": "2.1.61-5r2597"
+      "sha256": "27947f8461a16cf59d64cd23d7a78ddd27826e38dfe9fca3902e3b553591fb19",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps5000a/libps5000a_2.1.75-5r2957_amd64.deb",
+      "version": "2.1.75-5r2957"
     },
     "libps6000": {
-      "sha256": "bb05cf15661b837bb4def618828214bc7aedd99f42737d3f4b77757a113f66ae",
-      "url": "https://labs.picotech.com/debian/pool/main/libp/libps6000/libps6000_2.1.61-6r2597_amd64.deb",
-      "version": "2.1.61-6r2597"
+      "sha256": "d65e923db969e306fb9f3f3892229a297d6187574d901dde44375270cc1e1404",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps6000/libps6000_2.1.75-6r2957_amd64.deb",
+      "version": "2.1.75-6r2957"
     },
     "libps6000a": {
-      "sha256": "4fd31727e30c2f6833729e15ff7d88d8fa30876031707b5727752b4ce3582cc7",
-      "url": "https://labs.picotech.com/debian/pool/main/libp/libps6000a/libps6000a_1.0.61-0r2608_amd64.deb",
-      "version": "1.0.61-0r2608"
-    },
-    "libusbdrdaq": {
-      "sha256": "44badb6f876db1d47612bd1c37fdab8b27e95cc0ed4f2bd71dcec08adec74ce1",
-      "url": "https://labs.picotech.com/debian/pool/main/libu/libusbdrdaq/libusbdrdaq_2.0.61-1r2597_amd64.deb",
-      "version": "2.0.61-1r2597"
-    },
-    "picomono": {
-      "sha256": "2baf917e4e727ee8d6e395545a32b9ecb3820ffbc66cd28bc56e8aaeafbb0433",
-      "url": "https://labs.picotech.com/debian/pool/main/p/picomono/picomono_4.6.2.16-1r02_amd64.deb",
-      "version": "4.6.2.16-1r02"
+      "sha256": "eff8644ad44f9cc1cf9052e27786a1480a4ab599766c1c01e370fef40a76b224",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps6000a/libps6000a_1.0.75-0r2957_amd64.deb",
+      "version": "1.0.75-0r2957"
     },
     "picoscope": {
-      "sha256": "448cfebcb20b18e7b27c05b0af4f44779d087b2d6046ad99d98c773321fb3e17",
-      "url": "https://labs.picotech.com/debian/pool/main/p/picoscope/picoscope_6.14.44-4r5870_all.deb",
-      "version": "6.14.44-4r5870"
+      "sha256": "3d2a0e360c8143fc03c29b394c16bfc2387164e33099a46b6905af992cfab440",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/p/picoscope/picoscope_7.0.83-1r9320_amd64.deb",
+      "version": "7.0.83-1r9320"
     }
   }
 }

--- a/pkgs/applications/science/electronics/picoscope/update.py
+++ b/pkgs/applications/science/electronics/picoscope/update.py
@@ -23,15 +23,15 @@ def generate_sources(packages):
     sources_spec = {}
     for pkg in pkgs:
         sources_spec[pkg['Package']] = {
-            "url": "https://labs.picotech.com/debian/" + pkg["Filename"],
+            "url": "https://labs.picotech.com/rc/picoscope7/debian/" + pkg["Filename"],
             "sha256": pkg["SHA256"],
             "version": pkg["Version"]
         }
     return sources_spec
 
 out = {}
-for nix_system, release in {"x86_64-linux": "amd64", "armv7l-linux": "armhf"}.items():
-    resp = requests.get("https://labs.picotech.com/debian/dists/picoscope/main/binary-"+release+"/Packages")
+for nix_system, release in {"x86_64-linux": "amd64"}.items():
+    resp = requests.get("https://labs.picotech.com/rc/picoscope7/debian//dists/picoscope/main/binary-"+release+"/Packages")
     if resp.status_code != 200:
         print("error: could not fetch data for release {} (code {})".format(release, resp.code), file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
Based on https://github.com/NixOS/nixpkgs/pull/123511 (which is based on
https://github.com/NixOS/nixpkgs/pull/122160).

This also removes armv7l-linux for which there is no 7 release. The machinery is kept in place for multiple platforms though in case this changes in the future.

CC @yorickvP @wirew0rm

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).