### PR TITLE
doc: add ocaml end user doc to nixpkgs manual

### DIFF
--- a/doc/languages-frameworks/ocaml.section.md
+++ b/doc/languages-frameworks/ocaml.section.md
@@ -1,5 +1,31 @@
 # OCaml {#sec-language-ocaml}
 
+## End-user guide {#sec-language-ocaml-end-user}
+
+OCaml libraries are available in attribute sets of the form `ocaml-ng.ocamlPackages_X_XX` where X is to be replaced with the desired compiler version. For example, ocamlgraph compiled with OCaml 4.12 can be found in `ocaml-ng.ocamlPackages_4_12.ocamlgraph`. The compiler itself is also located in this set, under the name `ocaml`.
+
+If you don't care about the exact compiler version, `ocamlPackages` is a top-level alias pointing to a recent version of OCaml.
+
+OCaml applications are usually available top-level, and not inside `ocamlPackages`. Notable exceptions are build tools that must be built with the same compiler version as the compiler you intend to use like `dune` or `ocaml-lsp`.
+
+To open a shell able to build a typical OCaml project, put the dependencies in `buildInputs` and add `ocamlPackages.ocaml` and `ocamlPackages.findlib` to `nativeBuildInputs` at least.
+For example:
+```nix
+let
+ pkgs = import <nixpkgs> {};
+ # choose the ocaml version you want below
+ ocamlPackages = pkgs.ocaml-ng.ocamlPackages_4_12;
+in
+pkgs.mkShell {
+  # build tools
+  nativeBuildInputs = with ocamlPackages; [ ocaml findlib dune_2 ocaml-lsp ];
+  # dependencies
+  buildInputs = with ocamlPackages; [ ocamlgraph ];
+}
+```
+
+## Packaging guide {#sec-language-ocaml-packaging}
+
 OCaml libraries should be installed in `$(out)/lib/ocaml/${ocaml.version}/site-lib/`. Such directories are automatically added to the `$OCAMLPATH` environment variable when building another package that depends on them or when opening a `nix-shell`.
 
 Given that most of the OCaml ecosystem is now built with dune, nixpkgs includes a convenience build support function called `buildDunePackage` that will build an OCaml package using dune, OCaml and findlib and any additional dependencies provided as `buildInputs` or `propagatedBuildInputs`.

--- a/doc/languages-frameworks/ocaml.section.md
+++ b/doc/languages-frameworks/ocaml.section.md
@@ -1,6 +1,6 @@
 # OCaml {#sec-language-ocaml}
 
-## End-user guide {#sec-language-ocaml-end-user}
+## User guide {#sec-language-ocaml-user-guide}
 
 OCaml libraries are available in attribute sets of the form `ocaml-ng.ocamlPackages_X_XX` where X is to be replaced with the desired compiler version. For example, ocamlgraph compiled with OCaml 4.12 can be found in `ocaml-ng.ocamlPackages_4_12.ocamlgraph`. The compiler itself is also located in this set, under the name `ocaml`.
 

--- a/doc/languages-frameworks/ocaml.section.md
+++ b/doc/languages-frameworks/ocaml.section.md
@@ -13,7 +13,7 @@ For example:
 ```nix
 let
  pkgs = import <nixpkgs> {};
- # choose the ocaml version you want below
+ # choose the ocaml version you want to use
  ocamlPackages = pkgs.ocaml-ng.ocamlPackages_4_12;
 in
 pkgs.mkShell {


### PR DESCRIPTION
Currently the ocaml section of the manual only explains how to package new stuff, but not how to use the existing packages.

Rendered

![image](https://user-images.githubusercontent.com/12595971/140804284-beb4afa7-68db-4a06-9636-729af7ed2501.png)


c @vbgl