### PR TITLE
gpm: fix static build

### DIFF
--- a/pkgs/servers/gpm/default.nix
+++ b/pkgs/servers/gpm/default.nix
@@ -5,8 +5,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "gpm-unstable";
-  version = "2020-06-17";
+  pname = "gpm";
+  version = "unstable-2020-06-17";
 
   src = fetchFromGitHub {
     owner = "telmich";

--- a/pkgs/servers/gpm/default.nix
+++ b/pkgs/servers/gpm/default.nix
@@ -1,16 +1,18 @@
-{ lib, stdenv, fetchurl, automake, autoconf, libtool, flex, bison, texinfo, fetchpatch
+{ lib, stdenv, fetchFromGitHub, automake, autoconf, libtool, flex, bison, texinfo, fetchpatch, pkgsStatic
 
 # Optional Dependencies
 , ncurses ? null
 }:
 
 stdenv.mkDerivation rec {
-  pname = "gpm";
-  version = "1.20.7";
+  pname = "gpm-unstable";
+  version = "2020-06-17";
 
-  src = fetchurl {
-    url = "https://www.nico.schottelius.org/software/gpm/archives/gpm-${version}.tar.bz2";
-    sha256 = "13d426a8h403ckpc8zyf7s2p5rql0lqbg2bv0454x0pvgbfbf4gh";
+  src = fetchFromGitHub {
+    owner = "telmich";
+    repo = "gpm";
+    rev = "e82d1a653ca94aa4ed12441424da6ce780b1e530";
+    sha256 = "0ndn6dwc87slvyqp2cnbb02a6hkjwb6zjhs6viysykv06hq7ihy6";
   };
 
   postPatch = ''
@@ -23,24 +25,9 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ];
 
   patches = [
-    # musl compat patches, safe everywhere
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/gentoo/musl/5aed405d87dfa92a5cab1596f898e9dea07169b8/sys-libs/gpm/files/gpm-1.20.7-musl-missing-headers.patch";
-      sha256 = "1g338m6j1sba84wlqp1r6rpabj5nm6ki577hjalg46czg0lfp20h";
-    })
-    # Touches same code as glibc fix in postPatch above, but on the non-glibc route
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/gentoo/musl/5aed405d87dfa92a5cab1596f898e9dea07169b8/sys-libs/gpm/files/gpm-1.20.7-musl-portable-sigaction.patch";
-      sha256 = "0hfdqm9977hd5dpzn05y0a6jbj55w1kp4hd9gyzmg9wslmxni4rg";
-    })
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/gentoo/musl/5aed405d87dfa92a5cab1596f898e9dea07169b8/sys-libs/gpm/files/gpm-1.20.7-sysmacros.patch";
-      sha256 = "0lg4l9phvy2n8gy17qsn6zn0qq52vm8g01pgq5kqpr8sd3fb21c2";
-    })
-    (fetchpatch {
-      # upstream build fix against -fno-common compilers like >=gcc-10
-      url = "https://github.com/telmich/gpm/commit/f04f24dd5ca5c1c13608b144ab66e2ccd47f106a.patch";
-      sha256 = "1q5hl5m61pci2f0x7r5in99rmqh328v1k0zj2693wdlafk9dabks";
+    (fetchpatch { # pull request telmich/gpm#42
+      url = "https://github.com/kaction/gpm/commit/217b4fe4c9b62298a4e9a54c1f07e3b52b013a09.patch";
+      sha256 = "1f74h12iph4z1dldbxk9imcq11805c3ai2xhbsqvx8jpjrcfp19q";
     })
   ];
   preConfigure = ''
@@ -51,6 +38,7 @@ stdenv.mkDerivation rec {
     "--sysconfdir=/etc"
     "--localstatedir=/var"
     (if ncurses == null then "--without-curses" else "--with-curses")
+    (if stdenv.hostPlatform.isStatic then "--enable-shared=no" else "--enable-shared=yes")
   ];
 
   # Provide libgpm.so for compatability
@@ -58,6 +46,7 @@ stdenv.mkDerivation rec {
     ln -sv $out/lib/libgpm.so.2 $out/lib/libgpm.so
   '';
 
+  passthru.tests.static = pkgsStatic.gpm;
   meta = with lib; {
     homepage = "https://www.nico.schottelius.org/software/gpm/";
     description = "A daemon that provides mouse support on the Linux console";

--- a/pkgs/servers/gpm/default.nix
+++ b/pkgs/servers/gpm/default.nix
@@ -47,6 +47,7 @@ stdenv.mkDerivation rec {
   '';
 
   passthru.tests.static = pkgsStatic.gpm;
+
   meta = with lib; {
     homepage = "https://www.nico.schottelius.org/software/gpm/";
     description = "A daemon that provides mouse support on the Linux console";

--- a/pkgs/servers/gpm/default.nix
+++ b/pkgs/servers/gpm/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchFromGitHub, automake, autoconf, libtool, flex, bison, texinfo, fetchpatch, pkgsStatic
-
-# Optional Dependencies
-, ncurses ? null
+, withNcurses ? true, ncurses
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/servers/gpm/default.nix
+++ b/pkgs/servers/gpm/default.nix
@@ -38,7 +38,6 @@ stdenv.mkDerivation rec {
     "--sysconfdir=/etc"
     "--localstatedir=/var"
     (if ncurses == null then "--without-curses" else "--with-curses")
-    (if stdenv.hostPlatform.isStatic then "--enable-shared=no" else "--enable-shared=yes")
   ];
 
   # Provide libgpm.so for compatability


### PR DESCRIPTION
Patch I developed to add support for static build into upstream build system do
not apply cleanly on 1.20.7 release, so instead of backporting it, I decided to
switch to git snapshot instead.  It allowed to get rid of three other patches
in nix expression, since they are applied upstream.
=> https://github.com/telmich/gpm/pull/42

I requested proper release, but chance seems to be slim.
=> https://github.com/telmich/gpm/issues/33

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
