### PR TITLE
ethtool: 5.14 -> 5.15

### DIFF
--- a/pkgs/tools/misc/ethtool/default.nix
+++ b/pkgs/tools/misc/ethtool/default.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   pname = "ethtool";
-  version = "5.14";
+  version = "5.15";
 
   src = fetchurl {
     url = "mirror://kernel/software/network/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-uxPbkZFcrNekkrZbZd8Hpn5Ll03b6vdiBbGUWiPSdoY=";
+    sha256 = "sha256-aG/WEQOJ1JwqEg8Aw81d/kPeutqOAh5CcNdLvkUqEW0=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://lore.kernel.org/netdev/20211109210222.oofsxukjmxgebunw@lion.mk-sys.cz/T/

Tested and LGTM.

```
❯ sudo ./result/bin/ethtool -m enp4s0f1np1
	Identifier                                : 0x03 (SFP)
	Extended identifier                       : 0x04 (GBIC/SFP defined by 2-wire interface ID)
	Connector                                 : 0x07 (LC)
	Transceiver codes                         : 0x20 0x00 0x00 0x00 0x44 0x40 0x00 0x00 0x02
	Transceiver type                          : 10G Ethernet: 10G Base-LR
	Transceiver type                          : FC: short distance (S)
	Transceiver type                          : FC: Shortwave laser, linear Rx (SA)
	Transceiver type                          : FC: Shortwave laser w/o OFC (SN)
	Transceiver type                          : Extended: 100G Base-SR4 or 25GBase-SR
	Encoding                                  : 0x03 (NRZ)
	BR, Nominal                               : 25750MBd
	Rate identifier                           : 0x00 (unspecified)
	Length (SMF,km)                           : 10km
	Length (SMF)                              : 0m
	Length (50um)                             : 0m
	Length (62.5um)                           : 0m
	Length (Copper)                           : 0m
	Length (OM3)                              : 0m
	Laser wavelength                          : 1310nm
	Vendor name                               : FS
	Vendor OUI                                : 00:00:00
	Vendor PN                                 : SFP28-25GLR-31
	Vendor rev                                : 1A
	Option values                             : 0x08 0x1a
	Option                                    : RX_LOS implemented
	Option                                    : TX_FAULT implemented
	Option                                    : TX_DISABLE implemented
	Option                                    : Retimer or CDR implemented
	BR margin, max                            : 0%
	BR margin, min                            : 0%
	Vendor SN                                 : G2006362780
	Date code                                 : 200831
	Optical diagnostics support               : Yes
	Laser bias current                        : 39.062 mA
	Laser output power                        : 1.0008 mW / 0.00 dBm
	Receiver signal average optical power     : 1.1536 mW / 0.62 dBm
	Module temperature                        : 35.88 degrees C / 96.58 degrees F
	Module voltage                            : 3.2692 V
	Alarm/warning flags implemented           : Yes
	Laser bias current high alarm             : Off
	Laser bias current low alarm              : Off
	Laser bias current high warning           : Off
	Laser bias current low warning            : Off
	Laser output power high alarm             : Off
	Laser output power low alarm              : Off
	Laser output power high warning           : Off
	Laser output power low warning            : Off
	Module temperature high alarm             : Off
	Module temperature low alarm              : Off
	Module temperature high warning           : Off
	Module temperature low warning            : Off
	Module voltage high alarm                 : Off
	Module voltage low alarm                  : Off
	Module voltage high warning               : Off
	Module voltage low warning                : Off
	Laser rx power high alarm                 : Off
	Laser rx power low alarm                  : Off
	Laser rx power high warning               : Off
	Laser rx power low warning                : Off
	Laser bias current high alarm threshold   : 100.000 mA
	Laser bias current low alarm threshold    : 10.000 mA
	Laser bias current high warning threshold : 80.000 mA
	Laser bias current low warning threshold  : 20.000 mA
	Laser output power high alarm threshold   : 2.8184 mW / 4.50 dBm
	Laser output power low alarm threshold    : 0.2818 mW / -5.50 dBm
	Laser output power high warning threshold : 2.2387 mW / 3.50 dBm
	Laser output power low warning threshold  : 0.3548 mW / -4.50 dBm
	Module temperature high alarm threshold   : 95.00 degrees C / 203.00 degrees F
	Module temperature low alarm threshold    : -50.00 degrees C / -58.00 degrees F
	Module temperature high warning threshold : 90.00 degrees C / 194.00 degrees F
	Module temperature low warning threshold  : -45.00 degrees C / -49.00 degrees F
	Module voltage high alarm threshold       : 3.6000 V
	Module voltage low alarm threshold        : 3.0000 V
	Module voltage high warning threshold     : 3.5000 V
	Module voltage low warning threshold      : 3.1000 V
	Laser rx power high alarm threshold       : 2.2387 mW / 3.50 dBm
	Laser rx power low alarm threshold        : 0.0282 mW / -15.50 dBm
	Laser rx power high warning threshold     : 1.7783 mW / 2.50 dBm
	Laser rx power low warning threshold      : 0.0355 mW / -14.50 dBm
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
