### PR TITLE
[staging-next] firefox: use rustc.llvmPackages.stdenv with LLVM bintools, fix deadlock

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -110,7 +110,10 @@ let
   # When LTO for Darwin is fixed, the following will need updating as lld
   # doesn't work on it. For now it is fine since ltoSupport implies no Darwin.
   buildStdenv = if ltoSupport
-                then overrideCC stdenv llvmPackages.clangUseLLVM
+                # LTO requires LLVM bintools including ld.lld and llvm-ar.
+                then overrideCC llvmPackages.stdenv (llvmPackages.stdenv.cc.override {
+                  inherit (llvmPackages) bintools;
+                })
                 else stdenv;
 
   # --enable-release adds -ffunction-sections & LTO that require a big amount of

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -134,6 +134,12 @@ buildStdenv.mkDerivation ({
   ] ++
   lib.optional (lib.versionAtLeast version "86") ./env_var_for_system_dir-ff86.patch ++
   lib.optional (lib.versionAtLeast version "90") ./no-buildconfig-ffx90.patch ++
+  # This fixes a race condition causing deadlock.
+  # https://phabricator.services.mozilla.com/D128657
+  lib.optional (lib.versionAtLeast version "94") (fetchpatch {
+    url = "https://raw.githubusercontent.com/archlinux/svntogit-packages/9c7f25d45bb1dd6b1a865780bc249cdaa619aa83/trunk/0002-Bug-1735905-Upgrade-cubeb-pulse-to-fix-a-race-condit.patch";
+    sha256 = "l4bMK/YDXcDpIjPy9DPuUSFyDpzVQca201A4h9eav5g=";
+  }) ++
   patches;
 
   # Ignore trivial whitespace changes in patches, this fixes compatibility of


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix #144670
ZHF: #144627

Follows https://github.com/NixOS/nixpkgs/issues/144670#issuecomment-965935482

**Update:** Currently we switch to `llvmPackages*.stdenv` with LLVM `bintools` to build firefox. LLVM and cc-wrapper are not touched.


**Outdated:**

In `clangUseLLVM` we explicit use FULL LLVM toolchain, we should not set `--gcc-toolchain` anymore.

Well, it seems cannot explain why LLVM 12 works when this option is provided. According [Clang 13.0.0 Release Notes](https://releases.llvm.org/13.0.0/tools/clang/docs/ReleaseNotes.html#modified-compiler-flags), there are some internal changes occurs on `-B` and `--gcc-toolchain`. In our case and some experiments, in LLVM 13, when `--gcc-toolchain` is specified, its include path will take precedence over `libc++` and mess up everything, no matter whether this option is before `-isystem` or after. I guess that we are just not expected to set `gcc-toolchain` in full LLVM toolchain usage but it used to work due to some magic.

Currently I just remove `--gcc-toolchain` from `llvmPackages_13.clangUseLLVM`, not any older version.
I checked that LLVM 12 with that option removed doesn't affect a simple hello-world build, but not sure if downstream packages still build. So I'm just not touching them.

After this PR, `firefox` builds and runs flawless for me.
Note that `clangUseLLVM` is currently only used by `firefox` and cross compilation, I think no other package is affected.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
