### PR TITLE
treewide: replace '-git' packages with 'unstable-' in version 

### DIFF
--- a/pkgs/applications/audio/foo-yc20/default.nix
+++ b/pkgs/applications/audio/foo-yc20/default.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, fetchFromGitHub,  libjack2, gtk2, lv2, faust, pkg-config }:
+{ lib, stdenv, fetchFromGitHub, libjack2, gtk2, lv2, faust, pkg-config }:
 
 stdenv.mkDerivation {
-  version = "git-2015-05-21";
+  version = "unstable-2015-05-21";
   pname = "foo-yc20";
   src = fetchFromGitHub {
     owner = "sampov2";
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
     broken = true; # see: https://github.com/sampov2/foo-yc20/issues/7
     description = "A Faust implementation of a 1969 designed Yamaha combo organ, the YC-20";
     homepage = "https://github.com/sampov2/foo-yc20";
-    license     = with licenses; [ bsd3 lgpl21 mpl11 ] ;
+    license = with licenses; [ bsd3 lgpl21 mpl11 ];
     maintainers = [ maintainers.magnetophon ];
     platforms = platforms.linux;
   };

--- a/pkgs/applications/audio/mod-distortion/default.nix
+++ b/pkgs/applications/audio/mod-distortion/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub, lv2 }:
 
 stdenv.mkDerivation {
-  pname = "mod-distortion-git";
-  version = "2016-08-19";
+  pname = "mod-distortion";
+  version = "unstable-2016-08-19";
 
   src = fetchFromGitHub {
     owner = "portalmod";

--- a/pkgs/applications/audio/orca-c/default.nix
+++ b/pkgs/applications/audio/orca-c/default.nix
@@ -1,8 +1,7 @@
 { lib, stdenv, fetchgit, ncurses, portmidi }:
 stdenv.mkDerivation {
   pname = "orca-c";
-
-  version = "git-2021-02-13";
+  version = "unstable-2021-02-13";
 
   src = fetchgit {
     url = "https://git.sr.ht/~rabbits/orca";

--- a/pkgs/applications/editors/supertux-editor/default.nix
+++ b/pkgs/applications/editors/supertux-editor/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, mono, gtk-sharp-2_0, pkg-config, makeWrapper, gnome2, gtk2 }:
 stdenv.mkDerivation {
-  version = "git-2014-08-20";
+  version = "unstable-2014-08-20";
   pname = "supertux-editor";
 
   src = fetchFromGitHub {
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ pkg-config makeWrapper ];
-  buildInputs = [mono gtk-sharp-2_0 gnome2.libglade gtk2 ];
+  buildInputs = [ mono gtk-sharp-2_0 gnome2.libglade gtk2 ];
 
   installPhase = ''
     mkdir -p $out/bin $out/lib/supertux-editor

--- a/pkgs/applications/graphics/smartdeblur/default.nix
+++ b/pkgs/applications/graphics/smartdeblur/default.nix
@@ -1,14 +1,12 @@
 { fetchurl, lib, stdenv, cmake, qt4, fftw }:
 
-let
-  rev = "9895036d26";
-in
 stdenv.mkDerivation rec {
-  name = "smartdeblur-git-${rev}";
+  pname = "smartdeblur";
+  version = "unstable-2013-01-09";
 
   src = fetchurl {
-    url = "https://github.com/Y-Vladimir/SmartDeblur/tarball/${rev}";
-    name = "${name}.tar.gz";
+    url = "https://github.com/Y-Vladimir/SmartDeblur/tarball/9895036d26";
+    name = "smartdeblur-${version}.tar.gz";
     sha256 = "126x9x1zhqdarjz9in0p1qhmqg3jwz7frizadjvx723g2ppi33s4";
   };
 

--- a/pkgs/applications/misc/dfilemanager/default.nix
+++ b/pkgs/applications/misc/dfilemanager/default.nix
@@ -2,7 +2,7 @@
 
 mkDerivation {
   pname = "dfilemanager";
-  version = "git-2020-09-04";
+  version = "unstable-2020-09-04";
 
   src = fetchFromGitHub {
     owner = "probonopd";

--- a/pkgs/applications/misc/yarssr/default.nix
+++ b/pkgs/applications/misc/yarssr/default.nix
@@ -2,16 +2,33 @@
 
 let
   perlDeps = with perlPackages; [
-    Glib Gtk2 Gnome2 Pango Cairo Gnome2Canvas Gnome2VFS Gtk2GladeXML Gtk2TrayIcon
-    XMLLibXML XMLSAXBase XMLParser XMLRSS
+    Glib
+    Gtk2
+    Gnome2
+    Pango
+    Cairo
+    Gnome2Canvas
+    Gnome2VFS
+    Gtk2GladeXML
+    Gtk2TrayIcon
+    XMLLibXML
+    XMLSAXBase
+    XMLParser
+    XMLRSS
     HTMLParser
-    DateTime DateTimeFormatMail DateTimeFormatW3CDTF DateTimeLocale DateTimeTimeZone
+    DateTime
+    DateTimeFormatMail
+    DateTimeFormatW3CDTF
+    DateTimeLocale
+    DateTimeTimeZone
     ParamsValidate
-    ModuleImplementation ModuleRuntime
+    ModuleImplementation
+    ModuleRuntime
     TryTiny
     ClassSingleton
     URI
-    AnyEvent AnyEventHTTP
+    AnyEvent
+    AnyEventHTTP
     commonsense
     FileSlurp
     JSON
@@ -24,7 +41,7 @@ let
   ];
 in
 stdenv.mkDerivation {
-  version = "git-2017-12-01";
+  version = "unstable-2017-12-01";
   pname = "yarssr";
 
   src = fetchFromGitHub {
@@ -35,7 +52,7 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ perlPackages.perl gettext makeWrapper ];
-  buildInputs = perlDeps ++ [gnome2.libglade];
+  buildInputs = perlDeps ++ [ gnome2.libglade ];
   propagatedBuildInputs = libs ++ perlDeps;
 
   installPhase = ''

--- a/pkgs/applications/networking/instant-messengers/tensor/default.nix
+++ b/pkgs/applications/networking/instant-messengers/tensor/default.nix
@@ -1,17 +1,24 @@
-{ mkDerivation, lib, stdenv, fetchgit, qtbase, qtquickcontrols, qmake
-, makeDesktopItem }:
+{ mkDerivation
+, lib
+, stdenv
+, fetchgit
+, qtbase
+, qtquickcontrols
+, qmake
+, makeDesktopItem
+}:
 
 # we now have libqmatrixclient so a future version of tensor that supports it
 # should use that
 
 mkDerivation rec {
-  pname = "tensor-git";
-  version = "2017-02-21";
+  pname = "tensor";
+  version = "unstable-2017-02-21";
 
   src = fetchgit {
-    url             = "https://github.com/davidar/tensor.git";
-    rev             = "f3f3056d770d7fb4a21c610cee7936ee900569f5";
-    sha256          = "19in8c7a2hxsx2c4lj540w5c3pn1882645m21l91mcriynqr67k9";
+    url = "https://github.com/davidar/tensor.git";
+    rev = "f3f3056d770d7fb4a21c610cee7936ee900569f5";
+    sha256 = "19in8c7a2hxsx2c4lj540w5c3pn1882645m21l91mcriynqr67k9";
     fetchSubmodules = true;
   };
 
@@ -19,14 +26,14 @@ mkDerivation rec {
   nativeBuildInputs = [ qmake ];
 
   desktopItem = makeDesktopItem {
-    name        = "tensor";
-    exec        = "@bin@";
-    icon        = "tensor.png";
-    comment     = meta.description;
+    name = "tensor";
+    exec = "@bin@";
+    icon = "tensor.png";
+    comment = meta.description;
     desktopName = "Tensor Matrix Client";
     genericName = meta.description;
-    categories  = "Chat;Utility";
-    mimeType    = "application/x-chat";
+    categories = "Chat;Utility";
+    mimeType = "application/x-chat";
   };
 
   installPhase = if stdenv.isDarwin then ''

--- a/pkgs/applications/networking/znc/modules.nix
+++ b/pkgs/applications/networking/znc/modules.nix
@@ -1,25 +1,29 @@
 { lib, stdenv, fetchFromGitHub, znc }:
 
 let
-  zncDerivation = a@{
-    pname, src, module_name,
-    buildPhase ? "${znc}/bin/znc-buildmod ${module_name}.cpp",
-    installPhase ? "install -D ${module_name}.so $out/lib/znc/${module_name}.so", ...
-  } : stdenv.mkDerivation (a // {
-    inherit buildPhase;
-    inherit installPhase;
+  zncDerivation =
+    a@{ pname
+    , src
+    , module_name
+    , buildPhase ? "${znc}/bin/znc-buildmod ${module_name}.cpp"
+    , installPhase ? "install -D ${module_name}.so $out/lib/znc/${module_name}.so"
+    , ...
+    }: stdenv.mkDerivation (a // {
+      inherit buildPhase;
+      inherit installPhase;
 
-    buildInputs = znc.buildInputs;
+      buildInputs = znc.buildInputs;
 
-    meta = a.meta // { platforms = lib.platforms.unix; };
-    passthru.module_name = module_name;
-  });
+      meta = a.meta // { platforms = lib.platforms.unix; };
+      passthru.module_name = module_name;
+    });
 
-in {
+in
+{
 
   backlog = zncDerivation rec {
     pname = "znc-backlog";
-    version = "git-2017-06-13";
+    version = "unstable-2017-06-13";
     module_name = "backlog";
 
     src = fetchFromGitHub {
@@ -39,7 +43,7 @@ in {
 
   clientbuffer = zncDerivation rec {
     pname = "znc-clientbuffer";
-    version = "git-2020-04-24";
+    version = "unstable-2020-04-24";
     module_name = "clientbuffer";
 
     src = fetchFromGitHub {
@@ -59,7 +63,7 @@ in {
 
   clientaway = zncDerivation rec {
     pname = "znc-clientaway";
-    version = "git-2017-04-28";
+    version = "unstable-2017-04-28";
     module_name = "clientaway";
 
     src = fetchFromGitHub {
@@ -79,7 +83,7 @@ in {
 
   fish = zncDerivation rec {
     pname = "znc-fish";
-    version = "git-2017-06-26";
+    version = "unstable-2017-06-26";
     module_name = "fish";
 
     src = fetchFromGitHub {
@@ -99,7 +103,7 @@ in {
 
   ignore = zncDerivation rec {
     pname = "znc-ignore";
-    version = "git-2017-04-28";
+    version = "unstable-2017-04-28";
     module_name = "ignore";
 
     src = fetchFromGitHub {
@@ -139,7 +143,7 @@ in {
 
   playback = zncDerivation rec {
     pname = "znc-playback";
-    version = "git-2015-08-04";
+    version = "unstable-2015-08-04";
     module_name = "playback";
 
     src = fetchFromGitHub {
@@ -159,7 +163,7 @@ in {
 
   privmsg = zncDerivation rec {
     pname = "znc-privmsg";
-    version = "git-2015-02-22";
+    version = "unstable-2015-02-22";
     module_name = "privmsg";
 
     src = fetchFromGitHub {
@@ -177,7 +181,7 @@ in {
 
   push = zncDerivation rec {
     pname = "znc-push";
-    version = "git-2016-10-12";
+    version = "unstable-2016-10-12";
     module_name = "push";
 
     src = fetchFromGitHub {

--- a/pkgs/development/compilers/eql/default.nix
+++ b/pkgs/development/compilers/eql/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchgit, qt4, ecl, xorgserver, xkbcomp, xkeyboard_config }:
 
 stdenv.mkDerivation rec {
-  version = src.rev;
-  pname = "eql-git";
+  version = "unstable-2012-12-10";
+  pname = "eql";
   src = fetchgit {
     rev = "9097bf98446ee33c07bb155d800395775ce0d9b2";
     url = "https://gitlab.com/eql/eql.git";

--- a/pkgs/development/libraries/jabcode/default.nix
+++ b/pkgs/development/libraries/jabcode/default.nix
@@ -2,7 +2,9 @@
 , fetchFromGitHub
 , lib
 , subproject ? "library" # one of "library", "reader" or  "writer"
-, zlib, libpng, libtiff
+, zlib
+, libpng
+, libtiff
 , jabcode
 }:
 let
@@ -11,9 +13,10 @@ let
     "reader" = "jabcodeReader";
     "writer" = "jabcodeWriter";
   };
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "jabcode-${subproject}";
-  version = "git-2020-05-13";
+  version = "unstable-2020-05-13";
   src = fetchFromGitHub {
     repo = "jabcode";
     owner = "jabcode";
@@ -27,13 +30,14 @@ in stdenv.mkDerivation rec {
 
   preConfigure = "cd src/${subdir}";
 
-  installPhase = if subproject == "library" then ''
-    mkdir -p $out/lib
-    cp build/* $out/lib
-  '' else ''
-    mkdir -p $out/bin
-    cp -RT bin $out/bin
-  '';
+  installPhase =
+    if subproject == "library" then ''
+      mkdir -p $out/lib
+      cp build/* $out/lib
+    '' else ''
+      mkdir -p $out/bin
+      cp -RT bin $out/bin
+    '';
 
   meta = with lib; {
     description = "A high-capacity 2D color bar code (${subproject})";

--- a/pkgs/development/libraries/libqtav/default.nix
+++ b/pkgs/development/libraries/libqtav/default.nix
@@ -1,22 +1,42 @@
-{ mkDerivation, lib, fetchFromGitHub, extra-cmake-modules
-, qtbase, qtmultimedia, qtquick1, qttools
-, libGL, libX11
-, libass, openal, ffmpeg, libuchardet
-, alsa-lib, libpulseaudio, libva
+{ mkDerivation
+, lib
+, fetchFromGitHub
+, extra-cmake-modules
+, qtbase
+, qtmultimedia
+, qtquick1
+, qttools
+, libGL
+, libX11
+, libass
+, openal
+, ffmpeg
+, libuchardet
+, alsa-lib
+, libpulseaudio
+, libva
 }:
 
 with lib;
 
 mkDerivation rec {
   pname = "libqtav";
-  version = "git-2020-09-10";
+  version = "unstable-2020-09-10";
 
   nativeBuildInputs = [ extra-cmake-modules qttools ];
   buildInputs = [
-    qtbase qtmultimedia qtquick1
-    libGL libX11
-    libass openal ffmpeg libuchardet
-    alsa-lib libpulseaudio libva
+    qtbase
+    qtmultimedia
+    qtquick1
+    libGL
+    libX11
+    libass
+    openal
+    ffmpeg
+    libuchardet
+    alsa-lib
+    libpulseaudio
+    libva
   ];
 
   src = fetchFromGitHub {

--- a/pkgs/development/ocaml-modules/lwt/camlp4.nix
+++ b/pkgs/development/ocaml-modules/lwt/camlp4.nix
@@ -2,7 +2,7 @@
 
 buildDunePackage rec {
   pname = "lwt_camlp4";
-  version = "git-20180325";
+  version = "unstable-2018-03-25";
 
   src = fetchFromGitHub {
     owner = "ocsigen";

--- a/pkgs/games/quake3/ioquake/default.nix
+++ b/pkgs/games/quake3/ioquake/default.nix
@@ -1,10 +1,25 @@
-{ lib, stdenv, fetchFromGitHub, which, pkg-config, SDL2, libGL, openalSoft
-, curl, speex, opusfile, libogg, libvorbis, libopus, libjpeg, mumble, freetype
+{ lib
+, stdenv
+, fetchFromGitHub
+, which
+, pkg-config
+, SDL2
+, libGL
+, openalSoft
+, curl
+, speex
+, opusfile
+, libogg
+, libvorbis
+, libopus
+, libjpeg
+, mumble
+, freetype
 }:
 
 stdenv.mkDerivation {
-  pname = "ioquake3-git";
-  version = "2021-07-20";
+  pname = "ioquake3";
+  version = "unstable-2021-07-20";
 
   src = fetchFromGitHub {
     owner = "ioquake";
@@ -15,8 +30,18 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ which pkg-config ];
   buildInputs = [
-    SDL2 libGL openalSoft curl speex opusfile libogg libvorbis libopus libjpeg
-    freetype mumble
+    SDL2
+    libGL
+    openalSoft
+    curl
+    speex
+    opusfile
+    libogg
+    libvorbis
+    libopus
+    libjpeg
+    freetype
+    mumble
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/games/vdrift/default.nix
+++ b/pkgs/games/vdrift/default.nix
@@ -1,5 +1,18 @@
-{ lib, stdenv, fetchFromGitHub, fetchsvn, pkg-config, sconsPackages, libGLU, libGL, SDL2, SDL2_image
-, libvorbis, bullet, curl, gettext, writeTextFile
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchsvn
+, pkg-config
+, sconsPackages
+, libGLU
+, libGL
+, SDL2
+, SDL2_image
+, libvorbis
+, bullet
+, curl
+, gettext
+, writeTextFile
 
 , data ? fetchsvn {
     url = "svn://svn.code.sf.net/p/vdrift/code/vdrift-data";
@@ -8,7 +21,7 @@
   }
 }:
 let
-  version = "git";
+  version = "unstable-2017-12-09";
   bin = stdenv.mkDerivation {
     pname = "vdrift";
     inherit version;
@@ -36,7 +49,7 @@ let
       description = "Car racing game";
       homepage = "http://vdrift.net/";
       license = lib.licenses.gpl2Plus;
-      maintainers = with lib.maintainers; [viric];
+      maintainers = with lib.maintainers; [ viric ];
       platforms = lib.platforms.linux;
     };
   };
@@ -54,7 +67,7 @@ in writeTextFile {
   '';
 } // {
   meta = bin.meta // {
-    hydraPlatforms = [];
+    hydraPlatforms = [ ];
   };
   unwrapped = bin;
   inherit bin data;

--- a/pkgs/misc/drivers/moltengamepad/default.nix
+++ b/pkgs/misc/drivers/moltengamepad/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub, udev }:
 
 stdenv.mkDerivation {
-  pname = "moltengamepad-git";
-  version = "2016-05-04";
+  pname = "moltengamepad";
+  version = "unstable-2016-05-04";
 
   src = fetchFromGitHub {
     owner = "jgeumlek";

--- a/pkgs/servers/tt-rss/plugin-ff-instagram/default.nix
+++ b/pkgs/servers/tt-rss/plugin-ff-instagram/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation {
   pname = "tt-rss-plugin-ff-instagram";
-  version = "git-2019-01-10"; # No release, see https://github.com/wltb/ff_instagram/issues/6
+  version = "unstable-2019-01-10"; # No release, see https://github.com/wltb/ff_instagram/issues/6
 
   src = fetchFromGitHub {
     owner = "wltb";

--- a/pkgs/shells/fish/plugins/foreign-env/default.nix
+++ b/pkgs/shells/fish/plugins/foreign-env/default.nix
@@ -2,7 +2,7 @@
 
 buildFishPlugin {
   pname = "foreign-env";
-  version = "git-20200209";
+  version = "unstable-2020-02-09";
 
   src = fetchFromGitHub {
     owner = "oh-my-fish";

--- a/pkgs/tools/X11/run-scaled/default.nix
+++ b/pkgs/tools/X11/run-scaled/default.nix
@@ -1,13 +1,13 @@
 { lib, stdenv, fetchFromGitHub, makeWrapper, bc, xorgserver, xpra, xrandr }:
 
 stdenv.mkDerivation {
-  version = "git-2018-06-03";
+  version = "unstable-2018-06-03";
   pname = "run-scaled";
 
   src = fetchFromGitHub {
-    owner  = "kaueraal";
-    repo   = "run_scaled";
-    rev    = "fa71b3c17e627a96ff707ad69f1def5361f2245c";
+    owner = "kaueraal";
+    repo = "run_scaled";
+    rev = "fa71b3c17e627a96ff707ad69f1def5361f2245c";
     sha256 = "1ma4ax7ydq4xvyzrc4zapihmf7v3d9zl9mbi8bgpps7nlgz544ys";
   };
 

--- a/pkgs/tools/X11/skippy-xd/default.nix
+++ b/pkgs/tools/X11/skippy-xd/default.nix
@@ -1,14 +1,33 @@
-{lib, stdenv, fetchgit, xorgproto, libX11, libXft, libXcomposite, libXdamage
-, libXext, libXinerama, libjpeg, giflib, pkg-config
+{ lib
+, stdenv
+, fetchgit
+, xorgproto
+, libX11
+, libXft
+, libXcomposite
+, libXdamage
+, libXext
+, libXinerama
+, libjpeg
+, giflib
+, pkg-config
 }:
 let
   buildInputs = [
-    xorgproto libX11 libXft libXcomposite libXdamage libXext
-    libXinerama libjpeg giflib pkg-config
+    xorgproto
+    libX11
+    libXft
+    libXcomposite
+    libXdamage
+    libXext
+    libXinerama
+    libjpeg
+    giflib
+    pkg-config
   ];
 in
 stdenv.mkDerivation rec {
-  version = "git-2015-03-01";
+  version = "unstable-2015-03-01";
   pname = "skippy-xd";
   inherit buildInputs;
   src = fetchgit {
@@ -16,14 +35,14 @@ stdenv.mkDerivation rec {
     rev = "397216ca67";
     sha256 = "0zcjacilmsv69rv85j6nfr6pxy8z36w1sjz0dbjg6s5m4kga1zl8";
   };
-  makeFlags = ["PREFIX=$(out)"];
+  makeFlags = [ "PREFIX=$(out)" ];
   preInstall = ''
     sed -e "s@/etc/xdg@$out&@" -i Makefile
   '';
   meta = {
     description = "Expose-style compositing-based standalone window switcher";
-    license = lib.licenses.gpl2Plus ;
-    maintainers = [lib.maintainers.raskin];
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/tools/X11/xprintidle-ng/default.nix
+++ b/pkgs/tools/X11/xprintidle-ng/default.nix
@@ -1,11 +1,24 @@
-{ lib, stdenv, fetchFromGitHub, libX11, libXScrnSaver, libXext, gnulib
-  , autoconf, automake, libtool, gettext, pkg-config
-  , git, perl, texinfo, help2man
+{ lib
+, stdenv
+, fetchFromGitHub
+, libX11
+, libXScrnSaver
+, libXext
+, gnulib
+, autoconf
+, automake
+, libtool
+, gettext
+, pkg-config
+, git
+, perl
+, texinfo
+, help2man
 }:
 
 stdenv.mkDerivation rec {
   pname = "xprintidle-ng";
-  version = "git-2015-09-01";
+  version = "unstable-2015-09-01";
 
   src = fetchFromGitHub {
     owner = "taktoa";
@@ -20,8 +33,16 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
-    autoconf automake gettext git gnulib
-    help2man libtool perl pkg-config texinfo
+    autoconf
+    automake
+    gettext
+    git
+    gnulib
+    help2man
+    libtool
+    perl
+    pkg-config
+    texinfo
   ];
 
   configurePhase = ''
@@ -30,15 +51,17 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [
-    libX11 libXScrnSaver libXext
+    libX11
+    libXScrnSaver
+    libXext
   ];
 
   meta = {
-    inherit  version;
+    inherit version;
     description = "A command-line tool to print idle time from libXss";
     homepage = "http://taktoa.me/xprintidle-ng/";
     license = lib.licenses.gpl2;
-    maintainers = [lib.maintainers.raskin];
+    maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/tools/cd-dvd/vobsub2srt/default.nix
+++ b/pkgs/tools/cd-dvd/vobsub2srt/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchgit, cmake, libtiff, pkg-config, tesseract }:
 
 stdenv.mkDerivation rec {
-  pname = "vobsub2srt-git";
-  version = "20140817-${builtins.substring 0 7 rev}";
+  pname = "vobsub2srt";
+  version = "unstable-2014-08-17";
   rev = "a6abbd61127a6392d420bbbebdf7612608c943c2";
 
   src = fetchgit {

--- a/pkgs/tools/graphics/qrcode/default.nix
+++ b/pkgs/tools/graphics/qrcode/default.nix
@@ -1,13 +1,13 @@
 { lib, stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation {
-  pname = "qrcode-git";
-  version = "20160804";
+  pname = "qrcode";
+  version = "unstable-2016-08-04";
 
   src = fetchFromGitHub {
-    owner  = "qsantos";
-    repo   = "qrcode";
-    rev    = "ad0fdb4aafd0d56b903f110f697abaeb27deee73";
+    owner = "qsantos";
+    repo = "qrcode";
+    rev = "ad0fdb4aafd0d56b903f110f697abaeb27deee73";
     sha256 = "0v81745nx5gny2g05946k8j553j18a29ikmlyh6c3syq6c15k8cf";
   };
 

--- a/pkgs/tools/misc/clipnotify/default.nix
+++ b/pkgs/tools/misc/clipnotify/default.nix
@@ -1,12 +1,12 @@
 { libX11, libXfixes, lib, stdenv, fetchFromGitHub }:
 stdenv.mkDerivation rec {
   pname = "clipnotify";
-  version = "git-2018-02-20";
+  version = "unstable-2018-02-20";
 
   src = fetchFromGitHub {
     owner = "cdown";
-    repo  = "clipnotify";
-    rev   = "9cb223fbe494c5b71678a9eae704c21a97e3bddd";
+    repo = "clipnotify";
+    rev = "9cb223fbe494c5b71678a9eae704c21a97e3bddd";
     sha256 = "1x9avjq0fgw0svcbw6b6873qnsqxbacls9sipmcv86xia4bxh8dn";
   };
 

--- a/pkgs/tools/misc/colorpicker/default.nix
+++ b/pkgs/tools/misc/colorpicker/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "colorpicker";
-  version = "git-2018-01-14";
+  version = "unstable-2018-01-14";
 
   src = fetchFromGitHub {
     owner = "Ancurio";
-    repo  = "colorpicker";
-    rev   = "287676947e6e3b5b0cee784aeb1638cf22f0ce17";
+    repo = "colorpicker";
+    rev = "287676947e6e3b5b0cee784aeb1638cf22f0ce17";
     sha256 = "1kj1dpb79llrfpszraaz6r7ci114zqi5rmqxwsvq2dnnpjxyi29r";
   };
 

--- a/pkgs/tools/networking/connman/connman_dmenu/default.nix
+++ b/pkgs/tools/networking/connman/connman_dmenu/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation {
   pname = "connman_dmenu";
-  version = "git-29-9-2015";
+  version = "unstable-2015-09-29";
 
   src = fetchFromGitHub {
     owner = "march-linux";
@@ -26,10 +26,10 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    description  = "A dmenu wrapper for connmann";
-    homepage     = "https://github.com/march-linux/connman_dmenu";
-    license      = lib.licenses.free;
-    maintainers  = [ lib.maintainers.magnetophon ];
-    platforms    = lib.platforms.all;
+    description = "A dmenu wrapper for connmann";
+    homepage = "https://github.com/march-linux/connman_dmenu";
+    license = lib.licenses.free;
+    maintainers = [ lib.maintainers.magnetophon ];
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/tools/security/tpm-luks/default.nix
+++ b/pkgs/tools/security/tpm-luks/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation {
   pname = "tpm-luks";
-  version = "git-2015-07-11";
+  version = "unstable-2015-07-11";
 
   src = fetchgit {
     url = "https://github.com/momiji/tpm-luks";
@@ -23,14 +23,14 @@ stdenv.mkDerivation {
     make install DESTDIR=$out
     mv $out/$out/sbin $out/bin
     rm -r $out/nix
-    '';
+  '';
 
   meta = with lib; {
     description = "LUKS key storage in TPM NVRAM";
-    homepage    = "https://github.com/shpedoikal/tpm-luks/";
+    homepage = "https://github.com/shpedoikal/tpm-luks/";
     maintainers = [ maintainers.tstrobel ];
     license = with licenses; [ gpl2Only ];
-    platforms   = platforms.linux;
+    platforms = platforms.linux;
   };
 }
 

--- a/pkgs/tools/system/das_watchdog/default.nix
+++ b/pkgs/tools/system/das_watchdog/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation {
   pname = "das_watchdog";
-  version = "git-2015-09-12";
+  version = "unstable-2015-09-12";
 
   src = fetchgit {
     url = "https://github.com/kmatheussen/das_watchdog.git";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
some packages have the old "package-git" name. The current practice is to use the plain package name and have "unstable-" in the version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
