### PR TITLE
python3.pkgs.jedi-lanugage-server: init at 0.34.8

### DIFF
--- a/pkgs/development/python-modules/docstring-to-markdown/default.nix
+++ b/pkgs/development/python-modules/docstring-to-markdown/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "docstring-to-markdown";
+  version = "0.9";
+
+  src = fetchFromGitHub {
+    owner = "python-lsp";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-XVTlSqqWmvnB5nvjvgGDJmg71KKTq2hHB4//QW7ugvA=";
+  };
+
+  patches = [
+    # So pytest-flake8 and pytest-cov won't be needed
+    ./remove-coverage-tests.patch
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "docstring_to_markdown"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/python-lsp/docstring-to-markdown";
+    description = "On the fly conversion of Python docstrings to markdown";
+    license = licenses.lgpl2Plus;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/development/python-modules/docstring-to-markdown/remove-coverage-tests.patch
+++ b/pkgs/development/python-modules/docstring-to-markdown/remove-coverage-tests.patch
@@ -1,0 +1,16 @@
+diff --git i/setup.cfg w/setup.cfg
+index e880e74..e77133e 100644
+--- i/setup.cfg
++++ w/setup.cfg
+@@ -34,11 +34,7 @@ docstring-to-markdown = py.typed
+ [tool:pytest]
+ addopts =
+     --pyargs tests
+-    --cov docstring_to_markdown
+-    --cov-fail-under=98
+-    --cov-report term-missing:skip-covered
+     -p no:warnings
+-    --flake8
+     -vv
+ 
+ [flake8]

--- a/pkgs/development/python-modules/jedi-language-server/default.nix
+++ b/pkgs/development/python-modules/jedi-language-server/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, fetchFromGitHub
+, poetry
+, docstring-to-markdown
+, jedi
+, pygls
+, pytestCheckHook
+, pyhamcrest
+, python-jsonrpc-server
+}:
+
+buildPythonPackage rec {
+  pname = "jedi-language-server";
+  version = "0.34.8";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "pappasam";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-mJGgDDjPZXde4M4OHwj81KYoaFXFAwOZ+v18YE+arFE=";
+  };
+
+  nativeBuildInputs = [
+    poetry
+  ];
+
+  propagatedBuildInputs = [
+    docstring-to-markdown
+    jedi
+    pygls
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pyhamcrest
+    python-jsonrpc-server
+  ];
+
+  preCheck = ''
+    HOME="$(mktemp -d)"
+  '';
+
+  pythonImportsCheck = [
+    "jedi_language_server"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/pappasam/jedi-language-server";
+    description = "A Language Server for the latest version(s) of Jedi";
+    license = licenses.mit;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3931,6 +3931,8 @@ in {
 
   jedi = callPackage ../development/python-modules/jedi { };
 
+  jedi-language-server = callPackage ../development/python-modules/jedi-language-server { };
+
   jeepney = callPackage ../development/python-modules/jeepney { };
 
   jellyfin-apiclient-python = callPackage ../development/python-modules/jellyfin-apiclient-python { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2267,6 +2267,8 @@ in {
 
   docloud = callPackage ../development/python-modules/docloud { };
 
+  docstring-to-markdown = callPackage ../development/python-modules/docstring-to-markdown { };
+
   docopt = callPackage ../development/python-modules/docopt { };
 
   docopt-ng = callPackage ../development/python-modules/docopt-ng { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

For [coc-jedi](https://github.com/pappasam/coc-jedi).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
