### PR TITLE
moodle: 3.11.2 -> 3.11.4

### DIFF
--- a/pkgs/servers/web-apps/moodle/default.nix
+++ b/pkgs/servers/web-apps/moodle/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, writeText, plugins ? [ ] }:
 
 let
-  version = "3.11.2";
+  version = "3.11.4";
   stableVersion = lib.concatStrings (lib.take 2 (lib.splitVersion version));
 
 in stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   src = fetchurl {
     url =
       "https://download.moodle.org/stable${stableVersion}/${pname}-${version}.tgz";
-    sha256 = "sha256-owe/8CVz7+uBrHJQDN4csWVcdk49AvT1ip88lAe/tKg=";
+    sha256 = "sha256-OPTImFgXuRK7bxK8KCan68/5D43qUOEK+TcC/9VQxu8=";
   };
 
   phpConfig = writeText "config.php" ''

--- a/pkgs/servers/web-apps/moodle/default.nix
+++ b/pkgs/servers/web-apps/moodle/default.nix
@@ -9,8 +9,7 @@ in stdenv.mkDerivation rec {
   inherit version;
 
   src = fetchurl {
-    url =
-      "https://download.moodle.org/stable${stableVersion}/${pname}-${version}.tgz";
+    url = "https://download.moodle.org/stable${stableVersion}/${pname}-${version}.tgz";
     sha256 = "sha256-OPTImFgXuRK7bxK8KCan68/5D43qUOEK+TcC/9VQxu8=";
   };
 


### PR DESCRIPTION
###### Motivation for this change
https://docs.moodle.org/dev/Moodle_3.11.4_release_notes

###### Things done
Tested with database changes on a testing server

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
