### PR TITLE
rare: init at 1.8.8

### DIFF
--- a/pkgs/games/rare/default.nix
+++ b/pkgs/games/rare/default.nix
@@ -1,0 +1,64 @@
+{ lib, fetchPypi, buildPythonApplication, makeDesktopItem, copyDesktopItems, qt5
+, pillow, psutil, pypresence, pyqt5, python, qtawesome, requests }:
+
+buildPythonApplication rec {
+  pname = "rare";
+  version = "1.8.8";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "Rare";
+    sha256 = "sha256-00CtvBqSrT9yJUHZ5529VrIQtCOYkHRc8+rJHmrTSpg=";
+  };
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    qt5.wrapQtAppsHook
+  ];
+
+  propagatedBuildInputs = [
+    pillow
+    psutil
+    pypresence
+    pyqt5
+    qtawesome
+    requests
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = "rare";
+      icon = "Rare";
+      comment = meta.description;
+      desktopName = "Rare";
+      genericName = "Rare (Epic Games Launcher Open Source Alternative)";
+    })
+  ];
+
+  dontWrapQtApps = true;
+
+  preBuild = ''
+    # Solves "PermissionError: [Errno 13] Permission denied: '/homeless-shelter'"
+    export HOME=$(mktemp -d)
+  '';
+
+  postInstall = ''
+    install -Dm644 $out/${python.sitePackages}/rare/resources/images/Rare.png -t $out/share/pixmaps/
+  '';
+
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+  '';
+
+  # Project has no tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "GUI for Legendary, an Epic Games Launcher open source alternative";
+    homepage = "https://github.com/Dummerle/Rare";
+    maintainers = with maintainers; [ wolfangaukang ];
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3743,6 +3743,8 @@ with pkgs;
 
   psrecord = python3Packages.callPackage ../tools/misc/psrecord {};
 
+  rare = python3Packages.callPackage ../games/rare { };
+
   reg = callPackage ../tools/virtualization/reg { };
 
   river = callPackage ../applications/window-managers/river { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#145386


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
