### PR TITLE
roomeqwizard: init at 5.20.4

### DIFF
--- a/pkgs/applications/audio/roomeqwizard/default.nix
+++ b/pkgs/applications/audio/roomeqwizard/default.nix
@@ -1,0 +1,118 @@
+{ coreutils
+, fetchurl
+, gawk
+, gnused
+, jdk8
+, lib
+, makeDesktopItem
+, makeWrapper
+, stdenv
+, writeScript
+, writeTextFile
+, recommendedUdevRules ? true
+}:
+
+stdenv.mkDerivation rec {
+  pname = "roomeqwizard";
+  version = "5.20.4";
+
+  src = fetchurl {
+    url = "https://www.roomeqwizard.com/installers/REW_linux_${lib.replaceChars [ "." ] [ "_" ] version}.sh";
+    sha256 = "0m2b5hwazy4vyjk51cmayys250rircs3c0v7bv5mn28h7hyq29s8";
+  };
+
+  dontUnpack = true;
+
+  desktopItem = makeDesktopItem {
+    name = pname;
+    exec = pname;
+    icon = pname;
+    desktopName = "REW";
+    genericName = "Software for audio measurements";
+    categories = "AudioVideo;";
+  };
+
+  responseFile = writeTextFile {
+    name = "response.varfile";
+    text = ''
+      createDesktopLinkAction$Boolean=false
+      executeLauncherAction$Boolean=false
+      mem$Integer=1
+      opengl$Boolean=false
+      sys.adminRights$Boolean=false
+      sys.installationDir=INSTALLDIR
+      sys.languageId=en
+      sys.programGroupDisabled$Boolean=true
+    '';
+  };
+
+  udevRules = ''
+    # MiniDSP UMIK-1 calibrated USB microphone
+    SUBSYSTEM=="usb", ATTR{idVendor}=="2752", ATTR{idProduct}=="0007", TAG+="uaccess"
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    # set JDK path in installer
+    sed -E 's|^#\s*(INSTALL4J_JAVA_HOME_OVERRIDE=)|\1${jdk8}|' $src > installer
+    chmod +x installer
+
+    sed -e "s|INSTALLDIR|$out/share/roomeqwizard|" $responseFile > response.varfile
+
+    export HOME=$PWD
+
+    ./installer -q -varfile response.varfile
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/lib/udev/rules.d $out/share/icons/hicolor/256x256/apps
+    makeWrapper $out/share/roomeqwizard/roomeqwizard $out/bin/roomeqwizard \
+      --set INSTALL4J_JAVA_HOME_OVERRIDE ${jdk8} \
+      --prefix PATH : ${lib.makeBinPath [ coreutils gnused gawk ]}
+
+    cp -r "$desktopItem/share/applications" $out/share/
+    cp $out/share/roomeqwizard/.install4j/s_*.png "$out/share/icons/hicolor/256x256/apps/${pname}.png"
+
+    ${lib.optionalString recommendedUdevRules ''echo "$udevRules" > $out/lib/udev/rules.d/90-roomeqwizard.rules''}
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = writeScript "${pname}-update.sh" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl common-updater-scripts nixpkgs-fmt coreutils perl
+
+    set -euo pipefail
+
+    perlexpr='if (/current version.{1,10}v(\d+)\.(\d+)\.(\d+)/i) { print "$1.$2.$3"; break; }'
+
+    oldVersion="$(nix-instantiate --eval -E "with import ./. {}; lib.getVersion ${pname}" | tr -d '"')"
+    latestVersion="$(curl -sS https://www.roomeqwizard.com/index.html | perl -ne "$perlexpr")"
+
+    if [ ! "$oldVersion" = "$latestVersion" ]; then
+      update-source-version ${pname} "$latestVersion" --version-key=version --print-changes
+      nixpkgs-fmt "pkgs/applications/audio/roomeqwizard/default.nix"
+    else
+      echo "${pname} is already up-to-date"
+    fi
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.roomeqwizard.com/";
+    license = licenses.unfree;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ zaninime ];
+    description = "Room Acoustics Software";
+    longDescription = ''
+      REW is free software for room acoustic measurement, loudspeaker
+      measurement and audio device measurement.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27826,6 +27826,8 @@ with pkgs;
 
   renoise = callPackage ../applications/audio/renoise {};
 
+  roomeqwizard = callPackage ../applications/audio/roomeqwizard { };
+
   radiotray-ng = callPackage ../applications/audio/radiotray-ng {
     wxGTK = wxGTK30;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
