### PR TITLE
stargate: init at 21.11.5

### DIFF
--- a/pkgs/applications/audio/stargate/build_test.patch
+++ b/pkgs/applications/audio/stargate/build_test.patch
@@ -1,0 +1,71 @@
+diff --git a/src/Makefile b/src/Makefile
+index 5c9353d..7310e45 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -36,7 +36,7 @@ distro: commit_hash
+ 	# to provide and package: mido, pymarshal, SBSMS, python-wavefile
+ 	make -C engine
+ 
+-install: install_distro install_sbsms install_py_vendor
++install: install_distro install_sbsms
+ 	# General purpose install for users
+ 
+ install_distro: clean_pyc
+@@ -129,7 +129,6 @@ tests:
+ 	./test_parse.sh
+ 	make -C engine test
+ 	pytest test/
+-	$(BROWSER) htmlcov/index.html
+ 
+ uninstall:
+ 	rm -f $(DESTDIR)$(PREFIX)/bin/$(MAJOR)*
+diff --git a/src/engine/Makefile b/src/engine/Makefile
+index e893dac..b1f29bf 100644
+--- a/src/engine/Makefile
++++ b/src/engine/Makefile
+@@ -7,7 +7,7 @@ CC ?= gcc
+ CC_ARGS ?= -Wall -Wformat-truncation=0 -Werror=format-security
+ OPT_LVL ?= -O2 -g -ggdb3
+ # These assume a modern x86 CPU, change or remove for other platforms
+-PLAT_FLAGS ?= -mfpmath=sse -mssse3 -mtune=generic -mstackrealign
++PLAT_FLAGS ?= @platflags@
+ LIBEXT ?= so
+ 
+ INC = -Iinclude -Ilibcds/include
+@@ -210,13 +210,3 @@ test:
+ 	    -Itests $(LINK_FLAGS) -o $(NAME).tests
+ 	rm -rf tmp
+ 	mkdir -p tmp
+-	# If Valgrind exits non-zero, try running 'gdb ./engine.tests'
+-	# to debug the test suite
+-	valgrind ./$(NAME).tests --track-origins=yes
+-	mkdir html || rm -rf html/*
+-	gcovr -r . --html --html-details \
+-		--exclude=benchmark \
+-		-o html/coverage.html
+-	rm -rf *.gcda *.gcno
+-	$(BROWSER) html/coverage.html &
+-
+diff --git a/src/setup.cfg b/src/setup.cfg
+index d74165c..9b92f47 100644
+--- a/src/setup.cfg
++++ b/src/setup.cfg
+@@ -21,5 +21,3 @@ requires =
+     vorbis-tools
+ 
+ [tool:pytest]
+-addopts = --cov=sglib --cov-report=html --cov-report=term
+-
+diff --git a/src/vendor/sbsms/cli/Makefile b/src/vendor/sbsms/cli/Makefile
+index 9d53799..790206b 100644
+--- a/src/vendor/sbsms/cli/Makefile
++++ b/src/vendor/sbsms/cli/Makefile
+@@ -6,7 +6,7 @@ CXX ?= g++
+ PREFIX ?= /usr
+ 
+ #Default flags are mostly x86 specific
+-PLAT_FLAGS     ?=
++PLAT_FLAGS     ?= @platflags@
+ #-mstackrealign -msse -msse2 -msse3 -mfpmath=sse -mtune=generic
+ 
+ BASE_FLAGS     = -ffast-math -fprefetch-loop-arrays \

--- a/pkgs/applications/audio/stargate/default.nix
+++ b/pkgs/applications/audio/stargate/default.nix
@@ -1,0 +1,167 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, substituteAll
+, alsa-lib
+, autoconf
+, automake
+, ffmpegSupport ? true
+, ffmpeg
+, fftw
+, fftwSinglePrec
+, file
+, gdb
+, gettext
+, jq
+, lameSupport ? true
+, lame
+, libsbsms
+, libsndfile
+, pkg-config
+, portaudio
+, portmidi
+, python3
+, python3Packages
+, rubberband
+, stargate-libcds
+, vorbisToolsSupport ? true
+, vorbis-tools
+, wrapQtAppsHook
+}:
+
+let
+  python3CommonInputs = python3.withPackages
+    (ps: with ps; [
+      jinja2
+      mido
+      mutagen
+      numpy
+      psutil
+      pymarshal
+      pyqt5
+      pyyaml
+      wavefile
+      wheel
+    ]);
+in
+stdenv.mkDerivation rec {
+  pname = "stargate";
+  version = "21.11.6";
+
+  src = fetchFromGitHub {
+    owner = "stargateaudio";
+    repo = pname;
+    rev = "release-${version}";
+    sha256 = "sha256-opAJmxdibQe/mzCi7no+VNI5uSG0Jk5GILQbHvVOAIM=";
+  };
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    gdb
+    jq
+    pkg-config
+    python3Packages.cython
+    python3Packages.setuptools
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    fftw
+    fftwSinglePrec
+    gettext
+    libsbsms
+    libsndfile
+    portaudio
+    portmidi
+    python3
+    rubberband
+    stargate-libcds
+    file
+  ]
+  ++ lib.optional stdenv.isLinux alsa-lib
+  ++ lib.optional ffmpegSupport ffmpeg
+  ++ lib.optional lameSupport lame
+  ++ lib.optional vorbisToolsSupport vorbis-tools;
+
+  propagatedBuildInputs = [
+    python3CommonInputs
+  ];
+
+  checkInputs = with python3Packages; [
+    python3CommonInputs
+    pytest
+    yq
+  ];
+
+  patches = [
+    # Remove vendored python dependencies.
+    # Remove unecessary tests (coverage, valgrind).
+    # Use flags according to platform.
+    (substituteAll {
+      src = ./build_test.patch;
+      platflags = with stdenv;
+        if isLinux then "-mfpmath=sse -mssse3 -mtune=generic -mstackrealign"
+        else if (isAarch32 || isAarch64) then "-march=native"
+        else "";
+    })
+
+    # Patch paths of shared libraries and binaries.
+    (substituteAll {
+      src = ./path.patch;
+      libportaudio = "${lib.getLib portaudio}/lib/libportaudio${stdenv.hostPlatform.extensions.sharedLibrary}";
+      libportmidi = "${lib.getLib portmidi}/lib/libportmidi${stdenv.hostPlatform.extensions.sharedLibrary}";
+      file = "${file}/bin/file";
+    })
+
+    # Backport fix to find sbsms binary
+    # https://github.com/stargateaudio/stargate/pull/24
+    ./sglib-lib-util.py.patch
+  ];
+
+  preConfigure = ''
+    cd src
+  '';
+
+  SRC_SG_PY_VENDOR_DIR = "sg_py_vendor";
+
+  doCheck = true;
+
+  preCheck = ''
+    # Fix Permission denied: /homeless-shelter
+    # https://github.com/NixOS/nixpkgs/issues/12591
+    mkdir -p check-phase
+    export HOME=$PWD/check-phase
+
+    rm -rf ${SRC_SG_PY_VENDOR_DIR}/pymarshal ${SRC_SG_PY_VENDOR_DIR}/wavefile
+
+    mkdir -p ${SRC_SG_PY_VENDOR_DIR}
+
+    ln -s ${python3Packages.pymarshal} ${SRC_SG_PY_VENDOR_DIR}/pymarshal
+    ln -s ${python3Packages.wavefile} ${SRC_SG_PY_VENDOR_DIR}/wavefile
+  '';
+
+  checkTarget = [ "tests" ];
+
+  installFlags = [ "PREFIX=$(out)/usr" ];
+
+  dontWrapQtApps = true;
+
+  preFixup = ''
+    wrapQtApp "$out/usr/bin/stargate" \
+      --set PYTHONPATH "$PYTHONPATH:${python3.pkgs.pyqt5}/lib/python3.9/site-packages/PyQt5"
+  '';
+
+  meta = {
+    description = "Digital audio workstation, instrument and effect plugins, wave editor";
+    longDescription = ''
+      Stargate is a holistic audio production solution,
+      everything you need to make music on a computer.
+    '';
+    homepage = "https://stargateaudio.github.io";
+    changelog = "https://github.com/stargateaudio/stargate/releases";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ yuu ];
+  };
+}

--- a/pkgs/applications/audio/stargate/path.patch
+++ b/pkgs/applications/audio/stargate/path.patch
@@ -1,0 +1,60 @@
+diff --git a/src/sgui/widgets/hardware_dialog.py b/src/sgui/widgets/hardware_dialog.py
+index 13179b8..e6bd664 100755
+--- a/src/sgui/widgets/hardware_dialog.py
++++ b/src/sgui/widgets/hardware_dialog.py
+@@ -124,21 +124,11 @@ class hardware_dialog:
+ 
+     def open_devices(self):
+         if util.IS_LINUX:
+-            pa_paths = ("libportaudio.so.2", "libportaudio.so")
+-            pm_paths = ("libportmidi.so.0", "libportmidi.so")
++            pa_paths = ("libportaudio@.2", "@libportaudio@")
++            pm_paths = ("@libportmidi@")
+         elif util.IS_MAC_OSX:
+-            pa_paths = (
+-                os.path.join(util.INSTALL_PREFIX, 'libportaudio.2.dylib'),
+-                os.path.join(util.ENGINE_DIR, 'libportaudio.2.dylib'),
+-                "/usr/local/lib/libportaudio.dylib",
+-                "libportaudio.dylib",
+-            )
+-            pm_paths = (
+-                os.path.join(util.INSTALL_PREFIX, 'libportmidi.dylib'),
+-                os.path.join(util.ENGINE_DIR, 'libportmidi.dylib'),
+-                "/usr/local/lib/libportmidi.dylib",
+-                "libportmidi.dylib",
+-            )
++            pa_paths = ("@libportaudio@.2", "@libportaudio@")
++            pm_paths = ("@libportmidi@")
+         elif util.IS_WINDOWS:
+             pm_paths = (
+                 os.path.join(
+diff --git a/src/test/sglib/lib/test_ctypes.py b/src/test/sglib/lib/test_ctypes.py
+index 0f1c4c2..427728b 100644
+--- a/src/test/sglib/lib/test_ctypes.py
++++ b/src/test/sglib/lib/test_ctypes.py
+@@ -8,10 +8,10 @@ def test_patch_ctypes():
+     try:
+         patch_ctypes(env_vars=('SG_TEST_CTYPES',))
+         os.environ['SG_TEST_CTYPES'] = '/sg/test/path;/sg/test/path2/lib'
+-        ctypes.CDLL(("libportaudio.so", "libportaudio.so.2"))
++        ctypes.CDLL(("@libportaudio@", "@libportaudio@.2"))
+         revert_patch_ctypes()
+         patch_ctypes(True, env_vars=('SG_TEST_CTYPES',))
+-        ctypes.CDLL(("libportaudio.so", "libportaudio.so.2"))
++        ctypes.CDLL(("@libportaudio@", "@libportaudio@.2"))
+     finally:
+         revert_patch_ctypes()
+ 
+diff --git a/src/vendor/sbsms/configure b/src/vendor/sbsms/configure
+index dc57c83..ee59f72 100755
+--- a/src/vendor/sbsms/configure
++++ b/src/vendor/sbsms/configure
+@@ -5032,7 +5032,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+   ac_status=$?
+   echo "$as_me:$LINENO: \$? = $ac_status" >&5
+   (exit $ac_status); }; then
+-    case `/usr/bin/file conftest.o` in
++    case `@file@ conftest.o` in
+       *32-bit*)
+ 	case $host in
+ 	  x86_64-*kfreebsd*-gnu)

--- a/pkgs/applications/audio/stargate/sglib-lib-util.py.patch
+++ b/pkgs/applications/audio/stargate/sglib-lib-util.py.patch
@@ -1,0 +1,19 @@
+diff --git a/src/sglib/lib/util.py b/src/sglib/lib/util.py
+index d2fdf35..7872d65 100644
+--- a/src/sglib/lib/util.py
++++ b/src/sglib/lib/util.py
+@@ -187,10 +187,10 @@ elif IS_LINUX:
+         os.path.dirname(__file__),
+         '..',
+         '..',
+-        'vendor',
+-        'sbsms',
+-        'cli',
+-        'sbsms',
++        '..',
++        '..',
++        '..',
++        'bin',
+     )
+     if not os.path.exists(sbsms_util):
+         sbsms_util = which(f"{MAJOR_VERSION}-sbsms")

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9782,6 +9782,8 @@ with pkgs;
 
   staruml = callPackage ../tools/misc/staruml { };
 
+  stargate = libsForQt5.callPackage ../applications/audio/stargate { };
+
   stone-phaser = callPackage ../applications/audio/stone-phaser { };
 
   systrayhelper = callPackage ../tools/misc/systrayhelper {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
add free digital audio workstation https://github.com/stargateaudio/stargate

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I couldn't test the binary because the propagetedBuildInputs aren't referenced by the built derivation. So the binary can't find the needed run-time dependencies... More details in https://matrix.to/#/!KqkRjyTEzAGRiZFBYT:nixos.org/$PTJlfUTGzNTiZIzNCCcGdHGbEPNkZavpssrZRShY5Ew?via=nixos.org&via=matrix.org&via=tchncs.de

I opened separate pull requests for non-packaged dependencies (I can add all them to this PR to ease testing if someone requests):
-  #145155
-  #145156
- #145154
- #145157