### PR TITLE
 gamin,dbus-java: switch to pname+version, cleanup 

### DIFF
--- a/pkgs/development/libraries/gamin/default.nix
+++ b/pkgs/development/libraries/gamin/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, fetchpatch, pkg-config, glib, autoreconfHook }:
 
-let
-  cross = stdenv.hostPlatform != stdenv.buildPlatform;
-in stdenv.mkDerivation (rec {
-  name = "gamin-0.1.10";
+stdenv.mkDerivation rec {
+  pname = "gamin";
+  version = "0.1.10";
 
   src = fetchurl {
-    url = "https://www.gnome.org/~veillard/gamin/sources/${name}.tar.gz";
+    url = "https://www.gnome.org/~veillard/gamin/sources/gamin-${version}.tar.gz";
     sha256 = "18cr51y5qacvs2fc2p1bqv32rs8bzgs6l67zhasyl45yx055y218";
   };
 
@@ -22,6 +21,10 @@ in stdenv.mkDerivation (rec {
     "CPPFLAGS=-D_GNU_SOURCE"
   ];
 
+  preBuild = lib.optionalString stdenv.isDarwin ''
+    sed -i 's/,--version-script=.*$/\\/' libgamin/Makefile
+  '';
+
   patches = [ ./deadlock.patch ]
     ++ map fetchurl (import ./debian-patches.nix)
     ++ lib.optional stdenv.cc.isClang ./returnval.patch
@@ -29,7 +32,7 @@ in stdenv.mkDerivation (rec {
       name = "fix-pthread-mutex.patch";
       url = "https://git.alpinelinux.org/aports/plain/main/gamin/fix-pthread-mutex.patch?h=3.4-stable&id=a1a836b089573752c1b0da7d144c0948b04e8ea8";
       sha256 = "13igdbqsxb3sz0h417k6ifmq2n4siwqspj6slhc7fdl5wd1fxmdz";
-    }) ++ lib.optional (cross) ./abstract-socket-namespace.patch ;
+    }) ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) ./abstract-socket-namespace.patch;
 
 
   meta = with lib; {
@@ -41,8 +44,3 @@ in stdenv.mkDerivation (rec {
   };
 }
 
-// lib.optionalAttrs stdenv.isDarwin {
-  preBuild =  ''
-    sed -i 's/,--version-script=.*$/\\/' libgamin/Makefile
-  '';
-})

--- a/pkgs/development/libraries/java/dbus-java/default.nix
+++ b/pkgs/development/libraries/java/dbus-java/default.nix
@@ -1,18 +1,19 @@
-{lib, stdenv, fetchurl, gettext, jdk8, libmatthew_java}:
+{ lib, stdenv, fetchurl, gettext, jdk8, libmatthew_java }:
 
-let jdk = jdk8; in
-stdenv.mkDerivation {
-  name = "dbus-java-2.7";
+stdenv.mkDerivation rec {
+  pname = "dbus-java";
+  version = "2.7";
+
   src = fetchurl {
-    url = "https://dbus.freedesktop.org/releases/dbus-java/dbus-java-2.7.tar.gz";
+    url = "https://dbus.freedesktop.org/releases/dbus-java/dbus-java-${version}.tar.gz";
     sha256 = "0cyaxd8x6sxmi6pklkkx45j311a6w51fxl4jc5j3inc4cailwh5y";
   };
-  JAVA_HOME=jdk;
-  JAVA="${jdk}/bin/java";
+  JAVA_HOME=jdk8;
+  JAVA="${jdk8}/bin/java";
   PREFIX="\${out}";
   JAVAUNIXLIBDIR="${libmatthew_java}/lib/jni";
   JAVAUNIXJARDIR="${libmatthew_java}/share/java";
-  buildInputs = [ gettext jdk ];
+  buildInputs = [ gettext jdk8 ];
   # I'm too lazy to build the documentation
   preBuild = ''
     sed -i -e "s|all: bin doc man|all: bin|" \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
