### PR TITLE
adds numerous keepass plugins

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8166,6 +8166,17 @@
     githubId = 56316606;
     name = "Amneesh Singh";
   };
+  nazarewk = {
+    name = "Krzysztof Nazarewski";
+    email = "3494992+nazarewk@users.noreply.github.com";
+    matrix = "@nazarewk:matrix.org";
+    github = "nazarewk";
+    githubId = 3494992;
+    keys = [{
+      longkeyid = "rsa4096/0x916D8B67241892AE";
+      fingerprint = "4BFF 0614 03A2 47F0 AA0B 4BC4 916D 8B67 2418 92AE";
+    }];
+  };
   nbren12 = {
     email = "nbren12@gmail.com";
     github = "nbren12";

--- a/pkgs/applications/misc/keepass-plugins/charactercopy/default.nix
+++ b/pkgs/applications/misc/keepass-plugins/charactercopy/default.nix
@@ -1,0 +1,41 @@
+{ lib, stdenv, buildEnv, fetchurl, mono }:
+
+let
+  version = "1.0.0";
+
+  drv = stdenv.mkDerivation {
+    pname = "keepass-charactercopy";
+    inherit version;
+
+    src = fetchurl {
+      url    = "https://github.com/SketchingDev/Character-Copy/releases/download/v${version}/CharacterCopy.plgx";
+      sha256 = "f8a81a60cd1aacc04c92a242479a8e4210452add019c52ebfbb1810b58d8800a";
+    };
+
+    dontUnpack = true;
+    installPhase = ''
+      mkdir -p $out/lib/dotnet/keepass/
+      cp $src $out/lib/dotnet/keepass/
+    '';
+
+    meta = with lib; {
+      description = "Enables KeePass to copy individual characters by index";
+      longDescription = ''
+        Character Copy is a lightweight KeePass plugin that integrates into KeePass' entry menu and
+        allows users to securely copy individual characters from
+        an entry's protected string fields, such as the password field
+      '';
+      homepage    = "https://github.com/SketchingDev/Character-Copy";
+      platforms   = [
+        "aarch64-linux"
+        "i686-linux"
+        "x86_64-linux"
+      ];
+      # licensing info was found in source files https://github.com/SketchingDev/Character-Copy/search?q=license
+      license     = licenses.gpl2;
+      maintainers = with maintainers; [ nazarewk ];
+    };
+  };
+in
+  # Mono is required to compile plugin at runtime, after loading.
+  buildEnv { name = drv.name; paths = [ mono drv ]; }

--- a/pkgs/applications/misc/keepass-plugins/keetraytotp/default.nix
+++ b/pkgs/applications/misc/keepass-plugins/keetraytotp/default.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv, buildEnv, fetchurl, mono }:
+
+let
+  version = "0.108.0";
+
+  drv = stdenv.mkDerivation {
+    pname = "keepass-keetraytotp";
+    inherit version;
+
+    src = fetchurl {
+      url    = "https://github.com/KeeTrayTOTP/KeeTrayTOTP/releases/download/v${version}/KeeTrayTOTP.plgx";
+      sha256 = "4f7251a9bbb79cad04aee96d1809c6b36d43285a9f3834fef5330fc97ae8bc09";
+    };
+
+    dontUnpack = true;
+    installPhase = ''
+      mkdir -p $out/lib/dotnet/keepass/
+      cp $src $out/lib/dotnet/keepass/
+    '';
+
+    meta = with lib; {
+      description = "Augments KeePass with TOTP user interface";
+      longDescription = ''
+        This KeePass2 plugin adds advanced support for generating Time-based One-Time Passwords (TOTPs)
+        from the KeePass tray icon. It also provides a column in the main entry list to display and/or use TOTPs.
+        TOTPs can also be sent by auto-type. The plugin is compatible with Google, Dropbox, Steam, and many more services.
+      '';
+      homepage    = "https://github.com/KeeTrayTOTP/KeeTrayTOTP";
+      platforms   = [
+        "aarch64-linux"
+        "i686-linux"
+        "x86_64-linux"
+      ];
+      license     = licenses.gpl3;
+      maintainers = with maintainers; [ nazarewk ];
+    };
+  };
+in
+  # Mono is required to compile plugin at runtime, after loading.
+  buildEnv { name = drv.name; paths = [ mono drv ]; }

--- a/pkgs/applications/misc/keepass-plugins/qrcodeview/default.nix
+++ b/pkgs/applications/misc/keepass-plugins/qrcodeview/default.nix
@@ -1,0 +1,39 @@
+{ lib, stdenv, buildEnv, fetchurl, mono }:
+
+let
+  version = "1.0.4";
+
+  drv = stdenv.mkDerivation {
+    pname = "keepass-qrcodeview";
+    inherit version;
+
+    src = fetchurl {
+      url = "https://github.com/JanisEst/KeePassQRCodeView/releases/download/v${version}/KeePassQRCodeView.plgx";
+      sha256 = "e13c9f02bb0d79b479ca0e92490b822b5b88f49bb18ba2954d3bbe0808f46e6d";
+    };
+
+    dontUnpack = true;
+    installPhase = ''
+      mkdir -p $out/lib/dotnet/keepass/
+      cp $src $out/lib/dotnet/keepass/
+    '';
+
+    meta = with lib; {
+      description = "Enables KeePass to display data as QR code images";
+      longDescription = ''
+        KeePassQRCodeView is a plugin for KeePass 2.x which shows QR codes for entry fields.
+        These codes can be scanned to copy the encoded data to the scanner (smartphone, ...)
+      '';
+      homepage    = "https://github.com/JanisEst/KeePassQRCodeView";
+      platforms   = [
+        "aarch64-linux"
+        "i686-linux"
+        "x86_64-linux"
+      ];
+      license     = licenses.mit;
+      maintainers = with maintainers; [ nazarewk ];
+    };
+  };
+in
+  # Mono is required to compile plugin at runtime, after loading.
+  buildEnv { name = drv.name; paths = [ mono drv ]; }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24886,6 +24886,8 @@ with pkgs;
 
   keepass-keepassrpc = callPackage ../applications/misc/keepass-plugins/keepassrpc { };
 
+  keepass-keetraytotp = callPackage ../applications/misc/keepass-plugins/keetraytotp { };
+
   keepass-otpkeyprov = callPackage ../applications/misc/keepass-plugins/otpkeyprov { };
 
   kerbrute = callPackage ../tools/security/kerbrute { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24880,6 +24880,8 @@ with pkgs;
 
   keepass = callPackage ../applications/misc/keepass { };
 
+  keepass-charactercopy = callPackage ../applications/misc/keepass-plugins/charactercopy { };
+
   keepass-keeagent = callPackage ../applications/misc/keepass-plugins/keeagent { };
 
   keepass-keepasshttp = callPackage ../applications/misc/keepass-plugins/keepasshttp { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24890,6 +24890,8 @@ with pkgs;
 
   keepass-otpkeyprov = callPackage ../applications/misc/keepass-plugins/otpkeyprov { };
 
+  keepass-qrcodeview = callPackage ../applications/misc/keepass-plugins/qrcodeview { };
+
   kerbrute = callPackage ../tools/security/kerbrute { };
 
   exrdisplay = callPackage ../applications/graphics/exrdisplay { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds support for:
- [x] de-facto (as in built-into Keepass2Android etc.) standard plugin for handling OTPs in KeePass
- [x] copying passwords & fields on character-by-character basis without using autotype
- [ ] wayland autopaste enabler
- [x] plugin displaying fields as QRCodes for easy transfer between devices

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Tested by incorporating [into my NixOS configuration](https://github.com/nazarewk-iac/nix-configs/blob/a8f3b60ce5dafaa90e0afb035fe07bca15db9bd1/flake.nix#L30-L32)