### PR TITLE
zabbix: Support for 5.4

### DIFF
--- a/pkgs/servers/monitoring/zabbix/agent.nix
+++ b/pkgs/servers/monitoring/zabbix/agent.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, pkg-config, libiconv, openssl, pcre }:
 
-import ./versions.nix ({ version, sha256 }:
+import ./versions.nix ({ version, sha256, ... }:
   stdenv.mkDerivation {
     pname = "zabbix-agent";
     inherit version;

--- a/pkgs/servers/monitoring/zabbix/agent.nix
+++ b/pkgs/servers/monitoring/zabbix/agent.nix
@@ -28,6 +28,8 @@ import ./versions.nix ({ version, sha256, ... }:
       cp conf/zabbix_agentd/*.conf $out/etc/zabbix_agentd.conf.d/
     '';
 
+    passthru.updateScript = ./update.py;
+
     meta = with lib; {
       description = "An enterprise-class open source distributed monitoring solution (client-side agent)";
       homepage = "https://www.zabbix.com/";

--- a/pkgs/servers/monitoring/zabbix/agent2.nix
+++ b/pkgs/servers/monitoring/zabbix/agent2.nix
@@ -1,6 +1,6 @@
 { lib, buildGoModule, fetchurl, autoreconfHook, pkg-config, libiconv, openssl, pcre, zlib }:
 
-import ./versions.nix ({ version, sha256 }:
+import ./versions.nix ({ version, sha256, vendorSha256 ? throw "unsupported version ${version} for zabbix-agent2", ... }:
   buildGoModule {
     pname = "zabbix-agent2";
     inherit version;
@@ -12,10 +12,7 @@ import ./versions.nix ({ version, sha256 }:
 
     modRoot = "src/go";
 
-    vendorSha256 =
-        if "${lib.versions.majorMinor version}" == "5.0" then "1417qi061xc4m55z0vz420fr7qpi24kw5yj9wq7iic92smakgkjn"
-        else if "${lib.versions.majorMinor version}" == "5.4" then "17hx0lnxvc4vlsdp7h66x95rwwh5skk3kynphm605klfix4hjs2k"
-        else throw "unsupported version ${version} for zabbix-agent2";
+    inherit vendorSha256;
 
     nativeBuildInputs = [ autoreconfHook pkg-config ];
     buildInputs = [ libiconv openssl pcre zlib ];

--- a/pkgs/servers/monitoring/zabbix/agent2.nix
+++ b/pkgs/servers/monitoring/zabbix/agent2.nix
@@ -12,7 +12,10 @@ import ./versions.nix ({ version, sha256 }:
 
     modRoot = "src/go";
 
-    vendorSha256 = "1417qi061xc4m55z0vz420fr7qpi24kw5yj9wq7iic92smakgkjn";
+    vendorSha256 =
+        if "${lib.versions.majorMinor version}" == "5.0" then "1417qi061xc4m55z0vz420fr7qpi24kw5yj9wq7iic92smakgkjn"
+        else if "${lib.versions.majorMinor version}" == "5.4" then "17hx0lnxvc4vlsdp7h66x95rwwh5skk3kynphm605klfix4hjs2k"
+        else throw "unsupported version ${version} for zabbix-agent2";
 
     nativeBuildInputs = [ autoreconfHook pkg-config ];
     buildInputs = [ libiconv openssl pcre zlib ];

--- a/pkgs/servers/monitoring/zabbix/agent2.nix
+++ b/pkgs/servers/monitoring/zabbix/agent2.nix
@@ -55,6 +55,8 @@ import ./versions.nix ({ version, sha256, vendorSha256 ? throw "unsupported vers
       ln -s $out/bin/zabbix_agent2 $out/sbin/zabbix_agentd
     '';
 
+    passthru.updateScript = ./update.py;
+
     meta = with lib; {
       description = "An enterprise-class open source distributed monitoring solution (client-side agent)";
       homepage = "https://www.zabbix.com/";

--- a/pkgs/servers/monitoring/zabbix/proxy.nix
+++ b/pkgs/servers/monitoring/zabbix/proxy.nix
@@ -15,7 +15,7 @@ assert sqliteSupport -> !mysqlSupport && !postgresqlSupport;
 let
   inherit (lib) optional optionalString;
 in
-  import ./versions.nix ({ version, sha256 }:
+  import ./versions.nix ({ version, sha256, ... }:
     stdenv.mkDerivation {
       pname = "zabbix-proxy";
       inherit version;

--- a/pkgs/servers/monitoring/zabbix/proxy.nix
+++ b/pkgs/servers/monitoring/zabbix/proxy.nix
@@ -72,6 +72,8 @@ in
         cp -prvd database/postgresql/schema.sql $out/share/zabbix/database/postgresql/
       '';
 
+      passthru.updateScript = ./update.py;
+
       meta = with lib; {
         description = "An enterprise-class open source distributed monitoring solution (client-server proxy)";
         homepage = "https://www.zabbix.com/";

--- a/pkgs/servers/monitoring/zabbix/server.nix
+++ b/pkgs/servers/monitoring/zabbix/server.nix
@@ -16,7 +16,7 @@ assert postgresqlSupport -> !mysqlSupport;
 let
   inherit (lib) optional optionalString;
 in
-  import ./versions.nix ({ version, sha256 }:
+  import ./versions.nix ({ version, sha256, ... }:
     stdenv.mkDerivation {
       pname = "zabbix-server";
       inherit version;

--- a/pkgs/servers/monitoring/zabbix/server.nix
+++ b/pkgs/servers/monitoring/zabbix/server.nix
@@ -86,6 +86,8 @@ in
         cp -prvd database/postgresql/*.sql $out/share/zabbix/database/postgresql/
       '';
 
+      passthru.updateScript = ./update.py;
+
       meta = with lib; {
         description = "An enterprise-class open source distributed monitoring solution";
         homepage = "https://www.zabbix.com/";

--- a/pkgs/servers/monitoring/zabbix/update.py
+++ b/pkgs/servers/monitoring/zabbix/update.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i python3 -p python3 git nix
+
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+from urllib.parse import urljoin
+from urllib.request import urlopen
+
+
+def run(*args, check=True, **kwargs):
+    print('$', *map(shlex.quote, args), file=sys.stderr)
+    p = subprocess.run(args, **kwargs)
+    if check:
+        p.check_returncode()
+    return p
+
+
+def respect_numbers(x):
+    parts = re.split(r'(\d+)', x)
+    for i, part in enumerate(parts):
+        try:
+            parts[i] = int(part, 10)
+        except ValueError:
+            pass
+    return tuple(parts)
+
+
+def get_lastest_link(url):
+    with urlopen(url) as r:
+        text = r.read()
+    i = text.find(b'<pre>') + 5
+    j = text.find(b'</pre>', i)
+    links = re.findall(r'(?<=href=")(?!\.\./").*?(?=")', text[i:j].decode('ascii'))
+    links.sort(key=respect_numbers)
+    return urljoin(url, links[-1])
+
+
+def replace(info, **kwargs):
+    attr, value = kwargs.popitem()
+    assert not kwargs
+    pos = info[attr]['pos']
+    with tempfile.NamedTemporaryFile(dir=os.path.dirname(pos['file']), mode='wb') as fout:
+        with open(pos['file'], 'rb') as fin:
+            for lineno, line in enumerate(fin, 1):
+                if lineno == pos['line']:
+                    indent = pos['column'] - 1
+                    line = ('%s%s = %s;\n' % (' ' * indent, attr, json.dumps(value))).encode('utf-8')
+                fout.write(line)
+        fout.flush()
+        os.rename(fout.name, pos['file'])
+        fout._closer.delete = False
+
+
+info = json.loads(run('nix-instantiate', '--expr', '--strict', '--json', '--eval', '''
+with builtins;
+mapAttrs (_: attrs:
+  mapAttrs (k: v:
+    {
+      value = v;
+      pos = unsafeGetAttrPos k attrs;
+    }
+  ) attrs
+) (
+  import ./versions.nix (x: x)
+)
+''', stdout=subprocess.PIPE, encoding='utf-8').stdout)
+
+for attr, info in info.items():
+    if attr == 'latest':
+        index_url = get_lastest_link('https://cdn.zabbix.com/zabbix/sources/stable/')
+    else:
+        m = re.match(r'[^.]*\.[^.]*', info['version']['value'])
+        index_url = urljoin('https://cdn.zabbix.com/zabbix/sources/stable/', m[0] + '/')
+    url = get_lastest_link(index_url)
+    m = re.search(r'(?<=-).*?(?=\.tar\.[^.]*$)', url)
+    version = m[0]
+    sha256 = run('nix-prefetch-url', '--type', 'sha256', url,
+                 stdout=subprocess.PIPE, encoding='utf-8').stdout.strip()
+
+    replace(info, version=version)
+    replace(info, sha256=sha256)
+    if 'vendorSha256' in info:
+        vendorSha256 = '0' * 52
+        replace(info, vendorSha256=vendorSha256)
+        args = ['nix-build', '--no-out-link',
+                '--argstr', 'attr', attr,
+                '-E', '{ attr }: with import ../../../.. {}; (zabbixFor attr).agent2.go-modules']
+        print('$', *map(shlex.quote, args), file=sys.stderr)
+        p = subprocess.Popen(args, stderr=subprocess.PIPE, encoding='utf-8')
+        for line in p.stderr:
+            sys.stderr.write(line)
+            m = re.match(r'^  got:    sha256:(.*)', line)
+            if m:
+                vendorSha256 = m[1]
+        p.wait()
+        replace(info, vendorSha256=vendorSha256)
+
+    run('git', 'commit',
+        '-m', 'zabbix: %s -> %s' % (info['version']['value'], version),
+        'versions.nix', check=False)

--- a/pkgs/servers/monitoring/zabbix/update.py
+++ b/pkgs/servers/monitoring/zabbix/update.py
@@ -12,12 +12,9 @@ from urllib.parse import urljoin
 from urllib.request import urlopen
 
 
-def run(*args, check=True, **kwargs):
+def run(*args, **kwargs):
     print('$', *map(shlex.quote, args), file=sys.stderr)
-    p = subprocess.run(args, **kwargs)
-    if check:
-        p.check_returncode()
-    return p
+    return subprocess.run(args, **kwargs)
 
 
 def respect_numbers(x):
@@ -68,7 +65,7 @@ mapAttrs (_: attrs:
 ) (
   import ./versions.nix (x: x)
 )
-''', stdout=subprocess.PIPE, encoding='utf-8').stdout)
+''', check=True, stdout=subprocess.PIPE, encoding='utf-8').stdout)
 
 for attr, info in info.items():
     if attr == 'latest':
@@ -80,7 +77,7 @@ for attr, info in info.items():
     m = re.search(r'(?<=-).*?(?=\.tar\.[^.]*$)', url)
     version = m[0]
     sha256 = run('nix-prefetch-url', '--type', 'sha256', url,
-                 stdout=subprocess.PIPE, encoding='utf-8').stdout.strip()
+                 check=True, stdout=subprocess.PIPE, encoding='utf-8').stdout.strip()
 
     replace(info, version=version)
     replace(info, sha256=sha256)
@@ -102,4 +99,4 @@ for attr, info in info.items():
 
     run('git', 'commit',
         '-m', 'zabbix: %s -> %s' % (info['version']['value'], version),
-        'versions.nix', check=False)
+        'versions.nix')

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -2,11 +2,13 @@ generic: {
   v54 = generic {
     version = "5.4.7";
     sha256 = "02bjdmx40nyc3kmm0c6w9ss1hmz62n5wq4ib9cc1vxp00vwaywml";
+    vendorSha256 = "17hx0lnxvc4vlsdp7h66x95rwwh5skk3kynphm605klfix4hjs2k";
   };
 
   v50 = generic {
     version = "5.0.17";
     sha256 = "11ppax0l0m8lzd1872g4l0jhng8bkkq3577kc364fmfxnsvkc60k";
+    vendorSha256 = "1417qi061xc4m55z0vz420fr7qpi24kw5yj9wq7iic92smakgkjn";
   };
 
   v40 = generic {

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -1,4 +1,9 @@
 generic: {
+  v54 = generic {
+    version = "5.4.7";
+    sha256 = "02bjdmx40nyc3kmm0c6w9ss1hmz62n5wq4ib9cc1vxp00vwaywml";
+  };
+
   v50 = generic {
     version = "5.0.17";
     sha256 = "11ppax0l0m8lzd1872g4l0jhng8bkkq3577kc364fmfxnsvkc60k";

--- a/pkgs/servers/monitoring/zabbix/web.nix
+++ b/pkgs/servers/monitoring/zabbix/web.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, writeText }:
 
-import ./versions.nix ({ version, sha256 }:
+import ./versions.nix ({ version, sha256, ... }:
   stdenv.mkDerivation rec {
     pname = "zabbix-web";
     inherit version;

--- a/pkgs/servers/monitoring/zabbix/web.nix
+++ b/pkgs/servers/monitoring/zabbix/web.nix
@@ -22,6 +22,8 @@ import ./versions.nix ({ version, sha256, ... }:
       cp ${phpConfig} $out/share/zabbix/conf/zabbix.conf.php
     '';
 
+    passthru.updateScript = ./update.py;
+
     meta = with lib; {
       description = "An enterprise-class open source distributed monitoring solution (web frontend)";
       homepage = "https://www.zabbix.com/";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21581,6 +21581,7 @@ with pkgs;
     server = server-pgsql;
   };
 
+  zabbix54 = recurseIntoAttrs (zabbixFor "v54");
   zabbix50 = recurseIntoAttrs (zabbixFor "v50");
   zabbix40 = dontRecurseIntoAttrs (zabbixFor "v40");
 

--- a/pkgs/top-level/packages-config.nix
+++ b/pkgs/top-level/packages-config.nix
@@ -28,6 +28,7 @@
       ut2004Packages
       zabbix40
       zabbix50
+      zabbix54
       zeroadPackages
     ;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Zabbix' 5.4 branch wasn't previously supported

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


This adds zabbix54 as extra available packages, zabbix50 stays the default package. I've tested the packages with them being pulled in by NixOS' configuration.nix and so far couldn't find any errors.
I don't really know much about git or nix so I hope everything's alright :sweat_smile: 