### PR TITLE
emote: 2.0.0 -> 3.0.3

### DIFF
--- a/pkgs/development/python-modules/manimpango/default.nix
+++ b/pkgs/development/python-modules/manimpango/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, lib, buildPythonPackage, fetchFromGitHub, python, pkg-config, pango, cython, AppKit, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "manimpango";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "ManimCommunity";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "ldZfvv5kloQ0uj0agxOP8cRh+Ix8f9Z0PT+pnhWYjiQ=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.cfg --replace "--cov --no-cov-on-fail" ""
+  '';
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ pango ] ++ lib.optionals stdenv.isDarwin [ AppKit ];
+  propagatedBuildInputs = [
+    cython
+  ];
+
+  preBuild = ''
+    ${python.interpreter} setup.py build_ext --inplace
+  '';
+
+  checkInputs = [ pytestCheckHook ];
+  pythonImportsCheck = [ "manimpango" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/ManimCommunity/ManimPango";
+    license = licenses.gpl3Plus;
+    description = "Binding for Pango";
+    maintainers = [ maintainers.angustrau ];
+  };
+}

--- a/pkgs/tools/inputmethods/emote/default.nix
+++ b/pkgs/tools/inputmethods/emote/default.nix
@@ -2,18 +2,21 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "emote";
-  version = "2.0.0";
+  version = "3.0.3";
 
   src = fetchFromGitHub {
     owner = "tom-james-watson";
     repo = "Emote";
     rev = "v${version}";
-    sha256 = "kYXFD6VBnuEZ0ZMsF6ZmN4V0JN83puxRILpNlllVsKQ=";
+    sha256 = "mqCSl+EGbnL9AfzZT3aa/Y5Rsx433ZmI31BmK3wkaJk=";
   };
 
   postPatch = ''
-    substituteInPlace setup.py --replace "pygobject==3.36.0" "pygobject"
+    substituteInPlace setup.py \
+      --replace "pygobject==3.36.0" "pygobject" \
+      --replace "manimpango==0.3.0" "manimpango"
     substituteInPlace emote/config.py --replace 'os.environ.get("SNAP")' "'$out/share/emote'"
+    substituteInPlace emote/picker.py --replace 'os.environ.get("SNAP_VERSION", "dev build")' "'$version'"
     substituteInPlace snap/gui/emote.desktop --replace "Icon=\''${SNAP}/usr/share/icons/emote.svg" "Icon=emote.svg"
   '';
 
@@ -27,6 +30,7 @@ python3Packages.buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = [
+    python3Packages.manimpango
     python3Packages.pygobject3
     gtk3
     xdotool
@@ -36,7 +40,7 @@ python3Packages.buildPythonApplication rec {
   postInstall = ''
     install -D snap/gui/emote.desktop $out/share/applications/emote.desktop
     install -D snap/gui/emote.svg $out/share/pixmaps/emote.svg
-    install -D -t $out/share/emote/static static/{emojis.json,logo.svg,style.css}
+    install -D -t $out/share/emote/static static/{NotoColorEmoji.ttf,emojis.csv,logo.svg,style.css}
   '';
 
   dontWrapGApps = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4581,6 +4581,10 @@ in {
 
   manhole = callPackage ../development/python-modules/manhole { };
 
+  manimpango = callPackage ../development/python-modules/manimpango {
+    inherit (pkgs.darwin.apple_sdk.frameworks) AppKit;
+  };
+
   manifestparser = callPackage ../development/python-modules/marionette-harness/manifestparser.nix { };
 
   manuel = callPackage ../development/python-modules/manuel { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update emote to newest release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
