### PR TITLE
goverlay: 0.6.3 → 0.6.4

### DIFF
--- a/pkgs/tools/graphics/goverlay/default.nix
+++ b/pkgs/tools/graphics/goverlay/default.nix
@@ -17,6 +17,7 @@
 , polkit
 , procps
 , systemd
+, util-linux
 , vulkan-tools
 , which
 }:
@@ -35,13 +36,13 @@ let
   '';
 in stdenv.mkDerivation rec {
   pname = "goverlay";
-  version = "0.6.3";
+  version = "0.6.4";
 
   src = fetchFromGitHub {
     owner = "benjamimgois";
     repo = pname;
     rev = version;
-    hash = "sha256-ZksQse0xWAtH+U6EjcGWT2BOG5dfSnm6XvZLLE5ynHs=";
+    sha256 = "sha256-xuv7u2lLQAB0Zmu7UHGXP/sJwcb8vHDf9hFL+pF+818=";
   };
 
   outputs = [ "out" "man" ];
@@ -91,6 +92,7 @@ in stdenv.mkDerivation rec {
       polkit
       procps
       systemd
+      util-linux.bin
       vulkan-tools
       which
     ]}"

--- a/pkgs/tools/graphics/goverlay/find-xdg-data-files.patch
+++ b/pkgs/tools/graphics/goverlay/find-xdg-data-files.patch
@@ -1,8 +1,8 @@
 diff --git a/overlayunit.pas b/overlayunit.pas
-index a56cea7..9a4f547 100644
+index 8c2276d..a62e60a 100644
 --- a/overlayunit.pas
 +++ b/overlayunit.pas
-@@ -4880,7 +4880,7 @@ begin
+@@ -4913,7 +4913,7 @@ begin
     //Determine Mangohud dependency status
  
            //locate MangoHud and store result in tmp folder
@@ -11,7 +11,7 @@ index a56cea7..9a4f547 100644
  
            // Assign Text file dependency_mangohud to variable mangohudVAR
            AssignFile(mangohudVAR, '/tmp/goverlay/dependency_mangohud');
-@@ -4889,7 +4889,7 @@ begin
+@@ -4922,7 +4922,7 @@ begin
            CloseFile(mangohudVAR);
  
            // Read String and store value on mangohuddependencyVALUE based on result
@@ -20,7 +20,7 @@ index a56cea7..9a4f547 100644
            mangohuddependencyVALUE := 1
            else
            mangohuddependencyVALUE := 0;
-@@ -4898,7 +4898,7 @@ begin
+@@ -4931,7 +4931,7 @@ begin
     //Determine vkBasalt dependency staus
  
             //locate vkBasalt and store result in tmp folder
@@ -29,7 +29,7 @@ index a56cea7..9a4f547 100644
  
             // Assign Text file dependency_mangohud to variable mangohudVAR
             AssignFile(vkbasaltVAR, '/tmp/goverlay/dependency_vkbasalt');
-@@ -4907,7 +4907,7 @@ begin
+@@ -4940,7 +4940,7 @@ begin
             CloseFile(vkbasaltVAR);
  
             // Read String and store value on vkbasaltdependencyVALUE based on result


### PR DESCRIPTION
###### Motivation for this change
Update to the latest version: https://github.com/benjamimgois/goverlay/releases/tag/0.6.4

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).