### PR TITLE
platformio: 5.2.1 -> 5.2.3

### DIFF
--- a/pkgs/development/embedded/platformio/core.nix
+++ b/pkgs/development/embedded/platformio/core.nix
@@ -19,6 +19,27 @@ let
         };
       });
 
+      click = super.click.overridePythonAttrs (oldAttrs: rec {
+        version = "8.0.3";
+        src = fetchFromGitHub {
+          owner = "pallets";
+          repo = "click";
+          rev = version;
+          sha256 = "0pxvxgfhqjgsjbgfnilqjki1l24r0rdfd98cl77i71yqdd2f497g";
+        };
+      });
+
+      starlette = super.starlette.overridePythonAttrs (oldAttrs: rec {
+        version = "0.17.0";
+        src = fetchFromGitHub {
+          owner = "encode";
+          repo = "starlette";
+          rev = version;
+          sha256 = "1g76qpvqzivmwll5ir4bf45jx5kilnkadvy6b7qjisvr402i3qmw";
+        };
+        disabledTestPaths = [];
+      });
+
       uvicorn = super.uvicorn.overridePythonAttrs (oldAttrs: rec {
         version = "0.15.0";
         src = fetchFromGitHub {

--- a/pkgs/development/embedded/platformio/default.nix
+++ b/pkgs/development/embedded/platformio/default.nix
@@ -4,14 +4,14 @@
 let
   callPackage = newScope self;
 
-  version = "5.2.1";
+  version = "5.2.3";
 
   # pypi tarballs don't contain tests - https://github.com/platformio/platformio-core/issues/1964
   src = fetchFromGitHub {
     owner = "platformio";
     repo = "platformio-core";
     rev = "v${version}";
-    sha256 = "1kmwr21djcz1qnpbsk0za244rp6rkh0vp6wss1vjks4waambiqnl";
+    sha256 = "0wbmwawn25srkyrd6hwrgli1himzsj08vbm76fgnpqdc84n78ckl";
   };
 
   self = {

--- a/pkgs/development/embedded/platformio/use-local-spdx-license-list.patch
+++ b/pkgs/development/embedded/platformio/use-local-spdx-license-list.patch
@@ -1,8 +1,8 @@
 diff --git a/platformio/package/manifest/schema.py b/platformio/package/manifest/schema.py
-index addc4c5..514b0ad 100644
+index 416dccfd..896c3649 100644
 --- a/platformio/package/manifest/schema.py
 +++ b/platformio/package/manifest/schema.py
-@@ -253,9 +253,4 @@ class ManifestSchema(BaseSchema):
+@@ -253,9 +253,6 @@ class ManifestSchema(BaseSchema):
      @staticmethod
      @memoized(expire="1h")
      def load_spdx_licenses():
@@ -12,4 +12,6 @@ index addc4c5..514b0ad 100644
 -            "v%s/json/licenses.json" % version
 -        )
 -        return json.loads(fetch_remote_content(spdx_data_url))
-+        return json.load(open("@SPDX_LICENSE_LIST_DATA@/json/licenses.json"))
++        with open("@SPDX_LICENSE_LIST_DATA@/json/licenses.json") as f:
++            spdx = json.load(f)
++        return spdx


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Next to bumping the patch version, two changed dependencies were pinned.
Furthermore, the SPDX patch was altered to correctly close the JSON file
as non-closed files are now also covered by the tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
