### PR TITLE
yosys: remove pointless patching

### DIFF
--- a/pkgs/development/compilers/yosys/fix-clang-build.patch
+++ b/pkgs/development/compilers/yosys/fix-clang-build.patch
@@ -2,19 +2,6 @@ diff --git a/Makefile b/Makefile
 index 86abc6958..a72f7b792 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -145,7 +145,12 @@ bumpversion:
- ABCREV = 4f5f73d
- ABCPULL = 1
- ABCURL ?= https://github.com/YosysHQ/abc
-+
-+ifneq ($(CONFIG),clang)
-+ABCMKARGS = CC=clang CXX="$(CXX)" LD=clang ABC_USE_LIBSTDCXX=1 VERBOSE=$(Q)
-+else
- ABCMKARGS = CC="$(CXX)" CXX="$(CXX)" ABC_USE_LIBSTDCXX=1 VERBOSE=$(Q)
-+endif
- 
- # set ABCEXTERNAL = <abc-command> to use an external ABC instance
- # Note: The in-tree ABC (yosys-abc) will not be installed when ABCEXTERNAL is set.
 @@ -187,7 +192,7 @@ endif
  endif
  


### PR DESCRIPTION
(Follow-up to #145193)

This fixes the patch introduced in:

  94a047ca74cb (yosys: fix build on darwin, 2021-11-09)

Because we supply yosys with an external build of ABC, the patched
ABCMKARGS variable is without influence. Even if we were building with
in-tree ABC, that part of the patch is wrong, so drop it altogether.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
