### PR TITLE
plymouth: unstable-2020-12-07 -> unstable-2021-10-18

### DIFF
--- a/pkgs/os-specific/linux/plymouth/default.nix
+++ b/pkgs/os-specific/linux/plymouth/default.nix
@@ -15,8 +15,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "plymouth-unstable";
-  version = "2020-12-07";
+  pname = "plymouth";
+  version = "unstable-2021-10-18";
 
   outputs = [
     "out"
@@ -27,8 +27,8 @@ stdenv.mkDerivation rec {
     domain = "gitlab.freedesktop.org";
     owner = "plymouth";
     repo = "plymouth";
-    rev = "c4ced2a2d70edea7fbb95274aa1d01d95928df1b";
-    sha256 = "7CPuKMA0fTt8DBsaA4Td74kHT/O7PW8N3awP04nUnOI=";
+    rev = "18363cd887dbfe7e82a2f4cc1a49ef9513919142";
+    sha256 = "sha256-+AP4ALOFdYFt/8MDXjMaHptkogCwK1iXKuza1zfMaws=";
   };
 
   nativeBuildInputs = [
@@ -45,15 +45,6 @@ stdenv.mkDerivation rec {
     libdrm
     pango
     systemd
-  ];
-
-  patches = [
-    # KillMode=none is deprecated
-    # https://gitlab.freedesktop.org/plymouth/plymouth/-/issues/123
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/plymouth/plymouth/-/commit/b406b0895a95949db2adfedaeda451f36f2b51c3.patch";
-      sha256 = "/UBImNuFO0G/oxlttjGIXon8YXMXlc9XU8uVuR9QuxY=";
-    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Someone reported at #nixos-brasil Telegram issues with Gnome+Plymouth. It seems that our Plymouth derivation is very old, and this maybe the cause of the issues.

From [Arch Linux Wiki](https://wiki.archlinux.org/title/Plymouth#Installation):

> Plymouth is available from the AUR: the stable package is plymouth and the development version is plymouth-git. Due to the fact that upstream plymouth release only happen on a spotty and highly unregular schedule, it is generally recommended to use plymouth-git, because it is actually less likely to cause problems for most users than the stable package.

Now, this is a really difficult package to test since it doesn't seem to work in the traditional QEMU VM. So what I did is copy the derivation to my personal config, add it as an overlay, set `boot.plymouth.enable` and did a full reboot cycle. Seems to work fine.

However, keep in mind that I was using 21.05 release for this. I couldn't simply use the package from current `master` branch since there is some glibc version validation happening behind the scenes, and combining `plymouth` from `master` with my `release-21.05` didn't allow me to build. So it would be nice someone using `nixpkgs-unstable`/`master` to test this PR before merging.

At the same time, if this does fixes some issues, it would be interesting to merge this before release `21.11`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
