### PR TITLE
ocl-icd: fix ICD vendor path for NixOS

### DIFF
--- a/pkgs/development/libraries/ocl-icd/default.nix
+++ b/pkgs/development/libraries/ocl-icd/default.nix
@@ -25,10 +25,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ opencl-headers ];
 
+  configureFlags = [
+    "--enable-custom-vendordir=/run/opengl-driver/etc/OpenCL/vendors"
+  ];
+
   meta = with lib; {
     description = "OpenCL ICD Loader for ${opencl-headers.name}";
     homepage    = "https://github.com/OCL-dev/ocl-icd";
     license     = licenses.bsd2;
     platforms = platforms.unix;
+    maintainers = with maintainers; [ r-burns ];
   };
 }


### PR DESCRIPTION
This fixes the vendor ICD load path to work with NixOS's opengl path.
Previously, the only workaround to load ICD files was to manually
override the load path at runtime using an environment variable.

Tested against Intel and Nvidia drivers using the clinfo package:

Before:

```
$ clinfo
Number of platforms                               0
```

After:

```
$ clinfo
Number of platforms                               1
  Platform Name                                   NVIDIA CUDA
  Platform Vendor                                 NVIDIA Corporation
<...>
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Closes https://github.com/NixOS/nixpkgs/issues/131817 (cc @munksgaard @rowanG077)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
