### PR TITLE
lingeling: pre1_03b4860d -> pre1_708beb26, boolector: fix for aarch64-linux

### DIFF
--- a/pkgs/applications/science/logic/boolector/default.nix
+++ b/pkgs/applications/science/logic/boolector/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, lib, python3
+{ stdenv, fetchFromGitHub, lib, python3, fetchpatch
 , cmake, lingeling, btor2tools, gtest, gmp
 }:
 
@@ -12,6 +12,15 @@ stdenv.mkDerivation rec {
     rev    = version;
     sha256 = "1smcy6yp8wvnw2brgnv5bf40v87k4v4fbdbrhi7987vja632k50z";
   };
+
+  patches = [
+    # present in master - remove after 3.2.2
+    (fetchpatch {
+      name = "fix-parser-getc-char-casts.patch";
+      url = "https://github.com/Boolector/boolector/commit/cc3a70918538c1e71ea5e7273fa1ac098da37c1b.patch";
+      sha256 = "0pjvagcy74vxa2q75zbshcz8j7rvhl98549xfcf5y8yyxf5h8hyq";
+    })
+  ];
 
   postPatch = ''
     sed s@REPLACEME@file://${gtest.src}@ ${./cmake-gtest.patch} | patch -p1

--- a/pkgs/applications/science/logic/lingeling/default.nix
+++ b/pkgs/applications/science/logic/lingeling/default.nix
@@ -4,15 +4,14 @@
 
 stdenv.mkDerivation {
   pname = "lingeling";
-  # This is the version used in satcomp2018, which was
-  # relicensed, and also known as version 'bcj'
-  version = "pre1_03b4860d";
+  # This is the version used in satcomp2020
+  version = "pre1_708beb26";
 
   src = fetchFromGitHub {
     owner  = "arminbiere";
     repo   = "lingeling";
-    rev    = "03b4860d14016f42213ea271014f2f13d181f504";
-    sha256 = "1lw1yfy219p7rrk88sbq4zl24b70040zapbjdrpv5a6i0jsblksx";
+    rev    = "708beb26a7d5b5d5e7abd88d6f552fb1946b07c1";
+    sha256 = "1lb2g37nd8qq5hw5g6l691nx5095336yb2zlbaw43mg56hkj8357";
   };
 
   configurePhase = ''


### PR DESCRIPTION
###### Motivation for this change
ZHF: #144627 @NixOS/nixos-release-managers

Thanks to a responsive upstream (https://github.com/Boolector/boolector/issues/178), it turns out that aarch64 support for `boolector` can be fixed by updating `lingeling` and adding a patch that addresses some casting issues.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (emulated)
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
