### PR TITLE
coconut: 1.5.0 → 1.6.0

### DIFF
--- a/pkgs/development/python-modules/coconut/default.nix
+++ b/pkgs/development/python-modules/coconut/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonApplication
 , fetchFromGitHub
-, fetchpatch
 , cpyparsing
 , ipykernel
 , mypy
@@ -15,30 +14,22 @@
 
 buildPythonApplication rec {
   pname = "coconut";
-  version = "1.5.0";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "evhub";
     repo = "coconut";
     rev = "v${version}";
-    sha256 = "1gc0fwqwzn1j6mcg1f6fw832w66pbaaq9mmi0r4kw3xn5f877icz";
+    sha256 = "/397YGV6QWWmKfqr5hSvqRoPOu7Hx1Pak6rVPR3etzw=";
   };
 
   propagatedBuildInputs = [ cpyparsing ipykernel mypy pygments prompt-toolkit watchdog ];
 
-  postPatch = ''
-    substituteInPlace coconut/kernel_installer.py \
-      --replace "fixpath(os.path.join(sys.exec_prefix, icoconut_custom_kernel_install_loc))" \
-                "fixpath(icoconut_custom_kernel_install_loc)"
-  '';
-
   checkInputs = [ pexpect pytestCheckHook tkinter ];
 
-  # Currently most tests do not work on Hydra due to external fetches.
+  # Currently most tests have performance issues
   pytestFlagsArray = [
     "tests/constants_test.py"
-    "tests/main_test.py::TestShell::test_compile_to_file"
-    "tests/main_test.py::TestShell::test_convenience"
   ];
 
   pythonImportsCheck = [ "coconut" ];

--- a/pkgs/development/python-modules/cpyparsing/default.nix
+++ b/pkgs/development/python-modules/cpyparsing/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "cpyparsing";
-  version = "2.4.5.0.1.2";
+  version = "2.4.7.1.0.0";
 
   src = fetchFromGitHub {
     owner = "evhub";
     repo = pname;
-    rev = "38f2b323b99cee9a080106ae9951ffc5752599f0"; # No tags on repo
-    sha256 = "0wrm6vzwp968z7s0qhr23v39ivyxzvav3mv9i2n0iv9zl041kypv";
+    rev = "09073751d92cb40fb71c927c006baddc082df1db"; # No tags on repo
+    sha256 = "O9IdHipAxxbFcDFYNvmczue/wT4AF9Xb5uc3ZTAlTlo=";
   };
 
   nativeBuildInputs = [ cython ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
