### PR TITLE
gocyclo: Update gocyclo to upstream v0.3.1

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -1295,6 +1295,13 @@ Superuser created successfully.
           <literal>services.ddclient.passwordFile</literal>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          The <literal>gocyclo</literal> package is now based on the
+          upstream version <literal>v0.3.1</literal> from
+          https://github.com/fzipp/gocyclo
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-21.11-notable-changes">

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -392,6 +392,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The `services.ddclient.password` option was removed, and replaced with `services.ddclient.passwordFile`.
 
+- The `gocyclo` package is now based on the upstream version `v0.3.1` from https://github.com/fzipp/gocyclo
+
 ## Other Notable Changes {#sec-release-21.11-notable-changes}
 
 

--- a/pkgs/development/tools/gocyclo/default.nix
+++ b/pkgs/development/tools/gocyclo/default.nix
@@ -1,26 +1,24 @@
-{ buildGoPackage
-, lib
-, fetchFromGitHub
-}:
+{ buildGoPackage, lib, fetchFromGitHub }:
 
 buildGoPackage rec {
-  pname = "gocyclo-unstable";
-  version = "2015-02-08";
-  rev = "aa8f8b160214d8dfccfe3e17e578dd0fcc6fede7";
+  pname = "gocyclo";
+  version = "0.3.1";
+  rev = "v${version}";
 
-  goPackagePath = "github.com/alecthomas/gocyclo";
+  goPackagePath = "github.com/fzipp/gocyclo";
 
   src = fetchFromGitHub {
     inherit rev;
 
-    owner = "alecthomas";
+    owner = "fzipp";
     repo = "gocyclo";
-    sha256 = "094rj97q38j53lmn2scshrg8kws8c542yq5apih1ahm9wdkv8pxr";
+    sha256 = "1rimdrhmy6nkzh7ydpx6139hh9ml6rdqg5gvkpy2l1x9mhanvan0";
   };
 
   meta = with lib; {
-    description = "Calculate cyclomatic complexities of functions in Go source code";
-    homepage = "https://github.com/alecthomas/gocyclo";
+    description =
+      "Calculate cyclomatic complexities of functions in Go source code";
+    homepage = "https://github.com/fzipp/gocyclo";
     license = licenses.bsd3;
     maintainers = with maintainers; [ kalbasit ];
     platforms = platforms.linux ++ platforms.darwin;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update gocyclo to a more recent version that support ignoring of vendor-directory and recursive iteration

###### Things done

The original repository used in this package was a fork from https://github.com/fzipp/gocyclo but the upstream is a way more updated. So i switch this package to https://github.com/fzipp/gocyclo

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - aarch64-linux
  - x86_64-darwin
  - aarch64-darwin
- For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - (Module updates) Added a release notes entry if the change is significant
  - (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
