### PR TITLE
pulumi-bin: 3.16.0 -> 3.17.0

### DIFF
--- a/pkgs/tools/admin/pulumi/data.nix
+++ b/pkgs/tools/admin/pulumi/data.nix
@@ -1,16 +1,16 @@
 # DO NOT EDIT! This file is generated automatically by update.sh
 { }:
 {
-  version = "3.16.0";
+  version = "3.17.0";
   pulumiPkgs = {
     x86_64-linux = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.16.0-linux-x64.tar.gz";
-        sha256 = "0c9glgkwsbdj7iii0ng8znjfhlz51ph53y3ilnn3380368c4hxbg";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.17.0-linux-x64.tar.gz";
+        sha256 = "1n9zrqjvm6x6qgwd8hbbl9ywn13niw026a37nlsg5kza2xp8x3al";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v3.4.0-linux-amd64.tar.gz";
-        sha256 = "0wzbwpnnjm8lnph6kh2nrb0ns2v4y70sp10pp9qnwhcxggqjpb5r";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v3.9.0-linux-amd64.tar.gz";
+        sha256 = "19rmwbizkhpxlwayd32hfk2dvz9mddkbg956ryckhfgfis6s3scr";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v4.6.0-linux-amd64.tar.gz";
@@ -21,28 +21,36 @@
         sha256 = "1lmy0dmpspzflc9z8p4w1cz47lbqnbkq8dng3v40lpbs75pnprvs";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mailgun-v3.2.0-linux-amd64.tar.gz";
-        sha256 = "0jxcwn3zwqwg29ib5wylmkg8bpzd0vm86yxylh6b2nwfnbnn5d9v";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v5.25.0-linux-amd64.tar.gz";
-        sha256 = "1gdwbpls41svnmcgk042p5sp70pbncx8ryilgcxkky091fqxsbfh";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azure-v4.24.0-linux-amd64.tar.gz";
-        sha256 = "0l1gb324svdxn4i21xfxhmyf1kj25lvg51r53fmmlws12crxd0x5";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azure-v4.26.0-linux-amd64.tar.gz";
+        sha256 = "1rzwgfz2ikbcjp99yiiai2cqawk80xhwrc7335fylifrvl3wsqis";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-linode-v3.4.0-linux-amd64.tar.gz";
         sha256 = "0jmbfy6y0l7zpzwndz6xj6jv20ax9rbg8nbqwcadjf96a3zglwhf";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v4.25.0-linux-amd64.tar.gz";
-        sha256 = "0mv7n1cd4bn5kws2ddzyisdyy1sm1lhhp5xymnzcgn4fj7q379l9";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v4.0.0-linux-amd64.tar.gz";
+        sha256 = "1p21963qr8rdl5jp7f05j02yq0ab3flybvzjn7xadcl7m85mkyxh";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.0.0-linux-amd64.tar.gz";
-        sha256 = "04gaimdzh04v7f11xw1b7p95rbb142kbnix1zqas68wd6vpw9kyp";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v4.2.0-linux-amd64.tar.gz";
+        sha256 = "1h5159y7xlslnijs8lpi4vqgvj2px6whxk9m17p9n7wiyqbmd5na";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v4.26.0-linux-amd64.tar.gz";
+        sha256 = "0gwfw9gr8lrg27ivkw4xx18jjf3zik8cg6gq62nq2y0bclzb3hn6";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v4.3.1-linux-amd64.tar.gz";
+        sha256 = "1ixmsxawp0qbyjs37c74gcvj2icpbda6znl17yp9bhiyvnrdvxn7";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v3.4.0-linux-amd64.tar.gz";
+        sha256 = "0wzbwpnnjm8lnph6kh2nrb0ns2v4y70sp10pp9qnwhcxggqjpb5r";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mailgun-v3.2.0-linux-amd64.tar.gz";
+        sha256 = "0jxcwn3zwqwg29ib5wylmkg8bpzd0vm86yxylh6b2nwfnbnn5d9v";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-openstack-v3.4.0-linux-amd64.tar.gz";
@@ -53,34 +61,6 @@
         sha256 = "194kym832zfnf58z44y5n789xsvqp2dr3jy5sffqqhfrgcgabvr2";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-equinix-metal-v3.0.0-linux-amd64.tar.gz";
-        sha256 = "0bp7ki3slszmy1vh4a5d4y4fhbvafrazj1cjf081xv91gi99xxz6";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.2.0-linux-amd64.tar.gz";
-        sha256 = "0d88xfi7zzmpyrnvakwxsyavdx6d5hmfrcf4jhmd53mni0m0551l";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.8.0-linux-amd64.tar.gz";
-        sha256 = "0dc96mvy76i0d70jp8gln14cwzsgdxccyhrxrcf3kq38j4vf3bl1";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v3.8.3-linux-amd64.tar.gz";
-        sha256 = "0vigkbsiydfhiiv1rjy7ba9p7h5gbbyryrq3qmxr3bsbgv6aqixz";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vault-v4.5.1-linux-amd64.tar.gz";
-        sha256 = "0cb2b4rrz7zvdpnf0iff21y4kass7gqfimj854fh6za012j18fnx";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-packet-v3.2.2-linux-amd64.tar.gz";
-        sha256 = "0glbjhgrb2hiyhd6kwmy7v384j8zw641pw9737g1fczv3x16a3s3";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v4.2.0-linux-amd64.tar.gz";
-        sha256 = "1h5159y7xlslnijs8lpi4vqgvj2px6whxk9m17p9n7wiyqbmd5na";
-      }
-      {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-datadog-v4.3.0-linux-amd64.tar.gz";
         sha256 = "0mckcwyngxiv46khvchaxdylcgk82b5j5hlfjiky5qg60bic4gnr";
       }
@@ -89,12 +69,32 @@
         sha256 = "0ffqah4anhdacmfb8n3hdq17jhqq0qclc0l0cq77hvhvgn39yy4r";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v4.3.1-linux-amd64.tar.gz";
-        sha256 = "1ixmsxawp0qbyjs37c74gcvj2icpbda6znl17yp9bhiyvnrdvxn7";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.8.0-linux-amd64.tar.gz";
+        sha256 = "0dc96mvy76i0d70jp8gln14cwzsgdxccyhrxrcf3kq38j4vf3bl1";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v4.0.0-linux-amd64.tar.gz";
-        sha256 = "1p21963qr8rdl5jp7f05j02yq0ab3flybvzjn7xadcl7m85mkyxh";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-packet-v3.2.2-linux-amd64.tar.gz";
+        sha256 = "0glbjhgrb2hiyhd6kwmy7v384j8zw641pw9737g1fczv3x16a3s3";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-equinix-metal-v3.1.0-linux-amd64.tar.gz";
+        sha256 = "1rv6l82b1v44fa685dqq7ivsr1y4xaqln0mqd9hyqnajkb2761d5";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v5.26.0-linux-amd64.tar.gz";
+        sha256 = "0pd1a2xhhhxyb2sblq474hrwrm18k2dh4c20r3b2xqz77l25nzig";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.0.0-linux-amd64.tar.gz";
+        sha256 = "04gaimdzh04v7f11xw1b7p95rbb142kbnix1zqas68wd6vpw9kyp";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.2.0-linux-amd64.tar.gz";
+        sha256 = "0d88xfi7zzmpyrnvakwxsyavdx6d5hmfrcf4jhmd53mni0m0551l";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vault-v4.5.1-linux-amd64.tar.gz";
+        sha256 = "0cb2b4rrz7zvdpnf0iff21y4kass7gqfimj854fh6za012j18fnx";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vsphere-v4.0.1-linux-amd64.tar.gz";
@@ -103,12 +103,12 @@
     ];
     x86_64-darwin = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.16.0-darwin-x64.tar.gz";
-        sha256 = "1b8670hk7xc4wfkgwy2jy7ii4vsa3rz8g4w74pxzh09if7lxpvsd";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.17.0-darwin-x64.tar.gz";
+        sha256 = "1a1bafpwgzv6s80rd4zf9nvchm4jn22wan9z81plxk4d67yfnf7w";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v3.4.0-darwin-amd64.tar.gz";
-        sha256 = "0p3zkgr557ngl6pjdidrp76b741nkdsw4s7wf1aj4mpw74fshm3g";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v3.9.0-darwin-amd64.tar.gz";
+        sha256 = "148wdcdmip8rlh61clhcg44rk1kmvc15dkga1nhp8ngzry1f7lf2";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v4.6.0-darwin-amd64.tar.gz";
@@ -119,28 +119,36 @@
         sha256 = "1j7z5dbqzsdq1q8ks9g5pwzyc3ml6avhhp6xj94dzdhskl6pd8w5";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mailgun-v3.2.0-darwin-amd64.tar.gz";
-        sha256 = "1z38yhmbmna3d397kdgribqffgagw28xf6ffhksp428dcn979yh5";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v5.25.0-darwin-amd64.tar.gz";
-        sha256 = "1h4hyhjbbcn5643nimdznc8caim71bknfib9skkgjykfvbfsbprq";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azure-v4.24.0-darwin-amd64.tar.gz";
-        sha256 = "0lbf59aky33n3w3mwp4f1x6wali5q13q1ygx8qr1k72nzbp4nv3k";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azure-v4.26.0-darwin-amd64.tar.gz";
+        sha256 = "03ccnifs1maxnr7qnqw1mn3lc7x2c06icbc9m9j218bx16lwf8jq";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-linode-v3.4.0-darwin-amd64.tar.gz";
         sha256 = "0vd527sx49shr3mpbm5bs4sspmm6vsjli6zlbl5w61y85jp2as1m";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v4.25.0-darwin-amd64.tar.gz";
-        sha256 = "0zm073ga7xaq04dffj2mh4a0fpabxi6hmjvd6kj4ly9wr7kcphw0";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v4.0.0-darwin-amd64.tar.gz";
+        sha256 = "1idvdcmbbia0cwkw5v7zp7695p1a6sfmrgsfmzn0r9p8lyg66k8w";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.0.0-darwin-amd64.tar.gz";
-        sha256 = "18vrp0zzi92x4l5nkjszvd0zr7pk6nl6s3h5a3hvsz5qrj2830q3";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v4.2.0-darwin-amd64.tar.gz";
+        sha256 = "0r2ykjwam5m2mfiibhq993s8n5pzmks837cwb57jwgwx8lc3ra4x";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v4.26.0-darwin-amd64.tar.gz";
+        sha256 = "1pvicixr245cvziw1inhnzkqkzcm95zyjh6mc5gq6cdwwpagdik0";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v4.3.1-darwin-amd64.tar.gz";
+        sha256 = "1dy4n03xvirg6fihiid786d88qlkyqkvk4fq6ggnxc92620x7342";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v3.4.0-darwin-amd64.tar.gz";
+        sha256 = "0p3zkgr557ngl6pjdidrp76b741nkdsw4s7wf1aj4mpw74fshm3g";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mailgun-v3.2.0-darwin-amd64.tar.gz";
+        sha256 = "1z38yhmbmna3d397kdgribqffgagw28xf6ffhksp428dcn979yh5";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-openstack-v3.4.0-darwin-amd64.tar.gz";
@@ -151,34 +159,6 @@
         sha256 = "1gf83dv5wqvmx8ll7my3c8biklrddjrv069g97d3n510m0k7w85w";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-equinix-metal-v3.0.0-darwin-amd64.tar.gz";
-        sha256 = "1i73sxh6vf6adg6as1q1mab3fcjm7ma7gixj2b0y0d2a5d78lhpa";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.2.0-darwin-amd64.tar.gz";
-        sha256 = "12mkr0xczdnp21k0k7qn4r3swkaq3pr6v2z853p1db7ksz5kds23";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.8.0-darwin-amd64.tar.gz";
-        sha256 = "1lfai2xd9538cq89b4jg85hj0slnvbwndd24y2g2q9h5qla08cx2";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v3.8.3-darwin-amd64.tar.gz";
-        sha256 = "07vpzp23frgaqarrkx1i6bnzmx3g9fgw5hjnxpf80ckhjpr93pc5";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vault-v4.5.1-darwin-amd64.tar.gz";
-        sha256 = "1n82xwkngql039m3pa1pwa8wvqg089mr8xnai67jyj1kryjsij56";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-packet-v3.2.2-darwin-amd64.tar.gz";
-        sha256 = "0621njipng32x43lw8n49mapq10lnvibg8vlvgciqsfvrbpz1yp5";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v4.2.0-darwin-amd64.tar.gz";
-        sha256 = "0r2ykjwam5m2mfiibhq993s8n5pzmks837cwb57jwgwx8lc3ra4x";
-      }
-      {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-datadog-v4.3.0-darwin-amd64.tar.gz";
         sha256 = "04hhvakbrvjqzlhhacpb4syy6bz8qgkhqfl8339wjapsczy776j5";
       }
@@ -187,12 +167,32 @@
         sha256 = "0j8ysk4wh78xhk3nv6c1dvvyw5ihs7amwlyqicch52yc6jq3v5a6";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v4.3.1-darwin-amd64.tar.gz";
-        sha256 = "1dy4n03xvirg6fihiid786d88qlkyqkvk4fq6ggnxc92620x7342";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.8.0-darwin-amd64.tar.gz";
+        sha256 = "1lfai2xd9538cq89b4jg85hj0slnvbwndd24y2g2q9h5qla08cx2";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v4.0.0-darwin-amd64.tar.gz";
-        sha256 = "1idvdcmbbia0cwkw5v7zp7695p1a6sfmrgsfmzn0r9p8lyg66k8w";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-packet-v3.2.2-darwin-amd64.tar.gz";
+        sha256 = "0621njipng32x43lw8n49mapq10lnvibg8vlvgciqsfvrbpz1yp5";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-equinix-metal-v3.1.0-darwin-amd64.tar.gz";
+        sha256 = "04l07fqzf3fs7hj4giggzyjv9979qcpxrqbiapdjp7x4qsbsz0fv";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v5.26.0-darwin-amd64.tar.gz";
+        sha256 = "1f06x2h4i15vjzjyzcl5f01by2639hsfij2daayj5xiji3b415ps";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.0.0-darwin-amd64.tar.gz";
+        sha256 = "18vrp0zzi92x4l5nkjszvd0zr7pk6nl6s3h5a3hvsz5qrj2830q3";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.2.0-darwin-amd64.tar.gz";
+        sha256 = "12mkr0xczdnp21k0k7qn4r3swkaq3pr6v2z853p1db7ksz5kds23";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vault-v4.5.1-darwin-amd64.tar.gz";
+        sha256 = "1n82xwkngql039m3pa1pwa8wvqg089mr8xnai67jyj1kryjsij56";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vsphere-v4.0.1-darwin-amd64.tar.gz";
@@ -201,12 +201,12 @@
     ];
     aarch64-linux = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.16.0-linux-arm64.tar.gz";
-        sha256 = "0jkjgp4qjlvgm39axpj8ahkwb6nlgax52x72xnmi3a69z84vgyp1";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.17.0-linux-arm64.tar.gz";
+        sha256 = "1nnbm4djs23plycgsvgmi61779qriypzpv26psvi1153ad2qvg4b";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v3.4.0-linux-arm64.tar.gz";
-        sha256 = "1hiqcy51ag4y8j47di5h07mnplrhpc5f406ab6car2c06fwr2wdn";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v3.9.0-linux-arm64.tar.gz";
+        sha256 = "10p015rhp9dsxcwp0a0k3xvkphya8vji4ndv66z73jzr6z3vfqzm";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v4.6.0-linux-arm64.tar.gz";
@@ -217,28 +217,36 @@
         sha256 = "0mddv37k87wiygh6x9bnxpcr721qbmbqf6l5zk3xl61n56j8qyb1";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mailgun-v3.2.0-linux-arm64.tar.gz";
-        sha256 = "11yslyxhsqchqyd31b10krgxgf2shi5pxncw79zj26w31qcqdv3x";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v5.25.0-linux-arm64.tar.gz";
-        sha256 = "0l0ipkqp7920jrba43a3mh5z83p6nbglzyl5zaig7jdms97qchi5";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azure-v4.24.0-linux-arm64.tar.gz";
-        sha256 = "0yhnmxpjfirp187zw4xnhh23b186iv61xjidvlkrnjcmrv2ldpqv";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azure-v4.26.0-linux-arm64.tar.gz";
+        sha256 = "1v5b5bwpzmr124xblrrr0rl0zbvky8ljcilyh0fmjgrmai25zbz2";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-linode-v3.4.0-linux-arm64.tar.gz";
         sha256 = "0ybw5cbiw64zmaqjwlfk5b73h5sy0pk40f15hq41d9rdkc0sypxi";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v4.25.0-linux-arm64.tar.gz";
-        sha256 = "0qsvhinsnm8n1w984yvdvwd7gw2fcm7jgh8q30ljb0ikh4d5p98b";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v4.0.0-linux-arm64.tar.gz";
+        sha256 = "0k4yi9xqrmd5m99lr27h672ycwyh138d9jhh3wvgpmnjpdxy28jm";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.0.0-linux-arm64.tar.gz";
-        sha256 = "1slrl020xl092hjfr92zjf8i2ys8vzr3nxqh65fhnl0fzfsllvn0";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v4.2.0-linux-arm64.tar.gz";
+        sha256 = "1sc8rf930cz6nkyhqn6p0h7450iqzdsrlw2smhp8yyjjvcjmsksf";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v4.26.0-linux-arm64.tar.gz";
+        sha256 = "01mmfsfbggvhq8706irg1pv9n89lrxr9dp05m3fa8wdbfdxiwwvd";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v4.3.1-linux-arm64.tar.gz";
+        sha256 = "12iv8vjnal2ym70rxmdnvi02x6md7fxi8jbzhzfw526pzqs1dc47";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v3.4.0-linux-arm64.tar.gz";
+        sha256 = "1hiqcy51ag4y8j47di5h07mnplrhpc5f406ab6car2c06fwr2wdn";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mailgun-v3.2.0-linux-arm64.tar.gz";
+        sha256 = "11yslyxhsqchqyd31b10krgxgf2shi5pxncw79zj26w31qcqdv3x";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-openstack-v3.4.0-linux-arm64.tar.gz";
@@ -249,31 +257,6 @@
         sha256 = "0ap4izb3507rw965qvww1nd2h9jz7ilav92fjdhhvf33g44r6r8y";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-equinix-metal-v3.0.0-linux-arm64.tar.gz";
-        sha256 = "0mwpbvv62k8fg07447wwfigs4li4n78fswpzwi4alsjrkqlmw9dj";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.2.0-linux-arm64.tar.gz";
-        sha256 = "1l7zpvacq6kyzj8n82drs9gdfa16k4j945w8nsd0z33byrswxr3w";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.8.0-linux-arm64.tar.gz";
-        sha256 = "0hq4l91ynjk5qzqcwvzqpd978wikqdx6lxngrawdkk501y0yh6f6";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v3.8.3-linux-arm64.tar.gz";
-        sha256 = "1is34y7npwyl11fxksd68f3gc28f1pxm6ml9qkihvpvmihylan3i";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vault-v4.5.1-linux-arm64.tar.gz";
-        sha256 = "0kxi3fm2463bq6n0bnf0sbf4zjhg0c86bxw52dlmc8kp2zqc6lr3";
-      }
-      # pulumi-resource-packet skipped (does not exist on remote)
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v4.2.0-linux-arm64.tar.gz";
-        sha256 = "1sc8rf930cz6nkyhqn6p0h7450iqzdsrlw2smhp8yyjjvcjmsksf";
-      }
-      {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-datadog-v4.3.0-linux-arm64.tar.gz";
         sha256 = "1hxaz0m33vf92d1vwksmib5lnpl57yrh8nf90nqmmzvjzajkzzbl";
       }
@@ -282,12 +265,29 @@
         sha256 = "1lh1g90ab4blqmvx0yfp516hfsd6n1y751ab7fzhv7hcajf3klvi";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v4.3.1-linux-arm64.tar.gz";
-        sha256 = "12iv8vjnal2ym70rxmdnvi02x6md7fxi8jbzhzfw526pzqs1dc47";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.8.0-linux-arm64.tar.gz";
+        sha256 = "0hq4l91ynjk5qzqcwvzqpd978wikqdx6lxngrawdkk501y0yh6f6";
+      }
+      # pulumi-resource-packet skipped (does not exist on remote)
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-equinix-metal-v3.1.0-linux-arm64.tar.gz";
+        sha256 = "175bqcamkd2illd57gkycsfh5kyjw700g7phjsg057jij3cdfsr8";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v4.0.0-linux-arm64.tar.gz";
-        sha256 = "0k4yi9xqrmd5m99lr27h672ycwyh138d9jhh3wvgpmnjpdxy28jm";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v5.26.0-linux-arm64.tar.gz";
+        sha256 = "0vjdl01ggnf3hj0ak3dak5828d8cj8x05ny9hsii2cqdphxybsj4";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.0.0-linux-arm64.tar.gz";
+        sha256 = "1slrl020xl092hjfr92zjf8i2ys8vzr3nxqh65fhnl0fzfsllvn0";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.2.0-linux-arm64.tar.gz";
+        sha256 = "1l7zpvacq6kyzj8n82drs9gdfa16k4j945w8nsd0z33byrswxr3w";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vault-v4.5.1-linux-arm64.tar.gz";
+        sha256 = "0kxi3fm2463bq6n0bnf0sbf4zjhg0c86bxw52dlmc8kp2zqc6lr3";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vsphere-v4.0.1-linux-arm64.tar.gz";
@@ -296,12 +296,12 @@
     ];
     aarch64-darwin = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.16.0-darwin-arm64.tar.gz";
-        sha256 = "0k7bz1nxigzgggr4qpnhhrmsijyrgs8w7iigqvk5pjd2issvbc3r";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.17.0-darwin-arm64.tar.gz";
+        sha256 = "0y5gszzin1p9ck34s6jrg11p34629vvvv4dx0zl4w0j5srmycyjj";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v3.4.0-darwin-arm64.tar.gz";
-        sha256 = "18ggnqx9zh8kl5h6nn2sa4zxvyby9pvscrvqnsam2l9yjv86r7i0";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v3.9.0-darwin-arm64.tar.gz";
+        sha256 = "07ldq1anzrznan2a1x1igmgljfh6dx12cypggcyma7axiqj95ww1";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v4.6.0-darwin-arm64.tar.gz";
@@ -312,28 +312,36 @@
         sha256 = "0fj1ai1kv8xgmsvfbmy5gsinxag70rx9a9gkifqgcpn3r9mj48ks";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mailgun-v3.2.0-darwin-arm64.tar.gz";
-        sha256 = "1nsqxci7dzg433ydk34fkiq7clq00m45rj26rs4whx65y8hdhxrb";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v5.25.0-darwin-arm64.tar.gz";
-        sha256 = "0134jxl4jca6y7wd23kd6hg1cq28qxvdvjl5148iq85i23wafymr";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azure-v4.24.0-darwin-arm64.tar.gz";
-        sha256 = "19hxs3p7xvgw493grs02b7b1lhfqizqs6ha6zrwjx70kpwbxbkcd";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azure-v4.26.0-darwin-arm64.tar.gz";
+        sha256 = "141mm2wa211gbs1kzqzq9ivjjz1bd93bb6vh9s28rz4z9ciaq44z";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-linode-v3.4.0-darwin-arm64.tar.gz";
         sha256 = "1iyc67r551bi1h20lfb2qp5b2ds8kf09gklbaz73k90hcrf0g9la";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v4.25.0-darwin-arm64.tar.gz";
-        sha256 = "15vpbkly9cvwajrridhj9mkjx7ba0hm2c9gbgzg07855ncb0kxaj";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v4.0.0-darwin-arm64.tar.gz";
+        sha256 = "0fsmmgq0hvzyrw6vrdf3pppxjcj94fxxp52dl73r4f5wjkays33c";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.0.0-darwin-arm64.tar.gz";
-        sha256 = "10a2f5kdgk3jcd1441zbfcfnrl5zj6ks832jjmbyym33by7scvgc";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v4.2.0-darwin-arm64.tar.gz";
+        sha256 = "1c3pchbnk6dsnxsl02ypq7s4mmkxdgxszdhql1klpx5js7i1lv8k";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v4.26.0-darwin-arm64.tar.gz";
+        sha256 = "1nw1w3fj15d2536zy9im8sr4qn84c2cmvcqflf0fmwah8m21w61d";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v4.3.1-darwin-arm64.tar.gz";
+        sha256 = "0jrihnwfh5wvc95nipqv7ak77kq9xj0pk5hlapv9w2ls5pwykv0r";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v3.4.0-darwin-arm64.tar.gz";
+        sha256 = "18ggnqx9zh8kl5h6nn2sa4zxvyby9pvscrvqnsam2l9yjv86r7i0";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mailgun-v3.2.0-darwin-arm64.tar.gz";
+        sha256 = "1nsqxci7dzg433ydk34fkiq7clq00m45rj26rs4whx65y8hdhxrb";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-openstack-v3.4.0-darwin-arm64.tar.gz";
@@ -344,31 +352,6 @@
         sha256 = "1y0wc1279ka05ng7wq6skmwyrmp1sb2sc64wiqx52napxvzjpv9r";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-equinix-metal-v3.0.0-darwin-arm64.tar.gz";
-        sha256 = "1hzhlxbwji4p8apx4rnqllsgf1k11w49rplz0syzmzb2fxpkif75";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.2.0-darwin-arm64.tar.gz";
-        sha256 = "1rmvc2kgjmb978sfmlga6xy4i0f629lk1l95i30wg0rmj1hx3dag";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.8.0-darwin-arm64.tar.gz";
-        sha256 = "1w78lqdf4ynfhl5h0bzxmvqnf4s59mflbdlbqhxq78qxwwq4v193";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v3.8.3-darwin-arm64.tar.gz";
-        sha256 = "08jwgvklg2r78ag7cr5pm4ngy6s0wnj6z4ari50bpszzh69m9qiy";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vault-v4.5.1-darwin-arm64.tar.gz";
-        sha256 = "0h9lj565slf1gvzkk8vlk285jgssi62kmayim8473fgbgp3yj6jr";
-      }
-      # pulumi-resource-packet skipped (does not exist on remote)
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v4.2.0-darwin-arm64.tar.gz";
-        sha256 = "1c3pchbnk6dsnxsl02ypq7s4mmkxdgxszdhql1klpx5js7i1lv8k";
-      }
-      {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-datadog-v4.3.0-darwin-arm64.tar.gz";
         sha256 = "09vllijaql7141h0dw3p5ikvv4kp0mzfl5f0n7gd9d4pwl3q3yzv";
       }
@@ -377,12 +360,29 @@
         sha256 = "1z0gd0fagv55dl3ki340h0ljw7dqj8818w4072pc5xxy5id90gb0";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v4.3.1-darwin-arm64.tar.gz";
-        sha256 = "0jrihnwfh5wvc95nipqv7ak77kq9xj0pk5hlapv9w2ls5pwykv0r";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.8.0-darwin-arm64.tar.gz";
+        sha256 = "1w78lqdf4ynfhl5h0bzxmvqnf4s59mflbdlbqhxq78qxwwq4v193";
+      }
+      # pulumi-resource-packet skipped (does not exist on remote)
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-equinix-metal-v3.1.0-darwin-arm64.tar.gz";
+        sha256 = "0wzi2mb6jqmzyww2pbdx7cysi0xn4hp74g5n0jyz3mw68s5fm7vf";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v4.0.0-darwin-arm64.tar.gz";
-        sha256 = "0fsmmgq0hvzyrw6vrdf3pppxjcj94fxxp52dl73r4f5wjkays33c";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v5.26.0-darwin-arm64.tar.gz";
+        sha256 = "1lm26pinz7bjzv7bk22xq2qhyv5a4v7x7kwbl98sdv0gl1alj44f";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.0.0-darwin-arm64.tar.gz";
+        sha256 = "10a2f5kdgk3jcd1441zbfcfnrl5zj6ks832jjmbyym33by7scvgc";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.2.0-darwin-arm64.tar.gz";
+        sha256 = "1rmvc2kgjmb978sfmlga6xy4i0f629lk1l95i30wg0rmj1hx3dag";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vault-v4.5.1-darwin-arm64.tar.gz";
+        sha256 = "0h9lj565slf1gvzkk8vlk285jgssi62kmayim8473fgbgp3yj6jr";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vsphere-v4.0.1-darwin-arm64.tar.gz";

--- a/pkgs/tools/admin/pulumi/update.sh
+++ b/pkgs/tools/admin/pulumi/update.sh
@@ -6,7 +6,7 @@ API_URL="https://api.github.com/repos/pulumi"
 
 # Version of Pulumi from
 # https://www.pulumi.com/docs/get-started/install/versions/
-VERSION="3.16.0"
+VERSION="3.17.0"
 
 # A hashmap containing a plugin's name and it's respective repository inside
 # Pulumi's Github organization


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
