### PR TITLE
hercules-ci-*, cachix: nix: 2.3 -> 2.4

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -935,11 +935,11 @@ self: super: builtins.intersectAttrs super {
 
   rel8 = addTestToolDepend super.rel8 pkgs.postgresql;
 
-  cachix = generateOptparseApplicativeCompletion "cachix" (super.cachix.override { nix = pkgs.nix_2_3; });
+  cachix = generateOptparseApplicativeCompletion "cachix" (super.cachix.override { nix = pkgs.nix_2_4; });
 
-  hercules-ci-agent = super.hercules-ci-agent.override { nix = pkgs.nix_2_3; };
-  hercules-ci-cnix-expr = super.hercules-ci-cnix-expr.override { nix = pkgs.nix_2_3; };
-  hercules-ci-cnix-store = super.hercules-ci-cnix-store.override { nix = pkgs.nix_2_3; };
+  hercules-ci-agent = appendConfigureFlag (super.hercules-ci-agent.override { nix = pkgs.nix_2_4; }) "-fnix-2_4";
+  hercules-ci-cnix-expr = appendConfigureFlag (super.hercules-ci-cnix-expr.override { nix = pkgs.nix_2_4; }) "-fnix-2_4";
+  hercules-ci-cnix-store = appendConfigureFlag (super.hercules-ci-cnix-store.override { nix = pkgs.nix_2_4; }) "-fnix-2_4";
 
   # Enable extra optimisations which increase build time, but also
   # later compiler performance, so we should do this for user's benefit.

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -58,7 +58,7 @@ common =
            ];
 
       buildInputs =
-        [ curl libsodium openssl sqlite xz bzip2 nlohmann_json
+        [ curl libsodium openssl sqlite xz bzip2
           brotli boost editline
         ]
         ++ lib.optionals stdenv.isDarwin [ Security ]
@@ -209,6 +209,13 @@ common =
     ];
   });
 
+  # master: https://github.com/NixOS/nix/pull/5536
+  # 2.4: https://github.com/NixOS/nix/pull/5537
+  installNlohmannJsonPatch = fetchpatch {
+    url = "https://github.com/NixOS/nix/pull/5536.diff";
+    sha256 = "sha256-SPnam4xNIjbMgnq6IP1AaM1V62X0yZNo4DEVmI8sHOo=";
+  };
+
 in rec {
 
   nix = nixStable;
@@ -241,6 +248,8 @@ in rec {
 
     boehmgc = boehmgc_nixUnstable;
 
+    patches = [ installNlohmannJsonPatch ];
+
     inherit storeDir stateDir confDir;
   });
 
@@ -257,6 +266,8 @@ in rec {
     };
 
     boehmgc = boehmgc_nixUnstable;
+
+    patches = [ installNlohmannJsonPatch ];
 
     inherit storeDir stateDir confDir;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Follow-up to #144197 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
