### PR TITLE
libdeltachat: 1.60.0 -> 1.63.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/kdeltachat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/kdeltachat/default.nix
@@ -14,13 +14,13 @@
 
 mkDerivation rec {
   pname = "kdeltachat";
-  version = "unstable-2021-09-10";
+  version = "unstable-2021-10-27";
 
   src = fetchFromSourcehut {
     owner = "~link2xt";
     repo = "kdeltachat";
-    rev = "40092aa096bac7e279eb5a4cc97758bac484236c";
-    sha256 = "0vmsbxx4hxh35v1lbj82vq2w8z8inj83xpf24wzlbdr9inlbmym4";
+    rev = "e1201cdcce4311061643d90cc0132745023a82d2";
+    sha256 = "04xqvyj4rzgl9r7sfjjw1kc3vql30c80rwppff2zr5aijr15fgjj";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/libdeltachat/darwin-dylib.patch
+++ b/pkgs/development/libraries/libdeltachat/darwin-dylib.patch
@@ -1,0 +1,53 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5ed8020c..44ca43e7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2,12 +2,20 @@ cmake_minimum_required(VERSION 3.16)
+ project(deltachat LANGUAGES C)
+ include(GNUInstallDirs)
+ 
++if(APPLE)
++	set(DYNAMIC_EXT "dylib")
++elseif(UNIX)
++	set(DYNAMIC_EXT "so")
++else()
++	set(DYNAMIC_EXT "dll")
++endif()
++
+ find_program(CARGO cargo)
+ 
+ add_custom_command(
+ 	OUTPUT
+ 	"target/release/libdeltachat.a"
+-	"target/release/libdeltachat.so"
++	"target/release/libdeltachat.${DYNAMIC_EXT}"
+ 	"target/release/pkgconfig/deltachat.pc"
+         COMMAND
+         PREFIX=${CMAKE_INSTALL_PREFIX}
+@@ -32,11 +40,11 @@ add_custom_target(
+ 	ALL
+ 	DEPENDS
+ 	"target/release/libdeltachat.a"
+-	"target/release/libdeltachat.so"
++	"target/release/libdeltachat.${DYNAMIC_EXT}"
+ 	"target/release/pkgconfig/deltachat.pc"
+ )
+ 
+ install(FILES "deltachat-ffi/deltachat.h" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+ install(FILES "target/release/libdeltachat.a" DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-install(FILES "target/release/libdeltachat.so" DESTINATION ${CMAKE_INSTALL_LIBDIR})
++install(FILES "target/release/libdeltachat.${DYNAMIC_EXT}" DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ install(FILES "target/release/pkgconfig/deltachat.pc" DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+diff --git a/python/install_python_bindings.py b/python/install_python_bindings.py
+index c8ed43e2..714c7e30 100755
+--- a/python/install_python_bindings.py
++++ b/python/install_python_bindings.py
+@@ -24,7 +24,7 @@
+ 
+     print("running:", " ".join(cmd))
+     subprocess.check_call(cmd)
+-    subprocess.check_call("rm -rf build/ src/deltachat/*.so" , shell=True)
++    subprocess.check_call("rm -rf build/ src/deltachat/*.so src/deltachat/*.dylib" , shell=True)
+ 
+     if len(sys.argv) <= 1 or sys.argv[1] != "onlybuild":
+         subprocess.check_call([

--- a/pkgs/development/libraries/libdeltachat/default.nix
+++ b/pkgs/development/libraries/libdeltachat/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , cmake
 , openssl
 , perl
@@ -16,33 +15,25 @@
 
 stdenv.mkDerivation rec {
   pname = "libdeltachat";
-  version = "1.60.0";
+  version = "1.63.0";
 
   src = fetchFromGitHub {
     owner = "deltachat";
     repo = "deltachat-core-rust";
     rev = version;
-    sha256 = "1agm5xyaib4ynmw4mhgmkhh4lnxs91wv0q9i1zfihv2vkckfm2s2";
+    sha256 = "1511jh38h7nmn4dpyi1vfxvhybcacc6gavwfifxvb5npirphziga";
   };
 
   patches = [
     # https://github.com/deltachat/deltachat-core-rust/pull/2589
-    (fetchpatch {
-      url = "https://github.com/deltachat/deltachat-core-rust/commit/408467e85d04fbbfd6bed5908d84d9e995943487.patch";
-      sha256 = "1j2ywaazglgl6370js34acrg0wrh0b7krqg05dfjf65n527lzn59";
-    })
+    ./darwin-dylib.patch
     ./no-static-lib.patch
-    # https://github.com/deltachat/deltachat-core-rust/pull/2660
-    (fetchpatch {
-      url = "https://github.com/deltachat/deltachat-core-rust/commit/8fb5e038a97d8ae68564c885d61b93127a68366d.patch";
-      sha256 = "088pzfrrkgfi4646dc72404s3kykcpni7hgkppalwlzg0p4is41x";
-    })
   ];
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     name = "${pname}-${version}";
-    sha256 = "09d3mw2hb1gmqg7smaqwnfm7izw40znl0h1dz7s2imms2cnkjws1";
+    sha256 = "0hfp2k84mvq11h7q96hkcj3k6f3sxw8wx89acg4hy6lbh8xpy6ai";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/libdeltachat/no-static-lib.patch
+++ b/pkgs/development/libraries/libdeltachat/no-static-lib.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index fe7abe08..acdbe0d6 100644
+index 44ca43e7..8b6960dd 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -13,7 +13,6 @@ find_program(CARGO cargo)
+@@ -14,7 +14,6 @@ find_program(CARGO cargo)
  
  add_custom_command(
  	OUTPUT
@@ -10,7 +10,7 @@ index fe7abe08..acdbe0d6 100644
  	"target/release/libdeltachat.${DYNAMIC_EXT}"
  	"target/release/pkgconfig/deltachat.pc"
          COMMAND
-@@ -38,13 +37,11 @@ add_custom_target(
+@@ -39,12 +38,10 @@ add_custom_target(
  	lib_deltachat
  	ALL
  	DEPENDS
@@ -19,13 +19,12 @@ index fe7abe08..acdbe0d6 100644
  	"target/release/pkgconfig/deltachat.pc"
  )
  
- include(GNUInstallDirs)
  install(FILES "deltachat-ffi/deltachat.h" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 -install(FILES "target/release/libdeltachat.a" DESTINATION ${CMAKE_INSTALL_LIBDIR})
  install(FILES "target/release/libdeltachat.${DYNAMIC_EXT}" DESTINATION ${CMAKE_INSTALL_LIBDIR})
  install(FILES "target/release/pkgconfig/deltachat.pc" DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 diff --git a/deltachat-ffi/Cargo.toml b/deltachat-ffi/Cargo.toml
-index a34a27ba..cf354abb 100644
+index de0fbafe..120efec9 100644
 --- a/deltachat-ffi/Cargo.toml
 +++ b/deltachat-ffi/Cargo.toml
 @@ -12,7 +12,7 @@ categories = ["cryptography", "std", "email"]


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
