### PR TITLE
ocamlPackages.bistro: 0.5.0 -> unstable-2021-07-13

### DIFF
--- a/pkgs/development/ocaml-modules/bistro/default.nix
+++ b/pkgs/development/ocaml-modules/bistro/default.nix
@@ -1,40 +1,40 @@
-{ lib, fetchFromGitHub, fetchpatch, buildDunePackage
-, base64, bos, core, lwt_react, ocamlgraph, rresult, tyxml
+{ lib
+, ocaml
+, fetchFromGitHub
+, buildDunePackage
+, base64
+, bos
+, core
+, lwt_react
+, ocamlgraph
+, ppx_sexp_conv
+, rresult
+, sexplib
+, tyxml
 }:
 
 buildDunePackage rec {
   pname = "bistro";
-  version = "0.5.0";
+  version = "unstable-2021-07-13";
 
   useDune2 = true;
 
   src = fetchFromGitHub {
     owner = "pveber";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "114gq48cpj2mvycypa9lfyqqb26wa2gkdfwkcqhnx7m6sdwv9a38";
+    rev = "4ce8d98f34f15ebf63ececccc9c763fec2b5fa6d";
+    sha256 = "sha256:16vxcdsj4dmswgm6igshs3hirz8jrg8l5b2xgcnxxgvsrc9sxljs";
   };
-
-  patches = [
-  # The following patch adds support for core.v0.13
-  (fetchpatch {
-    url = "https://github.com/pveber/bistro/commit/0931db43a146ad7829dff5120161a775f732a878.patch";
-    sha256 = "06y0sxbbab1mssc1xfjjv12lpv4rny5iqv9qkdqyzrvzpl1bdvnd";
-  })
-  # The following patch adds support for core.v0.14
-  (fetchpatch {
-    url = "https://github.com/pveber/bistro/commit/afbdcb2af7777ef7711c7f3c45dff605350a27b2.patch";
-    sha256 = "0ix6lx9qjnn3vqp0164c6l5an8b4rq69h2mxrg89piyk2g1yv0zg";
-  })
-  ];
 
   # Fix build with ppxlib 0.23
   postPatch = ''
-    substituteInPlace ppx/ppx_bistro.ml \
+    substituteInPlace ppx/bistro_script.ml \
       --replace 'Parser.parse_expression' 'Ocaml_common.Parser.parse_expression'
   '';
 
-  propagatedBuildInputs = [ base64 bos core lwt_react ocamlgraph rresult tyxml ];
+  propagatedBuildInputs = [
+    base64 bos core lwt_react ocamlgraph ppx_sexp_conv rresult sexplib tyxml
+  ];
 
   minimalOCamlVersion = "4.12";
 
@@ -43,5 +43,7 @@ buildDunePackage rec {
     description = "Build and execute typed scientific workflows";
     maintainers = [ lib.maintainers.vbgl ];
     license = lib.licenses.gpl2;
+    # ppx-related build failure; see https://github.com/pveber/bistro/issues/49:
+    broken = lib.versionAtLeast ocaml.version "4.13";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Upstream hasn't cut a release in a couple years.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [NA] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [NA] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [NA] (Package updates) Added a release notes entry if the change is major or breaking
  - [NA] (Module updates) Added a release notes entry if the change is significant
  - [NA] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
