### PR TITLE
etc module: make `.text` and `.source` the same priority

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -119,7 +119,7 @@ let
       mkFixStrictness mkOrder mkBefore mkAfter mkAliasDefinitions
       mkAliasAndWrapDefinitions fixMergeModules mkRemovedOptionModule
       mkRenamedOptionModule mkMergedOptionModule mkChangedOptionModule
-      mkAliasOptionModule doRename;
+      mkAliasOptionModule mkDerivedConfig doRename;
     inherit (self.options) isOption mkEnableOption mkSinkUndeclaredOptions
       mergeDefaultOption mergeOneOption mergeEqualOption getValues
       getFiles optionAttrSetToDocList optionAttrSetToDocList'

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -956,6 +956,26 @@ rec {
     use = id;
   };
 
+  /* mkDerivedConfig : Option a -> (a -> Definition b) -> Definition b
+
+    Create config definitions with the same priority as the definition of another option.
+    This should be used for option definitions where one option sets the value of another as a convenience.
+    For instance a config file could be set with a `text` or `source` option, where text translates to a `source`
+    value using `mkDerivedConfig options.text (pkgs.writeText "filename.conf")`.
+
+    It takes care of setting the right priority using `mkOverride`.
+  */
+  # TODO: make the module system error message include information about `opt` in
+  # error messages about conflicts. E.g. introduce a variation of `mkOverride` which
+  # adds extra location context to the definition object. This will allow context to be added
+  # to all messages that report option locations "this value was derived from <full option name>
+  # which was defined in <locations>". It can provide a trace of options that contributed
+  # to definitions.
+  mkDerivedConfig = opt: f:
+    mkOverride
+      (opt.highestPrio or defaultPriority)
+      (f opt.value);
+
   doRename = { from, to, visible, warn, use, withPriority ? true }:
     { config, options, ... }:
     let

--- a/nixos/modules/system/etc/etc.nix
+++ b/nixos/modules/system/etc/etc.nix
@@ -172,9 +172,8 @@ in
             target = mkDefault name;
             source = mkIf (config.text != null) (
               let name' = "etc-" + baseNameOf name;
-              in mkOverride
-                (options.text.highestPrio or lib.modules.defaultPriority)
-                (pkgs.writeText name' config.text));
+              in mkDerivedConfig options.text (pkgs.writeText name')
+            );
           };
 
         }));

--- a/nixos/modules/system/etc/etc.nix
+++ b/nixos/modules/system/etc/etc.nix
@@ -85,7 +85,7 @@ in
       '';
 
       type = with types; attrsOf (submodule (
-        { name, config, ... }:
+        { name, config, options, ... }:
         { options = {
 
             enable = mkOption {
@@ -172,7 +172,9 @@ in
             target = mkDefault name;
             source = mkIf (config.text != null) (
               let name' = "etc-" + baseNameOf name;
-              in mkDefault (pkgs.writeText name' config.text));
+              in mkOverride
+                (options.text.highestPrio or lib.modules.defaultPriority)
+                (pkgs.writeText name' config.text));
           };
 
         }));


### PR DESCRIPTION
###### Motivation for this change

I accidentally set the `environment.etc.foo.text` and `environment.etc.foo.source` attributes for the same `foo` file, and there was no error. I realized by looking at the code that nixos just silently clobbers `.text` whenever `.source` is set. Note that this is the case even if (for an extreme example) `.text` is set with `mkForce` and `.source` is set with `mkDefault`. This seems like not the ideal / expected behaviour.

###### The change

This change causes `.text` and `.source` attributes to be treated with the same priority. If they are set with different priorities, the higher priority wins; if they are set with the same priority, an error is produced since they conflict.

###### Problems & alternative solutions

I discussed this with @layus, and he suggested one alternative of just generating warnings when `source` clobbers `text`, and allowing it to happen. It seems that in `home-manager`, there is a common pattern of modules setting a default (empty) config file with `.text`, and users clobber it with a `.source`. 

In which case my change would break a lot of existing configurations and require module authors to carefully select a default precedence for their `.text` attributes. For NixOS modules, this doesn't seem to be an issue. I looked through many of the modules that set a `.text` and they all seem to be fairly extensive configuration files that a user would be unlikely to overwrite, and if they did they would expect to use `mkForce`.

One other solution is to raise an error whenever both `.text` and `.source` are set, regardless of their priorities. This is done for example for `users.users.*.{hashedPassword,password,passwordFile}`. This in some sense seems less "automagical" to me as a user, but it also means that you can end up stuck and unable to override something set with one of the options by setting the other option, which seems like a bigger problem in the `environment.etc` case. Also, there is a ton of automagical stuff in the NixOS module system already, so I don't think this significantly increases the barrier to comprehension.

CC @Infinisil @layus 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
