### PR TITLE
python3Packages.nassl: improve overridden openssl versions

### DIFF
--- a/pkgs/development/python-modules/nassl/default.nix
+++ b/pkgs/development/python-modules/nassl/default.nix
@@ -3,7 +3,8 @@
 , fetchurl
 , buildPythonPackage
 , pkgsStatic
-, openssl
+, openssl_1_1
+, openssl_1_0_2
 , invoke
 , tls-parser
 , cacert
@@ -36,7 +37,7 @@ let
     "enable-mdc2"
     "-fPIC"
   ];
-  opensslStatic = (openssl.override nasslOpensslArgs).overrideAttrs (
+  opensslStatic = (openssl_1_1.override nasslOpensslArgs).overrideAttrs (
     oldAttrs: rec {
       name = "openssl-${version}";
       version = "1.1.1h";
@@ -49,10 +50,24 @@ let
         "enable-tls1_3"
         "no-async"
       ];
+      patches = builtins.filter (
+        p: (builtins.baseNameOf (toString p)) != "macos-yosemite-compat.patch"
+      ) oldAttrs.patches;
       buildInputs = oldAttrs.buildInputs ++ [ zlibStatic cacert ];
+      meta = oldAttrs.meta // {
+        knownVulnerabilities = [
+          "CVE-2020-1971"
+          "CVE-2021-23840"
+          "CVE-2021-23841"
+          "CVE-2021-3449"
+          "CVE-2021-3450"
+          "CVE-2021-3711"
+          "CVE-2021-3712"
+        ];
+      };
     }
   );
-  opensslLegacyStatic = (openssl.override nasslOpensslArgs).overrideAttrs (
+  opensslLegacyStatic = (openssl_1_0_2.override nasslOpensslArgs).overrideAttrs (
     oldAttrs: rec {
       name = "openssl-${version}";
       version = "1.0.2e";
@@ -61,7 +76,9 @@ let
         sha256 = "1zqb1rff1wikc62a7vj5qxd1k191m8qif5d05mwdxz2wnzywlg72";
       };
       configureFlags = oldAttrs.configureFlags ++ nasslOpensslFlagsCommon;
-      patches = [ ];
+      patches = builtins.filter (
+        p: (builtins.baseNameOf (toString p)) == "darwin64-arm64.patch"
+      ) oldAttrs.patches;
       buildInputs = oldAttrs.buildInputs ++ [ zlibStatic ];
       # openssl_1_0_2 needs `withDocs = false`
       outputs = lib.remove "doc" oldAttrs.outputs;


### PR DESCRIPTION
###### Motivation for this change
ZHF #144627

Firstly override the correct respective base openssl version - this gives us an approximately appropriate set of patches and `knownVulnerabilities` to start with.

Filter patches that don't apply to the overridden source, fixing the build on darwin.

Add `knownVulnerabilities` for openssl 1.1.1h.

Would appreciate an `aarch64-darwin` tester as I _think_ I might have fixed it there too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
