### PR TITLE
openttd: 12.0 -> 12.1, openttd-jgrpp: 0.43.1 -> 0.44.0

### DIFF
--- a/pkgs/games/openttd/default.nix
+++ b/pkgs/games/openttd/default.nix
@@ -11,8 +11,8 @@ let
   };
 
   opensfx = fetchzip {
-    url = "https://cdn.openttd.org/opensfx-releases/1.0.2/opensfx-1.0.2-all.zip";
-    sha256 = "sha256-yRCb49/k8uUUAe9VzUG0LQaBDFP7n9QdrLSJDIthdbA=";
+    url = "https://cdn.openttd.org/opensfx-releases/1.0.3/opensfx-1.0.3-all.zip";
+    sha256 = "sha256-QmfXizrRTu/fUcVOY7tCndv4t4BVW+fb0yUi8LgSYzM=";
   };
 
   openmsx = fetchzip {
@@ -29,11 +29,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "openttd";
-  version = "12.0";
+  version = "12.1";
 
   src = fetchurl {
     url = "https://cdn.openttd.org/openttd-releases/${version}/${pname}-${version}-source.tar.xz";
-    sha256 = "sha256-u6D9OADfA3AlnmQtJR82LHwAtHii41Mfa6f4TBwrMtw=";
+    sha256 = "sha256-JYv1uZgwEIkLoQUYtQa8SrgPfAjM7FlJfpulWkqj5+M=";
   };
 
   nativeBuildInputs = [ cmake makeWrapper ];

--- a/pkgs/games/openttd/jgrpp.nix
+++ b/pkgs/games/openttd/jgrpp.nix
@@ -2,12 +2,12 @@
 
 openttd.overrideAttrs (oldAttrs: rec {
   pname = "openttd-jgrpp";
-  version = "0.43.1";
+  version = "0.44.0";
 
   src = fetchFromGitHub rec {
     owner = "JGRennison";
     repo = "OpenTTD-patches";
     rev = "jgrpp-${version}";
-    sha256 = "sha256-nCZ3UN2BdpDGbW0CKX/ijxlA3cQ7FPflajQ5TBM1Hdk=";
+    sha256 = "sha256-/kqwMZGXUYWlCnjk6uShJ5UARtvBSZWPExVel5o4xA8=";
   };
 })


### PR DESCRIPTION
###### Motivation for this change

https://cdn.openttd.org/openttd-releases/12.1/changelog.txt

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
