### PR TITLE
tesseract4: apply patches to fix build on aarch64-darwin

### DIFF
--- a/pkgs/applications/graphics/tesseract/tesseract4.nix
+++ b/pkgs/applications/graphics/tesseract/tesseract4.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, autoreconfHook, autoconf-archive, pkg-config
-, leptonica, libpng, libtiff, icu, pango, opencl-headers }:
+, leptonica, libpng, libtiff, icu, pango, opencl-headers, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "tesseract";
@@ -11,6 +11,18 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "1ca27zbjpx35nxh9fha410z3jskwyj06i5hqiqdc08s2d7kdivwn";
   };
+
+  patches = [
+    # https://github.com/tesseract-ocr/tesseract/issues/3447
+    (fetchpatch {
+      url = "https://github.com/tesseract-ocr/tesseract/commit/dbc79b09d195490dfa3f7d338eadac07ad6683f7.patch";
+      sha256 = "sha256-lGlg0etuU4RXfdq1QH2bYObdeGrFHKf9O8zMUAbfNIQ=";
+    })
+    (fetchpatch {
+      url = "https://github.com/tesseract-ocr/tesseract/commit/6dc4b184b1ebf2e68461f6b63f63a033bc7245f7.patch";
+      sha256 = "sha256-DwIX3r5NmeajI6WgIVHDbkhLH/ygJIjPO5XrbzWQhSw=";
+    })
+  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
it wasn't tagged but it does exist
https://github.com/tesseract-ocr/tesseract/blob/4.1/ChangeLog

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
