### PR TITLE
google-cloud-sdk: 362.0.0 -> 365.0.0 and add update script

### DIFF
--- a/pkgs/tools/admin/google-cloud-sdk/data.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/data.nix
@@ -1,0 +1,32 @@
+# DO NOT EDIT! This file is generated automatically by update.sh
+{ }:
+{
+  version = "364.0.0";
+  googleCloudSdkPkgs = {
+    x86_64-linux =
+      {
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-364.0.0-linux-x86_64.tar.gz";
+        sha256 = "0i9h61qsd0pmvypjkmp8nzgrdr3n6wdvmizrsnm9azrsmsqbx4cl";
+      };
+    x86_64-darwin =
+      {
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-364.0.0-darwin-x86_64.tar.gz";
+        sha256 = "0p2jpzkd0mn70wvs5m6xh9v1f5wfxww6miz2xgd50wa71kh5q9hl";
+      };
+    aarch64-linux =
+      {
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-364.0.0-linux-arm.tar.gz";
+        sha256 = "0v8hrymq0iwrw936v7bll012gi20zrhjn4jjgn940y5rrdz7pk2i";
+      };
+    aarch64-darwin =
+      {
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-364.0.0-darwin-arm.tar.gz";
+        sha256 = "0lp5l79dm263ymm32abkz7hnfb9zwhwi9xspr2gx8h4jgpw4hmxm";
+      };
+    i686-linux =
+      {
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-364.0.0-linux-x86.tar.gz";
+        sha256 = "1cfh5bx7zcjbjqbsin4aqd10jlaibbckgjpp16lh4aywrysdfdzh";
+      };
+  };
+}

--- a/pkgs/tools/admin/google-cloud-sdk/data.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/data.nix
@@ -1,32 +1,32 @@
 # DO NOT EDIT! This file is generated automatically by update.sh
 { }:
 {
-  version = "364.0.0";
+  version = "365.0.0";
   googleCloudSdkPkgs = {
     x86_64-linux =
       {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-364.0.0-linux-x86_64.tar.gz";
-        sha256 = "0i9h61qsd0pmvypjkmp8nzgrdr3n6wdvmizrsnm9azrsmsqbx4cl";
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-365.0.0-linux-x86_64.tar.gz";
+        sha256 = "1h1z2ddhgrc74gnfaicvginl2yy7zjx8dlvkx017vsd3vijavl41";
       };
     x86_64-darwin =
       {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-364.0.0-darwin-x86_64.tar.gz";
-        sha256 = "0p2jpzkd0mn70wvs5m6xh9v1f5wfxww6miz2xgd50wa71kh5q9hl";
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-365.0.0-darwin-x86_64.tar.gz";
+        sha256 = "0428pc85jlwsydn5nl7vya3rsbiww8z2jvc68wy1sdk7a1md01cy";
       };
     aarch64-linux =
       {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-364.0.0-linux-arm.tar.gz";
-        sha256 = "0v8hrymq0iwrw936v7bll012gi20zrhjn4jjgn940y5rrdz7pk2i";
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-365.0.0-linux-arm.tar.gz";
+        sha256 = "0ji29kd6cfyl59vlms77bnlqf95yh86g9c08wkx1f1kdavi78l0d";
       };
     aarch64-darwin =
       {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-364.0.0-darwin-arm.tar.gz";
-        sha256 = "0lp5l79dm263ymm32abkz7hnfb9zwhwi9xspr2gx8h4jgpw4hmxm";
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-365.0.0-darwin-arm.tar.gz";
+        sha256 = "1rg996y4r24aif5vv6cnl3g7g6fknz8zv6m87ayl8x7yljrqcy27";
       };
     i686-linux =
       {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-364.0.0-linux-x86.tar.gz";
-        sha256 = "1cfh5bx7zcjbjqbsin4aqd10jlaibbckgjpp16lh4aywrysdfdzh";
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-365.0.0-linux-x86.tar.gz";
+        sha256 = "0jvcridqlk2r5m6b22ldxi9g4mxfy120428ynw9rgpwx0chjmpi6";
       };
   };
 }

--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -21,33 +21,33 @@ let
   sources = name: system: {
     x86_64-darwin = {
       url = "${baseUrl}/${name}-darwin-x86_64.tar.gz";
-      sha256 = "19s3nryngzv7zs7piwx92hii5p2y97fs7wngqrd9v8cxvgavp1dc";
+      sha256 = "0p2jpzkd0mn70wvs5m6xh9v1f5wfxww6miz2xgd50wa71kh5q9hl";
     };
 
     aarch64-darwin = {
       url = "${baseUrl}/${name}-darwin-arm.tar.gz";
-      sha256 = "1iphpkxrrp0gdan7ikbjbhykdpazcs1fnlcwkfyv2m9baggkd53z";
+      sha256 = "0lp5l79dm263ymm32abkz7hnfb9zwhwi9xspr2gx8h4jgpw4hmxm";
     };
 
     x86_64-linux = {
       url = "${baseUrl}/${name}-linux-x86_64.tar.gz";
-      sha256 = "1z1ymvij9vi8jc05b004jhd08dqbk133wd03fdxnagd6nfr0bjqm";
+      sha256 = "0i9h61qsd0pmvypjkmp8nzgrdr3n6wdvmizrsnm9azrsmsqbx4cl";
     };
 
     i686-linux = {
       url = "${baseUrl}/${name}-linux-x86.tar.gz";
-      sha256 = "17i5pkwjmi38klgr12xqgza7iwkx459cbavlq0x33zaq2a4zanlc";
+      sha256 = "1cfh5bx7zcjbjqbsin4aqd10jlaibbckgjpp16lh4aywrysdfdzh";
     };
 
     aarch64-linux = {
       url = "${baseUrl}/${name}-linux-arm.tar.gz";
-      sha256 = "17zjnab4ai5w6p3cbxys9zsg4bdlp0lh6pvmkvdz9hszxxch4yms";
+      sha256 = "0v8hrymq0iwrw936v7bll012gi20zrhjn4jjgn940y5rrdz7pk2i";
     };
   }.${system} or (throw "Unsupported system: ${system}");
 
 in stdenv.mkDerivation rec {
   pname = "google-cloud-sdk";
-  version = "362.0.0";
+  version = "364.0.0";
 
   src = fetchurl (sources "${pname}-${version}" stdenv.hostPlatform.system);
 

--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -17,39 +17,15 @@ let
     crcmod
   ] ++ lib.optional (with-gce) google-compute-engine);
 
-  baseUrl = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads";
-  sources = name: system: {
-    x86_64-darwin = {
-      url = "${baseUrl}/${name}-darwin-x86_64.tar.gz";
-      sha256 = "0p2jpzkd0mn70wvs5m6xh9v1f5wfxww6miz2xgd50wa71kh5q9hl";
-    };
-
-    aarch64-darwin = {
-      url = "${baseUrl}/${name}-darwin-arm.tar.gz";
-      sha256 = "0lp5l79dm263ymm32abkz7hnfb9zwhwi9xspr2gx8h4jgpw4hmxm";
-    };
-
-    x86_64-linux = {
-      url = "${baseUrl}/${name}-linux-x86_64.tar.gz";
-      sha256 = "0i9h61qsd0pmvypjkmp8nzgrdr3n6wdvmizrsnm9azrsmsqbx4cl";
-    };
-
-    i686-linux = {
-      url = "${baseUrl}/${name}-linux-x86.tar.gz";
-      sha256 = "1cfh5bx7zcjbjqbsin4aqd10jlaibbckgjpp16lh4aywrysdfdzh";
-    };
-
-    aarch64-linux = {
-      url = "${baseUrl}/${name}-linux-arm.tar.gz";
-      sha256 = "0v8hrymq0iwrw936v7bll012gi20zrhjn4jjgn940y5rrdz7pk2i";
-    };
-  }.${system} or (throw "Unsupported system: ${system}");
+  data = import ./data.nix { };
+  sources = system:
+    data.googleCloudSdkPkgs.${system} or (throw "Unsupported system: ${system}");
 
 in stdenv.mkDerivation rec {
   pname = "google-cloud-sdk";
-  version = "364.0.0";
+  inherit (data) version;
 
-  src = fetchurl (sources "${pname}-${version}" stdenv.hostPlatform.system);
+  src = fetchurl (sources stdenv.hostPlatform.system);
 
   buildInputs = [ python ];
 
@@ -128,8 +104,9 @@ in stdenv.mkDerivation rec {
     # This package contains vendored dependencies. All have free licenses.
     license = licenses.free;
     homepage = "https://cloud.google.com/sdk/";
+    changelog = "https://cloud.google.com/sdk/docs/release-notes";
     maintainers = with maintainers; [ iammrinal0 pradyuman stephenmw zimbatm ];
-    platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+    platforms = builtins.attrNames data.googleCloudSdkPkgs;
     mainProgram = "gcloud";
   };
 }

--- a/pkgs/tools/admin/google-cloud-sdk/update.sh
+++ b/pkgs/tools/admin/google-cloud-sdk/update.sh
@@ -5,7 +5,7 @@ BASE_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-clou
 
 # Version of Google Cloud SDK from
 # https://cloud.google.com/sdk/docs/release-notes
-VERSION="364.0.0"
+VERSION="365.0.0"
 
 function genMainSrc() {
     local url="${BASE_URL}-${VERSION}-${1}-${2}.tar.gz"

--- a/pkgs/tools/admin/google-cloud-sdk/update.sh
+++ b/pkgs/tools/admin/google-cloud-sdk/update.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p nix
+
+BASE_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk"
+
+# Version of Google Cloud SDK from
+# https://cloud.google.com/sdk/docs/release-notes
+VERSION="364.0.0"
+
+function genMainSrc() {
+    local url="${BASE_URL}-${VERSION}-${1}-${2}.tar.gz"
+    local sha256
+    sha256=$(nix-prefetch-url "$url")
+    echo "      {"
+    echo "        url = \"${url}\";"
+    echo "        sha256 = \"${sha256}\";"
+    echo "      };"
+}
+
+{
+    cat <<EOF
+# DO NOT EDIT! This file is generated automatically by update.sh
+{ }:
+{
+  version = "${VERSION}";
+  googleCloudSdkPkgs = {
+EOF
+
+    echo "    x86_64-linux ="
+    genMainSrc "linux" "x86_64"
+
+    echo "    x86_64-darwin ="
+    genMainSrc "darwin" "x86_64"
+
+    echo "    aarch64-linux ="
+    genMainSrc "linux" "arm"
+
+    echo "    aarch64-darwin ="
+    genMainSrc "darwin" "arm"
+
+    echo "    i686-linux ="
+    genMainSrc "linux" "x86"
+
+    echo "  };"
+    echo "}"
+
+} >data.nix


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
* Upstream update: [Release notes for 364.0.0](https://cloud.google.com/sdk/docs/release-notes#36400_2021-11-09) 
* Upstream update: [Release ntoes for 365.0.0](https://cloud.google.com/sdk/docs/release-notes#36500_2021-11-16)
* Add update script


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
