### PR TITLE
giflib: fix static build

### DIFF
--- a/pkgs/development/libraries/giflib/default.nix
+++ b/pkgs/development/libraries/giflib/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchpatch, xmlto, docbook_xml_dtd_412, docbook_xsl, libxml2, fixDarwinDylibNames }:
+{ lib, stdenv, fetchurl, fetchpatch, xmlto, docbook_xml_dtd_412, docbook_xsl, libxml2, fixDarwinDylibNames, pkgsStatic }:
 
 stdenv.mkDerivation rec {
   name = "giflib-5.2.1";
@@ -19,12 +19,20 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace Makefile \
       --replace 'PREFIX = /usr/local' 'PREFIX = ${builtins.placeholder "out"}'
+  ''
+  # Upstream build system does not support NOT building shared libraries.
+  + lib.optionalString stdenv.hostPlatform.isStatic ''
+    sed -i '/all:/ s/libgif.so//' Makefile
+    sed -i '/all:/ s/libutil.so//' Makefile
+    sed -i '/-m 755 libgif.so/ d' Makefile
+    sed -i '/ln -sf libgif.so/ d' Makefile
   '';
 
   nativeBuildInputs = lib.optionals stdenv.isDarwin [ fixDarwinDylibNames ];
 
   buildInputs = [ xmlto docbook_xml_dtd_412 docbook_xsl libxml2 ];
 
+  passthru.tests.static = pkgsStatic.giflib;
   meta = {
     description = "A library for reading and writing gif images";
     platforms = lib.platforms.unix;

--- a/pkgs/development/libraries/giflib/default.nix
+++ b/pkgs/development/libraries/giflib/default.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ xmlto docbook_xml_dtd_412 docbook_xsl libxml2 ];
 
   passthru.tests.static = pkgsStatic.giflib;
+
   meta = {
     description = "A library for reading and writing gif images";
     platforms = lib.platforms.unix;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
