### PR TITLE
radare2: Add support for darwin platforms

### DIFF
--- a/pkgs/development/libraries/libewf/default.nix
+++ b/pkgs/development/libraries/libewf/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, lib, stdenv, zlib, openssl, libuuid, pkg-config }:
+{ fetchurl, lib, stdenv, zlib, openssl, libuuid, pkg-config, bzip2 }:
 
 stdenv.mkDerivation rec {
   version = "20201230";
@@ -10,7 +10,8 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ zlib openssl libuuid ];
+  buildInputs = [ zlib openssl libuuid ]
+    ++ lib.optionals stdenv.isDarwin [ bzip2 ];
 
   meta = {
     description = "Library for support of the Expert Witness Compression Format";

--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -51,6 +51,12 @@ stdenv.mkDerivation rec {
     chmod -R +w libr/asm/arch/arm/v35arm64/arch-arm64
   '';
 
+  postFixup = lib.optionalString stdenv.isDarwin ''
+    for file in $out/bin/rasm2 $out/bin/ragg2 $out/bin/rabin2 $out/lib/libr_asm.${version}.dylib; do
+      install_name_tool -change libcapstone.4.dylib ${capstone}/lib/libcapstone.4.dylib $file
+    done
+  '';
+
   postInstall = ''
     install -D -m755 $src/binr/r2pm/r2pm $out/bin/r2pm
   '';
@@ -59,7 +65,10 @@ stdenv.mkDerivation rec {
   makeFlags = [
     "GITTAP=${version}"
     "RANLIB=${stdenv.cc.bintools.bintools}/bin/${stdenv.cc.bintools.targetPrefix}ranlib"
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "HOST_CC=${stdenv.cc.targetPrefix}cc"
   ];
+
   configureFlags = [
     "--with-sysmagic"
     "--with-syszip"
@@ -94,11 +103,11 @@ stdenv.mkDerivation rec {
     xxHash
   ];
 
-  meta = {
+  meta = with lib; {
     description = "unix-like reverse engineering framework and commandline tools";
-    homepage = "http://radare.org/";
-    license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ raskin makefu mic92 ];
-    platforms = with lib.platforms; linux;
+    homepage = "https://radare.org/";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ raskin makefu mic92 arkivm ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
* Add support for darwin
* For `libewf` the configure script tries `AC_CHECK_HEADERS` for `bzlib.h`. On darwin platforms, this header file comes along with the SDK `/Library/Developer/CommandLineTools/SDKs/MacOSX12.0.sdk/usr/include/bzlib.h` and this adds `-lbz2` while linking. Maybe this should be fixed in a totally different way.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
