### PR TITLE
termscp: fix darwin build

### DIFF
--- a/pkgs/tools/networking/termscp/default.nix
+++ b/pkgs/tools/networking/termscp/default.nix
@@ -5,6 +5,7 @@
 , openssl
 , pkg-config
 , rustPlatform
+, Foundation
 , Security
 , stdenv
 }:
@@ -31,6 +32,7 @@ rustPlatform.buildRustPackage rec {
     libssh
     openssl
   ] ++ lib.optional stdenv.isDarwin [
+    Foundation
     Security
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9857,7 +9857,7 @@ with pkgs;
   telescope = callPackage ../applications/networking/browsers/telescope { };
 
   termscp = callPackage ../tools/networking/termscp {
-    inherit (darwin.apple_sdk.frameworks) Security;
+    inherit (darwin.apple_sdk.frameworks) Foundation Security;
   };
 
   termius = callPackage ../applications/networking/termius { };


### PR DESCRIPTION
###### Motivation for this change

I was running into `Foundation.h` errors during compilation on mac/darwin, adding Foundation fixes that for me.

<details>
<summary>Error</summary>

```
The following warnings were emitted during compilation:

warning: In file included from objc/notify.m:1:
warning: objc/notify.h:1:9: fatal error: 'Foundation/Foundation.h' file not found
warning: #import <Foundation/Foundation.h>
warning:         ^~~~~~~~~~~~~~~~~~~~~~~~~
warning: 1 error generated.

error: failed to run custom build command for `mac-notification-sys v0.3.0`

Caused by:
  process didn't exit successfully: `/tmp/cargo-installEt3UWW/release/build/mac-notification-sys-f414f8995c05e541/build-script-build` (exit status: 1)
  --- stdout
  TARGET = Some("x86_64-apple-darwin")
  OPT_LEVEL = Some("3")
  HOST = Some("x86_64-apple-darwin")
  CC_x86_64-apple-darwin = None
  CC_x86_64_apple_darwin = None
  HOST_CC = None
  CC = Some("clang")
  CFLAGS_x86_64-apple-darwin = None
  CFLAGS_x86_64_apple_darwin = None
  HOST_CFLAGS = None
  CFLAGS = None
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some("false")
  running: "clang" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "--target=x86_64-apple-darwin" "-fmodules" "-o" "/tmp/cargo-installEt3UWW/release/build/mac-notification-sys-ce5dd87fdfef4721/out/objc/notify.o" "-c" "objc/notify.m"
  cargo:warning=In file included from objc/notify.m:1:
  cargo:warning=objc/notify.h:1:9: fatal error: 'Foundation/Foundation.h' file not found
  cargo:warning=#import <Foundation/Foundation.h>
  cargo:warning=        ^~~~~~~~~~~~~~~~~~~~~~~~~
  cargo:warning=1 error generated.
  exit status: 1

  --- stderr

  error occurred: Command "clang" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "--target=x86_64-apple-darwin" "-fmodules" "-o" "/tmp/cargo-installEt3UWW/release/build/mac-notification-sys-ce5dd87fdfef4721/out/objc/notify.o" "-c" "objc/notify.m" with args "clang" did not execute successfully (status code exit status: 1).

warning: build failed, waiting for other jobs to finish...
error: failed to compile `termscp v0.7.0`, intermediate artifacts can be found at `/tmp/cargo-installEt3UWW`

Caused by:
  build failed
```
</details>

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
