### PR TITLE
python3Packages.anybadge: 1.7.0 -> 1.8.0

### DIFF
--- a/pkgs/development/python-modules/anybadge/default.nix
+++ b/pkgs/development/python-modules/anybadge/default.nix
@@ -1,27 +1,36 @@
-{ lib, fetchFromGitHub, buildPythonPackage, pytestCheckHook }:
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "anybadge";
-  version = "1.7.0";
+  version = "1.8.0";
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "jongracecox";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1d02fnig04zlrhfqqcf4505vy4p51whl2ifilnx3mkhis9lcwrmr";
+    sha256 = "sha256-xKHIoV/8qsNMcU5fd92Jjh7d7jTeYN5xakMEjR6qPX8=";
   };
 
   # setup.py reads its version from the TRAVIS_TAG environment variable
   TRAVIS_TAG = "v${version}";
 
-  pythonImportsCheck = [ "anybadge" ];
+  checkInputs = [
+    pytestCheckHook
+  ];
 
-  checkInputs = [ pytestCheckHook ];
+  pythonImportsCheck = [
+    "anybadge"
+  ];
 
   meta = with lib; {
-    description = "A Python project for generating badges for your projects, with a focus on simplicity and flexibility";
-    license = licenses.mit;
+    description = "Python tool for generating badges for your projects";
     homepage = "https://github.com/jongracecox/anybadge";
-    maintainers = [ maintainers.fabiangd ];
+    license = licenses.mit;
+    maintainers = with maintainers; [ fabiangd ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.8.0

Change log: https://github.com/jongracecox/anybadge/releases/tag/v1.8.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
