### PR TITLE
dhall-grafana: Fix Prelude dependency.

### DIFF
--- a/pkgs/development/dhall-modules/dhall-grafana.nix
+++ b/pkgs/development/dhall-modules/dhall-grafana.nix
@@ -4,8 +4,8 @@ buildDhallGitHubPackage {
   name = "grafana";
   owner = "weeezes";
   repo = "dhall-grafana";
-  # 2021-11-05
-  rev = "bf2f8c8ab44682c8cef4fdce2d2f7fbeb0cfe162";
-  sha256 = "0h1l39kj49yvadpbw6jw3mc7qzsmhxlqqpx3cgnr9f063nh73f96";
+  # 2021-11-06
+  rev = "9ee0bb643f01db6d9935cf7df1914c32a92730b4";
+  sha256 = "0a123r5a33p8kaqs68rx2ycjr72xvxcpcmvpqxgb2jb05mnjj540";
   dependencies = [ dhallPackages.Prelude ];
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

At init, dhall-grafana would not compile because it has a dependency
on Prelude version 19.  It is fixed upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Bump the revision of the package repo.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
