### PR TITLE
hdf5: fix non-determinism by removing timestamps from .data

### DIFF
--- a/pkgs/tools/misc/hdf5/default.nix
+++ b/pkgs/tools/misc/hdf5/default.nix
@@ -67,6 +67,13 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./bin-mv.patch
+
+    # Avoid non-determinism in autoconf build system:
+    # - build time
+    # - build user
+    # - uname -a (kernel version)
+    # Can be dropped once/if we switch to cmake.
+    ./hdf5-more-determinism.patch
   ];
 
   postInstall = ''

--- a/pkgs/tools/misc/hdf5/hdf5-more-determinism.patch
+++ b/pkgs/tools/misc/hdf5/hdf5-more-determinism.patch
@@ -1,0 +1,15 @@
+diff --git a/src/libhdf5.settings.in b/src/libhdf5.settings.in
+index a4d4af6..70f1909 100644
+--- a/src/libhdf5.settings.in
++++ b/src/libhdf5.settings.in
+@@ -4,10 +4,7 @@
+ General Information:
+ -------------------
+                    HDF5 Version: @H5_VERSION@
+-                  Configured on: @CONFIG_DATE@
+-                  Configured by: @CONFIG_USER@
+                     Host system: @host_cpu@-@host_vendor@-@host_os@
+-              Uname information: @UNAME_INFO@
+                        Byte sex: @BYTESEX@
+              Installation point: @prefix@
+ 


### PR DESCRIPTION
    $ diffoscope '...-hdf5-1.12.1' '...-hdf5-1.12.1.check'
    --- ...-hdf5-1.12.1/lib/libhdf5.settings
    +++ ...-hdf5-1.12.1.check/lib/libhdf5.settings
     -1,17 +1,17 @@
                      HDF5 Version: 1.12.1
    -                Configured on: Thu Oct 28 17:42:30 UTC 2021
    +                Configured on: Sat Nov  6 19:02:02 UTC 2021
                     Configured by: nixbld@
                       Host system: x86_64-unknown-linux-gnu
    -            Uname information: Linux localhost 5.10.76 #1-NixOS SMP Wed Oct 27 07:56:57 UTC 2021 x86_64 GNU/Linux
    +            Uname information: Linux localhost 5.14.15 #1-NixOS SMP Wed Oct 27 07:59:56 UTC 2021 x86_64 GNU/Linux

The patch removes `Configured on`, `Configured by` and `Uname information` fields.