### PR TITLE
patool: fix the non-use of hard-coded binary

### DIFF
--- a/pkgs/development/python-modules/patool/default.nix
+++ b/pkgs/development/python-modules/patool/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchFromGitHub, pytestCheckHook, p7zip,
-  unzip, cabextract, zip, zopfli, lzip, zpaq, gnutar, gnugrep, diffutils, file,
+  cabextract, zip, lzip, zpaq, gnutar, gnugrep, diffutils, file,
   gzip, bzip2, xz}:
 
 # unrar is unfree, as well as 7z with unrar support, not including it (patool doesn't support unar)
@@ -8,11 +8,9 @@
 let
   compression-utilities = [
     p7zip
-    unzip
     gnutar
     cabextract
     zip
-    zopfli
     lzip
     zpaq
     gzip

--- a/pkgs/development/python-modules/patool/default.nix
+++ b/pkgs/development/python-modules/patool/default.nix
@@ -3,6 +3,7 @@
   gzip, bzip2, xz}:
 
 # unrar is unfree, as well as 7z with unrar support, not including it (patool doesn't support unar)
+# it will still use unrar if present in the path
 
 let
   compression-utilities = [
@@ -34,9 +35,9 @@ buildPythonPackage rec {
     sha256 = "0v4r77sm3yzh7y1whfwxmp01cchd82jbhvbg9zsyd2yb944imzjy";
   };
 
-  prePatch = ''
+  postPatch = ''
     substituteInPlace patoolib/util.py \
-      --replace "path = None" 'path = append_to_path(os.environ["PATH"], "${lib.makeBinPath compression-utilities}")'
+      --replace "path = None" 'path = os.environ["PATH"] + ":${lib.makeBinPath compression-utilities}"'
   '';
 
   checkInputs = [ pytestCheckHook ] ++ compression-utilities;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://gitlab.com/portmod/portmod/-/issues/327

(didn't used the hard-coded function at all)

###### Things done

Simple fix. The function didn't did what I expected. Just use $PATH + ":/nix/store/.../bin:/nix/store/.../bin:...". Tested with both existing and empty path.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
