### PR TITLE
curl: update build configuration

### DIFF
--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -3,6 +3,7 @@
 , idnSupport ? false, libidn2 ? null
 , ldapSupport ? false, openldap ? null
 , zlibSupport ? true, zlib ? null
+, zstdSupport ? false, zstd ? null
 , opensslSupport ? zlibSupport, openssl ? null
 , gnutlsSupport ? false, gnutls ? null
 , wolfsslSupport ? false, wolfssl ? null
@@ -30,6 +31,7 @@ assert http2Support -> nghttp2 != null;
 assert idnSupport -> libidn2 != null;
 assert ldapSupport -> openldap != null;
 assert zlibSupport -> zlib != null;
+assert zstdSupport -> zstd != null;
 assert opensslSupport -> openssl != null;
 assert !(gnutlsSupport && opensslSupport);
 assert !(gnutlsSupport && wolfsslSupport);
@@ -74,6 +76,7 @@ stdenv.mkDerivation rec {
     optional idnSupport libidn2 ++
     optional ldapSupport openldap ++
     optional zlibSupport zlib ++
+    optional zstdSupport zstd ++
     optional gssSupport libkrb5 ++
     optional c-aresSupport c-ares ++
     optional opensslSupport openssl ++
@@ -102,6 +105,7 @@ stdenv.mkDerivation rec {
       (lib.enableFeature ldapSupport "ldap")
       (lib.enableFeature ldapSupport "ldaps")
       (lib.withFeatureAs idnSupport "libidn2" (lib.getDev libidn2))
+      (lib.withFeature zstdSupport "zstd")
       (lib.withFeature brotliSupport "brotli")
     ]
     ++ lib.optional wolfsslSupport "--with-wolfssl=${lib.getDev wolfssl}"

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -8,6 +8,7 @@
 , gnutlsSupport ? false, gnutls ? null
 , wolfsslSupport ? false, wolfssl ? null
 , scpSupport ? zlibSupport && !stdenv.isSunOS && !stdenv.isCygwin, libssh2 ? null
+, gsaslSupport ? false, gsasl ? null
 , gssSupport ? with stdenv.hostPlatform; (
     !isWindows &&
     # disable gss becuase of: undefined reference to `k5_bcmp'
@@ -41,6 +42,7 @@ assert wolfsslSupport -> wolfssl != null;
 assert scpSupport -> libssh2 != null;
 assert c-aresSupport -> c-ares != null;
 assert brotliSupport -> brotli != null;
+assert gsaslSupport -> gsasl != null;
 assert gssSupport -> libkrb5 != null;
 
 stdenv.mkDerivation rec {
@@ -77,6 +79,7 @@ stdenv.mkDerivation rec {
     optional ldapSupport openldap ++
     optional zlibSupport zlib ++
     optional zstdSupport zstd ++
+    optional gsaslSupport gsasl ++
     optional gssSupport libkrb5 ++
     optional c-aresSupport c-ares ++
     optional opensslSupport openssl ++

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -14,6 +14,7 @@
     !(isDarwin && (stdenv.buildPlatform != stdenv.hostPlatform))
   ), libkrb5 ? null
 , http2Support ? true, nghttp2 ? null
+, http3Support ? false, nghttp3, ngtcp2 ? null
 , idnSupport ? false, libidn2 ? null
 , ldapSupport ? false, openldap ? null
 , opensslSupport ? zlibSupport, openssl ? null
@@ -39,6 +40,8 @@ assert gnutlsSupport -> gnutls != null;
 assert gsaslSupport -> gsasl != null;
 assert gssSupport -> libkrb5 != null;
 assert http2Support -> nghttp2 != null;
+assert http3Support -> nghttp3 != null;
+assert http3Support -> ngtcp2 != null;
 assert idnSupport -> libidn2 != null;
 assert ldapSupport -> openldap != null;
 assert opensslSupport -> openssl != null;
@@ -84,6 +87,7 @@ stdenv.mkDerivation rec {
     optional gsaslSupport gsasl ++
     optional gssSupport libkrb5 ++
     optional http2Support nghttp2 ++
+    optionals http3Support [ nghttp3 ngtcp2 ] ++
     optional idnSupport libidn2 ++
     optional ldapSupport openldap ++
     optional opensslSupport openssl ++
@@ -112,6 +116,8 @@ stdenv.mkDerivation rec {
       (lib.enableFeature ldapSupport "ldaps")
       # The build fails when using wolfssl with --with-ca-fallback
       (lib.withFeature (!wolfsslSupport) "ca-fallback")
+      (lib.withFeature http3Support "nghttp3")
+      (lib.withFeature http3Support "ngtcp2")
       (lib.withFeature rtmpSupport "librtmp")
       (lib.withFeature zstdSupport "zstd")
       (lib.withFeatureAs brotliSupport "brotli" (lib.getDev brotli))

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -22,6 +22,7 @@
 , c-aresSupport ? false, c-ares ? null
 , brotliSupport ? false, brotli ? null
 , rtmpSupport ? false, rtmpdump ? null
+, pslSupport ? false, libpsl ? null
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -46,6 +47,7 @@ assert brotliSupport -> brotli != null;
 assert gsaslSupport -> gsasl != null;
 assert gssSupport -> libkrb5 != null;
 assert rtmpSupport -> rtmpdump !=null;
+assert pslSupport -> libpsl !=null;
 
 stdenv.mkDerivation rec {
   pname = "curl";
@@ -89,7 +91,8 @@ stdenv.mkDerivation rec {
     optional wolfsslSupport wolfssl ++
     optional scpSupport libssh2 ++
     optional brotliSupport brotli ++
-    optional rtmpSupport rtmpdump;
+    optional rtmpSupport rtmpdump ++
+    optional pslSupport libpsl;
 
   # for the second line see https://curl.haxx.se/mail/tracker-2014-03/0087.html
   preConfigure = ''

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -21,6 +21,7 @@
   ), libkrb5 ? null
 , c-aresSupport ? false, c-ares ? null
 , brotliSupport ? false, brotli ? null
+, rtmpSupport ? false, rtmpdump ? null
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -44,6 +45,7 @@ assert c-aresSupport -> c-ares != null;
 assert brotliSupport -> brotli != null;
 assert gsaslSupport -> gsasl != null;
 assert gssSupport -> libkrb5 != null;
+assert rtmpSupport -> rtmpdump !=null;
 
 stdenv.mkDerivation rec {
   pname = "curl";
@@ -86,7 +88,8 @@ stdenv.mkDerivation rec {
     optional gnutlsSupport gnutls ++
     optional wolfsslSupport wolfssl ++
     optional scpSupport libssh2 ++
-    optional brotliSupport brotli;
+    optional brotliSupport brotli ++
+    optional rtmpSupport rtmpdump;
 
   # for the second line see https://curl.haxx.se/mail/tracker-2014-03/0087.html
   preConfigure = ''
@@ -110,6 +113,7 @@ stdenv.mkDerivation rec {
       (lib.withFeatureAs idnSupport "libidn2" (lib.getDev libidn2))
       (lib.withFeature zstdSupport "zstd")
       (lib.withFeature brotliSupport "brotli")
+      (lib.withFeature rtmpSupport "librtmp")
     ]
     ++ lib.optional wolfsslSupport "--with-wolfssl=${lib.getDev wolfssl}"
     ++ lib.optional c-aresSupport "--enable-ares=${c-ares}"

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, pkg-config, perl
 , http2Support ? true, nghttp2
-, idnSupport ? false, libidn ? null
+, idnSupport ? false, libidn2 ? null
 , ldapSupport ? false, openldap ? null
 , zlibSupport ? true, zlib ? null
 , opensslSupport ? zlibSupport, openssl ? null
@@ -27,7 +27,7 @@
 # files.
 
 assert http2Support -> nghttp2 != null;
-assert idnSupport -> libidn != null;
+assert idnSupport -> libidn2 != null;
 assert ldapSupport -> openldap != null;
 assert zlibSupport -> zlib != null;
 assert opensslSupport -> openssl != null;
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
   # applications that use Curl.
   propagatedBuildInputs = with lib;
     optional http2Support nghttp2 ++
-    optional idnSupport libidn ++
+    optional idnSupport libidn2 ++
     optional ldapSupport openldap ++
     optional zlibSupport zlib ++
     optional gssSupport libkrb5 ++
@@ -101,7 +101,7 @@ stdenv.mkDerivation rec {
       (lib.withFeatureAs scpSupport "libssh2" (lib.getDev libssh2))
       (lib.enableFeature ldapSupport "ldap")
       (lib.enableFeature ldapSupport "ldaps")
-      (lib.withFeatureAs idnSupport "libidn" (lib.getDev libidn))
+      (lib.withFeatureAs idnSupport "libidn2" (lib.getDev libidn2))
       (lib.withFeature brotliSupport "brotli")
     ]
     ++ lib.optional wolfsslSupport "--with-wolfssl=${lib.getDev wolfssl}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4400,6 +4400,7 @@ with pkgs;
 
   curlFull = curl.override {
     ldapSupport = true;
+    gsaslSupport = true;
   };
 
   curl = curlMinimal.override ({

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4404,6 +4404,7 @@ with pkgs;
 
   curl = curlMinimal.override ({
     idnSupport = true;
+    zstdSupport = true;
   } // lib.optionalAttrs (!stdenv.hostPlatform.isStatic) {
     gssSupport = true;
     brotliSupport = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4402,6 +4402,7 @@ with pkgs;
     ldapSupport = true;
     gsaslSupport = true;
     rtmpSupport = true;
+    pslSupport = true;
   };
 
   curl = curlMinimal.override ({

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4401,6 +4401,7 @@ with pkgs;
   curlFull = curl.override {
     ldapSupport = true;
     gsaslSupport = true;
+    rtmpSupport = true;
   };
 
   curl = curlMinimal.override ({

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4405,6 +4405,11 @@ with pkgs;
     pslSupport = true;
   };
 
+  curlHTTP3 = curl.override {
+    openssl = quictls;
+    http3Support = true;
+  };
+
   curl = curlMinimal.override ({
     idnSupport = true;
     zstdSupport = true;


### PR DESCRIPTION
###### Motivation for this change
Update curl to version 7.80.0.
Fix support IDN.
Add support zstd compression,  sasl authentication, rtmp protocol and psl.
Small cleanup build configuraton.

```
nix log -f ./default.nix curlFull
```
```
...
  curl version:     7.80.0
  SSL:              enabled (OpenSSL)
  SSH:              enabled (libSSH2)
  zlib:             enabled
  brotli:           enabled (libbrotlidec)
  zstd:             enabled (libzstd)
  GSS-API:          enabled (MIT Kerberos/Heimdal)
  GSASL:            enabled
  TLS-SRP:          enabled
  resolver:         POSIX threaded
  IPv6:             enabled
  Unix sockets:     enabled
  IDN:              enabled (libidn2)
  Build libcurl:    Shared=yes, Static=no
  Built-in manual:  no      (--enable-manual)
  --libcurl option: enabled (--disable-libcurl-option)
  Verbose errors:   enabled (--disable-verbose)
  Code coverage:    disabled
  SSPI:             no      (--enable-sspi)
  ca cert bundle:   no
  ca cert path:     no
  ca fallback:      yes
  LDAP:             enabled (OpenLDAP)
  LDAPS:            enabled
  RTSP:             enabled
  RTMP:             enabled (librtmp)
  PSL:              enabled
  Alt-svc:          enabled (--disable-alt-svc)
  HSTS:             enabled (--disable-hsts)
  HTTP1:            enabled (internal)
  HTTP2:            enabled (nghttp2)
  HTTP3:            no      (--with-ngtcp2, --with-quiche)
  ECH:              no      (--enable-ech)
  Protocols:        DICT FILE FTP FTPS GOPHER GOPHERS HTTP HTTPS IMAP IMAPS LDAP LDAPS MQTT POP3 POP3S RTMP RTSP SCP SFTP SMB SMBS SMTP SMTPS TELNET TFTP
  Features:         AsynchDNS GSASL GSS-API HSTS HTTP2 HTTPS-proxy IDN IPv6 Kerberos Largefile NTLM NTLM_WB PSL SPNEGO SSL TLS-SRP UnixSockets alt-svc brotli libz zstd

...
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
