### PR TITLE
libsbsms: init at 2.0.2 and 2.3.0

### DIFF
--- a/pkgs/development/libraries/libsbsms/common.nix
+++ b/pkgs/development/libraries/libsbsms/common.nix
@@ -1,0 +1,36 @@
+{ lib
+, stdenv
+, fetchurl
+, substituteAll
+, pname
+, version
+, url
+, sha256
+, homepage
+}:
+
+stdenv.mkDerivation rec {
+  inherit pname version;
+
+  src = fetchurl {
+    inherit url sha256;
+  };
+
+  patches = [
+    # Fix buidling on platforms other than x86
+    (substituteAll {
+      src = ./configure.patch;
+      msse = lib.optionalString stdenv.isx86_64 "-msse";
+    })
+  ];
+
+  doCheck = true;
+
+  meta = {
+    inherit homepage;
+    description = "Subband sinusoidal modeling library for time stretching and pitch scaling audio";
+    maintainers =  with lib.maintainers; [ yuu ];
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/development/libraries/libsbsms/configure.patch
+++ b/pkgs/development/libraries/libsbsms/configure.patch
@@ -1,0 +1,22 @@
+diff --git a/configure b/configure
+index 3d40335..faa3ac6 100755
+--- a/configure
++++ b/configure
+@@ -14722,7 +14722,7 @@ if ${ax_cv_cxx_flags__msse+:} false; then :
+ else
+ 
+       ax_save_FLAGS=$CXXFLAGS
+-      CXXFLAGS="-msse"
++      CXXFLAGS="@msse@"
+       cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
+@@ -14747,7 +14747,7 @@ eval ax_check_compiler_flags=$ax_cv_cxx_flags__msse
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_check_compiler_flags" >&5
+ $as_echo "$ax_check_compiler_flags" >&6; }
+ if test "x$ax_check_compiler_flags" = xyes; then
+-	SBSMS_CFLAGS="$SBSMS_CFLAGS -msse"
++	SBSMS_CFLAGS="$SBSMS_CFLAGS @msse@"
+ else
+ 	as_fn_error $? "Need a version of gcc with -msse" "$LINENO" 5
+ fi

--- a/pkgs/development/libraries/libsbsms/default.nix
+++ b/pkgs/development/libraries/libsbsms/default.nix
@@ -1,0 +1,22 @@
+let
+  pname = "libsbsms";
+in
+pkgs: rec {
+  libsbsms_2_0_2 = pkgs.callPackage ./common.nix rec {
+    inherit pname;
+    version = "2.0.2";
+    url = "mirror://sourceforge/sbsms/${pname}-${version}.tar.gz";
+    sha256 = "sha256-zqs9lwZkszcFe0a89VKD1Q0ynaY2v4PQ7nw24iNBru4=";
+    homepage = "https://sourceforge.net/projects/sbsms/files/sbsms";
+  };
+
+  libsbsms_2_3_0 = pkgs.callPackage ./common.nix rec {
+    inherit pname;
+    version = "2.3.0";
+    url = "https://github.com/claytonotey/${pname}/archive/refs/tags/${version}.tar.gz";
+    sha256 = "sha256-T4jRUrwG/tvanV1lUX1AJUpzEMkFBgGpMSIwnUWv0sk=";
+    homepage = "https://github.com/claytonotey/libsbsms";
+  };
+
+  libsbsms = libsbsms_2_0_2;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4063,6 +4063,12 @@ with pkgs;
 
   libpinyin = callPackage ../development/libraries/libpinyin { };
 
+  inherit (import ../development/libraries/libsbsms pkgs)
+    libsbsms
+    libsbsms_2_0_2
+    libsbsms_2_3_0
+  ;
+
   libskk = callPackage ../development/libraries/libskk {
     inherit (gnome) gnome-common;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Dependency for #145153

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
