### PR TITLE
openvscode-server: init at 1.62.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2665,6 +2665,12 @@
     githubId = 2439413;
     name = "Derek Gonyeo";
   };
+  dguenther = {
+    email = "dguenther9@gmail.com";
+    github = "dguenther";
+    githubId = 767083;
+    name = "Derek Guenther";
+  };
   dhkl = {
     email = "david@davidslab.com";
     github = "dhl";

--- a/pkgs/servers/openvscode-server/default.nix
+++ b/pkgs/servers/openvscode-server/default.nix
@@ -1,0 +1,173 @@
+{ lib, stdenv, fetchFromGitHub, makeWrapper, runCommand
+, cacert, moreutils, jq, git, pkg-config, yarn, python3
+, esbuild, nodejs-14_x, libsecret, xorg, ripgrep
+, AppKit, Cocoa, Security, cctools }:
+
+let
+  system = stdenv.hostPlatform.system;
+
+  nodejs = nodejs-14_x;
+  yarn' = yarn.override { inherit nodejs; };
+  defaultYarnOpts = [ "frozen-lockfile" "non-interactive" "no-progress"];
+
+  vsBuildTarget = {
+    x86_64-linux = "linux-x64";
+    aarch64-linux = "linux-arm64";
+    x86_64-darwin = "darwin";
+  }.${system} or (throw "Unsupported system ${system}");
+
+  # replaces esbuild's download script with a binary from nixpkgs
+  patchEsbuild = path : version : ''
+    mkdir -p ${path}/node_modules/esbuild/bin
+    jq "del(.scripts.postinstall)" ${path}/node_modules/esbuild/package.json | sponge ${path}/node_modules/esbuild/package.json
+    sed -i 's/${version}/${esbuild.version}/g' ${path}/node_modules/esbuild/lib/main.js
+    ln -s -f ${esbuild}/bin/esbuild ${path}/node_modules/esbuild/bin/esbuild
+  '';
+
+in stdenv.mkDerivation rec {
+  pname = "openvscode-server";
+  version = "1.62.0";
+
+  src = fetchFromGitHub {
+    owner = "gitpod-io";
+    repo = "openvscode-server";
+    rev = "openvscode-server-v${version}";
+    sha256 = "0lmka1hgf1703h70s7i2lx07535n2l867kmnc5h89c4vaswy6649";
+  };
+
+  yarnCache = stdenv.mkDerivation {
+    name = "${pname}-${version}-${system}-yarn-cache";
+    inherit src;
+    nativeBuildInputs = [ cacert yarn git ];
+    buildPhase = ''
+      export HOME=$PWD
+
+      yarn config set yarn-offline-mirror $out
+      find "$PWD" -name "yarn.lock" -printf "%h\n" | \
+        xargs -I {} yarn --cwd {} \
+          --frozen-lockfile --ignore-scripts --ignore-platform \
+          --ignore-engines --no-progress --non-interactive
+    '';
+
+    installPhase = ''
+      echo yarnCache
+    '';
+
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash = "142m0vkddzv09rbbqw7y7x19q7akkn00dn6az5ppr86k6bmhyk6p";
+  };
+
+  # Extract the Node.js source code which is used to compile packages with
+  # native bindings
+  nodeSources = runCommand "node-sources" {} ''
+    tar --no-same-owner --no-same-permissions -xf ${nodejs.src}
+    mv node-* $out
+  '';
+
+  nativeBuildInputs = [
+    nodejs yarn' python3 pkg-config makeWrapper git jq moreutils
+  ];
+  buildInputs = lib.optionals (!stdenv.isDarwin) [ libsecret ]
+    ++ (with xorg; [ libX11 libxkbfile ])
+    ++ lib.optionals stdenv.isDarwin [
+      AppKit Cocoa Security cctools
+    ];
+
+  patches = [
+    # Patch out remote download of nodejs from build script
+    ./remove-node-download.patch
+  ];
+
+  postPatch = ''
+    export HOME=$PWD
+
+    # remove all built-in extensions, as these are 3rd party extensions that
+    # get downloaded from vscode marketplace
+    jq --slurp '.[0] * .[1]' "product.json" <(
+      cat << EOF
+    {
+      "builtInExtensions": []
+    }
+    EOF
+    ) | sponge product.json
+  '';
+
+  configurePhase = ''
+    # set default yarn opts
+    ${lib.concatMapStrings (option: ''
+      yarn --offline config set ${option}
+    '') defaultYarnOpts}
+
+    # set offline mirror to yarn cache we created in previous steps
+    yarn --offline config set yarn-offline-mirror "${yarnCache}"
+  '' + lib.optionalString stdenv.isLinux ''
+    # set nodedir, so we can build binaries later
+    npm config set nodedir "${nodeSources}"
+  '';
+
+  buildPhase = ''
+    # install dependencies
+    yarn --offline --ignore-scripts
+
+    # run yarn install everywhere, skipping postinstall so we can patch esbuild
+    find . -path "*node_modules" -prune -o \
+      -path "./*/*" -name "yarn.lock" -printf "%h\n" | \
+        xargs -I {} yarn --cwd {} \
+          --frozen-lockfile --offline --ignore-scripts --ignore-engines
+
+    ${patchEsbuild "./build" "0.12.6"}
+    ${patchEsbuild "./extensions" "0.11.23"}
+
+    # patch shebangs of node_modules to allow binary packages to build
+    patchShebangs ./remote/node_modules
+
+    # put ripgrep binary into bin so postinstall does not try to download it
+    find -name vscode-ripgrep -type d \
+      -execdir mkdir -p {}/bin \; \
+      -execdir ln -s ${ripgrep}/bin/rg {}/bin/rg \;
+  '' + lib.optionalString stdenv.isDarwin ''
+    # use prebuilt binary for @parcel/watcher, which requires macOS SDK 10.13+
+    # (see issue #101229)
+    pushd ./remote/node_modules/@parcel/watcher
+    mkdir -p ./build/Release
+    mv ./prebuilds/darwin-x64/node.napi.glibc.node ./build/Release/watcher.node
+    jq "del(.scripts) | .gypfile = false" ./package.json | sponge ./package.json
+    popd
+  '' + ''
+    # rebuild binaries, we use npm here, as yarn does not provide an alternative
+    # that would not attempt to try to reinstall everything and break our
+    # patching attempts
+    npm --prefix ./remote rebuild --build-from-source
+
+    # run postinstall scripts after patching
+    find . -path "*node_modules" -prune -o \
+      -path "./*/*" -name "yarn.lock" -printf "%h\n" | \
+        xargs -I {} sh -c 'jq -e ".scripts.postinstall" {}/package.json >/dev/null && yarn --cwd {} postinstall --frozen-lockfile --offline || true'
+
+    # build and minify
+    yarn --offline gulp vscode-reh-web-${vsBuildTarget}-min
+  '';
+
+  installPhase = ''
+    mkdir -p $out/libexec
+
+    cp -R -T ../vscode-reh-web-${vsBuildTarget} "$out/libexec"
+
+    ln -s ${nodejs}/bin/node $out/libexec
+
+    makeWrapper "$out/libexec/server.sh" "$out/bin/openvscode-server"
+  '';
+
+  meta = with lib; {
+    description = "Run VS Code on a remote machine";
+    longDescription = ''
+      Run upstream VS Code on a remote machine with access through a modern web
+      browser from any device, anywhere.
+    '';
+    homepage = "https://github.com/gitpod-io/openvscode-server";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dguenther ghuntley ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
+  };
+}

--- a/pkgs/servers/openvscode-server/remove-node-download.patch
+++ b/pkgs/servers/openvscode-server/remove-node-download.patch
@@ -1,0 +1,27 @@
+--- ./build/gulpfile.reh.js
++++ ./build/gulpfile.reh.js
+@@ -277,8 +277,6 @@
+ 			.pipe(util.stripSourceMappingURL())
+ 			.pipe(jsFilter.restore);
+ 
+-		const nodePath = `.build/node/v${nodeVersion}/${platform}-${platform === 'darwin' ? 'x64' : arch}`;
+-		const node = gulp.src(`${nodePath}/**`, { base: nodePath, dot: true });
+ 
+ 		let web = [];
+ 		if (type === 'reh-web') {
+@@ -296,7 +294,6 @@
+ 			license,
+ 			sources,
+ 			deps,
+-			node,
+ 			...web
+ 		);
+ 
+@@ -376,7 +373,6 @@
+ 			const destinationFolderName = `vscode-${type}${dashed(platform)}${dashed(arch)}`;
+ 
+ 			const serverTaskCI = task.define(`vscode-${type}${dashed(platform)}${dashed(arch)}${dashed(minified)}-ci`, task.series(
+-				gulp.task(`node-${platform}-${platform === 'darwin' ? 'x64' : arch}`),
+ 				util.rimraf(path.join(BUILD_ROOT, destinationFolderName)),
+ 				packageTask(type, platform, arch, sourceFolderName, destinationFolderName)
+ 			));

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28405,6 +28405,11 @@ with pkgs;
   vscodium-fhs = vscodium.fhs;
   vscodium-fhsWithPackages = vscodium.fhsWithPackages;
 
+  openvscode-server = callPackage ../servers/openvscode-server {
+    inherit (darwin.apple_sdk.frameworks) AppKit Cocoa Security;
+    inherit (darwin) cctools;
+  };
+
   code-server = callPackage ../servers/code-server {
     inherit (darwin.apple_sdk.frameworks) AppKit Cocoa Security;
     inherit (darwin) cctools;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The derivation is based on the work done for [code-server](https://github.com/NixOS/nixpkgs/blob/17f230461a1010cdb0d0bb92594546429c69de47/pkgs/servers/code-server/default.nix), but is structured as a fork of upstream VS Code instead of a series of nested NPM packages.

ccing @colemickens as the creator of #140344

Closes #140344

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
