### PR TITLE
catatonit: pull pending upstream inclusion fix for automake-1.16.5

### DIFF
--- a/pkgs/applications/virtualization/catatonit/default.nix
+++ b/pkgs/applications/virtualization/catatonit/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, glibc, nixosTests }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, glibc, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "catatonit";
@@ -10,6 +10,16 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-jX4fYC/rpfd3ro2UZ6OEu4kU5wpusOwmEVPWEjxwlW4=";
   };
+
+  patches = [
+    # Pull the fix pending upstream inclusion to support automake-1.16.5:
+    #  https://github.com/openSUSE/catatonit/pull/18
+    (fetchpatch {
+      name = "automake-1.16.5.patch";
+      url = "https://github.com/openSUSE/catatonit/commit/99bb9048f532257f3a2c3856cfa19fe957ab6cec.patch";
+      sha256 = "sha256-ooxVjtWXJddQiBvO9I5aRyLeL8y3ecxW/Kvtfg/bpRA=";
+    })
+  ];
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = lib.optionals (!stdenv.hostPlatform.isMusl) [ glibc glibc.static ];


### PR DESCRIPTION
Without the fix build on automake-1.16.5 fails as:

    configure.ac:34: error: AM_INIT_AUTOMAKE expanded multiple times
    .../automake-1.16.5/share/aclocal-1.16/init.m4:29: AM_INIT_AUTOMAKE is expanded from...
    configure.ac:19: the top level
    .../automake-1.16.5/share/aclocal-1.16/init.m4:29: AM_INIT_AUTOMAKE is expanded from...
    configure.ac:34: the top level