### PR TITLE
tree: cleanup, take maintainership

### DIFF
--- a/pkgs/tools/system/tree/default.nix
+++ b/pkgs/tools/system/tree/default.nix
@@ -4,22 +4,20 @@ let
   # These settings are found in the Makefile, but there seems to be no
   # way to select one ore the other setting other than editing the file
   # manually, so we have to duplicate the know how here.
-  systemFlags = with stdenv;
-    if isDarwin then ''
-      CFLAGS="-O2 -Wall -fomit-frame-pointer"
-      LDFLAGS=
-      EXTRA_OBJS=strverscmp.o
-    '' else if isCygwin then ''
-      CFLAGS="-O2 -Wall -fomit-frame-pointer -DCYGWIN"
-      LDFLAGS=-s
-      TREE_DEST=tree.exe
-      EXTRA_OBJS=strverscmp.o
-    '' else if (isFreeBSD || isOpenBSD) then ''
-      CFLAGS="-O2 -Wall -fomit-frame-pointer"
-      LDFLAGS=-s
-      EXTRA_OBJS=strverscmp.o
-    '' else
-    ""; # use linux flags by default
+  systemFlags = lib.optionalString stdenv.isDarwin ''
+    CFLAGS="-O2 -Wall -fomit-frame-pointer"
+    LDFLAGS=
+    EXTRA_OBJS=strverscmp.o
+  '' + lib.optionalString stdenv.isCygwin ''
+    CFLAGS="-O2 -Wall -fomit-frame-pointer -DCYGWIN"
+    LDFLAGS=-s
+    TREE_DEST=tree.exe
+    EXTRA_OBJS=strverscmp.o
+  '' + lib.optionalString (stdenv.isFreeBSD || stdenv.isOpenBSD) ''
+    CFLAGS="-O2 -Wall -fomit-frame-pointer"
+    LDFLAGS=-s
+    EXTRA_OBJS=strverscmp.o
+  ''; # use linux flags by default
 in
 stdenv.mkDerivation rec {
   pname = "tree";
@@ -30,27 +28,27 @@ stdenv.mkDerivation rec {
     sha256 = "1hmpz6k0mr6salv0nprvm1g0rdjva1kx03bdf1scw8a38d5mspbi";
   };
 
-  configurePhase = ''
+  preConfigure = ''
     sed -i Makefile -e 's|^OBJS=|OBJS=$(EXTRA_OBJS) |'
-    makeFlagsArray=(
-      prefix=$out
-      MANDIR=$out/share/man/man1
-      ${systemFlags}
-      CC="$CC"
-    )
   '';
 
-  meta = {
+  makeFlags = [
+    "prefix=${placeholder "out"}"
+    "MANDIR=${placeholder "out"}/share/man/man1"
+    "CC=$CC"
+    systemFlags
+  ];
+
+  meta = with lib; {
     homepage = "http://mama.indstate.edu/users/ice/tree/";
     description = "Command to produce a depth indented directory listing";
-    license = lib.licenses.gpl2;
-
+    license = licenses.gpl2;
     longDescription = ''
       Tree is a recursive directory listing command that produces a
       depth indented listing of files, which is colorized ala dircolors if
       the LS_COLORS environment variable is set and output is to tty.
     '';
-
-    platforms = lib.platforms.all;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ SuperSandro2000 ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
