### PR TITLE
cliscord: init at unstable-2020-12-08

### DIFF
--- a/pkgs/misc/cliscord/default.nix
+++ b/pkgs/misc/cliscord/default.nix
@@ -1,0 +1,27 @@
+{ lib, rustPlatform, openssl, pkg-config, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cliscord";
+  version = "unstable-2020-12-08";
+
+  src = fetchFromGitHub {
+    owner = "somebody1234";
+    repo = pname;
+    rev = "b02fbe5516fd7f153d0b0e3c7d5d11e2ab651b43";
+    sha256 = "sha256-hzZozgOkw8kFppuHiX9TQxHhxKRv8utWWbhEOIzKDLo=";
+  };
+
+  buildInputs = [ openssl ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  cargoSha256 = "12zfwdssyv0j83bff6s4376d99pv7z8ya8q8adwmf5ayvgmj4xz4";
+
+  meta = with lib; {
+    description = "Simple command-line tool to send text and files to discord";
+    homepage = "https://github.com/somebody1234/cliscord";
+    license = licenses.mit;
+    maintainers = with maintainers; [ legendofmiracles ];
+    mainProgram = "cliscord";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13156,6 +13156,8 @@ with pkgs;
 
   clips = callPackage ../development/interpreters/clips { };
 
+  cliscord = callPackage ../misc/cliscord/default.nix { };
+
   clisp = callPackage ../development/interpreters/clisp { };
   clisp-tip = callPackage ../development/interpreters/clisp/hg.nix { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
