### PR TITLE
qemu: Add patch to fix incorrect permissions on samba >= 2.0.5

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -86,6 +86,14 @@ stdenv.mkDerivation rec {
   patches = [
     ./fix-qemu-ga.patch
     ./9p-ignore-noatime.patch
+    # Fix qemu writing `smb.conf` incorrectly, breaking
+    # `-net user,smb=/dir` mounts on samba >= 2.0.5.
+    # Remove when https://lists.gnu.org/archive/html/qemu-devel/2021-02/msg07156.html is merged and available
+    (fetchpatch {
+      name = "net-slirp-Fix-incorrect-permissions-on-samba-2.0.5.patch";
+      url = "https://github.com/nh2/qemu/commit/de30898a738bd073593d20930496ef63e54d62a3.patch";
+      sha256 = "14jwfip0l6y0i1sr14avn2di9w4748kla679p4qhb7xxvifgqdcj";
+    })
     # Cocoa clipboard support only works on macOS 10.14+
     (fetchpatch {
       url = "https://gitlab.com/qemu-project/qemu/-/commit/7e3e20d89129614f4a7b2451fe321cc6ccca3b76.diff";


### PR DESCRIPTION
###### Motivation for this change

QEMU's builtin Samba config does not work for current Samba versions (including the one used in nixpkgs), see:

https://lists.gnu.org/archive/html/qemu-devel/2021-02/msg07156.html

Discussion so far (note `lists` -> `mail` in the URL, the old mailing list URL doesn't seem to update any longer):

https://mail.gnu.org/archive/html/qemu-devel/2021-04/msg06741.html

Unfortunately nobody has replied to my patch yet.

I think it makes sense to have this in nixpkgs, because otherwise mounting QEMU-provided Samba shares for Windows VM guests does not work.

We've been using this patch successfully on our company infrastructure for the last 9 months.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

CC from #114064: @bb2020 

CC from #94370: @andir 