### PR TITLE
python3Packages.python-engineio: 4.2.1 -> 4.3.0, python3Packages.python-socketio: 5.4.0 -> 5.4.1

### DIFF
--- a/pkgs/development/python-modules/python-engineio/default.nix
+++ b/pkgs/development/python-modules/python-engineio/default.nix
@@ -1,28 +1,32 @@
-{ lib, stdenv
-, buildPythonPackage
-, fetchFromGitHub
+{ lib
+, stdenv
 , aiohttp
+, buildPythonPackage
 , eventlet
+, fetchFromGitHub
 , iana-etc
 , libredirect
 , mock
+, pytestCheckHook
+, pythonOlder
 , requests
 , six
 , tornado
 , websocket-client
-, websockets
-, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "python-engineio";
-  version = "4.2.1";
+  version = "4.3.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "miguelgrinberg";
     repo = "python-engineio";
     rev = "v${version}";
-    sha256 = "sha256-aAoTeQZCtxddVBPwlyv2j4aACMO9p0vQ/ESkkv4E3VE=";
+    sha256 = "sha256-ohNRtceh0bHBlnGSFUckG5KzoLY8Q1jvpFee7T78Vto=";
   };
 
   checkInputs = [
@@ -32,7 +36,6 @@ buildPythonPackage rec {
     requests
     tornado
     websocket-client
-    websockets
     pytestCheckHook
   ];
 
@@ -43,11 +46,19 @@ buildPythonPackage rec {
     export NIX_REDIRECTS=/etc/protocols=${iana-etc}/etc/protocols:/etc/resolv.conf=$(realpath resolv.conf) \
       LD_PRELOAD=${libredirect}/lib/libredirect.so
   '';
-  postCheck = "unset NIX_REDIRECTS LD_PRELOAD";
+
+  postCheck = ''
+    unset NIX_REDIRECTS LD_PRELOAD
+  '';
 
   # somehow effective log level does not change?
-  disabledTests = [ "test_logger" ];
-  pythonImportsCheck = [ "engineio" ];
+  disabledTests = [
+    "test_logger"
+  ];
+
+  pythonImportsCheck = [
+    "engineio"
+  ];
 
   meta = with lib; {
     description = "Python based Engine.IO client and server";

--- a/pkgs/development/python-modules/python-socketio/default.nix
+++ b/pkgs/development/python-modules/python-socketio/default.nix
@@ -1,4 +1,5 @@
 { lib
+, aiohttp
 , bidict
 , buildPythonPackage
 , fetchFromGitHub
@@ -6,22 +7,31 @@
 , msgpack
 , pytestCheckHook
 , python-engineio
+, pythonOlder
+, requests
+, websocket-client
 }:
 
 buildPythonPackage rec {
   pname = "python-socketio";
-  version = "5.4.0";
+  version = "5.4.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "miguelgrinberg";
     repo = "python-socketio";
     rev = "v${version}";
-    sha256 = "sha256-0Q1R8XPciU5AEkj7Exlc906eyA5juYKzzA/Ygnzx7XU=";
+    sha256 = "sha256-qmC7AL2ZNB0D5p3c8ozacNMKc2COzYzPJfz6KXwWsd0=";
   };
 
   propagatedBuildInputs = [
+    aiohttp
     bidict
     python-engineio
+    requests
+    websocket-client
   ];
 
   checkInputs = [
@@ -30,7 +40,9 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "socketio" ];
+  pythonImportsCheck = [
+    "socketio"
+  ];
 
   meta = with lib; {
     description = "Python Socket.IO server and client";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream releases

Change log:
- https://github.com/miguelgrinberg/python-socketio/blob/main/CHANGES.md
- https://github.com/miguelgrinberg/python-engineio/blob/main/CHANGES.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
