### PR TITLE
Quote variable references

### DIFF
--- a/pkgs/build-support/wrapper-common/utils.bash
+++ b/pkgs/build-support/wrapper-common/utils.bash
@@ -146,7 +146,7 @@ checkLinkType() {
 # When building static-pie executables we cannot have rpath
 # set. At least glibc requires rpath to be empty
 filterRpathFlags() {
-    local linkType=$1 ret="" i
+    local linkType=$1 ret i
     shift
 
     if [[ "$linkType" == "static-pie" ]]; then
@@ -156,11 +156,11 @@ filterRpathFlags() {
                 # also skip its argument
                 shift
             else
-                ret+="$i "
+                ret+=("$i")
             fi
         done
     else
-        ret=$@
+        ret=("$@")
     fi
-    echo $ret
+    echo "${ret[@]}"
 }

--- a/pkgs/build-support/wrapper-common/utils.bash
+++ b/pkgs/build-support/wrapper-common/utils.bash
@@ -27,7 +27,7 @@ mangleVarListGeneric() {
     for suffix in "${role_suffixes[@]}"; do
         local inputVar="${var}${suffix}"
         if [ -v "$inputVar" ]; then
-            export ${outputVar}+="${!outputVar:+$sep}${!inputVar}"
+            export "${outputVar}+=${!outputVar:+$sep}${!inputVar}"
         fi
     done
 }
@@ -42,7 +42,7 @@ mangleVarBool() {
     local -a role_suffixes=("$@")
 
     local outputVar="${var}_@suffixSalt@"
-    declare -gxi ${outputVar}+=0
+    declare -gxi "${outputVar}+=0"
     for suffix in "${role_suffixes[@]}"; do
         local inputVar="${var}${suffix}"
         if [ -v "$inputVar" ]; then

--- a/pkgs/build-support/wrapper-common/utils.bash
+++ b/pkgs/build-support/wrapper-common/utils.bash
@@ -21,7 +21,7 @@ mangleVarListGeneric() {
     local -a role_suffixes=("$@")
 
     local outputVar="${var}_@suffixSalt@"
-    declare -gx ${outputVar}+=''
+    declare -gx "$outputVar"+=''
     # For each role we serve, we accumulate the input parameters into our own
     # cc-wrapper-derivation-specific environment variables.
     for suffix in "${role_suffixes[@]}"; do


### PR DESCRIPTION
###### Motivation for this change

Existing issues requesting ShellCheck compliance: https://github.com/NixOS/nixpkgs/issues/133088, https://github.com/NixOS/nixpkgs/issues/21166.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
