### PR TITLE
python3Packages.jupyter-repo2docker: add missing dependencies

### DIFF
--- a/pkgs/development/python-modules/jupyter-repo2docker/default.nix
+++ b/pkgs/development/python-modules/jupyter-repo2docker/default.nix
@@ -1,9 +1,16 @@
-{ lib, buildPythonPackage, fetchPypi, pythonOlder
+{ lib
+, bash
+, buildPythonPackage
+, chardet
 , docker
+, entrypoints
 , escapism
+, fetchFromGitHub
+, iso8601
 , jinja2
 , pkgs-docker
 , python-json-logger
+, pythonOlder
 , pyyaml
 , ruamel_yaml
 , semver
@@ -12,18 +19,24 @@
 }:
 
 buildPythonPackage rec {
-  version = "2021.8.0";
+  version = "2021.08.0";
   pname = "jupyter-repo2docker";
-  disabled = pythonOlder "3.4";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "9d1b3c3ec7944ea6b0a234d6fa77293a2d1ed1c080eba8466aba94f811b3465d";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "jupyterhub";
+    repo = "repo2docker";
+    rev = version;
+    sha256 = "10hcdag7ivyqyiqrmr9c48zynp8d81ic3px1ffgnaysih7lvkwb6";
   };
 
   propagatedBuildInputs = [
     docker
+    entrypoints
     escapism
+    iso8601
     jinja2
     pkgs-docker
     python-json-logger
@@ -33,7 +46,7 @@ buildPythonPackage rec {
     traitlets
   ];
 
-  # tests not packaged with pypi release
+  # Tests require a running Docker instance
   doCheck = false;
 
   pythonImportsCheck = [
@@ -44,9 +57,9 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    homepage = "https://repo2docker.readthedocs.io/en/latest/";
-    description = "Repo2docker: Turn code repositories into Jupyter enabled Docker Images";
+    description = "Turn code repositories into Jupyter enabled Docker Images";
+    homepage = "https://repo2docker.readthedocs.io/";
     license = licenses.bsdOriginal;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add missing deps

Fix build (https://hydra.nixos.org/build/157261029)

ZHF: #144627

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
