### PR TITLE
kde-gear: 21.08.2 -> 21.08.3

### DIFF
--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/release-service/21.08.2/src -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/release-service/21.08.3/src -A '*.tar.xz' )

--- a/pkgs/applications/kde/srcs.nix
+++ b/pkgs/applications/kde/srcs.nix
@@ -4,1811 +4,1811 @@
 
 {
   akonadi = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/akonadi-21.08.2.tar.xz";
-      sha256 = "0jwhjdqha82hbyg2wmzjl5qi2rgmyd2sghdw85s77y63bxm9f0s2";
-      name = "akonadi-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/akonadi-21.08.3.tar.xz";
+      sha256 = "1yqlgzni7kj0n7k2wvi65wfz4il75j7qvmrdjw3a0ld6115j2vqs";
+      name = "akonadi-21.08.3.tar.xz";
     };
   };
   akonadi-calendar = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/akonadi-calendar-21.08.2.tar.xz";
-      sha256 = "0k4cbcr6cw9rcrzidlbjbpshmsfh0p2m8bd9inkgzxi08drwizsa";
-      name = "akonadi-calendar-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/akonadi-calendar-21.08.3.tar.xz";
+      sha256 = "17pl7viz89zn43iyp6hk9q2dix1mzfxmxf08jk5wcciphabyj2sc";
+      name = "akonadi-calendar-21.08.3.tar.xz";
     };
   };
   akonadi-calendar-tools = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/akonadi-calendar-tools-21.08.2.tar.xz";
-      sha256 = "1hxah75grydlaz6hzd3ng91dsap860111alph7vnrqcakhcfm0yc";
-      name = "akonadi-calendar-tools-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/akonadi-calendar-tools-21.08.3.tar.xz";
+      sha256 = "0wc3yfb8riijmmwqbny7vpfav24w8id4s2ysbcljrvypv420ii2g";
+      name = "akonadi-calendar-tools-21.08.3.tar.xz";
     };
   };
   akonadi-contacts = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/akonadi-contacts-21.08.2.tar.xz";
-      sha256 = "1ap2c16c0z4m7f3zsp5w5wqwcdr3fn1n2kvb6d647c3knszgibvg";
-      name = "akonadi-contacts-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/akonadi-contacts-21.08.3.tar.xz";
+      sha256 = "1i5mwjf8vp40mmdfkafhhbcmvdd2sihd6aa4z1wnhnbg59cjvp8i";
+      name = "akonadi-contacts-21.08.3.tar.xz";
     };
   };
   akonadi-import-wizard = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/akonadi-import-wizard-21.08.2.tar.xz";
-      sha256 = "0hgbjdkl4nva9dy9ljn8f5g4v9bw1rl84x2m0x94msf6bih20nr3";
-      name = "akonadi-import-wizard-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/akonadi-import-wizard-21.08.3.tar.xz";
+      sha256 = "1splq2fgifk4mh00j4dd1lmgyc4bvz8sbsw0fznmafg76k1fvama";
+      name = "akonadi-import-wizard-21.08.3.tar.xz";
     };
   };
   akonadi-mime = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/akonadi-mime-21.08.2.tar.xz";
-      sha256 = "0fkv26zl92xijkibpxvbqcmip24qrq58lan3w9s642gqh972a6x3";
-      name = "akonadi-mime-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/akonadi-mime-21.08.3.tar.xz";
+      sha256 = "19dbgl9940wwsiyhysh1lm5ks9xb6a5m53p9qmdr5siid9karq64";
+      name = "akonadi-mime-21.08.3.tar.xz";
     };
   };
   akonadi-notes = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/akonadi-notes-21.08.2.tar.xz";
-      sha256 = "0r19g9a0asqlw1qsh9vidbwpgbslfwqc8g577hdkhahfvg7hplmq";
-      name = "akonadi-notes-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/akonadi-notes-21.08.3.tar.xz";
+      sha256 = "0g1kdhj4qjl29x70dl4fl30f4r67s6ldpmqrf0xnj7zwz008r0fn";
+      name = "akonadi-notes-21.08.3.tar.xz";
     };
   };
   akonadi-search = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/akonadi-search-21.08.2.tar.xz";
-      sha256 = "1a1pf9q93z0cv7v2fxksiw3vn5dylg0lgniv98z9p6zv0wijxhn5";
-      name = "akonadi-search-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/akonadi-search-21.08.3.tar.xz";
+      sha256 = "1fvfd1410zy9dbcjl21463wj91s5vly00l53ixaizylnjbj67lm0";
+      name = "akonadi-search-21.08.3.tar.xz";
     };
   };
   akonadiconsole = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/akonadiconsole-21.08.2.tar.xz";
-      sha256 = "07vr4nwjzz6y1babwnhhidpv8pldx7vk2mq98midqji87xxh7r10";
-      name = "akonadiconsole-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/akonadiconsole-21.08.3.tar.xz";
+      sha256 = "1id1l6ifc1b8qsx16badhww33idk7c8qnn4lh3bg6mg1whmvy4k2";
+      name = "akonadiconsole-21.08.3.tar.xz";
     };
   };
   akregator = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/akregator-21.08.2.tar.xz";
-      sha256 = "15qkkfrxiwcd1gz5skqj8sb8fkr1mkc51wc2chqr4jv6aa0lbf5r";
-      name = "akregator-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/akregator-21.08.3.tar.xz";
+      sha256 = "1jb2vd43pn7i1b7ylhm74q0jkk3hwbjxh6nc2hqpl9c0ic20arf2";
+      name = "akregator-21.08.3.tar.xz";
     };
   };
   analitza = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/analitza-21.08.2.tar.xz";
-      sha256 = "1y4amcl3sjpxhlqzyjmnpycgv3jfdn4458zch9qzakvjxamq6m9c";
-      name = "analitza-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/analitza-21.08.3.tar.xz";
+      sha256 = "04g1l9q80j5rigz0667js35zjm3as0dpfkjhcm997bna1yb0d92z";
+      name = "analitza-21.08.3.tar.xz";
     };
   };
   ark = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/ark-21.08.2.tar.xz";
-      sha256 = "0hxzd0qr07wyz5v76nj4qj4db4lav53xapknmakif1fkghj1r51g";
-      name = "ark-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/ark-21.08.3.tar.xz";
+      sha256 = "1wrxv8csj1irrwcddkjgbcivpxi2v3nj06lvayzr32b29i85h637";
+      name = "ark-21.08.3.tar.xz";
     };
   };
   artikulate = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/artikulate-21.08.2.tar.xz";
-      sha256 = "0b4fvxwrynnwr8mm87h60mhk293invaq8vw4y9dk6hv36l1z5fbf";
-      name = "artikulate-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/artikulate-21.08.3.tar.xz";
+      sha256 = "14g5wcw1bxxmbc9vvy07zbk2ma2cj1zbb5fdcwdf4ybaal9r43jq";
+      name = "artikulate-21.08.3.tar.xz";
     };
   };
   audiocd-kio = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/audiocd-kio-21.08.2.tar.xz";
-      sha256 = "1l0wym8gisgwv2mg2jsvpj8hb2yvmzd7dcximg540ljphv3hp1p2";
-      name = "audiocd-kio-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/audiocd-kio-21.08.3.tar.xz";
+      sha256 = "0fp29igj87pff8jya230j67vcz9pv7g27g4dv2pl3r6gm2kv8c9i";
+      name = "audiocd-kio-21.08.3.tar.xz";
     };
   };
   baloo-widgets = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/baloo-widgets-21.08.2.tar.xz";
-      sha256 = "1fk8qvqh1xx6139wvyfk607vkb7w3d79gc3v3c8s96pkp5b228ax";
-      name = "baloo-widgets-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/baloo-widgets-21.08.3.tar.xz";
+      sha256 = "1pjlw22ivqhpd6bf50d8s9jaq6h2k0l2szwnh841qq7bwwkp9kcb";
+      name = "baloo-widgets-21.08.3.tar.xz";
     };
   };
   blinken = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/blinken-21.08.2.tar.xz";
-      sha256 = "1ciq6fk9430p8sihc1q40djjw4994w1lghps9kr3415ryv08bfci";
-      name = "blinken-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/blinken-21.08.3.tar.xz";
+      sha256 = "03s3pv61jhkx3lm5rik25fglhda9l4w43blpwh78rbdk3c3s3ijg";
+      name = "blinken-21.08.3.tar.xz";
     };
   };
   bomber = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/bomber-21.08.2.tar.xz";
-      sha256 = "0wk6j89m8lbp83yfz2xwy78x99cvph9p36jzscpp4i894j6fad61";
-      name = "bomber-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/bomber-21.08.3.tar.xz";
+      sha256 = "0h5iwpmpw8xnqh6xcm4zqqcp1ia5wir0ghwsbcgrz9ka59dfdh4z";
+      name = "bomber-21.08.3.tar.xz";
     };
   };
   bovo = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/bovo-21.08.2.tar.xz";
-      sha256 = "1k5ncxxx64yj2b71jlpz7ll935mrilhrhphwz1h8n8pdr6dn91mf";
-      name = "bovo-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/bovo-21.08.3.tar.xz";
+      sha256 = "0p5pi6rnnmikhg72gagld67r022bq3nsrhls0gglx14zfj6pgln3";
+      name = "bovo-21.08.3.tar.xz";
     };
   };
   calendarsupport = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/calendarsupport-21.08.2.tar.xz";
-      sha256 = "01plq4qzp94lxcc2gp04afnlvmni8993c8mf6kl256158z0y24ik";
-      name = "calendarsupport-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/calendarsupport-21.08.3.tar.xz";
+      sha256 = "1kial8x8sw0039n2s3nl9i0wadf8xda1bv2g9kws0kp29k58lyfy";
+      name = "calendarsupport-21.08.3.tar.xz";
     };
   };
   cantor = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/cantor-21.08.2.tar.xz";
-      sha256 = "07xxwm3aa00v6cax7nyv326glapll01qh4libszhhn8pwpiyl00w";
-      name = "cantor-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/cantor-21.08.3.tar.xz";
+      sha256 = "1l3z0aikrfjdpcfq6apmwla9k7dqymvysi275kpx0dqi5sfgi9lb";
+      name = "cantor-21.08.3.tar.xz";
     };
   };
   cervisia = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/cervisia-21.08.2.tar.xz";
-      sha256 = "0x4hisqfkizjxzl34s0yc6dn5r5fyh7f5yaadq5g47fdcah5cmmf";
-      name = "cervisia-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/cervisia-21.08.3.tar.xz";
+      sha256 = "0a7g3g849vf0c0222944iwqhymnxcn9qj0v85m2b0bfxgdf0fgk7";
+      name = "cervisia-21.08.3.tar.xz";
     };
   };
   dolphin = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/dolphin-21.08.2.tar.xz";
-      sha256 = "18aiqpf8qsig64gpcn6b1f0fs5mvzbdg8ncbhcjq0gy8gh3xamj2";
-      name = "dolphin-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/dolphin-21.08.3.tar.xz";
+      sha256 = "19yrgfliqabmymrh3sx2i5129rcc14nxb86f21wd616b3pcby5rv";
+      name = "dolphin-21.08.3.tar.xz";
     };
   };
   dolphin-plugins = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/dolphin-plugins-21.08.2.tar.xz";
-      sha256 = "0278pmakd4xqc8ckyxkzvf1xj1jp7jdq3a86i0n0k691zfljnan7";
-      name = "dolphin-plugins-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/dolphin-plugins-21.08.3.tar.xz";
+      sha256 = "098i2zydzi95i860pk6p0g0wx1bryyxanawhcis5d5h3xra66s0p";
+      name = "dolphin-plugins-21.08.3.tar.xz";
     };
   };
   dragon = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/dragon-21.08.2.tar.xz";
-      sha256 = "0ddijz96z58582w298jp11vns9fx3rmzqd3x1qplxvp4sl0hp9l7";
-      name = "dragon-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/dragon-21.08.3.tar.xz";
+      sha256 = "0zfh5kmw2mvnwpcbh9i6xzzdigkglr6y0y7acw2dw6bi2cqx5cc7";
+      name = "dragon-21.08.3.tar.xz";
     };
   };
   elisa = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/elisa-21.08.2.tar.xz";
-      sha256 = "14wi7dva0bfagxw49bs80qszqcv6k16s0569mh1c4m97gzlzgv35";
-      name = "elisa-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/elisa-21.08.3.tar.xz";
+      sha256 = "0w3sk52ghkka305hagld5ia6z6czavbqgc0abqdz442bgnk1f1vb";
+      name = "elisa-21.08.3.tar.xz";
     };
   };
   eventviews = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/eventviews-21.08.2.tar.xz";
-      sha256 = "0d1ahknazkjav9641i1wggj9f67cr3s3y176v1j6ljhr4dl3m3xj";
-      name = "eventviews-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/eventviews-21.08.3.tar.xz";
+      sha256 = "08bcw79iag71yiaf7ck27b2ja4pg18ah04rxa1c6g5fr9x6kkk46";
+      name = "eventviews-21.08.3.tar.xz";
     };
   };
   ffmpegthumbs = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/ffmpegthumbs-21.08.2.tar.xz";
-      sha256 = "1gsxcm86aq3r485ivk532a949z5l4129kildbd752c2qy0hdy5z1";
-      name = "ffmpegthumbs-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/ffmpegthumbs-21.08.3.tar.xz";
+      sha256 = "10l9592f2l63rfak3f0knvzapsaa8nyx3dl82n724359qj43m530";
+      name = "ffmpegthumbs-21.08.3.tar.xz";
     };
   };
   filelight = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/filelight-21.08.2.tar.xz";
-      sha256 = "0phisyrnxc6i19253fdayx8cn51y6vxd66gfdy08hi4r31ih57jd";
-      name = "filelight-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/filelight-21.08.3.tar.xz";
+      sha256 = "0j5106x93ljkcxk90cs1yvd9dw3pnr007cd4plsw5z7kgmch3zww";
+      name = "filelight-21.08.3.tar.xz";
     };
   };
   granatier = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/granatier-21.08.2.tar.xz";
-      sha256 = "1bly3jlmn9d2im05srr3v28mw8wmr3hnw180wi8lpfzianh589v7";
-      name = "granatier-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/granatier-21.08.3.tar.xz";
+      sha256 = "1igia7fxll361np76763nw915d90f5hklgqii9iyld8si99amy4y";
+      name = "granatier-21.08.3.tar.xz";
     };
   };
   grantlee-editor = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/grantlee-editor-21.08.2.tar.xz";
-      sha256 = "1sm35c4r5sawcrclv1sc6ij4gsll87zwmissahgf30km32vz0rbv";
-      name = "grantlee-editor-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/grantlee-editor-21.08.3.tar.xz";
+      sha256 = "04yry04cdysh4a1y6nznxmfw2pww956xan0dnf77yjzssri9p2fq";
+      name = "grantlee-editor-21.08.3.tar.xz";
     };
   };
   grantleetheme = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/grantleetheme-21.08.2.tar.xz";
-      sha256 = "0xm19a21y8b4cqiqg6mhxip1xxk7hrz88z1sijhhgc8d14i7mkdk";
-      name = "grantleetheme-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/grantleetheme-21.08.3.tar.xz";
+      sha256 = "11c72jp9ywpmsc3d92cj2c9xvwmqbilsfddmlxlwnpnp2rf8q933";
+      name = "grantleetheme-21.08.3.tar.xz";
     };
   };
   gwenview = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/gwenview-21.08.2.tar.xz";
-      sha256 = "0yignay0g4vz3zj9xpziinsqd8pwywd1cq43f0n5hmzxrrv0abcf";
-      name = "gwenview-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/gwenview-21.08.3.tar.xz";
+      sha256 = "06hg20sygi6xfbifgi1d6s5zba5qqpm949xa7gyxi1vsq0kbvrq4";
+      name = "gwenview-21.08.3.tar.xz";
     };
   };
   incidenceeditor = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/incidenceeditor-21.08.2.tar.xz";
-      sha256 = "0xrz3kzf4mc37zgfbjgc23l7wxry9m6d5igvyf1qm33yxwr4w78q";
-      name = "incidenceeditor-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/incidenceeditor-21.08.3.tar.xz";
+      sha256 = "0p45x5qkzbfklxk22kzp9zlvl8ggdjgniq889q8hzb1s89ia1cck";
+      name = "incidenceeditor-21.08.3.tar.xz";
     };
   };
   itinerary = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/itinerary-21.08.2.tar.xz";
-      sha256 = "059n7xy3gjbqxl9cn7nxng9y4662ggi2lh2zj3yv0knwy78ccwjk";
-      name = "itinerary-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/itinerary-21.08.3.tar.xz";
+      sha256 = "0w7kb4wvy1sfhlkikvq1ajckizf7k2bzy2wcjdz5is69rrd5cab5";
+      name = "itinerary-21.08.3.tar.xz";
     };
   };
   juk = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/juk-21.08.2.tar.xz";
-      sha256 = "0c74s9ylx1xh1y581ygm6zyafwv3l5d7297wfg50f64nyr5npxm2";
-      name = "juk-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/juk-21.08.3.tar.xz";
+      sha256 = "19g1dpvrssip8vysds3j4wa599ivapznz10p0p1254gkjyxdxdm3";
+      name = "juk-21.08.3.tar.xz";
     };
   };
   k3b = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/k3b-21.08.2.tar.xz";
-      sha256 = "1g9xgzklsyard3ghcmr9irixcilga6kcj46jav884y8w7zxb4mrd";
-      name = "k3b-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/k3b-21.08.3.tar.xz";
+      sha256 = "1k5xn33sggx3a7lns8y64sa3schqvg476q81rig9mylh68x8rr5y";
+      name = "k3b-21.08.3.tar.xz";
     };
   };
   kaccounts-integration = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kaccounts-integration-21.08.2.tar.xz";
-      sha256 = "1ckwm2kwb83kl89491wrmpd748zhkwd1vyaffwiyaqkp4rkrjph0";
-      name = "kaccounts-integration-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kaccounts-integration-21.08.3.tar.xz";
+      sha256 = "0hyaygrsdp6s96s4wa9z5l1w5w5hxwbw432zs6a2fkgq5dpa3wn4";
+      name = "kaccounts-integration-21.08.3.tar.xz";
     };
   };
   kaccounts-providers = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kaccounts-providers-21.08.2.tar.xz";
-      sha256 = "15q1ibhxwxcvsjn6b2whyynhipq5b571d98bz20dn25fff88xllg";
-      name = "kaccounts-providers-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kaccounts-providers-21.08.3.tar.xz";
+      sha256 = "0chajl87w3gp1a8l7h6bxf93js6jxdkx90ir82glgh45p5qhdhcr";
+      name = "kaccounts-providers-21.08.3.tar.xz";
     };
   };
   kaddressbook = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kaddressbook-21.08.2.tar.xz";
-      sha256 = "1pvd31zpam13jv0mhxzaagdlvnav60znd68l24y1dw5i98wk7n72";
-      name = "kaddressbook-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kaddressbook-21.08.3.tar.xz";
+      sha256 = "1c16pcbjd5w04xbkjalvf697nqi751f4g8ldaing3k2rmdvhsqwg";
+      name = "kaddressbook-21.08.3.tar.xz";
     };
   };
   kajongg = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kajongg-21.08.2.tar.xz";
-      sha256 = "0c8kxh6kbk7ml16df4gmr142rjllc7v0v7m3kw4ksngk93f7vz2s";
-      name = "kajongg-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kajongg-21.08.3.tar.xz";
+      sha256 = "15i5vdcwm7a5amrxxbi0f4c3ls7ly1ccg88hff2wc960wwc6nvqb";
+      name = "kajongg-21.08.3.tar.xz";
     };
   };
   kalarm = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kalarm-21.08.2.tar.xz";
-      sha256 = "06cww023m4ng4g3v344lci0rvapk4zyzf1vi5jlajfs5d8bfkgf5";
-      name = "kalarm-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kalarm-21.08.3.tar.xz";
+      sha256 = "0zcmaf4x9jvpyri1kirnm2rij3886z9k1vx6wxxxmx6sbllpb669";
+      name = "kalarm-21.08.3.tar.xz";
     };
   };
   kalarmcal = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kalarmcal-21.08.2.tar.xz";
-      sha256 = "0xdcazbbkm2z0r2g1avwh9bvdkvv0fy6qhhddlmfzj4cwh4c9vih";
-      name = "kalarmcal-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kalarmcal-21.08.3.tar.xz";
+      sha256 = "03zmw8pxhfmrm7xl5h2k42xyqwn4cllhrp43sv7pjbym9ya41wyk";
+      name = "kalarmcal-21.08.3.tar.xz";
     };
   };
   kalgebra = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kalgebra-21.08.2.tar.xz";
-      sha256 = "07fw8ab8gy9mam5dij6i9nl1zv4fp13vari6nzdk337klhsdbsjr";
-      name = "kalgebra-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kalgebra-21.08.3.tar.xz";
+      sha256 = "0w2n3nyds9069c4cj1ap2b14w8nw5dc3yb62j5y6yj9qz9ip7cdk";
+      name = "kalgebra-21.08.3.tar.xz";
     };
   };
   kalzium = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kalzium-21.08.2.tar.xz";
-      sha256 = "0hjkpgclm67nyninywdmcpi7vn3jmf7ikbd4afg4bhj5mcz2a4vg";
-      name = "kalzium-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kalzium-21.08.3.tar.xz";
+      sha256 = "0x7dn0f2bwzplzxal2wvnc3qh2qs522626ksp6ajgf16jwf7d4kl";
+      name = "kalzium-21.08.3.tar.xz";
     };
   };
   kamera = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kamera-21.08.2.tar.xz";
-      sha256 = "1arb93sa730ha8bgbcvp6bng8s4fp9yvcv0qvkhk2nl4db4m5rng";
-      name = "kamera-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kamera-21.08.3.tar.xz";
+      sha256 = "1yv87rmb8k6yh5150915fsnh8rdj1d4k8zpc8k54hxa9gjw5wqm7";
+      name = "kamera-21.08.3.tar.xz";
     };
   };
   kamoso = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kamoso-21.08.2.tar.xz";
-      sha256 = "0rkd9mk7rgha40j19rwpyqmn8lchqahakn4p3sbab7h3p3cq2b7p";
-      name = "kamoso-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kamoso-21.08.3.tar.xz";
+      sha256 = "1k2kis36a6dlsnh85qc01yd6qnz8kwrv4hvzpkpqvvp3m4ik17wx";
+      name = "kamoso-21.08.3.tar.xz";
     };
   };
   kanagram = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kanagram-21.08.2.tar.xz";
-      sha256 = "12iq58jc36rp664c92s7442gnxq6k1fi4017a4hwqq67b9ismgzl";
-      name = "kanagram-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kanagram-21.08.3.tar.xz";
+      sha256 = "1rxirjrw6dj23awv6gbypv0jlwfdh4baz86l32rx8pnmd9icg7s3";
+      name = "kanagram-21.08.3.tar.xz";
     };
   };
   kapman = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kapman-21.08.2.tar.xz";
-      sha256 = "04yv6j2bjlgclp916k2gibhhv5d64sxk181cqw7sh5j4aq555a3r";
-      name = "kapman-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kapman-21.08.3.tar.xz";
+      sha256 = "0v8ay2s868l7dxasq0rhy065rp9sfb4fzldcqs46lxy7jmk3ws93";
+      name = "kapman-21.08.3.tar.xz";
     };
   };
   kapptemplate = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kapptemplate-21.08.2.tar.xz";
-      sha256 = "0vgfz4pz9yjns4dpks8mrp8zzipka4chw257l1db25khibksgh48";
-      name = "kapptemplate-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kapptemplate-21.08.3.tar.xz";
+      sha256 = "02dp4qwrv3gylri936c82imh4lv1a3vfzlphmwadyhiy7j9ic5fa";
+      name = "kapptemplate-21.08.3.tar.xz";
     };
   };
   kate = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kate-21.08.2.tar.xz";
-      sha256 = "1cm6iq3cqmp0kvsxhv0vlqy1dyzmis9fb0a6298q0lyjkmsri26n";
-      name = "kate-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kate-21.08.3.tar.xz";
+      sha256 = "1gdz0wxkh34a2zi9vks9qw70g7dvkbvrbp6y68rjg7720sdb0gp2";
+      name = "kate-21.08.3.tar.xz";
     };
   };
   katomic = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/katomic-21.08.2.tar.xz";
-      sha256 = "0lng3fpc1b255n8hayla3lpb77rmgvx8bkzi1s152kq7bf2mnxj7";
-      name = "katomic-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/katomic-21.08.3.tar.xz";
+      sha256 = "1sgrpqbv4zz22qijm00lzv1cv4rwjh7bbf4gz9xmnfmhyw0n88i1";
+      name = "katomic-21.08.3.tar.xz";
     };
   };
   kbackup = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kbackup-21.08.2.tar.xz";
-      sha256 = "06xvw94m6zr7zj0i54if9vanbflnj88b0c16751br6ibp2m9zvlp";
-      name = "kbackup-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kbackup-21.08.3.tar.xz";
+      sha256 = "1cjb2invbc60i2lahn01kd28q3wb6s35grwglgmx2cgqqkmgl42s";
+      name = "kbackup-21.08.3.tar.xz";
     };
   };
   kblackbox = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kblackbox-21.08.2.tar.xz";
-      sha256 = "093k42259lwbhmq6pm5hv1iqm4maqd63qic80p748wmh88bsh8yg";
-      name = "kblackbox-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kblackbox-21.08.3.tar.xz";
+      sha256 = "1i4c5v5w42akf4b44sqrl9x4rhqgyjljr7k5i440ahch9qkf93pj";
+      name = "kblackbox-21.08.3.tar.xz";
     };
   };
   kblocks = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kblocks-21.08.2.tar.xz";
-      sha256 = "0p4k3wr8756qfxr09daqp7z3461ljnd3yv34h893j5dini1lfy3d";
-      name = "kblocks-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kblocks-21.08.3.tar.xz";
+      sha256 = "0326fxv1nvh37h8xhvv5x4fy3l4gbrzmwsgcwslma1hakys9dhrs";
+      name = "kblocks-21.08.3.tar.xz";
     };
   };
   kbounce = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kbounce-21.08.2.tar.xz";
-      sha256 = "06zd4p8glpzp7q4a8qcmnj1lszgfdircfkgc8ay5abmfx2rr9hcw";
-      name = "kbounce-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kbounce-21.08.3.tar.xz";
+      sha256 = "00d9m7c564qrifpaldvjk6ahclrjk1aawhypjj9sls2sisx2mip4";
+      name = "kbounce-21.08.3.tar.xz";
     };
   };
   kbreakout = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kbreakout-21.08.2.tar.xz";
-      sha256 = "1gj37ryhak1czv95ksigssmbmicdpirzi1l5zsv1w7jdh4nqcz54";
-      name = "kbreakout-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kbreakout-21.08.3.tar.xz";
+      sha256 = "1h3s4cr4bxi24j55anks946h7iba2wda5kbglsyfqw1ifrsq13vz";
+      name = "kbreakout-21.08.3.tar.xz";
     };
   };
   kbruch = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kbruch-21.08.2.tar.xz";
-      sha256 = "1syy188f3sg3r22f7dklzman0h8fz6r1n4r5z986240q0r316rbn";
-      name = "kbruch-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kbruch-21.08.3.tar.xz";
+      sha256 = "15bfqxz4j5f5ix55fsk780p7ddrzqzmk55gmbjy796sgh8b71wcr";
+      name = "kbruch-21.08.3.tar.xz";
     };
   };
   kcachegrind = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kcachegrind-21.08.2.tar.xz";
-      sha256 = "126qa061bwz2d4s721vbv2099mz07vw3i1yw7vm0b3ih43h95149";
-      name = "kcachegrind-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kcachegrind-21.08.3.tar.xz";
+      sha256 = "188m15y7sj17jyr9963gblgkknhgf32331kvzz4cwqzk14b9krr2";
+      name = "kcachegrind-21.08.3.tar.xz";
     };
   };
   kcalc = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kcalc-21.08.2.tar.xz";
-      sha256 = "01923w7zav2iia5pffs33vhblzh26lr1zpf2274cgplsbb5lcc9p";
-      name = "kcalc-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kcalc-21.08.3.tar.xz";
+      sha256 = "1d7716law49cwmis4w9ij1xmi4g2wrv4mnc78xcms8kmgba5gs7v";
+      name = "kcalc-21.08.3.tar.xz";
     };
   };
   kcalutils = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kcalutils-21.08.2.tar.xz";
-      sha256 = "0kvfpsz6zxdbgl4qvk3q55fjgjql1chx844cys26anhza0ld9afz";
-      name = "kcalutils-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kcalutils-21.08.3.tar.xz";
+      sha256 = "0l209pyi866mf1pr4rkq7g3pgjvyss5sqhpy9vb2b2w66w3f66ri";
+      name = "kcalutils-21.08.3.tar.xz";
     };
   };
   kcharselect = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kcharselect-21.08.2.tar.xz";
-      sha256 = "08x060xmnyzqyadimwdqz767q29rmd48m8aqr3dsrzvb969ijnha";
-      name = "kcharselect-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kcharselect-21.08.3.tar.xz";
+      sha256 = "0fk06whwi4h43sw3adcs4b2s9ycwjamzrwr23m33c31mlpcb3i8z";
+      name = "kcharselect-21.08.3.tar.xz";
     };
   };
   kcolorchooser = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kcolorchooser-21.08.2.tar.xz";
-      sha256 = "00vn2001crd0in3zd016xkhm38qgl7m03k1n90fiashjlnfd0928";
-      name = "kcolorchooser-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kcolorchooser-21.08.3.tar.xz";
+      sha256 = "07fvl4rfzhgz4kh9dhqkq6kf4913jv9cw9abfdb7k3pbr0r26qgz";
+      name = "kcolorchooser-21.08.3.tar.xz";
     };
   };
   kcron = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kcron-21.08.2.tar.xz";
-      sha256 = "1ryfa084cfp7v11lbr58j4rx3n4m70ynpzbyavin31x1zzbw7bh8";
-      name = "kcron-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kcron-21.08.3.tar.xz";
+      sha256 = "1374agj9qc5ifm0yckq8m94gq7sjd42n4wwb59p756736asan8k5";
+      name = "kcron-21.08.3.tar.xz";
     };
   };
   kde-dev-scripts = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kde-dev-scripts-21.08.2.tar.xz";
-      sha256 = "093i4k4qqmjlffjyz7wqfv4lpsq6x9rc4svldbq5iszk8a7ldal5";
-      name = "kde-dev-scripts-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kde-dev-scripts-21.08.3.tar.xz";
+      sha256 = "152n6iir4xzx1a5d5bi4lb42rgl222pi6jz0hfkchk7swfgpvdfs";
+      name = "kde-dev-scripts-21.08.3.tar.xz";
     };
   };
   kde-dev-utils = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kde-dev-utils-21.08.2.tar.xz";
-      sha256 = "1gidcxnixymzvdqjyzwdc9bfphvrbq7xx1miabn221gjc42bkggs";
-      name = "kde-dev-utils-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kde-dev-utils-21.08.3.tar.xz";
+      sha256 = "1xs4fybbqlxji2py06hxabsisfb3bkvbfb3vy9lyj2k5vnnmpkf8";
+      name = "kde-dev-utils-21.08.3.tar.xz";
     };
   };
   kdebugsettings = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kdebugsettings-21.08.2.tar.xz";
-      sha256 = "1wpj1hldrpbi538fd69i36zr3q3dg04i5bcmy41i1brzbddxl6sv";
-      name = "kdebugsettings-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kdebugsettings-21.08.3.tar.xz";
+      sha256 = "1d47igv0xg1hlxzyfg10h5g7s79yq44d3ixpr82risyrslbwvll4";
+      name = "kdebugsettings-21.08.3.tar.xz";
     };
   };
   kdeconnect-kde = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kdeconnect-kde-21.08.2.tar.xz";
-      sha256 = "09dv3l5g0wjilpga11mkxbyy3d8xk46pb2i35yvjbgi9yzp0xzfv";
-      name = "kdeconnect-kde-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kdeconnect-kde-21.08.3.tar.xz";
+      sha256 = "1gfsbg6rwqv3cpfxcayn3q9i99mnhjz666p9x9ih205idlrn6iij";
+      name = "kdeconnect-kde-21.08.3.tar.xz";
     };
   };
   kdeedu-data = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kdeedu-data-21.08.2.tar.xz";
-      sha256 = "0zm7gl4nz1b6m9m8hw5zklf5nbfh6qms7qbrrdxzcn6kj50zx6m2";
-      name = "kdeedu-data-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kdeedu-data-21.08.3.tar.xz";
+      sha256 = "15qqcl6gws6ddyv373dfql3wj2fryvr5b6d66q4l1xwc1mg6wnqs";
+      name = "kdeedu-data-21.08.3.tar.xz";
     };
   };
   kdegraphics-mobipocket = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kdegraphics-mobipocket-21.08.2.tar.xz";
-      sha256 = "15wd7sfwfz3n1a0m0l2ymyhsdxjajw3kkl4piv9956amcg1bxlcp";
-      name = "kdegraphics-mobipocket-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kdegraphics-mobipocket-21.08.3.tar.xz";
+      sha256 = "1bli0ld2mymgppjsjjvkyk7ldpz787p30d7lf6lpafrf64di2bhm";
+      name = "kdegraphics-mobipocket-21.08.3.tar.xz";
     };
   };
   kdegraphics-thumbnailers = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kdegraphics-thumbnailers-21.08.2.tar.xz";
-      sha256 = "1261kn4fa2lrissqc9cb5s7rd94pzfzq79kjw3gagbhrjfs91872";
-      name = "kdegraphics-thumbnailers-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kdegraphics-thumbnailers-21.08.3.tar.xz";
+      sha256 = "1hbjmkjymb3pi1lz43bl5clgdyy6kr928q7fniwiwmak3k1xrng5";
+      name = "kdegraphics-thumbnailers-21.08.3.tar.xz";
     };
   };
   kdenetwork-filesharing = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kdenetwork-filesharing-21.08.2.tar.xz";
-      sha256 = "0xyph51w7ba0jrp9dds0v97k7av2h5a3098h7wpwd0sclj2hbnwc";
-      name = "kdenetwork-filesharing-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kdenetwork-filesharing-21.08.3.tar.xz";
+      sha256 = "19c3my0i9xb3salf7sk870nhv797wkk83dyrczw672skwl8xcnd9";
+      name = "kdenetwork-filesharing-21.08.3.tar.xz";
     };
   };
   kdenlive = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kdenlive-21.08.2.tar.xz";
-      sha256 = "10x160sdj7dk27aa7iyvfmpgfidc8pisfmx6a50z0b23y54kg77m";
-      name = "kdenlive-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kdenlive-21.08.3.tar.xz";
+      sha256 = "00ss9i9gw112vc3bjayp193qnfd3dq47bij9mv429azl20ff0y0c";
+      name = "kdenlive-21.08.3.tar.xz";
     };
   };
   kdepim-addons = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kdepim-addons-21.08.2.tar.xz";
-      sha256 = "050kbxh89drd0yd9gzjjipmz1cvxkk5riivr5fcccqayyvskvyh2";
-      name = "kdepim-addons-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kdepim-addons-21.08.3.tar.xz";
+      sha256 = "1ham9yzmj89lp3zwxwpyh0qy7fxrlhgmhphn9crrkx9gsy77ddsf";
+      name = "kdepim-addons-21.08.3.tar.xz";
     };
   };
   kdepim-runtime = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kdepim-runtime-21.08.2.tar.xz";
-      sha256 = "0vzly768f2g0zhprl1970k16kza128izhrby2mm1wdskrmdrvflq";
-      name = "kdepim-runtime-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kdepim-runtime-21.08.3.tar.xz";
+      sha256 = "1d2208pwalc6mjfnn4gfq2f2fqgxp9w3g8igx6r6l9qsgybh1msx";
+      name = "kdepim-runtime-21.08.3.tar.xz";
     };
   };
   kdesdk-kioslaves = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kdesdk-kioslaves-21.08.2.tar.xz";
-      sha256 = "1g4i7sc30m7sjmmgjf12b83yhcwpdnvb7gzdjs1da5np5nq96j4y";
-      name = "kdesdk-kioslaves-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kdesdk-kioslaves-21.08.3.tar.xz";
+      sha256 = "0frw2zxwckmqmffxn5gszdxz61zc0k8xpbhbiyfxsqprh3ck4a2y";
+      name = "kdesdk-kioslaves-21.08.3.tar.xz";
     };
   };
   kdesdk-thumbnailers = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kdesdk-thumbnailers-21.08.2.tar.xz";
-      sha256 = "1bdwdpvdqx19j714fnxfhi3b647ynm1cgrkny7i27pkqlyw72hjg";
-      name = "kdesdk-thumbnailers-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kdesdk-thumbnailers-21.08.3.tar.xz";
+      sha256 = "06s7i85g5gpknxlrq59i5w8czpaz5wl1b8kfx9flzx0x6ibm5s9q";
+      name = "kdesdk-thumbnailers-21.08.3.tar.xz";
     };
   };
   kdf = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kdf-21.08.2.tar.xz";
-      sha256 = "1z2m9a4rzjsjxv9pkassn3j7pxkqrpq04hw0j6q913q69a999rwg";
-      name = "kdf-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kdf-21.08.3.tar.xz";
+      sha256 = "061xclwkhmc9m8f113hlb46dwk5zvqlmgahz13yfbvyrpj810a7k";
+      name = "kdf-21.08.3.tar.xz";
     };
   };
   kdialog = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kdialog-21.08.2.tar.xz";
-      sha256 = "08klapfcxwp3mf7jv7swsia4719fq6aqdv7lnxr16j8sd6h3z0yx";
-      name = "kdialog-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kdialog-21.08.3.tar.xz";
+      sha256 = "1ibqz8s8p90rxy843f1wn3jnyzrm54srhfpr4ix48amf86afj2gp";
+      name = "kdialog-21.08.3.tar.xz";
     };
   };
   kdiamond = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kdiamond-21.08.2.tar.xz";
-      sha256 = "1k458rs0x82jf4sjzcry4xzazwfn9drg41736749nc5d26k6csz1";
-      name = "kdiamond-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kdiamond-21.08.3.tar.xz";
+      sha256 = "1vkflwvi1wa2kd6hq647g9skxg6c7jdk9hakzfphlq2jw6daml94";
+      name = "kdiamond-21.08.3.tar.xz";
     };
   };
   keditbookmarks = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/keditbookmarks-21.08.2.tar.xz";
-      sha256 = "07yscqr3zzjvb1snl1k0ilmpgv8wrxvjrjdcr1410llfwd80fpvi";
-      name = "keditbookmarks-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/keditbookmarks-21.08.3.tar.xz";
+      sha256 = "0v9grm385zyxpsqjp287cz8lvrvfzkk7b4blvdr1hi66sng7nr2n";
+      name = "keditbookmarks-21.08.3.tar.xz";
     };
   };
   kfind = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kfind-21.08.2.tar.xz";
-      sha256 = "1rqn77m8i3fvknkq4gdl4fyihxkc34537010d6i992pxcx9yxv4d";
-      name = "kfind-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kfind-21.08.3.tar.xz";
+      sha256 = "04qdxqa8gfipjm5akplxrjbnlaky2djkx8nkvcqzqfhvw5i9rxqp";
+      name = "kfind-21.08.3.tar.xz";
     };
   };
   kfloppy = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kfloppy-21.08.2.tar.xz";
-      sha256 = "0g54qwrmqkd3jxi6nwprzd0jckzdq3iawibfsfblkchnd8hnlxiw";
-      name = "kfloppy-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kfloppy-21.08.3.tar.xz";
+      sha256 = "14l53a0mrzhnfrhalr71fv0j0ksz6c1zqj8j33nayhqz386yrccx";
+      name = "kfloppy-21.08.3.tar.xz";
     };
   };
   kfourinline = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kfourinline-21.08.2.tar.xz";
-      sha256 = "0z28lzx9jqp2krgwf6cpwv4hhyl8q8azgw3ni24c8hjl81sxidvb";
-      name = "kfourinline-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kfourinline-21.08.3.tar.xz";
+      sha256 = "0w2zdl0yfhwdwbnlqd4l9pdx7q9mr0xq7kw49h9wiajy1zmh8vls";
+      name = "kfourinline-21.08.3.tar.xz";
     };
   };
   kgeography = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kgeography-21.08.2.tar.xz";
-      sha256 = "16rqlh2n4xz5rcs0p9ppzsk7wh060zf1i5yfx4cjrswfn2wk5brv";
-      name = "kgeography-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kgeography-21.08.3.tar.xz";
+      sha256 = "03wchz3bd4vlijywp9r2xilmhw4gc3ka54ilf2w60baazslhlnr3";
+      name = "kgeography-21.08.3.tar.xz";
     };
   };
   kget = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kget-21.08.2.tar.xz";
-      sha256 = "11h073nkk5axr263wz5wjq8pdad2wk3nmhixx12ilkqqinb0pi6h";
-      name = "kget-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kget-21.08.3.tar.xz";
+      sha256 = "0zpzh7bf65kz469viff794zdwc54aq84ndafx6g07nhqs3jhnmjp";
+      name = "kget-21.08.3.tar.xz";
     };
   };
   kgoldrunner = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kgoldrunner-21.08.2.tar.xz";
-      sha256 = "13y8a1zxfy16sbdf2c94wdx15ghmb436pzx7kvvsfv8d5yizlzdz";
-      name = "kgoldrunner-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kgoldrunner-21.08.3.tar.xz";
+      sha256 = "0c566c83a7kdc4kvzn37q4kdmr373hfrjgmq7mvn9bji5gcaqzch";
+      name = "kgoldrunner-21.08.3.tar.xz";
     };
   };
   kgpg = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kgpg-21.08.2.tar.xz";
-      sha256 = "051z9h12zqmhgvr8pk17vsfzld25mpklk1z6nknlf3hydjnq6ns1";
-      name = "kgpg-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kgpg-21.08.3.tar.xz";
+      sha256 = "0q8da9mzqxg0xmclcpgjh8c744l1sm180ga6hxbasan47wwq67as";
+      name = "kgpg-21.08.3.tar.xz";
     };
   };
   khangman = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/khangman-21.08.2.tar.xz";
-      sha256 = "0xrwsg5pv1y5lh6d2na1gx8aiimpbl8y2i9a4qj3qg5l4nf0inal";
-      name = "khangman-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/khangman-21.08.3.tar.xz";
+      sha256 = "1iq4njq0fa7all8zm2q585i1grmv2nfb5qnpr8xpyn13np39q8sr";
+      name = "khangman-21.08.3.tar.xz";
     };
   };
   khelpcenter = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/khelpcenter-21.08.2.tar.xz";
-      sha256 = "0ivm1z7c6yy6dm9sb88ggiww9c2k526lhpipkgiwm6kslzallxsn";
-      name = "khelpcenter-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/khelpcenter-21.08.3.tar.xz";
+      sha256 = "1pn5822yxqw62hynkf05a33gzs9xvrwwrxam024g6gs0y0v5nsfp";
+      name = "khelpcenter-21.08.3.tar.xz";
     };
   };
   kidentitymanagement = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kidentitymanagement-21.08.2.tar.xz";
-      sha256 = "0kaws0w21sm0mb0fd5av7gid8gvyz0zxxjrbx0kf3c52dwkrmw5c";
-      name = "kidentitymanagement-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kidentitymanagement-21.08.3.tar.xz";
+      sha256 = "00fhw2c7jmv0xqyd1jlrlkahszw163a7cbljn83msws8m5mrnlcb";
+      name = "kidentitymanagement-21.08.3.tar.xz";
     };
   };
   kig = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kig-21.08.2.tar.xz";
-      sha256 = "1i5lszzj200mda7vbc8c6bzdlx8ycf2d8kk28pl2n17ajra33iim";
-      name = "kig-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kig-21.08.3.tar.xz";
+      sha256 = "1l4zap7lm1pigyldbqy20jaqysid0r4a6y71qalxk3f565jsqfx5";
+      name = "kig-21.08.3.tar.xz";
     };
   };
   kigo = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kigo-21.08.2.tar.xz";
-      sha256 = "0ss15k2qpmrf4xvsjpqpvf9pvw8wijmk4zqqhvsjrbd5xrk53bkf";
-      name = "kigo-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kigo-21.08.3.tar.xz";
+      sha256 = "1cdrmlwpzbkz1mi2f72z9dh1pvkdkjn885zqqybhqbqicn3w3qch";
+      name = "kigo-21.08.3.tar.xz";
     };
   };
   killbots = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/killbots-21.08.2.tar.xz";
-      sha256 = "11cgkx5wpzgzx62frn90h35ga2scrvyxv7sasfsxldf3yiv15m30";
-      name = "killbots-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/killbots-21.08.3.tar.xz";
+      sha256 = "1mwa46r7yvxhavprc6yjh773gjhz5ks0znsvpzambn6hk23r11p8";
+      name = "killbots-21.08.3.tar.xz";
     };
   };
   kimagemapeditor = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kimagemapeditor-21.08.2.tar.xz";
-      sha256 = "0k1jl5d9qxdg9lrz19vzjbsnpnf236hmckvwy9c620sik0rzpj12";
-      name = "kimagemapeditor-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kimagemapeditor-21.08.3.tar.xz";
+      sha256 = "0vzy028cgq0ai4f9rgkc32w09yz5836y280nck2wxk2dajjc5k6x";
+      name = "kimagemapeditor-21.08.3.tar.xz";
     };
   };
   kimap = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kimap-21.08.2.tar.xz";
-      sha256 = "0qdl94zqk0qvy5mcnbhskh7dskcx8g1bkv4qv8zjjj9rz1r2rm2x";
-      name = "kimap-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kimap-21.08.3.tar.xz";
+      sha256 = "11xwkgxm0ghbpcy6bmvkw1hlsfkdrlyyfbblv5m4s881ky7h4aim";
+      name = "kimap-21.08.3.tar.xz";
     };
   };
   kio-extras = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kio-extras-21.08.2.tar.xz";
-      sha256 = "0735c9n50qflkcl8j032m84wvb6alv8rr9yfhyzflzv56k8r4034";
-      name = "kio-extras-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kio-extras-21.08.3.tar.xz";
+      sha256 = "0lx0b9q68mfb96jfwsf0awcx9wn47nmnqqnk57wrbx8zx880q0j2";
+      name = "kio-extras-21.08.3.tar.xz";
     };
   };
   kio-gdrive = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kio-gdrive-21.08.2.tar.xz";
-      sha256 = "0mbh5ccw3iyfnhqkidds9kq8bm7dwpx5zrnbqi93fach7zmpidk2";
-      name = "kio-gdrive-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kio-gdrive-21.08.3.tar.xz";
+      sha256 = "1h781cksqq5qana80rlc0x3cfz5prl1g3il4282vf2yqihl3zgrd";
+      name = "kio-gdrive-21.08.3.tar.xz";
     };
   };
   kipi-plugins = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kipi-plugins-21.08.2.tar.xz";
-      sha256 = "0ygji1dm6bzyn6f455l1avbw12kl5vdhx1g8lwvgfc51vflv3vxp";
-      name = "kipi-plugins-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kipi-plugins-21.08.3.tar.xz";
+      sha256 = "1vscmljcadz11m4jsbkkx5f8ywbyvmfxnw1g7x5ks8d8hqsrcgd0";
+      name = "kipi-plugins-21.08.3.tar.xz";
     };
   };
   kirigami-gallery = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kirigami-gallery-21.08.2.tar.xz";
-      sha256 = "1i5aly7pwc39avarqmi8wwzv6bbza5pxaz5v8jm6b57d5mampkn8";
-      name = "kirigami-gallery-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kirigami-gallery-21.08.3.tar.xz";
+      sha256 = "0d2psfq5q7zjmd4k1jz0fgwi3gnhi78jn10hrwvc7f8fb6pw4rzc";
+      name = "kirigami-gallery-21.08.3.tar.xz";
     };
   };
   kiriki = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kiriki-21.08.2.tar.xz";
-      sha256 = "1l3sc3fi4b8hc9dyrsi66src52wygckngiwqq8hf4mj2h0hf9s55";
-      name = "kiriki-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kiriki-21.08.3.tar.xz";
+      sha256 = "19qvbxc0dpjq0vb5kh3qsrkv1793bz5ii958a4yqfmmc8xb26v2x";
+      name = "kiriki-21.08.3.tar.xz";
     };
   };
   kiten = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kiten-21.08.2.tar.xz";
-      sha256 = "12jmsg26y4ldkh5qyz2bzyd14wk401p7kl48m5ngxv95qxw2ix9s";
-      name = "kiten-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kiten-21.08.3.tar.xz";
+      sha256 = "0ly44w9y4ha5nw6lqpm5gavxc3ywqc4wh04nl7wpg0m2rm624mci";
+      name = "kiten-21.08.3.tar.xz";
     };
   };
   kitinerary = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kitinerary-21.08.2.tar.xz";
-      sha256 = "1l21q95rszdm1gp1msr9mzlj8ay115dl4cxchhm1mz7w7h53scg3";
-      name = "kitinerary-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kitinerary-21.08.3.tar.xz";
+      sha256 = "066rq42g5l1rmzf5c7xg21p35ln60ir92d0sp2wg9s5li0l0azbf";
+      name = "kitinerary-21.08.3.tar.xz";
     };
   };
   kjumpingcube = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kjumpingcube-21.08.2.tar.xz";
-      sha256 = "1akg30mz8j6w6dzc43z56siiljblqpah80ghbashq3h2wq3q1lxz";
-      name = "kjumpingcube-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kjumpingcube-21.08.3.tar.xz";
+      sha256 = "0iya370m6n9g6m6rzfkdsb9ypwdd0ksfddiy2g0yvjf1xdxr7im9";
+      name = "kjumpingcube-21.08.3.tar.xz";
     };
   };
   kldap = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kldap-21.08.2.tar.xz";
-      sha256 = "1vc94n9wq1422bp9ky2sapy8wra0gi5gfl6dz0h8wxnxflb28zvw";
-      name = "kldap-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kldap-21.08.3.tar.xz";
+      sha256 = "1jb1k5xpicsmazc6c57z203w75h8klja7jp7p8934nvj9dgqqcd1";
+      name = "kldap-21.08.3.tar.xz";
     };
   };
   kleopatra = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kleopatra-21.08.2.tar.xz";
-      sha256 = "1ym40xxwl9qqz8sbsck606vzxys5qhkca8g23gqn3sxx3kk8zpn9";
-      name = "kleopatra-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kleopatra-21.08.3.tar.xz";
+      sha256 = "1gpn0kpxrw4jn214k5swg2frkfgp9clr99n45z3mzjdccl8zfsbi";
+      name = "kleopatra-21.08.3.tar.xz";
     };
   };
   klettres = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/klettres-21.08.2.tar.xz";
-      sha256 = "1n3qw190nznz0h4l68iy9azky57f8pflx10dihhl541jspgga5lg";
-      name = "klettres-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/klettres-21.08.3.tar.xz";
+      sha256 = "0w4fynbvnvlizz0qjkn2qcnn3xs1b0jjfmy9a01wff93a4nw2cj8";
+      name = "klettres-21.08.3.tar.xz";
     };
   };
   klickety = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/klickety-21.08.2.tar.xz";
-      sha256 = "1vi4xx4y7s225b3vgi2z8l1d5z4fgz3v5jfg4zq6v1pis46zpmwz";
-      name = "klickety-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/klickety-21.08.3.tar.xz";
+      sha256 = "00dl0c6si302mprdwdngxa4361qmr27ii5kvk38vrdlq0cynzgzv";
+      name = "klickety-21.08.3.tar.xz";
     };
   };
   klines = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/klines-21.08.2.tar.xz";
-      sha256 = "1gxaadl8gnbaliwbnr6ychp1da5dgppk58jgv5z0zngacwy80d97";
-      name = "klines-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/klines-21.08.3.tar.xz";
+      sha256 = "0n3mdnwlyl0q09bz7dkb3796ki3l181085rb2r1k2mjnjwmn8zya";
+      name = "klines-21.08.3.tar.xz";
     };
   };
   kmag = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kmag-21.08.2.tar.xz";
-      sha256 = "0y68vg95fjhfsjvvn2i214jrv06f6811j1asjxrgvwcmwdf0fnc0";
-      name = "kmag-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kmag-21.08.3.tar.xz";
+      sha256 = "09jvp1hhdam31qwljzpflcnm1mczsai6xlxlks6q0qi2n52cxkhb";
+      name = "kmag-21.08.3.tar.xz";
     };
   };
   kmahjongg = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kmahjongg-21.08.2.tar.xz";
-      sha256 = "1fx4almqcz8x3pzbrjv9yd9kfb7akrfy45z7idhyb31dkdaxi40w";
-      name = "kmahjongg-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kmahjongg-21.08.3.tar.xz";
+      sha256 = "0afjg3svj1sg47xrz3fgvgkd74lvl71sy26br7jjyxjbq1ag9sin";
+      name = "kmahjongg-21.08.3.tar.xz";
     };
   };
   kmail = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kmail-21.08.2.tar.xz";
-      sha256 = "0way147xqjhapswdfqnnvav8dk41lf2050jzmd6jz7qj0dina977";
-      name = "kmail-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kmail-21.08.3.tar.xz";
+      sha256 = "02kina7xn10f963xb7jgzrf15z6akzgl8ba4c9a7yb46ra4w2707";
+      name = "kmail-21.08.3.tar.xz";
     };
   };
   kmail-account-wizard = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kmail-account-wizard-21.08.2.tar.xz";
-      sha256 = "0ac4p9jy3n45i0aj0fn2151pdbjmvkzyr3qlzdidzf386y7m7y9b";
-      name = "kmail-account-wizard-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kmail-account-wizard-21.08.3.tar.xz";
+      sha256 = "1wfzbkipdhmbsj1q5c79ssij1sz57mapg1kkypw10p0nlriklz89";
+      name = "kmail-account-wizard-21.08.3.tar.xz";
     };
   };
   kmailtransport = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kmailtransport-21.08.2.tar.xz";
-      sha256 = "0q76wanhby9gb9c07z8gpkmdqn6rv82bh6fz182m7bdzkqh4rbxx";
-      name = "kmailtransport-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kmailtransport-21.08.3.tar.xz";
+      sha256 = "0xn4imfb4085wx5czxb3yiigslwfxwdi2dmgv7ng01wbphpg0chw";
+      name = "kmailtransport-21.08.3.tar.xz";
     };
   };
   kmbox = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kmbox-21.08.2.tar.xz";
-      sha256 = "055vx2cr9zqab887grjans5cassh2g86r1lcn64jb61sh1cvzj7y";
-      name = "kmbox-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kmbox-21.08.3.tar.xz";
+      sha256 = "19dkc5l5h5x4h5nq924clc06vz5abll2ki70pc6r9py33rfjs11j";
+      name = "kmbox-21.08.3.tar.xz";
     };
   };
   kmime = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kmime-21.08.2.tar.xz";
-      sha256 = "1dg0vm576gqvj7ia80zcdyf9cyg3fzvj7j3fkxx79mw17binlzg4";
-      name = "kmime-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kmime-21.08.3.tar.xz";
+      sha256 = "1bmgnsslhfzyix85c5p3mym6r9f2sjw5ajd5kzw9yxzyvzyc7kv6";
+      name = "kmime-21.08.3.tar.xz";
     };
   };
   kmines = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kmines-21.08.2.tar.xz";
-      sha256 = "0vzspy446pwbd04zyq7x0s7q6nrhmdnzq3jfvv6nnazhjmxpfafv";
-      name = "kmines-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kmines-21.08.3.tar.xz";
+      sha256 = "0x2ligjxam6aaxpzl1zj5circ0ssn9ycafl3ydvhk9pz9j3c9cx1";
+      name = "kmines-21.08.3.tar.xz";
     };
   };
   kmix = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kmix-21.08.2.tar.xz";
-      sha256 = "1srv1alrq2w87rmv9jriz1y37rb0fp7w14291ky64gf23phwmfdq";
-      name = "kmix-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kmix-21.08.3.tar.xz";
+      sha256 = "0smfvkw8svg4fd3sf3f3l5my516jjh2n203kffkg6nr2pgscfw58";
+      name = "kmix-21.08.3.tar.xz";
     };
   };
   kmousetool = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kmousetool-21.08.2.tar.xz";
-      sha256 = "1b09z6793zjjspcrhz4f1vxk3zbs4qdrkdp59q61i7ganm49znma";
-      name = "kmousetool-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kmousetool-21.08.3.tar.xz";
+      sha256 = "0fyhni1m96xh7ir7zhggszfvn7rsf5dp8l065pzvla73w7l6iqwy";
+      name = "kmousetool-21.08.3.tar.xz";
     };
   };
   kmouth = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kmouth-21.08.2.tar.xz";
-      sha256 = "1b9bc0vnqihaqa4wfa9sqcrq92q1kyw0w1ikkx3pb8rzdzkk4cv2";
-      name = "kmouth-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kmouth-21.08.3.tar.xz";
+      sha256 = "0d30r0kyq260pmbk4n9ild0zibwf1sdqwpszvi2j8y5v3gn2bg69";
+      name = "kmouth-21.08.3.tar.xz";
     };
   };
   kmplot = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kmplot-21.08.2.tar.xz";
-      sha256 = "0p81x7qlpj1b84wzqqb7sxmbmnxfys0clg1k07d2hw4rb8gisgic";
-      name = "kmplot-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kmplot-21.08.3.tar.xz";
+      sha256 = "0az7krs0m7xly9v2aclfh4schw9hj99qmv6qmqwa1qvdhhhxd52p";
+      name = "kmplot-21.08.3.tar.xz";
     };
   };
   knavalbattle = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/knavalbattle-21.08.2.tar.xz";
-      sha256 = "0zhp8zmnsjv1ainlc98waixv2p05w8jh91clb8747rc8x4k3phxk";
-      name = "knavalbattle-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/knavalbattle-21.08.3.tar.xz";
+      sha256 = "0ydbkfi1n1j9fv0rjxpvh6nsjp20zwmb5ii47pv77z6a3rk5sqf4";
+      name = "knavalbattle-21.08.3.tar.xz";
     };
   };
   knetwalk = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/knetwalk-21.08.2.tar.xz";
-      sha256 = "1jb6w790jfngifhgp4clgakiacw0lbn40jnj00zlzcg751vl6ajl";
-      name = "knetwalk-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/knetwalk-21.08.3.tar.xz";
+      sha256 = "0nplhxvqiw9ap12hxyk1z247f31jqwg59d5q75jiqi1xr1gf27n2";
+      name = "knetwalk-21.08.3.tar.xz";
     };
   };
   knights = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/knights-21.08.2.tar.xz";
-      sha256 = "0v72niszn93671c4313f3cz2y8wq5nsww0c4irsbz9jpivcq080z";
-      name = "knights-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/knights-21.08.3.tar.xz";
+      sha256 = "0ajnn8jaa1h97k89qj5c7i51c2wr3zgbsiiz9bxhhmb6gwrwjqpi";
+      name = "knights-21.08.3.tar.xz";
     };
   };
   knotes = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/knotes-21.08.2.tar.xz";
-      sha256 = "1g3rmkpwbicga09qwhxn47rhiv9rfaacpzapsrhddh63831bl999";
-      name = "knotes-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/knotes-21.08.3.tar.xz";
+      sha256 = "0v5kg8gi2wmz4dhwg6pmq5pd6kh91ha9hg64z21p38b3nc4z07l4";
+      name = "knotes-21.08.3.tar.xz";
     };
   };
   kolf = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kolf-21.08.2.tar.xz";
-      sha256 = "1dziji28syv7rirm959ahcch6696sc4y6pnfp40v11j1pw58jm8p";
-      name = "kolf-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kolf-21.08.3.tar.xz";
+      sha256 = "1mz30vzdcsa9nhwqmcr6kxwvi9843b876kzpmqrlrxc19ixqbyq4";
+      name = "kolf-21.08.3.tar.xz";
     };
   };
   kollision = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kollision-21.08.2.tar.xz";
-      sha256 = "04hb91gqy58lvhwy0hx27xcd1pvqm378lcavswh7b142f63mhmjf";
-      name = "kollision-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kollision-21.08.3.tar.xz";
+      sha256 = "1m46xrik0ppp6nhrsx264zzy0fdvryamcj0w5m6bm0hnyj75c4rk";
+      name = "kollision-21.08.3.tar.xz";
     };
   };
   kolourpaint = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kolourpaint-21.08.2.tar.xz";
-      sha256 = "0p64dp63m8ycy5qrgd6fdgf670y5iqdyw4gjbkwphg01qp8kpj6d";
-      name = "kolourpaint-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kolourpaint-21.08.3.tar.xz";
+      sha256 = "11ciijpr8aa8nd3zgxrikdnx1gk1w78h1v1nhgqn399lxn3vkchi";
+      name = "kolourpaint-21.08.3.tar.xz";
     };
   };
   kompare = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kompare-21.08.2.tar.xz";
-      sha256 = "14bbqxdzj67g2m6zmz28ax6v4bzz9nmyy45flqzm8jqvq9afqb1d";
-      name = "kompare-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kompare-21.08.3.tar.xz";
+      sha256 = "1988y00mb5wz9c6h4kchkyda4vas44bhiqd1zc4i0fkyl5wi5vp0";
+      name = "kompare-21.08.3.tar.xz";
     };
   };
   konqueror = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/konqueror-21.08.2.tar.xz";
-      sha256 = "0v5l1nqa0fm4q17l0rncriwyvkgq0pdg2q4kjc92kvvdvrpm3jjp";
-      name = "konqueror-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/konqueror-21.08.3.tar.xz";
+      sha256 = "1ls9avkwcf7c9qnmxasbi933sjw9q3hnjyys5zf69v7p5hqvg0dz";
+      name = "konqueror-21.08.3.tar.xz";
     };
   };
   konquest = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/konquest-21.08.2.tar.xz";
-      sha256 = "0shky9cys79prdgr6bcmi50gvfmqr0famdq6gqacv9krbja4pl20";
-      name = "konquest-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/konquest-21.08.3.tar.xz";
+      sha256 = "0vsvzz47yn5wyl8zjnbfs1g97466l5ldxcc7mpg1q4y28fxb4jiv";
+      name = "konquest-21.08.3.tar.xz";
     };
   };
   konsole = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/konsole-21.08.2.tar.xz";
-      sha256 = "1lhpgags85y0s5p44dpa2k0b9vq46m7h19pha59w1wy72an884ig";
-      name = "konsole-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/konsole-21.08.3.tar.xz";
+      sha256 = "1w802g95s8hrlpkilxs2mh7fsg7xq3x9vzw48766kpl9ri3ppx91";
+      name = "konsole-21.08.3.tar.xz";
     };
   };
   kontact = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kontact-21.08.2.tar.xz";
-      sha256 = "1a7d7xfby796kk9hbqqnnhjnn5yvk99hglm4270azlcgbjxf4s2j";
-      name = "kontact-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kontact-21.08.3.tar.xz";
+      sha256 = "0rwi34avk98m0jjbaij895ganfcz5c8l926nr399j5qnv9r6j82l";
+      name = "kontact-21.08.3.tar.xz";
     };
   };
   kontactinterface = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kontactinterface-21.08.2.tar.xz";
-      sha256 = "0wavclk0z55z8xmqiq6wjhlf2byiggmj9fr5kwdk8wsjfj30npwg";
-      name = "kontactinterface-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kontactinterface-21.08.3.tar.xz";
+      sha256 = "1284f6cndf3l4il4mw1qrqvf9jmww6nmhh6fx7asw7mfc32r5zaj";
+      name = "kontactinterface-21.08.3.tar.xz";
     };
   };
   kontrast = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kontrast-21.08.2.tar.xz";
-      sha256 = "12pmkkgrj848whwfz523ciix2a4dm3wgw1vva30svyvlv6qyrgwa";
-      name = "kontrast-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kontrast-21.08.3.tar.xz";
+      sha256 = "1yy4gfckabb175apvm7fcj77nxdc2fdszz1f1zrikrss20r7dc79";
+      name = "kontrast-21.08.3.tar.xz";
     };
   };
   konversation = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/konversation-21.08.2.tar.xz";
-      sha256 = "1blaxxpp0831frw2v4ylvq23ffyqabbq1zcqj0v4kq736acdl8pa";
-      name = "konversation-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/konversation-21.08.3.tar.xz";
+      sha256 = "0wfjhp6scrq9a5llr5f9fcz2k7b5jnid8m8hrp520ai4wg4ll7zv";
+      name = "konversation-21.08.3.tar.xz";
     };
   };
   kopeninghours = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kopeninghours-21.08.2.tar.xz";
-      sha256 = "1g4g3hc0zpklnw8an49dk25zfw740w4slkm52191q2ajymp589l0";
-      name = "kopeninghours-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kopeninghours-21.08.3.tar.xz";
+      sha256 = "090rp2qpsbsyqm4nipq398c3pkr0rx46rwmr4393wffzmnbiwcb9";
+      name = "kopeninghours-21.08.3.tar.xz";
     };
   };
   kopete = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kopete-21.08.2.tar.xz";
-      sha256 = "015pjfc5kxhm5nmjv8fx4jlczp0l3vhqrkxgfvq83a200nlvg2pm";
-      name = "kopete-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kopete-21.08.3.tar.xz";
+      sha256 = "105zwy4k7idkdmjjx754x7acszd4yw3y3r7lrf61f44wsm9dv2wr";
+      name = "kopete-21.08.3.tar.xz";
     };
   };
   korganizer = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/korganizer-21.08.2.tar.xz";
-      sha256 = "0izrzg5xxqgz0wq0vkv1i1xcf0xnzgfwixy8f4gcvihpqxyvixb7";
-      name = "korganizer-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/korganizer-21.08.3.tar.xz";
+      sha256 = "00r7abidj71yqgx4g0kd09dfnq0ilqh3kyzq47ms912gp1dkr5b9";
+      name = "korganizer-21.08.3.tar.xz";
     };
   };
   kosmindoormap = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kosmindoormap-21.08.2.tar.xz";
-      sha256 = "0yf4n48x041wl07f575hzqdkn1qmx3idpxswinsk9r8zdr2dwch7";
-      name = "kosmindoormap-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kosmindoormap-21.08.3.tar.xz";
+      sha256 = "15qq6w14yxfprzzj3267z15zkalsb8y0igq772hwyz4v7f6xhydp";
+      name = "kosmindoormap-21.08.3.tar.xz";
     };
   };
   kpat = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kpat-21.08.2.tar.xz";
-      sha256 = "16cj3w4cibar1q12wam3i623kzddhl39ychvi3nphlni5cmr4x42";
-      name = "kpat-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kpat-21.08.3.tar.xz";
+      sha256 = "0s8k8q12hvciz2c38gn5w7miz0i97pqn4jrs69sm294nw7wh1xi4";
+      name = "kpat-21.08.3.tar.xz";
     };
   };
   kpimtextedit = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kpimtextedit-21.08.2.tar.xz";
-      sha256 = "0v479g998amh822lxr0l2d9xhlrwbij9prlrn1z9y9al056cic7h";
-      name = "kpimtextedit-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kpimtextedit-21.08.3.tar.xz";
+      sha256 = "18bjvhlvjn5a1gnzw478l15mgda4c7qba0qqk9rrbh2ryr1ksf7h";
+      name = "kpimtextedit-21.08.3.tar.xz";
     };
   };
   kpkpass = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kpkpass-21.08.2.tar.xz";
-      sha256 = "003rmp8svnz74qfd3727l7p5wj56j9x8w3dwk19ysyklh2rbaj2p";
-      name = "kpkpass-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kpkpass-21.08.3.tar.xz";
+      sha256 = "0l6n358gng24fqhwjmfpxfmmcw8x80di120k72zahiqplk2arcf5";
+      name = "kpkpass-21.08.3.tar.xz";
     };
   };
   kpmcore = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kpmcore-21.08.2.tar.xz";
-      sha256 = "0rn8x0add1qflsbgppmhz1zbnjvy39d5wckxga0vmhdix2m3d60g";
-      name = "kpmcore-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kpmcore-21.08.3.tar.xz";
+      sha256 = "0y9bpw71dn9c39rjsl44az3y2bdczrj833dvwmrwaz6jbnhxl1kj";
+      name = "kpmcore-21.08.3.tar.xz";
     };
   };
   kpublictransport = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kpublictransport-21.08.2.tar.xz";
-      sha256 = "1g4k1wxhvjya0k79ysr92kq37fbdfly5qdrmp11apvar4la4xmr8";
-      name = "kpublictransport-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kpublictransport-21.08.3.tar.xz";
+      sha256 = "06jbc0qgi5dgx9jwhdnimw1k480whbqw5x75jrx9bspv5y5br16j";
+      name = "kpublictransport-21.08.3.tar.xz";
     };
   };
   kqtquickcharts = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kqtquickcharts-21.08.2.tar.xz";
-      sha256 = "04cxw88lv7mj74znzfl3m9jzks11z837y3bch40qdn8ysk9wqjhn";
-      name = "kqtquickcharts-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kqtquickcharts-21.08.3.tar.xz";
+      sha256 = "0kyznsq7bjzj5c091kpgn443zvkn3qbmn2b0sppj78a7b8ica5ca";
+      name = "kqtquickcharts-21.08.3.tar.xz";
     };
   };
   krdc = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/krdc-21.08.2.tar.xz";
-      sha256 = "0zrpfbs4r0d4wnficmhn0av7877hbrl4jvxpi0qiy2gdc7zksnbd";
-      name = "krdc-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/krdc-21.08.3.tar.xz";
+      sha256 = "0jcbbq9vd4f1kp76fanwnp6q4hq10w3z7ygrb8makpa0daa96vx4";
+      name = "krdc-21.08.3.tar.xz";
     };
   };
   kreversi = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kreversi-21.08.2.tar.xz";
-      sha256 = "18z2aclpd0xln1n442jg13n5j2yip6dldfvd5z56g7n23l9paywq";
-      name = "kreversi-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kreversi-21.08.3.tar.xz";
+      sha256 = "1ifcckbf9lr4pr9n2ggqjvv6xz747k9hk7m43y5ij0bixi6cq474";
+      name = "kreversi-21.08.3.tar.xz";
     };
   };
   krfb = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/krfb-21.08.2.tar.xz";
-      sha256 = "1hn21d0cp2k6zair2wwf492y0ip69f1b5axaaz9fqgmgqn0l47qb";
-      name = "krfb-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/krfb-21.08.3.tar.xz";
+      sha256 = "17q0hpwqbwqg4xbq5lmk5g1fl5jplzpx1acyhcbx7il0j06cfcn4";
+      name = "krfb-21.08.3.tar.xz";
     };
   };
   kross-interpreters = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kross-interpreters-21.08.2.tar.xz";
-      sha256 = "07f153ib1gmbfnkchzymvwlng3sgn28zspxkrx75g8xa5jszwwym";
-      name = "kross-interpreters-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kross-interpreters-21.08.3.tar.xz";
+      sha256 = "0z9lmazpw5389sgvhsjsm1219ys3fybr7hg95nrz8a334vw39nqv";
+      name = "kross-interpreters-21.08.3.tar.xz";
     };
   };
   kruler = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kruler-21.08.2.tar.xz";
-      sha256 = "082z14vcp1ww42jrlxl128gp6y5iqrz360cipvj4xph4q7lpgb0r";
-      name = "kruler-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kruler-21.08.3.tar.xz";
+      sha256 = "0rjxy4ipxxk91wlzhrw9mg5avz18l4p01in29l1ccfz278b97lqm";
+      name = "kruler-21.08.3.tar.xz";
     };
   };
   kshisen = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kshisen-21.08.2.tar.xz";
-      sha256 = "12mi59n8sm7wqf53wbi2nlh4d2i673x93rlqz6qxkaqznlpf7lrr";
-      name = "kshisen-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kshisen-21.08.3.tar.xz";
+      sha256 = "1fnd2qck51gxnw6ncq52rd1q08abh70azs0apjnh9qk0dyjk91wh";
+      name = "kshisen-21.08.3.tar.xz";
     };
   };
   ksirk = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/ksirk-21.08.2.tar.xz";
-      sha256 = "1j6nzyl3ppi68d1y84yals0y90km5mxzz4x44frn3k3bb1n1imzc";
-      name = "ksirk-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/ksirk-21.08.3.tar.xz";
+      sha256 = "03v8sghnipkpca3c71s3008m3psawinj90a7637r19h7gyvlyws7";
+      name = "ksirk-21.08.3.tar.xz";
     };
   };
   ksmtp = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/ksmtp-21.08.2.tar.xz";
-      sha256 = "08bdi23qwvayl9w1nsfgpxpxmxrw820qcmvw03ivdk1h7m6sl3yh";
-      name = "ksmtp-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/ksmtp-21.08.3.tar.xz";
+      sha256 = "0diz01z8gczkwy8c8gvjd583w02vma7kpngzg1ax0wx640vbjq50";
+      name = "ksmtp-21.08.3.tar.xz";
     };
   };
   ksnakeduel = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/ksnakeduel-21.08.2.tar.xz";
-      sha256 = "0n7digcymwrcg24y2libp0x67s1rj2qmps4yzp2bxpgasx9pf6ik";
-      name = "ksnakeduel-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/ksnakeduel-21.08.3.tar.xz";
+      sha256 = "0gmcn31dg3isv5dxv01rg8w6cbfdhwsz5rpp98lrr0qx4abphva7";
+      name = "ksnakeduel-21.08.3.tar.xz";
     };
   };
   kspaceduel = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kspaceduel-21.08.2.tar.xz";
-      sha256 = "1gjb23dw8fh61b7s23b2bfkgcfxqvndrv1x7lkk2bpi4i4g6sqz3";
-      name = "kspaceduel-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kspaceduel-21.08.3.tar.xz";
+      sha256 = "0099rc25zvbl2zg1gpmxdhnphl32bd0cxlgikyfvanigq3mx8zkd";
+      name = "kspaceduel-21.08.3.tar.xz";
     };
   };
   ksquares = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/ksquares-21.08.2.tar.xz";
-      sha256 = "10sl49mjjlpqyh6f930iz1nncy2dqzm1b8hksn8zxz5kwi2gvfrc";
-      name = "ksquares-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/ksquares-21.08.3.tar.xz";
+      sha256 = "1mgs9yapz8fm2nmv0zg2x9qfd0ijj518s43dqmss41zrjr0g3mv2";
+      name = "ksquares-21.08.3.tar.xz";
     };
   };
   ksudoku = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/ksudoku-21.08.2.tar.xz";
-      sha256 = "15svd1paf1hx5aqmdrh6bcdag7k8iq18fpjflk3vkkip6s76lrv6";
-      name = "ksudoku-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/ksudoku-21.08.3.tar.xz";
+      sha256 = "09s91xvkbybhwdkf80d7kvjj2jvii938vf650fqicypki2vf0zyx";
+      name = "ksudoku-21.08.3.tar.xz";
     };
   };
   ksystemlog = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/ksystemlog-21.08.2.tar.xz";
-      sha256 = "1qnnhbi75glgvcvpmpy5zrq6x6hygl7r7v4h99lfm48jdfpyxilj";
-      name = "ksystemlog-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/ksystemlog-21.08.3.tar.xz";
+      sha256 = "1m20nvvvfbgzd3aay7hsb5pm1bgjngc36ixqs0hrklhrcmwjq9g6";
+      name = "ksystemlog-21.08.3.tar.xz";
     };
   };
   kteatime = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kteatime-21.08.2.tar.xz";
-      sha256 = "02vkh3dyacba9x0zl8j8g8isj50h8wz7mjnfqgxc67azcwwx41sp";
-      name = "kteatime-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kteatime-21.08.3.tar.xz";
+      sha256 = "175vmcbhhlan6smhagli0jpa3ik0y0wwiijigfk2srm8cyk29ymn";
+      name = "kteatime-21.08.3.tar.xz";
     };
   };
   ktimer = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/ktimer-21.08.2.tar.xz";
-      sha256 = "0rfmrh7i8c23r6wdyh4w55980vlj2p127mbpiw5brj4dazdjll5x";
-      name = "ktimer-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/ktimer-21.08.3.tar.xz";
+      sha256 = "1nr116cxw81c2bh32l2xrzmrglk36qkzycbfcffxnm7ka4flwzbm";
+      name = "ktimer-21.08.3.tar.xz";
     };
   };
   ktnef = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/ktnef-21.08.2.tar.xz";
-      sha256 = "05l4g38f2m3qjl6q45j12zarpazsizjl2pyqh87vhaxgnf4fbqqp";
-      name = "ktnef-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/ktnef-21.08.3.tar.xz";
+      sha256 = "0vfsy894hs3538ssbqky6nfnjzhyn8yjlmvh0mb6gg69952gcvqa";
+      name = "ktnef-21.08.3.tar.xz";
     };
   };
   ktorrent = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/ktorrent-21.08.2.tar.xz";
-      sha256 = "1nd72jcvsc0kabd23ddy93dxp59ihg5npa8r3vbzvic89xlpkivi";
-      name = "ktorrent-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/ktorrent-21.08.3.tar.xz";
+      sha256 = "0y1vpfc8xsm98lrf119r5clmb6xwq2a8adb347ksyvvr4l7rdkwm";
+      name = "ktorrent-21.08.3.tar.xz";
     };
   };
   ktouch = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/ktouch-21.08.2.tar.xz";
-      sha256 = "16r3hj160y1517dk1nzvikwkjlfbzmjpx54k9jc98csaplbv683l";
-      name = "ktouch-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/ktouch-21.08.3.tar.xz";
+      sha256 = "0i0ph52k2zw6q37qam2s09msxsdxr5v8qiqwxirjab8ad7g9z0gf";
+      name = "ktouch-21.08.3.tar.xz";
     };
   };
   ktp-accounts-kcm = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/ktp-accounts-kcm-21.08.2.tar.xz";
-      sha256 = "0fxlkbx8kzlbfyfj7ac6m0y6vc80n3nlm5skrq106vbm1nnh565p";
-      name = "ktp-accounts-kcm-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/ktp-accounts-kcm-21.08.3.tar.xz";
+      sha256 = "1ymq8cnvvw62xd4va969imm2g62fw7fhbs8rw3wqrc2lal9d5l1g";
+      name = "ktp-accounts-kcm-21.08.3.tar.xz";
     };
   };
   ktp-approver = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/ktp-approver-21.08.2.tar.xz";
-      sha256 = "1pbc2f477xysv707j1xbcw799pxas31j5cmf26wrkbjmzxh5nhnd";
-      name = "ktp-approver-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/ktp-approver-21.08.3.tar.xz";
+      sha256 = "0z9kw2gamgdz425aw6li6nvv1g0b1ffil0rmjh0b0z89bbpbc6jx";
+      name = "ktp-approver-21.08.3.tar.xz";
     };
   };
   ktp-auth-handler = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/ktp-auth-handler-21.08.2.tar.xz";
-      sha256 = "1fwzm15s8q8h47kfqw4jz2vfv81fc4azxg7c9r4vvlh23grlzbx8";
-      name = "ktp-auth-handler-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/ktp-auth-handler-21.08.3.tar.xz";
+      sha256 = "1z89ycwpq46w82hylwq1sizd7a563g5a22jdc1chhhlwp9dqmdc2";
+      name = "ktp-auth-handler-21.08.3.tar.xz";
     };
   };
   ktp-call-ui = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/ktp-call-ui-21.08.2.tar.xz";
-      sha256 = "0d4iaqpl67w3q7rrk2h9glq91ha03hvnrywi6271nc4892r4b2ys";
-      name = "ktp-call-ui-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/ktp-call-ui-21.08.3.tar.xz";
+      sha256 = "1nr064h0f4rqjka030xflhrmq0l8g87fwyi853plk7y0473fy6h2";
+      name = "ktp-call-ui-21.08.3.tar.xz";
     };
   };
   ktp-common-internals = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/ktp-common-internals-21.08.2.tar.xz";
-      sha256 = "1jc8dv4563y4xlx13sz07lmkfnxraidqpxq08plapkliq56hv2xd";
-      name = "ktp-common-internals-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/ktp-common-internals-21.08.3.tar.xz";
+      sha256 = "0ndfdggs4j2jc93pf998r0fyj7fjnc2pz98acc1l6laq8d8aawd2";
+      name = "ktp-common-internals-21.08.3.tar.xz";
     };
   };
   ktp-contact-list = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/ktp-contact-list-21.08.2.tar.xz";
-      sha256 = "1glh9np0q82x9z7pb3xzvq1mwmfggzq8lc5in1lhhjzhpnla2n21";
-      name = "ktp-contact-list-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/ktp-contact-list-21.08.3.tar.xz";
+      sha256 = "0pdl3w1vj6f4nms4cs91yagfyf5ssqms0bzmcnjf53pcpyf8rhjs";
+      name = "ktp-contact-list-21.08.3.tar.xz";
     };
   };
   ktp-contact-runner = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/ktp-contact-runner-21.08.2.tar.xz";
-      sha256 = "15xvw84c4ygz1zz3qkjmxfjrkczwrdwdmls5a4bc4d4i78df8v4m";
-      name = "ktp-contact-runner-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/ktp-contact-runner-21.08.3.tar.xz";
+      sha256 = "0zjw9f66rn5nc37q3q54qy8m09qlama949ksfrvyyh3qhsxp17pm";
+      name = "ktp-contact-runner-21.08.3.tar.xz";
     };
   };
   ktp-desktop-applets = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/ktp-desktop-applets-21.08.2.tar.xz";
-      sha256 = "09bli0hhibwhia5zsprf1mv2li344lcqjq6pkirzz8h2dr1nr2s5";
-      name = "ktp-desktop-applets-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/ktp-desktop-applets-21.08.3.tar.xz";
+      sha256 = "1wlls0rhynfq9cfn48g31avviy067r409c5pcvasfwgzcv5hjan5";
+      name = "ktp-desktop-applets-21.08.3.tar.xz";
     };
   };
   ktp-filetransfer-handler = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/ktp-filetransfer-handler-21.08.2.tar.xz";
-      sha256 = "0g0w1ayj3m6lkmy71xqvfg829rk9y5z98h6rnim3ag9yx44namzw";
-      name = "ktp-filetransfer-handler-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/ktp-filetransfer-handler-21.08.3.tar.xz";
+      sha256 = "1vnwgcmn3j18spcn2dl468n2y073mk9nsc3557hid5mmg7byp8ng";
+      name = "ktp-filetransfer-handler-21.08.3.tar.xz";
     };
   };
   ktp-kded-module = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/ktp-kded-module-21.08.2.tar.xz";
-      sha256 = "1rx79zqqk2gl2qi28q429ss63kyndfzs24mdrn4491hsbln0sv1x";
-      name = "ktp-kded-module-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/ktp-kded-module-21.08.3.tar.xz";
+      sha256 = "0mgw2w812306w04w1xgv9ngd31zj0m4v9hv3cyyk2dz1hi97g9hz";
+      name = "ktp-kded-module-21.08.3.tar.xz";
     };
   };
   ktp-send-file = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/ktp-send-file-21.08.2.tar.xz";
-      sha256 = "1791zhp5rpwizx3y48hgamk7pgbx2yk650nczxbnza828m1lxzab";
-      name = "ktp-send-file-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/ktp-send-file-21.08.3.tar.xz";
+      sha256 = "1c0yrir3z6p6ravizaqhdgjiwcj2cyzd61n4zcx2mrr4mfq7wr4l";
+      name = "ktp-send-file-21.08.3.tar.xz";
     };
   };
   ktp-text-ui = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/ktp-text-ui-21.08.2.tar.xz";
-      sha256 = "1pinn61dkb2jcyzms3kf70sxjbkd3pkn6cxvxs8zsj1m1bdkydym";
-      name = "ktp-text-ui-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/ktp-text-ui-21.08.3.tar.xz";
+      sha256 = "0xk9lcdp99rd1n6gg9a4ix5bdfk229y1ddf115ldjsk30ksfv0r0";
+      name = "ktp-text-ui-21.08.3.tar.xz";
     };
   };
   ktuberling = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/ktuberling-21.08.2.tar.xz";
-      sha256 = "0h7vhvh03w11dr17zxdmb5j2vz8flwahvz70h9kw8a63sxpw0x6f";
-      name = "ktuberling-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/ktuberling-21.08.3.tar.xz";
+      sha256 = "1i0ykflfr2q3043z5j5h1m093n103la8zbax7cacid109d0kca5g";
+      name = "ktuberling-21.08.3.tar.xz";
     };
   };
   kturtle = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kturtle-21.08.2.tar.xz";
-      sha256 = "1f3iw3fk4l8q2jnnadaqjbj6jzmw86ibf0p515x4rrqz4l8m6plg";
-      name = "kturtle-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kturtle-21.08.3.tar.xz";
+      sha256 = "1fw7hgx0zxsl1l9ymjhf3k3w5999ijj8vdagnyiz01y2i2hlnvhc";
+      name = "kturtle-21.08.3.tar.xz";
     };
   };
   kubrick = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kubrick-21.08.2.tar.xz";
-      sha256 = "0kvd8dsg9hdgid70jd5b1vngqpmi9rigkvxl2v4h2ps1ziqqxa78";
-      name = "kubrick-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kubrick-21.08.3.tar.xz";
+      sha256 = "1fq2icsfbd6k4gm9w25aml2rigzami934vvkvb30222vbhs86qr4";
+      name = "kubrick-21.08.3.tar.xz";
     };
   };
   kwalletmanager = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kwalletmanager-21.08.2.tar.xz";
-      sha256 = "134690b4bhkjczwxg8776163aggwrqmb84xkvb7612wgs5jygyib";
-      name = "kwalletmanager-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kwalletmanager-21.08.3.tar.xz";
+      sha256 = "0cbq0md317fipd4lfqvcgan1jm5n0zyilzbrkjymbnl7cy276ajq";
+      name = "kwalletmanager-21.08.3.tar.xz";
     };
   };
   kwave = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kwave-21.08.2.tar.xz";
-      sha256 = "0sivhgcypwpdi6g0mkdzf1k2hqkj1vj4b5cdcvn8chs2gk9pisgh";
-      name = "kwave-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kwave-21.08.3.tar.xz";
+      sha256 = "08qs33mi047jcqaavglgxk3i6gq4h73aygn6gj8xpcpqhq82kjl5";
+      name = "kwave-21.08.3.tar.xz";
     };
   };
   kwordquiz = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/kwordquiz-21.08.2.tar.xz";
-      sha256 = "1prj7iz71z8zy2ynjad7yqkgswg96q4hmc76kg1lvahn2waikr0y";
-      name = "kwordquiz-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/kwordquiz-21.08.3.tar.xz";
+      sha256 = "066v2w8i2fvrrqb1aakscwcd6rchlm4m5pwsql0s6k59mn7wab6b";
+      name = "kwordquiz-21.08.3.tar.xz";
     };
   };
   libgravatar = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/libgravatar-21.08.2.tar.xz";
-      sha256 = "047fbdj02rnb7bn2vn9lava2mh4ypzlyd8iiri4mbpd686lmi0s1";
-      name = "libgravatar-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/libgravatar-21.08.3.tar.xz";
+      sha256 = "0ni2lgrfpx8vx9mmm43gsn1kw4jj8j52yq4ylfam89q6mhpxcnix";
+      name = "libgravatar-21.08.3.tar.xz";
     };
   };
   libkcddb = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/libkcddb-21.08.2.tar.xz";
-      sha256 = "03az77p3p0c0shzi2y2n5721gppzgrq469afvpjppria1n3ks5d2";
-      name = "libkcddb-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/libkcddb-21.08.3.tar.xz";
+      sha256 = "00wivb6viw5w1ylcsx3m9ps7j00z7fzjh2s7nap95xnprraihcmv";
+      name = "libkcddb-21.08.3.tar.xz";
     };
   };
   libkcompactdisc = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/libkcompactdisc-21.08.2.tar.xz";
-      sha256 = "0sjr8gdbqsjlggxax0l2bxn42l9znplrjiln15izj2zwfkah7d69";
-      name = "libkcompactdisc-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/libkcompactdisc-21.08.3.tar.xz";
+      sha256 = "1rsmibz9mamqvhppnxwn2db6jmsipvjx2kj8ikpsp9bx8h421n2g";
+      name = "libkcompactdisc-21.08.3.tar.xz";
     };
   };
   libkdcraw = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/libkdcraw-21.08.2.tar.xz";
-      sha256 = "0yhcrzl7piginz19vmyg63154j9rrqxfvfchn9k8g9jiddwnjfd8";
-      name = "libkdcraw-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/libkdcraw-21.08.3.tar.xz";
+      sha256 = "0gm8nfc6ayg1ipba4yvhy5nzfrpdwx6l434bg9y7yqvbm3lm1g86";
+      name = "libkdcraw-21.08.3.tar.xz";
     };
   };
   libkdegames = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/libkdegames-21.08.2.tar.xz";
-      sha256 = "0jbb4h515c9h08r7dqaslqgrpmb6f08ai46phwgipd67jzgh6wh7";
-      name = "libkdegames-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/libkdegames-21.08.3.tar.xz";
+      sha256 = "0ysc5g6ap207c5yq3ryiaxmvkrh6wzqzdgccdffs0lncd24g641a";
+      name = "libkdegames-21.08.3.tar.xz";
     };
   };
   libkdepim = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/libkdepim-21.08.2.tar.xz";
-      sha256 = "1j8nkfgzixpchz34p338mcm87f112ddy1linhaczg5fal1brangh";
-      name = "libkdepim-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/libkdepim-21.08.3.tar.xz";
+      sha256 = "1776fjzd88kj2crr8lcrwxmkvjsxxyll2gy21wlbmqy4h04bi130";
+      name = "libkdepim-21.08.3.tar.xz";
     };
   };
   libkeduvocdocument = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/libkeduvocdocument-21.08.2.tar.xz";
-      sha256 = "051mzwbrlpvjnqphf01nzzc76zbz9hasd57sn6y6x8cviflf7kmy";
-      name = "libkeduvocdocument-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/libkeduvocdocument-21.08.3.tar.xz";
+      sha256 = "1qyi5y5v1zp3qid58sdfpcp83rkmz2s1hsvir4f9j5ngir0czcq1";
+      name = "libkeduvocdocument-21.08.3.tar.xz";
     };
   };
   libkexiv2 = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/libkexiv2-21.08.2.tar.xz";
-      sha256 = "0spa6pbr6rpnznvm2z0c410k5wssw4rw15rdc3f5ds9mbzbyxpva";
-      name = "libkexiv2-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/libkexiv2-21.08.3.tar.xz";
+      sha256 = "15d8d3mzp0yhj6lm5799mfncqkxnw0cvfxcgpkz0lf9askv2cq8n";
+      name = "libkexiv2-21.08.3.tar.xz";
     };
   };
   libkgapi = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/libkgapi-21.08.2.tar.xz";
-      sha256 = "13dna8iv3qzkc1jagjgji928g88wrgds47lcfj3dqkn8swamisa0";
-      name = "libkgapi-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/libkgapi-21.08.3.tar.xz";
+      sha256 = "101yb495k5bxq402qdvyqd0sdhzc5z3r8szymfmrlilgk35wy9rs";
+      name = "libkgapi-21.08.3.tar.xz";
     };
   };
   libkipi = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/libkipi-21.08.2.tar.xz";
-      sha256 = "134iaagdn49y79aihi6k5pgx0cyk52wq38cdiinpcsxqc4xmzswh";
-      name = "libkipi-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/libkipi-21.08.3.tar.xz";
+      sha256 = "12qjvd7ynab33qid2d4j06z8fbfziaxdlrpq0h3ywd2drks0ykvf";
+      name = "libkipi-21.08.3.tar.xz";
     };
   };
   libkleo = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/libkleo-21.08.2.tar.xz";
-      sha256 = "14p3x2jq9sa5gkhcd7q3g5ras2sl62shrjm9kx4426mbnj10n0q2";
-      name = "libkleo-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/libkleo-21.08.3.tar.xz";
+      sha256 = "0ivyqmc1hv1cljbpxr5xrzyf9z96dbaa48ak54cxxpanphpialrl";
+      name = "libkleo-21.08.3.tar.xz";
     };
   };
   libkmahjongg = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/libkmahjongg-21.08.2.tar.xz";
-      sha256 = "195c7bgn4jp2whqrg7l8g147kj92bvdcvcrh7n186kac9q0jqr3b";
-      name = "libkmahjongg-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/libkmahjongg-21.08.3.tar.xz";
+      sha256 = "0rh61491dl90rrlmqmqjdj7vlrjhayhkk5i50zb6jfvrysq9axkc";
+      name = "libkmahjongg-21.08.3.tar.xz";
     };
   };
   libkomparediff2 = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/libkomparediff2-21.08.2.tar.xz";
-      sha256 = "08y9p3il0i5sayq42v9p1v9f6yynp7ljb5d4ls1hf5ww4xxvx10x";
-      name = "libkomparediff2-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/libkomparediff2-21.08.3.tar.xz";
+      sha256 = "0a3980kiigc5kqkyxf4glcxvgr3f4rnc43gcx9vj9mk2qhfcsiqy";
+      name = "libkomparediff2-21.08.3.tar.xz";
     };
   };
   libksane = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/libksane-21.08.2.tar.xz";
-      sha256 = "094k5f0qwcm74jn5jlzs0mr74myp4s217ah2pl1kny1fm5hv5pyj";
-      name = "libksane-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/libksane-21.08.3.tar.xz";
+      sha256 = "086zrddpammihia888nrx2p18if1fyzvhs3igkxq9q2p551vk9fy";
+      name = "libksane-21.08.3.tar.xz";
     };
   };
   libksieve = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/libksieve-21.08.2.tar.xz";
-      sha256 = "1jxb0a18mf8yqxbi90jbgjh90x17qr6z7ga6zxdb8gk1hjsyb10y";
-      name = "libksieve-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/libksieve-21.08.3.tar.xz";
+      sha256 = "1snli2yvq2n567vgi1xs6iiqgn4zp31cid17aqpxllyw8a3xa0l7";
+      name = "libksieve-21.08.3.tar.xz";
     };
   };
   libktorrent = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/libktorrent-21.08.2.tar.xz";
-      sha256 = "16rx0na7gy03c0qbwy07q7si35z62p0pq7fcvf3ggr594akwz4kl";
-      name = "libktorrent-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/libktorrent-21.08.3.tar.xz";
+      sha256 = "1zjnnxhd0mv9if61rr28h35wban7sif61dmgc3wsixp4dz1xfrm6";
+      name = "libktorrent-21.08.3.tar.xz";
     };
   };
   lokalize = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/lokalize-21.08.2.tar.xz";
-      sha256 = "01f48fsrv095vlgxfjfdlm70xwsw73x5zhqbm38szn6r404jcmjm";
-      name = "lokalize-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/lokalize-21.08.3.tar.xz";
+      sha256 = "0m084mayd9b0iwm4j5cckw22ix1mc4zcwxjfk0cdapm3g2ls1rzd";
+      name = "lokalize-21.08.3.tar.xz";
     };
   };
   lskat = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/lskat-21.08.2.tar.xz";
-      sha256 = "03www1ix31ifmn6hvzymvhg157rdhahjfwvc9arns23zxpn1sq9p";
-      name = "lskat-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/lskat-21.08.3.tar.xz";
+      sha256 = "09l209fz82ibsxzg2f53lhbcsaq6zpwllpyklj2988xzn7h49cqg";
+      name = "lskat-21.08.3.tar.xz";
     };
   };
   mailcommon = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/mailcommon-21.08.2.tar.xz";
-      sha256 = "0d0czxrf3i796pyrlifv4psq3hl4z2abhsqj1ns30xng45pzyrvz";
-      name = "mailcommon-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/mailcommon-21.08.3.tar.xz";
+      sha256 = "0vpbp88pl462d1j9f3ww22zybrmz92zx3b5cj4gsl7gmb7ijwb19";
+      name = "mailcommon-21.08.3.tar.xz";
     };
   };
   mailimporter = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/mailimporter-21.08.2.tar.xz";
-      sha256 = "0vd0bghszwr1wh4x2ygd7flg0kypb8m92gvh0q800gdgnqj87lw7";
-      name = "mailimporter-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/mailimporter-21.08.3.tar.xz";
+      sha256 = "00vm445i5c7vjfmbfgzdj3xildqbnlzpi5i16w4c47wyg5kvpj2c";
+      name = "mailimporter-21.08.3.tar.xz";
     };
   };
   marble = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/marble-21.08.2.tar.xz";
-      sha256 = "1l8dwj0kyq8r3cap2sjsr4blbz591l6cxhglkhxwds901igacmxa";
-      name = "marble-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/marble-21.08.3.tar.xz";
+      sha256 = "0bapnmm2x0ihms5gd12brqb2yx7g5h4c8ky70l1czd4a8d95ha0a";
+      name = "marble-21.08.3.tar.xz";
     };
   };
   markdownpart = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/markdownpart-21.08.2.tar.xz";
-      sha256 = "0vx2d31d9c9ipwkbnlrjhzkaj97a7vz6vigbbkvw4cyaqhq6zkqp";
-      name = "markdownpart-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/markdownpart-21.08.3.tar.xz";
+      sha256 = "1cqkwvs1ssg203fkaiibcmqjm2viaq3iq880cjlkx9irh0bv9q9h";
+      name = "markdownpart-21.08.3.tar.xz";
     };
   };
   mbox-importer = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/mbox-importer-21.08.2.tar.xz";
-      sha256 = "1bf4awkrivx209rnwflxrqdxzvj8mzlgzis79hn9n654qy6ar2d5";
-      name = "mbox-importer-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/mbox-importer-21.08.3.tar.xz";
+      sha256 = "19i5a1rax3xfkcz0hv0vqq9iavggqrliwpqsqnx6zvwjzgjrvsif";
+      name = "mbox-importer-21.08.3.tar.xz";
     };
   };
   messagelib = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/messagelib-21.08.2.tar.xz";
-      sha256 = "0gsxik4ib72xhw948h257m17w4k49sa3ymbg87n0q8nd6gykxyhr";
-      name = "messagelib-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/messagelib-21.08.3.tar.xz";
+      sha256 = "0q9mligkkvbwb92ghv5g66rkn0vpbw2xfbgsdnn4jajjxsixipg7";
+      name = "messagelib-21.08.3.tar.xz";
     };
   };
   minuet = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/minuet-21.08.2.tar.xz";
-      sha256 = "13i37xw2aarmqi25m1r68z9zjwqf9nx8bxlflb0wxghzf3pgrp4v";
-      name = "minuet-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/minuet-21.08.3.tar.xz";
+      sha256 = "1g2chj23dw9p2lgf094mn9cd26wnhwgslwdwzwax2a23p42j7kb8";
+      name = "minuet-21.08.3.tar.xz";
     };
   };
   okular = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/okular-21.08.2.tar.xz";
-      sha256 = "0y3n340fbhsgmmrq4vz2p9682xzs7hsvvna8ffh4r15wgl1qdb9q";
-      name = "okular-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/okular-21.08.3.tar.xz";
+      sha256 = "00ghh7z39904d5x5sa39adkavkhl09hzib6fpwjn14f6sz925f9r";
+      name = "okular-21.08.3.tar.xz";
     };
   };
   palapeli = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/palapeli-21.08.2.tar.xz";
-      sha256 = "0pl6hi0c5fa6zs3gdicm1s7rmzzdjjvrm8s8ds6f4ghq6dmlknqj";
-      name = "palapeli-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/palapeli-21.08.3.tar.xz";
+      sha256 = "084nvavgzkmrv77rsg2zf2vykfjwwsvn2i2y24jsh63hs7i5xqhb";
+      name = "palapeli-21.08.3.tar.xz";
     };
   };
   parley = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/parley-21.08.2.tar.xz";
-      sha256 = "0lykvjaxfj6blgjkmipvlw9531npz46d6jwq6w5wxvk6f1b2cgbh";
-      name = "parley-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/parley-21.08.3.tar.xz";
+      sha256 = "0wyv5qx4g0941kg870qb9rc9npdw39ggvndjk7ywaad9nkvdj73g";
+      name = "parley-21.08.3.tar.xz";
     };
   };
   partitionmanager = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/partitionmanager-21.08.2.tar.xz";
-      sha256 = "1fa90mnby2kf5a85wjz7xvb999gh5c2yn0j3g562zndqznqhcpvx";
-      name = "partitionmanager-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/partitionmanager-21.08.3.tar.xz";
+      sha256 = "0im782ggbnkyzcczxx3mv5qi4nlqmcyhwkbf0mzh8cz56qkfvzhr";
+      name = "partitionmanager-21.08.3.tar.xz";
     };
   };
   picmi = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/picmi-21.08.2.tar.xz";
-      sha256 = "0qvz4fl4jb256rwmaw0bszr3x2b5jd8priilc3jr33v393f3pd6q";
-      name = "picmi-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/picmi-21.08.3.tar.xz";
+      sha256 = "0h208sy2r2jzy7a6rmla349d8lydvfvdb2vahdfxrqql0m15s07s";
+      name = "picmi-21.08.3.tar.xz";
     };
   };
   pim-data-exporter = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/pim-data-exporter-21.08.2.tar.xz";
-      sha256 = "0li96fkwkdg4ziyv4n56vn49wav4kilf7lqb4s9xwj8h44kjpa5f";
-      name = "pim-data-exporter-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/pim-data-exporter-21.08.3.tar.xz";
+      sha256 = "0l6gkwh6pxp6px50n8i0374by3n7nv0gjkb2qy0s4hsvfz8nwlwk";
+      name = "pim-data-exporter-21.08.3.tar.xz";
     };
   };
   pim-sieve-editor = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/pim-sieve-editor-21.08.2.tar.xz";
-      sha256 = "173c595djmz3wyzl9dl3br8m3k0940ncdyjf8rjfgrh79y86bh7m";
-      name = "pim-sieve-editor-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/pim-sieve-editor-21.08.3.tar.xz";
+      sha256 = "1z01c0wsxzl69kr0cxfq23l56dgi0xfjak5qbpfd9p4b2kr095s7";
+      name = "pim-sieve-editor-21.08.3.tar.xz";
     };
   };
   pimcommon = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/pimcommon-21.08.2.tar.xz";
-      sha256 = "074pbxprzx8hd6fikjvx8hn9g9135swzhj1f5zvfvhyvlpyj90wg";
-      name = "pimcommon-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/pimcommon-21.08.3.tar.xz";
+      sha256 = "1hj49spfjwqrwh7h86kw7ydcx13rknagj54mhcn60kawz639533l";
+      name = "pimcommon-21.08.3.tar.xz";
     };
   };
   poxml = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/poxml-21.08.2.tar.xz";
-      sha256 = "1h7y4y1n3xcpgrkabik21ilck5dmq6p3qxs3xm9vzq1jxpb9izyf";
-      name = "poxml-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/poxml-21.08.3.tar.xz";
+      sha256 = "0yrn2dbdhm3ap55w401ma8z64b7pgs57lzgakzkdpcf69bww9xkw";
+      name = "poxml-21.08.3.tar.xz";
     };
   };
   print-manager = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/print-manager-21.08.2.tar.xz";
-      sha256 = "0g2y2i7iysi6i397gd9fpqpk9cha7z4b2wz6shcqp0jyvvwl1pd3";
-      name = "print-manager-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/print-manager-21.08.3.tar.xz";
+      sha256 = "0dmd1wp6c5f58fssnyc977d29gqcr6pmzplvq5pj97xq0i8fq15z";
+      name = "print-manager-21.08.3.tar.xz";
     };
   };
   rocs = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/rocs-21.08.2.tar.xz";
-      sha256 = "0cvgi42w1a7zd6bzazly9w2azbyp9gzvkyx5wlff5z99nk6v3mp0";
-      name = "rocs-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/rocs-21.08.3.tar.xz";
+      sha256 = "0mdn58wbv5rhljp7ai0282h5z5j7m9yly6q9s6c8vm5kaxhbwg58";
+      name = "rocs-21.08.3.tar.xz";
     };
   };
   signon-kwallet-extension = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/signon-kwallet-extension-21.08.2.tar.xz";
-      sha256 = "19jp6h9xqhlyvddgyg9jz74by0pcxqm920c5h8vln5vkkcgsdwws";
-      name = "signon-kwallet-extension-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/signon-kwallet-extension-21.08.3.tar.xz";
+      sha256 = "1m3wyyndlwk4snjzz45j377hz5plx01bl69y39aw1y53rsx0baln";
+      name = "signon-kwallet-extension-21.08.3.tar.xz";
     };
   };
   skanlite = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/skanlite-21.08.2.tar.xz";
-      sha256 = "1zwrb7j7x234vbb57p8gzbqz2mfr1n2i84yjf16jrsv1fm53z9md";
-      name = "skanlite-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/skanlite-21.08.3.tar.xz";
+      sha256 = "1llvq89vdsypbak8lmhnyfr61s72c4lra1yypxmgw0hwqvwqzyjk";
+      name = "skanlite-21.08.3.tar.xz";
     };
   };
   spectacle = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/spectacle-21.08.2.tar.xz";
-      sha256 = "0m59cnfqkm379i6ayj1g5flszqs26dmnwl79324d1j6bxk24mjrh";
-      name = "spectacle-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/spectacle-21.08.3.tar.xz";
+      sha256 = "0l1p565y2d04fw9mz1ns11bwc9z5apkjd4llgdihz4qwq5j0ri5y";
+      name = "spectacle-21.08.3.tar.xz";
     };
   };
   step = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/step-21.08.2.tar.xz";
-      sha256 = "15l11s39hw847kd37fhq6kp3ajbsxidkfpp2ryb9dfh595lncg2r";
-      name = "step-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/step-21.08.3.tar.xz";
+      sha256 = "1pznz6hxj1h0vcsidsyjm9zgzx4pla47yckykc3mxb9biraalhi5";
+      name = "step-21.08.3.tar.xz";
     };
   };
   svgpart = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/svgpart-21.08.2.tar.xz";
-      sha256 = "14xgwdvpcvgw0jj4gy3175ah38x9f8lhknqbw5bczvm9cy8j7qfw";
-      name = "svgpart-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/svgpart-21.08.3.tar.xz";
+      sha256 = "1zpzmhgvxlyalq4nn446k7plz5fw2pl4r7zv7q3hjrzla1wgcqx8";
+      name = "svgpart-21.08.3.tar.xz";
     };
   };
   sweeper = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/sweeper-21.08.2.tar.xz";
-      sha256 = "1yvcfdhapml1vzqns67v6j2c39g752f8czxs7bnczi69fq1ksh0b";
-      name = "sweeper-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/sweeper-21.08.3.tar.xz";
+      sha256 = "0sa8dfx26m9ry3pvqryx41w51l76r8l2xh16b783ixqln7x08z5j";
+      name = "sweeper-21.08.3.tar.xz";
     };
   };
   umbrello = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/umbrello-21.08.2.tar.xz";
-      sha256 = "1xiz006ppgss6rxg7lndgnrbcdbm0iq1hjly3rjn943ff11wq5yr";
-      name = "umbrello-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/umbrello-21.08.3.tar.xz";
+      sha256 = "025qds7nahm6kpi94j4blk8xpv6vh2alrbgwby20vvn3h678z26x";
+      name = "umbrello-21.08.3.tar.xz";
     };
   };
   yakuake = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/yakuake-21.08.2.tar.xz";
-      sha256 = "1d8dh10jkpm4pm8fh1bmkdwvv59gk0fg6dr3gahlspnh4hhzy4hg";
-      name = "yakuake-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/yakuake-21.08.3.tar.xz";
+      sha256 = "1za4vhnr495dadrarqqanavmyn1mmzm3y8jx05cpbjyqmlm353dk";
+      name = "yakuake-21.08.3.tar.xz";
     };
   };
   zeroconf-ioslave = {
-    version = "21.08.2";
+    version = "21.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.2/src/zeroconf-ioslave-21.08.2.tar.xz";
-      sha256 = "0xgm4y29iklal5kd5z76jdw6wgw0mg9xn0f0d07zyshv5hjgllv6";
-      name = "zeroconf-ioslave-21.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.3/src/zeroconf-ioslave-21.08.3.tar.xz";
+      sha256 = "1dkig267znwyw03fq6mpdb5g1xnkhr0brnvxskjm44a4d5ipbv2g";
+      name = "zeroconf-ioslave-21.08.3.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Trivial patch update for KDE Applications/Gear

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
