### PR TITLE
dotnet: make SDK 6.0 default

### DIFF
--- a/pkgs/development/compilers/dotnet/default.nix
+++ b/pkgs/development/compilers/dotnet/default.nix
@@ -17,9 +17,9 @@ rec {
 
   # EOL
 
-  sdk_2_1 = throw "Dotnet SDK 2.1 is EOL, please use 3.1 (LTS) or 5.0 (Current)";
-  sdk_2_2 = throw "Dotnet SDK 2.2 is EOL, please use 3.1 (LTS) or 5.0 (Current)";
-  sdk_3_0 = throw "Dotnet SDK 3.0 is EOL, please use 3.1 (LTS) or 5.0 (Current)";
+  sdk_2_1 = throw "Dotnet SDK 2.1 is EOL, please use 3.1 (LTS), 5.0 (Current) or 6.0 (LTS)";
+  sdk_2_2 = throw "Dotnet SDK 2.2 is EOL, please use 3.1 (LTS), 5.0 (Current) or 6.0 (LTS)";
+  sdk_3_0 = throw "Dotnet SDK 3.0 is EOL, please use 3.1 (LTS), 5.0 (Current) or 6.0 (LTS)";
 
   # v3.1 (LTS)
 
@@ -79,7 +79,7 @@ rec {
     };
   };
 
-  # v6.0
+  # v6.0 (LTS)
 
   aspnetcore_6_0 = buildAspNetCore {
     version = "6.0.0";

--- a/pkgs/development/compilers/dotnet/print-hashes.sh
+++ b/pkgs/development/compilers/dotnet/print-hashes.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl
+
+set -eu
+
+if [[ $# -lt 1 ]]; then
+    echo \"usage: $0 version\" >&2
+    exit 1
+fi
+
+VERSION=$1
+HASHFILE=$(mktemp /tmp/dotnet.hashes.XXXXXXXX)
+trap "rm -f $HASHFILE" EXIT
+
+curl -L https://dotnetcli.blob.core.windows.net/dotnet/checksums/$VERSION-sha.txt -o $HASHFILE
+
+ASPNETCORE_VERSION=$(grep aspnetcore-runtime- $HASHFILE | grep -- -linux-x64.tar.gz | tail -n -1 | sed -e 's:.*aspnetcore-runtime-::' -e 's:-linux-x64.tar.gz.*$::' )
+ASPNETCORE_HASH_LINUX_X64=$(grep aspnetcore-runtime- $HASHFILE | grep -- -linux-x64.tar.gz | cut -d ' ' -f 1)
+ASPNETCORE_HASH_LINUX_ARM64=$(grep aspnetcore-runtime- $HASHFILE | grep -- -linux-arm64.tar.gz | cut -d ' ' -f 1)
+ASPNETCORE_HASH_OSX_X64=$(grep aspnetcore-runtime- $HASHFILE | grep -- -osx-x64.tar.gz | cut -d ' ' -f 1)
+ASPNETCORE_HASH_OSX_ARM64=$(grep aspnetcore-runtime- $HASHFILE | grep -- -osx-arm64.tar.gz | cut -d ' ' -f 1)
+
+RUNTIME_VERSION=$(grep dotnet-runtime- $HASHFILE | grep -- -linux-x64.tar.gz | tail -n -1 | sed -e 's:.*dotnet-runtime-::' -e 's:-linux-x64.tar.gz.*$::' )
+RUNTIME_HASH_LINUX_X64=$(grep dotnet-runtime- $HASHFILE | grep -- -linux-x64.tar.gz | cut -d ' ' -f 1)
+RUNTIME_HASH_LINUX_ARM64=$(grep dotnet-runtime- $HASHFILE | grep -- -linux-arm64.tar.gz | cut -d ' ' -f 1)
+RUNTIME_HASH_OSX_X64=$(grep dotnet-runtime- $HASHFILE | grep -- -osx-x64.tar.gz | cut -d ' ' -f 1)
+RUNTIME_HASH_OSX_ARM64=$(grep dotnet-runtime- $HASHFILE | grep -- -osx-arm64.tar.gz | cut -d ' ' -f 1)
+
+# dotnet-sdk has multiple entries in file, but the latest is the newest
+SDK_VERSION=$(grep dotnet-sdk- $HASHFILE | grep -- -linux-x64.tar.gz | tail -n -1 | sed -e 's:.*dotnet-sdk-::' -e 's:-linux-x64.tar.gz.*$::' )
+SDK_HASH_LINUX_X64=$(grep dotnet-sdk- $HASHFILE | grep -- -linux-x64.tar.gz | tail -n 1 | cut -d ' ' -f 1)
+SDK_HASH_LINUX_ARM64=$(grep dotnet-sdk- $HASHFILE | grep -- -linux-arm64.tar.gz | tail -n 1 | cut -d ' ' -f 1)
+SDK_HASH_OSX_X64=$(grep dotnet-sdk- $HASHFILE | grep -- -osx-x64.tar.gz | tail -n 1 | cut -d ' ' -f 1)
+SDK_HASH_OSX_ARM64=$(grep dotnet-sdk- $HASHFILE | grep -- -osx-arm64.tar.gz | tail -n 1 | cut -d ' ' -f 1)
+
+V=${VERSION/./_}
+MAJOR_MINOR_VERSION=${V%%.*}
+
+echo """
+  aspnetcore_${MAJOR_MINOR_VERSION} = buildAspNetCore {
+    version = \"${ASPNETCORE_VERSION}\";
+    sha512 = {
+      x86_64-linux = \"${ASPNETCORE_HASH_LINUX_X64}\";
+      aarch64-linux = \"${ASPNETCORE_HASH_LINUX_ARM64}\";
+      x86_64-darwin = \"${ASPNETCORE_HASH_OSX_X64}\";
+      aarch64-darwin = \"${ASPNETCORE_HASH_OSX_ARM64}\";
+    };
+  };
+
+  runtime_${MAJOR_MINOR_VERSION} = buildNetRuntime {
+    version = \"${RUNTIME_VERSION}\";
+    sha512 = {
+      x86_64-linux = \"${RUNTIME_HASH_LINUX_X64}\";
+      aarch64-linux = \"${RUNTIME_HASH_LINUX_ARM64}\";
+      x86_64-darwin = \"${RUNTIME_HASH_OSX_X64}\";
+      aarch64-darwin = \"${RUNTIME_HASH_OSX_ARM64}\";
+    };
+  };
+
+  sdk_${MAJOR_MINOR_VERSION} = buildNetSdk {
+    version = \"${SDK_VERSION}\";
+    sha512 = {
+      x86_64-linux = \"${SDK_HASH_LINUX_X64}\";
+      aarch64-linux = \"${SDK_HASH_LINUX_ARM64}\";
+      x86_64-darwin = \"${SDK_HASH_OSX_X64}\";
+      aarch64-darwin = \"${SDK_HASH_OSX_ARM64}\";
+    };
+  };
+"""

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -422,9 +422,9 @@ with pkgs;
   dotnet-sdk_5 = dotnetCorePackages.sdk_5_0;
   dotnet-sdk_6 = dotnetCorePackages.sdk_6_0;
 
-  dotnet-sdk = dotnetCorePackages.sdk_5_0;
-  dotnet-runtime = dotnetCorePackages.runtime_5_0;
-  dotnet-aspnetcore = dotnetCorePackages.aspnetcore_5_0;
+  dotnet-sdk = dotnetCorePackages.sdk_6_0;
+  dotnet-runtime = dotnetCorePackages.runtime_6_0;
+  dotnet-aspnetcore = dotnetCorePackages.aspnetcore_6_0;
 
   dumb-init = callPackage ../applications/virtualization/dumb-init {};
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

let's make Dotnet SDK 6.0 default since it is now officially released - see https://dotnet.microsoft.com/download
    
should not cause any trouble since all packages should use pinned versions via either of these:
- `dotnet-sdk = dotnetCorePackages.sdk_5_0`
- `dotnet-sdk_5`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
