### PR TITLE
pythonPackages.pydeck: init at 0.7.1

### DIFF
--- a/pkgs/development/python-modules/pydeck/default.nix
+++ b/pkgs/development/python-modules/pydeck/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, ipykernel
+, ipywidgets
+, jinja2
+, numpy
+, pandas
+, pytestCheckHook
+, pytest
+, pythonOlder
+, traitlets
+}:
+
+buildPythonPackage rec {
+  pname = "pydeck";
+  version = "0.7.1";
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0bmx5q1mpdp2rx89qp1bd8b6s8a5l6zn5jyp4xny243mkz4h2xlh";
+  };
+
+  propagatedBuildInputs =  [
+    ipykernel
+    ipywidgets
+    jinja2
+    numpy
+    traitlets
+  ];
+
+  checkInputs =  [
+    pytestCheckHook
+    pandas
+  ];
+
+  disabledTests = [
+    # touches network
+    "test_nbconvert"
+  ];
+
+  pythonImportsCheck = [
+    "pydeck"
+  ];
+
+  meta = with lib; {
+    description = "Python bindings for spatial visualizations with deck.gl";
+    homepage = "https://github.com/visgl/deck.gl/tree/master/bindings/pydeck";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ nphilou ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6284,6 +6284,8 @@ in {
 
   pydbus = callPackage ../development/python-modules/pydbus { };
 
+  pydeck = callPackage ../development/python-modules/pydeck { };
+
   pydeconz = callPackage ../development/python-modules/pydeconz { };
 
   pydelijn = callPackage ../development/python-modules/pydelijn { };


### PR DESCRIPTION
###### Motivation for this change

Needed package for streamlit 0.79.0 (see https://github.com/NixOS/nixpkgs/issues/118764)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
