### PR TITLE
winetricks: remove wine dependency

### DIFF
--- a/pkgs/games/grapejuice/default.nix
+++ b/pkgs/games/grapejuice/default.nix
@@ -49,7 +49,7 @@ python3Packages.buildPythonApplication rec  {
 
   makeWrapperArgs = [
     "\${gappsWrapperArgs[@]}"
-    "--prefix PATH : ${lib.makeBinPath [ xdg-user-dirs xdg-utils wine (winetricks.override { wine = wine; }) ]}"
+    "--prefix PATH : ${lib.makeBinPath [ xdg-user-dirs xdg-utils wine winetricks ]}"
   ];
 
   postPatch = ''

--- a/pkgs/misc/emulators/wine/winetricks.nix
+++ b/pkgs/misc/emulators/wine/winetricks.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, callPackage, wine, perl, which, coreutils, zenity, curl
+{ lib, stdenv, callPackage, perl, which, coreutils, zenity, curl
 , cabextract, unzip, p7zip, gnused, gnugrep, bash } :
 
 stdenv.mkDerivation rec {
@@ -9,9 +9,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ perl which ];
 
   # coreutils is for sha1sum
-  pathAdd = lib.concatMapStringsSep ":" (x: x + "/bin")
-    (lib.filter (x: x != null)
-      [ wine perl which coreutils zenity curl cabextract unzip p7zip gnused gnugrep bash ]);
+  pathAdd = lib.makeBinPath [
+    perl which coreutils zenity curl cabextract unzip p7zip gnused gnugrep bash
+  ];
 
   makeFlags = [ "PREFIX=$(out)" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30450,13 +30450,7 @@ with pkgs;
   steam-acf = callPackage ../tools/games/steam-acf { };
 
   protontricks = python3Packages.callPackage ../tools/package-management/protontricks {
-    winetricks = winetricks.override {
-      # Remove default build of wine to reduce closure size.
-      # Falls back to wine in PATH.
-      wine = null;
-    };
-
-    inherit steam-run yad;
+    inherit winetricks steam-run yad;
   };
 
   protonup = with python3Packages; toPythonApplication protonup;


### PR DESCRIPTION
###### Motivation for this change

Wintricks shouldn't be tied to a particular Wine installation, it should use the one in $PATH. Especially after https://github.com/NixOS/nixpkgs/pull/144085.
Also massively reduces the closure size.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - [x] winetricks
  - [ ] grapejuice - I can't test this
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Review
Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>grapejuice</li>
    <li>winetricks</li>
  </ul>
</details>
