### PR TITLE
gnome.gnome-todo: Apply patch to fix build race condition

### DIFF
--- a/pkgs/desktops/gnome/apps/gnome-todo/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-todo/default.nix
@@ -36,8 +36,10 @@ stdenv.mkDerivation rec {
   patches = [
     # fix build race bug https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=257667
     (fetchpatch {
-      url = "https://cgit.freebsd.org/ports/patch/?id=a4faaf6cf7835014b5f69a337b544ea4ee7f9655";
-      sha256 = "sha256-IMBfqtrqBw3DdmJG0qchZFR6Am1PICMnM5P6BcS8oqI=";
+      url = "https://cgit.freebsd.org/ports/plain/deskutils/gnome-todo/files/patch-src_meson.build?id=a4faaf6cf7835014b5f69a337b544ea4ee7f9655";
+      sha256 = "sha256:0ihixyq72yhx6njij7bldsqb80x3y217yh6livknlf5r1wr3hakn";
+      extraPrefix = "";
+      name = "gnome-todo_meson-build.patch";
     })
   ];
 


### PR DESCRIPTION
###### Motivation for this change

PR #136519 added a patch to fix a race condition when building, but builds for gnome-todo are still failing on hydra with the same error message.

The patch contains a patch itself which is just unpacked and still has to be applied to have any effect.

ZHF #144627

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
