### PR TITLE
python3Packages.aiosmtpd: enable tests

### DIFF
--- a/pkgs/development/python-modules/atpublic/default.nix
+++ b/pkgs/development/python-modules/atpublic/default.nix
@@ -1,6 +1,8 @@
-{ lib, isPy3k, pythonOlder, fetchPypi, buildPythonPackage
-, pytest
-, pytest-cov
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+, pythonOlder
 , sybil
 , typing-extensions
 }:
@@ -8,7 +10,9 @@
 buildPythonPackage rec {
   pname = "atpublic";
   version = "2.3";
-  disabled = !isPy3k;
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
@@ -20,25 +24,25 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    pytest pytest-cov sybil
+    pytestCheckHook
+    sybil
   ];
 
-  checkPhase = ''
-    pytest
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov=public" ""
   '';
 
+  pythonImportsCheck = [
+    "public"
+  ];
+
   meta = with lib; {
-    homepage = "https://public.readthedocs.io/en/latest/";
-    description = "A decorator and function which populates a module's __all__ and globals";
+    description = "Python decorator and function which populates a module's __all__ and globals";
+    homepage = "https://public.readthedocs.io/";
     longDescription = ''
       This is a very simple decorator and function which populates a module's
       __all__ and optionally the module globals.
-
-      This provides both a pure-Python implementation and a C implementation. It is
-      proposed that the C implementation be added to builtins_ for Python 3.6.
-
-      This proposal seems to have been rejected, for more information see
-      https://bugs.python.org/issue26632.
     '';
     license = licenses.asl20;
     maintainers = with maintainers; [ eadwu ];

--- a/pkgs/development/python-modules/mailman-hyperkitty/default.nix
+++ b/pkgs/development/python-modules/mailman-hyperkitty/default.nix
@@ -5,6 +5,7 @@
 , mock
 , nose2
 , python
+, pythonOlder
 , requests
 , zope_interface
 }:
@@ -13,6 +14,8 @@ buildPythonPackage rec {
   pname = "mailman-hyperkitty";
   version = "1.1.0";
   format = "setuptools";
+
+  disabled = pythonOlder "3.9";
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Enable tests

Fix build (https://hydra.nixos.org/build/157843437). `mailman` is only available for one release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
