### PR TITLE
fiji: init at 20201104-1356

### DIFF
--- a/pkgs/applications/graphics/fiji/default.nix
+++ b/pkgs/applications/graphics/fiji/default.nix
@@ -1,0 +1,77 @@
+{ stdenv
+, lib
+, fetchurl
+, makeWrapper
+, autoPatchelfHook
+, jdk11
+, makeDesktopItem
+, copyDesktopItems
+, runtimeShell
+}:
+stdenv.mkDerivation rec {
+  pname = "fiji";
+  version = "20201104-1356";
+
+  src = fetchurl {
+    url = "https://downloads.imagej.net/${pname}/archive/${version}/${pname}-nojre.tar.gz";
+    sha256 = "1jv4wjjkpid5spr2nk5xlvq3hg687qx1n5zh8zlw48y1y09c4q7a";
+  };
+
+  dontBuild = true;
+
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper copyDesktopItems ];
+  buildInputs = [ stdenv.cc.cc.lib ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "fiji";
+      exec = "fiji %F";
+      icon = "fiji";
+      mimeType = "image/*;";
+      comment = "Scientific Image Analysis";
+      desktopName = "Fiji Is Just ImageJ";
+      genericName = "Fiji Is Just ImageJ";
+      categories = "Education;Science;ImageProcessing;";
+      terminal = false;
+      startupNotify = true;
+      extraEntries = ''
+        Version=1.0
+        TryExec=fiji
+        X-GNOME-FullName=Fiji Is Just ImageJ
+        StartupWMClass=fiji-Main
+      '';
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,fiji,share/pixmaps}
+
+    cp -R * $out/fiji
+    rm -f $out/fiji/jars/imagej-updater-*.jar
+
+    # Disgusting hack to stop a local desktop entry being created
+    cat <<EOF > $out/bin/.fiji-launcher-hack
+    #!${runtimeShell}
+    exec \$($out/fiji/ImageJ-linux64 --dry-run "\$@")
+    EOF
+    chmod +x $out/bin/.fiji-launcher-hack
+
+    makeWrapper $out/bin/.fiji-launcher-hack $out/bin/fiji \
+      --prefix PATH : ${lib.makeBinPath [ jdk11 ]} \
+      --set JAVA_HOME ${jdk11.home}
+
+    ln $out/fiji/images/icon.png $out/share/pixmaps/fiji.png
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://imagej.net/software/fiji/";
+    description = "batteries-included distribution of ImageJ2, bundling a lot of plugins which facilitate scientific image analysis";
+    platforms = [ "x86_64-linux" ];
+    license = with lib.licenses; [ gpl2Plus gpl3Plus bsd2 publicDomain ];
+    maintainers = with maintainers; [ zane ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25818,6 +25818,8 @@ with pkgs;
 
   imagej = callPackage ../applications/graphics/imagej { };
 
+  fiji = callPackage ../applications/graphics/fiji { };
+
   imagemagick6_light = imagemagick6.override {
     bzip2 = null;
     zlib = null;


### PR DESCRIPTION
###### Motivation for this change
Packaging.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
