### PR TITLE
python39Packages.ansible-runner: 2.0.2 -> 2.0.3

### DIFF
--- a/pkgs/development/python-modules/ansible-runner/default.nix
+++ b/pkgs/development/python-modules/ansible-runner/default.nix
@@ -8,20 +8,33 @@
 , six
 , stdenv
 , ansible
-, pytest
 , mock
+, openssh
+, pytest-mock
+, pytest-timeout
+, pytest-xdist
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "ansible-runner";
-  version = "2.0.2";
+  version = "2.0.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "c02b690803ec0be4453411c53743cd3fdca1dfc66dfa075794e14e717c5b61b3";
+    sha256 = "15j0ljgw1rjxq4xiywxxxnxj4r6vwk8dwljkdsjmq3qmwgifcswg";
   };
 
-  checkInputs = [ pytest mock ];
+  checkInputs = [
+    ansible # required to place ansible CLI onto the PATH in tests
+    pytestCheckHook
+    pytest-mock
+    pytest-timeout
+    pytest-xdist
+    mock
+    openssh
+  ];
+
   propagatedBuildInputs = [
     ansible
     psutil
@@ -31,13 +44,30 @@ buildPythonPackage rec {
     six
   ];
 
-  # test_process_isolation_settings is currently broken on Darwin Catalina
-  # https://github.com/ansible/ansible-runner/issues/413
-  checkPhase = ''
-    HOME=$TMPDIR pytest \
-      --ignore test/unit/test_runner.py \
-      -k "not prepare ${lib.optionalString stdenv.isDarwin "and not process_isolation_settings"}"
+  preCheck = ''
+    export HOME=$(mktemp -d)
   '';
+
+  disabledTests = [
+    "test_callback_plugin_task_args_leak" # requires internet
+    "test_env_accuracy"
+    "test_large_stdout_blob" # times out on slower hardware
+  ]
+    # test_process_isolation_settings is currently broken on Darwin Catalina
+    # https://github.com/ansible/ansible-runner/issues/413
+  ++ lib.optional stdenv.isDarwin "process_isolation_settings";
+
+  disabledTestPaths = [
+    # these tests unset PATH and then run executables like `bash` (see https://github.com/ansible/ansible-runner/pull/918)
+    "test/integration/test_runner.py"
+    "test/unit/test_runner.py"
+  ]
+  ++ lib.optionals stdenv.isDarwin [
+    # integration tests on Darwin are not regularly passing in ansible-runner's own CI
+    "test/integration"
+    # these tests write to `/tmp` which is not writable on Darwin
+    "test/unit/config/test__base.py"
+  ];
 
   meta = with lib; {
     description = "Helps when interfacing with Ansible";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF: #144627

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
