### PR TITLE
sdat2img: init at unstable-2021-11-9

### DIFF
--- a/pkgs/tools/filesystems/sdat2img/default.nix
+++ b/pkgs/tools/filesystems/sdat2img/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, fetchFromGitHub, python3Packages }:
+
+python3Packages.buildPythonApplication {
+  pname = "sdat2img";
+  version = "unstable-2021-11-09";
+
+  src = fetchFromGitHub {
+    repo = "sdat2img";
+    owner = "xpirt";
+    rev = "b432c988a412c06ff24d196132e354712fc18929";
+    sha256 = "sha256-NCbf9H0hoJgeDtP6cQY0H280BQqgKXv3ConZ87QixVY=";
+  };
+
+  format = "other";
+  installPhase = ''
+    install -D $src/sdat2img.py $out/bin/sdat2img
+  '';
+
+  meta = {
+    description = "Convert sparse Android data image (.dat) into filesystem ext4 image (.img)";
+    homepage = "https://github.com/xpirt/sdat2img";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.xaverdh ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9330,6 +9330,8 @@ with pkgs;
 
   sdate = callPackage ../tools/misc/sdate { };
 
+  sdat2img = callPackage ../tools/filesystems/sdat2img { };
+
   sdcv = callPackage ../applications/misc/sdcv { };
 
   sdl-jstest = callPackage ../tools/misc/sdl-jstest { };


### PR DESCRIPTION
###### Motivation for this change
Useful for working with Android roms. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
