### PR TITLE
OpenWebRX: init, nixos/openwebrx

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1015,6 +1015,7 @@
   ./services/web-apps/pgpkeyserver-lite.nix
   ./services/web-apps/matomo.nix
   ./services/web-apps/moinmoin.nix
+  ./services/web-apps/openwebrx.nix
   ./services/web-apps/restya-board.nix
   ./services/web-apps/sogo.nix
   ./services/web-apps/rss-bridge.nix

--- a/nixos/modules/services/web-apps/openwebrx.nix
+++ b/nixos/modules/services/web-apps/openwebrx.nix
@@ -1,0 +1,33 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.services.openwebrx;
+in
+{
+  options.services.openwebrx = with lib; {
+    enable = mkEnableOption "OpenWebRX Web interface for Software-Defined Radios on http://localhost:8073";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.openwebrx;
+      description = "OpenWebRX package to use for the service";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.openwebrx = {
+      wantedBy = [ "multi-user.target" ];
+      path = with pkgs; [
+        csdr
+        alsaUtils
+        netcat
+      ];
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/openwebrx";
+        Restart = "always";
+        DynamicUser = true;
+        # openwebrx uses /var/lib/openwebrx by default
+        StateDirectory = [ "openwebrx" ];
+      };
+    };
+  };
+}

--- a/pkgs/applications/radio/csdr/default.nix
+++ b/pkgs/applications/radio/csdr/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, lib, fetchFromGitHub
+, autoreconfHook, pkg-config, fftwFloat, libsamplerate
+}:
+
+stdenv.mkDerivation rec {
+  pname = "csdr";
+  version = "0.17.1";
+
+  src = fetchFromGitHub {
+    owner = "jketterl";
+    repo = pname;
+    rev = version;
+    sha256 = "1vip5a3xgskcwba3xi66zfr986xrsch9na7my818cm8vw345y57b";
+  };
+
+  patchPhase = ''
+    substituteInPlace configure.ac \
+      --replace -Wformat=0 ""
+  '';
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    fftwFloat
+    libsamplerate
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/jketterl/csdr";
+    description = "A simple DSP library and command-line tool for Software Defined Radio";
+    license = licenses.gpl3Only;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ astro ];
+  };
+}

--- a/pkgs/applications/radio/openwebrx/default.nix
+++ b/pkgs/applications/radio/openwebrx/default.nix
@@ -1,0 +1,92 @@
+{ stdenv, lib, buildPythonPackage, buildPythonApplication, fetchFromGitHub
+, pkg-config, cmake, setuptools
+, rtl-sdr, soapysdr-with-plugins, csdr, direwolf
+}:
+
+let
+
+  js8py = buildPythonPackage rec {
+    pname = "js8py";
+    version = "0.1.1";
+
+    src = fetchFromGitHub {
+      owner = "jketterl";
+      repo = pname;
+      rev = version;
+      sha256 = "1j80zclg1cl5clqd00qqa16prz7cyc32bvxqz2mh540cirygq24w";
+    };
+
+    pythonImportsCheck = [ "js8py" "test" ];
+
+    meta = with lib; {
+      homepage = "https://github.com/jketterl/js8py";
+      description = "A library to decode the output of the js8 binary of JS8Call";
+      license = licenses.gpl3Only;
+      maintainers = with maintainers; [ astro ];
+    };
+  };
+
+  owrx_connector = stdenv.mkDerivation rec {
+    pname = "owrx_connector";
+    version = "0.5.0";
+
+    src = fetchFromGitHub {
+      owner = "jketterl";
+      repo = pname;
+      rev = version;
+      sha256 = "0gz4nf2frrkx1mpjfjpz2j919fkc99g5lxd8lhva3lgqyisvf4yj";
+    };
+
+    nativeBuildInputs = [
+      cmake
+      pkg-config
+    ];
+
+    buildInputs = [
+      rtl-sdr
+      soapysdr-with-plugins
+    ];
+
+    meta = with lib; {
+      homepage = "https://github.com/jketterl/owrx_connector";
+      description = "A set of connectors that are used by OpenWebRX to interface with SDR hardware";
+      license = licenses.gpl3Only;
+      platforms = platforms.unix;
+      maintainers = with maintainers; [ astro ];
+    };
+  };
+
+in
+buildPythonApplication rec {
+  pname = "openwebrx";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "jketterl";
+    repo = pname;
+    rev = version;
+    sha256 = "0maxs07yx235xknvkbmhi2zds3vfkd66l6wz6kspz3jzl4c0v1f9";
+  };
+
+  propagatedBuildInputs = [
+    setuptools
+    csdr
+    js8py
+    soapysdr-with-plugins
+    owrx_connector
+    direwolf
+  ];
+
+  pythonImportsCheck = [ "csdr" "owrx" "test" ];
+
+  passthru = {
+    inherit js8py owrx_connector;
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/jketterl/openwebrx";
+    description = "A simple DSP library and command-line tool for Software Defined Radio";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ astro ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18895,6 +18895,11 @@ with pkgs;
 
   openrct2 = callPackage ../games/openrct2 { };
 
+  openwebrx = callPackage ../applications/radio/openwebrx {
+    inherit (python3Packages)
+    buildPythonPackage buildPythonApplication setuptools;
+  };
+
   optparse-bash = callPackage ../development/libraries/optparse-bash { };
 
   orcania = callPackage ../development/libraries/orcania { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15875,6 +15875,8 @@ with pkgs;
 
   cryptominisat = callPackage ../applications/science/logic/cryptominisat { };
 
+  csdr = callPackage ../applications/radio/csdr { };
+
   ctypes_sh = callPackage ../development/libraries/ctypes_sh { };
 
   curlcpp = callPackage ../development/libraries/curlcpp { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add a web-app for Software-Defined Radio

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
