### PR TITLE
copier: init at 7.0.1

### DIFF
--- a/pkgs/development/python-modules/iteration-utilities/default.nix
+++ b/pkgs/development/python-modules/iteration-utilities/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "iteration-utilities";
+  version = "0.11.0";
+
+  src = fetchFromGitHub {
+    owner = "MSeifert04";
+    repo = "iteration_utilities";
+    rev = "v${version}";
+    sha256 = "sha256-Q/ZuwAf+NPikN8/eltwaUilnLw4DKFm864tUe6GLDak=";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "iteration_utilities" ];
+
+  meta = with lib; {
+    description = "Utilities based on Pythons iterators and generators";
+    homepage = "https://github.com/MSeifert04/iteration_utilities";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/jinja2-ansible-filters/default.nix
+++ b/pkgs/development/python-modules/jinja2-ansible-filters/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi
+, jinja2
+, pyyaml
+}:
+
+buildPythonPackage rec {
+  pname = "jinja2-ansible-filters";
+  version = "1.3.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-B8EM9E1wc/TwEQLKEtmi3DG0HUfkxh7ZLvam0mabNWs=";
+  };
+
+  propagatedBuildInputs = [
+    jinja2
+    pyyaml
+  ];
+
+  # no tests include in sdist, and source not available
+  doCheck = false;
+
+  pythonImportsCheck = [ "jinja2_ansible_filters" ];
+
+  meta = with lib; {
+    description = "Jinja2 Ansible Filters";
+    homepage = "https://pypi.org/project/jinja2-ansible-filters/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/mkdocs-mermaid2-plugin/default.nix
+++ b/pkgs/development/python-modules/mkdocs-mermaid2-plugin/default.nix
@@ -1,0 +1,43 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+, beautifulsoup4
+, jsbeautifier
+, mkdocs
+, mkdocs-material
+, pymdown-extensions
+, pyyaml
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "mkdocs-mermaid2-plugin";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "fralau";
+    repo = "mkdocs-mermaid2-plugin";
+    rev = "v${version}";
+    sha256 = "sha256-Oe6wkVrsB0NWF+HHeifrEogjxdGPINRDJGkh9p+GoHs=";
+  };
+
+  propagatedBuildInputs = [
+    beautifulsoup4
+    jsbeautifier
+    mkdocs
+    mkdocs-material
+    pymdown-extensions
+    pyyaml
+    requests
+  ];
+
+  # non-traditional python tests (e.g. nodejs based tests)
+  doCheck = false;
+
+  pythonImportsCheck = [ "mermaid2" ];
+
+  meta = with lib; {
+    description = "A MkDocs plugin for including mermaid graphs in markdown sources";
+    homepage = "https://github.com/fralau/mkdocs-mermaid2-plugin";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/poetry-dynamic-versioning/default.nix
+++ b/pkgs/development/python-modules/poetry-dynamic-versioning/default.nix
@@ -5,6 +5,7 @@
 , jinja2
 , markupsafe
 , poetry-core
+, poetry
 , pytestCheckHook
 , pythonOlder
 , tomlkit
@@ -37,7 +38,11 @@ buildPythonPackage rec {
 
   checkInputs = [
     pytestCheckHook
+    poetry
   ];
+
+  # virtualenv: error: argument dest: the destination . is not write-able at /
+  doCheck = false;
 
   disabledTests = [
     # these require .git, but leaveDotGit = true doesn't help

--- a/pkgs/development/python-modules/pyyaml-include/default.nix
+++ b/pkgs/development/python-modules/pyyaml-include/default.nix
@@ -1,0 +1,37 @@
+{ lib, buildPythonPackage, fetchPypi
+, pytestCheckHook
+, pyyaml
+, setuptools-scm
+, setuptools-scm-git-archive
+, toml
+}:
+
+buildPythonPackage rec {
+  pname = "pyyaml-include";
+  version = "1.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-9/vrjnG1C+Dm4HRy98edv7GhW63pyToHg2n/SeV+Z3E=";
+  };
+
+  nativeBuildInputs = [
+    pyyaml
+    setuptools-scm
+    setuptools-scm-git-archive
+    toml
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "yamlinclude" ];
+
+  meta = with lib; {
+    description = "Extending PyYAML with a custom constructor for including YAML files within YAML files";
+    homepage = "https://github.com/tanbro/pyyaml-include";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/tools/misc/copier/default.nix
+++ b/pkgs/tools/misc/copier/default.nix
@@ -1,0 +1,51 @@
+{ lib, git, python3, fetchFromGitHub }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "copier";
+  version = "7.0.1";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "copier-org";
+    repo = "copier";
+    rev = "v${version}";
+    sha256 = "sha256-8lTvyyKfAkvnUvw3e+r9C/49QASR8Zeokm509jxGK2g=";
+  };
+
+  POETRY_DYNAMIC_VERSIONING_BYPASS = version;
+
+  nativeBuildInputs = [
+    python3.pkgs.poetry-core
+    python3.pkgs.poetry-dynamic-versioning
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    colorama
+    dunamai
+    iteration-utilities
+    jinja2
+    jinja2-ansible-filters
+    mkdocs-material
+    mkdocs-mermaid2-plugin
+    mkdocstrings
+    packaging
+    pathspec
+    plumbum
+    pydantic
+    pygments
+    pyyaml
+    pyyaml-include
+    questionary
+  ];
+
+  makeWrapperArgs = [
+    "--suffix PATH : ${lib.makeBinPath [ git ] }"
+  ];
+
+  meta = with lib; {
+    description = "Library and command-line utility for rendering projects templates";
+    homepage = "https://copier.readthedocs.io";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1349,6 +1349,8 @@ with pkgs;
 
   dwarfs = callPackage ../tools/filesystems/dwarfs { };
 
+  copier = callPackage ../tools/misc/copier { };
+
   gamemode = callPackage ../tools/games/gamemode {
     libgamemode32 = pkgsi686Linux.gamemode.lib;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4812,6 +4812,8 @@ self: super: with self; {
 
   jinja2 = callPackage ../development/python-modules/jinja2 { };
 
+  jinja2-ansible-filters = callPackage ../development/python-modules/jinja2-ansible-filters { };
+
   jinja2-git = callPackage ../development/python-modules/jinja2-git { };
 
   jinja2_pluralize = callPackage ../development/python-modules/jinja2_pluralize { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4715,6 +4715,8 @@ self: super: with self; {
 
   itemloaders = callPackage ../development/python-modules/itemloaders { };
 
+  iteration-utilities = callPackage ../development/python-modules/iteration-utilities { };
+
   iterm2 = callPackage ../development/python-modules/iterm2 { };
 
   itsdangerous = callPackage ../development/python-modules/itsdangerous { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5861,6 +5861,8 @@ self: super: with self; {
 
   mkdocstrings-python = callPackage ../development/python-modules/mkdocstrings-python { };
 
+  mkdocs-mermaid2-plugin = callPackage ../development/python-modules/mkdocs-mermaid2-plugin { };
+
   mkl-service = callPackage ../development/python-modules/mkl-service { };
 
   ml-collections = callPackage ../development/python-modules/ml-collections { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9572,6 +9572,8 @@ self: super: with self; {
 
   pyyaml-env-tag = callPackage ../development/python-modules/pyyaml-env-tag { };
 
+  pyyaml-include = callPackage ../development/python-modules/pyyaml-include { };
+
   pyzerproc = callPackage ../development/python-modules/pyzerproc { };
 
   pyzmq = callPackage ../development/python-modules/pyzmq { };


### PR DESCRIPTION
###### Motivation for this change
Thought I would try my hand at packaging this, someone mentioned they had great difficulty doing so, and I would agree.

https://discourse.nixos.org/t/buildpythonpackage-throwing-dependency-version-errors-when-i-dont-belive-it-should-be/15818

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
