### PR TITLE
python3Packages.aiohttp: 3.7.4.post0 -> 3.8.0

### DIFF
--- a/pkgs/development/python-modules/aiohttp/default.nix
+++ b/pkgs/development/python-modules/aiohttp/default.nix
@@ -3,15 +3,22 @@
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
-, async-timeout
+# install_requires
 , attrs
-, chardet
-, idna-ssl
+, charset-normalizer
 , multidict
-, typing-extensions
+, async-timeout
 , yarl
+, frozenlist
+, aiosignal
+, aiodns
+, brotli
+, cchardet
+, asynctest
+, typing-extensions
+, idna-ssl
+# tests_require
 , async_generator
-, brotlipy
 , freezegun
 , gunicorn
 , pytest-mock
@@ -22,32 +29,39 @@
 
 buildPythonPackage rec {
   pname = "aiohttp";
-  version = "3.7.4.post0";
+  version = "3.8.0";
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "493d3299ebe5f5a7c66b9819eacdcfbbaaf1a8e84911ddffcdc48888497afecf";
+    sha256 = "sha256-07GdjRg7z9aLJb7rq43DMIKC/iyj1uo8tM0QGzwnn40=";
   };
 
   postPatch = ''
-    substituteInPlace setup.cfg --replace " --cov=aiohttp" ""
+    sed -i '/--cov/d' setup.cfg
   '';
 
   propagatedBuildInputs = [
-    async-timeout
     attrs
-    chardet
+    charset-normalizer
     multidict
-    typing-extensions
+    async-timeout
     yarl
+    typing-extensions
+    frozenlist
+    aiosignal
+    aiodns
+    brotli
+    cchardet
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    asynctest
+    typing-extensions
   ] ++ lib.optionals (pythonOlder "3.7") [
     idna-ssl
   ];
 
   checkInputs = [
     async_generator
-    brotlipy
     freezegun
     gunicorn
     pytest-mock
@@ -58,12 +72,18 @@ buildPythonPackage rec {
 
   disabledTests = [
     # Disable tests that require network access
+    "test_client_session_timeout_zero"
     "test_mark_formdata_as_processed"
+    "test_requote_redirect_url_default"
   ] ++ lib.optionals stdenv.is32bit [
     "test_cookiejar"
   ] ++ lib.optionals stdenv.isDarwin [
     "test_addresses"  # https://github.com/aio-libs/aiohttp/issues/3572, remove >= v4.0.0
     "test_close"
+  ];
+
+  disabledTestPaths = [
+    "test_proxy_functional.py" # FIXME package proxy.py
   ];
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/python-modules/async_timeout/default.nix
+++ b/pkgs/development/python-modules/async_timeout/default.nix
@@ -2,21 +2,26 @@
 , fetchPypi
 , buildPythonPackage
 , pythonOlder
+, typing-extensions
 }:
 
 buildPythonPackage rec {
   pname = "async-timeout";
-  version = "3.0.1";
+  version = "4.0.1";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f";
+    sha256 = "sha256-uTDLFho5BC+SIvbvtzATmch+6rOUcn7FQ3kko21u71E=";
   };
+
+  propagatedBuildInputs = [
+    typing-extensions
+  ];
 
   # Circular dependency on aiohttp
   doCheck = false;
-
-  disabled = pythonOlder "3.4";
 
   meta = {
     description = "Timeout context manager for asyncio programs";

--- a/pkgs/development/python-modules/yarl/default.nix
+++ b/pkgs/development/python-modules/yarl/default.nix
@@ -11,11 +11,11 @@
 
 buildPythonPackage rec {
   pname = "yarl";
-  version = "1.7.0";
+  version = "1.7.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "8e7ebaf62e19c2feb097ffb7c94deb0f0c9fab52590784c8cd679d30ab009162";
+    sha256 = "sha256-RTmbRtYMJTMnpGDpmFZ1IAn87l9dPICy98DK4cONVt0=";
   };
 
   postPatch = ''

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -293,9 +293,7 @@ in {
 
   aiohomekit = callPackage ../development/python-modules/aiohomekit { };
 
-  aiohttp = callPackage ../development/python-modules/aiohttp {
-    pytestCheckHook = self.pytestCheckHook_6_1;
-  };
+  aiohttp = callPackage ../development/python-modules/aiohttp { };
 
   aiohttp-cors = callPackage ../development/python-modules/aiohttp-cors { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
