### PR TITLE
offlineimap: 7.3.4 -> 8.0.0

### DIFF
--- a/pkgs/tools/networking/offlineimap/default.nix
+++ b/pkgs/tools/networking/offlineimap/default.nix
@@ -1,6 +1,6 @@
 { lib
 , fetchFromGitHub
-, python2Packages
+, python3
 , asciidoc
 , cacert
 , docbook_xsl
@@ -9,15 +9,15 @@
 , libxslt
 }:
 
-python2Packages.buildPythonApplication rec {
-  version = "7.3.4";
+python3.pkgs.buildPythonApplication rec {
   pname = "offlineimap";
+  version = "8.0.0";
 
   src = fetchFromGitHub {
     owner = "OfflineIMAP";
-    repo = "offlineimap";
+    repo = "offlineimap3";
     rev = "v${version}";
-    sha256 = "sha256-sra2H0+5+LAIU3+uJnii+AYA05nuDyKVMW97rbaFOfI=";
+    sha256 = "0y3giaz9i8vvczlxkbwymfkn3vi9fv599dy4pc2pn2afxsl4mg2w";
   };
 
   nativeBuildInputs = [
@@ -28,11 +28,14 @@ python2Packages.buildPythonApplication rec {
     libxslt
   ];
 
-  propagatedBuildInputs = with python2Packages; [
-    six
+  propagatedBuildInputs = with python3.pkgs; [
+    certifi
+    distro
+    imaplib2
     kerberos
-    rfc6555
     pysocks
+    rfc6555
+    urllib3
   ];
 
   postPatch = ''
@@ -40,7 +43,7 @@ python2Packages.buildPythonApplication rec {
     sed -i docs/Makefile -e "s|a2x -v -d |a2x -L -v -d |"
 
     # Provide CA certificates (Used when "sslcacertfile = OS-DEFAULT" is configured")
-    sed -i offlineimap/utils/distro.py -e '/def get_os_sslcertfile():/a\ \ \ \ return "${cacert}/etc/ssl/certs/ca-bundle.crt"'
+    sed -i offlineimap/utils/distro_utils.py -e '/def get_os_sslcertfile():/a\ \ \ \ return "${cacert}/etc/ssl/certs/ca-bundle.crt"'
   '';
 
   postInstall = ''
@@ -51,6 +54,10 @@ python2Packages.buildPythonApplication rec {
 
   # Test requires credentials
   doCheck = false;
+
+  pythonImportsCheck = [
+    "offlineimap"
+  ];
 
   meta = with lib; {
     description = "Synchronize emails between two repositories, so that you can read the same mailbox from multiple computers";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 8.0.0

Change log: https://github.com/OfflineIMAP/offlineimap3/blob/master/Changelog.md#offlineimap-v800-2021-10-18

`offlineimap` is now using Python 3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
