### PR TITLE
dolphin-emu-primehack: init at 1.0.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6934,6 +6934,12 @@
     githubId = 109141;
     name = "Georges Dubus";
   };
+  Madouura = {
+    email = "madouura@gmail.com";
+    github = "Madouura";
+    githubId = 93990818;
+    name = "Madoura";
+  };
   mafo = {
     email = "Marc.Fontaine@gmx.de";
     github = "MarcFontaine";

--- a/pkgs/misc/emulators/dolphin-emu/primehack.nix
+++ b/pkgs/misc/emulators/dolphin-emu/primehack.nix
@@ -1,0 +1,151 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, cmake
+, wrapQtAppsHook
+, qtbase
+, bluez
+, ffmpeg
+, libao
+, libGLU
+, libGL
+, pcre
+, gettext
+, libXrandr
+, libusb1
+, lzo
+, libpthreadstubs
+, libXext
+, libXxf86vm
+, libXinerama
+, libSM
+, libXdmcp
+, readline
+, openal
+, udev
+, libevdev
+, portaudio
+, curl
+, alsa-lib
+, miniupnpc
+, enet
+, mbedtls
+, soundtouch
+, sfml
+, fmt
+, vulkan-loader
+, libpulseaudio
+
+# - Inputs used for Darwin
+, CoreBluetooth
+, ForceFeedback
+, IOKit
+, OpenGL
+, libpng
+, hidapi
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dolphin-emu-primehack";
+  version = "1.0.5";
+
+  src = fetchFromGitHub {
+    owner = "shiiion";
+    repo = "dolphin";
+    rev = version;
+    sha256 = "011qghswgh9l7k993lfn1hrwhgyrv9m33smgspsjq50jww6r27fl";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+  ] ++ lib.optional stdenv.isLinux wrapQtAppsHook;
+
+  buildInputs = [
+    curl
+    ffmpeg
+    libao
+    libGLU
+    libGL
+    pcre
+    gettext
+    libpthreadstubs
+    libpulseaudio
+    libXrandr
+    libXext
+    libXxf86vm
+    libXinerama
+    libSM
+    readline
+    openal
+    libXdmcp
+    lzo
+    portaudio
+    libusb1
+    libpng
+    hidapi
+    miniupnpc
+    enet
+    mbedtls
+    soundtouch
+    sfml
+    fmt
+    qtbase
+  ] ++ lib.optionals stdenv.isLinux [
+    bluez
+    udev
+    libevdev
+    alsa-lib
+    vulkan-loader
+  ] ++ lib.optionals stdenv.isDarwin [
+    CoreBluetooth
+    OpenGL
+    ForceFeedback
+    IOKit
+  ];
+
+  cmakeFlags = [
+    "-DUSE_SHARED_ENET=ON"
+    "-DENABLE_LTO=ON"
+  ] ++ lib.optionals stdenv.isDarwin [
+    "-DOSX_USE_DEFAULT_SEARCH_PATH=True"
+  ];
+
+  qtWrapperArgs = lib.optionals stdenv.isLinux [
+    "--prefix LD_LIBRARY_PATH : ${vulkan-loader}/lib"
+    # https://bugs.dolphin-emu.org/issues/11807
+    # The .desktop file should already set this, but Dolphin may be launched in other ways
+    "--set QT_QPA_PLATFORM xcb"
+  ];
+
+  # - Allow Dolphin to use nix-provided libraries instead of building them
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace 'DISTRIBUTOR "None"' 'DISTRIBUTOR "NixOS"'
+  '' + lib.optionalString stdenv.isDarwin ''
+    substituteInPlace CMakeLists.txt --replace 'if(NOT APPLE)' 'if(true)'
+    substituteInPlace CMakeLists.txt --replace 'if(LIBUSB_FOUND AND NOT APPLE)' 'if(LIBUSB_FOUND)'
+  '';
+
+  postInstall = ''
+    mv $out/bin/dolphin-emu $out/bin/dolphin-emu-primehack
+    mv $out/bin/dolphin-emu-nogui $out/bin/dolphin-emu-primehack-nogui
+    mv $out/share/applications/dolphin-emu.desktop $out/share/applications/dolphin-emu-primehack.desktop
+    mv $out/share/icons/hicolor/256x256/apps/dolphin-emu.png $out/share/icons/hicolor/256x256/apps/dolphin-emu-primehack.png
+    substituteInPlace $out/share/applications/dolphin-emu-primehack.desktop --replace 'dolphin-emu' 'dolphin-emu-primehack'
+  '' + lib.optionalString stdenv.hostPlatform.isLinux ''
+    install -D $src/Data/51-usb-device.rules $out/etc/udev/rules.d/51-usb-device.rules
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/shiiion/dolphin";
+    description = "Gamecube/Wii/Triforce emulator for x86_64 and ARMv8";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ MP2E ashkitten Madouura ];
+    # x86_32 is an unsupported platform.
+    # Enable generic build if you really want a JIT-less binary.
+    broken = stdenv.isDarwin;
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4575,6 +4575,9 @@ with pkgs;
   dolphinEmuMaster = qt5.callPackage ../misc/emulators/dolphin-emu/master.nix {
     inherit (darwin.apple_sdk.frameworks) CoreBluetooth ForceFeedback IOKit OpenGL;
   };
+  dolphin-emu-primehack = qt5.callPackage ../misc/emulators/dolphin-emu/primehack.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreBluetooth ForceFeedback IOKit OpenGL;
+  };
 
   domoticz = callPackage ../servers/domoticz { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Dolphin fork specifically for the Metroid Prime games.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
