### PR TITLE
kcat: rename from kafkcat + update 1.6.0 → 1.7.0

### DIFF
--- a/pkgs/development/tools/kcat/default.nix
+++ b/pkgs/development/tools/kcat/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   pname = "kcat";
 
-  version = "1.6.0";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "edenhill";
     repo = "kcat";
     rev = version;
-    sha256 = "0z3bw00s269myfd1xqksjyznmgp74xfs09xqlq347adsgby3cmfs";
+    sha256 = "sha256-koDhj/RQc9fhfqjrJylhURw6tppPELhLlBGbNVJsii8=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/tools/kcat/default.nix
+++ b/pkgs/development/tools/kcat/default.nix
@@ -1,13 +1,13 @@
 { lib, stdenv, fetchFromGitHub, pkg-config, zlib, rdkafka, yajl, avro-c, libserdes }:
 
 stdenv.mkDerivation rec {
-  pname = "kafkacat";
+  pname = "kcat";
 
   version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "edenhill";
-    repo = "kafkacat";
+    repo = "kcat";
     rev = version;
     sha256 = "0z3bw00s269myfd1xqksjyznmgp74xfs09xqlq347adsgby3cmfs";
   };
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A generic non-JVM producer and consumer for Apache Kafka";
-    homepage = "https://github.com/edenhill/kafkacat";
+    homepage = "https://github.com/edenhill/kcat";
     license = licenses.bsd2;
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ nyarly ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14676,9 +14676,11 @@ with pkgs;
 
   k2tf = callPackage ../development/tools/misc/k2tf { };
 
-  kafkacat = callPackage ../development/tools/kafkacat { };
+  kafkacat = kcat;
 
   kati = callPackage ../development/tools/build-managers/kati { };
+
+  kcat = callPackage ../development/tools/kcat { };
 
   kcc = libsForQt5.callPackage ../applications/graphics/kcc { };
 


### PR DESCRIPTION
###### Motivation for this change

Software was renamed in last update. I kept kafkacat around as an alias in `all-packages.nix` for backwards-compatibility.

Somehow the Makefile seems to be broken and does not produce the right binary any more. Unsure why, would love some insight from someone more experienced with Makefiles.


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
