### PR TITLE
haskellPackages.lapack-ffi: remove from broken.yaml

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -2778,7 +2778,6 @@ broken-packages:
   - language-typescript
   - language-vhdl
   - language-webidl
-  - lapack-ffi
   - LargeCardinalHierarchy
   - Lastik
   - latest-npm-version


### PR DESCRIPTION
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
