### PR TITLE
python3Packages.pytmx: 3.27 -> 3.30

### DIFF
--- a/pkgs/development/python-modules/pytmx/default.nix
+++ b/pkgs/development/python-modules/pytmx/default.nix
@@ -1,23 +1,32 @@
-{ lib, fetchFromGitHub
-, python, buildPythonPackage, isPy27
-, pygame, pyglet, pysdl2, six
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pygame
+, pyglet
+, pysdl2
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "pytmx";
-  version = "3.27";
+  version = "3.30";
+  format = "setuptools";
 
-  disabled = isPy27;
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "bitcraft";
     repo = "PyTMX";
-    # Release was not tagged.
-    rev = "5bb094c45e648d1de6c9ba8d8c8f31f7b83478e1";
-    sha256 = "0kpd39sr2ggwzh7nd3f5801mgwm57rzrrkqcgbcypdm8l2ayga3b";
+    rev = version;
+    sha256 = "sha256-d6VPmRdqUO6YhkOYYeXOEcrli/35IFkxK73AcZYHixw=";
   };
 
-  propagatedBuildInputs = [ pygame pyglet pysdl2 six ];
+  propagatedBuildInputs = [
+    pygame
+    pyglet
+    pysdl2
+  ];
 
   pythonImportsCheck = [
     "pytmx.pytmx"
@@ -26,11 +35,14 @@ buildPythonPackage rec {
     "pytmx.util_pysdl2"
   ];
 
-  checkPhase = ''
-    # Change into the test directory due to a relative resource path.
-    cd tests/pytmx
-    ${python.interpreter} -m unittest test_pytmx
-  '';
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # AssertionError on the property name
+    "test_contains_reserved_property_name"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/bitcraft/PyTMX";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 3.30

Change log: https://github.com/bitcraft/pytmx/releases/tag/3.30

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
