### PR TITLE
pynut2: init at 2.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6861,6 +6861,12 @@
     githubId = 13791;
     name = "Luke Gorrie";
   };
+  luker = {
+    email = "luker@fenrirproject.org";
+    github = "LucaFulchir";
+    githubId = 2486026;
+    name = "Luca Fulchir";
+  };
   lumi = {
     email = "lumi@pew.im";
     github = "lumi-me-not";

--- a/pkgs/development/python-modules/pynut2/default.nix
+++ b/pkgs/development/python-modules/pynut2/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, requests
+#, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pynut2";
+  version = "2.1.2";
+
+  src = fetchFromGitHub {
+    owner = "mezz64";
+    repo = "python-nut2";
+    rev = version;
+    sha256 = "1lg7n1frndfgw73s0ssl1h7kc6zxm7fpiwlc6v6d60kxzaj1dphx";
+  };
+
+  propagatedBuildInputs = [
+    requests
+  ];
+
+  # tests are completely broken, wrong imports and old api
+  #checkInputs = [
+  #  pytestCheckHook
+  #];
+
+  pythonImportsCheck = [ "pynut2.nut2" ];
+
+  meta = with lib; {
+    description = "API overhaul of PyNUT, a Python library to allow communication with NUT (Network UPS Tools) servers.";
+    homepage = "https://github.com/mezz64/python-nut2";
+    license = with licenses; [ gpl3Plus ];
+    maintainers = [ maintainers.luker ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -590,7 +590,7 @@
     "nuki" = ps: with ps; [ pynuki ];
     "numato" = ps: with ps; [ ]; # missing inputs: numato-gpio
     "number" = ps: with ps; [ ];
-    "nut" = ps: with ps; [ ]; # missing inputs: pynut2
+    "nut" = ps: with ps; [ pynut2 ];
     "nws" = ps: with ps; [ pynws ];
     "nx584" = ps: with ps; [ pynx584 ];
     "nzbget" = ps: with ps; [ ]; # missing inputs: pynzbgetapi

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5731,6 +5731,8 @@ in {
 
   pynuki = callPackage ../development/python-modules/pynuki { };
 
+  pynut2 = callPackage ../development/python-modules/pynut2 { };
+
   pynws = callPackage ../development/python-modules/pynws { };
 
   pynx584 = callPackage ../development/python-modules/pynx584 { };


### PR DESCRIPTION
Added pynut2 and added home-assistant dependency to it

###### Motivation for this change

Home-assistant integration with Network Ups Tools was not working, this library was missing.  
Added it to nixpkg and added the dependency to home-assistant.

Tested and currently working on x86-64  
Note that python tests are disabled, due to broken tests (I think)  
I left that part commented out to avoid others wasting time trying to reintroduce tests  

to test in home-assistant, add a `nut: {}` section in the config (Again, working and reporting correct values)

This is my first contribution, feel free to comment on what to do better.
I added myself to the maintainers list as required from CONTRIBUTING.md

###### Things done


- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
