### PR TITLE
qt512: Make apps work on macOS Big Sur

### DIFF
--- a/pkgs/applications/video/mkvtoolnix/default.nix
+++ b/pkgs/applications/video/mkvtoolnix/default.nix
@@ -122,11 +122,6 @@ stdenv.mkDerivation rec {
 
   dontWrapQtApps = true;
 
-  # Avoid Qt 5.12 problem on Big Sur: https://bugreports.qt.io/browse/QTBUG-87014
-  qtWrapperArgs = lib.optionals stdenv.isDarwin [
-    "--set QT_MAC_WANTS_LAYER 1"
-  ];
-
   postFixup = optionalString withGUI ''
     wrapQtApp $out/bin/mkvtoolnix-gui
   '';

--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -187,11 +187,6 @@ let
     # Fix linker error on Darwin (see https://trac.macports.org/ticket/61865)
     NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-lobjc";
 
-    # Avoid Qt 5.12 problem on Big Sur: https://bugreports.qt.io/browse/QTBUG-87014
-    qtWrapperArgs = lib.optionals stdenv.isDarwin [
-      "--set QT_MAC_WANTS_LAYER 1"
-    ];
-
     # See https://savannah.gnu.org/bugs/?50339
     F77_INTEGER_8_FLAG = if use64BitIdx then "-fdefault-integer-8" else "";
 

--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -70,6 +70,17 @@ let
       # Ensure -I${includedir} is added to Cflags in pkg-config files.
       # See https://github.com/NixOS/nixpkgs/issues/52457
       ./qtbase.patch.d/0014-qtbase-pkg-config.patch
+
+      # Make Qt applications work on macOS Big Sur even if they're
+      # built with an older version of the macOS SDK (<10.14). This
+      # issue is fixed in 5.12.11, but it requires macOS SDK 10.13 to
+      # build. See https://bugreports.qt.io/browse/QTBUG-87014 for
+      # more info.
+      (fetchpatch {
+        name = "big_sur_layer_backed_views.patch";
+        url = "https://codereview.qt-project.org/gitweb?p=qt/qtbase.git;a=patch;h=c5d904639dbd690a36306e2b455610029704d821";
+        sha256 = "0crkw3j1iwdc1pbf5dhar0b4q3h5gs2q1sika8m12y02yk3ns697";
+      })
     ];
     qtdeclarative = [ ./qtdeclarative.patch ];
     qtlocation = [ ./qtlocation-gcc-9.patch ];


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Currently, almost no Qt apps work on macOS Big Sur or, most likely, Monterey. This is seemingly due to Apple deprecating surface-backed rendering in favor of layer-backed rendering, removing all backwards compatibility. If we had built with macOS SDK >=10.14 this wouldn't be a problem, but we're still on 10.12.

This issue is fixed in Qt 5.12.11, but it requires macOS SDK 10.13 to build. @toonn is doing [great work on upgrading the SDK to 10.13](https://discourse.nixos.org/t/nix-macos-monthly/12330), though. When that's done, we can drop this patch and upgrade Qt instead.

See https://bugreports.qt.io/browse/QTBUG-87014 for more info on the issue.

cc @NixOS/darwin-maintainers @NixOS/qt-kde 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
