### PR TITLE
gmni{,srv}: unstable-2021 → 1.0

### DIFF
--- a/pkgs/applications/networking/browsers/gmni/default.nix
+++ b/pkgs/applications/networking/browsers/gmni/default.nix
@@ -1,24 +1,24 @@
-{ stdenv, lib, fetchFromSourcehut, pkg-config, bearssl, scdoc }:
+{ stdenv, lib, fetchFromSourcehut, bearssl, scdoc }:
 
 stdenv.mkDerivation rec {
   pname = "gmni";
-  version = "unstable-2021-03-26";
+  version = "1.0";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "gmni";
-    rev = "77b73efbcd3ea7ed9e3e4c0aa19d9247e21d3c87";
-    sha256 = "1wvnzyv7vyddcd39y6q5aflpnnsdl4k4y5aj5ssb7vgkld0h1b7r";
+    rev = version;
+    sha256 = "sha256-3MFNAI/SfFigNfitfFs3o9kkz7JeEflMHiH7iJpLfi4=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ bearssl scdoc ];
+  nativeBuildInputs = [ scdoc ];
+  buildInputs = [ bearssl ];
 
   meta = with lib; {
     description = "A Gemini client";
     homepage = "https://git.sr.ht/~sircmpwn/gmni";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ bsima jb55 ];
-    platforms = platforms.all;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/servers/gemini/gmnisrv/default.nix
+++ b/pkgs/servers/gemini/gmnisrv/default.nix
@@ -2,14 +2,19 @@
 
 stdenv.mkDerivation rec {
   pname = "gmnisrv";
-  version = "unstable-2021-05-16";
+  version = "1.0";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "gmnisrv";
-    rev = "b9a92193e96bbe621ebc8430d8308d45a5b86cef";
-    sha256 = "sha256-eMKsoq3Y+eS20nxI7EoDLbdwdoB6shbGt6p8wS+uoPc=";
+    rev = version;
+    sha256 = "sha256-V9HXXYQIo3zeqZjJEn+dhemNg6AU+ee3FRmBmXgLuYQ=";
   };
+
+  postPatch = ''
+    substituteInPlace config.sh \
+      --replace "pkg-config" "${stdenv.cc.targetPrefix}pkg-config"
+  '';
 
   MIMEDB = "${mime-types}/etc/mime.types";
   nativeBuildInputs = [ pkg-config scdoc ];


### PR DESCRIPTION
###### Motivation for this change
* gmnisrv: unstable-2021-05-16 → 1.0
* gmni: unstable-2021-03-26 → 1.0
* fix cross-compilation:
```
$ nix build .#pkgsCross.raspberryPi.gmnisrv
$ nix build .#pkgsCross.raspberryPi.gmni
```

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
