### PR TITLE
librepcb: 0.1.5 -> 0.1.6

### DIFF
--- a/pkgs/applications/science/electronics/librepcb/default.nix
+++ b/pkgs/applications/science/electronics/librepcb/default.nix
@@ -1,36 +1,21 @@
 { stdenv, lib, fetchFromGitHub
-, qtbase, qttools, qmake, wrapQtAppsHook
+, qtbase, qttools, cmake, wrapQtAppsHook
 }:
 
 stdenv.mkDerivation rec {
   pname = "librepcb";
-  version = "0.1.5";
+  version = "0.1.6";
 
   src = fetchFromGitHub {
     owner  = pname;
     repo   = pname;
     rev    = version;
-    sha256 = "0ag8h3id2c1k9ds22rfrvyhf2vjhkv82xnrdrz4n1hnlr9566vcx";
+    sha256 = "0gzf3asdgdicpikb412134ybqnbbark948yrfhvba2w4i9cwbk2r";
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ qmake qttools wrapQtAppsHook ];
+  nativeBuildInputs = [ cmake qttools wrapQtAppsHook ];
   buildInputs = [ qtbase ];
-
-  qmakeFlags = ["-r"];
-
-  # the build system tries to use 'git' at build time to find the HEAD hash.
-  # that's a no-no, so replace it with a quick hack. NOTE: the # adds a comment
-  # at the end of the line to remove the git call.
-  postPatch = ''
-    substituteInPlace ./libs/librepcb/common/common.pro \
-      --replace 'GIT_COMMIT_SHA' 'GIT_COMMIT_SHA="\\\"${src.rev}\\\"" # '
-  '';
-
-  postInstall = ''
-    mkdir -p $out/share/librepcb/fontobene
-    cp share/librepcb/fontobene/newstroke.bene $out/share/librepcb/fontobene/
-  '';
 
   meta = with lib; {
     description = "A free EDA software to develop printed circuit boards";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
