### PR TITLE
vim-configurable: rename from vim_configurable

### DIFF
--- a/doc/languages-frameworks/vim.section.md
+++ b/doc/languages-frameworks/vim.section.md
@@ -17,7 +17,7 @@ At the moment we support three different methods for managing plugins:
 Adding custom .vimrc lines can be done using the following code:
 
 ```nix
-vim_configurable.customize {
+vim-configurable.customize {
   # `name` specifies the name of the executable and package
   name = "vim-with-plugins";
 
@@ -61,7 +61,7 @@ neovim-qt.override {
 To store you plugins in Vim packages (the native Vim plugin manager, see `:help packages`) the following example can be used:
 
 ```nix
-vim_configurable.customize {
+vim-configurable.customize {
   vimrcConfig.packages.myVimPackage = with pkgs.vimPlugins; {
     # loaded on launch
     start = [ youcompleteme fugitive ];
@@ -100,7 +100,7 @@ The resulting package can be added to `packageOverrides` in `~/.nixpkgs/config.n
 ```nix
 {
   packageOverrides = pkgs: with pkgs; {
-    myVim = vim_configurable.customize {
+    myVim = vim-configurable.customize {
       # `name` specifies the name of the executable and package
       name = "vim-with-plugins";
       # add here code from the example section
@@ -187,7 +187,7 @@ To use [vim-plug](https://github.com/junegunn/vim-plug) to manage your Vim
 plugins the following example can be used:
 
 ```nix
-vim_configurable.customize {
+vim-configurable.customize {
   vimrcConfig.packages.myVimPackage = with pkgs.vimPlugins; {
     # loaded on launch
     plug.plugins = [ youcompleteme fugitive phpCompletion elm-vim ];
@@ -237,7 +237,7 @@ Create a default.nix file:
 
 ```nix
 { nixpkgs ? import <nixpkgs> {}, compiler ? "ghc7102" }:
-nixpkgs.vim_configurable.customize { name = "vim"; vimrcConfig.vam.pluginDictionaries = [ "vim-addon-vim2nix" ]; }
+nixpkgs.vim-configurable.customize { name = "vim"; vimrcConfig.vam.pluginDictionaries = [ "vim-addon-vim2nix" ]; }
 ```
 
 Create a generate.vim file:
@@ -266,7 +266,7 @@ You can add your Vim to your system's configuration file like this and start it 
 my-vim =
   let plugins = let inherit (vimUtils) buildVimPluginFrom2Nix; in {
     copy paste output1 here
-  }; in vim_configurable.customize {
+  }; in vim-configurable.customize {
     name = "vim-my";
 
     vimrcConfig.vam.knownPlugins = plugins; # optional

--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -1966,6 +1966,13 @@ Superuser created successfully.
           <literal>1.5.4</literal>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <literal>vim_configurable</literal> has been renamed to
+          <literal>vim-configurable</literal>,
+          <literal>vim_configurable</literal> is now an alias to it.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
 </section>

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -539,3 +539,5 @@ In addition to numerous new and upgraded packages, this release has the followin
 - Loki has had another release. Some default values have been changed for the configuration and some configuration options have been renamed. For more details, please check [the upgrade guide](https://grafana.com/docs/loki/latest/upgrading/#240).
 
 - `julia` now refers to `julia-stable` instead of `julia-lts`. In practice this means it has been upgraded from `1.0.4` to `1.5.4`.
+
+- `vim_configurable` has been renamed to `vim-configurable`, `vim_configurable` is now an alias to it.

--- a/pkgs/applications/editors/neovim/tests.nix
+++ b/pkgs/applications/editors/neovim/tests.nix
@@ -1,4 +1,4 @@
-{ vimUtils, vim_configurable, writeText, neovim, vimPlugins
+{ vimUtils, vim-configurable, writeText, neovim, vimPlugins
 , lib, fetchFromGitHub, neovimUtils, wrapNeovimUnstable
 , neovim-unwrapped
 , fetchFromGitLab

--- a/pkgs/applications/editors/spacevim/default.nix
+++ b/pkgs/applications/editors/spacevim/default.nix
@@ -2,7 +2,7 @@
 , git
 , fzf
 , makeWrapper
-, vim_configurable
+, vim-configurable
 , vimPlugins
 , fetchFromGitHub
 , lib
@@ -14,7 +14,7 @@
 
 let
   format = formats.toml { };
-  vim-customized = vim_configurable.customize {
+  vim-customized = vim-configurable.customize {
     name = "vim";
     # Not clear at the moment how to import plugins such that
     # SpaceVim finds them and does not auto download them to

--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -64,7 +64,7 @@ let
 
 in stdenv.mkDerivation rec {
 
-  pname = "vim_configurable";
+  pname = "vim-configurable";
 
   inherit (common) version postPatch hardeningDisable enableParallelBuilding meta;
 

--- a/pkgs/applications/editors/vim/macvim-configurable.nix
+++ b/pkgs/applications/editors/vim/macvim-configurable.nix
@@ -6,9 +6,9 @@ let
   makeCustomizable = macvim: macvim // {
     # configure expects the same args as vimUtils.vimrcFile.
     # This is the same as the value given to neovim.override { configure = … }
-    # or the value of vim_configurable.customize { vimrcConfig = … }
+    # or the value of vim-configurable.customize { vimrcConfig = … }
     #
-    # Note: Like neovim and vim_configurable, configuring macvim disables the
+    # Note: Like neovim and vim-configurable, configuring macvim disables the
     # sourcing of the user's vimrc. Use `customRC = "source $HOME/.vim/vimrc"`
     # if you want to preserve that behavior.
     configure = let

--- a/pkgs/applications/editors/vim/vimacs.nix
+++ b/pkgs/applications/editors/vim/vimacs.nix
@@ -1,11 +1,11 @@
-{ lib, stdenv, config, vim_configurable, macvim, vimPlugins
+{ lib, stdenv, config, vim-configurable, macvim, vimPlugins
 , useMacvim ? stdenv.isDarwin && (config.vimacs.macvim or true)
 , vimacsExtraArgs ? "" }:
 
 stdenv.mkDerivation rec {
   pname = "vimacs";
   version = lib.getVersion vimPackage;
-  vimPackage = if useMacvim then macvim else vim_configurable;
+  vimPackage = if useMacvim then macvim else vim-configurable;
 
   buildInputs = [ vimPackage vimPlugins.vimacs ];
 

--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -1,5 +1,5 @@
 # tests available at pkgs/test/vim
-{ lib, stdenv, vim, vimPlugins, vim_configurable, buildEnv, writeText, writeScriptBin
+{ lib, stdenv, vim, vimPlugins, vim-configurable, buildEnv, writeText, writeScriptBin
 , nix-prefetch-hg, nix-prefetch-git
 , fetchFromGitHub, runtimeShell
 , hasLuaModule
@@ -15,7 +15,7 @@ USAGE EXAMPLE
 Install Vim like this eg using nixos option environment.systemPackages which will provide
 vim-with-plugins in PATH:
 
-  vim_configurable.customize {
+  vim-configurable.customize {
     name = "vim-with-plugins";
 
     # add custom .vimrc lines like this:
@@ -128,7 +128,7 @@ fitting the vimrcConfig.vam.pluginDictionaries option.
 Thus the most simple usage would be:
 
   vim_with_plugins =
-    let vim = vim_configurable;
+    let vim = vim-configurable;
         inherit (vimUtil.override {inherit vim}) rtpPath addRtp buildVimPlugin vimHelpTags;
         vimPlugins = [
           # the derivation list from the buffer created by nix#ExportPluginsForNix
@@ -461,7 +461,7 @@ rec {
     overrideAttrs = f: makeCustomizable (vim.overrideAttrs f);
   };
 
-  pluginnames2Nix = {name, namefiles} : vim_configurable.customize {
+  pluginnames2Nix = {name, namefiles} : vim-configurable.customize {
     inherit name;
     vimrcConfig.vam.knownPlugins = vimPlugins;
     vimrcConfig.vam.pluginDictionaries = ["vim2nix"];

--- a/pkgs/test/vim/default.nix
+++ b/pkgs/test/vim/default.nix
@@ -1,4 +1,4 @@
-{ vimUtils, vim_configurable, writeText, vimPlugins
+{ vimUtils, vim-configurable, writeText, vimPlugins
 , lib, fetchFromGitHub
 , pkgs
 }:
@@ -13,27 +13,27 @@ in
 
   ### vim tests
   ##################
-  vim_with_vim2nix = vim_configurable.customize {
+  vim_with_vim2nix = vim-configurable.customize {
     name = "vim"; vimrcConfig.vam.pluginDictionaries = [ "vim-addon-vim2nix" ];
   };
 
   # test cases:
-  test_vim_with_vim_nix_using_vam = vim_configurable.customize {
+  test_vim_with_vim_nix_using_vam = vim-configurable.customize {
    name = "vim-with-vim-addon-nix-using-vam";
     vimrcConfig.vam.pluginDictionaries = [{name = "vim-nix"; }];
   };
 
-  test_vim_with_vim_nix_using_pathogen = vim_configurable.customize {
+  test_vim_with_vim_nix_using_pathogen = vim-configurable.customize {
     name = "vim-with-vim-addon-nix-using-pathogen";
     vimrcConfig.pathogen.pluginNames = [ "vim-nix" ];
   };
 
-  test_vim_with_vim_nix_using_plug = vim_configurable.customize {
+  test_vim_with_vim_nix_using_plug = vim-configurable.customize {
     name = "vim-with-vim-addon-nix-using-plug";
     vimrcConfig.plug.plugins = with vimPlugins; [ vim-nix ];
   };
 
-  test_vim_with_vim_nix = vim_configurable.customize {
+  test_vim_with_vim_nix = vim-configurable.customize {
     name = "vim-with-vim-addon-nix";
     vimrcConfig.packages.myVimPackage.start = with vimPlugins; [ vim-nix ];
   };
@@ -42,7 +42,7 @@ in
   # The user may have specified their own plugins which may not be formatted
   # exactly as the generated ones. In particular, they may not have the `pname`
   # attribute.
-  test_vim_with_custom_plugin = vim_configurable.customize {
+  test_vim_with_custom_plugin = vim-configurable.customize {
     name = "vim_with_custom_plugin";
     vimrcConfig.vam.knownPlugins =
       vimPlugins // ({

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -971,6 +971,7 @@ mapAliases ({
   vdirsyncerStable  = vdirsyncer; # added 2020-11-08, see https://github.com/NixOS/nixpkgs/issues/103026#issuecomment-723428168
   vimbWrapper = vimb; # added 2015-01
   vimprobable2 = throw "vimprobable2 has been removed from nixpkgs. It relied on webkitgtk24x that has been removed."; # added 2019-12-05
+  vim_configurable = vim-configurable; # added 2021-11-10
   vimprobable2-unwrapped = vimprobable2; # added 2019-12-05
   virtviewer = virt-viewer; # added 2015-12-24
   virtmanager = virt-manager; # added 2019-10-29

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23970,7 +23970,7 @@ with pkgs;
   assign-lb-ip = callPackage ../applications/networking/cluster/assign-lb-ip { };
 
   astroid = callPackage ../applications/networking/mailreaders/astroid {
-    vim = vim_configurable.override { features = "normal"; gui = "auto"; };
+    vim = vim-configurable.override { features = "normal"; gui = "auto"; };
   };
 
   aucatctl = callPackage ../applications/audio/aucatctl { };
@@ -28712,16 +28712,16 @@ with pkgs;
 
   macvim = callPackage ../applications/editors/vim/macvim-configurable.nix { stdenv = clangStdenv; };
 
-  vimHugeX = vim_configurable;
+  vimHugeX = vim-configurable;
 
-  vim_configurable = vimUtils.makeCustomizable (callPackage ../applications/editors/vim/configurable.nix {
+  vim-configurable = vimUtils.makeCustomizable (callPackage ../applications/editors/vim/configurable.nix {
     inherit (darwin.apple_sdk.frameworks) CoreServices Cocoa Foundation CoreData;
     inherit (darwin) libobjc;
     gtk2 = if stdenv.isDarwin then gtk2-x11 else gtk2;
     gtk3 = if stdenv.isDarwin then gtk3-x11 else gtk3;
   });
 
-  vim-darwin = (vim_configurable.override {
+  vim-darwin = (vim-configurable.override {
     config = {
       vim = {
         gui = "none";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
