### PR TITLE
Update pipewire and pipewire-media-session

### DIFF
--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchFromGitLab
-, fetchpatch
 , removeReferencesTo
 , python3
 , meson
@@ -63,7 +62,7 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "pipewire";
-    version = "0.3.39";
+    version = "0.3.40";
 
     outputs = [
       "out"
@@ -81,7 +80,7 @@ let
       owner = "pipewire";
       repo = "pipewire";
       rev = version;
-      sha256 = "sha256-peTS1+NuQxZg1rrv8DrnJW5BR9yReleqooIwhZWHLjM=";
+      sha256 = "sha256-eY6uQa4+sC6yUWhF4IpAgRoppwhHO4s5fIMXOkS0z7A=";
     };
 
     patches = [
@@ -97,12 +96,6 @@ let
       ./0090-pipewire-config-template-paths.patch
       # Place SPA data files in lib output to avoid dependency cycles
       ./0095-spa-data-dir.patch
-      # Fix compilation on some architectures
-      # XXX: REMOVE ON NEXT RELEASE
-      (fetchpatch {
-        url = "https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/651f0decea5f83730c271e9bed03cdd0048fcd49.diff";
-        sha256 = "1bmpi5qn750mcspaw7m57ww0503sl9781jswqby4gr0f7c5wmqvj";
-      })
     ];
 
     nativeBuildInputs = [
@@ -188,7 +181,7 @@ let
     '';
 
     passthru = {
-      updateScript = ./update.sh;
+      updateScript = ./update-pipewire.sh;
       tests = {
         installedTests = nixosTests.installed-tests.pipewire;
 

--- a/pkgs/development/libraries/pipewire/media-session.nix
+++ b/pkgs/development/libraries/pipewire/media-session.nix
@@ -20,14 +20,14 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "pipewire-media-session";
-    version = "0.4.0";
+    version = "0.4.1";
 
     src = fetchFromGitLab {
       domain = "gitlab.freedesktop.org";
       owner = "pipewire";
       repo = "media-session";
       rev = version;
-      sha256 = "sha256-zhOvBlG7DuQkJ+ZZBhBhfKwk+bbLljpt3w4JlK3cJLk=";
+      sha256 = "sha256-e537gTkiNYMz2YJrOff/MXYWVDgHZDkqkSn8Qh+7Wr4=";
     };
 
     nativeBuildInputs = [
@@ -67,6 +67,7 @@ let
     '';
 
     passthru = {
+      updateScript = ./update-media-session.sh;
       tests = {
         test-paths = callPackage ./test-paths.nix { package = self; } {
           paths-out = [

--- a/pkgs/development/libraries/pipewire/update-media-session.sh
+++ b/pkgs/development/libraries/pipewire/update-media-session.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -p nix-update -i bash
+# shellcheck shell=bash
+
+set -o errexit -o pipefail -o nounset -o errtrace
+shopt -s inherit_errexit
+shopt -s nullglob
+IFS=$'\n'
+
+NIXPKGS_ROOT="$(git rev-parse --show-toplevel)"
+
+cd "$NIXPKGS_ROOT"
+nix-update pipewire-media-session
+outputs=$(nix-build . -A pipewire-media-session)
+for p in $outputs; do
+    conf_files=$(find "$p/nix-support/" -name '*.conf.json')
+    for c in $conf_files; do
+        file_name=$(basename "$c")
+        if [[ ! -e "nixos/modules/services/desktops/pipewire/media-session/$file_name" ]]; then
+            echo "New file $file_name found! Add it to the module config and passthru tests!"
+        fi
+        install -m 0644 "$c" "nixos/modules/services/desktops/pipewire/media-session/"
+    done
+done

--- a/pkgs/development/libraries/pipewire/update-pipewire.sh
+++ b/pkgs/development/libraries/pipewire/update-pipewire.sh
@@ -23,15 +23,3 @@ for p in $outputs; do
     done
 done
 
-nix-update pipewire-media-session
-outputs=$(nix-build . -A pipewire-media-session)
-for p in $outputs; do
-    conf_files=$(find "$p/nix-support/" -name '*.conf.json')
-    for c in $conf_files; do
-        file_name=$(basename "$c")
-        if [[ ! -e "nixos/modules/services/desktops/pipewire/media-session/$file_name" ]]; then
-            echo "New file $file_name found! Add it to the module config and passthru tests!"
-        fi
-        install -m 0644 "$c" "nixos/modules/services/desktops/pipewire/media-session/"
-    done
-done


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Closes #144220

###### Motivation for this change

Split the update script into separate files for each package to fix automatic updates by nixpkgs-update bots.

https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/0.3.40
https://gitlab.freedesktop.org/pipewire/media-session/-/releases/0.4.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
