### PR TITLE
python3Packages.peewee: 3.14.4 -> 3.14.8

### DIFF
--- a/pkgs/development/python-modules/peewee/default.nix
+++ b/pkgs/development/python-modules/peewee/default.nix
@@ -1,50 +1,58 @@
 { lib
-, buildPythonPackage
-, fetchFromGitHub
-, sqlite
-, cython
 , apsw
+, buildPythonPackage
+, cython
+, fetchFromGitHub
 , flask
-, withPostgres ? false, psycopg2
-, withMysql ? false, mysql-connector
+, python
+, sqlite
+, withMysql ? false
+, mysql-connector
+, withPostgres ? false
+, psycopg2
 }:
 
 buildPythonPackage rec {
-
   pname = "peewee";
-  version = "3.14.4";
+  version = "3.14.8";
+  format = "setuptools";
 
-  # pypi release does not provide tests
   src = fetchFromGitHub {
     owner = "coleifer";
     repo = pname;
     rev = version;
-    sha256 = "0x85swpaffysc05kka0mab87cnilzw1lpacfhcx5ayabh0i2qsh6";
+    sha256 = "sha256-BJSM+7+VdW6SxN4/AXsX8NhQPdIFoYrVRVwR9OsJ3QE=";
   };
-
-
-  checkInputs = [ flask ];
-
-  checkPhase = ''
-    rm -r playhouse # avoid using the folder in the cwd
-    python runtests.py
-  '';
 
   buildInputs = [
     sqlite
-    cython # compile speedups
+    cython
   ];
 
   propagatedBuildInputs = [
-    apsw # sqlite performance improvement
-  ] ++ (lib.optional withPostgres psycopg2)
-    ++ (lib.optional withMysql mysql-connector);
+    apsw
+  ] ++ lib.optional withPostgres psycopg2
+  ++ lib.optional withMysql mysql-connector;
+
+  checkInputs = [
+    flask
+  ];
 
   doCheck = withPostgres;
 
+  checkPhase = ''
+    rm -r playhouse # avoid using the folder in the cwd
+    ${python.interpreter} runtests.py
+  '';
+
+  pythonImportsCheck = [
+    "peewee"
+  ];
+
   meta = with lib; {
-    description = "a small, expressive orm";
-    homepage    = "http://peewee-orm.com";
-    license     = licenses.mit;
+    description = "Python ORM with support for various database implementation";
+    homepage = "http://peewee-orm.com";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 3.14.8

Change log:
- https://github.com/coleifer/peewee/releases/tag/3.14.8
- https://github.com/coleifer/peewee/releases/tag/3.14.7
- https://github.com/coleifer/peewee/releases/tag/3.14.6
- https://github.com/coleifer/peewee/releases/tag/3.14.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
