### PR TITLE
python3.pkgs.sphinxcontrib-sphinxemoji: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/sphinxemoji/default.nix
+++ b/pkgs/development/python-modules/sphinxemoji/default.nix
@@ -1,0 +1,37 @@
+{ lib, buildPythonPackage, fetchFromGitHub, sphinx }:
+
+buildPythonPackage rec {
+  pname = "sphinxemoji";
+  version = "0.2.0";
+
+  outputs = [ "out" "doc" ];
+
+  src = fetchFromGitHub {
+    owner = "sphinx-contrib";
+    repo = "emojicodes"; # does not match pypi name
+    rev = "v${version}";
+    sha256 = "sha256-TLhjpJpUIoDAe3RZ/7sjTgdW+5s7OpMEd1/w0NyCQ3A=";
+  };
+
+  propagatedBuildInputs = [ sphinx ];
+
+  nativeBuildInputs = [ sphinx ];
+
+  postBuild = ''
+    PYTHONPATH=$PWD:$PYTHONPATH make -C docs html
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/doc/python/$pname
+    cp -r ./docs/build/html $out/share/doc/python/$pname
+  '';
+
+  pythonImportsCheck = [ "sphinxemoji" ];
+
+  meta = with lib; {
+    description = "extension to use emoji codes in your Sphinx documentation";
+    homepage = "https://github.com/sphinx-contrib/emojicodes";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kaction ];
+  };
+}

--- a/pkgs/development/python-modules/sphinxemoji/default.nix
+++ b/pkgs/development/python-modules/sphinxemoji/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "sphinxemoji" ];
 
   meta = with lib; {
-    description = "extension to use emoji codes in your Sphinx documentation";
+    description = "Extension to use emoji codes in your Sphinx documentation";
     homepage = "https://github.com/sphinx-contrib/emojicodes";
     license = licenses.mit;
     maintainers = with maintainers; [ kaction ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10392,6 +10392,8 @@ in {
 
   sphinx-copybutton = callPackage ../development/python-modules/sphinx-copybutton { };
 
+  sphinxemoji = callPackage ../development/python-modules/sphinxemoji { };
+
   sphinx-inline-tabs = callPackage ../development/python-modules/sphinx-inline-tabs { };
 
   sphinx-jinja = callPackage ../development/python-modules/sphinx-jinja { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
