### PR TITLE
linuxPackages.rr-zen_workaround: mark x86_64-only

### DIFF
--- a/pkgs/development/tools/analysis/rr/zen_workaround.nix
+++ b/pkgs/development/tools/analysis/rr/zen_workaround.nix
@@ -2,7 +2,7 @@
 
 /* The python script shouldn't be needed for users of this kernel module.
   https://github.com/rr-debugger/rr/blob/master/scripts/zen_workaround.py
-  The module itself is called "zen_workaround" (a bit generic unfortunatelly).
+  The module itself is called "zen_workaround" (a bit generic unfortunately).
 */
 stdenv.mkDerivation rec {
   pname = "rr-zen_workaround";
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/rr-debugger/rr/wiki/Zen#kernel-module";
     license = licenses.gpl2;
     maintainers = [ maintainers.vcunat ];
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" ];
     broken = versionOlder kernel.version "4.19"; # 4.14 breaks and 4.19 works
   };
 }


### PR DESCRIPTION
This will stop Hydra trying to build it for aarch64.

ZHF: #144627

@NixOS/nixos-release-managers

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
