### PR TITLE
indent: fix static build

### DIFF
--- a/pkgs/development/tools/misc/indent/default.nix
+++ b/pkgs/development/tools/misc/indent/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ "AR=${stdenv.cc.targetPrefix}ar" ];
 
   nativeBuildInputs = [ texinfo ];
-  pkgsBuildBuild = [ buildPackages.stdenv.cc ];
+  pkgsBuildBuild = [ buildPackages.stdenv.cc ]; # needed when cross-compiling
 
   NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang
     "-Wno-implicit-function-declaration";

--- a/pkgs/development/tools/misc/indent/default.nix
+++ b/pkgs/development/tools/misc/indent/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, texinfo }:
+{ lib, stdenv, fetchurl, texinfo, buildPackages, pkgsStatic }:
 
 stdenv.mkDerivation rec {
   pname = "indent";
@@ -10,14 +10,17 @@ stdenv.mkDerivation rec {
   };
 
   patches = [ ./darwin.patch ];
+  makeFlags = [ "AR=${stdenv.cc.targetPrefix}ar" ];
 
-  buildInputs = [ texinfo ];
+  nativeBuildInputs = [ texinfo ];
+  pkgsBuildBuild = [ buildPackages.stdenv.cc ];
 
   NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang
     "-Wno-implicit-function-declaration";
 
   hardeningDisable = [ "format" ];
 
+  passthru.tests.static = pkgsStatic.indent;
   meta = {
     homepage = "https://www.gnu.org/software/indent/";
     description = "A source code reformatter";

--- a/pkgs/development/tools/misc/indent/default.nix
+++ b/pkgs/development/tools/misc/indent/default.nix
@@ -12,6 +12,7 @@ stdenv.mkDerivation rec {
   patches = [ ./darwin.patch ];
   makeFlags = [ "AR=${stdenv.cc.targetPrefix}ar" ];
 
+  strictDeps = true;
   nativeBuildInputs = [ texinfo ];
   pkgsBuildBuild = [ buildPackages.stdenv.cc ]; # needed when cross-compiling
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
