### PR TITLE
dhall-packages: format

### DIFF
--- a/pkgs/top-level/dhall-packages.nix
+++ b/pkgs/top-level/dhall-packages.nix
@@ -1,6 +1,6 @@
 { lib
 , newScope
-, overrides ? (self: super: {})
+, overrides ? (self: super: { })
 }:
 
 let
@@ -8,38 +8,32 @@ let
     let
       callPackage = newScope self;
 
-      buildDhallPackage =
-        callPackage ../development/interpreters/dhall/build-dhall-package.nix { };
+      buildDhallPackage = callPackage ../development/interpreters/dhall/build-dhall-package.nix { };
 
-      buildDhallGitHubPackage =
-        callPackage ../development/interpreters/dhall/build-dhall-github-package.nix { };
+      buildDhallGitHubPackage = callPackage ../development/interpreters/dhall/build-dhall-github-package.nix { };
 
-      buildDhallDirectoryPackage =
-        callPackage ../development/interpreters/dhall/build-dhall-directory-package.nix { };
+      buildDhallDirectoryPackage = callPackage ../development/interpreters/dhall/build-dhall-directory-package.nix { };
 
-      buildDhallUrl =
-        callPackage ../development/interpreters/dhall/build-dhall-url.nix { };
+      buildDhallUrl = callPackage ../development/interpreters/dhall/build-dhall-url.nix { };
 
     in
-      { inherit
-          callPackage
-          buildDhallPackage
-          buildDhallGitHubPackage
-          buildDhallDirectoryPackage
-          buildDhallUrl
+    {
+      inherit
+        callPackage
+        buildDhallPackage
+        buildDhallGitHubPackage
+        buildDhallDirectoryPackage
+        buildDhallUrl
         ;
 
-        lib = import ../development/dhall-modules/lib.nix { inherit lib; };
+      lib = import ../development/dhall-modules/lib.nix { inherit lib; };
 
-        dhall-grafana =
-          callPackage ../development/dhall-modules/dhall-grafana.nix { };
+      dhall-grafana = callPackage ../development/dhall-modules/dhall-grafana.nix { };
 
-        dhall-kubernetes =
-          callPackage ../development/dhall-modules/dhall-kubernetes.nix { };
+      dhall-kubernetes = callPackage ../development/dhall-modules/dhall-kubernetes.nix { };
 
-        Prelude =
-          callPackage ../development/dhall-modules/Prelude.nix { };
-      };
+      Prelude = callPackage ../development/dhall-modules/Prelude.nix { };
+    };
 
 in
-  lib.fix' (lib.extends overrides packages)
+lib.fix' (lib.extends overrides packages)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
