### PR TITLE
stargate-libcds: init at 1.0.0

### DIFF
--- a/pkgs/development/libraries/stargate-libcds/Makefile.patch
+++ b/pkgs/development/libraries/stargate-libcds/Makefile.patch
@@ -1,0 +1,19 @@
+diff --git a/Makefile b/Makefile
+index 872af46..7eba8a1 100644
+--- a/Makefile
++++ b/Makefile
+@@ -156,13 +156,7 @@ test:
+ 	# Compile and run the test suite through Valgrind to check for
+ 	# memory errors, then generate an HTML code coverage report
+ 	# using gcovr
+-	$(CC) $(CC_ARGS) -O0 $(DEBUG_FLAGS) $(PLAT_FLAGS) $(GCOVARGS) \
++	$(CC) $(CC_ARGS) -O0 $(DEBUG_FLAGS) $(PLAT_FLAGS) \
+ 	    $(shell find src tests -name *.c) \
+ 	    -Iinclude \
+ 	    -o $(NAME).tests
+-	# If Valgrind exits non-zero, try running 'gdb ./libcds.tests'
+-	# to debug the test suite
+-	valgrind ./$(NAME).tests --track-origins=yes --leak-check=full
+-	mkdir html || rm -rf html/*
+-	gcovr -r . --exclude=bench --html --html-details -o html/coverage.html
+-	$(BROWSER) html/coverage.html &

--- a/pkgs/development/libraries/stargate-libcds/default.nix
+++ b/pkgs/development/libraries/stargate-libcds/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, stdenv
+, fetchpatch
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "stargate-libcds";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "stargateaudio";
+    repo = "libcds";
+    rev = version;
+    sha256 = "sha256-THThEzS8gGdwn3h0EBttaX5ljZH9Ma2Rcg143+GIdU8=";
+  };
+
+  # Fix 'error: unrecognized command line option' in platforms other than x86
+  PLAT_FLAGS = lib.optionalString stdenv.isx86_64 "-mfpmath=sse -mssse3";
+
+  patches = [
+    # Remove unecessary tests (valgrind, coverage)
+    ./Makefile.patch
+
+    # Fix for building on darwin
+    (fetchpatch {
+      name = "malloc-to-stdlib.patch";
+      url = "https://github.com/stargateaudio/libcds/commit/65dc08f059deda8ba5707ba6116b616d0ad0bd8d.patch";
+      sha256 = "sha256-FIGlobUVrDYOtnHjsWyE420PoULPHEK/3T9Fv8hfTl4=";
+    })
+  ];
+
+  doCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -D libcds.so -t $out/lib/
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "C data structure library";
+    homepage = "https://github.com/stargateaudio/libcds";
+    maintainers = with maintainers; [ yuu ];
+    license = licenses.lgpl3Only;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19567,6 +19567,8 @@ with pkgs;
 
   srtp = callPackage ../development/libraries/srtp { };
 
+  stargate-libcds = callPackage ../development/libraries/stargate-libcds { };
+
   stb = callPackage ../development/libraries/stb { };
 
   StormLib = callPackage ../development/libraries/StormLib { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Dependency for  #145153

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
