### PR TITLE
python3Packages.sanic: disable failing tests on aarch64-linux

### DIFF
--- a/pkgs/development/python-modules/sanic/default.nix
+++ b/pkgs/development/python-modules/sanic/default.nix
@@ -5,7 +5,6 @@
 , buildPythonPackage
 , doCheck ? true
 , fetchFromGitHub
-, fetchpatch
 , gunicorn
 , httptools
 , multidict
@@ -68,8 +67,8 @@ buildPythonPackage rec {
   inherit doCheck;
 
   preCheck = ''
-    # Some tests depends on executables on PATH
-    PATH="$out/bin:${gunicorn}/bin:$PATH"
+    # Some tests depends on sanic on PATH
+    PATH="$out/bin:$PATH"
   '';
 
   disabledTests = [
@@ -86,6 +85,16 @@ buildPythonPackage rec {
     "test_auto_reload"
   ] ++ lib.optionals stdenv.isDarwin [
     # https://github.com/sanic-org/sanic/issues/2298
+    "test_no_exceptions_when_cancel_pending_request"
+  ] ++ lib.optionals (stdenv.hostPlatform.system == "aarch64-linux") [
+    # These appear to be very sensitive to output of commands
+    # Output is different on aarch64
+    "test_server_run"
+    "test_host_port"
+    "test_num_workers"
+    "test_access_logs"
+    "test_version"
+    # Failing for a different reason than Darwin
     "test_no_exceptions_when_cancel_pending_request"
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF: https://github.com/NixOS/nixpkgs/issues/144627

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
