### PR TITLE
resholve: 0.6.6 -> 0.6.7

### DIFF
--- a/pkgs/development/misc/resholve/source.nix
+++ b/pkgs/development/misc/resholve/source.nix
@@ -3,7 +3,7 @@
 }:
 
 rec {
-  version = "0.6.6";
+  version = "0.6.7";
   rSrc =
     # local build -> `make ci`; `make clean` to restore
     # return to remote source
@@ -14,6 +14,6 @@ rec {
         owner = "abathur";
         repo = "resholve";
         rev = "v${version}";
-        hash = "sha256-bupf3c9tNPAEMzFEDcvg483bSiwZFuB3ZqveG89dgkE=";
+        hash = "sha256-UDY8E9XWtNIG/4ovZcSR5iWKD19NVaWIwmnI0JROCYs=";
       };
 }

--- a/pkgs/development/misc/resholve/test.nix
+++ b/pkgs/development/misc/resholve/test.nix
@@ -21,10 +21,17 @@
 , rSrc
 , runDemo ? false
 , binlore
+, sqlite
+, util-linux
+, gawk
+, rlwrap
+, gnutar
+, bc
 }:
 
 let
-
+  default_packages = [ bash file findutils gettext ];
+  parsed_packages = [ coreutils sqlite util-linux gnused gawk findutils rlwrap gnutar bc ];
 in
 rec {
   re_shunit2 = with shunit2;
@@ -56,9 +63,6 @@ rec {
             "/usr/bin/od" = true;
           };
           keep = {
-            # dynamically defined in shunit2:_shunit_mktempFunc
-            eval = [ "shunit_condition_" "_shunit_test_" "_shunit_prepForSourcing" ];
-
             # variables invoked as commands; long-term goal is to
             # resolve the *variable*, but that is complexish, so
             # this is where we are...
@@ -166,13 +170,14 @@ rec {
     # LOGLEVEL="DEBUG";
 
     # default path
-    RESHOLVE_PATH = "${lib.makeBinPath [ bash file findutils gettext ]}";
+    RESHOLVE_PATH = "${lib.makeBinPath default_packages}";
     # but separate packages for combining as needed
     PKG_FILE = "${lib.makeBinPath [ file ]}";
     PKG_FINDUTILS = "${lib.makeBinPath [ findutils ]}";
     PKG_GETTEXT = "${lib.makeBinPath [ gettext ]}";
     PKG_COREUTILS = "${lib.makeBinPath [ coreutils ]}";
-    RESHOLVE_LORE = "${binlore.collect { drvs = [ bash file findutils gettext coreutils ]; } }";
+    RESHOLVE_LORE = "${binlore.collect { drvs = default_packages ++ [ coreutils ] ++ parsed_packages; } }";
+    PKG_PARSED = "${lib.makeBinPath parsed_packages}";
 
     # explicit interpreter for demo suite; maybe some better way...
     INTERP = "${bash}/bin/bash";


### PR DESCRIPTION
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
