### PR TITLE
freesweep: pull pending upstream inclusion fix for ncurses-6.3

### DIFF
--- a/pkgs/games/freesweep/default.nix
+++ b/pkgs/games/freesweep/default.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, ncurses, lib, stdenv,
+{ fetchFromGitHub, fetchpatch, ncurses, lib, stdenv,
   updateAutotoolsGnuConfigScriptsHook }:
 
 stdenv.mkDerivation rec {
@@ -11,6 +11,25 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "0grkwmz9whg1vlnk6gbr0vv9i2zgbd036182pk0xj4cavaj9rpjb";
   };
+
+  patches = [
+    # Pull fix pending upstream inclusion for -fno-common toolchains
+    # like upstream gcc-10+ or clang-13:
+    #  https://github.com/rwestlund/freesweep/pull/8
+    (fetchpatch {
+      name = "fno-common.patch";
+      url = "https://github.com/rwestlund/freesweep/commit/a86245df4f3ff276a393f799d737d28a5cb0a5a8.patch";
+      sha256 = "13gs3bjb68ixyn9micza7gjd489rd2f5pdrv6sip9fsa6ya29xky";
+    })
+
+    # Pull fix pending upstream inclusion for ncurses-6.3:
+    #  https://github.com/rwestlund/freesweep/pull/10
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/rwestlund/freesweep/commit/b0aef2bd0b2409d1e859af7d29bf2d86fc7bcea7.patch";
+      sha256 = "1nzvmvxhjxgm8228h1zz16w62iy6lak5sibif1s1f6p1ssn659jp";
+    })
+  ];
 
   nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ];
   buildInputs = [ ncurses ];


### PR DESCRIPTION
Without the fix build on ncurses-6.3 fails as:

    gpl.c:416:25: error: format not a string literal and no format arguments [-Werror=format-security]
      416 |                         mvwprintw(GPLWin,CurrentY++,2,Messages[CurrentLine++]);
          |                         ^~~~~~~~~

While at it also pull fix for tool chains that default to -fno-common.