### PR TITLE
terranix: use wrapProgram on terranix-doc-json

### DIFF
--- a/pkgs/applications/networking/cluster/terranix/default.nix
+++ b/pkgs/applications/networking/cluster/terranix/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, jq, nix, ... }:
+{ stdenv, lib, fetchFromGitHub, jq, nix, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "terranix";
@@ -11,29 +11,21 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-HDiyJGgyDUoLnpL8N+wDm3cM/vEfYYc/p4N1kKH/kLk=";
   };
 
+  nativeBuildInputs = [ makeWrapper ];
+
   installPhase = ''
     mkdir -p $out/{bin,core,modules,lib}
     mv bin core modules lib $out/
 
-    mv $out/bin/terranix-doc-json $out/bin/.wrapper_terranix-doc-json
-
-    # manual wrapper because makeWrapper expectes executables
-    wrapper=$out/bin/terranix-doc-json
-    cat <<EOF>$wrapper
-    #!/usr/bin/env bash
-    export PATH=$PATH:${jq}/bin:${nix}/bin
-    $out/bin/.wrapper_terranix-doc-json "\$@"
-    EOF
-    chmod +x $wrapper
+    wrapProgram $out/bin/terranix-doc-json \
+      --prefix PATH : ${lib.makeBinPath [ jq nix ]}
   '';
 
   meta = with lib; {
     description = "A NixOS like terraform-json generator";
     homepage = "https://terranix.org";
     license = licenses.gpl3;
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ mrVanDalo ];
   };
-
 }
-


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`wrapProgram` does work in scripts.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
