### PR TITLE
python3Packages.pur: 5.4.1 -> 5.4.2; fix build

### DIFF
--- a/pkgs/development/python-modules/pur/default.nix
+++ b/pkgs/development/python-modules/pur/default.nix
@@ -1,19 +1,27 @@
 { lib
-, buildPythonPackage
-, click
+, python3
 , fetchFromGitHub
-, pytestCheckHook
 }:
+
+let
+  py = python3.override {
+    packageOverrides = self: super: {
+      # newest version doesn't support click >8.0 https://github.com/alanhamlett/pip-update-requirements/issues/38
+      click = self.callPackage ../../../development/python-modules/click/7.nix { };
+    };
+  };
+in
+with py.pkgs;
 
 buildPythonPackage rec {
   pname = "pur";
-  version = "5.4.1";
+  version = "5.4.2";
 
   src = fetchFromGitHub {
     owner = "alanhamlett";
     repo = "pip-update-requirements";
     rev = version;
-    sha256 = "sha256-a2wViLJW+UXgHcURxr4irFVkH8STH84AVcwQIkvH+Fg=";
+    sha256 = "sha256-coJO9AYm0Qx0arMf/e+pZFG/VxK6bnxxXRgw7x7V2hY=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pur/default.nix
+++ b/pkgs/development/python-modules/pur/default.nix
@@ -10,8 +10,8 @@ let
       click = self.callPackage ../../../development/python-modules/click/7.nix { };
     };
   };
+  inherit (py.pkgs) buildPythonPackage click pytestCheckHook;
 in
-with py.pkgs;
 
 buildPythonPackage rec {
   pname = "pur";

--- a/pkgs/development/tools/pur/default.nix
+++ b/pkgs/development/tools/pur/default.nix
@@ -10,10 +10,10 @@ let
       click = self.callPackage ../../../development/python-modules/click/7.nix { };
     };
   };
-  inherit (py.pkgs) buildPythonPackage click pytestCheckHook;
+  inherit (py.pkgs) buildPythonApplication click pytestCheckHook;
 in
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   pname = "pur";
   version = "5.4.2";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27353,6 +27353,8 @@ with pkgs;
 
   pika-backup = callPackage ../applications/backup/pika-backup { };
 
+  pur = callPackage ../development/tools/pur { };
+
   purple-discord = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-discord { };
 
   purple-hangouts = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-hangouts { };

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -65,6 +65,7 @@ mapAliases ({
   privacyidea = throw "privacyidea has been renamed to pkgs.privacyidea"; # added 2021-06-20
   prometheus_client = prometheus-client; # added 2021-06-10
   prompt_toolkit = prompt-toolkit; # added 2021-07-22
+  pur = throw "pur has been renamed to pkgs.pur"; # added 2021-11-08
   pylibgen = throw "pylibgen is unmaintained upstreamed, and removed from nixpkgs"; # added 2020-06-20
   pymssql = throw "pymssql has been abandoned upstream."; # added 2020-05-04
   pysmart-smartx = pysmart; # added 2021-10-22

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6041,8 +6041,6 @@ in {
 
   pulsectl = callPackage ../development/python-modules/pulsectl { };
 
-  pur = callPackage ../development/python-modules/pur { };
-
   pure-cdb = callPackage ../development/python-modules/pure-cdb { };
 
   pure-eval = callPackage ../development/python-modules/pure-eval { };


### PR DESCRIPTION
###### Motivation for this change
ZHF: #144627
Unforunately click<8.0 is a hard requirement, and although maintainer promised to work, no progress has been made: https://github.com/alanhamlett/pip-update-requirements/issues/38


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
