### PR TITLE
buildDotnetPackage: fix nativeBuildInputs

### DIFF
--- a/pkgs/build-support/build-dotnet-package/default.nix
+++ b/pkgs/build-support/build-dotnet-package/default.nix
@@ -3,6 +3,7 @@
 attrsOrig @
 { baseName
 , version
+, nativeBuildInputs ? []
 , buildInputs ? []
 , xBuildFiles ? [ ]
 , xBuildFlags ? [ "/p:Configuration=Release" ]
@@ -19,7 +20,9 @@ attrsOrig @
     attrs = {
       name = "${baseName}-${version}";
 
-      nativeBuildInputs = [ pkg-config ];
+      nativeBuildInputs = [
+        pkg-config
+      ] ++ nativeBuildInputs;
       buildInputs = [
         mono
         dotnetbuildhelpers
@@ -113,4 +116,4 @@ attrsOrig @
       '';
     };
   in
-    stdenv.mkDerivation (attrs // (builtins.removeAttrs attrsOrig [ "buildInputs" ] ))
+    stdenv.mkDerivation (attrs // (builtins.removeAttrs attrsOrig [ "nativeBuildInputs" "buildInputs" ] ))

--- a/pkgs/build-support/build-dotnet-package/default.nix
+++ b/pkgs/build-support/build-dotnet-package/default.nix
@@ -4,7 +4,6 @@ attrsOrig @
 { baseName
 , version
 , nativeBuildInputs ? []
-, buildInputs ? []
 , xBuildFiles ? [ ]
 , xBuildFlags ? [ "/p:Configuration=Release" ]
 , outputFiles ? [ "bin/Release/*" ]
@@ -22,12 +21,10 @@ attrsOrig @
 
       nativeBuildInputs = [
         pkg-config
-      ] ++ nativeBuildInputs;
-      buildInputs = [
-        mono
-        dotnetbuildhelpers
         makeWrapper
-      ] ++ buildInputs;
+        dotnetbuildhelpers
+        mono
+      ] ++ nativeBuildInputs;
 
       configurePhase = ''
         runHook preConfigure
@@ -90,7 +87,7 @@ attrsOrig @
             then
               echo "$dll already exported by a buildInputs, not re-exporting"
             else
-              ${dotnetbuildhelpers}/bin/create-pkg-config-for-dll.sh "$out/lib/pkgconfig" "$dll"
+              create-pkg-config-for-dll.sh "$out/lib/pkgconfig" "$dll"
             fi
           done
         done
@@ -116,4 +113,4 @@ attrsOrig @
       '';
     };
   in
-    stdenv.mkDerivation (attrs // (builtins.removeAttrs attrsOrig [ "nativeBuildInputs" "buildInputs" ] ))
+    stdenv.mkDerivation (attrs // (builtins.removeAttrs attrsOrig [ "nativeBuildInputs" ] ))

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -6,7 +6,6 @@
 , fetchFromGitHub
 , fetchNuGet
 , glib
-, pkg-config
 , mono
 , overrides ? {}
 }:


### PR DESCRIPTION
the nativeBuildInputs of the derivation that uses buildDotnetPackage overshadowed the nativeBuildInputs of buildDotnetPackage
so pkg-config wasn't getting added to the path

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
