### PR TITLE
keymapviz: init at 1.9.0

### DIFF
--- a/pkgs/tools/misc/keymapviz/default.nix
+++ b/pkgs/tools/misc/keymapviz/default.nix
@@ -1,0 +1,22 @@
+{ fetchFromGitHub, lib, python3 }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "keymapviz";
+  version = "1.9.0";
+
+  src = fetchFromGitHub {
+    owner = "yskoht";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-lNpUH4BvlnHx0SDq5YSsHdcTeEnf6MH2WRUEsCWWHA0=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [ regex ];
+
+  meta = with lib; {
+    description = "A qmk keymap.c visualizer";
+    homepage = "https://github.com/yskoht/keymapviz";
+    license = licenses.mit;
+    maintainers = with maintainers; [ legendofmiracles ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31443,6 +31443,8 @@ with pkgs;
 
   key = callPackage ../applications/science/logic/key { };
 
+  keymapviz = callPackage ../tools/misc/keymapviz { };
+
   lean = callPackage ../applications/science/logic/lean {};
   lean2 = callPackage ../applications/science/logic/lean2 {};
   lean3 = lean;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
