### PR TITLE
haskellPackages.graphviz: hardcode references to graphviz tools

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -996,4 +996,15 @@ self: super: builtins.intersectAttrs super {
       fi
     '' + (drv.postConfigure or "");
   }) super.procex;
+
+  # Apply a patch which hardcodes the store path of graphviz instead of using
+  # whatever graphviz is in PATH.
+  graphviz = overrideCabal (drv: {
+    patches = [
+      (pkgs.substituteAll {
+        src = ./patches/graphviz-hardcode-graphviz-store-path.patch;
+        inherit (pkgs) graphviz;
+      })
+    ] ++ (drv.patches or []);
+  }) super.graphviz;
 }

--- a/pkgs/development/haskell-modules/patches/graphviz-hardcode-graphviz-store-path.patch
+++ b/pkgs/development/haskell-modules/patches/graphviz-hardcode-graphviz-store-path.patch
@@ -1,0 +1,40 @@
+diff --git a/Data/GraphViz/Commands.hs b/Data/GraphViz/Commands.hs
+index 20e7dbe..514c29d 100644
+--- a/Data/GraphViz/Commands.hs
++++ b/Data/GraphViz/Commands.hs
+@@ -63,14 +63,14 @@ import           System.IO        (Handle, hPutStrLn, hSetBinaryMode, stderr)
+ -- -----------------------------------------------------------------------------
+ 
+ showCmd           :: GraphvizCommand -> String
+-showCmd Dot       = "dot"
+-showCmd Neato     = "neato"
+-showCmd TwoPi     = "twopi"
+-showCmd Circo     = "circo"
+-showCmd Fdp       = "fdp"
+-showCmd Sfdp      = "sfdp"
+-showCmd Osage     = "osage"
+-showCmd Patchwork = "patchwork"
++showCmd Dot       = "@graphviz@/bin/dot"
++showCmd Neato     = "@graphviz@/bin/neato"
++showCmd TwoPi     = "@graphviz@/bin/twopi"
++showCmd Circo     = "@graphviz@/bin/circo"
++showCmd Fdp       = "@graphviz@/bin/fdp"
++showCmd Sfdp      = "@graphviz@/bin/sfdp"
++showCmd Osage     = "@graphviz@/bin/osage"
++showCmd Patchwork = "@graphviz@/bin/patchwork"
+ 
+ -- | The default command for directed graphs.
+ dirCommand :: GraphvizCommand
+@@ -312,8 +312,11 @@ runGraphvizCanvas' d = runGraphvizCanvas (commandFor d) d
+ 
+ -- | Is the Graphviz suite of tools installed?  This is determined by
+ --   whether @dot@ is available in the @PATH@.
++--
++--   Note: With nixpkgs, this will always return 'True' as graphviz'
++--   store paths are hardcoded instead of looking at @PATH@.
+ isGraphvizInstalled :: IO Bool
+-isGraphvizInstalled = liftM isJust . findExecutable $ showCmd Dot
++isGraphvizInstalled = pure True -- :)
+ 
+ -- | If Graphviz does not seem to be available, print the provided
+ --   error message and then exit fatally.


### PR DESCRIPTION
This will make everything using graphviz just work without graphviz
having to be able from PATH (in a nix-shell or installed globally).

Did a small sanity check, more testing would be appreciated.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
