### PR TITLE
skypeforlinux: 8.75.0.140 -> 8.77.0.97

### DIFF
--- a/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
@@ -7,7 +7,7 @@ let
 
   # Please keep the version x.y.0.z and do not update to x.y.76.z because the
   # source of the latter disappears much faster.
-  version = "8.69.0.77";
+  version = "8.77.0.97";
 
   rpath = lib.makeLibraryPath [
     alsaLib
@@ -55,6 +55,7 @@ let
     xorg.libXi
     xorg.libXrandr
     xorg.libXrender
+    xorg.libxshmfence
     xorg.libXtst
     xorg.libXScrnSaver
     xorg.libxcb
@@ -68,7 +69,7 @@ let
           "https://mirror.cs.uchicago.edu/skype/pool/main/s/skypeforlinux/skypeforlinux_${version}_amd64.deb"
           "https://web.archive.org/web/https://repo.skype.com/deb/pool/main/s/skypeforlinux/skypeforlinux_${version}_amd64.deb"
         ];
-        sha256 = "PaqlPp+BRS0cH7XI4x1/5HqYti63rQThmTtPaghIQH0=";
+        sha256 = "sha256-0u1fpKJrsEgbvTwdkqJZ/SwCRDmJwEi9IXHbMmY8MJI=";
       }
     else
       throw "Skype for linux is not supported on ${stdenv.hostPlatform.system}";


### PR DESCRIPTION
In addition to the SHA and version update, an extra required dependency on
libxshmfence is added.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Skype had one of those irritating "needlessly change the UI but keep everything else identical" updates, which is integrated into master. I've cherry-picked and fixed a bit of the updating commit in master, as it's probably not a good idea to let nixos fall *too* far behind on upstream. I don't believe that this is the latest version, but it's pretty close.

###### Things done
It's just one commit, so see the diff.
+ updated the verison
+ updated the sha
+ added a required runtime dep

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] [N/A] aarch64-linux
  - [ ] [N/A] x86_64-darwin
  - [ ] [N/A] aarch64-darwin
- [ ] [N/A] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` (nothing depends on this)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] [not major/breaking] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] [not significant] (Module updates) Added a release notes entry if the change is significant
  - [ ] [not a new nixos module] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

@PanAeon @jraygauthier, it looks like y'all are marked as the maintainers - happy to update for feedback you or anyone else might have!