### PR TITLE
kodi.packages.iagl: init at 1101521-2

### DIFF
--- a/pkgs/applications/video/kodi-packages/archive_tool/default.nix
+++ b/pkgs/applications/video/kodi-packages/archive_tool/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildKodiAddon, fetchFromGitHub, vfs-libarchive }:
+buildKodiAddon rec {
+  pname = "archive_tool";
+  namespace = "script.module.archive_tool";
+  version = "2.0.3";
+
+  src = fetchFromGitHub {
+    owner = "zach-morris";
+    repo = "script.module.archive_tool";
+    rev = version;
+    sha256 = "0hbkyk59xxfjv6vzfjplahmqxi5564qjlwyq6k8ijy6jjcwnd3p7";
+  };
+
+  propagatedBuildInputs = [
+    vfs-libarchive
+  ];
+
+  passthru = {
+    pythonPath = "lib";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/zach-morris/script.module.archive_tool";
+    description = "A set of common python functions to work with the Kodi archive virtual file system (vfs) binary addons";
+    license = licenses.gpl3Plus;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/applications/video/kodi-packages/iagl/default.nix
+++ b/pkgs/applications/video/kodi-packages/iagl/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildKodiAddon, fetchFromGitHub, fetchzip, dateutil, requests, routing, vfs-libarchive, archive_tool, youtube }:
+
+buildKodiAddon rec {
+  pname = "iagl";
+  namespace = "plugin.program.iagl";
+  version = "1101521-2";
+
+  src = fetchFromGitHub {
+    owner = "zach-morris";
+    repo = "plugin.program.iagl";
+    rev = "30e82eec1a909b31767f0e298cf77fc970b256d3";
+    sha256 = "11y05i5f7lzik23w2kr52jdgr8db3gin8i683sy1hzxlmplk4699";
+  };
+
+  propagatedBuildInputs = [
+    dateutil
+    requests
+    routing
+    vfs-libarchive
+    archive_tool
+    youtube
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/zach-morris/plugin.program.iagl";
+    description = "Launch Games from the Internet using Kodi";
+    license = licenses.gpl3Plus;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -112,6 +112,8 @@ let self = rec {
 
   # addon packages (dependencies)
 
+  archive_tool = callPackage ../applications/video/kodi-packages/archive_tool { };
+
   certifi = callPackage ../applications/video/kodi-packages/certifi { };
 
   chardet = callPackage ../applications/video/kodi-packages/chardet { };

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -72,6 +72,8 @@ let self = rec {
     snes = callPackage ../applications/video/kodi-packages/controllers { controller = "snes"; };
   };
 
+  iagl = callPackage ../applications/video/kodi-packages/iagl { };
+
   libretro = callPackage ../applications/video/kodi-packages/libretro { };
 
   libretro-genplus = callPackage ../applications/video/kodi-packages/libretro-genplus { inherit genesis-plus-gx; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
i recently found out this `kodi` addon exists

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
