### PR TITLE
factorio{,demo,headless}: 1.1.42 -> 1.1.46

### DIFF
--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -10,22 +10,22 @@
         "version": "1.1.45"
       },
       "stable": {
-        "name": "factorio_alpha_x64-1.1.42.tar.xz",
+        "name": "factorio_alpha_x64-1.1.46.tar.xz",
         "needsAuth": true,
-        "sha256": "08h2pxzsk7sigjqnqm1jxya3i9i5g2mgl378gmbp2jcy2mnn4dvm",
+        "sha256": "sha256-ikvtD5X0WRBVMsByXLXC5jtVZeIFQIsWlZ9vzomYdGU=",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.42/alpha/linux64",
-        "version": "1.1.42"
+        "url": "https://factorio.com/get-download/1.1.46/alpha/linux64",
+        "version": "1.1.46"
       }
     },
     "demo": {
       "stable": {
-        "name": "factorio_demo_x64-1.1.42.tar.xz",
+        "name": "factorio_demo_x64-1.1.46.tar.xz",
         "needsAuth": false,
-        "sha256": "155m1ijdbc7szhpdw8f8g82ysd7av9zb6llqq4z96nn834px9m2d",
+        "sha256": "sha256-CJVk1b3GXqs8xV2a7Pa6p6JxEOy86xAnRfz6kphCDHk=",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.42/demo/linux64",
-        "version": "1.1.42"
+        "url": "https://factorio.com/get-download/1.1.46/demo/linux64",
+        "version": "1.1.46"
       }
     },
     "headless": {
@@ -38,12 +38,12 @@
         "version": "1.1.45"
       },
       "stable": {
-        "name": "factorio_headless_x64-1.1.42.tar.xz",
+        "name": "factorio_headless_x64-1.1.46.tar.xz",
         "needsAuth": false,
-        "sha256": "1l217fcjcwfi0g5dilsi703cl0wyxsqdqn422hwdbp2ql839k422",
+        "sha256": "sha256-xJ/NBwQR6tdwoAz/1RZmcGwutqETWgzyAlpg5ls2ba0=",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.42/headless/linux64",
-        "version": "1.1.42"
+        "url": "https://factorio.com/get-download/1.1.46/headless/linux64",
+        "version": "1.1.46"
       }
     }
   }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
[update](https://wiki.factorio.com/Version_history/1.1.0#1.1.46)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
