### PR TITLE
pkgs/build-support: Redirect to standard error rather than file "2"

### DIFF
--- a/pkgs/build-support/setup-hooks/role.bash
+++ b/pkgs/build-support/setup-hooks/role.bash
@@ -17,7 +17,7 @@ function getRole() {
             role_post='_FOR_TARGET'
             ;;
         *)
-            echo "@name@: used as improper sort of dependency" >2
+            echo "@name@: used as improper sort of dependency" >&2
             return 1
             ;;
     esac
@@ -64,7 +64,7 @@ function getTargetRoleWrapper() {
             export NIX_@wrapperName@_TARGET_TARGET_@suffixSalt@=1
             ;;
         *)
-            echo "@name@: used as improper sort of dependency" >2
+            echo "@name@: used as improper sort of dependency" >&2
             return 1
             ;;
     esac


### PR DESCRIPTION
###### Motivation for this change

Existing issues requesting ShellCheck compliance: https://github.com/NixOS/nixpkgs/issues/133088, https://github.com/NixOS/nixpkgs/issues/21166.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
