### PR TITLE
sarasa-gothic: Use TTC format instead of TTF

### DIFF
--- a/pkgs/data/fonts/sarasa-gothic/default.nix
+++ b/pkgs/data/fonts/sarasa-gothic/default.nix
@@ -5,8 +5,10 @@ let
 in fetchurl {
   name = "sarasa-gothic-${version}";
 
-  url = "https://github.com/be5invis/Sarasa-Gothic/releases/download/v${version}/sarasa-gothic-ttf-${version}.7z";
-  sha256 = "094sl6gklrdv9pk4r6451dvz0fjyjmwys7i81qrz4ik1km5dfq9b";
+  # Use the 'ttc' files here for a smaller closure size.
+  # (Using 'ttf' files gives a closure size about 15x larger, as of November 2021.)
+  url = "https://github.com/be5invis/Sarasa-Gothic/releases/download/v${version}/sarasa-gothic-ttc-${version}.7z";
+  sha256 = "0fzbqj32jiffqsr4s0i8fignk01v5d1rik6ldg2q7dgl1298sgk8";
 
   recursiveHash = true;
   downloadToTemp = true;
@@ -21,7 +23,6 @@ in fetchurl {
     homepage = "https://github.com/be5invis/Sarasa-Gothic";
     license = licenses.ofl;
     maintainers = [ maintainers.ChengCat ];
-    hydraPlatforms = [ ]; # disabled from hydra because it's so big
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

(This is pretty much the same as the most important part of #50974.)

This greatly reduces closure size, from 12GB to less than 800MB

```text
# Before
/nix/store/zcfrphbpv407345czsi6a0mjq8q0iiff-sarasa-gothic-0.34.7         12.0G

# After
/nix/store/fd125y79xrymwgiz22glx4yc25n7s93z-sarasa-gothic-0.34.7         763.6M
```

I see no good reason to use the TTF versions of these fonts. All other distros that I could find that have sarasa-gothic uses the TTC files:

- Arch Linux: https://github.com/archlinux/svntogit-community/blob/packages/ttf-sarasa-gothic/trunk/PKGBUILD
- Guix: https://git.savannah.gnu.org/cgit/guix.git/tree/gnu/packages/fonts.scm#n1448 (I couldn't find a permalink. If link goes out of date, search for `define-public font-sarasa-gothic`)
- Void Linux: https://github.com/void-linux/void-packages/blob/master/srcpkgs/font-sarasa-gothic/template

Since the closure size is much smaller, I also removed `hydraPlatforms = [];` from the expression.

(cc: @marsam, Was the change to use ttf intentional? Trying to make sure I'm not breaking something over and over again.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
