### PR TITLE
gmu: pull pending upstream inclusion fix for ncurses-6.3

### DIFF
--- a/pkgs/applications/audio/gmu/default.nix
+++ b/pkgs/applications/audio/gmu/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchurl, SDL, SDL_gfx, SDL_image, tremor, flac, mpg123, libmikmod
+{lib, stdenv, fetchurl, fetchpatch, SDL, SDL_gfx, SDL_image, tremor, flac, mpg123, libmikmod
 , speex, ncurses
 , keymap ? "default"
 , conf ? "unknown"
@@ -12,6 +12,24 @@ stdenv.mkDerivation rec {
     url = "https://wej.k.vu/files/${pname}-${version}.tar.gz";
     sha256 = "03x0mc0xw2if0bpf0a15yprcyx1xccki039zvl2099dagwk6xskv";
   };
+
+  patches = [
+     # pull pending upstream inclusion fix for ncurses-6.3:
+     #  https://github.com/jhe2/gmu/pull/7
+     (fetchpatch {
+       name = "ncurses-6.3.patch";
+       url = "https://github.com/jhe2/gmu/commit/c8b3a10afee136feb333754ef6ec26383b11072f.patch";
+       sha256 = "0xp2j3jp8pkmv6yvnzi378m2dylbfsaqrsrkw7hbxw6kglzj399r";
+     })
+
+     # pull upstream fix for -fno-common toolchains like
+     # upstream gcc-10 of clang-13.
+     (fetchpatch {
+       name = "fno-common.patch";
+       url = "https://github.com/jhe2/gmu/commit/b705209f08ddfda141ad358ccd0c3d2d099be5e6.patch";
+       sha256 = "1ci2b8kz3r58rzmivlfhqjmcgqwlkwlzzhnyxlk36vmk240a3gqq";
+     })
+  ];
 
   buildInputs = [ SDL SDL_gfx SDL_image tremor flac mpg123 libmikmod speex ncurses ];
 


### PR DESCRIPTION
Without the fix build on ncurses-6.3 fails as:

    src/tools/ui.c: In function 'ui_draw_footer_button':
    src/tools/ui.c:329:9: error: format not a string literal and no format arguments [-Werror=format-security]
      329 |         wprintw(ui->win_footer->win, key);
          |         ^~~~~~~

While at it pulled fix for upstream gcc-10 and clang-12 which
default to -fno-common. Otherwise build would fail as:

    $ nix build --impure --expr 'with import ./. {}; gmu.override { stdenv = clang12Stdenv; }' -L
    ...
    gmu> ld: feloader.o:(.bss+0x8): multiple definition of `dlsymunion';
      decloader.o:(.bss+0x8): first defined here