### PR TITLE
flex-ndax: 0.1-20210714.0 -> 0.2-20211111.0

### DIFF
--- a/pkgs/applications/radio/flex-ndax/default.nix
+++ b/pkgs/applications/radio/flex-ndax/default.nix
@@ -2,18 +2,18 @@
 
 buildGoModule rec {
   pname = "flex-ndax";
-  version = "0.1-20210714.0";
+  version = "0.2-20211111.0";
 
   src = fetchFromGitHub {
     owner = "kc2g-flex-tools";
     repo = "nDAX";
     rev = "v${version}";
-    sha256 = "16zx6kbax59rcxyz9dhq7m8yx214knz3xayna1gzb85m6maly8v8";
+    sha256 = "0m2hphj0qvgq25pfm3s76naf672ll43jv7gll8cfs7276ckg1904";
   };
 
   buildInputs = [ pulseaudio ];
 
-  vendorSha256 = "0qn8vg84j9kp0ycn24lkaqjnnk339j3vis4bn48ia3z5vfc22gi5";
+  vendorSha256 = "1bf0iidb8ggzahy3fvxispf3g940mv6vj9wqd8i3rldc6ca2i3pf";
 
   meta = with lib; {
     homepage = "https://github.com/kc2g-flex-tools/nDAX";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New upstream release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] ~Tested, as applicable:~
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- ~[21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)~
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
