### PR TITLE
opendungeons: 0.7.1 -> unstable-2021-11-06

### DIFF
--- a/pkgs/games/opendungeons/cmakepaths.patch
+++ b/pkgs/games/opendungeons/cmakepaths.patch
@@ -1,13 +1,16 @@
---- ../CMakeLists.txt	
-+++ ../CMakeLists.txt	
-@@ -31,12 +31,12 @@
-     set(OD_PLUGINS_CFG_PATH ".")
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f8ff3c28..b57ee337 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -30,13 +30,13 @@ if(WIN32)
+     set(OD_BIN_PATH ${CMAKE_INSTALL_PREFIX})
  else()
      # Set binary and data install locations if we want to use the installer
 -    set(OD_BIN_PATH ${CMAKE_INSTALL_PREFIX}/games CACHE PATH "Absolute path to the game binary directory")
 +    set(OD_BIN_PATH ${CMAKE_INSTALL_PREFIX}/bin CACHE PATH "Absolute path to the game binary directory")
      set(OD_DATA_PATH ${CMAKE_INSTALL_PREFIX}/share/games/${PROJECT_NAME} CACHE PATH "Absolute path to the game data directory")
      set(OD_SHARE_PATH ${CMAKE_INSTALL_PREFIX}/share CACHE PATH "Absolute path to the shared data directory (desktop file, icons, etc.)")
+     set(OD_MAN_PATH ${OD_SHARE_PATH}/man CACHE PATH "Absolute path to the manpages directory")
      # Set the plugins.cfg file path to a common but architecture-dependent location.
      # Because the plugins.cfg Ogre plugins path path may vary depending on the architecture used.
 -    set(OD_PLUGINS_CFG_PATH /etc/${PROJECT_NAME} CACHE PATH "Absolute path to the Ogre plugins.cfg file")

--- a/pkgs/games/opendungeons/default.nix
+++ b/pkgs/games/opendungeons/default.nix
@@ -2,20 +2,19 @@
 
 stdenv.mkDerivation rec {
   pname = "opendungeons";
-  version = "0.7.1";
+  version = "unstable-2021-11-06";
 
   src = fetchFromGitHub {
     owner = "OpenDungeons";
     repo = "OpenDungeons";
-    rev = version;
-    sha256 = "0nipb2h0gn628yxlahjgnfhmpfqa19mjdbj3aqabimdfqds9pryh";
+    rev = "c180ed1864eab5fbe847d1dd5c5c936c4e45444e";
+    sha256 = "0xf7gkpy8ll1h59wyaljf0hr8prg7p4ixz80mxqwcnm9cglpgn63";
   };
 
   patches = [ ./cmakepaths.patch ];
 
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ ogre cegui boost sfml openal ois ];
-  NIX_LDFLAGS = "-lpthread";
 
   meta = with lib; {
     description = "An open source, real time strategy game sharing game elements with the Dungeon Keeper series and Evil Genius";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30186,7 +30186,7 @@ with pkgs;
   openarena = callPackage ../games/openarena { };
 
   opendungeons = callPackage ../games/opendungeons {
-    ogre = ogre1_9;
+    ogre = ogre1_10;
   };
 
   openlierox = callPackage ../games/openlierox { };


### PR DESCRIPTION
###### Motivation for this change

- no stable release for over 5 years, switch to unstable
  (fixes ois include path issue)
- update ogre dependency to ogre_1.10 to match cegui's version
  (fixes crash on init)

ZHF: #144627

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Ping: @jonringer, @tomberek , @nrdxp