### PR TITLE
mariadb: fix invalid PLUGIN_AUTH_PAM value

### DIFF
--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -142,7 +142,7 @@ in stdenv.mkDerivation (common // {
   ];
 
   cmakeFlags = common.cmakeFlags ++ [
-    "-DPLUGIN_AUTH_PAM=OFF"
+    "-DPLUGIN_AUTH_PAM=NO"
     "-DWITHOUT_SERVER=ON"
     "-DWITH_WSREP=OFF"
     "-DINSTALL_MYSQLSHAREDIR=share/mysql-client"
@@ -207,7 +207,8 @@ in stdenv.mkDerivation (common // {
   ] ++ lib.optional (!stdenv.hostPlatform.isDarwin) [
     "-DWITH_JEMALLOC=yes"
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    "-DPLUGIN_AUTH_PAM=OFF"
+    "-DPLUGIN_AUTH_PAM=NO"
+    "-DPLUGIN_AUTH_PAM_V1=NO"
     "-DWITHOUT_OQGRAPH=1"
     "-DWITHOUT_PLUGIN_S3=1"
   ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [


### PR DESCRIPTION
###### Motivation for this change

Fix CMake build error on Mac:

```
CMake Error at cmake/plugin.cmake:108 (MESSAGE):
  Invalid value for PLUGIN_AUTH_PAM
Call Stack (most recent call first):
  plugin/auth_pam/CMakeLists.txt:41 (MYSQL_ADD_PLUGIN)
```

Based on https://mariadb.com/kb/en/specifying-which-plugins-to-build/, valid values of the flag are `YES`,`NO`,`STATIC`,`DYNAMIC`,`AUTO`. I believe the `OFF` is supposed to be `NO`.

###### Things done

I tried building the package locally using `nix-env -i mariadb.server -f $PWD`. It did allow the build process to get pass the configuration phase, but unfortunately I couldn't complete the build as it ran into a compilation error in RocksDB, which seem to be an M1 Mac problem. That said, I think the `PLUGIN_AUTH_PAM` flag still need be changed.

```[ 35%] Building CXX object storage/rocksdb/CMakeFiles/rocksdblib.dir/rocksdb/util/murmurhash.cc.o
/tmp/nix-build-mariadb-server-10.6.3.drv-1/mariadb-10.6.3/storage/rocksdb/rocksdb/util/crc32c.cc:500:18: error: use of undeclared identifier 'isSSE42'
  has_fast_crc = isSSE42();
                 ^
/tmp/nix-build-mariadb-server-10.6.3.drv-1/mariadb-10.6.3/storage/rocksdb/rocksdb/util/crc32c.cc:1230:7: error: use of undeclared identifier 'isSSE42'
  if (isSSE42()) {
      ^
/tmp/nix-build-mariadb-server-10.6.3.drv-1/mariadb-10.6.3/storage/rocksdb/rocksdb/util/crc32c.cc:1231:9: error: use of undeclared identifier 'isPCLMULQDQ'
    if (isPCLMULQDQ()) {
```