### PR TITLE
waydroid: 1.1.1 -> 1.2.0

### DIFF
--- a/pkgs/os-specific/linux/waydroid/default.nix
+++ b/pkgs/os-specific/linux/waydroid/default.nix
@@ -3,9 +3,15 @@
 , fetchFromGitHub
 , python3Packages
 , dnsmasq
+, getent
+, kmod
 , lxc
+, iproute2
+, iptables
 , nftables
-, python
+, util-linux
+, which
+, xclip
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -21,6 +27,7 @@ python3Packages.buildPythonApplication rec {
 
   propagatedBuildInputs = with python3Packages; [
     gbinder-python
+    pyclip
     pygobject3
   ];
 
@@ -36,20 +43,33 @@ python3Packages.buildPythonApplication rec {
 
     cp -ra data $out/${python3Packages.python.sitePackages}/data
     wrapProgram $out/${python3Packages.python.sitePackages}/data/scripts/waydroid-net.sh \
-       --prefix PATH ":" ${lib.makeBinPath [ dnsmasq nftables ]}
+       --prefix PATH ":" ${lib.makeBinPath [ dnsmasq getent iproute2 iptables nftables ]}
 
     mkdir -p $out/share/waydroid/gbinder.d
     cp gbinder/anbox.conf $out/share/waydroid/gbinder.d/anbox.conf
+
+    mkdir -p $out/share/applications
+    ln -s $out/${python3Packages.python.sitePackages}/data/Waydroid.desktop $out/share/applications/Waydroid.desktop
 
     mkdir $out/bin
     cp -a waydroid.py $out/${python3Packages.python.sitePackages}/waydroid.py
     ln -s $out/${python3Packages.python.sitePackages}/waydroid.py $out/bin/waydroid
 
-    wrapPythonProgramsIn $out/${python3Packages.python.sitePackages} "$out ${python3Packages.gbinder-python} ${python3Packages.pygobject3} ${lxc}"
+    wrapPythonProgramsIn $out/${python3Packages.python.sitePackages} "${lib.concatStringsSep " " [
+      "$out"
+      python3Packages.gbinder-python
+      python3Packages.pygobject3
+      python3Packages.pyclip
+      kmod
+      lxc
+      util-linux
+      which
+      xclip
+    ]}"
   '';
 
   meta = with lib; {
-    description = "Waydroid is a container-based approach to boot a full Android system on a regular GNU/Linux system like Ubuntu.";
+    description = "Waydroid is a container-based approach to boot a full Android system on a regular GNU/Linux system like Ubuntu";
     homepage = "https://github.com/waydroid/waydroid";
     license = licenses.gpl3;
     platforms = platforms.linux;

--- a/pkgs/os-specific/linux/waydroid/default.nix
+++ b/pkgs/os-specific/linux/waydroid/default.nix
@@ -16,13 +16,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "waydroid";
-  version = "1.1.1";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "0cabh7rysh2v15wrxg250370mw26s5d073yxmczxsarbp4ri2pl4";
+    sha256 = "03d87sh443kn0j2mpih1g909khkx3wgb04h605f9jhd0znskkbmw";
   };
 
   propagatedBuildInputs = with python3Packages; [


### PR DESCRIPTION
###### Motivation for this change
Keeping waydroid up-to-date and fixing some packaging issues.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
