### PR TITLE
weylus: add pipewire gst plugins to GST_PLUGIN_PATH

### DIFF
--- a/pkgs/applications/graphics/weylus/default.nix
+++ b/pkgs/applications/graphics/weylus/default.nix
@@ -66,5 +66,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/H-M-H/Weylus";
     license = with licenses; [ agpl3Only ];
     maintainers = with maintainers; [ lom ];
+    platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/graphics/weylus/default.nix
+++ b/pkgs/applications/graphics/weylus/default.nix
@@ -9,6 +9,8 @@
 , copyDesktopItems
 , fontconfig
 , libpng
+, pipewire
+, makeWrapper
 , autoPatchelfHook
 }:
 
@@ -38,6 +40,7 @@ stdenv.mkDerivation rec {
     fontconfig
     libva
     gst_all_1.gst-plugins-base
+    pipewire
     # autoPatchelfHook complains if these are missing, even on wayland
     xorg.libXft
     xorg.libXinerama
@@ -47,7 +50,16 @@ stdenv.mkDerivation rec {
     xorg.libXtst
   ];
 
-  nativeBuildInputs = [ copyDesktopItems autoPatchelfHook ];
+  nativeBuildInputs = [ copyDesktopItems autoPatchelfHook makeWrapper ];
+
+  postFixup = let
+    GST_PLUGIN_PATH = lib.makeSearchPathOutput  "lib" "lib/gstreamer-1.0" [
+      gst_all_1.gst-plugins-base
+      pipewire
+    ];
+  in ''
+    wrapProgram $out/bin/weylus --prefix GST_PLUGIN_PATH : ${GST_PLUGIN_PATH}
+  '';
 
   meta = with lib; {
     description = "Use your tablet as graphic tablet/touch screen on your computer";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Our current derivation for `weylus` does not work with PipeWire due to not adding the appropriate GStreamer plugins from `pipewire`:

```
  WARN weylus::websocket: Failed to init screen cast: Failed to create element from factory name!
``` 

cc @legendofmiracles 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
