### PR TITLE
pythonPackages.shtab: init at 1.4.2

### DIFF
--- a/pkgs/development/python-modules/shtab/default.nix
+++ b/pkgs/development/python-modules/shtab/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, bashInteractive
+, pytestCheckHook
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "shtab";
+  version = "1.4.2";
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    pname = "shtab";
+    inherit version;
+    sha256 = "sha256-oR8pa/FJ3ywcx4GUHkhRkSmK0bdF3BHQHLImxVWv98s=";
+  };
+
+  buildInputs = [ setuptools-scm ];
+
+  checkInputs = [ bashInteractive pytestCheckHook ];
+  pythonImportsCheck = [ "shtab" ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "use_scm_version=True" "version='${version}'"
+
+    substituteInPlace setup.cfg \
+      --replace "--cov=shtab" "" \
+      --replace "--cov-report=term-missing" "" \
+      --replace "--cov-report=xml" "" \
+      --replace "timeout = 5" ""
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/iterative/shtab";
+    description = "Automagic shell tab completion for Python CLI applications";
+    maintainers = with maintainers; [ michaeladler ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8677,6 +8677,8 @@ in {
 
   showit = callPackage ../development/python-modules/showit { };
 
+  shtab = callPackage ../development/python-modules/shtab { };
+
   shutilwhich = callPackage ../development/python-modules/shutilwhich { };
 
   sievelib = callPackage ../development/python-modules/sievelib { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[shtab](https://github.com/iterative/shtab) is a tool to easily generate bash and zsh completions for Python and even **non-Python** applications.
The tests are failing (and are therefore skipped) because the tests invoke bash and this version of bash does not come with completion features (compgen not found). shtab works fine though, I have already generated completions for non-trivial applications. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
