### PR TITLE
treewide: quote urls according to rfc 0045

### DIFF
--- a/nixos/modules/services/web-apps/hledger-web.nix
+++ b/nixos/modules/services/web-apps/hledger-web.nix
@@ -118,7 +118,7 @@ in {
         ++ extraOptions);
     in {
       description = "hledger-web - web-app for the hledger accounting tool.";
-      documentation = [ https://hledger.org/hledger-web.html ];
+      documentation = [ "https://hledger.org/hledger-web.html" ];
       wantedBy = [ "multi-user.target" ];
       after = [ "networking.target" ];
       serviceConfig = mkMerge [

--- a/pkgs/applications/audio/freqtweak/default.nix
+++ b/pkgs/applications/audio/freqtweak/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with lib; {
-    homepage = http://essej.net/freqtweak/;
+    homepage = "http://essej.net/freqtweak/";
     description = "Realtime audio frequency spectral manipulation";
     maintainers = [ maintainers.magnetophon ];
     platforms = platforms.linux;

--- a/pkgs/applications/audio/kapitonov-plugins-pack/default.nix
+++ b/pkgs/applications/audio/kapitonov-plugins-pack/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Set of LADSPA and LV2 plugins for guitar sound processing";
-    homepage = https://github.com/olegkapitonov/Kapitonov-Plugins-Pack;
+    homepage = "https://github.com/olegkapitonov/Kapitonov-Plugins-Pack";
     license = licenses.gpl3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ magnetophon ];

--- a/pkgs/applications/blockchains/whirlpool-gui/default.nix
+++ b/pkgs/applications/blockchains/whirlpool-gui/default.nix
@@ -96,7 +96,7 @@ in stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Desktop GUI for Whirlpool by Samourai-Wallet";
-    homepage = https://www.samouraiwallet.com/whirlpool;
+    homepage = "https://www.samouraiwallet.com/whirlpool";
     license = licenses.unlicense;
     maintainers = [ maintainers.offline ];
     platforms = [ "x86_64-linux" ];

--- a/pkgs/applications/misc/smos/default.nix
+++ b/pkgs/applications/misc/smos/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A comprehensive self-management system";
-    homepage = https://smos.online;
+    homepage = "https://smos.online";
     license = licenses.mit;
     maintainers = with maintainers; [ norfair ];
     platforms = platforms.linux ++ platforms.darwin;

--- a/pkgs/applications/networking/cluster/nixops/default.nix
+++ b/pkgs/applications/networking/cluster/nixops/default.nix
@@ -23,7 +23,7 @@ let
                 '';
 
                 meta = old.meta // {
-                  homepage = https://github.com/NixOS/nixops;
+                  homepage = "https://github.com/NixOS/nixops";
                   description = "NixOS cloud provisioning and deployment tool";
                   maintainers = with lib.maintainers; [ adisbladis aminechikhaoui eelco rob domenkozar ];
                   platforms = lib.platforms.unix;

--- a/pkgs/applications/radio/dsd/default.nix
+++ b/pkgs/applications/radio/dsd/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
       tap audio and synthesize the decoded speech. Speech synthesis requires
       mbelib, which is a separate package.
     '';
-    homepage = https://github.com/szechyjs/dsd;
+    homepage = "https://github.com/szechyjs/dsd";
     license = licenses.gpl2;
     platforms = platforms.unix;
     maintainers = with maintainers; [ andrew-d ];

--- a/pkgs/applications/science/machine-learning/starspace/default.nix
+++ b/pkgs/applications/science/machine-learning/starspace/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "General-purpose neural model for efficient learning of entity embeddings";
-    homepage = https://ai.facebook.com/tools/starspace/;
+    homepage = "https://ai.facebook.com/tools/starspace/";
     license = licenses.mit;
     platforms = platforms.unix;
     maintainers = [ maintainers.mausch ];

--- a/pkgs/applications/science/physics/xflr5/default.nix
+++ b/pkgs/applications/science/physics/xflr5/default.nix
@@ -13,7 +13,7 @@ mkDerivation rec {
 
   meta = with lib; {
     description = "An analysis tool for airfoils, wings and planes";
-    homepage = https://sourceforge.net/projects/xflr5/;
+    homepage = "https://sourceforge.net/projects/xflr5/";
     license = licenses.gpl3;
     maintainers = [ maintainers.esclear ];
     platforms = platforms.linux;

--- a/pkgs/applications/version-management/commitizen/node-packages.nix
+++ b/pkgs/applications/version-management/commitizen/node-packages.nix
@@ -9061,7 +9061,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Git commit, but play nice with conventions.";
-      homepage = https://github.com/commitizen/cz-cli;
+      homepage = "https://github.com/commitizen/cz-cli";
       license = "MIT";
     };
     production = false;

--- a/pkgs/data/fonts/vista-fonts-cht/default.nix
+++ b/pkgs/data/fonts/vista-fonts-cht/default.nix
@@ -5,7 +5,7 @@ stdenvNoCC.mkDerivation {
   version = "1";
 
   src = fetchurl {
-    url = https://download.microsoft.com/download/7/6/b/76bd7a77-be02-47f3-8472-fa1de7eda62f/VistaFont_CHT.EXE;
+    url = "https://download.microsoft.com/download/7/6/b/76bd7a77-be02-47f3-8472-fa1de7eda62f/VistaFont_CHT.EXE";
     sha256 = "sha256-fSnbbxlMPzbhFSQyKxQaS5paiWji8njK7tS8Eppsj6g=";
   };
 

--- a/pkgs/development/compilers/gnatboot/default.nix
+++ b/pkgs/development/compilers/gnatboot/default.nix
@@ -10,12 +10,12 @@ stdenv.mkDerivation {
 
   src = if stdenv.hostPlatform.system == "i686-linux" then
     fetchurl {
-      url = mirror://gentoo/distfiles/gnatboot-4.1-i386.tar.bz2;
+      url = "mirror://gentoo/distfiles/gnatboot-4.1-i386.tar.bz2";
       sha256 = "0665zk71598204bf521vw68i5y6ccqarq9fcxsqp7ccgycb4lysr";
     }
   else if stdenv.hostPlatform.system == "x86_64-linux" then
     fetchurl {
-      url = mirror://gentoo/distfiles/gnatboot-4.1-amd64.tar.bz2;
+      url = "mirror://gentoo/distfiles/gnatboot-4.1-amd64.tar.bz2";
       sha256 = "1li4d52lmbnfs6llcshlbqyik2q2q4bvpir0f7n38nagp0h6j0d4";
     }
   else

--- a/pkgs/development/coq-modules/serapi/default.nix
+++ b/pkgs/development/coq-modules/serapi/default.nix
@@ -57,7 +57,7 @@ in
   '';
 
   meta = with lib; {
-    homepage = https://github.com/ejgallego/coq-serapi;
+    homepage = "https://github.com/ejgallego/coq-serapi";
     description = "SerAPI is a library for machine-to-machine interaction with the Coq proof assistant";
     license = licenses.lgpl21Plus;
     maintainers = [ maintainers.Zimmi48 ];

--- a/pkgs/development/interpreters/jelly/default.nix
+++ b/pkgs/development/interpreters/jelly/default.nix
@@ -20,7 +20,7 @@ python3Packages.buildPythonApplication {
 
   meta = with lib; {
     description = "A recreational programming language inspired by J";
-    homepage    = https://github.com/DennisMitchell/jellylanguage;
+    homepage    = "https://github.com/DennisMitchell/jellylanguage";
     license     = licenses.mit;
     maintainers = [ maintainers.tckmn ];
     platforms   = platforms.all;

--- a/pkgs/development/libraries/LAStools/default.nix
+++ b/pkgs/development/libraries/LAStools/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Software for rapid LiDAR processing";
-    homepage = http://lastools.org/;
+    homepage = "http://lastools.org/";
     license = licenses.unfree;
     maintainers = with maintainers; [ stephenwithph ];
     platforms = platforms.unix;

--- a/pkgs/development/libraries/audio/mbelib/default.nix
+++ b/pkgs/development/libraries/audio/mbelib/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "P25 Phase 1 and ProVoice vocoder";
-    homepage = https://github.com/szechyjs/mbelib;
+    homepage = "https://github.com/szechyjs/mbelib";
     license = licenses.isc;
     platforms = platforms.unix;
     maintainers = with maintainers; [ andrew-d ];

--- a/pkgs/development/libraries/blitz/default.nix
+++ b/pkgs/development/libraries/blitz/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Fast multi-dimensional array library for C++";
-    homepage = https://sourceforge.net/projects/blitz/;
+    homepage = "https://sourceforge.net/projects/blitz/";
     license = licenses.lgpl3;
     platforms = platforms.unix;
     maintainers = with maintainers; [ ToxicFrog ];

--- a/pkgs/development/libraries/libbacktrace/default.nix
+++ b/pkgs/development/libraries/libbacktrace/default.nix
@@ -19,7 +19,7 @@ in stdenv.mkDerivation rec {
   ];
   meta = with lib; {
     description = "A C library that may be linked into a C/C++ program to produce symbolic backtraces";
-    homepage = https://github.com/ianlancetaylor/libbacktrace;
+    homepage = "https://github.com/ianlancetaylor/libbacktrace";
     maintainers = with maintainers; [ twey ];
     license = with licenses; [ bsd3 ];
   };

--- a/pkgs/development/libraries/libsmartcols/default.nix
+++ b/pkgs/development/libraries/libsmartcols/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "smart column output alignment library";
-    homepage = https://github.com/karelzak/util-linux/tree/master/libsmartcols;
+    homepage = "https://github.com/karelzak/util-linux/tree/master/libsmartcols";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     maintainers = with lib.maintainers; [ rb2k ];

--- a/pkgs/development/libraries/science/math/itpp/default.nix
+++ b/pkgs/development/libraries/science/math/itpp/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "IT++ is a C++ library of mathematical, signal processing and communication classes and functions";
-    homepage = http://itpp.sourceforge.net/;
+    homepage = "http://itpp.sourceforge.net/";
     license = licenses.gpl3;
     platforms = platforms.unix;
     maintainers = with maintainers; [ andrew-d ];

--- a/pkgs/development/libraries/sqlite/tools.nix
+++ b/pkgs/development/libraries/sqlite/tools.nix
@@ -20,7 +20,7 @@ let
 
     meta = with lib; {
       inherit description homepage;
-      downloadPage = http://sqlite.org/download.html;
+      downloadPage = "http://sqlite.org/download.html";
       license = licenses.publicDomain;
       maintainers = with maintainers; [ johnazoidberg ];
       platforms = platforms.unix;

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
@@ -298,7 +298,7 @@ $out/lib/common-lisp/query-fs"
         patch -p1 < ${
           pkgs.fetchurl {
             # https://github.com/sabracrolleton/uax-15/pull/12
-            url = https://github.com/nuddyco/uax-15/commit/d553181669f488636df03d60ad7f5bec64d566bf.diff;
+            url = "https://github.com/nuddyco/uax-15/commit/d553181669f488636df03d60ad7f5bec64d566bf.diff";
             sha256 = "sha256:1608jzw7giy18vlw7pz4pl8prwlprgif8zcl9hwa0wf5gdxwd7gn";
           }}
       '';

--- a/pkgs/development/misc/msp430/mspds/binary.nix
+++ b/pkgs/development/misc/msp430/mspds/binary.nix
@@ -27,7 +27,7 @@ in stdenv.mkDerivation rec {
 
   meta = {
     description = "Unfree binary release of the TI MSP430 FET debug driver";
-    homepage = https://www.ti.com/tool/MSPDS;
+    homepage = "https://www.ti.com/tool/MSPDS";
     license = licenses.unfree;
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ aerialx ];

--- a/pkgs/development/misc/msp430/mspds/default.nix
+++ b/pkgs/development/misc/msp430/mspds/default.nix
@@ -48,7 +48,7 @@ in stdenv.mkDerivation {
 
   meta = {
     description = "TI MSP430 FET debug driver";
-    homepage = https://www.ti.com/tool/MSPDS;
+    homepage = "https://www.ti.com/tool/MSPDS";
     license = licenses.bsd3;
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ aerialx ];

--- a/pkgs/development/ocaml-modules/genspio/default.nix
+++ b/pkgs/development/ocaml-modules/genspio/default.nix
@@ -24,7 +24,7 @@ buildDunePackage rec {
   doCheck = true;
 
   meta = with lib; {
-    homepage = https://smondet.gitlab.io/genspio-doc/;
+    homepage = "https://smondet.gitlab.io/genspio-doc/";
     description = "Typed EDSL to generate POSIX Shell scripts";
     license = licenses.asl20;
     maintainers = [ maintainers.alexfmpe ];

--- a/pkgs/development/ocaml-modules/hidapi/default.nix
+++ b/pkgs/development/ocaml-modules/hidapi/default.nix
@@ -21,7 +21,7 @@ buildDunePackage rec {
   doCheck = true;
 
   meta = with lib; {
-    homepage = https://github.com/vbmithr/ocaml-hidapi;
+    homepage = "https://github.com/vbmithr/ocaml-hidapi";
     description = "Bindings to Signal11's hidapi library";
     license = licenses.isc;
     maintainers = [ maintainers.alexfmpe ];

--- a/pkgs/development/ocaml-modules/nonstd/default.nix
+++ b/pkgs/development/ocaml-modules/nonstd/default.nix
@@ -14,7 +14,7 @@ buildDunePackage rec {
   doCheck = true;
 
   meta = with lib; {
-    homepage = https://bitbucket.org/smondet/nonstd;
+    homepage = "https://bitbucket.org/smondet/nonstd";
     description = "Non-standard mini-library";
     license = licenses.isc;
     maintainers = [ maintainers.alexfmpe ];

--- a/pkgs/development/ocaml-modules/sosa/default.nix
+++ b/pkgs/development/ocaml-modules/sosa/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = with lib; {
-    homepage = http://www.hammerlab.org/docs/sosa/master/index.html;
+    homepage = "http://www.hammerlab.org/docs/sosa/master/index.html";
     description = "Sane OCaml String API";
     license = licenses.isc;
     maintainers = [ maintainers.alexfmpe ];

--- a/pkgs/development/ocaml-modules/uecc/default.nix
+++ b/pkgs/development/ocaml-modules/uecc/default.nix
@@ -27,7 +27,7 @@ buildDunePackage rec {
 
   meta = {
     description = "Bindings for ECDH and ECDSA for 8-bit, 32-bit, and 64-bit processors";
-    homepage = https://gitlab.com/nomadic-labs/ocaml-uecc;
+    homepage = "https://gitlab.com/nomadic-labs/ocaml-uecc";
     license = lib.licenses.isc;
     maintainers = [ lib.maintainers.ulrikstrid ];
   };

--- a/pkgs/development/python-modules/android-backup/default.nix
+++ b/pkgs/development/python-modules/android-backup/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Unpack and repack android backups";
-    homepage = https://github.com/bluec0re/android-backup-tools;
+    homepage = "https://github.com/bluec0re/android-backup-tools";
     license = licenses.asl20;
     maintainers = with maintainers; [ dotlambda ];
   };

--- a/pkgs/development/python-modules/gviz-api/default.nix
+++ b/pkgs/development/python-modules/gviz-api/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Python API for Google Visualization";
-    homepage = https://developers.google.com/chart/interactive/docs/dev/gviz_api_lib;
+    homepage = "https://developers.google.com/chart/interactive/docs/dev/gviz_api_lib";
     license = licenses.asl20;
     maintainers = with maintainers; [ ndl ];
   };

--- a/pkgs/development/python-modules/ifcopenshell/default.nix
+++ b/pkgs/development/python-modules/ifcopenshell/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Open source IFC library and geometry engine";
-    homepage    = http://ifcopenshell.org/;
+    homepage    = "http://ifcopenshell.org/";
     license     = licenses.lgpl3;
     maintainers = with maintainers; [ fehnomenal ];
   };

--- a/pkgs/development/python-modules/python-csxcad/default.nix
+++ b/pkgs/development/python-modules/python-csxcad/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Python interface to CSXCAD";
-    homepage = http://openems.de/index.php/Main_Page.html;
+    homepage = "http://openems.de/index.php/Main_Page.html";
     license = licenses.gpl3;
     maintainers = with maintainers; [ matthuszagh ];
     platforms = platforms.linux;

--- a/pkgs/development/python-modules/pyworld/default.nix
+++ b/pkgs/development/python-modules/pyworld/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "PyWorld is a Python wrapper for WORLD vocoder";
-    homepage = https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder;
+    homepage = "https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder";
     license = licenses.mit;
     maintainers = [ maintainers.mic92 ];
   };

--- a/pkgs/development/python-modules/tensorboard-plugin-profile/default.nix
+++ b/pkgs/development/python-modules/tensorboard-plugin-profile/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Profile Tensorboard Plugin.";
-    homepage = http://tensorflow.org;
+    homepage = "http://tensorflow.org";
     license = licenses.asl20;
     maintainers = with maintainers; [ ndl ];
   };

--- a/pkgs/development/tools/checkmake/default.nix
+++ b/pkgs/development/tools/checkmake/default.nix
@@ -37,7 +37,7 @@ buildGoPackage rec {
 
   meta = with lib; {
     description = "Experimental tool for linting and checking Makefiles";
-    homepage = https://github.com/mrtazz/checkmake;
+    homepage = "https://github.com/mrtazz/checkmake";
     license = licenses.mit;
     maintainers = with maintainers; [ vidbina ];
     platforms = platforms.linux;

--- a/pkgs/development/tools/java/dex2jar/default.nix
+++ b/pkgs/development/tools/java/dex2jar/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = https://sourceforge.net/projects/dex2jar/;
+    homepage = "https://sourceforge.net/projects/dex2jar/";
     description = "Tools to work with android .dex and java .class files";
     maintainers = with maintainers; [ makefu ];
     license = licenses.asl20;

--- a/pkgs/servers/pleroma/default.nix
+++ b/pkgs/servers/pleroma/default.nix
@@ -204,7 +204,7 @@ beamPackages.mixRelease rec {
 
   meta = with lib; {
     description = "ActivityPub microblogging server";
-    homepage = https://git.pleroma.social/pleroma/pleroma;
+    homepage = "https://git.pleroma.social/pleroma/pleroma";
     license = licenses.agpl3;
     maintainers = with maintainers; [ petabyteboy ninjatrappeur yuka ];
     platforms = [ "x86_64-linux" "aarch64-linux" ];

--- a/pkgs/servers/search/meilisearch/default.nix
+++ b/pkgs/servers/search/meilisearch/default.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage {
   buildInputs = lib.optionals stdenv.isDarwin [ Security DiskArbitration Foundation ];
   meta = with lib; {
     description = "Powerful, fast, and an easy to use search engine ";
-    homepage = https://docs.meilisearch.com/;
+    homepage = "https://docs.meilisearch.com/";
     license = licenses.mit;
     maintainers = with maintainers; [ happysalada ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ];

--- a/pkgs/servers/web-apps/bookstack/php-packages.nix
+++ b/pkgs/servers/web-apps/bookstack/php-packages.nix
@@ -7,7 +7,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "aws-aws-crt-php-3942776a8c99209908ee0b287746263725685732";
         src = fetchurl {
-          url = https://api.github.com/repos/awslabs/aws-crt-php/zipball/3942776a8c99209908ee0b287746263725685732;
+          url = "https://api.github.com/repos/awslabs/aws-crt-php/zipball/3942776a8c99209908ee0b287746263725685732";
           sha256 = "0g4vjln6s1419ydljn5m64kzid0b7cplbc0nwn3y4cj72408fyiz";
         };
       };
@@ -17,7 +17,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "aws-aws-sdk-php-fda176884d2952cffc7e67209470bff49609339c";
         src = fetchurl {
-          url = https://api.github.com/repos/aws/aws-sdk-php/zipball/fda176884d2952cffc7e67209470bff49609339c;
+          url = "https://api.github.com/repos/aws/aws-sdk-php/zipball/fda176884d2952cffc7e67209470bff49609339c";
           sha256 = "07cjzhbw4qv7jvi7lly5zg15dcvpgd1py604pas68al7k1lg4343";
         };
       };
@@ -27,7 +27,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "bacon-bacon-qr-code-f73543ac4e1def05f1a70bcd1525c8a157a1ad09";
         src = fetchurl {
-          url = https://api.github.com/repos/Bacon/BaconQrCode/zipball/f73543ac4e1def05f1a70bcd1525c8a157a1ad09;
+          url = "https://api.github.com/repos/Bacon/BaconQrCode/zipball/f73543ac4e1def05f1a70bcd1525c8a157a1ad09";
           sha256 = "1df22bfrc8q62qz8brrs8p2rmmv5gsaxdyjrd2ln6d6j7i4jkjpk";
         };
       };
@@ -37,7 +37,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "barryvdh-laravel-dompdf-5b99e1f94157d74e450f4c97e8444fcaffa2144b";
         src = fetchurl {
-          url = https://api.github.com/repos/barryvdh/laravel-dompdf/zipball/5b99e1f94157d74e450f4c97e8444fcaffa2144b;
+          url = "https://api.github.com/repos/barryvdh/laravel-dompdf/zipball/5b99e1f94157d74e450f4c97e8444fcaffa2144b";
           sha256 = "1r82fzrnjrjy5jgpyc071miiw1rwhwys9ccj81gs3yydq9hi4crw";
         };
       };
@@ -47,7 +47,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "barryvdh-laravel-snappy-1903ab84171072b6bff8d98eb58d38b2c9aaf645";
         src = fetchurl {
-          url = https://api.github.com/repos/barryvdh/laravel-snappy/zipball/1903ab84171072b6bff8d98eb58d38b2c9aaf645;
+          url = "https://api.github.com/repos/barryvdh/laravel-snappy/zipball/1903ab84171072b6bff8d98eb58d38b2c9aaf645";
           sha256 = "1awr5kwj482qsh5wpg0q44fjqi7a9q26ghcc9wp1n9zm97y0rx7a";
         };
       };
@@ -57,7 +57,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "dasprid-enum-5abf82f213618696dda8e3bf6f64dd042d8542b2";
         src = fetchurl {
-          url = https://api.github.com/repos/DASPRiD/Enum/zipball/5abf82f213618696dda8e3bf6f64dd042d8542b2;
+          url = "https://api.github.com/repos/DASPRiD/Enum/zipball/5abf82f213618696dda8e3bf6f64dd042d8542b2";
           sha256 = "0rs7i1xiwhssy88s7bwnp5ri5fi2xy3fl7pw6l5k27xf2f1hv7q6";
         };
       };
@@ -67,7 +67,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "doctrine-cache-331b4d5dbaeab3827976273e9356b3b453c300ce";
         src = fetchurl {
-          url = https://api.github.com/repos/doctrine/cache/zipball/331b4d5dbaeab3827976273e9356b3b453c300ce;
+          url = "https://api.github.com/repos/doctrine/cache/zipball/331b4d5dbaeab3827976273e9356b3b453c300ce";
           sha256 = "1ksr3460a5dpqgq5kgy2l7kdz7fairpvmip8nwaz9y833r5hnnyz";
         };
       };
@@ -77,7 +77,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "doctrine-dbal-2411a55a2a628e6d8dd598388ab13474802c7b6e";
         src = fetchurl {
-          url = https://api.github.com/repos/doctrine/dbal/zipball/2411a55a2a628e6d8dd598388ab13474802c7b6e;
+          url = "https://api.github.com/repos/doctrine/dbal/zipball/2411a55a2a628e6d8dd598388ab13474802c7b6e";
           sha256 = "19vyv64ikbzk0pm9nn67a2kidhfvfcm9s5d91h0hk6kbq85f292v";
         };
       };
@@ -87,7 +87,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "doctrine-deprecations-9504165960a1f83cc1480e2be1dd0a0478561314";
         src = fetchurl {
-          url = https://api.github.com/repos/doctrine/deprecations/zipball/9504165960a1f83cc1480e2be1dd0a0478561314;
+          url = "https://api.github.com/repos/doctrine/deprecations/zipball/9504165960a1f83cc1480e2be1dd0a0478561314";
           sha256 = "04kpbzk5iw86imspkg7dgs54xx877k9b5q0dfg2h119mlfkvxil6";
         };
       };
@@ -97,7 +97,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "doctrine-event-manager-41370af6a30faa9dc0368c4a6814d596e81aba7f";
         src = fetchurl {
-          url = https://api.github.com/repos/doctrine/event-manager/zipball/41370af6a30faa9dc0368c4a6814d596e81aba7f;
+          url = "https://api.github.com/repos/doctrine/event-manager/zipball/41370af6a30faa9dc0368c4a6814d596e81aba7f";
           sha256 = "0pn2aiwl4fvv6fcwar9alng2yrqy8bzc58n4bkp6y2jnpw5gp4m8";
         };
       };
@@ -107,7 +107,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "doctrine-inflector-8b7ff3e4b7de6b2c84da85637b59fd2880ecaa89";
         src = fetchurl {
-          url = https://api.github.com/repos/doctrine/inflector/zipball/8b7ff3e4b7de6b2c84da85637b59fd2880ecaa89;
+          url = "https://api.github.com/repos/doctrine/inflector/zipball/8b7ff3e4b7de6b2c84da85637b59fd2880ecaa89";
           sha256 = "1l83jbj4k59m1agi041gzx1rxix1wzxw9mvnivmg1hqr158149n7";
         };
       };
@@ -117,7 +117,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "doctrine-lexer-e864bbf5904cb8f5bb334f99209b48018522f042";
         src = fetchurl {
-          url = https://api.github.com/repos/doctrine/lexer/zipball/e864bbf5904cb8f5bb334f99209b48018522f042;
+          url = "https://api.github.com/repos/doctrine/lexer/zipball/e864bbf5904cb8f5bb334f99209b48018522f042";
           sha256 = "11lg9fcy0crb8inklajhx3kyffdbx7xzdj8kwl21xsgq9nm9iwvv";
         };
       };
@@ -127,7 +127,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "dompdf-dompdf-8768448244967a46d6e67b891d30878e0e15d25c";
         src = fetchurl {
-          url = https://api.github.com/repos/dompdf/dompdf/zipball/8768448244967a46d6e67b891d30878e0e15d25c;
+          url = "https://api.github.com/repos/dompdf/dompdf/zipball/8768448244967a46d6e67b891d30878e0e15d25c";
           sha256 = "0mgsry4mq5bx6b74h3akay1bp03rnsl8ppcjxjkfjlq4svq7m5yf";
         };
       };
@@ -137,7 +137,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "dragonmantank-cron-expression-65b2d8ee1f10915efb3b55597da3404f096acba2";
         src = fetchurl {
-          url = https://api.github.com/repos/dragonmantank/cron-expression/zipball/65b2d8ee1f10915efb3b55597da3404f096acba2;
+          url = "https://api.github.com/repos/dragonmantank/cron-expression/zipball/65b2d8ee1f10915efb3b55597da3404f096acba2";
           sha256 = "07yqbhf6n4d818gvla60mgg23gichwiafd5ypd70w4b4dlbcxcpl";
         };
       };
@@ -147,7 +147,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "egulias-email-validator-0dbf5d78455d4d6a41d186da50adc1122ec066f4";
         src = fetchurl {
-          url = https://api.github.com/repos/egulias/EmailValidator/zipball/0dbf5d78455d4d6a41d186da50adc1122ec066f4;
+          url = "https://api.github.com/repos/egulias/EmailValidator/zipball/0dbf5d78455d4d6a41d186da50adc1122ec066f4";
           sha256 = "00kwb8rhk1fq3a1i152xniipk3y907q1v5r3szqbkq5rz82dwbck";
         };
       };
@@ -157,7 +157,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "fideloper-proxy-c073b2bd04d1c90e04dc1b787662b558dd65ade0";
         src = fetchurl {
-          url = https://api.github.com/repos/fideloper/TrustedProxy/zipball/c073b2bd04d1c90e04dc1b787662b558dd65ade0;
+          url = "https://api.github.com/repos/fideloper/TrustedProxy/zipball/c073b2bd04d1c90e04dc1b787662b558dd65ade0";
           sha256 = "05jzgjj4fy5p1smqj41b5qxj42zn0mnczvsaacni4fmq174mz4gy";
         };
       };
@@ -167,7 +167,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "filp-whoops-f056f1fe935d9ed86e698905a957334029899895";
         src = fetchurl {
-          url = https://api.github.com/repos/filp/whoops/zipball/f056f1fe935d9ed86e698905a957334029899895;
+          url = "https://api.github.com/repos/filp/whoops/zipball/f056f1fe935d9ed86e698905a957334029899895";
           sha256 = "1qqznxsrlvjlnxlnr786a39igvq3pslxrvm5ks1v09ni88w44g7g";
         };
       };
@@ -177,7 +177,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "guzzlehttp-guzzle-868b3571a039f0ebc11ac8f344f4080babe2cb94";
         src = fetchurl {
-          url = https://api.github.com/repos/guzzle/guzzle/zipball/868b3571a039f0ebc11ac8f344f4080babe2cb94;
+          url = "https://api.github.com/repos/guzzle/guzzle/zipball/868b3571a039f0ebc11ac8f344f4080babe2cb94";
           sha256 = "1n8kng76v4gb51z1qq7wx63pwlyiz3pa44shfla4mcxl2js0r6r0";
         };
       };
@@ -187,7 +187,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "guzzlehttp-promises-fe752aedc9fd8fcca3fe7ad05d419d32998a06da";
         src = fetchurl {
-          url = https://api.github.com/repos/guzzle/promises/zipball/fe752aedc9fd8fcca3fe7ad05d419d32998a06da;
+          url = "https://api.github.com/repos/guzzle/promises/zipball/fe752aedc9fd8fcca3fe7ad05d419d32998a06da";
           sha256 = "09ivi77y49bpc2sy3xhvgq22rfh2fhv921mn8402dv0a8bdprf56";
         };
       };
@@ -197,7 +197,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "guzzlehttp-psr7-089edd38f5b8abba6cb01567c2a8aaa47cec4c72";
         src = fetchurl {
-          url = https://api.github.com/repos/guzzle/psr7/zipball/089edd38f5b8abba6cb01567c2a8aaa47cec4c72;
+          url = "https://api.github.com/repos/guzzle/psr7/zipball/089edd38f5b8abba6cb01567c2a8aaa47cec4c72";
           sha256 = "1k29gax82rf82sbw2cbcp4qn3s3096csvmw9848l94q6ryc4j2rb";
         };
       };
@@ -207,7 +207,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "intervention-image-9a8cc99d30415ec0b3f7649e1647d03a55698545";
         src = fetchurl {
-          url = https://api.github.com/repos/Intervention/image/zipball/9a8cc99d30415ec0b3f7649e1647d03a55698545;
+          url = "https://api.github.com/repos/Intervention/image/zipball/9a8cc99d30415ec0b3f7649e1647d03a55698545";
           sha256 = "1fvfhxr8jyh6jjg3imacgvddgn222g822fq5p9yz8lqlw2ymcfnz";
         };
       };
@@ -217,7 +217,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "knplabs-knp-snappy-349c2e872bbeb15dff825a17dd92ea9c6ae4120e";
         src = fetchurl {
-          url = https://api.github.com/repos/KnpLabs/snappy/zipball/349c2e872bbeb15dff825a17dd92ea9c6ae4120e;
+          url = "https://api.github.com/repos/KnpLabs/snappy/zipball/349c2e872bbeb15dff825a17dd92ea9c6ae4120e";
           sha256 = "12fsslr3k1zn7rw9xnma3pvlmm4qvrapizhn4il4zqcmw51lgnl7";
         };
       };
@@ -227,7 +227,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "laravel-framework-10f6bfaec9efb68aa88d7196b8b1b162d83040ae";
         src = fetchurl {
-          url = https://api.github.com/repos/laravel/framework/zipball/10f6bfaec9efb68aa88d7196b8b1b162d83040ae;
+          url = "https://api.github.com/repos/laravel/framework/zipball/10f6bfaec9efb68aa88d7196b8b1b162d83040ae";
           sha256 = "1r04396755jixbhbw1zzmyz74ng8np0ysv7g7mgcvv01s6wxw66l";
         };
       };
@@ -237,7 +237,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "laravel-socialite-fd0f6a3dd963ca480b598649b54f92d81a43617f";
         src = fetchurl {
-          url = https://api.github.com/repos/laravel/socialite/zipball/fd0f6a3dd963ca480b598649b54f92d81a43617f;
+          url = "https://api.github.com/repos/laravel/socialite/zipball/fd0f6a3dd963ca480b598649b54f92d81a43617f";
           sha256 = "08x0pn4ib5nhh9jkkb5brf8yj0fq6v6gn1qg97hss3mvnhazk5wx";
         };
       };
@@ -247,7 +247,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "league-commonmark-c4228d11e30d7493c6836d20872f9582d8ba6dcf";
         src = fetchurl {
-          url = https://api.github.com/repos/thephpleague/commonmark/zipball/c4228d11e30d7493c6836d20872f9582d8ba6dcf;
+          url = "https://api.github.com/repos/thephpleague/commonmark/zipball/c4228d11e30d7493c6836d20872f9582d8ba6dcf";
           sha256 = "0x18k1qmvskd5x1b3jkkmig6l734sxffj5xyfb82yrzgpw9lrld5";
         };
       };
@@ -257,7 +257,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "league-flysystem-18634df356bfd4119fe3d6156bdb990c414c14ea";
         src = fetchurl {
-          url = https://api.github.com/repos/thephpleague/flysystem/zipball/18634df356bfd4119fe3d6156bdb990c414c14ea;
+          url = "https://api.github.com/repos/thephpleague/flysystem/zipball/18634df356bfd4119fe3d6156bdb990c414c14ea";
           sha256 = "1cy0xmnl3ck7cb6ibl9jjw5pmbw15mww5q06vacgq5lnx8r5w700";
         };
       };
@@ -267,7 +267,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "league-flysystem-aws-s3-v3-4e25cc0582a36a786c31115e419c6e40498f6972";
         src = fetchurl {
-          url = https://api.github.com/repos/thephpleague/flysystem-aws-s3-v3/zipball/4e25cc0582a36a786c31115e419c6e40498f6972;
+          url = "https://api.github.com/repos/thephpleague/flysystem-aws-s3-v3/zipball/4e25cc0582a36a786c31115e419c6e40498f6972";
           sha256 = "1q2vkgyaz7h6z3q0z3v3l5rsvhv4xc45prgzr214cgm656i2h1ab";
         };
       };
@@ -277,7 +277,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "league-html-to-markdown-e5600a2c5ce7b7571b16732c7086940f56f7abec";
         src = fetchurl {
-          url = https://api.github.com/repos/thephpleague/html-to-markdown/zipball/e5600a2c5ce7b7571b16732c7086940f56f7abec;
+          url = "https://api.github.com/repos/thephpleague/html-to-markdown/zipball/e5600a2c5ce7b7571b16732c7086940f56f7abec";
           sha256 = "1a46ki1lbhnc9gqddrka2hypw0h8zcd8dhi8gc1jf5bflhb1wmqk";
         };
       };
@@ -287,7 +287,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "league-mime-type-detection-b38b25d7b372e9fddb00335400467b223349fd7e";
         src = fetchurl {
-          url = https://api.github.com/repos/thephpleague/mime-type-detection/zipball/b38b25d7b372e9fddb00335400467b223349fd7e;
+          url = "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/b38b25d7b372e9fddb00335400467b223349fd7e";
           sha256 = "02ywmarr58z5w9pf5qvk6hyrnykdh6v7n5jdkgb4ykdn2plinmlz";
         };
       };
@@ -297,7 +297,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "league-oauth1-client-88dd16b0cff68eb9167bfc849707d2c40ad91ddc";
         src = fetchurl {
-          url = https://api.github.com/repos/thephpleague/oauth1-client/zipball/88dd16b0cff68eb9167bfc849707d2c40ad91ddc;
+          url = "https://api.github.com/repos/thephpleague/oauth1-client/zipball/88dd16b0cff68eb9167bfc849707d2c40ad91ddc";
           sha256 = "1b0zza3qxqgn57105wbfw2fzphj3l3f7iqh7v3w98pdvaiapaf5d";
         };
       };
@@ -307,7 +307,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "league-oauth2-client-badb01e62383430706433191b82506b6df24ad98";
         src = fetchurl {
-          url = https://api.github.com/repos/thephpleague/oauth2-client/zipball/badb01e62383430706433191b82506b6df24ad98;
+          url = "https://api.github.com/repos/thephpleague/oauth2-client/zipball/badb01e62383430706433191b82506b6df24ad98";
           sha256 = "1j2bmvy39k8wafisxdc0xn58gga5w9jpwp5hqjy51sk1s2ssws8i";
         };
       };
@@ -317,7 +317,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "monolog-monolog-fd4380d6fc37626e2f799f29d91195040137eba9";
         src = fetchurl {
-          url = https://api.github.com/repos/Seldaek/monolog/zipball/fd4380d6fc37626e2f799f29d91195040137eba9;
+          url = "https://api.github.com/repos/Seldaek/monolog/zipball/fd4380d6fc37626e2f799f29d91195040137eba9";
           sha256 = "1k56si01sjl93mxq1pk599yqqqhldqz34qi73y5jaga0m9iq07wk";
         };
       };
@@ -327,7 +327,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "mtdowling-jmespath.php-9b87907a81b87bc76d19a7fb2d61e61486ee9edb";
         src = fetchurl {
-          url = https://api.github.com/repos/jmespath/jmespath.php/zipball/9b87907a81b87bc76d19a7fb2d61e61486ee9edb;
+          url = "https://api.github.com/repos/jmespath/jmespath.php/zipball/9b87907a81b87bc76d19a7fb2d61e61486ee9edb";
           sha256 = "1ig3gi6f8gisagcn876598ps48s86s6m0c82diyksylarg3yn0yd";
         };
       };
@@ -337,7 +337,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "nesbot-carbon-f4655858a784988f880c1b8c7feabbf02dfdf045";
         src = fetchurl {
-          url = https://api.github.com/repos/briannesbitt/Carbon/zipball/f4655858a784988f880c1b8c7feabbf02dfdf045;
+          url = "https://api.github.com/repos/briannesbitt/Carbon/zipball/f4655858a784988f880c1b8c7feabbf02dfdf045";
           sha256 = "18px9mynqabrhgss5nyhadncdcf7aq1mzbbyrxfqbvyv54zq4zjh";
         };
       };
@@ -347,7 +347,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "nunomaduro-collision-f7c45764dfe4ba5f2618d265a6f1f9c72732e01d";
         src = fetchurl {
-          url = https://api.github.com/repos/nunomaduro/collision/zipball/f7c45764dfe4ba5f2618d265a6f1f9c72732e01d;
+          url = "https://api.github.com/repos/nunomaduro/collision/zipball/f7c45764dfe4ba5f2618d265a6f1f9c72732e01d";
           sha256 = "1cazbjxl5rqw4cl783nrymhcvjhvwwwjswr5w0si1wfhmpvr349q";
         };
       };
@@ -357,7 +357,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "onelogin-php-saml-f30f5062f3653c4d2082892d207f4dc3e577d979";
         src = fetchurl {
-          url = https://api.github.com/repos/onelogin/php-saml/zipball/f30f5062f3653c4d2082892d207f4dc3e577d979;
+          url = "https://api.github.com/repos/onelogin/php-saml/zipball/f30f5062f3653c4d2082892d207f4dc3e577d979";
           sha256 = "0nl431rx1gngc2g92w4hjf2y26vjvscgbrwhq0m6kzm9kq043qzh";
         };
       };
@@ -367,7 +367,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "opis-closure-06e2ebd25f2869e54a306dda991f7db58066f7f6";
         src = fetchurl {
-          url = https://api.github.com/repos/opis/closure/zipball/06e2ebd25f2869e54a306dda991f7db58066f7f6;
+          url = "https://api.github.com/repos/opis/closure/zipball/06e2ebd25f2869e54a306dda991f7db58066f7f6";
           sha256 = "0fpa1w0rmwywj67jgaldmw563p7gycahs8gpkpjvrra9zhhj4yyc";
         };
       };
@@ -377,7 +377,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "paragonie-constant_time_encoding-f34c2b11eb9d2c9318e13540a1dbc2a3afbd939c";
         src = fetchurl {
-          url = https://api.github.com/repos/paragonie/constant_time_encoding/zipball/f34c2b11eb9d2c9318e13540a1dbc2a3afbd939c;
+          url = "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/f34c2b11eb9d2c9318e13540a1dbc2a3afbd939c";
           sha256 = "1r1xj3j7s5mskw5gh3ars4dfhvcn7d252gdqgpif80026kj5fvrp";
         };
       };
@@ -387,7 +387,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "paragonie-random_compat-996434e5492cb4c3edcb9168db6fbb1359ef965a";
         src = fetchurl {
-          url = https://api.github.com/repos/paragonie/random_compat/zipball/996434e5492cb4c3edcb9168db6fbb1359ef965a;
+          url = "https://api.github.com/repos/paragonie/random_compat/zipball/996434e5492cb4c3edcb9168db6fbb1359ef965a";
           sha256 = "0ky7lal59dihf969r1k3pb96ql8zzdc5062jdbg69j6rj0scgkyx";
         };
       };
@@ -397,7 +397,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "phenx-php-font-lib-ca6ad461f032145fff5971b5985e5af9e7fa88d8";
         src = fetchurl {
-          url = https://api.github.com/repos/PhenX/php-font-lib/zipball/ca6ad461f032145fff5971b5985e5af9e7fa88d8;
+          url = "https://api.github.com/repos/PhenX/php-font-lib/zipball/ca6ad461f032145fff5971b5985e5af9e7fa88d8";
           sha256 = "0kl9lks1kpniby8dn8racjcjp6xjnhl3065y7ivarbl6ni6hyyxw";
         };
       };
@@ -407,7 +407,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "phenx-php-svg-lib-5fa61b65e612ce1ae15f69b3d223cb14ecc60e32";
         src = fetchurl {
-          url = https://api.github.com/repos/PhenX/php-svg-lib/zipball/5fa61b65e612ce1ae15f69b3d223cb14ecc60e32;
+          url = "https://api.github.com/repos/PhenX/php-svg-lib/zipball/5fa61b65e612ce1ae15f69b3d223cb14ecc60e32";
           sha256 = "1ppi3hs2r4cbd6b2xwf4znci6hpbs8469kqxk3msf7vi6vfnybbj";
         };
       };
@@ -417,7 +417,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "php-parallel-lint-php-console-color-b6af326b2088f1ad3b264696c9fd590ec395b49e";
         src = fetchurl {
-          url = https://api.github.com/repos/php-parallel-lint/PHP-Console-Color/zipball/b6af326b2088f1ad3b264696c9fd590ec395b49e;
+          url = "https://api.github.com/repos/php-parallel-lint/PHP-Console-Color/zipball/b6af326b2088f1ad3b264696c9fd590ec395b49e";
           sha256 = "030449mkpxs35y8dk336ls3bfdq3zjnxswnk5khlg45z5147cr3k";
         };
       };
@@ -427,7 +427,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "php-parallel-lint-php-console-highlighter-21bf002f077b177f056d8cb455c5ed573adfdbb8";
         src = fetchurl {
-          url = https://api.github.com/repos/php-parallel-lint/PHP-Console-Highlighter/zipball/21bf002f077b177f056d8cb455c5ed573adfdbb8;
+          url = "https://api.github.com/repos/php-parallel-lint/PHP-Console-Highlighter/zipball/21bf002f077b177f056d8cb455c5ed573adfdbb8";
           sha256 = "013phmp5n6hp6mvlpbqbrih0zd8h7xc152dpzxxf49b0jczxh8y4";
         };
       };
@@ -437,7 +437,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "phpoption-phpoption-5455cb38aed4523f99977c4a12ef19da4bfe2a28";
         src = fetchurl {
-          url = https://api.github.com/repos/schmittjoh/php-option/zipball/5455cb38aed4523f99977c4a12ef19da4bfe2a28;
+          url = "https://api.github.com/repos/schmittjoh/php-option/zipball/5455cb38aed4523f99977c4a12ef19da4bfe2a28";
           sha256 = "009q2afjkjl8psisr8jsw9k08qnkb0f4hgd6izrjmm06bd7bk9ah";
         };
       };
@@ -447,7 +447,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "phpseclib-phpseclib-6e794226a35159eb06f355efe59a0075a16551dd";
         src = fetchurl {
-          url = https://api.github.com/repos/phpseclib/phpseclib/zipball/6e794226a35159eb06f355efe59a0075a16551dd;
+          url = "https://api.github.com/repos/phpseclib/phpseclib/zipball/6e794226a35159eb06f355efe59a0075a16551dd";
           sha256 = "1jjgzckgpr6myf4lcngsgmmqib5x2rv93yj7syg1xyawls4qj3yb";
         };
       };
@@ -457,7 +457,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "pragmarx-google2fa-26c4c5cf30a2844ba121760fd7301f8ad240100b";
         src = fetchurl {
-          url = https://api.github.com/repos/antonioribeiro/google2fa/zipball/26c4c5cf30a2844ba121760fd7301f8ad240100b;
+          url = "https://api.github.com/repos/antonioribeiro/google2fa/zipball/26c4c5cf30a2844ba121760fd7301f8ad240100b";
           sha256 = "1jmc7s3hbczvb0h4kfmya67l969nfww3lmc4slvzsz0zd769434h";
         };
       };
@@ -467,7 +467,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "predis-predis-c50c3393bb9f47fa012d0cdfb727a266b0818259";
         src = fetchurl {
-          url = https://api.github.com/repos/predis/predis/zipball/c50c3393bb9f47fa012d0cdfb727a266b0818259;
+          url = "https://api.github.com/repos/predis/predis/zipball/c50c3393bb9f47fa012d0cdfb727a266b0818259";
           sha256 = "09riabf99jmxydrqn8cm6nsw3fbp307fqcpc9iw4ag2qfhwm2v73";
         };
       };
@@ -477,7 +477,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "psr-container-8622567409010282b7aeebe4bb841fe98b58dcaf";
         src = fetchurl {
-          url = https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf;
+          url = "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf";
           sha256 = "0qfvyfp3mli776kb9zda5cpc8cazj3prk0bg0gm254kwxyfkfrwn";
         };
       };
@@ -487,7 +487,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "psr-http-client-2dfb5f6c5eff0e91e20e913f8c5452ed95b86621";
         src = fetchurl {
-          url = https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621;
+          url = "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621";
           sha256 = "0cmkifa3ji1r8kn3y1rwg81rh8g2crvnhbv2am6d688dzsbw967v";
         };
       };
@@ -497,7 +497,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "psr-http-factory-12ac7fcd07e5b077433f5f2bee95b3a771bf61be";
         src = fetchurl {
-          url = https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be;
+          url = "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be";
           sha256 = "0inbnqpc5bfhbbda9dwazsrw9xscfnc8rdx82q1qm3r446mc1vds";
         };
       };
@@ -507,7 +507,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "psr-http-message-f6561bf28d520154e4b0ec72be95418abe6d9363";
         src = fetchurl {
-          url = https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363;
+          url = "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363";
           sha256 = "195dd67hva9bmr52iadr4kyp2gw2f5l51lplfiay2pv6l9y4cf45";
         };
       };
@@ -517,7 +517,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "psr-log-d49695b909c3b7628b6289db5479a1c204601f11";
         src = fetchurl {
-          url = https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11;
+          url = "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11";
           sha256 = "0sb0mq30dvmzdgsnqvw3xh4fb4bqjncx72kf8n622f94dd48amln";
         };
       };
@@ -527,7 +527,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "psr-simple-cache-408d5eafb83c57f6365a3ca330ff23aa4a5fa39b";
         src = fetchurl {
-          url = https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b;
+          url = "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b";
           sha256 = "1djgzclkamjxi9jy4m9ggfzgq1vqxaga2ip7l3cj88p7rwkzjxgw";
         };
       };
@@ -537,7 +537,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "ralouphie-getallheaders-120b605dfeb996808c31b6477290a714d356e822";
         src = fetchurl {
-          url = https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822;
+          url = "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822";
           sha256 = "1bv7ndkkankrqlr2b4kw7qp3fl0dxi6bp26bnim6dnlhavd6a0gg";
         };
       };
@@ -547,7 +547,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "ramsey-uuid-ffa80ab953edd85d5b6c004f96181a538aad35a3";
         src = fetchurl {
-          url = https://api.github.com/repos/ramsey/uuid/zipball/ffa80ab953edd85d5b6c004f96181a538aad35a3;
+          url = "https://api.github.com/repos/ramsey/uuid/zipball/ffa80ab953edd85d5b6c004f96181a538aad35a3";
           sha256 = "043g1nwpbvqrvq6ri2517254d72538h5jfzv9miafnws4ajwfpzg";
         };
       };
@@ -557,7 +557,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "robrichards-xmlseclibs-f8f19e58f26cdb42c54b214ff8a820760292f8df";
         src = fetchurl {
-          url = https://api.github.com/repos/robrichards/xmlseclibs/zipball/f8f19e58f26cdb42c54b214ff8a820760292f8df;
+          url = "https://api.github.com/repos/robrichards/xmlseclibs/zipball/f8f19e58f26cdb42c54b214ff8a820760292f8df";
           sha256 = "01zlpm36rrdj310cfmiz2fnabszxd3fq80fa8x8j3f9ki7dvhh5y";
         };
       };
@@ -567,7 +567,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "sabberworm-php-css-parser-d217848e1396ef962fb1997cf3e2421acba7f796";
         src = fetchurl {
-          url = https://api.github.com/repos/sabberworm/PHP-CSS-Parser/zipball/d217848e1396ef962fb1997cf3e2421acba7f796;
+          url = "https://api.github.com/repos/sabberworm/PHP-CSS-Parser/zipball/d217848e1396ef962fb1997cf3e2421acba7f796";
           sha256 = "17jkly8k02p54qa004spikakxis8syjw3vhwgrsi9g1cb4wsg3g9";
         };
       };
@@ -577,7 +577,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "socialiteproviders-discord-c6eddeb07ace7473e82d02d4db852dfacf5ef574";
         src = fetchurl {
-          url = https://api.github.com/repos/SocialiteProviders/Discord/zipball/c6eddeb07ace7473e82d02d4db852dfacf5ef574;
+          url = "https://api.github.com/repos/SocialiteProviders/Discord/zipball/c6eddeb07ace7473e82d02d4db852dfacf5ef574";
           sha256 = "1w8m7jmlsdk94cqckgd75mwblh3jj6j16w3g4hzysyms25g091xc";
         };
       };
@@ -587,7 +587,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "socialiteproviders-gitlab-a8f67d3b02c9ee8c70c25c6728417c0eddcbbb9d";
         src = fetchurl {
-          url = https://api.github.com/repos/SocialiteProviders/GitLab/zipball/a8f67d3b02c9ee8c70c25c6728417c0eddcbbb9d;
+          url = "https://api.github.com/repos/SocialiteProviders/GitLab/zipball/a8f67d3b02c9ee8c70c25c6728417c0eddcbbb9d";
           sha256 = "1blv2h69dmm0r0djz3h0l0cxkxmzd1fzgg13r3npxx7c80xjpw3a";
         };
       };
@@ -597,7 +597,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "socialiteproviders-manager-0f5e82af0404df0080bdc5c105cef936c1711524";
         src = fetchurl {
-          url = https://api.github.com/repos/SocialiteProviders/Manager/zipball/0f5e82af0404df0080bdc5c105cef936c1711524;
+          url = "https://api.github.com/repos/SocialiteProviders/Manager/zipball/0f5e82af0404df0080bdc5c105cef936c1711524";
           sha256 = "0ppmln72khli94ylnsjarnhzkqzpkc32pn3zf3ljahm1yghccczx";
         };
       };
@@ -607,7 +607,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "socialiteproviders-microsoft-azure-9b23e02ff711de42e513aa55f768a4f1c67c0e41";
         src = fetchurl {
-          url = https://api.github.com/repos/SocialiteProviders/Microsoft-Azure/zipball/9b23e02ff711de42e513aa55f768a4f1c67c0e41;
+          url = "https://api.github.com/repos/SocialiteProviders/Microsoft-Azure/zipball/9b23e02ff711de42e513aa55f768a4f1c67c0e41";
           sha256 = "01i53v1pcr3nfpydpy0ka5jrdyygpi4vc5w24022913nfjqg3bqm";
         };
       };
@@ -617,7 +617,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "socialiteproviders-okta-e3ef9f23c7d2f86b3b16a174b82333cf4e2459e8";
         src = fetchurl {
-          url = https://api.github.com/repos/SocialiteProviders/Okta/zipball/e3ef9f23c7d2f86b3b16a174b82333cf4e2459e8;
+          url = "https://api.github.com/repos/SocialiteProviders/Okta/zipball/e3ef9f23c7d2f86b3b16a174b82333cf4e2459e8";
           sha256 = "1a3anw5di5nqiabvqpmsjv5x0jasmsn4y876qsv77gazxja880ng";
         };
       };
@@ -627,7 +627,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "socialiteproviders-slack-2b781c95daf06ec87a8f3deba2ab613d6bea5e8d";
         src = fetchurl {
-          url = https://api.github.com/repos/SocialiteProviders/Slack/zipball/2b781c95daf06ec87a8f3deba2ab613d6bea5e8d;
+          url = "https://api.github.com/repos/SocialiteProviders/Slack/zipball/2b781c95daf06ec87a8f3deba2ab613d6bea5e8d";
           sha256 = "1xilg7l1wc1vgwyakhfl8dpvgkjqx90g4khvzi411j9xa2wvpprh";
         };
       };
@@ -637,7 +637,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "socialiteproviders-twitch-7accf30ae7a3139b757b4ca8f34989c09a3dbee7";
         src = fetchurl {
-          url = https://api.github.com/repos/SocialiteProviders/Twitch/zipball/7accf30ae7a3139b757b4ca8f34989c09a3dbee7;
+          url = "https://api.github.com/repos/SocialiteProviders/Twitch/zipball/7accf30ae7a3139b757b4ca8f34989c09a3dbee7";
           sha256 = "089i4fwxb32zmbxib0544jfs48wzjyp7bsqss2bf2xx89dsrx4ah";
         };
       };
@@ -647,7 +647,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "ssddanbrown-htmldiff-f60d5cc278b60305ab980a6665f46117c5b589c0";
         src = fetchurl {
-          url = https://api.github.com/repos/ssddanbrown/HtmlDiff/zipball/f60d5cc278b60305ab980a6665f46117c5b589c0;
+          url = "https://api.github.com/repos/ssddanbrown/HtmlDiff/zipball/f60d5cc278b60305ab980a6665f46117c5b589c0";
           sha256 = "12h3swr8rjf5w78kfgwzkf0zb59b4a8mjwf65fgcgvjg115wha9x";
         };
       };
@@ -657,7 +657,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "swiftmailer-swiftmailer-8a5d5072dca8f48460fce2f4131fcc495eec654c";
         src = fetchurl {
-          url = https://api.github.com/repos/swiftmailer/swiftmailer/zipball/8a5d5072dca8f48460fce2f4131fcc495eec654c;
+          url = "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/8a5d5072dca8f48460fce2f4131fcc495eec654c";
           sha256 = "1p9m4fw9y9md9a7msbmnc0hpdrky8dwrllnyg1qf1cdyp9d70x1d";
         };
       };
@@ -667,7 +667,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-console-8dbd23ef7a8884051482183ddee8d9061b5feed0";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/console/zipball/8dbd23ef7a8884051482183ddee8d9061b5feed0;
+          url = "https://api.github.com/repos/symfony/console/zipball/8dbd23ef7a8884051482183ddee8d9061b5feed0";
           sha256 = "1p03ls8djpyhplf1irbg5ym3rjqviknwvg1mz9v6kdvnr694vzxn";
         };
       };
@@ -677,7 +677,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-css-selector-7fb120adc7f600a59027775b224c13a33530dd90";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/css-selector/zipball/7fb120adc7f600a59027775b224c13a33530dd90;
+          url = "https://api.github.com/repos/symfony/css-selector/zipball/7fb120adc7f600a59027775b224c13a33530dd90";
           sha256 = "03jblgg300imj7s731ynxm579a6qj87lhd4lnhahbf4m7y65vj7w";
         };
       };
@@ -687,7 +687,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-debug-43ede438d4cb52cd589ae5dc070e9323866ba8e0";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/debug/zipball/43ede438d4cb52cd589ae5dc070e9323866ba8e0;
+          url = "https://api.github.com/repos/symfony/debug/zipball/43ede438d4cb52cd589ae5dc070e9323866ba8e0";
           sha256 = "1min1v940rrv83w4fan9ypw4zj62wmi5nwn76pq618pdi8z00kpn";
         };
       };
@@ -697,7 +697,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-deprecation-contracts-5f38c8804a9e97d23e0c8d63341088cd8a22d627";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/deprecation-contracts/zipball/5f38c8804a9e97d23e0c8d63341088cd8a22d627;
+          url = "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5f38c8804a9e97d23e0c8d63341088cd8a22d627";
           sha256 = "11k6a8v9b6p0j788fgykq6s55baba29lg37fwvmn4igxxkfwmbp3";
         };
       };
@@ -707,7 +707,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-error-handler-51f98f7aa99f00f3b1da6bafe934e67ae6ba6dc5";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/error-handler/zipball/51f98f7aa99f00f3b1da6bafe934e67ae6ba6dc5;
+          url = "https://api.github.com/repos/symfony/error-handler/zipball/51f98f7aa99f00f3b1da6bafe934e67ae6ba6dc5";
           sha256 = "1qy8j16crb271pz6frjxyy2b41f1ap8w2mwb2n5zr3gmg0iqm487";
         };
       };
@@ -717,7 +717,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-event-dispatcher-2fe81680070043c4c80e7cedceb797e34f377bac";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/event-dispatcher/zipball/2fe81680070043c4c80e7cedceb797e34f377bac;
+          url = "https://api.github.com/repos/symfony/event-dispatcher/zipball/2fe81680070043c4c80e7cedceb797e34f377bac";
           sha256 = "0qf59l1a1h25hl6bp1wwfl5s825f8ybw2jiwhalw7gfnrx8x68fb";
         };
       };
@@ -727,7 +727,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-event-dispatcher-contracts-84e23fdcd2517bf37aecbd16967e83f0caee25a7";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/84e23fdcd2517bf37aecbd16967e83f0caee25a7;
+          url = "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/84e23fdcd2517bf37aecbd16967e83f0caee25a7";
           sha256 = "1pcfrlc0rg8vdnp23y3y1p5qzng5nxf5i2c36g9x9f480xrnc1fw";
         };
       };
@@ -737,7 +737,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-finder-70362f1e112280d75b30087c7598b837c1b468b6";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/finder/zipball/70362f1e112280d75b30087c7598b837c1b468b6;
+          url = "https://api.github.com/repos/symfony/finder/zipball/70362f1e112280d75b30087c7598b837c1b468b6";
           sha256 = "0f75c5mjig5ypigb4s1av3w67xizx6pl15wrqbyxa39a9qq58x6v";
         };
       };
@@ -747,7 +747,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-http-client-contracts-7e82f6084d7cae521a75ef2cb5c9457bbda785f4";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/http-client-contracts/zipball/7e82f6084d7cae521a75ef2cb5c9457bbda785f4;
+          url = "https://api.github.com/repos/symfony/http-client-contracts/zipball/7e82f6084d7cae521a75ef2cb5c9457bbda785f4";
           sha256 = "04mszmb94y0xjs0cwqxzhpf65kfqhhqznldifbxvrrlxb9nn23qc";
         };
       };
@@ -757,7 +757,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-http-foundation-b9a91102f548e0111f4996e8c622fb1d1d479850";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/http-foundation/zipball/b9a91102f548e0111f4996e8c622fb1d1d479850;
+          url = "https://api.github.com/repos/symfony/http-foundation/zipball/b9a91102f548e0111f4996e8c622fb1d1d479850";
           sha256 = "0f6hxzrcijpjiwfjlw0bgn17a6d7bdfr7bc8nlmhfig7v945rbwq";
         };
       };
@@ -767,7 +767,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-http-kernel-6f1fcca1154f782796549f4f4e5090bae9525c0e";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/http-kernel/zipball/6f1fcca1154f782796549f4f4e5090bae9525c0e;
+          url = "https://api.github.com/repos/symfony/http-kernel/zipball/6f1fcca1154f782796549f4f4e5090bae9525c0e";
           sha256 = "1i9bd9kp1yz55922hf95chdnzxbaavx87hxjzy6dysg81sjw89fw";
         };
       };
@@ -777,7 +777,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-mime-a756033d0a7e53db389618653ae991eba5a19a11";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/mime/zipball/a756033d0a7e53db389618653ae991eba5a19a11;
+          url = "https://api.github.com/repos/symfony/mime/zipball/a756033d0a7e53db389618653ae991eba5a19a11";
           sha256 = "06awwbkbg6fkkbls4rk4qkdzrigik3zm68cwa8bazsy7izqrh3nj";
         };
       };
@@ -787,7 +787,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-polyfill-ctype-46cd95797e9df938fdd2b03693b5fca5e64b01ce";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce;
+          url = "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce";
           sha256 = "0z4iiznxxs4r72xs4irqqb6c0wnwpwf0hklwn2imls67haq330zn";
         };
       };
@@ -797,7 +797,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-polyfill-iconv-63b5bb7db83e5673936d6e3b8b3e022ff6474933";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/polyfill-iconv/zipball/63b5bb7db83e5673936d6e3b8b3e022ff6474933;
+          url = "https://api.github.com/repos/symfony/polyfill-iconv/zipball/63b5bb7db83e5673936d6e3b8b3e022ff6474933";
           sha256 = "1jyjsjprsgb3r6cbc4x1wg1q1zqakqm8a62ah5lppxnjgq1sgjc5";
         };
       };
@@ -807,7 +807,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-polyfill-intl-idn-65bd267525e82759e7d8c4e8ceea44f398838e65";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/65bd267525e82759e7d8c4e8ceea44f398838e65;
+          url = "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/65bd267525e82759e7d8c4e8ceea44f398838e65";
           sha256 = "1cx2cjx0vzni297l7avd3cb1q4c8d2hylkvdqcjlpxjqdimn4jkn";
         };
       };
@@ -817,7 +817,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-polyfill-intl-normalizer-8590a5f561694770bdcd3f9b5c69dde6945028e8";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8;
+          url = "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8";
           sha256 = "1c60xin00q0d2gbyaiglxppn5hqwki616v5chzwyhlhf6aplwsh3";
         };
       };
@@ -827,7 +827,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-polyfill-mbstring-9174a3d80210dca8daa7f31fec659150bbeabfc6";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9174a3d80210dca8daa7f31fec659150bbeabfc6;
+          url = "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9174a3d80210dca8daa7f31fec659150bbeabfc6";
           sha256 = "17bhba3093di6xgi8f0cnf3cdd7fnbyp9l76d9y33cym6213ayx1";
         };
       };
@@ -837,7 +837,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-polyfill-php72-9a142215a36a3888e30d0a9eeea9766764e96976";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/polyfill-php72/zipball/9a142215a36a3888e30d0a9eeea9766764e96976;
+          url = "https://api.github.com/repos/symfony/polyfill-php72/zipball/9a142215a36a3888e30d0a9eeea9766764e96976";
           sha256 = "06ipbcvrxjzgvraf2z9fwgy0bzvzjvs5z1j67grg1gb15x3d428b";
         };
       };
@@ -847,7 +847,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-polyfill-php73-fba8933c384d6476ab14fb7b8526e5287ca7e010";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/polyfill-php73/zipball/fba8933c384d6476ab14fb7b8526e5287ca7e010;
+          url = "https://api.github.com/repos/symfony/polyfill-php73/zipball/fba8933c384d6476ab14fb7b8526e5287ca7e010";
           sha256 = "0fc1d60iw8iar2zcvkzwdvx0whkbw8p6ll0cry39nbkklzw85n1h";
         };
       };
@@ -857,7 +857,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-polyfill-php80-1100343ed1a92e3a38f9ae122fc0eb21602547be";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/polyfill-php80/zipball/1100343ed1a92e3a38f9ae122fc0eb21602547be;
+          url = "https://api.github.com/repos/symfony/polyfill-php80/zipball/1100343ed1a92e3a38f9ae122fc0eb21602547be";
           sha256 = "0kwk2qgwswsmbfp1qx31ahw3lisgyivwhw5dycshr5v2iwwx3rhi";
         };
       };
@@ -867,7 +867,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-process-13d3161ef63a8ec21eeccaaf9a4d7f784a87a97d";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/process/zipball/13d3161ef63a8ec21eeccaaf9a4d7f784a87a97d;
+          url = "https://api.github.com/repos/symfony/process/zipball/13d3161ef63a8ec21eeccaaf9a4d7f784a87a97d";
           sha256 = "1h41y2k100fmrjz90m0vafpfgg2da6byy9m6vf1j9q41bhv6zccl";
         };
       };
@@ -877,7 +877,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-routing-9ddf033927ad9f30ba2bfd167a7b342cafa13e8e";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/routing/zipball/9ddf033927ad9f30ba2bfd167a7b342cafa13e8e;
+          url = "https://api.github.com/repos/symfony/routing/zipball/9ddf033927ad9f30ba2bfd167a7b342cafa13e8e";
           sha256 = "1l3b5z0kn7f9q0whrm2wnxv0l038w3la75bf95pbs74szlnibfhz";
         };
       };
@@ -887,7 +887,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-service-contracts-f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/service-contracts/zipball/f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb;
+          url = "https://api.github.com/repos/symfony/service-contracts/zipball/f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb";
           sha256 = "1i573rmajc33a9nrgwgc4k3svg29yp9xv17gp133rd1i705hwv1y";
         };
       };
@@ -897,7 +897,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-translation-db0ba1e85280d8ff11e38d53c70f8814d4d740f5";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/translation/zipball/db0ba1e85280d8ff11e38d53c70f8814d4d740f5;
+          url = "https://api.github.com/repos/symfony/translation/zipball/db0ba1e85280d8ff11e38d53c70f8814d4d740f5";
           sha256 = "08qxma91sffj8vqzb8dshwsxqf80y9kym3bsxx3gz05ksi01hk1d";
         };
       };
@@ -907,7 +907,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-translation-contracts-95c812666f3e91db75385749fe219c5e494c7f95";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/translation-contracts/zipball/95c812666f3e91db75385749fe219c5e494c7f95;
+          url = "https://api.github.com/repos/symfony/translation-contracts/zipball/95c812666f3e91db75385749fe219c5e494c7f95";
           sha256 = "073l1pbmwbkaviwwjq9ypb1w7dk366nn2vn1vancbal0zqk0zx7b";
         };
       };
@@ -917,7 +917,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "symfony-var-dumper-50286e2b7189bfb4f419c0731e86632cddf7c5ee";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/var-dumper/zipball/50286e2b7189bfb4f419c0731e86632cddf7c5ee;
+          url = "https://api.github.com/repos/symfony/var-dumper/zipball/50286e2b7189bfb4f419c0731e86632cddf7c5ee";
           sha256 = "05yb04dvb5higlbhgdl2hv4wnnmxi6l53xvls5v56wj21ddsk6vf";
         };
       };
@@ -927,7 +927,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "tijsverkoyen-css-to-inline-styles-b43b05cf43c1b6d849478965062b6ef73e223bb5";
         src = fetchurl {
-          url = https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/b43b05cf43c1b6d849478965062b6ef73e223bb5;
+          url = "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/b43b05cf43c1b6d849478965062b6ef73e223bb5";
           sha256 = "0lc6jviz8faqxxs453dbqvfdmm6l2iczxla22v2r6xhakl58pf3w";
         };
       };
@@ -937,7 +937,7 @@ let
       src = composerEnv.buildZipPackage {
         name = "vlucas-phpdotenv-a1bf4c9853d90ade427b4efe35355fc41b3d6988";
         src = fetchurl {
-          url = https://api.github.com/repos/vlucas/phpdotenv/zipball/a1bf4c9853d90ade427b4efe35355fc41b3d6988;
+          url = "https://api.github.com/repos/vlucas/phpdotenv/zipball/a1bf4c9853d90ade427b4efe35355fc41b3d6988";
           sha256 = "04cks58khh2rx1ni5p1v8i37k4hy6zwkazlas0jqlrxhznmd50wi";
         };
       };

--- a/pkgs/servers/zigbee2mqtt/default.nix
+++ b/pkgs/servers/zigbee2mqtt/default.nix
@@ -20,7 +20,7 @@ package.override rec {
   meta = with pkgs.lib; {
     description = "Zigbee to MQTT bridge using zigbee-shepherd";
     license = licenses.gpl3;
-    homepage = https://github.com/Koenkk/zigbee2mqtt;
+    homepage = "https://github.com/Koenkk/zigbee2mqtt";
     maintainers = with maintainers; [ sweber ];
     platforms = platforms.linux;
   };

--- a/pkgs/servers/zigbee2mqtt/node-packages.nix
+++ b/pkgs/servers/zigbee2mqtt/node-packages.nix
@@ -10076,7 +10076,7 @@ let
     buildInputs = globalBuildInputs;
     meta = {
       description = "Zigbee to MQTT bridge using Zigbee-herdsman";
-      homepage = https://koenkk.github.io/zigbee2mqtt;
+      homepage = "https://koenkk.github.io/zigbee2mqtt";
       license = "GPL-3.0";
     };
     production = true;

--- a/pkgs/tools/audio/stt/default.nix
+++ b/pkgs/tools/audio/stt/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = https://github.com/coqui-ai/STT;
+    homepage = "https://github.com/coqui-ai/STT";
     description = "Deep learning toolkit for Speech-to-Text, battle-tested in research and production";
     license = licenses.mpl20;
     platforms = [ "x86_64-linux" ];

--- a/pkgs/tools/misc/graylog/plugins.nix
+++ b/pkgs/tools/misc/graylog/plugins.nix
@@ -107,7 +107,7 @@ in {
       cp ${pluginName}-${version}.jar $out/bin/${pluginName}-${version}.jar
     '';
     meta = {
-      homepage = https://github.com/Graylog2/graylog-plugin-integrations;
+      homepage = "https://github.com/Graylog2/graylog-plugin-integrations";
       description = "A collection of open source Graylog integrations that will be released together";
     };
   };
@@ -224,7 +224,7 @@ in {
       sha256 = "1hkaklwzcsvqq45b98chwqxqdgnnbj4dg68agsll13yq4zx37qpp";
     };
     meta = {
-      homepage = https://github.com/graylog-labs/graylog-plugin-snmp;
+      homepage = "https://github.com/graylog-labs/graylog-plugin-snmp";
       description = "Graylog plugin to receive SNMP traps";
     };
   };

--- a/pkgs/tools/misc/livedl/default.nix
+++ b/pkgs/tools/misc/livedl/default.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
 
   sourceRoot = "source/src";
 
-  vendorSha256 = sha256:g5Y1IH1U1zOOHygTzAJuBnUj+MyPe64KHTYikipt3TY=;
+  vendorSha256 = "sha256:g5Y1IH1U1zOOHygTzAJuBnUj+MyPe64KHTYikipt3TY=";
 
   meta = with lib; {
     description = "Command-line tool to download nicovideo.jp livestreams";

--- a/pkgs/tools/misc/livedl/default.nix
+++ b/pkgs/tools/misc/livedl/default.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
 
   sourceRoot = "source/src";
 
-  vendorSha256 = "sha256:g5Y1IH1U1zOOHygTzAJuBnUj+MyPe64KHTYikipt3TY=";
+  vendorSha256 = "g5Y1IH1U1zOOHygTzAJuBnUj+MyPe64KHTYikipt3TY=";
 
   meta = with lib; {
     description = "Command-line tool to download nicovideo.jp livestreams";

--- a/pkgs/tools/virtualization/extra-container/default.nix
+++ b/pkgs/tools/virtualization/extra-container/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Run declarative containers without full system rebuilds";
-    homepage = https://github.com/erikarvstedt/extra-container;
+    homepage = "https://github.com/erikarvstedt/extra-container";
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = [ maintainers.earvstedt ];


### PR DESCRIPTION
###### Motivation for this change
rfc 0045

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
