### PR TITLE
WIP (broken) nixpkgs-basic-release-checks: try with --store

### DIFF
--- a/pkgs/applications/networking/cluster/spacegun/node-packages.nix
+++ b/pkgs/applications/networking/cluster/spacegun/node-packages.nix
@@ -10895,11 +10895,7 @@ in
   nodeDependencies = nodeEnv.buildNodeDependencies (lib.overrideExisting args {
     src = stdenv.mkDerivation {
       name = args.name + "-package-json";
-      src = nix-gitignore.gitignoreSourcePure [
-        "*"
-        "!package.json"
-        "!package-lock.json"
-      ] args.src;
+      src = args.src;
       dontBuild = true;
       installPhase = "mkdir -p $out; cp -r ./* $out;";
     };

--- a/pkgs/development/python-modules/panel/node/node-packages.nix
+++ b/pkgs/development/python-modules/panel/node/node-packages.nix
@@ -550,11 +550,7 @@ in
   nodeDependencies = nodeEnv.buildNodeDependencies (lib.overrideExisting args {
     src = stdenv.mkDerivation {
       name = args.name + "-package-json";
-      src = nix-gitignore.gitignoreSourcePure [
-        "*"
-        "!package.json"
-        "!package-lock.json"
-      ] args.src;
+      src = args.src;
       dontBuild = true;
       installPhase = "mkdir -p $out; cp -r ./* $out;";
     };

--- a/pkgs/tools/misc/fx_cast/node-packages.nix
+++ b/pkgs/tools/misc/fx_cast/node-packages.nix
@@ -1694,11 +1694,7 @@ in
   nodeDependencies = nodeEnv.buildNodeDependencies (lib.overrideExisting args {
     src = stdenv.mkDerivation {
       name = args.name + "-package-json";
-      src = nix-gitignore.gitignoreSourcePure [
-        "*"
-        "!package.json"
-        "!package-lock.json"
-      ] args.src;
+      src = args.src;
       dontBuild = true;
       installPhase = "mkdir -p $out; cp -r ./* $out;";
     };

--- a/pkgs/top-level/nixpkgs-basic-release-checks.nix
+++ b/pkgs/top-level/nixpkgs-basic-release-checks.nix
@@ -4,7 +4,7 @@ pkgs.runCommand "nixpkgs-release-checks" { src = nixpkgs; buildInputs = [nix]; }
     set -o pipefail
 
     export NIX_PATH=nixpkgs=$TMPDIR/barf.nix
-    opts=(--option build-users-group "" --store $TMPDIR/store --readonly-mode)
+    opts=(--option build-users-group "" --store dummy://)
     # ???: Does not support the opts
     # nix-store --init "''${opts[@]}"
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Follow advice from https://github.com/NixOS/nix/pull/5529#discussion_r746537748

Observations:
 - node2nix has generated numerous nix-gitignore.gitignoreSourcePure calls. This seems to be in the IFD-free part of nix-gitignore. Nonetheless, I've removed a couple of them to be sure.
 - now the derivation is stuck on a plain `filterSource`, producing the error below
 - if I remove `--readonly-mode`, the same error occurs
 - if I change it to `--store dummy://` I get the same error

```
checking Nixpkgs on x86_64-linux
error: path '/nix/store/w30dp3r17fn8p7ag2kczjdl6xllj8wq0-source' is not valid

       … while adding path '/nix/store/w30dp3r17fn8p7ag2kczjdl6xllj8wq0-source/pkgs/applications/networking/cluster/k3s'

       at /nix/store/w30dp3r17fn8p7ag2kczjdl6xllj8wq0-source/pkgs/applications/networking/cluster/k3s/default.nix:246:9:

          245|   # `src` here is a workaround for the updateScript bot. It couldn't be empty.
          246|   src = builtins.filterSource (path: type: false) ./.;
             |         ^
          247|

       … while evaluating the attribute 'src' of the derivation 'k3s-1.22.2+k3s2'

       at /nix/store/w30dp3r17fn8p7ag2kczjdl6xllj8wq0-source/pkgs/stdenv/generic/make-derivation.nix:205:7:

          204|     // (lib.optionalAttrs (attrs ? name || (attrs ? pname && attrs ? version)) {
          205|       name =
             |       ^
          206|         let

       … while querying the derivation named 'k3s-1.22.2+k3s2'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.  -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
