### PR TITLE
pantheon.elementary-default-settings: cleanup

### DIFF
--- a/pkgs/desktops/pantheon/desktop/elementary-default-settings/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-default-settings/default.nix
@@ -58,20 +58,12 @@ stdenv.mkDerivation rec {
     # Our launchers that use paths at /run/current-system/sw/bin
     mkdir -p $out/etc/skel/.config/plank/dock1
     cp -avr ${./launchers} $out/etc/skel/.config/plank/dock1/launchers
-
-    # Whitelist wingpanel indicators to be used in the greeter
-    # https://github.com/elementary/greeter/blob/fc19752f147c62767cd2097c0c0c0fcce41e5873/debian/io.elementary.greeter.whitelist
-    # wingpanel 2.3.2 renamed this to .allowed to .forbidden
-    # https://github.com/elementary/wingpanel/pull/326
-    install -D ${./io.elementary.greeter.allowed} $out/etc/wingpanel.d/io.elementary.greeter.allowed
   '';
 
   postFixup = ''
     # https://github.com/elementary/default-settings/issues/55
-    rm -rf $out/share/plymouth
-    rm -rf $out/share/cups
-
-    rm -rf $out/share/applications
+    rm -r $out/share/cups
+    rm -r $out/share/applications
   '';
 
   passthru = {

--- a/pkgs/desktops/pantheon/desktop/elementary-default-settings/io.elementary.greeter.allowed
+++ b/pkgs/desktops/pantheon/desktop/elementary-default-settings/io.elementary.greeter.allowed
@@ -1,6 +1,0 @@
-liba11y.so
-libbluetooth.so
-libkeyboard.so
-libnetwork.so
-libpower.so
-libsession.so


### PR DESCRIPTION
###### Motivation for this change

~~I need to re-read the changes so drafting.~~ But at least `$out/share/plymouth` is no longer there (since version 5.9).

Also https://github.com/elementary/greeter/pull/450 says:

> This (`io.elementary.greeter.allowed`) should probably not be needed anymore since indicators know whether they're running in session or not and adapt accordingly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
