### PR TITLE
pluginupdate.py: fix compatibility with nix 2.4

### DIFF
--- a/maintainers/scripts/pluginupdate.py
+++ b/maintainers/scripts/pluginupdate.py
@@ -305,7 +305,7 @@ class CleanEnvironment(object):
 
 def get_current_plugins(editor: Editor) -> List[Plugin]:
     with CleanEnvironment():
-        cmd = ["nix", "eval", "--json", editor.get_plugins]
+        cmd = ["nix", "eval", "--impure", "--json", "--expr", editor.get_plugins]
         log.debug("Running command %s", cmd)
         out = subprocess.check_output(cmd)
     data = json.loads(out)

--- a/pkgs/applications/editors/kakoune/plugins/update-shell.nix
+++ b/pkgs/applications/editors/kakoune/plugins/update-shell.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import ../../.. { } }:
+{ pkgs ? import ../../../../.. { } }:
 
 with pkgs;
 let

--- a/pkgs/applications/editors/kakoune/plugins/update.py
+++ b/pkgs/applications/editors/kakoune/plugins/update.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -p nix-prefetch-git -p python3 -p python3Packages.GitPython nix -i python3
+#!nix-shell update-shell.nix -i python3
 
 # format:
 # $ nix run nixpkgs.python3Packages.black -c black update.py


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

this breaks compatibility with nix 2.3

- [x] tested pkgs/misc/vim-plugins/update.py
- [x] tested maintainers/scripts/update-luarocks-packages
- [x] tested pkgs/applications/editors/kakoune/plugins/update.py: It's giving two 404 errors because the plugins seems to be deleted, probably unrelated to this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
