### PR TITLE
bismuth: init at 2.1.0

### DIFF
--- a/pkgs/desktops/plasma-5/3rdparty/addons/bismuth/0001-Avoid-usage-of-npx.patch
+++ b/pkgs/desktops/plasma-5/3rdparty/addons/bismuth/0001-Avoid-usage-of-npx.patch
@@ -1,0 +1,37 @@
+From c9aaff2461daba31a25ed20c0789ffd7c3561887 Mon Sep 17 00:00:00 2001
+From: Pasquale <p3dimaria@hotmail.it>
+Date: Tue, 9 Nov 2021 23:12:50 +0100
+Subject: [PATCH] Avoid usage of npx
+
+tsc is only used for checking type annotation
+that are stripped by esbuild
+
+---
+ src/kwinscript/CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/kwinscript/CMakeLists.txt b/src/kwinscript/CMakeLists.txt
+index 6d85d5d..6f966a4 100644
+--- a/src/kwinscript/CMakeLists.txt
++++ b/src/kwinscript/CMakeLists.txt
+@@ -29,7 +29,7 @@ add_custom_target(
+
+ add_custom_command(
+   OUTPUT "bismuth/contents/code/index.mjs"
+-  COMMAND "npx" "esbuild"
++  COMMAND "esbuild"
+   "--bundle" "${CMAKE_CURRENT_SOURCE_DIR}/index.ts"
+   "--outfile=${CMAKE_CURRENT_BINARY_DIR}/bismuth/contents/code/index.mjs"
+   "--format=esm"
+@@ -40,7 +40,7 @@ add_custom_command(
+
+ add_custom_target(
+   LintViaTSC
+-  COMMAND "npx" "tsc" "--noEmit" "--incremental"
++  COMMAND "true"
+   COMMENT "👮 Checking sources using TS Compiler..."
+ )
+
+--
+2.33.1
+

--- a/pkgs/desktops/plasma-5/3rdparty/addons/bismuth/default.nix
+++ b/pkgs/desktops/plasma-5/3rdparty/addons/bismuth/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, kcoreaddons
+, kwindowsystem
+, plasma-framework
+, systemsettings
+, cmake
+, extra-cmake-modules
+, esbuild
+}:
+
+mkDerivation rec {
+  pname = "bismuth";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "Bismuth-Forge";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-ICpGgFvVi7tiYbMCo3JWQmbA36rdWF4NFYTWIejhxr4=";
+  };
+
+  patches = [
+    ./0001-Avoid-usage-of-npx.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    esbuild
+  ];
+
+  buildInputs = [
+    kcoreaddons
+    kwindowsystem
+    plasma-framework
+    systemsettings
+  ];
+
+  meta = with lib; {
+    description = "A dynamic tiling extension for KWin";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pasqui23 ];
+    homepage = "https://bismuth-forge.github.io/bismuth/";
+    inherit (kwindowsystem.meta) platforms;
+  };
+}

--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -155,6 +155,7 @@ let
       thirdParty = let inherit (libsForQt5) callPackage; in {
         plasma-applet-caffeine-plus = callPackage ./3rdparty/addons/caffeine-plus.nix { };
         plasma-applet-virtual-desktop-bar = callPackage ./3rdparty/addons/virtual-desktop-bar.nix { };
+        bismuth = callPackage ./3rdparty/addons/bismuth { };
         kwin-dynamic-workspaces = callPackage ./3rdparty/kwin/scripts/dynamic-workspaces.nix { };
         kwin-tiling = callPackage ./3rdparty/kwin/scripts/tiling.nix { };
         krohnkite = callPackage ./3rdparty/kwin/scripts/krohnkite.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ x ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
