### PR TITLE
smemstat: pull pending upstream inclusion fix for ncurses-6.3

### DIFF
--- a/pkgs/os-specific/linux/smemstat/default.nix
+++ b/pkgs/os-specific/linux/smemstat/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, ncurses }:
+{ stdenv, lib, fetchurl, fetchpatch, ncurses }:
 
 stdenv.mkDerivation rec {
   pname = "smemstat";
@@ -7,6 +7,15 @@ stdenv.mkDerivation rec {
     url = "https://kernel.ubuntu.com/~cking/tarballs/smemstat/smemstat-${version}.tar.xz";
     sha256 = "sha256-Vrs1jOg5yHdEffVo769aaxSawo4iZtGrFJ65Nu+RhcU=";
   };
+  patches = [
+    # Pull patch pending upstream inclusion to support ncurses-6.3:
+    #  https://github.com/ColinIanKing/smemstat/pull/1
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/ColinIanKing/smemstat/commit/95119558d1679295c9f9f7f618ddbe212674a4bf.patch";
+      sha256 = "sha256-Cl3Y0HIy1nXqBux6+AXoPuKJatSv3Z0X/4bD+MNjkAQ=";
+    })
+  ];
   buildInputs = [ ncurses ];
   installFlags = [ "DESTDIR=$(out)" ];
   postInstall = ''
@@ -15,7 +24,7 @@ stdenv.mkDerivation rec {
   '';
   meta = with lib; {
     description = "Memory usage monitoring tool";
-    homepage = "https://kernel.ubuntu.com/~cking/smemstat/";
+    homepage = "https://github.com/ColinIanKing/smemstat";
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ womfoo ];


### PR DESCRIPTION
Without the fix build on ncurses-6.3 fails as:

    smemstat.c:348:33: error: format not a string literal and no format arguments [-Werror=format-security]
      348 |         (void)mvprintw(cury, 0, buf);
          |                                 ^~~