### PR TITLE
7zz: 21.01 -> 21.04

### DIFF
--- a/pkgs/tools/archivers/7zz/default.nix
+++ b/pkgs/tools/archivers/7zz/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Command line archiver utility";
     homepage = "https://7zip.org";
-    license = licenses.lgpl21Only;
+    license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ anna328p peterhoeg ];
     platforms = platforms.linux;
   };

--- a/pkgs/tools/archivers/7zz/default.nix
+++ b/pkgs/tools/archivers/7zz/default.nix
@@ -1,47 +1,45 @@
-{ lib, stdenv, fetchurl, autoPatchelfHook }:
+{ stdenv, lib, fetchurl, gnugrep, p7zip }:
 
-let platform =       if stdenv.isi686    then "x86"
-                else if stdenv.isx86_64  then "x64"
-                else if stdenv.isAarch32 then "arm"
-                else if stdenv.isAarch64 then "arm64"
-                else throw "Unsupported architecture";
-
-    url = "https://7-zip.org/a/7z2101-linux-${platform}.tar.xz";
-
-    hashes = {
-      x86 = "0k6vg85ld8i2pcv5sv3xbvf3swqh9qj8hf2jcpadssys3yyidqyj";
-      x64 = "1yfanx98fizj8d2s87yxgsy30zydx7h5w9wf4wy3blgsp0vkbjb3";
-      arm = "04iah9vijm86r8rbkhxig86fx3lpag4xi7i3vq7gfrlwkymclhm1";
-      arm64 = "0a26ginpb22aydcyvffxpbi7lxh4sgs9gb6cj96qqx7cnf7bk2ri";
-    };
-    sha256 = hashes."${platform}";
-
-in stdenv.mkDerivation {
+# https://sourceforge.net/p/sevenzip/discussion/45797/thread/7fe6c21efa/
+stdenv.mkDerivation rec {
   pname = "7zz";
-  version = "21.01";
+  version = "21.02";
 
-  src = fetchurl { inherit url sha256; };
-  sourceRoot = ".";
+  src = fetchurl {
+    url = "https://7-zip.org/a/7z${lib.replaceStrings ["." ] [""] version}-src.7z";
+    sha256 = "sha256-7pdV/qoDTnB1cSvGsfrSVEC9Co8h8Qahbje8S0CfESI=";
+  };
 
-  nativeBuildInputs = [ autoPatchelfHook ];
-  buildInputs = [ stdenv.cc.cc.lib ];
+  sourceRoot = "CPP/7zip/Bundles/Alone2";
 
-  dontBuild = true;
+  # we need https://github.com/nidud/asmc/tree/master/source/asmc/linux in order
+  # to build with the optimized assembler but that doesn't support building with
+  # GCC
+  # "../../cmpl_gcc_x64.mak";
+  makefile = "../../cmpl_gcc.mak";
+
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=maybe-uninitialized" ];
+
+  nativeBuildInputs = [ gnugrep p7zip ];
+
+  enableParallelBuilding = true;
 
   installPhase = ''
-    runHook preInstall
-    install -D -t $out/bin 7zz
-    runHook postInstall
+    install -Dm555 -t $out/bin b/g/7zz
+    install -Dm444 -t $out/share/doc/${pname} ../../../../DOC/*.txt
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    $out/bin/7zz --help | grep ${version}
   '';
 
   meta = with lib; {
     description = "Command line archiver utility";
-    homepage = "https://www.7-zip.org";
-
-    # source not released yet. will be under LGPL 2.1+ with RAR exception
-    license = licenses.unfree;
-
-    platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" "armv7l-linux" ];
-    maintainers = with maintainers; [ anna328p ];
+    homepage = "https://7zip.org";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ anna328p peterhoeg ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/archivers/7zz/default.nix
+++ b/pkgs/tools/archivers/7zz/default.nix
@@ -3,11 +3,11 @@
 # https://sourceforge.net/p/sevenzip/discussion/45797/thread/7fe6c21efa/
 stdenv.mkDerivation rec {
   pname = "7zz";
-  version = "21.02";
+  version = "21.04";
 
   src = fetchurl {
     url = "https://7-zip.org/a/7z${lib.replaceStrings ["." ] [""] version}-src.7z";
-    sha256 = "sha256-7pdV/qoDTnB1cSvGsfrSVEC9Co8h8Qahbje8S0CfESI=";
+    sha256 = "sha256-XmuEyIJAJQM0ZbgrW02lQ2rp4KFDBjLXKRaTfY+VCOg=";
   };
 
   sourceRoot = "CPP/7zip/Bundles/Alone2";

--- a/pkgs/tools/archivers/7zz/default.nix
+++ b/pkgs/tools/archivers/7zz/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, gnugrep, p7zip }:
+{ stdenv, lib, fetchurl, p7zip }:
 
 # https://sourceforge.net/p/sevenzip/discussion/45797/thread/7fe6c21efa/
 stdenv.mkDerivation rec {
@@ -14,19 +14,22 @@ stdenv.mkDerivation rec {
 
   # we need https://github.com/nidud/asmc/tree/master/source/asmc/linux in order
   # to build with the optimized assembler but that doesn't support building with
-  # GCC
-  # "../../cmpl_gcc_x64.mak";
-  makefile = "../../cmpl_gcc.mak";
+  # GCC: https://github.com/nidud/asmc/issues/8
+  makefile = "../../cmpl_gcc.mak"; # "../../cmpl_gcc_x64.mak";
 
   NIX_CFLAGS_COMPILE = [ "-Wno-error=maybe-uninitialized" ];
 
-  nativeBuildInputs = [ gnugrep p7zip ];
+  nativeBuildInputs = [ p7zip ];
 
   enableParallelBuilding = true;
 
   installPhase = ''
+    runHook preInstall
+
     install -Dm555 -t $out/bin b/g/7zz
     install -Dm444 -t $out/share/doc/${pname} ../../../../DOC/*.txt
+
+    runHook postInstall
   '';
 
   doInstallCheck = true;


### PR DESCRIPTION
###### Motivation for this change

Also build from source instead of using the binaries.

We cannot (yet) build the fully optimized version as it requires the
ASMC assembler which currently doesn't build with GCC.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
