### PR TITLE
pidgin-with-plugins: fix evaluation failure in use of non-existent 'm…

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, pkg-config, gtk2, gtk2-x11, gtkspell2, aspell
+{ callPackage, stdenv, fetchurl, makeWrapper, pkg-config, gtk2, gtk2-x11, gtkspell2, aspell
 , gst_all_1, libstartup_notification, gettext, perlPackages, libxml2, nss
 , nspr, farstream, libXScrnSaver, avahi, dbus, dbus-glib, intltool, libidn
 , lib, python3, libICE, libXext, libSM, libgnt, ncurses, cyrus_sasl, openssl
@@ -93,7 +93,7 @@ let unwrapped = stdenv.mkDerivation rec {
 };
 
 in if plugins == [] then unwrapped
-    else import ./wrapper.nix {
-      inherit lib makeWrapper symlinkJoin plugins;
+    else callPackage ./wrapper.nix {
+      inherit plugins;
       pidgin = unwrapped;
     }

--- a/pkgs/applications/networking/instant-messengers/pidgin/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/default.nix
@@ -92,8 +92,10 @@ let unwrapped = stdenv.mkDerivation rec {
   };
 };
 
-in if plugins == [] then unwrapped
-    else callPackage ./wrapper.nix {
+# Always wrap pidgin even if plugin list is empty.
+# That way we always evaluate 'wrapper.nix' and make
+# sure we can instantiate and build it on hydra.
+in callPackage ./wrapper.nix {
       inherit plugins;
       pidgin = unwrapped;
     }

--- a/pkgs/applications/networking/instant-messengers/pidgin/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/default.nix
@@ -94,6 +94,6 @@ let unwrapped = stdenv.mkDerivation rec {
 
 in if plugins == [] then unwrapped
     else import ./wrapper.nix {
-      inherit makeWrapper symlinkJoin plugins;
+      inherit lib makeWrapper symlinkJoin plugins;
       pidgin = unwrapped;
     }

--- a/pkgs/applications/networking/instant-messengers/pidgin/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/default.nix
@@ -92,10 +92,8 @@ let unwrapped = stdenv.mkDerivation rec {
   };
 };
 
-# Always wrap pidgin even if plugin list is empty.
-# That way we always evaluate 'wrapper.nix' and make
-# sure we can instantiate and build it on hydra.
-in callPackage ./wrapper.nix {
+in if plugins == [] then unwrapped
+    else callPackage ./wrapper.nix {
       inherit plugins;
       pidgin = unwrapped;
     }

--- a/pkgs/applications/networking/instant-messengers/pidgin/wrapper.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/wrapper.nix
@@ -1,4 +1,4 @@
-{ symlinkJoin, pidgin, makeWrapper, plugins }:
+{ lib, symlinkJoin, pidgin, makeWrapper, plugins }:
 
 let
 extraArgs = map (x: x.wrapArgs or "") plugins;
@@ -11,10 +11,10 @@ in symlinkJoin {
 
   postBuild = ''
     wrapProgram $out/bin/pidgin \
-      --suffix-each PURPLE_PLUGIN_PATH ':' "$out/lib/purple-${pidgin.majorVersion} $out/lib/pidgin" \
+      --suffix-each PURPLE_PLUGIN_PATH ':' "$out/lib/purple-${lib.versions.major pidgin.version} $out/lib/pidgin" \
       ${toString extraArgs}
     wrapProgram $out/bin/finch \
-      --suffix-each PURPLE_PLUGIN_PATH ':' "$out/lib/purple-${pidgin.majorVersion}" \
+      --suffix-each PURPLE_PLUGIN_PATH ':' "$out/lib/purple-${lib.versions.major pidgin.version}" \
       ${toString extraArgs}
   '';
 }


### PR DESCRIPTION
…ajorVersion'

Currently attempt to evaluate `pidgin-with-plugins` with plugins fails as:

    $ nix build --impure --expr 'with import ./. {}; pidgin-with-plugins.override { plugins = [ pidgin-window-merge ]; }'
    error: attribute 'majorVersion' missing

       at pkgs/applications/networking/instant-messengers/pidgin/wrapper.nix:14:63:

           13|     wrapProgram $out/bin/pidgin \
           14|       --suffix-each PURPLE_PLUGIN_PATH ':' "$out/lib/purple-${pidgin.majorVersion} $out/lib/pidgin" \
             |                                                               ^
           15|       ${toString extraArgs}
