### PR TITLE
irqbalance: pull pending upstream inclusion fix for ncurses-6.3

### DIFF
--- a/pkgs/os-specific/linux/irqbalance/default.nix
+++ b/pkgs/os-specific/linux/irqbalance/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, glib, ncurses, libcap_ng }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, pkg-config, glib, ncurses, libcap_ng }:
 
 stdenv.mkDerivation rec {
   pname = "irqbalance";
@@ -10,6 +10,16 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-K+Nv6HqBZb0pwfNV127QDq+suaUD7TTV413S6j8NdUU=";
   };
+
+  patches = [
+    # pull pending upstream inclusion fix for ncurses-6.3:
+    #  https://github.com/Irqbalance/irqbalance/pull/194
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/Irqbalance/irqbalance/commit/f8bdd0e64284d841544fd3ebe22f4652902ba8d2.patch";
+      sha256 = "sha256-QJIXr8BiKmn/81suuhNJsBRhY2as19/e480lsp2wd6g=";
+    })
+  ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
 


### PR DESCRIPTION
Without the fix build on ncurses-6.3 fails as:

    ui/ui.c:714:16: error: format not a string literal and no format arguments [-Werror=format-security]
      714 |         printw(copy_to);
          |                ^~~~~~~