### PR TITLE
Add a simple builder for merging self-contained NixOS modules

### DIFF
--- a/doc/builders/special.xml
+++ b/doc/builders/special.xml
@@ -7,5 +7,6 @@
  </para>
  <xi:include href="special/fhs-environments.section.xml" />
  <xi:include href="special/mkshell.section.xml" />
+ <xi:include href="special/mergeNixOSModules.section.xml" />
  <xi:include href="special/invalidateFetcherByDrvHash.section.xml" />
 </chapter>

--- a/doc/builders/special/mergeNixOSModules.section.md
+++ b/doc/builders/special/mergeNixOSModules.section.md
@@ -1,0 +1,46 @@
+# mergeNixOSModules {#sec-merge-nixos-modules}
+
+Merge multiple NixOS modules and configuration files in to a single-file module.
+
+This is for NixOS configuration files being written to servers during creation, intended for merging configuration snippets which describe the hardware properties of the host.
+As a deployer it is nice to have a single file that you fetch from the remote to describe the host, especially when you're integrating with existing asset databases and tooling.
+
+Note that each provided NixOS module must be self-contained and have no relative references.
+
+Accepted arguments are:
+
+- `name`
+        Name of the resulting configuration file. Default: `configuration.nix`.
+        Note the result of this builder will be a single-file output, ie: `/nix/store/<hash>-${name}`.
+- `moduleFiles`
+        A list of files containing NixOS modules to merge together.
+
+## Example
+
+```nix
+# example.nix
+let
+  pkgs = import <nixpkgs> {};
+
+  configA = pkgs.writeText "configA.nix" ''
+    { config, pkgs, ... }: {
+      services.configA.enable = true;
+      environment.systemPackages = with pkgs; [ hello ];
+    }
+  '';
+
+  configB = pkgs.writeText "configB.nix" ''
+    {
+      services.configB.enable = true;
+    }
+  '';
+in
+{
+  myConfigFile = pkgs.mergeNixOSModules {
+    name = "configuration.nix";
+    moduleFiles = [ configA configB ];
+  };
+}
+```
+
+Running `nix-build ./example.nix -A myConfigFile` will produce a single file containing both configA and configB.

--- a/nixos/lib/make-zfs-image.nix
+++ b/nixos/lib/make-zfs-image.nix
@@ -219,23 +219,12 @@ let
       nixpkgs-fmt $out
     '';
 
-  mergedConfig =
-    if configFile == null
-    then fileSystemsCfgFile
-    else
-      pkgs.runCommand "configuration.nix" {
-        buildInputs = with pkgs; [ nixpkgs-fmt ];
-      }
-        ''
-          (
-            echo '{ imports = ['
-            printf "(%s)\n" "$(cat ${fileSystemsCfgFile})";
-            printf "(%s)\n" "$(cat ${configFile})";
-            echo ']; }'
-          ) > $out
-
-          nixpkgs-fmt $out
-        '';
+  mergedConfig = pkgs.mergeNixOSModules {
+    name = "configuration.nix";
+    moduleFiles = [
+      fileSystemsCfgFile
+    ] ++ lib.optional (configFile != null) configFile;
+  };
 
   image = (
     pkgs.vmTools.override {

--- a/pkgs/build-support/merge-nixos-modules/default.nix
+++ b/pkgs/build-support/merge-nixos-modules/default.nix
@@ -1,0 +1,76 @@
+{ lib, runCommand, nixpkgs-fmt, nix }:
+# Merge a list of self contained NixOS modules together in to a single file.
+# Note: since these modules will be aggregated in to a new, single file, they
+# should not refer to other files using relative paths.
+{
+  # The name of the resulting file. Note the result of this builder is
+  # a single-file output, ie: /nix/store/<hash>-${name}
+  name ? "configuration.nix"
+
+  # A list of files containing NixOS modules to merge together.
+, moduleFiles
+}:
+let
+  validateOneScript = file:
+    ''
+      printf "Validating file %s...\n" ${lib.escapeShellArg file};
+      if ! nix-instantiate --parse ${lib.escapeShellArg file} > /dev/null; then
+        cat -n ${lib.escapeShellArg file}
+        invalid=1
+      else
+        echo "....Ok."
+      fi
+    '';
+
+  validateListScript = files: lib.concatMapStringsSep "\n" validateOneScript files;
+
+  produceOneScript = file:
+    let
+      template = ''
+        {
+          _file = "${name}:merged-from:%s";
+          imports = [ (%s) ];
+        }
+      '';
+    in
+    ''
+      printf ${lib.escapeShellArg template} ${lib.escapeShellArg file} "$(cat ${lib.escapeShellArg file})"
+    '';
+
+  importListScript = files: lib.concatMapStringsSep "\n" produceOneScript files;
+
+in
+runCommand name
+{
+  buildInputs = [ nixpkgs-fmt nix ];
+} ''
+  export NIX_STATE_DIR=$TMPDIR
+
+  (
+    invalid=0
+    echo "Validating the input configuration files before merging..."
+    ${validateListScript moduleFiles}
+
+    if [ $invalid -ne 0 ]; then
+      echo "Input modules failed validation, cannot merge."
+      exit 1
+    fi
+  )
+
+  (
+    echo '{ imports = [';
+    ${importListScript moduleFiles}
+    echo ']; }'
+  ) > $out
+
+  echo "Formatting the merged configuration file..."
+  nixpkgs-fmt "$out"
+
+  (
+    invalid=0
+    ${validateOneScript (builtins.placeholder "out")}
+    exit $invalid
+  )
+''
+
+

--- a/pkgs/build-support/merge-nixos-modules/tests.nix
+++ b/pkgs/build-support/merge-nixos-modules/tests.nix
@@ -1,0 +1,51 @@
+let
+  pkgs = import ../../.. { };
+
+  configA = pkgs.writeText "configA.nix" ''
+    { config, pkgs, ... }: {
+      services.configA.enable = true;
+      networking.hostName = "example";
+      environment.systemPackages = with pkgs; [ hello ];
+    }
+  '';
+
+  configB = pkgs.writeText "configB.nix" ''
+    { config, pkgs, ... }: {
+      services.configB.enable = true;
+    }
+  '';
+
+  configC = pkgs.writeText "configC.nix" ''
+    { config, pkgs, ... }: {
+      services.configC.enable = true;
+    }
+  '';
+
+  configBroken = pkgs.writeText "configBroken.nix" ''
+    { config, pkgs, ... }: {
+      services.configBroken.enable =
+    }
+  '';
+in
+{
+  none = pkgs.mergeNixOSModules {
+    name = "merge-none.nix";
+    moduleFiles = [ ];
+  };
+
+  one = pkgs.mergeNixOSModules {
+    name = "merge-one.nix";
+    moduleFiles = [ configA ];
+  };
+
+  many = pkgs.mergeNixOSModules {
+    name = "merge-many.nix";
+    moduleFiles = [ configA configB configC configC configC ];
+  };
+
+  broken = pkgs.mergeNixOSModules {
+    name = "merge-broken.nix";
+    moduleFiles = [ configA configB configC configBroken configBroken ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -723,6 +723,8 @@ with pkgs;
 
   replaceDependency = callPackage ../build-support/replace-dependency.nix { };
 
+  mergeNixOSModules = callPackage ../build-support/merge-nixos-modules { };
+
   nukeReferences = callPackage ../build-support/nuke-references {
     inherit (darwin) signingUtils;
   };


### PR DESCRIPTION
###### Motivation for this change

I have, in a number of places, created various functions to merge NixOS configuration files in to one. Mostly to make automation easier downstream. Instead of implementing it in yet another place, I thought I'd make a good version of it and upstream it.

This is, in particular, useful for NixOS configuration files being written to servers during creation, to merge configuration snippets which describe the hardware properties of the host. As a deployer it is nice to have a single file that you fetch from the remote to describe the host, especially when you're integrating with existing asset databases and tooling.

One of the problems this is seeking to improve on is the self-containdedness of a NixOS configuration. This may be improved by Flakes in the future, although special consideration for very large deployments (hundreds-of-thousands) may complicate it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
