### PR TITLE
python3Packages.tqdm: allow disabling Pandas

### DIFF
--- a/pkgs/development/python-modules/tqdm/default.nix
+++ b/pkgs/development/python-modules/tqdm/default.nix
@@ -10,6 +10,9 @@
 , pandas
 , rich
 , tkinter
+# tqdm integrates with pandas dataframes, but not all consumers of tqdm care about
+# this large dependency
+, usePandas ? true
 }:
 
 buildPythonPackage rec {
@@ -35,7 +38,7 @@ buildPythonPackage rec {
     tkinter
   ] ++
     # pandas is not supported on i686 or risc-v
-    lib.optional (!stdenv.isi686 && !stdenv.hostPlatform.isRiscV) pandas;
+    lib.optional (usePandas && !stdenv.isi686 && !stdenv.hostPlatform.isRiscV) pandas;
 
   # Remove performance testing.
   # Too sensitive for on Hydra.

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4631,7 +4631,7 @@ in {
 
   matchpy = callPackage ../development/python-modules/matchpy { };
 
-  mathlibtools = callPackage ../development/python-modules/mathlibtools { };
+  mathlibtools = callPackage ../development/python-modules/mathlibtools { tqdm = callPackage ../development/python-modules/tqdm { usePandas = false; }; };
 
   matplotlib = callPackage ../development/python-modules/matplotlib/default.nix {
     stdenv = if stdenv.isDarwin then pkgs.clangStdenv else pkgs.stdenv;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`mathlibtools` contains an implicit dependency on pandas, and hence numpy, via tqdm. But it doesn't use that dependency at all - tqdm only has that dependency so that it can hook in to report pandas progress - so we can save quite a bit of dependency tree by just skipping it.

###### Things done

Please note that I'm very much a Nix noob and am likely to have done things wrong. In particular, the way I've done the top-level change feels very odd.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
