### PR TITLE
python3Packages.skytemple-rust: unstable-2021-05-30 -> unstable-2021-08-11

### DIFF
--- a/pkgs/development/python-modules/skytemple-rust/default.nix
+++ b/pkgs/development/python-modules/skytemple-rust/default.nix
@@ -2,19 +2,19 @@
 
 buildPythonPackage rec {
   pname = "skytemple-rust";
-  version = "unstable-2021-05-30"; # Contains build bug fixes, but is otherwise identical to 0.0.1.post0
+  version = "unstable-2021-08-11";
 
   src = fetchFromGitHub {
     owner = "SkyTemple";
     repo = pname;
-    rev = "cff8b2930af6d25d41331fab8c04f56a4fd75e95";
-    sha256 = "18y6wwvzyw062zlv3gcirr1hgld9d97ffyrvy0jvw8nr3b9h9x0i";
+    rev = "e306e5edc096cb3fef25585d9ca5a2817543f1cd";
+    sha256 = "0ja231gsy9i1z6jsaywawz93rnyjhldngi5i787nhnf88zrwx9ml";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     name = "${pname}-${version}";
-    sha256 = "1ypcsf9gbq1bz29kfn7g4kg8741mxg1lfcbb14a0vfhjq4d6pnx9";
+    sha256 = "0gjvfblyv72m0nqv90m7qvbdnazsh5ind1pxwqz83vm4zjh9a873";
   };
 
   buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
@@ -27,6 +27,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/SkyTemple/skytemple-rust";
     description = "Binary Rust extensions for SkyTemple";
     license = licenses.mit;
-    maintainers = with maintainers; [ xfix ];
+    maintainers = with maintainers; [ xfix marius851000 ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Applying security fixes necessary for #141368.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
