### PR TITLE
bullet: 2.87 -> 3.17

### DIFF
--- a/pkgs/development/libraries/bullet/default.nix
+++ b/pkgs/development/libraries/bullet/default.nix
@@ -4,22 +4,23 @@
 
 stdenv.mkDerivation rec {
   pname = "bullet";
-  version = "2.87";
+  version = "3.17";
 
   src = fetchFromGitHub {
     owner = "bulletphysics";
     repo = "bullet3";
     rev = version;
-    sha256 = "1msp7w3563vb43w70myjmqsdb97kna54dcfa7yvi9l3bvamb92w3";
+    sha256 = "sha256-uQ4X8F8nmagbcFh0KexrmnhHIXFSB3A1CCnjPVeHL3Q=";
   };
 
   nativeBuildInputs = [ cmake ];
   buildInputs = lib.optionals stdenv.isLinux [ libGLU libGL freeglut ]
     ++ lib.optionals stdenv.isDarwin [ Cocoa OpenGL ];
 
-  patches = [ ./gwen-narrowing.patch ];
-
-  postPatch = lib.optionalString stdenv.isDarwin ''
+  postPatch = ''
+    substituteInPlace examples/ThirdPartyLibs/Gwen/CMakeLists.txt \
+      --replace "-DGLEW_STATIC" "-DGLEW_STATIC -Wno-narrowing"
+  '' + lib.optionalString stdenv.isDarwin ''
     sed -i 's/FIND_PACKAGE(OpenGL)//' CMakeLists.txt
     sed -i 's/FIND_LIBRARY(COCOA_LIBRARY Cocoa)//' CMakeLists.txt
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
There was a new version avalaible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`) (there are none)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of a proposition here : https://github.com/NixOS/nixpkgs/pull/144798 .
Tested the execution of vdrift and stuntrally.

(may need some testing to see if it still compile on darwin)

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>15 packages built:</summary>
  <ul>
    <li>bullet</li>
    <li>enlightenment.econnman</li>
    <li>enlightenment.efl</li>
    <li>enlightenment.enlightenment</li>
    <li>enlightenment.ephoto</li>
    <li>enlightenment.evisum</li>
    <li>enlightenment.rage</li>
    <li>enlightenment.terminology</li>
    <li>openmw</li>
    <li>openmw-tes3mp</li>
    <li>python38Packages.pythonefl</li>
    <li>python39Packages.pythonefl</li>
    <li>stuntrally</li>
    <li>vdrift</li>
    <li>vdrift-bin</li>
  </ul>
</details>

maintainer: @aforemny 