### PR TITLE
ocamlPackages: fix some packages for cross-compilation

### DIFF
--- a/pkgs/development/ocaml-modules/afl-persistent/default.nix
+++ b/pkgs/development/ocaml-modules/afl-persistent/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "06yyds2vcwlfr2nd3gvyrazlijjcrd1abnvkfpkaadgwdw3qam1i";
   };
 
-  buildInputs = [ ocaml findlib ];
+  nativeBuildInputs = [ ocaml findlib ];
 
   # don't run tests in buildPhase
   # don't overwrite test binary

--- a/pkgs/development/ocaml-modules/lwt/default.nix
+++ b/pkgs/development/ocaml-modules/lwt/default.nix
@@ -18,8 +18,7 @@ buildDunePackage rec {
   };
 
   nativeBuildInputs = [ pkg-config cppo dune-configurator ];
-  buildInputs = [ ]
-   ++ optional (!versionAtLeast ocaml.version "4.08") ocaml-syntax-shims
+  buildInputs = optional (!versionAtLeast ocaml.version "4.08") ocaml-syntax-shims
    ++ optional (!versionAtLeast ocaml.version "4.07") ncurses;
   propagatedBuildInputs = [ libev mmap ocplib-endian seq result ];
 

--- a/pkgs/development/ocaml-modules/lwt/default.nix
+++ b/pkgs/development/ocaml-modules/lwt/default.nix
@@ -17,8 +17,8 @@ buildDunePackage rec {
     sha256 = "0cq2qy23sa1a5zk6nja3c652mp29i84yfrkcwks6i8sdqwli36jy";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ cppo dune-configurator ]
+  nativeBuildInputs = [ pkg-config cppo dune-configurator ];
+  buildInputs = [ ]
    ++ optional (!versionAtLeast ocaml.version "4.08") ocaml-syntax-shims
    ++ optional (!versionAtLeast ocaml.version "4.07") ncurses;
   propagatedBuildInputs = [ libev mmap ocplib-endian seq result ];

--- a/pkgs/development/ocaml-modules/mrmime/default.nix
+++ b/pkgs/development/ocaml-modules/mrmime/default.nix
@@ -36,15 +36,6 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  buildInputs = [
-    afl-persistent
-    bigarray-compat
-    bigarray-overlap
-    bigstringaf
-    fpath
-    mirage-crypto-rng
-  ];
-
   propagatedBuildInputs = [
     angstrom
     base64
@@ -59,6 +50,12 @@ buildDunePackage rec {
     rresult
     unstrctrd
     uutf
+    afl-persistent
+    bigarray-compat
+    bigarray-overlap
+    bigstringaf
+    fpath
+    mirage-crypto-rng
   ];
 
   checkInputs = [

--- a/pkgs/development/ocaml-modules/ocplib-endian/default.nix
+++ b/pkgs/development/ocaml-modules/ocplib-endian/default.nix
@@ -11,7 +11,7 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  buildInputs = [ cppo ];
+  nativeBuildInputs = [ cppo ];
 
   meta = with lib; {
     description = "Optimised functions to read and write int16/32/64";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
