### PR TITLE
qmapshack: fix localization

### DIFF
--- a/pkgs/applications/gis/qmapshack/default.nix
+++ b/pkgs/applications/gis/qmapshack/default.nix
@@ -1,5 +1,5 @@
-{ mkDerivation, lib, fetchFromGitHub, cmake
-, qtscript, qtwebengine, gdal, proj, routino, quazip }:
+{ mkDerivation, lib, fetchFromGitHub, cmake, substituteAll
+, qtscript, qttranslations, qtwebengine, gdal, proj, routino, quazip }:
 
 mkDerivation rec {
   pname = "qmapshack";
@@ -11,6 +11,14 @@ mkDerivation rec {
     rev = "V_${version}";
     sha256 = "1yzgkdjxwyg8ggbxyjwr0zjrx99ckrbz2p2524iii9i7qqn8wfsx";
   };
+
+  patches = [
+    # See https://github.com/NixOS/nixpkgs/issues/86054
+    (substituteAll {
+      src = ./fix-qttranslations-path.patch;
+      inherit qttranslations;
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/applications/gis/qmapshack/fix-qttranslations-path.patch
+++ b/pkgs/applications/gis/qmapshack/fix-qttranslations-path.patch
@@ -1,0 +1,74 @@
+diff --git i/src/qmapshack/setup/CAppSetupLinux.cpp w/src/qmapshack/setup/CAppSetupLinux.cpp
+index 63ea06c0..3a03b816 100644
+--- i/src/qmapshack/setup/CAppSetupLinux.cpp
++++ w/src/qmapshack/setup/CAppSetupLinux.cpp
+@@ -30,7 +30,7 @@ void CAppSetupLinux::initQMapShack()
+     prepareGdal("", "");
+ 
+     // setup translators
+-    QString resourceDir = QLibraryInfo::location(QLibraryInfo::TranslationsPath);
++    QLatin1String resourceDir = QLatin1String("@qttranslations@/translations");
+     QString translationPath = QCoreApplication::applicationDirPath();
+     translationPath.replace(QRegExp("bin$"), "share/qmapshack/translations");
+     prepareTranslator(resourceDir, "qt_");
+diff --git i/src/qmapshack/setup/CAppSetupMac.cpp w/src/qmapshack/setup/CAppSetupMac.cpp
+index ad9b21e9..9dca8a1e 100644
+--- i/src/qmapshack/setup/CAppSetupMac.cpp
++++ w/src/qmapshack/setup/CAppSetupMac.cpp
+@@ -63,7 +63,7 @@ void CAppSetupMac::initQMapShack()
+ 
+     // setup translators
+     QString translationPath = getApplicationDir(relTranslationDir).absolutePath();
+-    prepareTranslator(translationPath, "qt_");
++    prepareTranslator(QLatin1String("@qttranslations@/translations"), "qt_");
+     prepareTranslator(translationPath, "qmapshack_");
+ 
+     // load and apply style sheet
+diff --git i/src/qmaptool/setup/CAppSetupLinux.cpp w/src/qmaptool/setup/CAppSetupLinux.cpp
+index dea1c4f3..8da95574 100644
+--- i/src/qmaptool/setup/CAppSetupLinux.cpp
++++ w/src/qmaptool/setup/CAppSetupLinux.cpp
+@@ -29,7 +29,7 @@ void CAppSetupLinux::initQMapTool()
+     prepareGdal("", "");
+ 
+     // setup translators
+-    QString resourceDir = QLibraryInfo::location(QLibraryInfo::TranslationsPath);
++    QLatin1String resourceDir = QLatin1String("@qttranslations@/translations");
+     QString translationPath = QCoreApplication::applicationDirPath();
+     translationPath.replace(QRegExp("bin$"), "share/qmaptool/translations");
+     prepareTranslator(resourceDir, "qt_");
+diff --git i/src/qmaptool/setup/CAppSetupMac.cpp w/src/qmaptool/setup/CAppSetupMac.cpp
+index 02b27e07..fae27748 100644
+--- i/src/qmaptool/setup/CAppSetupMac.cpp
++++ w/src/qmaptool/setup/CAppSetupMac.cpp
+@@ -64,7 +64,7 @@ void CAppSetupMac::initQMapTool()
+ 
+     // setup translators
+     QString translationPath = getApplicationDir(relTranslationDir).absolutePath();
+-    prepareTranslator(translationPath, "qt_");
++    prepareTranslator(QLatin1String("@qttranslations@/translations"), "qt_");
+     prepareTranslator(translationPath, "qmaptool_");
+ 
+     migrateDirContent(defaultCachePath());
+diff --git i/src/qmt_rgb2pct/main.cpp w/src/qmt_rgb2pct/main.cpp
+index 21267d03..d539cec8 100644
+--- i/src/qmt_rgb2pct/main.cpp
++++ w/src/qmt_rgb2pct/main.cpp
+@@ -50,7 +50,7 @@ static void prepareTranslator(QString translationPath, QString translationPrefix
+ static void loadTranslations()
+ {
+ #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) || defined(__FreeBSD_kernel__) || defined(__GNU__) || defined(Q_OS_CYGWIN)
+-    QString resourceDir = QLibraryInfo::location(QLibraryInfo::TranslationsPath);
++    QLatin1String resourceDir = QLatin1String("@qttranslations@/translations");
+     QString translationPath = QCoreApplication::applicationDirPath();
+     translationPath.replace(QRegExp("bin$"), "share/" APP_STR "/translations");
+     prepareTranslator(resourceDir, "qt_");
+@@ -61,7 +61,7 @@ static void loadTranslations()
+     // os x
+     static QString relTranslationDir = "Resources/translations"; // app
+     QString translationPath = getApplicationDir(relTranslationDir).absolutePath();
+-    prepareTranslator(translationPath, "qt_");
++    prepareTranslator(QLatin1String("@qttranslations@/translations"), "qt_");
+     prepareTranslator(translationPath, APP_STR "_");
+ #endif
+ 


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/86054

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
