### PR TITLE
lib/orphans: add utility functions to find orphan packages

### DIFF
--- a/doc/doc-support/lib-function-docs.nix
+++ b/doc/doc-support/lib-function-docs.nix
@@ -23,5 +23,6 @@ with pkgs; stdenv.mkDerivation {
     docgen debug 'Debugging functions'
     docgen options 'NixOS / nixpkgs option handling'
     docgen sources 'Source filtering functions'
+    docgen orphans 'Package maintainer utilities'
   '';
 }

--- a/doc/functions/library.xml
+++ b/doc/functions/library.xml
@@ -27,4 +27,6 @@
  <xi:include href="./library/generated/options.xml" />
 
  <xi:include href="./library/generated/sources.xml" />
+
+ <xi:include href="./library/generated/orphans.xml" />
 </section>

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -24,6 +24,7 @@ let
     # packaging
     customisation = callLibs ./customisation.nix;
     maintainers = import ../maintainers/maintainer-list.nix;
+    orphans = callLibs ./orphans.nix;
     teams = callLibs ../maintainers/team-list.nix;
     meta = callLibs ./meta.nix;
     sources = callLibs ./sources.nix;

--- a/lib/orphans.nix
+++ b/lib/orphans.nix
@@ -1,0 +1,97 @@
+{ lib }:
+let
+  inherit (builtins)
+    attrValues
+    concatStringsSep
+    length
+    mapAttrs
+    tryEval
+    isAttrs
+  ;
+  inherit (lib)
+    any
+    flatten
+    isDerivation
+    optional
+    types
+    concatLists
+    mapAttrsToList
+  ;
+  isAttr = types.attrs.check;
+in
+rec {
+  /* Return a list of maintainers from a package, empty list if inaccessible.
+
+     Example:
+       listMaintainers pkgs.foo
+       => [ { name = "Foo Bar"; email = "name@domain.com"; github = "foo"; } ]
+       listMaintainers pkgs.bar
+       => [ ]
+       listMaintainers {}
+       => error: listMaintainers must receive a package
+  */
+  listMaintainers =
+  # Must be a package
+  p:
+    if isDerivation p then
+      p.meta.maintainers or []
+    else
+      throw "listMaintainers must receive a package"
+  ;
+
+  /* Returns if a package has a maintainer (i.e.: not orphan).
+
+     Example:
+       hasMaintainer pkgs.foo
+       => true
+       hasMaintainer pkgs.bar
+       => false
+       hasMaintainer {}
+       => error: listMaintainers must receive a package
+  */
+  hasMaintainer =
+  # Must be a package
+  p:
+    (listMaintainers p) != [];
+
+  /* Returns a list of addresses from the node attrset/package of orphan packages.
+
+     It works recursively, so theorically you can find unmaintained packages in the whole nixpkgs.
+     However, evaluation errors halt the execution, and these type of errors can't be caught by builtins.tryEval.
+     So prefer to use it in smaller package sets you might be interested.
+
+     Example:
+       listOrphans { node = pkgs; }
+       => [ "bar" ]
+       listOrphans { node = pkgs; minMaintainers = 2; }
+       => [ "foo" "bar" ]
+       listOrphans { node = pkgs; minMaintainers = 2; recur = [ "pkgs" ]; }
+       => [ [ "pkgs" "foo" ] [ "pkgs" "bar" ] ]
+  */
+  listOrphans =
+    {
+    # The packages
+    packages,
+    # Maximum recursion depth.
+    maxDepth ? 20,
+    # The minimum maintainer amount necessary to not put the package on the return list.
+    minMaintainers ? 1
+  }:
+    let
+      go = path: maxDepth: packages:
+        let
+          fun = name: value:
+            let
+              result = tryEval value;
+              path' = path ++ [ name ];
+            in
+            if ! result.success then []
+            else if ! isAttrs result.value then []
+            else if isDerivation result.value then
+              optional (length (listMaintainers result.value) < minMaintainers) path'
+            else if ! (result.value.recurseForDerivations or false) then []
+            else go path' (maxDepth - 1) result.value;
+        in if maxDepth <= 0 then []
+        else concatLists (mapAttrsToList fun packages);
+    in go [] maxDepth packages;
+}


### PR DESCRIPTION
Signed-off-by: lucasew <lucas59356@gmail.com>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Easily find orphan packages

Sadly evaluation errors halt the function, I am already using tryEval but some errors are not catched by that function.

BTW it found some warnings still from the `stdenv.lib` deprecation and a error in androidndk-pkgs.

Very cool. If someone knows a way to reference where do the unmaintained derivation lives I will add to this function, didn't found a reference using nix-repl.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
