### PR TITLE
pkgsMusl.libieee1284: fix build

### DIFF
--- a/pkgs/development/libraries/libieee1284/default.nix
+++ b/pkgs/development/libraries/libieee1284/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, autoconf, automake, libtool, xmlto, docbook_xml_dtd_412, docbook_xsl }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch
+, autoconf, automake, libtool, xmlto, docbook_xml_dtd_412, docbook_xsl
+}:
 
 stdenv.mkDerivation rec {
   pname = "libieee1284";
@@ -10,6 +12,14 @@ stdenv.mkDerivation rec {
     rev = "V${builtins.replaceStrings [ "." ] [ "_" ] version}";
     sha256 = "0wfv1prmhhpyll9l4g1ij3im7hk9mm96ydw3l9fvhjp3993cdn2x";
   };
+
+  patches = [
+    # Fix build on Musl.
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/void-linux/void-packages/861ac185a6b60134292ff93d40e40b5391d0aa8e/srcpkgs/libieee1284/patches/musl.patch";
+      sha256 = "03xivd6z7m51i5brlmzs60pjrlqyr4561qlnh182wa7rrm01x5y6";
+    })
+  ];
 
   nativeBuildInputs = [
     autoconf
@@ -24,7 +34,7 @@ stdenv.mkDerivation rec {
     "--without-python"
   ];
 
-  preConfigure = ''
+  prePatch = ''
     ./bootstrap
   '';
 


### PR DESCRIPTION
When building for Linux, it assumes that Glibc-specific functionality
is available even though it has a fallback for when it isn't.  This
patch teaches it to only use Glibc-specific functionality on Glibc.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
