### PR TITLE
ansifilter: fix non-determinism in gzipped manpages with s/gzip/gzip -n/

### DIFF
--- a/pkgs/tools/text/ansifilter/default.nix
+++ b/pkgs/tools/text/ansifilter/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace src/makefile --replace "CC=g++" "CC=c++"
+    # avoid timestamp non-determinism with '-n'
+    substituteInPlace makefile --replace 'gzip -9f' 'gzip -9nf'
   '';
 
   makeFlags = [


### PR DESCRIPTION
Before the change ansifilter diffoscope shows non-determinism as:

    $ diffoscope '...-ansifilter-2.18' '...-ansifilter-2.18.check'
    --- ...-ansifilter-2.18/share/man/man1/ansifilter.1.gz
    +++ ...-ansifilter-2.18.check/share/man/man1/ansifilter.1.gz
    ─ filetype from file(1)
    @@ -1 +1 @@
    -gzip compressed data, was "ansifilter.1", last modified: Sat Oct 30 13:16:29 2021, max compression, from Unix
    +gzip compressed data, was "ansifilter.1", last modified: Sat Nov  6 18:04:36 2021, max compression, from Unix