### PR TITLE
shogun: refactor derivation and fix build

### DIFF
--- a/pkgs/applications/science/machine-learning/shogun/default.nix
+++ b/pkgs/applications/science/machine-learning/shogun/default.nix
@@ -95,6 +95,9 @@ stdenv.mkDerivation rec {
       sha256 = "sha256-AgJJKQA8vc5oKaTQDqMdwBR4hT4sn9+uW0jLe7GteJw=";
     })
 
+    # Fix compile errors with Eigen 3.4
+    ./eigen-3.4.patch
+
   ] ++ lib.optional (!withSvmLight) ./svmlight-scrubber.patch;
 
   nativeBuildInputs = [ cmake swig ctags ]

--- a/pkgs/applications/science/machine-learning/shogun/default.nix
+++ b/pkgs/applications/science/machine-learning/shogun/default.nix
@@ -6,6 +6,7 @@
   # build
 , cmake
 , ctags
+, pythonPackages
 , swig
   # math
 , eigen
@@ -30,7 +31,6 @@
 , colpack
   # extra support
 , pythonSupport ? true
-, pythonPackages ? null
 , opencvSupport ? false
 , opencv ? null
 , withSvmLight ? false
@@ -56,7 +56,8 @@ let
       sha256 = "05s9dclmk7x5d7wnnj4qr6r6c827m72a44gizcv09lxr28pr9inz";
       fetchSubmodules = true;
     };
-    # we need the packed archive
+
+    # The CMake external projects expect the packed archives
     rxcpp = fetchurl {
       url = "https://github.com/Reactive-Extensions/RxCpp/archive/v${rxcppVersion}.tar.gz";
       sha256 = "0y2isr8dy2n1yjr9c5570kpc9lvdlch6jv0jvw000amwn5d3krsh";
@@ -71,16 +72,33 @@ in
 stdenv.mkDerivation rec {
   inherit pname version;
 
+  outputs = [ "out" "dev" "doc" ];
+
   src = srcs.toolbox;
 
   patches = [
+    # Fix compile errors with json-c
+    # https://github.com/shogun-toolbox/shogun/pull/4104
     (fetchpatch {
-      url = "https://github.com/awild82/shogun/commit/365ce4c4c700736d2eec8ba6c975327a5ac2cd9b.patch";
+      url = "https://github.com/shogun-toolbox/shogun/commit/365ce4c4c700736d2eec8ba6c975327a5ac2cd9b.patch";
       sha256 = "158hqv4xzw648pmjbwrhxjp7qcppqa7kvriif87gn3zdn711c49s";
     })
+
+    # Fix compile errors with GCC 9+
+    # https://github.com/shogun-toolbox/shogun/pull/4811
+    (fetchpatch {
+      url = "https://github.com/shogun-toolbox/shogun/commit/c8b670be4790e0f06804b048a6f3d77c17c3ee95.patch";
+      sha256 = "sha256-MxsR3Y2noFQevfqWK3nmX5iK4OVWeKBl5tfeDNgjcXk=";
+    })
+    (fetchpatch {
+      url = "https://github.com/shogun-toolbox/shogun/commit/5aceefd9fb0e2132c354b9a0c0ceb9160cc9b2f7.patch";
+      sha256 = "sha256-AgJJKQA8vc5oKaTQDqMdwBR4hT4sn9+uW0jLe7GteJw=";
+    })
+
   ] ++ lib.optional (!withSvmLight) ./svmlight-scrubber.patch;
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake swig ctags ]
+    ++ (with pythonPackages; [ python jinja2 ply ]);
 
   buildInputs = [
     eigen
@@ -100,34 +118,37 @@ stdenv.mkDerivation rec {
     nlopt
     lp_solve
     colpack
-    ctags
-    swig
-  ] ++ lib.optionals pythonSupport (with pythonPackages; [ python ply numpy ])
+  ] ++ lib.optionals pythonSupport (with pythonPackages; [ python numpy ])
     ++ lib.optional opencvSupport opencv;
 
   cmakeFlags = let
     enableIf = cond: if cond then "ON" else "OFF";
   in [
-    "-DBUILD_META_EXAMPLES=${enableIf doCheck}"
-    "-DCMAKE_VERBOSE_MAKEFILE=${enableIf doCheck}"
+    "-DBUILD_META_EXAMPLES=ON"
+    "-DCMAKE_DISABLE_FIND_PACKAGE_ARPACK=ON"
+    "-DCMAKE_DISABLE_FIND_PACKAGE_ARPREC=ON"
+    "-DCMAKE_DISABLE_FIND_PACKAGE_CPLEX=ON"
+    "-DCMAKE_DISABLE_FIND_PACKAGE_Mosek=ON"
+    "-DCMAKE_DISABLE_FIND_PACKAGE_TFLogger=ON"
+    "-DCMAKE_DISABLE_FIND_PACKAGE_ViennaCL=ON"
+    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
+    "-DCMAKE_CTEST_ARGUMENTS='--exclude-regex;TrainedModelSerialization'"  # Sporadic segfault
     "-DENABLE_TESTING=${enableIf doCheck}"
+    "-DDISABLE_META_INTEGRATION_TESTS=ON"
+    "-DTRAVIS_DISABLE_META_CPP=ON"
     "-DPythonModular=${enableIf pythonSupport}"
     "-DOpenCV=${enableIf opencvSupport}"
     "-DUSE_SVMLIGHT=${enableIf withSvmLight}"
   ];
 
-  CCACHE_DISABLE="1";
-  CCACHE_DIR=".ccache";
+  CXXFLAGS = "-faligned-new";
 
-  NIX_CFLAGS_COMPILE="-faligned-new";
-
-  # broken
-  doCheck = false;
+  doCheck = true;
 
   postUnpack = ''
-    mkdir -p $sourceRoot/third_party/{rxcpp,gtest}
+    mkdir -p $sourceRoot/third_party/{rxcpp,GoogleMock}
     ln -s ${srcs.rxcpp} $sourceRoot/third_party/rxcpp/v${rxcppVersion}.tar.gz
-    ln -s ${srcs.gtest} $sourceRoot/third_party/gtest/release-${gtestVersion}.tar.gz
+    ln -s ${srcs.gtest} $sourceRoot/third_party/GoogleMock/release-${gtestVersion}.tar.gz
   '';
 
   postPatch = ''
@@ -144,6 +165,13 @@ stdenv.mkDerivation rec {
     patchShebangs scripts/light-scrubber.sh
     echo "removing SVMlight code"
     ./scripts/light-scrubber.sh
+  '';
+
+  postInstall = ''
+    mkdir -p $doc/share/doc/shogun/examples
+    mv $out/share/shogun/examples/cpp $doc/share/doc/shogun/examples
+    cp ../examples/undocumented/libshogun/*.cpp $doc/share/doc/shogun/examples/cpp
+    rm -r $out/share
   '';
 
   meta = with lib; {

--- a/pkgs/applications/science/machine-learning/shogun/default.nix
+++ b/pkgs/applications/science/machine-learning/shogun/default.nix
@@ -150,6 +150,6 @@ stdenv.mkDerivation rec {
     description = "A toolbox which offers a wide range of efficient and unified machine learning methods";
     homepage = "http://shogun-toolbox.org/";
     license = if withSvmLight then licenses.unfree else licenses.gpl3Plus;
-    maintainers = with maintainers; [ edwtjo ];
+    maintainers = with maintainers; [ edwtjo smancill ];
   };
 }

--- a/pkgs/applications/science/machine-learning/shogun/eigen-3.4.patch
+++ b/pkgs/applications/science/machine-learning/shogun/eigen-3.4.patch
@@ -1,0 +1,74 @@
+From: Sebastián Mancilla <smancill@smancill.dev>
+Subject: [PATCH] Fix compile errors when using Eigen 3.4
+
+---
+ .../machine/gp/MultiLaplaceInferenceMethod.cpp | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/src/shogun/machine/gp/MultiLaplaceInferenceMethod.cpp b/src/shogun/machine/gp/MultiLaplaceInferenceMethod.cpp
+index 2e27678d2..60050afea 100644
+--- a/src/shogun/machine/gp/MultiLaplaceInferenceMethod.cpp
++++ b/src/shogun/machine/gp/MultiLaplaceInferenceMethod.cpp
+@@ -84,9 +84,9 @@ class CMultiPsiLine : public func_base
+ 		float64_t result=0;
+ 		for(index_t bl=0; bl<C; bl++)
+ 		{
+-			eigen_f.block(bl*n,0,n,1)=K*alpha->block(bl*n,0,n,1)*CMath::exp(log_scale*2.0);
+-			result+=alpha->block(bl*n,0,n,1).dot(eigen_f.block(bl*n,0,n,1))/2.0;
+-			eigen_f.block(bl*n,0,n,1)+=eigen_m;
++			eigen_f.segment(bl*n,n)=K*alpha->segment(bl*n,n)*CMath::exp(log_scale*2.0);
++			result+=alpha->segment(bl*n,n).dot(eigen_f.segment(bl*n,n))/2.0;
++			eigen_f.segment(bl*n,n)+=eigen_m;
+ 		}
+ 
+ 		// get first and second derivatives of log likelihood
+@@ -272,7 +272,7 @@ void CMultiLaplaceInferenceMethod::update_alpha()
+ 	{
+ 		Map<VectorXd> alpha(m_alpha.vector, m_alpha.vlen);
+ 		for(index_t bl=0; bl<C; bl++)
+-			eigen_mu.block(bl*n,0,n,1)=eigen_ktrtr*CMath::exp(m_log_scale*2.0)*alpha.block(bl*n,0,n,1);
++			eigen_mu.segment(bl*n,n)=eigen_ktrtr*CMath::exp(m_log_scale*2.0)*alpha.segment(bl*n,n);
+ 
+ 		//alpha'*(f-m)/2.0
+ 		Psi_New=alpha.dot(eigen_mu)/2.0;
+@@ -316,7 +316,7 @@ void CMultiLaplaceInferenceMethod::update_alpha()
+ 
+ 		for(index_t bl=0; bl<C; bl++)
+ 		{
+-			VectorXd eigen_sD=eigen_dpi.block(bl*n,0,n,1).cwiseSqrt();
++			VectorXd eigen_sD=eigen_dpi.segment(bl*n,n).cwiseSqrt();
+ 			LLT<MatrixXd> chol_tmp((eigen_sD*eigen_sD.transpose()).cwiseProduct(eigen_ktrtr*CMath::exp(m_log_scale*2.0))+
+ 				MatrixXd::Identity(m_ktrtr.num_rows, m_ktrtr.num_cols));
+ 			MatrixXd eigen_L_tmp=chol_tmp.matrixU();
+@@ -341,11 +341,11 @@ void CMultiLaplaceInferenceMethod::update_alpha()
+ 		VectorXd tmp2=m_tmp.array().rowwise().sum();
+ 
+ 		for(index_t bl=0; bl<C; bl++)
+-			eigen_b.block(bl*n,0,n,1)+=eigen_dpi.block(bl*n,0,n,1).cwiseProduct(eigen_mu.block(bl*n,0,n,1)-eigen_mean_bl-tmp2);
++			eigen_b.segment(bl*n,n)+=eigen_dpi.segment(bl*n,n).cwiseProduct(eigen_mu.segment(bl*n,n)-eigen_mean_bl-tmp2);
+ 
+ 		Map<VectorXd> &eigen_c=eigen_W;
+ 		for(index_t bl=0; bl<C; bl++)
+-			eigen_c.block(bl*n,0,n,1)=eigen_E.block(0,bl*n,n,n)*(eigen_ktrtr*CMath::exp(m_log_scale*2.0)*eigen_b.block(bl*n,0,n,1));
++			eigen_c.segment(bl*n,n)=eigen_E.block(0,bl*n,n,n)*(eigen_ktrtr*CMath::exp(m_log_scale*2.0)*eigen_b.segment(bl*n,n));
+ 
+ 		Map<MatrixXd> c_tmp(eigen_c.data(),n,C);
+ 
+@@ -409,7 +409,7 @@ float64_t CMultiLaplaceInferenceMethod::get_derivative_helper(SGMatrix<float64_t
+ 	{
+ 		result+=((eigen_E.block(0,bl*n,n,n)-eigen_U.block(0,bl*n,n,n).transpose()*eigen_U.block(0,bl*n,n,n)).array()
+ 			*eigen_dK.array()).sum();
+-		result-=(eigen_dK*eigen_alpha.block(bl*n,0,n,1)).dot(eigen_alpha.block(bl*n,0,n,1));
++		result-=(eigen_dK*eigen_alpha.segment(bl*n,n)).dot(eigen_alpha.segment(bl*n,n));
+ 	}
+ 
+ 	return result/2.0;
+@@ -489,7 +489,7 @@ SGVector<float64_t> CMultiLaplaceInferenceMethod::get_derivative_wrt_mean(
+ 		result[i]=0;
+ 		//currently only compute the explicit term
+ 		for(index_t bl=0; bl<C; bl++)
+-			result[i]-=eigen_alpha.block(bl*n,0,n,1).dot(eigen_dmu);
++			result[i]-=eigen_alpha.segment(bl*n,n).dot(eigen_dmu);
+ 	}
+ 
+ 	return result;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26918,16 +26918,7 @@ with pkgs;
   shotcut = libsForQt5.callPackage ../applications/video/shotcut { };
 
   shogun = callPackage ../applications/science/machine-learning/shogun {
-    stdenv = gcc8Stdenv;
-
-    # Workaround for the glibc abi version mismatch.
-    # Please note that opencv builds are by default disabled.
-    opencv = opencv3.override {
-      stdenv = gcc8Stdenv;
-      openexr = openexr.override {
-        stdenv = gcc8Stdenv;
-      };
-    };
+    opencv = opencv3;
   };
 
   smplayer = libsForQt5.callPackage ../applications/video/smplayer { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Build Shogun on Darwin and fix #142811.

###### Things done

This is a big refactoring that fixes some issues with the derivation, enables building on Darwin, uses multiple outputs, enables testing, and fixes the compilation errors that appeared after Eigen was updated to latest 3.4 release.

Also add myself as a maintainer.

Generating the Python bindings is not enabled due to an unfixed bug in the derivation, that I think is better to fix in another PR that adds shogun as a proper Python module.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
