### PR TITLE
doc: Document how to leverages packages with extensions.

### DIFF
--- a/nixos/doc/manual/configuration/customizing-packages.section.md
+++ b/nixos/doc/manual/configuration/customizing-packages.section.md
@@ -13,7 +13,7 @@ configuration options.
 :::
 
 ::: {.note}
-However, many packages in the `nix` store come with extensions one might add.
+Alternatively, many packages come with extensions one might add.
 Examples include:
 - [`python310Packages.requests`](https://search.nixos.org/packages/query=python310Packages.requests)
 - [`passExtensions.pass-otp`](https://search.nixos.org/packages/query=passExtensions.pass-otp)

--- a/nixos/doc/manual/configuration/customizing-packages.section.md
+++ b/nixos/doc/manual/configuration/customizing-packages.section.md
@@ -15,8 +15,8 @@ configuration options.
 ::: {.note}
 Alternatively, many packages come with extensions one might add.
 Examples include:
-- [`python310Packages.requests`](https://search.nixos.org/packages/query=python310Packages.requests)
 - [`passExtensions.pass-otp`](https://search.nixos.org/packages/query=passExtensions.pass-otp)
+- [`python310Packages.requests`](https://search.nixos.org/packages/query=python310Packages.requests)
 
 You can use them like this:
 ```nix

--- a/nixos/doc/manual/configuration/customizing-packages.section.md
+++ b/nixos/doc/manual/configuration/customizing-packages.section.md
@@ -12,6 +12,29 @@ Unfortunately, Nixpkgs currently lacks a way to query available
 configuration options.
 :::
 
+::: {.note}
+However, many packages in the `nix` store come with extensions one might add.
+Examples include:
+- [`python310Packages.requests`](https://search.nixos.org/packages/query=python310Packages.requests)
+- [`passExtensions.pass-otp`](https://search.nixos.org/packages/query=passExtensions.pass-otp)
+
+You can use them like this:
+```nix
+environment.systemPackages = with pkgs; [
+  sl
+  (pass.withExtensions (subpkgs: with subpkgs; [
+    pass-audit
+    pass-otp
+    pass-genphrase
+  ]))
+  (python3.withPackages (subpkgs: with subpkgs; [
+      requests
+  ]))
+  cowsay
+];
+```
+:::
+
 Apart from high-level options, it's possible to tweak a package in
 almost arbitrary ways, such as changing or disabling dependencies of a
 package. For instance, the Emacs package in Nixpkgs by default has a


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Clarification of /making more explicit something that might be considered "tribal knowledge", AKA my two cents in making this particular cornerstone more "noob friendly".

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

```
[2021-11-07 21:33:07] 0 x10an14@laptop:~/github/nixpkgs/nixos/doc/manual
-> $ ./md-to-db.sh
~/github/nixpkgs/nixos/doc/manual ~/github/nixpkgs/nixos/doc/manual
~/github/nixpkgs/nixos/doc/manual
[2021-11-07 21:33:37] 0 x10an14@laptop:~/github/nixpkgs/nixos/doc/manual
-> $ nix-build ../../release.nix -A manual.x86_64-linux
these derivations will be built:
  /nix/store/bzncn49iijnin90a9kpx3xjfcpjhyksj-nixos-manual-combined.drv
  /nix/store/9vygy8y6rscgs65r5kj3drq7dg4clwqv-manual-olinkdb.drv
  /nix/store/76vwy7jg9hk0w9wlm5fjsih824axpics-nixos-manual-html.drv
building '/nix/store/bzncn49iijnin90a9kpx3xjfcpjhyksj-nixos-manual-combined.drv'...

manual-combined.xml validates

man-pages-combined.xml validates
building '/nix/store/9vygy8y6rscgs65r5kj3drq7dg4clwqv-manual-olinkdb.drv'...
Writing /nix/store/ckpx4b01s8ilkpljmjch4d19d5c7rf36-manual-olinkdb/manual.db for book(book-nixos-manual)
building '/nix/store/76vwy7jg9hk0w9wlm5fjsih824axpics-nixos-manual-html.drv'...
Writing options.html for appendix(ch-options)
Writing release-notes.html for appendix(ch-release-notes)
Writing index.html for book(book-nixos-manual)
/nix/store/wd2zrqplvm36if080wp1q00d7vwbpi7l-nixos-manual-html
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
