### PR TITLE
python3Packages.natsort: 7.1.1 -> 8.0.0

### DIFF
--- a/pkgs/development/python-modules/fastnumbers/default.nix
+++ b/pkgs/development/python-modules/fastnumbers/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fastnumbers
+, fetchFromGitHub
+, hypothesis
+, pytestCheckHook
+, pythonOlder
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "fastnumbers";
+  version = "3.2.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "SethMMorton";
+    repo = pname;
+    rev = version;
+    sha256 = "1v9l5p90y6ygrs0qmgdzxfv2vp1mpfp65snkl9jp6kcy44g3alhp";
+  };
+
+  propagatedBuildInputs = [
+    typing-extensions
+  ];
+
+  checkInputs = [
+    hypothesis
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "fastnumbers"
+  ];
+
+  meta = with lib; {
+    description = "Python module for number conversion";
+    homepage = "https://github.com/SethMMorton/fastnumbers";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/natsort/default.nix
+++ b/pkgs/development/python-modules/natsort/default.nix
@@ -1,48 +1,47 @@
 { lib
 , buildPythonPackage
-, pythonOlder
+, fastnumbers
 , fetchPypi
-, pytest
-, pytest-cov
-, pytest-mock
-, hypothesis
 , glibcLocales
-, pathlib ? null
-, isPy3k
+, hypothesis
+, PyICU
+, pytest-mock
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "natsort";
   version = "7.1.1";
+  format = "setuptools";
 
-  checkInputs = [
-    pytest
-    pytest-cov
-    pytest-mock
-    hypothesis
-    glibcLocales
-  ]
-  # pathlib was made part of standard library in 3.5:
-  ++ (lib.optionals (pythonOlder "3.4") [ pathlib ]);
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "00c603a42365830c4722a2eb7663a25919551217ec09a243d3399fa8dd4ac403";
   };
 
-  # Does not support Python 2
-  disabled = !isPy3k;
+  propagatedBuildInputs = [
+    fastnumbers
+    PyICU
+  ];
 
-  # testing based on project's tox.ini
-  # natsort_keygen has pytest mock issues
-  checkPhase = ''
-    pytest --doctest-modules natsort
-    pytest --ignore=tests/test_natsort_keygen.py
-  '';
+  checkInputs = [
+    glibcLocales
+    hypothesis
+    pytest-mock
+    pytestCheckHook
+  ];
 
-  meta = {
-    description = "Natural sorting for python";
+  pythonImportsCheck = [
+    "natsort"
+  ];
+
+  meta = with lib; {
+    description = "Natural sorting for Python";
     homepage = "https://github.com/SethMMorton/natsort";
-    license = lib.licenses.mit;
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2640,6 +2640,8 @@ in {
     inherit python;
   });
 
+  fastnumbers = callPackage ../development/python-modules/fastnumbers { };
+
   fastpair = callPackage ../development/python-modules/fastpair { };
 
   fastparquet = callPackage ../development/python-modules/fastparquet { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 8.0.0

Change log: https://github.com/SethMMorton/natsort/blob/master/CHANGELOG.md#800---2021-11-03

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
