### PR TITLE
openrct2: 0.3.4.1 -> 0.3.5

### DIFF
--- a/pkgs/games/openrct2/default.nix
+++ b/pkgs/games/openrct2/default.nix
@@ -5,32 +5,37 @@
 }:
 
 let
-  version = "0.3.4.1";
+  openrct2-version = "0.3.5";
+
+  # Those versions MUST match the pinned versions within the CMakeLists.txt
+  # file. The REPLAYS repository from the CMakeLists.txt is not necessary.
+  objects-version = "1.0.21";
+  title-sequences-version = "0.1.2c";
 
   openrct2-src = fetchFromGitHub {
     owner = "OpenRCT2";
     repo = "OpenRCT2";
-    rev = "v${version}";
-    sha256 = "0zjqn47pbgd2nrrbdl3lqk1mcdvwvvpjby2g0gfv6ssfw72fji7d";
+    rev = "v${openrct2-version}";
+    sha256 = "0xmj0qs49d1xlc8lbspr1vg66i0jdjlhcfxci72x6knjvd0vcgz0";
   };
 
   objects-src = fetchFromGitHub {
     owner = "OpenRCT2";
     repo = "objects";
-    rev = "v1.0.21";
+    rev = "v${objects-version}";
     sha256 = "0r2vp2y67jc1mpfl4j83sx5khvvaddx7xs26ppkigmr2d1xpxgr7";
   };
 
   title-sequences-src = fetchFromGitHub {
     owner = "OpenRCT2";
     repo = "title-sequences";
-    rev = "v0.1.2c";
+    rev = "v${title-sequences-version}";
     sha256 = "1qdrm4q75bznmgdrpjdaiqvbf3q4vwbkkmls45izxvyg1djrpsdf";
   };
 in
 stdenv.mkDerivation {
   pname = "openrct2";
-  inherit version;
+  version = openrct2-version;
 
   src = openrct2-src;
 
@@ -66,6 +71,15 @@ stdenv.mkDerivation {
   postUnpack = ''
     cp -r ${objects-src}         $sourceRoot/data/object
     cp -r ${title-sequences-src} $sourceRoot/data/sequence
+  '';
+
+  preConfigure = ''
+    # Verify that the correct version of the third party repositories is used.
+
+    grep -q '^set(OBJECTS_VERSION "${objects-version}")$' CMakeLists.txt \
+      || (echo "OBJECTS_VERSION differs!"; exit 1)
+    grep -q '^set(TITLE_SEQUENCE_VERSION "${title-sequences-version}")$' CMakeLists.txt \
+      || (echo "TITLE_SEQUENCE_VERSION differs!"; exit 1)
   '';
 
   preFixup = "ln -s $out/share/openrct2 $out/bin/data";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Bump OpenRCT2 to its latest release.
Next to the version bump, some hints for maintainers to select the right version of the other modules were added.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
