### PR TITLE
sfm: fix cross-compilation

### DIFF
--- a/pkgs/applications/misc/sfm/default.nix
+++ b/pkgs/applications/misc/sfm/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
 
   postPatch = lib.optionalString (conf!=null) "cp ${configFile} config.def.h";
 
+  makeFlags = [ "CC:=$(CC)" ];
+
   installFlags = [ "PREFIX=$(out)" ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
Fix cross-compilation:
```
$ nix build .#pkgsCross.raspberryPi.sfm
error: builder for '/nix/store/xjmj44lkdb03v0mnv53i93b1lb8mrwv0-sfm-armv6l-unknown-linux-gnueabihf-0.4.drv' failed with exit code 2;
       last 10 log lines:
       > building
       > build flags: SHELL=/nix/store/phqa311klldrcbwid1i22dwnpfc9dnma-bash-5.1-p8/bin/bash
       > sfm build options:
       > CFLAGS   = -std=c99 -pedantic -Wextra -Wall -Wno-unused-parameter -Os -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700 -DVERSION="0.4"
       > LDFLAGS  = -pthread -s
       > CC       = cc
       > cp config.def.h config.h
       > cc -c -std=c99 -pedantic -Wextra -Wall -Wno-unused-parameter -Os -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700 -DVERSION=\"0.4\" sfm.c
       > /nix/store/phqa311klldrcbwid1i22dwnpfc9dnma-bash-5.1-p8/bin/bash: line 1: cc: command not found
       > make: *** [Makefile:18: sfm.o] Error 127
       For full logs, run 'nix log /nix/store/xjmj44lkdb03v0mnv53i93b1lb8mrwv0-sfm-armv6l-unknown-linux-gnueabihf-0.4.drv'.
```
###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
