### PR TITLE
acl2: fix build on darwin

### DIFF
--- a/pkgs/development/interpreters/acl2/0001-Fix-some-paths-for-Nix-build.patch
+++ b/pkgs/development/interpreters/acl2/0001-Fix-some-paths-for-Nix-build.patch
@@ -102,7 +102,7 @@ index e5db28645..65eb818a1 100644
 -                "libcrypto.dylib"                ;; default system libcrypto, which may have insufficient crypto
 -                "/usr/lib/libcrypto.dylib"))
 -  (:cygwin (:or "cygcrypto-1.1.dll" "cygcrypto-1.0.0.dll")))
-+  (t "@openssl@/lib/libcrypto.so"))
++  (t "@libcrypto@"))
  
  (cffi:define-foreign-library libssl
 -  (:windows (:or #+(and windows x86-64) "libssl-1_1-x64.dll"
@@ -145,7 +145,7 @@ index e5db28645..65eb818a1 100644
 -                                  "libssl.so"))
 -  (:cygwin (:or "cygssl-1.1.dll" "cygssl-1.0.0.dll"))
 -  (t (:default "libssl3")))
-+  (t "@openssl@/lib/libssl.so"))
++  (t "@libssl@"))
  
  (unless (member :cl+ssl-foreign-libs-already-loaded
                  *features*)

--- a/pkgs/development/interpreters/acl2/default.nix
+++ b/pkgs/development/interpreters/acl2/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, callPackage, fetchFromGitHub, runCommandLocal, makeWrapper, substituteAll
-, sbcl, bash, which, perl, nettools
+, sbcl, bash, which, perl, hostname
 , openssl, glucose, minisat, abc-verifier, z3, python
 , certifyBooks ? true
 } @ args:
@@ -36,7 +36,8 @@ in stdenv.mkDerivation rec {
   patches = [(substituteAll {
     src = ./0001-Fix-some-paths-for-Nix-build.patch;
     libipasir = "${libipasir}/lib/${libipasir.libname}";
-    openssl = openssl.out;
+    libssl = "${openssl.out}/lib/libssl${stdenv.hostPlatform.extensions.sharedLibrary}";
+    libcrypto = "${openssl.out}/lib/libcrypto${stdenv.hostPlatform.extensions.sharedLibrary}";
   })];
 
   buildInputs = [
@@ -44,7 +45,7 @@ in stdenv.mkDerivation rec {
     sbcl
   ] ++ lib.optionals certifyBooks [
     # To build community books, we need Perl and a couple of utilities:
-    which perl nettools makeWrapper
+    which perl hostname makeWrapper
     # Some of the books require one or more of these external tools:
     openssl.out glucose minisat abc-verifier libipasir
     z3 (python.withPackages (ps: [ ps.z3 ]))


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/145271

cc: @jwiegley 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
