### PR TITLE
tasknc: fix build against upcoming ncurses-6.3

### DIFF
--- a/pkgs/applications/misc/tasknc/default.nix
+++ b/pkgs/applications/misc/tasknc/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper, perl, ncurses5, taskwarrior }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, makeWrapper, perl, ncurses5, taskwarrior }:
 
 stdenv.mkDerivation rec {
   version = "2020-12-17";
@@ -10,6 +10,16 @@ stdenv.mkDerivation rec {
     rev = "a182661fbcc097a933d5e8cce3922eb1734a563e";
     sha256 = "0jrv2k1yizfdjndbl06lmy2bb62ky2rjdk308967j31c5kqqnw56";
   };
+
+  # Pull pending upstream inclusion for ncurses-6.3:
+  #  https://github.com/lharding/tasknc/pull/57
+  patches = [
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/lharding/tasknc/commit/f74ea0641e9bf287acf22fac9f6eeea571b01800.patch";
+      sha256 = "18a90zj85sw2zfnfcv055nvi0lx3h8lcgsyabdfk94ksn78pygrv";
+    })
+  ];
 
   nativeBuildInputs = [
     makeWrapper


### PR DESCRIPTION
Without the change build fails as:

    src/keys.c:122:6: error: 'KEY_EVENT' undeclared here (not in a function); did you mean 'KEY_SLEFT'?
      122 |     {KEY_EVENT, "event"},
          |      ^~~~~~~~~
          |      KEY_SLEFT
