### PR TITLE
hexcurse: pull pending upstream inclusion fix for ncurses-6.3

### DIFF
--- a/pkgs/applications/editors/hexcurse/default.nix
+++ b/pkgs/applications/editors/hexcurse/default.nix
@@ -23,6 +23,22 @@ stdenv.mkDerivation rec {
       url = "https://github.com/LonnyGomes/hexcurse/commit/716b5d58ac859cc240b8ccb9cbd79ace3e0593c1.patch";
       sha256 = "0v6gbp6pjpmnzswlf6d97aywiy015g3kcmfrrkspsbb7lh1y3nix";
     })
+
+    # Fix pending upstream inclusion for gcc10 -fno-common compatibility:
+    #  https://github.com/LonnyGomes/hexcurse/pull/28
+    (fetchpatch {
+      name = "fno-common.patch";
+      url = "https://github.com/LonnyGomes/hexcurse/commit/9cf7c9dcd012656df949d06f2986b57db3a72bdc.patch";
+      sha256 = "1awsyxys4pd3gkkgyckgjg3njgqy07223kcmnpfdkidh2xb0s360";
+    })
+
+    # Fix pending upstream inclusion for ncurses-6.3 support:
+    #  https://github.com/LonnyGomes/hexcurse/pull/40
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/LonnyGomes/hexcurse/commit/cb70d4a93a46102f488f471fad31a7cfc9fec025.patch";
+      sha256 = "19674zhhp7gc097kl4bxvi0gblq6jzjy8cw8961svbq5y3hv1v5y";
+    })
   ];
 
   meta = with lib; {


### PR DESCRIPTION
Without the fix build on ncurses-6.3 fails as:

    screen.c:495:5: error: format not a string literal and no format arguments [-Werror=format-security]
      495 |     mvwprintw(tmpwin,2,3, msg);
          |     ^~~~~~~~~

While at it pulled fix for upstream gcc-10 and clang-12 which
default to -fno-common.