### PR TITLE
pngout: 20150319 → 20200115

### DIFF
--- a/pkgs/tools/graphics/pngout/default.nix
+++ b/pkgs/tools/graphics/pngout/default.nix
@@ -1,34 +1,49 @@
-{lib, stdenv, fetchurl}:
+{ lib
+, stdenv
+, fetchurl
+, unzip
+}:
 
 let
-  folder = if stdenv.hostPlatform.system == "i686-linux" then "i686"
-  else if stdenv.hostPlatform.system == "x86_64-linux" then "x86_64"
-  else throw "Unsupported system: ${stdenv.hostPlatform.system}";
+  platforms = {
+    aarch64-linux = { folder = "aarch64"; ld-linux = "ld-linux-aarch64.so.1"; };
+    armv7l-linux = { folder = "armv7"; ld-linux = "ld-linux-armhf.so.3"; };
+    i686-linux = { folder = "i686"; ld-linux = "ld-linux.so.2"; };
+    x86_64-darwin = { folder = "."; };
+    x86_64-linux = { folder = "amd64"; ld-linux = "ld-linux-x86-64.so.2"; };
+  };
+  platform = platforms."${stdenv.hostPlatform.system}"
+    or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+  download = if stdenv.isDarwin
+    then { extension = "macos.zip"; hash = "sha256-MnL6lH7q/BrACG4fFJNfnvoh0JClVeaJIlX+XIj2aG4="; }
+    else { extension = "linux.tar.gz"; hash = "sha256-rDi7pvDeKQM96GZTjDr6ZDQTGbaVu+OI77xf2egw6Sg="; };
 in
 stdenv.mkDerivation rec {
   pname = "pngout";
-  version = "20150319";
+  version = "20200115";
 
   src = fetchurl {
-    url = "http://static.jonof.id.au/dl/kenutils/pngout-${version}-linux.tar.gz";
-    sha256 = "0iwv941hgs2g7ljpx48fxs24a70m2whrwarkrb77jkfcd309x2h7";
+    inherit (download) hash;
+    url = "http://static.jonof.id.au/dl/kenutils/pngout-${version}-${download.extension}";
   };
+
+  nativeBuildInputs = lib.optionals stdenv.isDarwin [ unzip ];
+
+  # pngout is code-signed on Darwin, so don’t alter the binary to avoid breaking the signature.
+  dontFixup = stdenv.isDarwin;
 
   installPhase = ''
     mkdir -p $out/bin
-    cp ${folder}/pngout $out/bin
-
-    ${if stdenv.hostPlatform.system == "i686-linux" then ''
-        patchelf --set-interpreter ${stdenv.glibc.out}/lib/ld-linux.so.2 $out/bin/pngout
-      '' else if stdenv.hostPlatform.system == "x86_64-linux" then ''
-        patchelf --set-interpreter ${stdenv.glibc.out}/lib/ld-linux-x86-64.so.2 $out/bin/pngout
-      '' else ""}
+    cp ${platform.folder}/pngout $out/bin
+  '' + lib.optionalString stdenv.isLinux ''
+    patchelf --set-interpreter ${stdenv.glibc.out}/lib/${platform.ld-linux} $out/bin/pngout
   '';
 
   meta = {
     description = "A tool that aggressively optimizes the sizes of PNG images";
-    license = lib.licenses.unfree;
+    license = lib.licenses.unfreeRedistributable;
     homepage = "http://advsys.net/ken/utils.htm";
+    platforms = lib.attrNames platforms;
     maintainers = [ lib.maintainers.sander ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update pngout. Also include support for additional architectures: aarch64-linux, armv7l-linux, and x86_64-darwin.

###### Things done

- Built on platform(s)
  - [x] i686-linux
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] armv7l-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
