### PR TITLE
tfk8s & minio-certgen: add myself as maintainer

### DIFF
--- a/pkgs/tools/misc/tfk8s/default.nix
+++ b/pkgs/tools/misc/tfk8s/default.nix
@@ -44,6 +44,6 @@ buildGoModule rec {
       * Strip out server side fields when piping kubectl get $R -o yaml | tfk8s --strip
     '';
     homepage = "https://github.com/jrhouston/tfk8s/";
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ bryanasdev000 ];
   };
 }

--- a/pkgs/tools/security/minio-certgen/default.nix
+++ b/pkgs/tools/security/minio-certgen/default.nix
@@ -17,6 +17,6 @@ buildGoModule rec {
     description = "A simple Minio tool to generate self-signed certificates, and provides SAN certificates with DNS and IP entries";
     downloadPage = "https://github.com/minio/certgen";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ bryanasdev000 ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Add myself as maintainer to both packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
