### PR TITLE
python3Packages.sievelib: 1.1.1 -> 1.2.1

### DIFF
--- a/pkgs/development/python-modules/sievelib/default.nix
+++ b/pkgs/development/python-modules/sievelib/default.nix
@@ -1,37 +1,36 @@
-{ lib, buildPythonPackage, fetchPypi, fetchpatch, mock
-, future, six, setuptools-scm }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, mock
+, pytestCheckHook
+, setuptools-scm
+}:
 
 buildPythonPackage rec {
   pname = "sievelib";
-  version = "1.1.1";
+  version = "1.2.1";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1sl1fnwr5jdacrrnq2rvzh4vv1dyxd3x31vnqga36gj8h546h7mz";
+    sha256 = "sha256-7cubQWqYWjzFt9f01+wBPjcuv5DmTJ2eAOIDEpmvOP0=";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "pip-10-pip-req.patch";
-      url = "https://github.com/tonioo/sievelib/commit/1deef0e2bf039a0e817ea6f19aaf1947dc9fafbc.patch";
-      sha256 = "0vaj73mcij9dism8vfaai82irh8j1b2n8gf9jl1a19d2l26jrflk";
-    })
-    (fetchpatch {
-      name = "requirements-in-setup-py.patch";
-      url = "https://github.com/tonioo/sievelib/commit/91f40ec226ea288e98379da01672a46dabd89fc9.patch";
-      sha256 = "0hph89xn16r353rg6f05bh0cgigmwdc736bya089qc03jhssrgns";
-    })
+  nativeBuildInputs = [
+    setuptools-scm
   ];
 
-  buildInputs = [ setuptools-scm ];
-  propagatedBuildInputs = [ future six ];
-  checkInputs = [ mock ];
+  checkInputs = [
+    mock
+    pytestCheckHook
+  ];
 
-  meta = {
+  pythonImportsCheck = [
+    "sievelib"
+  ];
+
+  meta = with lib; {
     description = "Client-side Sieve and Managesieve library written in Python";
-    homepage    = "https://github.com/tonioo/sievelib";
-    license     = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ leenaars ];
     longDescription = ''
       A library written in Python that implements RFC 5228 (Sieve: An Email
       Filtering Language) and RFC 5804 (ManageSieve: A Protocol for
@@ -43,5 +42,8 @@ buildPythonPackage rec {
        * Vacation (RFC 5230)
        * Imap4flags (RFC 5232)
     '';
+    homepage = "https://github.com/tonioo/sievelib";
+    license = licenses.mit;
+    maintainers = with maintainers; [ leenaars ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.2.1

Change log: https://github.com/tonioo/sievelib/releases/tag/1.2.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
