### PR TITLE
sqlitebrowser: fix darwin build

### DIFF
--- a/pkgs/development/tools/database/sqlitebrowser/default.nix
+++ b/pkgs/development/tools/database/sqlitebrowser/default.nix
@@ -1,5 +1,6 @@
-{ mkDerivation, lib, fetchFromGitHub, cmake
-, qtbase, qttools, sqlcipher, wrapGAppsHook }:
+{ lib, stdenv, mkDerivation, fetchFromGitHub, cmake
+, qtbase, qttools, sqlcipher, wrapGAppsHook, qtmacextras
+}:
 
 mkDerivation rec {
   pname = "sqlitebrowser";
@@ -16,7 +17,7 @@ mkDerivation rec {
   # but qscintilla is currently in a bit of a mess as some consumers expect a
   # -qt4 or -qt5 prefix while others do not.
   # We *really* should get that cleaned up.
-  buildInputs = [ qtbase sqlcipher ];
+  buildInputs = [ qtbase sqlcipher ] ++ lib.optionals stdenv.isDarwin [ qtmacextras ];
 
   nativeBuildInputs = [ cmake qttools wrapGAppsHook ];
 


### PR DESCRIPTION
###### Motivation for this change
Fixes the darwin build of sqlitebrowser

ZHF: #144627

###### Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
  lrelease from qttools segfaults in sandbox
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@NixOS/nixos-release-managers

<img width="1057" alt="Screen Shot 2021-11-09 at 10 00 23 PM" src="https://user-images.githubusercontent.com/382041/141042658-75b3d63e-35a6-45c2-85d9-1d08d93df217.png">
