### PR TITLE
ouch: don't use vendored sources

### DIFF
--- a/pkgs/tools/compression/ouch/default.nix
+++ b/pkgs/tools/compression/ouch/default.nix
@@ -1,4 +1,14 @@
-{ lib, rustPlatform, fetchFromGitHub, help2man, installShellFiles }:
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, help2man
+, installShellFiles
+, pkg-config
+, bzip2
+, xz
+, zlib
+, zstd
+}:
 
 rustPlatform.buildRustPackage rec {
   pname = "ouch";
@@ -13,7 +23,13 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-jEprWtIl5LihD9fOMYHGGlk0+h4woUlwUWNfSkd2t10=";
 
-  nativeBuildInputs = [ help2man installShellFiles ];
+  nativeBuildInputs = [ help2man installShellFiles pkg-config ];
+
+  buildInputs = [ bzip2 xz zlib zstd ];
+
+  cargoBuildFlags = [ "--features" "zstd/pkg-config" ];
+
+  cargoTestFlags = cargoBuildFlags;
 
   postInstall = ''
     help2man $out/bin/ouch > ouch.1


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
