### PR TITLE
python3Packages.vt-py: 0.7.6 -> 0.8.0

### DIFF
--- a/pkgs/development/python-modules/vt-py/default.nix
+++ b/pkgs/development/python-modules/vt-py/default.nix
@@ -10,7 +10,8 @@
 
 buildPythonPackage rec {
   pname = "vt-py";
-  version = "0.7.6";
+  version = "0.8.0";
+  format = "setuptools";
 
   disabled = pythonOlder "3.6";
 
@@ -18,7 +19,7 @@ buildPythonPackage rec {
     owner = "VirusTotal";
     repo = pname;
     rev = version;
-    sha256 = "sha256-Gf3hNCXioaLiQ0fZWPe9PO2YQeId4ZLmWsSZ5WvjSk0=";
+    sha256 = "sha256-j9TlZDzl9sWFPt8TeuyoJi01JhyPBVXs1w3YJMoVvLw=";
   };
 
   propagatedBuildInputs = [
@@ -36,7 +37,9 @@ buildPythonPackage rec {
       --replace "'pytest-runner'" ""
   '';
 
-  pythonImportsCheck = [ "vt" ];
+  pythonImportsCheck = [
+    "vt"
+  ];
 
   meta = with lib; {
     description = "Python client library for VirusTotal";

--- a/pkgs/tools/security/ioccheck/default.nix
+++ b/pkgs/tools/security/ioccheck/default.nix
@@ -8,8 +8,6 @@ python3.pkgs.buildPythonApplication rec {
   version = "unstable-2021-09-29";
   format = "pyproject";
 
-  disabled = python3.pythonOlder "3.7";
-
   src = fetchFromGitHub {
     owner = "ranguli";
     repo = pname;
@@ -43,10 +41,13 @@ python3.pkgs.buildPythonApplication rec {
   postPatch = ''
     # Can be removed with the next release
     substituteInPlace pyproject.toml \
-      --replace '"hurry.filesize" = "^0.9"' ""
+      --replace '"hurry.filesize" = "^0.9"' "" \
+      --replace 'vt-py = ">=0.6.1,<0.8.0"' 'vt-py = ">=0.6.1"'
   '';
 
-  pythonImportsCheck = [ "ioccheck" ];
+  pythonImportsCheck = [
+    "ioccheck"
+  ];
 
   meta = with lib; {
     description = "Tool for researching IOCs";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.8.0

Change log: https://github.com/VirusTotal/vt-py/releases/tag/0.8.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
