### PR TITLE
hpe-ltfs: fix build

### DIFF
--- a/pkgs/tools/backup/hpe-ltfs/default.nix
+++ b/pkgs/tools/backup/hpe-ltfs/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fuse, icu, pkg-config, libxml2, libuuid }:
+{ lib, stdenv, fetchFromGitHub, fuse, icu66, pkg-config, libxml2, libuuid }:
 
 stdenv.mkDerivation rec {
   version = "3.4.2_Z7550-02501";
@@ -13,10 +13,15 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "source/ltfs";
 
+  # include sys/sysctl.h is deprecated in glibc. The sysctl calls are only used
+  # for Apple to determine the kernel version. Because this build only targets
+  # Linux is it safe to remove.
+  patches = [ ./remove-sysctl.patch ];
+
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [
-    fuse icu libxml2 libuuid
+    fuse icu66 libxml2 libuuid
   ];
 
   meta = with lib; {

--- a/pkgs/tools/backup/hpe-ltfs/remove-sysctl.patch
+++ b/pkgs/tools/backup/hpe-ltfs/remove-sysctl.patch
@@ -1,0 +1,14 @@
+diff --git a/src/libltfs/arch/arch_info.c b/src/libltfs/arch/arch_info.c
+index 179428f..114acf0 100644
+--- a/src/libltfs/arch/arch_info.c
++++ b/src/libltfs/arch/arch_info.c
+@@ -47,9 +47,6 @@
+ */
+ 
+ #include "libltfs/ltfs.h"
+-#ifndef mingw_PLATFORM
+-#include <sys/sysctl.h>
+-#endif
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <unistd.h>


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`hpe-ltfs` is broken on `master`. Lower the version of the `icu` library is part of the fix. The other part is removing the use of the deprecated `sys/sysctl.h` include file of glibc. It looks safe to remove because the `sysctl` call is only used for Apple builds, and this build only targets Linux.

ZHF: #144627

@NixOS/nixos-release-managers @redvers 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
