### PR TITLE
ldc-bootstrap: 1.19.0 -> 1.25.0

### DIFF
--- a/pkgs/development/compilers/ldc/binary.nix
+++ b/pkgs/development/compilers/ldc/binary.nix
@@ -3,8 +3,8 @@
 
 let
   inherit (stdenv) hostPlatform;
-  OS = if stdenv.hostPlatform.isDarwin then "osx" else hostPlatform.parsed.kernel.name;
-  ARCH = toString hostPlatform.parsed.cpu.name;
+  OS = if hostPlatform.isDarwin then "osx" else hostPlatform.parsed.kernel.name;
+  ARCH = if hostPlatform.isDarwin && hostPlatform.isAarch64 then "arm64" else hostPlatform.parsed.cpu.name;
 in stdenv.mkDerivation {
   pname = "ldc-bootstrap";
   inherit version;
@@ -37,6 +37,6 @@ in stdenv.mkDerivation {
     # from https://github.com/ldc-developers/ldc/blob/master/LICENSE
     license = with licenses; [ bsd3 boost mit ncsa gpl2Plus ];
     maintainers = with maintainers; [ ThomasMader lionello ];
-    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
   };
 }

--- a/pkgs/development/compilers/ldc/bootstrap.nix
+++ b/pkgs/development/compilers/ldc/bootstrap.nix
@@ -1,10 +1,11 @@
 { callPackage }:
 callPackage ./binary.nix {
-  version = "1.19.0";
+  version = "1.25.0";
   hashes = {
     # Get these from `nix-prefetch-url https://github.com/ldc-developers/ldc/releases/download/v1.19.0/ldc2-1.19.0-osx-x86_64.tar.xz` etc..
-    osx-x86_64 = "1bp3xkh9zp64dzq8isanib1gacb3nfbl70qv15qygwk1zan6zgy7";
-    linux-x86_64 = "146grr2lwarfk13wgkpyb77xb6b3as1is2rf4s2hipqjmc8biy1h";
-    linux-aarch64  = "1fv6jshfvi15m7masgxq1hgp216qjd5amizrqdf26vhrq3a08li3";
+    osx-x86_64 = "1xaqxf1lz8kdb0n5iycfpxpvabf1zy0akg14kg554sm85xnsf8pa";
+    linux-x86_64 = "1shzdq564jg3ga1hwrvpx30lpszc6pqndqndr5mqmc352znkiy5i";
+    linux-aarch64  = "04i4xxwhq02d98r3qrrnv5dbd4xr4d7ph3zv94z2m58z3vgphdjh";
+    osx-arm64  = "0b0cpgzn23clggx0cvdaja29q7w7ihkmjbnf1md03h9h5nzp9z1v";
   };
 }

--- a/pkgs/development/compilers/ldc/generic.nix
+++ b/pkgs/development/compilers/ldc/generic.nix
@@ -132,6 +132,6 @@ stdenv.mkDerivation rec {
     # from https://github.com/ldc-developers/ldc/blob/master/LICENSE
     license = with licenses; [ bsd3 boost mit ncsa gpl2Plus ];
     maintainers = with maintainers; [ ThomasMader lionello ];
-    platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
+    platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-darwin" ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
LDC v1.25.0 is the first build that has binaries for Darwin on Arm, `aarch64-darwin`. Using this for bootstrapping allows for building LDC from source on Apple M1 MacBooks.


###### Things done
* Update bootstrap version and hashes to 1.25.0. 
* Add `aarch64-darwin` to supported platforms for both the binary/bootstrap and the regular (from source) derivations.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
