### PR TITLE
unar: make it build on Darwin

### DIFF
--- a/pkgs/tools/archivers/unar/default.nix
+++ b/pkgs/tools/archivers/unar/default.nix
@@ -1,4 +1,17 @@
-{ lib, stdenv, fetchFromGitHub, installShellFiles, gnustep, bzip2, zlib, icu, openssl, wavpack }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, installShellFiles
+, gnustep
+, bzip2
+, zlib
+, icu
+, openssl
+, wavpack
+, xcbuildHook
+, Foundation
+, AppKit
+}:
 
 stdenv.mkDerivation rec {
   pname = "unar";
@@ -12,35 +25,54 @@ stdenv.mkDerivation rec {
     sha256 = "0p846q1l66k3rnd512sncp26zpv411b8ahi145sghfcsz9w8abc4";
   };
 
-  postPatch = ''
-    for f in Makefile.linux ../UniversalDetector/Makefile.linux ; do
-      substituteInPlace $f \
-        --replace "= gcc" "=${stdenv.cc.targetPrefix}cc" \
-        --replace "= g++" "=${stdenv.cc.targetPrefix}c++" \
-        --replace "-DGNU_RUNTIME=1" "" \
-        --replace "-fgnu-runtime" "-fobjc-nonfragile-abi"
-    done
+  postPatch =
+    if stdenv.isDarwin then ''
+      substituteInPlace "./XADMaster.xcodeproj/project.pbxproj" \
+        --replace "libstdc++.6.dylib" "libc++.1.dylib"
+    '' else ''
+      for f in Makefile.linux ../UniversalDetector/Makefile.linux ; do
+        substituteInPlace $f \
+          --replace "= gcc" "=${stdenv.cc.targetPrefix}cc" \
+          --replace "= g++" "=${stdenv.cc.targetPrefix}c++" \
+          --replace "-DGNU_RUNTIME=1" "" \
+          --replace "-fgnu-runtime" "-fobjc-nonfragile-abi"
+      done
 
-    # we need to build inside this directory as well, so we have to make it writeable
-    chmod +w ../UniversalDetector -R
-  '';
+      # we need to build inside this directory as well, so we have to make it writeable
+      chmod +w ../UniversalDetector -R
+    '';
 
-  buildInputs = [ gnustep.base bzip2 icu openssl wavpack zlib ];
+  buildInputs = [ bzip2 icu openssl wavpack zlib ] ++
+    lib.optionals stdenv.isLinux [ gnustep.base ] ++
+    lib.optionals stdenv.isDarwin [ Foundation AppKit ];
 
-  nativeBuildInputs = [ gnustep.make installShellFiles ];
+  nativeBuildInputs = [ installShellFiles ] ++
+    lib.optionals stdenv.isLinux [ gnustep.make ] ++
+    lib.optionals stdenv.isDarwin [ xcbuildHook ];
+
+  xcbuildFlags = lib.optionals stdenv.isDarwin [
+    "-target unar"
+    "-target lsar"
+    "-configuration Release"
+    "MACOSX_DEPLOYMENT_TARGET=10.12"
+    # Fix "ld: file not found: /nix/store/*-clang-7.1.0/lib/arc/libarclite_macosx." error
+    # Disabling ARC may leak memory, however since this program is generally not used for
+    # long periods of time, it shouldn't be an issue
+    "CLANG_LINK_OBJC_RUNTIME=NO"
+  ];
+
+  makefile = lib.optionalString (!stdenv.isDarwin) "Makefile.linux";
 
   enableParallelBuilding = true;
 
   dontConfigure = true;
-
-  makefile = "Makefile.linux";
 
   sourceRoot = "./source/XADMaster";
 
   installPhase = ''
     runHook preInstall
 
-    install -Dm555 -t $out/bin lsar unar
+    install -Dm555 -t $out/bin ${lib.optionalString stdenv.isDarwin "Products/Release/"}{lsar,unar}
     for f in lsar unar; do
       installManPage ./Extra/$f.?
       installShellCompletion --bash --name $f ./Extra/$f.bash_completion
@@ -60,7 +92,7 @@ stdenv.mkDerivation rec {
       ADF, DMS, LZX, PowerPacker, LBR, Squeeze, Crunch, and other old formats.
     '';
     license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ peterhoeg ];
-    platforms = platforms.linux;
+    maintainers = with maintainers; [ peterhoeg thiagokokada ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10665,7 +10665,10 @@ with pkgs;
     inherit (chickenPackages_4) eggDerivation fetchegg;
   };
 
-  unar = callPackage ../tools/archivers/unar { stdenv = clangStdenv; };
+  unar = callPackage ../tools/archivers/unar {
+    inherit (darwin.apple_sdk.frameworks) Foundation AppKit;
+    stdenv = clangStdenv;
+  };
 
   unp = callPackage ../tools/archivers/unp { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix https://github.com/NixOS/nixpkgs/issues/145368.

Now that we have https://github.com/NixOS/nixpkgs/pull/145229 merged, this PR is specially useful since we can try to use `unrar-wrapper` in place of `unrar` for packages that has `unrar` optional because of its proprietary nature (e.g.: `mcomix3` and `calibre`).

Thanks for the help @veprbl.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
