### PR TITLE
python3Packages.wavefile: init at 1.5

### DIFF
--- a/pkgs/development/python-modules/wavefile/default.nix
+++ b/pkgs/development/python-modules/wavefile/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, pyaudio
+, numpy
+, libsndfile
+, substituteAll
+}:
+
+buildPythonPackage rec {
+  pname = "wavefile";
+  version = "1.5";
+
+  src = fetchFromGitHub {
+    owner = "vokimon";
+    repo = "python-wavefile";
+    rev = "python-wavefile-${version}";
+    sha256 = "9sHj1gb93mCVpejRGSdLJzeFDCeTflZctE7kMWfqFrE=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  buildInputs = [
+    pyaudio
+    libsndfile
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+  ];
+
+  checkInputs = [
+    pyaudio
+    numpy
+    libsndfile
+  ];
+
+  patches = [
+    # Fix check error
+    # OSError: libsndfile.so.1: cannot open shared object file: No such file or directory
+    (substituteAll {
+      src = ./libsndfile.py.patch;
+      libsndfile = "${lib.getLib libsndfile}/lib/libsndfile${stdenv.hostPlatform.extensions.sharedLibrary}";
+    })
+  ];
+
+  doCheck = false; # all test files (test/wavefileTest.py) are failing
+
+  pythonImportsCheck = [
+    "wavefile"
+  ];
+
+  meta = with lib; {
+    description = "Pythonic libsndfile wrapper to read and write audio files";
+    homepage = "https://github.com/vokimon/python-wavefile";
+    changelog = "https://github.com/vokimon/python-wavefile#version-history";
+    maintainers = with maintainers; [ yuu ];
+    license = licenses.gpl3Plus;
+  };
+}

--- a/pkgs/development/python-modules/wavefile/libsndfile.py.patch
+++ b/pkgs/development/python-modules/wavefile/libsndfile.py.patch
@@ -1,0 +1,18 @@
+diff --git a/wavefile/libsndfile.py b/wavefile/libsndfile.py
+index 67f0a46..ce066ee 100644
+--- a/wavefile/libsndfile.py
++++ b/wavefile/libsndfile.py
+@@ -19,11 +19,11 @@ import numpy as np
+ if sys.platform == "win32":
+     dllName = 'libsndfile-1'
+ elif "linux" in sys.platform:
+-    dllName = 'libsndfile.so.1'
++    dllName = '@libsndfile@'
+ elif "cygwin" in sys.platform:
+     dllName = 'libsndfile-1.dll'
+ elif "darwin" in sys.platform:
+-    dllName = 'libsndfile.dylib'
++    dllName = '@libsndfile@'
+ else:
+     dllName = 'libsndfile'
+ 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9782,6 +9782,8 @@ in {
 
   wavedrom = callPackage ../development/python-modules/wavedrom { };
 
+  wavefile = callPackage ../development/python-modules/wavefile { };
+
   wazeroutecalculator = callPackage ../development/python-modules/wazeroutecalculator { };
 
   wcmatch = callPackage ../development/python-modules/wcmatch { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Dependency for #145153

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
