### PR TITLE
autoconf: pull upstream fix for autoreconf race

### DIFF
--- a/pkgs/development/tools/misc/autoconf/2.71-fix-race.patch
+++ b/pkgs/development/tools/misc/autoconf/2.71-fix-race.patch
@@ -1,0 +1,36 @@
+https://savannah.gnu.org/support/index.php?110521
+https://git.savannah.gnu.org/cgit/autoconf.git/patch/?id=3a9802d60156809c139e9b4620bf04917e143ee2
+--- a/lib/Autom4te/FileUtils.pm
++++ b/lib/Autom4te/FileUtils.pm
+@@ -34,12 +34,12 @@ This perl module provides various general purpose file handling functions.
+ 
+ =cut
+ 
+-use 5.006;
++use 5.008;
+ use strict;
+ use warnings FATAL => 'all';
+ 
+ use Exporter;
+-use File::stat;
++use Time::HiRes qw(stat);
+ use IO::File;
+ 
+ use Autom4te::Channels;
+@@ -115,10 +115,11 @@ sub mtime ($)
+   return 0
+     if $file eq '-' || ! -f $file;
+ 
+-  my $stat = stat ($file)
++  my ($dev,$ino,$mode,$nlink,$uid,$gid,$rdev,$size,
++    $atime,$mtime,$ctime,$blksize,$blocks) = stat ($file)
+     or fatal "cannot stat $file: $!";
+ 
+-  return $stat->mtime;
++  return $mtime;
+ }
+ 
+ 
+-- 
+cgit v1.2.1
+

--- a/pkgs/development/tools/misc/autoconf/default.nix
+++ b/pkgs/development/tools/misc/autoconf/default.nix
@@ -13,6 +13,11 @@ stdenv.mkDerivation rec {
     url = "mirror://gnu/autoconf/autoconf-${version}.tar.xz";
     sha256 = "197sl23irn6s9pd54rxj5vcp5y8dv65jb9yfqgr2g56cxg7q6k7i";
   };
+  patches = [
+    # fix stale autom4te cache race condition:
+    #  https://savannah.gnu.org/support/index.php?110521
+    ./2.71-fix-race.patch
+  ];
 
   nativeBuildInputs = [ m4 perl ];
   buildInputs = [ m4 ];


### PR DESCRIPTION
Before this change `xfce.garcon` did not always compile successfully:

    $ c=1; while nix build --rebuild -f. xfce.garcon --cores 1; do (( c+=1 )); echo again with $c; done
    ...
    again with 4
    garcon-gtk/Makefile.am: installing './depcomp'
    .../am/depend2.am: error: am__fastdepCC does not appear in AM_CONDITIONAL
    .../am/depend2.am:   The usual way to define 'am__fastdepCC' is to add 'AC_PROG_CC'

This happens due to an autoconf bug when m4 is called within 1 second:
    Upstream report and fix: https://savannah.gnu.org/support/index.php?110521

The change allows `xfce.garcon` to rebuild 60 times in a row without failures.