### PR TITLE
gcc-arm-embedded-10: 10.3-2021.07 -> 10.3-2021.10

### DIFF
--- a/pkgs/development/compilers/gcc-arm-embedded/10/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/10/default.nix
@@ -8,20 +8,20 @@
 stdenv.mkDerivation rec {
   pname = "gcc-arm-embedded";
   version = "10.3.1";
-  release = "10.3-2021.07";
+  release = "10.3-2021.10";
 
   suffix = {
     aarch64-linux = "aarch64-linux";
-    x86_64-darwin = "mac-10.14.6";
+    x86_64-darwin = "mac";
     x86_64-linux  = "x86_64-linux";
   }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   src = fetchurl {
     url = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/${release}/gcc-arm-none-eabi-${release}-${suffix}.tar.bz2";
     sha256 = {
-      aarch64-linux = "0y4nyrff5bq90v44z2h90gqgl18bs861i9lygx4z89ym85jycx9s";
-      x86_64-darwin = "1r3yidmgx1xq1f19y2c5njf2g95vs9cssmmsxsb68qm192r58i8a";
-      x86_64-linux  = "1skcalz1sr0hhpjcl8qjsqd16n2w0zrbnlrbr8sx0g728kiqsnwc";
+      aarch64-linux = "020j8gkzc0i0b74vz98gvngnwjm5222j1gk5nswfk6587krba1gn";
+      x86_64-darwin = "0fr8pki2g4bfk1rk90dzwql37d0b71ngzs9zyx0g2jainan3sqgv";
+      x86_64-linux  = "18y92vpl22hf74yqdvmpw8adrkl92s4crzzs6avm05md37qb9nwp";
     }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   };
 

--- a/pkgs/development/compilers/gcc-arm-embedded/10/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/10/default.nix
@@ -11,6 +11,7 @@ stdenv.mkDerivation rec {
   release = "10.3-2021.10";
 
   suffix = {
+    aarch64-darwin = "mac";  # use intel binaries via rosetta
     aarch64-linux = "aarch64-linux";
     x86_64-darwin = "mac";
     x86_64-linux  = "x86_64-linux";
@@ -19,6 +20,7 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     url = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/${release}/gcc-arm-none-eabi-${release}-${suffix}.tar.bz2";
     sha256 = {
+      aarch64-darwin = "0fr8pki2g4bfk1rk90dzwql37d0b71ngzs9zyx0g2jainan3sqgv";
       aarch64-linux = "020j8gkzc0i0b74vz98gvngnwjm5222j1gk5nswfk6587krba1gn";
       x86_64-darwin = "0fr8pki2g4bfk1rk90dzwql37d0b71ngzs9zyx0g2jainan3sqgv";
       x86_64-linux  = "18y92vpl22hf74yqdvmpw8adrkl92s4crzzs6avm05md37qb9nwp";
@@ -49,6 +51,6 @@ stdenv.mkDerivation rec {
     homepage = "https://developer.arm.com/open-source/gnu-toolchain/gnu-rm";
     license = with licenses; [ bsd2 gpl2 gpl3 lgpl21 lgpl3 mit ];
     maintainers = with maintainers; [ prusnak ];
-    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
   };
 }

--- a/pkgs/development/compilers/gcc-arm-embedded/9/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/9/default.nix
@@ -12,6 +12,7 @@ stdenv.mkDerivation rec {
   subdir = "9-2020q2";
 
   suffix = {
+    aarch64-darwin = "mac";  # use intel binaries via rosetta
     aarch64-linux = "aarch64-linux";
     x86_64-darwin = "mac";
     x86_64-linux  = "x86_64-linux";
@@ -20,6 +21,7 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     url = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/${subdir}/gcc-arm-none-eabi-${release}-${suffix}.tar.bz2";
     sha256 = {
+      aarch64-darwin = "1ils9z16wrvglh72m428y5irmd36biq79yj86756whib8izbifdv";
       aarch64-linux = "1b5q2y710hy7lddj8vj3zl54gfl74j30kx3hk3i81zrcbv16ah8z";
       x86_64-darwin = "1ils9z16wrvglh72m428y5irmd36biq79yj86756whib8izbifdv";
       x86_64-linux  = "07zi2yr5gvhpbij5pnj49zswb9g2gw7zqp4xwwniqmq477h2xp2s";
@@ -50,6 +52,6 @@ stdenv.mkDerivation rec {
     homepage = "https://developer.arm.com/open-source/gnu-toolchain/gnu-rm";
     license = with licenses; [ bsd2 gpl2 gpl3 lgpl21 lgpl3 mit ];
     maintainers = with maintainers; [ prusnak ];
-    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- version update for gcc-arm-embedded-10
- enable gcc-arm-embedded-{9,10} on aarch64-darwin (by using x86_64-darwin binaries which can be launched via rosetta)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
