### PR TITLE
portmod: 2.0.3 -> 2.1.0

### DIFF
--- a/pkgs/games/portmod/default.nix
+++ b/pkgs/games/portmod/default.nix
@@ -1,6 +1,6 @@
-{ lib, callPackage, python3Packages, fetchFromGitLab, cacert,
-  rustPlatform, bubblewrap, git, perlPackages, imagemagick, fetchurl, fetchzip,
-  jre, makeWrapper, tr-patcher, tes3cmd, fetchpatch, openmw }:
+{ lib, callPackage, python3Packages, fetchFromGitLab, cacert
+, rustPlatform, bubblewrap, git, perlPackages, imagemagick, fetchurl, fetchzip
+, jre, makeWrapper, tr-patcher, tes3cmd, openmw }:
 
 let
   version = "2.1.0";

--- a/pkgs/games/portmod/default.nix
+++ b/pkgs/games/portmod/default.nix
@@ -1,22 +1,22 @@
 { lib, callPackage, python3Packages, fetchFromGitLab, cacert,
   rustPlatform, bubblewrap, git, perlPackages, imagemagick, fetchurl, fetchzip,
-  jre, makeWrapper, tr-patcher, tes3cmd, fetchpatch }:
+  jre, makeWrapper, tr-patcher, tes3cmd, fetchpatch, openmw }:
 
 let
-  version = "2.0.3";
+  version = "2.1.0";
 
   src = fetchFromGitLab {
     owner = "portmod";
     repo = "Portmod";
     rev = "v${version}";
-    sha256 = "sha256-vMdyaI1Ps7bFoRvwdVNVG9vPFEiGb7CPvKEWfxiM128=";
+    sha256 = "sha256-b/ENApFovMPNUMbJhwY+TZCnSzpr1e/IKJ/5XAGTQjE=";
   };
 
   portmod-rust = rustPlatform.buildRustPackage rec {
     inherit src version;
     pname = "portmod-rust";
 
-    cargoHash = "sha256-tAghZmlg34jHr8gtNgL3MQ8EI7K6/TfDcTbBjxdWLr0=";
+    cargoHash = "sha256-3EfMMpSWSYsB3nXaoGGDuKQ9duyCKzbrT6oeATnzqLE=";
 
     nativeBuildInputs = [ python3Packages.python ];
 
@@ -30,6 +30,7 @@ let
     tr-patcher
     tes3cmd
     imagemagick
+    openmw
   ];
 
 in
@@ -46,15 +47,6 @@ python3Packages.buildPythonApplication rec {
       --replace "from setuptools_rust import Binding, RustExtension" "" \
       --replace "RustExtension(\"portmodlib.portmod\", binding=Binding.PyO3, strip=True)" ""
   '';
-
-  patches = [
-    (fetchpatch {
-      # fix error when symlinks are present in the path (https://gitlab.com/portmod/portmod/-/merge_requests/393)
-      # happen with ~/.nix-profile
-      url = "https://gitlab.com/portmod/portmod/-/merge_requests/393.patch";
-      sha256 = "sha256-XHifwD/Nh7UiMZdvSNudVF7qpBOpjGTKSr4VVdJqUdA=";
-    })
-  ];
 
   propagatedBuildInputs = with python3Packages; [
     setuptools-scm


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
A new version was released

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [ ] [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - [ ] and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - [ ] or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Tried to update the graphics-overhaul mod set. As a result, added openmw to the binary dependancies for ``bsatool``.
This mod set contain other bugs that I'll upstream later. Portmod comes with it's own updating method for mod repository.


*(Ooh... didn't knew this package tests stuff...)*