### PR TITLE
unrar-wrapper: init at 1.0.0

### DIFF
--- a/pkgs/tools/archivers/unrar-wrapper/default.nix
+++ b/pkgs/tools/archivers/unrar-wrapper/default.nix
@@ -1,0 +1,36 @@
+{ lib, buildPythonApplication, fetchFromGitHub, unar }:
+
+buildPythonApplication rec {
+  pname = "unrar-wrapper";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "openSUSE";
+    repo = "unrar_wrapper";
+    rev = "unrar_wrapper-${version}";
+    sha256 = "sha256-HjrUif8MrbtLjRQMAPZ/Y2o43rGSDj0HHY4fZQfKz5w=";
+  };
+
+  makeWrapperArgs = [
+    "--prefix" "PATH" ":" "${lib.makeBinPath [ unar ]}"
+  ];
+
+  postFixup = ''
+    ln -s $out/bin/unrar_wrapper $out/bin/unrar
+    rm -rf $out/nix-support/propagated-build-inputs
+  '';
+
+  setupHook = ./setup-hook.sh;
+
+  meta = with lib; {
+    homepage = "https://github.com/openSUSE/unrar_wrapper";
+    description = "Backwards compatibility between unar and unrar";
+    longDescription = ''
+      unrar_wrapper is a wrapper python script that transforms the basic UnRAR commands
+      to unar and lsar calls in order to provide a backwards compatibility.
+    '';
+    license = licenses.gpl3Only;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ artturin ];
+  };
+}

--- a/pkgs/tools/archivers/unrar-wrapper/setup-hook.sh
+++ b/pkgs/tools/archivers/unrar-wrapper/setup-hook.sh
@@ -1,0 +1,5 @@
+unpackCmdHooks+=(_tryUnrar)
+_tryUnrar() {
+    if ! [[ "$curSrc" =~ \.rar$ ]]; then return 1; fi
+    unrar x "$curSrc" >/dev/null
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10602,6 +10602,8 @@ with pkgs;
 
   unrar = callPackage ../tools/archivers/unrar { };
 
+  unrar-wrapper = python3Packages.callPackage ../tools/archivers/unrar-wrapper { };
+
   vul = callPackage ../applications/misc/vul { };
 
   xar = callPackage ../tools/compression/xar { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
a non-nonfree wrapper alternative to unrar from openSUSE
https://github.com/openSUSE/unrar_wrapper

>>>  unrar_wrapper is a wrapper python script that transforms the basic UnRAR commands to unar and lsar calls in order to provide a backwards compatibility. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
