### PR TITLE
python3Packages.knack: 0.8.2 -> 0.9.0

### DIFF
--- a/pkgs/development/python-modules/knack/default.nix
+++ b/pkgs/development/python-modules/knack/default.nix
@@ -1,51 +1,55 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , argcomplete
-, colorama
 , jmespath
 , pygments
 , pyyaml
-, six
 , tabulate
 , mock
 , vcrpy
-, pytest
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "knack";
-  version = "0.8.2";
+  version = "0.9.0";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "4eaa50a1c5e79d1c5c8e5e1705b661721b0b83a089695e59e229cc26c64963b9";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1kjg62slxy6ixb3af72qg6n9vid78bh29vh3vaq3vsk5yxz5az2y";
   };
 
   propagatedBuildInputs = [
     argcomplete
-    colorama
     jmespath
     pygments
     pyyaml
-    six
     tabulate
   ];
 
   checkInputs = [
-    mock
     vcrpy
-    pytest
+    pytestCheckHook
   ];
 
-  checkPhase = ''
-    HOME=$TMPDIR pytest .
+  preCheck = ''
+    export HOME=$(mktemp -d);
   '';
 
+  pythonImportsCheck = [
+    "knack"
+  ];
+
   meta = with lib; {
-    homepage = "https://github.com/microsoft/knack";
     description = "A Command-Line Interface framework";
-    platforms = platforms.all;
+    homepage = "https://github.com/microsoft/knack";
     license = licenses.mit;
     maintainers = with maintainers; [ jonringer ];
   };

--- a/pkgs/tools/admin/azure-cli/python-packages.nix
+++ b/pkgs/tools/admin/azure-cli/python-packages.nix
@@ -495,6 +495,17 @@ let
           inherit version;
           sha256 = "sha256-TqpQocXnnRxcjl4XBbZhchsLg6CJaV5Z4inMJsZJY7k=";
         };
+        propagatedBuildInputs = [
+          argcomplete
+          colorama
+          jmespath
+          pygments
+          pyyaml
+          tabulate
+        ];
+
+        checkInputs = [ mock vcrpy pytestCheckHook ];
+
       });
 
       sshtunnel = super.sshtunnel.overridePythonAttrs(oldAttrs: rec {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.9.0

Change log: https://github.com/microsoft/knack/releases/tag/v0.9.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
