### PR TITLE
pactorio: 0.5.1 -> 0.5.2

### DIFF
--- a/pkgs/development/tools/pactorio/default.nix
+++ b/pkgs/development/tools/pactorio/default.nix
@@ -1,28 +1,36 @@
-{ fetchFromGitHub, installShellFiles, lib, stdenv, rustPlatform, Security }:
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, installShellFiles
+, pkg-config
+, bzip2
+, stdenv
+, Security
+}:
 
 rustPlatform.buildRustPackage rec {
   pname = "pactorio";
-  version = "0.5.1";
+  version = "0.5.2";
 
   src = fetchFromGitHub {
     owner = "figsoda";
     repo = pname;
     rev = "v${version}";
-    sha256 = "07h9hywz0pc29411myhxjq6pks4p6q6czbqjv7fxf3xkb1mg9grq";
+    sha256 = "sha256-tRmchXDg8flvByjg6GLwwdwQgp/5NdZIgnjYgPLcLP8=";
   };
 
-  cargoSha256 = "1rac2s36j88vm231aji8d0ndfbaa2gzxwsrxrvsi0zp9cqisc6rh";
+  cargoSha256 = "sha256-FIn+6wflDAjshP2Vz/rXRTrrjPQFW63XtXo8hBHMdkg=";
 
-  nativeBuildInputs = [ installShellFiles ];
-  buildInputs = lib.optional stdenv.isDarwin Security;
+  nativeBuildInputs = [ installShellFiles pkg-config ];
 
-  preFixup = ''
+  buildInputs = [ bzip2 ] ++ lib.optional stdenv.isDarwin Security;
+
+  postInstall = ''
     completions=($releaseDir/build/pactorio-*/out/completions)
-    installShellCompletion ''${completions[0]}/pactorio.{bash,fish}
-    installShellCompletion --zsh ''${completions[0]}/_pactorio
+    installShellCompletion $completions/pactorio.{bash,fish} --zsh $completions/_pactorio
   '';
 
-  GEN_COMPLETIONS = "1";
+  GEN_COMPLETIONS = 1;
 
   meta = with lib; {
     description = "Mod packager for factorio";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/figsoda/pactorio/compare/v0.5.1...v0.5.2
https://github.com/figsoda/pactorio/blob/main/CHANGELOG.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
