### PR TITLE
coqPackages.time-invariance-thesis-for-L: init

### DIFF
--- a/pkgs/development/coq-modules/time-invariance-thesis-for-L/default.nix
+++ b/pkgs/development/coq-modules/time-invariance-thesis-for-L/default.nix
@@ -1,0 +1,24 @@
+{ lib, mkCoqDerivation, smpl, equations, metacoq, coq, version ? null }:
+with lib;
+
+mkCoqDerivation {
+  pname = "time-invariance-thesis-for-L";
+  owner = "uds-psl";
+
+  release."8.12".rev = "41f4eb1f788cc4f096d9c7c286c9ca907588859f";
+  release."8.12".sha256 = "sha256-fkBZKpOEZ+aqcF7bZRJN4CMcTVgy6rf+fYnLvbhxUsA=";
+
+  inherit version;
+  defaultVersion = with versions; switch coq.version [
+    { case = isGe "8.12"; out = "8.12"; }
+  ] null;
+
+  propagatedBuildInputs = [ smpl equations metacoq ];
+
+  meta = {
+    description = "A Mechanised Proof of the Time Invariance Thesis for the Weak Call-by-value λ-Calculus";
+    maintainers = with maintainers; [ siraben ];
+    license = licenses.cecill21;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -99,6 +99,7 @@ let
       smtcoq = callPackage ../development/coq-modules/smtcoq { };
       stdpp = callPackage ../development/coq-modules/stdpp { };
       StructTact = callPackage ../development/coq-modules/StructTact {};
+      time-invariance-thesis-for-L = callPackage ../development/coq-modules/time-invariance-thesis-for-L {};
       tlc = callPackage ../development/coq-modules/tlc {};
       topology = callPackage ../development/coq-modules/topology {};
       trakt = callPackage ../development/coq-modules/trakt {};


### PR DESCRIPTION
###### Motivation for this change
Add mechanization of the time invariance thesis for the weak call-by-value λ-calculus. This also adds `smpl` and `metacoq`.  At the moment metacoq doesn't build, however: http://ix.io/3Ekd

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
