### PR TITLE
python3Packages.jax: 0.2.21 -> 0.2.24

### DIFF
--- a/pkgs/development/python-modules/jax/default.nix
+++ b/pkgs/development/python-modules/jax/default.nix
@@ -1,39 +1,64 @@
-{ buildPythonPackage, fetchFromGitHub, lib
-# propagatedBuildInputs
-, absl-py, numpy, opt-einsum
-# checkInputs
-, jaxlib, pytestCheckHook
+{ lib
+, absl-py
+, buildPythonPackage
+, fetchFromGitHub
+, jaxlib
+, numpy
+, opt-einsum
+, pytestCheckHook
+, pythonOlder
+, scipy
+, typing-extensions
 }:
 
 buildPythonPackage rec {
   pname = "jax";
-  version = "0.2.21";
+  version = "0.2.24";
+  format = "setuptools";
 
-  # Fetching from pypi doesn't allow us to run the test suite. See https://discourse.nixos.org/t/pythonremovetestsdir-hook-being-run-before-checkphase/14612/3.
+  disabled = pythonOlder "3.7";
+
   src = fetchFromGitHub {
     owner = "google";
     repo = pname;
     rev = "jax-v${version}";
-    sha256 = "05w157h6jv20k8w2gnmlxbycmzf24lr5v392q0c5v0qcql11q7pn";
+    sha256 = "1mmn1m4mprpwqlb1smjfdy3f74zm9p3l9dhhn25x6jrcj2cgc5pi";
   };
 
   # jaxlib is _not_ included in propagatedBuildInputs because there are
   # different versions of jaxlib depending on the desired target hardware. The
   # JAX project ships separate wheels for CPU, GPU, and TPU. Currently only the
   # CPU wheel is packaged.
-  propagatedBuildInputs = [ absl-py numpy opt-einsum ];
+  propagatedBuildInputs = [
+    absl-py
+    numpy
+    opt-einsum
+    scipy
+    typing-extensions
+  ];
 
-  checkInputs = [ jaxlib pytestCheckHook ];
+  checkInputs = [
+    jaxlib
+    pytestCheckHook
+  ];
+
   # NOTE: Don't run the tests in the expiremental directory as they require flax
   # which creates a circular dependency. See https://discourse.nixos.org/t/how-to-nix-ify-python-packages-with-circular-dependencies/14648/2.
   # Not a big deal, this is how the JAX docs suggest running the test suite
   # anyhow.
-  pytestFlagsArray = [ "-W ignore::DeprecationWarning" "tests/" ];
+  pytestFlagsArray = [
+    "-W ignore::DeprecationWarning"
+    "tests/"
+  ];
+
+  pythonImportsCheck = [
+    "jax"
+  ];
 
   meta = with lib; {
     description = "Differentiate, compile, and transform Numpy code";
-    homepage    = "https://github.com/google/jax";
-    license     = licenses.asl20;
+    homepage = "https://github.com/google/jax";
+    license = licenses.asl20;
     maintainers = with maintainers; [ samuela ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.2.24

Change log: https://github.com/google/jax/releases/tag/jax-v0.2.24 

Fix build (https://hydra.nixos.org/build/157336817)

ZHF: #144627

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
