### PR TITLE
treewide: eliminate stdenv.lib usage

### DIFF
--- a/nixos/tests/seafile.nix
+++ b/nixos/tests/seafile.nix
@@ -6,7 +6,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
     };
   in {
     name = "seafile";
-    meta = with pkgs.stdenv.lib.maintainers; {
+    meta = with pkgs.lib.maintainers; {
       maintainers = [ kampfschlaefer schmittlauch ];
     };
 

--- a/nixos/tests/systemd-boot.nix
+++ b/nixos/tests/systemd-boot.nix
@@ -42,7 +42,7 @@ in
   # Check that specialisations create corresponding boot entries.
   specialisation = makeTest {
     name = "systemd-boot-specialisation";
-    meta.maintainers = with pkgs.stdenv.lib.maintainers; [ lukegb ];
+    meta.maintainers = with pkgs.lib.maintainers; [ lukegb ];
 
     machine = { pkgs, lib, ... }: {
       imports = [ common ];


### PR DESCRIPTION
It was breaking evaluation on Hydra.