### PR TITLE
knockknock: enable on darwin

### DIFF
--- a/pkgs/tools/security/knockknock/default.nix
+++ b/pkgs/tools/security/knockknock/default.nix
@@ -1,14 +1,13 @@
 { lib, fetchFromGitHub, python2Packages, hping }:
-let
-  rev  = "bf14bbff";
-in python2Packages.buildPythonApplication rec {
-  pname = "knockknock-r";
-  version = rev;
+
+python2Packages.buildPythonApplication rec {
+  pname = "knockknock";
+  version = "unstable-2012-09-17";
 
   src = fetchFromGitHub {
-    inherit rev;
     owner  = "moxie0";
     repo   = "knockknock";
+    rev    = "bf14bbffc5f1d2105cd1d955dabca26b3faa0db4";
     sha256 = "1chpfs3w2vkjrgay69pbdr116z1jldv53fi768a1i05fdqhy1px4";
   };
 
@@ -25,10 +24,10 @@ in python2Packages.buildPythonApplication rec {
 
   meta = with lib; {
     description = "Simple, secure port knocking daemon and client written in Python";
-    homepage    = "http://www.thoughtcrime.org/software/knockknock/";
-    license     = licenses.gpl3;
+    homepage    = "https://github.com/moxie0/knockknock";
+    license     = licenses.gpl3Plus;
     maintainers = with maintainers; [ copumpkin ];
-    platforms   = platforms.linux;
+    platforms   = platforms.unix;
   };
 }
 


### PR DESCRIPTION
###### Motivation for this change
* enable on darwin
* fix license
* fix version: bf14bbff -> 2012-09-17

###### Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
