### PR TITLE
haskellPackages.mkDerivation: add doHaddockInterfaces option

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -56,6 +56,7 @@ in
 , mainProgram ? null
 , doCoverage ? false
 , doHaddock ? !(ghc.isHaLVM or false)
+, doHaddockInterfaces ? doHaddock && lib.versionAtLeast ghc.version "9.0.1"
 , passthru ? {}
 , pkg-configDepends ? [], libraryPkgconfigDepends ? [], executablePkgconfigDepends ? [], testPkgconfigDepends ? [], benchmarkPkgconfigDepends ? []
 , testDepends ? [], testHaskellDepends ? [], testSystemDepends ? [], testFrameworkDepends ? []
@@ -226,7 +227,11 @@ let
   ] ++ optionals isCross ([
     "--configure-option=--host=${stdenv.hostPlatform.config}"
   ] ++ crossCabalFlags
-  ) ++ optionals enableSeparateBinOutput ["--bindir=${binDir}"];
+  ) ++ optionals enableSeparateBinOutput [
+    "--bindir=${binDir}"
+  ] ++ optionals (doHaddockInterfaces && isLibrary) [
+    "--ghc-options=-haddock"
+  ];
 
   setupCompileFlags = [
     (optionalString (!coreSetup) "-${nativePackageDbFlag}=$setupPackageConfDir")


### PR DESCRIPTION
Revive #91557, this time enabling it for 9.0.1 only.

(Edited) Commit message:

```
This adds a new builder option `doHaddockInterfaces` to enable the -haddock flag in GHC,
which results in Haddock comments parsed at compile-time and embedded in
interface files. These are used by the :doc command in GHCi, as well as IDE
tools like ghcide and hls to display docs on hover.

The `-haddock` flag has been around since at least 8.2, even though it does not
get a mention in the GHC Users guide.

There are two downsides to turning on this flag:

1. Increased compile times, since Haddocks must be parsed and then encoded
2. Haddock parse errors now become compile errors for GHC < 9.0.1
   (https://gitlab.haskell.org/ghc/ghc/-/issues/8944)

Thus we only enable the feature if we have GHC 9.0.1 and haddock is
enabled; when 9.0.1 becomes the default GHC, we may need to reevaluate
the performance concern.
```

Verified this works with 9.0.1, checking 9.2.1 now:

```
ghci> import Control.Lens
ghci> :doc set
 Replace the target of a 'Lens' or all of the targets of a 'Setter'
 or 'Traversal' with a constant value.

 @
 ('<$') ≡ 'set' 'mapped'
 @

 >>> set _2 "hello" (1,())
 (1,"hello")

 >>> set mapped () [1,2,3,4]
 [(),(),(),()]

 Note: Attempting to 'set' a 'Fold' or 'Getter' will fail at compile time with an
 relatively nice error message.

 @
 'set' :: 'Setter' s t a b    -> b -> s -> t
 'set' :: 'Iso' s t a b       -> b -> s -> t
 'set' :: 'Lens' s t a b      -> b -> s -> t
 'set' :: 'Traversal' s t a b -> b -> s -> t
 @
```


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
