### PR TITLE
gfs2-utils: pull pending upstream inclusion fix for ncurses-6.3

### DIFF
--- a/pkgs/tools/filesystems/gfs2-utils/default.nix
+++ b/pkgs/tools/filesystems/gfs2-utils/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl
+{ lib, stdenv, fetchurl, fetchpatch
 , autoreconfHook, bison, flex, pkg-config
 , bzip2, check, ncurses, util-linux, zlib
 }:
@@ -11,6 +11,20 @@ stdenv.mkDerivation rec {
     url = "https://pagure.io/gfs2-utils/archive/${version}/gfs2-utils-${version}.tar.gz";
     sha256 = "sha256-gwKxBBG5PtG4/RxX4sUC25ZeG8K2urqVkFDKL7NS4ZI=";
   };
+
+  patches = [
+    # pull pending upstream inclusion fix for ncurses-6.3: sent upstream over email.
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://pagure.io/fork/slyfox/gfs2-utils/c/c927b635f380cca77665195a3aaae804d92870a4.patch";
+      sha256 = "sha256-0M1xAqRXoUi2el03WODF/nqEe9JEE5GehMWs776QZNI=";
+    })
+  ];
+  postPatch = ''
+    # Apply fix for ncurses-6.3. Upstream development branch already reworked the code.
+    # To be removed on next reelase.
+    substituteInPlace gfs2/edit/gfs2hex.c --replace 'printw(title);' 'printw("%s",title);'
+  '';
 
   outputs = [ "bin" "doc" "out" "man" ];
 


### PR DESCRIPTION
Without the fix build on ncurses-6.3 fails as:

        hexedit.c:227:9: error: format not a string literal and no format arguments [-Werror=format-security]
          227 |         printw(s2);
              |         ^~~~~~
