### PR TITLE
youtube-dl: fix youtube.com download throttling

### DIFF
--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildPythonPackage
+{ lib, fetchurl, fetchpatch, buildPythonPackage
 , zip, ffmpeg, rtmpdump, phantomjs2, atomicparsley, pycryptodome, pandoc
 # Pandoc is required to build the package's man page. Release tarballs contain a
 # formatted man page already, though, it will still be installed. We keep the
@@ -24,6 +24,20 @@ buildPythonPackage rec {
     url = "https://yt-dl.org/downloads/${version}/${pname}-${version}.tar.gz";
     sha256 = "1hqan9h55x9gfdakw554vic68w9gpvhblchwxlw265zxp56hxjrw";
   };
+
+  patches = [
+    # Fixes throttling on youtube.com. Without the patch downloads are capped at
+    # about 80KiB/s. See, e.g.,
+    #
+    #   https://github.com/ytdl-org/youtube-dl/issues/29326
+    #
+    # The patch comes from PR https://github.com/ytdl-org/youtube-dl/pull/30188
+    (fetchpatch {
+      name = "fix-youtube-dl-speed.patch";
+      url = "https://github.com/ytdl-org/youtube-dl/pull/30188.patch";
+      sha256 = "15liban37ina2y4bnykfdywdy4rbkfff2r6vd0kqn2k7rfkcczyz";
+    })
+  ];
 
   nativeBuildInputs = [ installShellFiles makeWrapper ];
   buildInputs = [ zip ] ++ lib.optional generateManPage pandoc;


### PR DESCRIPTION
###### Motivation for this change

Applies a patch that fixes throttling on youtube.com, without the patch downloads are capped at about 80KiB/s.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
