### PR TITLE
zfsUnstable: 2.1.1 -> 2021-11-11

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -1325,6 +1325,17 @@ Superuser created successfully.
           <literal>services.ddclient.passwordFile</literal>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          The <literal>zfsUnstable</literal> package now tracks the
+          OpenZFS master branch and disables the kernel compatibility
+          checks. This way it can always be used with the latest kernel
+          even if it has not been marked compatible by upstream. The
+          documentation of the
+          <literal>boot.zfs.enableUnstable</literal> option has been
+          updated to reflect this change.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-21.11-notable-changes">

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -398,6 +398,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The `services.ddclient.password` option was removed, and replaced with `services.ddclient.passwordFile`.
 
+- The `zfsUnstable` package now tracks the OpenZFS master branch and disables the kernel compatibility checks. This way it can always be used with the latest kernel even if it has not been marked compatible by upstream. The documentation of the `boot.zfs.enableUnstable` option has been updated to reflect this change.
+
 ## Other Notable Changes {#sec-release-21.11-notable-changes}
 
 

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -121,10 +121,12 @@ in
         description = ''
           Use the unstable zfs package. This might be an option, if the latest
           kernel is not yet supported by a published release of ZFS. Enabling
-          this option will install a development version of ZFS on Linux. The
-          version will have already passed an extensive test suite, but it is
-          more likely to hit an undiscovered bug compared to running a released
-          version of ZFS on Linux.
+          this option will install a development version of ZFS on Linux.
+
+          <emphasis>Caution</emphasis>: This version will track the OpenZFS
+          master branch and has all kernel compatibility checks disabled. It is
+          therefore more likely to hit an undiscovered bug compared to running a
+          released version of OpenZFS.
           '';
       };
 

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -225,18 +225,18 @@ in {
   };
 
   zfsUnstable = common {
-    # check the release notes for compatible kernels
-    kernelCompatible = kernel.kernelAtLeast "3.10" && kernel.kernelOlder "5.15";
-    latestCompatibleLinuxPackages = linuxPackages_5_14;
+    # kernel compatibility checks are disabled
+    kernelCompatible = true;
+    latestCompatibleLinuxPackages = pkgs.linuxPackages_latest;
 
-    # this package should point to a version / git revision compatible with the latest kernel release
-    # IMPORTANT: Always use a tagged release candidate or commits from the
-    # zfs-<version>-staging branch, because this is tested by the OpenZFS
-    # maintainers.
-    version = "2.1.1";
-    # rev = "0000000000000000000000000000000000000000";
+    # this package should always point to a commit on the master branch.
+    # DO NOT set this to a tag of a release or release candidate because this
+    # usually implies a downgrade from the master branch which has a potentially
+    # incompatible pool format
+    version = "2021-11-11";
+    rev = "c23803be84cb5cc9d98186221f4106a9962dfc45";
 
-    sha256 = "sha256-UUuJa5w/GsEvsgH/BnXFsP/dsOt9wwmPqKzDxLPrhiY=";
+    sha256 = "sha256-outvCyHh48SncJsfKK3a58AXJwvU802n/m6IL8BF1t8=";
 
     isUnstable = true;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

With this change zfsUnstable will always track the latest master branch and has all kernel compatibility checks disabled. This allows using zfsUnstable with kernels that have not been marked compatible by upstream.

Alternative to https://github.com/NixOS/nixpkgs/pull/145458

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
