### PR TITLE
tree-sitter: update grammars

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-beancount.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-beancount.json
@@ -4,6 +4,7 @@
   "date": "2021-09-07T00:09:23-04:00",
   "path": "/nix/store/adv2yl8kr4pk6430iclkppirhb5ibcqc-tree-sitter-beancount",
   "sha256": "1g2p2dnxm50l7npg2cbycwcfz9c9682bj02nrlycyjhwl4may9dn",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c-sharp",
-  "rev": "1b01d838cc2c0435eef59bc4ee9d0c77eea458d0",
-  "date": "2021-10-07T21:04:41+01:00",
-  "path": "/nix/store/ghx94r76acsnz4q11nhvfwf4pmslpwz8-tree-sitter-c-sharp",
-  "sha256": "03in0smvj6f12mmc744nk772myhrd5qjswfad1vvmmhd50y35ygx",
+  "rev": "69921685a7688361626600543a2beaf82b67a64d",
+  "date": "2021-11-03T12:36:17+00:00",
+  "path": "/nix/store/f4rd6avwf2flqr9yv0dvy9288qrgn2bs-tree-sitter-c-sharp",
+  "sha256": "18yzr0yvkbp5wf2slcfn04fc23jn0ray72ica0jyv92jkp5pxc03",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-cpp",
-  "rev": "f44509141e7e483323d2ec178f2d2e6c0fc041c1",
-  "date": "2021-10-25T11:23:25-07:00",
-  "path": "/nix/store/v6034ry75lfdwsiqydff601zla6xb7a2-tree-sitter-cpp",
-  "sha256": "0hxcpdvyyig8njga1mxp4qcnbbnr1d0aiy27vahijwbh98b081nr",
+  "rev": "e8dcc9d2b404c542fd236ea5f7208f90be8a6e89",
+  "date": "2021-10-28T08:16:36-05:00",
+  "path": "/nix/store/d08ymiv4qjs9hnc8b0yw700da47879wb-tree-sitter-cpp",
+  "sha256": "1h0q4prr8yf714abz16i2ym41sskmilmga521sxv9d75kqhyb3wl",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-haskell",
-  "rev": "bf7d643b494b7c7eed909ed7fbd8447231152cb0",
-  "date": "2021-09-09T20:07:38+02:00",
-  "path": "/nix/store/nkx9qf63nwl1ql6gl3q1fm4ykqax1isx-tree-sitter-haskell",
-  "sha256": "1wlp6kncjadhfz8y2wn90gkbqf35iidrn0y1ga360l5wyzx1mpid",
+  "rev": "6668085e7d3dc6205a3ef27e6293988cf4a10419",
+  "date": "2021-11-08T00:39:03+01:00",
+  "path": "/nix/store/srhxv4hmg6if8diww64fi9spaanfkpy2-tree-sitter-haskell",
+  "sha256": "0bw0hszac5krw52ywzdvgb9jm2s8669ym7sb6vivxihr46inwkr2",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-norg.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-norg.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/nvim-neorg/tree-sitter-norg",
-  "rev": "ff9ba2caf2c600f327370d516464d3222b9aa1f0",
-  "date": "2021-10-14T12:18:22+02:00",
-  "path": "/nix/store/4142dr4yy1jnbs7lf5kqmsn0rwyr1q7y-tree-sitter-norg",
-  "sha256": "0n74ad636p8q046sw94jxmfd640vabnzqzqjbqypyfw4fx95zwkj",
+  "rev": "995d7e0be4dc2a9655d2285405c0ef3fededf63c",
+  "date": "2021-11-05T21:28:42+01:00",
+  "path": "/nix/store/1l5dq21x6sln1gvixf20gx3pkadjad4d-tree-sitter-norg",
+  "sha256": "181y8p91hl5j7mrff0pmnx91d9vr24nvklgx12qvc0297vdp8c5v",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rst.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rst.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/stsewd/tree-sitter-rst",
-  "rev": "632596b1fe5816315cafa90cdf8f8000e30c93e4",
-  "date": "2021-10-01T17:00:56-05:00",
-  "path": "/nix/store/pnbw1j9ynj4zgjqxjnhq9hgqp3nxm77j-tree-sitter-rst",
-  "sha256": "1l831aw4a080qin7dkq04b28nnyxs1r8zqrbp92d7j4y2lz31dla",
+  "rev": "a5514617ae3644effa80d4696be428e4a371c01a",
+  "date": "2021-11-05T20:58:51-05:00",
+  "path": "/nix/store/is0j0cpd3i7q7liqlcrfdflabmm9rnlg-tree-sitter-rst",
+  "sha256": "1bw0yry968qz4arzckxpyz5zkw6ajyirrxyf78m9lr1zmz1vnivy",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-svelte.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-svelte.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/Himujjal/tree-sitter-svelte",
-  "rev": "c696a13a587b0595baf7998f1fb9e95c42750263",
-  "date": "2021-03-20T16:45:11+05:30",
-  "path": "/nix/store/8krdxqwpi95ljrb5jgalwgygz3aljqr8-tree-sitter-svelte",
-  "sha256": "0ckmss5gmvffm6danlsvgh6gwvrlznxsqf6i6ipkn7k5lxg1awg3",
+  "rev": "98274d94ec33e994e8354d9ddfdef58cca471294",
+  "date": "2021-10-28T16:53:33+05:30",
+  "path": "/nix/store/q3dapi6k6zdnnr0lki2ic9l6cbxdi2rq-tree-sitter-svelte",
+  "sha256": "1kav0h755sa1j9j930kjrykb17aih017mbi0a97ncjjrlc6nyak5",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-typescript",
-  "rev": "11f8f151327e99361c1ff6764599daeef8633615",
-  "date": "2021-10-21T09:23:26-07:00",
-  "path": "/nix/store/r7vpx7g7d1hdxzqyigmr3v9yp5cmmzsg-tree-sitter-typescript",
-  "sha256": "18gk00glysqapys883hq9v33ca9x6nzgy8lk26wa5pip3spzcsm0",
+  "rev": "cc745b774e3986aa3a7dfd6b7a0fc01ddc853bf8",
+  "date": "2021-10-29T14:55:07-07:00",
+  "path": "/nix/store/c0a2j72pfsb7zw44jqlk73vrhvkzk2db-tree-sitter-typescript",
+  "sha256": "0nc8wr04h0wz169p60x4zai37yd351qj9mim7099g1fmbd1w7hq9",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Things done
Ran the update script to update all tree-sitter grammars.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
