### PR TITLE
yosys: fix build on darwin

### DIFF
--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -51,6 +51,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./plugin-search-dirs.patch
+    ./fix-clang-build.patch # see https://github.com/YosysHQ/yosys/issues/2011
   ];
 
   postPatch = ''
@@ -104,12 +105,5 @@ stdenv.mkDerivation rec {
     license     = licenses.isc;
     platforms   = platforms.all;
     maintainers = with maintainers; [ shell thoughtpolice emily ];
-    #In file included from kernel/driver.cc:20:
-    #./kernel/yosys.h:42:10: fatal error: 'map' file not found
-    ##include <map>
-
-    #https://github.com/YosysHQ/yosys/issues/681
-    #https://github.com/YosysHQ/yosys/issues/2011
-    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/compilers/yosys/fix-clang-build.patch
+++ b/pkgs/development/compilers/yosys/fix-clang-build.patch
@@ -1,0 +1,26 @@
+diff --git a/Makefile b/Makefile
+index 86abc6958..a72f7b792 100644
+--- a/Makefile
++++ b/Makefile
+@@ -145,7 +145,12 @@ bumpversion:
+ ABCREV = 4f5f73d
+ ABCPULL = 1
+ ABCURL ?= https://github.com/YosysHQ/abc
++
++ifneq ($(CONFIG),clang)
++ABCMKARGS = CC=clang CXX="$(CXX)" LD=clang ABC_USE_LIBSTDCXX=1 VERBOSE=$(Q)
++else
+ ABCMKARGS = CC="$(CXX)" CXX="$(CXX)" ABC_USE_LIBSTDCXX=1 VERBOSE=$(Q)
++endif
+ 
+ # set ABCEXTERNAL = <abc-command> to use an external ABC instance
+ # Note: The in-tree ABC (yosys-abc) will not be installed when ABCEXTERNAL is set.
+@@ -187,7 +192,7 @@ endif
+ endif
+ 
+ ifeq ($(CONFIG),clang)
+-CXX = clang
++CXX = clang++
+ LD = clang++
+ CXXFLAGS += -std=$(CXXSTD) -Os
+ ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H"


### PR DESCRIPTION
Attempt to work around a confusion in yosys' build system that causes
builds under clang to fail.

Related: [yosys#2011](https://github.com/YosysHQ/yosys/issues/2011)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  (__Note__: I only checked functionality of yosys and yosys-config, other binaries seem to be okay but I don't know enough about their purpose to actually test them on some task.)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
