### PR TITLE
roxterm: 3.7.5 -> 3.11.1

### DIFF
--- a/pkgs/applications/terminal-emulators/roxterm/default.nix
+++ b/pkgs/applications/terminal-emulators/roxterm/default.nix
@@ -1,4 +1,4 @@
-{ at-spi2-core, cmake, dbus, dbus-glib, docbook_xsl, epoxy, fetchpatch, fetchFromGitHub
+{ at-spi2-core, cmake, dbus, dbus-glib, docbook_xsl, epoxy, fetchFromGitHub
 , glib, gtk3, harfbuzz, libXdmcp, libXtst, libpthreadstubs
 , libselinux, libsepol, libtasn1, libxkbcommon, libxslt, p11-kit, pcre2
 , pkg-config, lib, stdenv, util-linuxMinimal, vte, wrapGAppsHook, xmlto
@@ -6,24 +6,14 @@
 
 stdenv.mkDerivation rec {
   pname = "roxterm";
-  version = "3.7.5";
+  version = "3.11.1";
 
   src = fetchFromGitHub {
     owner = "realh";
     repo = "roxterm";
     rev = version;
-    sha256 = "042hchvgk9jzz035zsgnfhh8105zvspbzz6b78waylsdlgqn0pp1";
+    sha256 = "1n7588bl83sp51jwjq97f526c7fkh0kq90idw3nayb4zmi530irx";
   };
-
-  patches = [
-    # This is the commit directly after v3.7.5.  It is needed to get roxterm to
-    # build correctly.  It can be removed when v3.7.6 (or v3.8.0) has been
-    # released.
-    (fetchpatch {
-      url = "https://github.com/realh/roxterm/commit/f7c38fd48bd1810e16d82794bdfb61a9760a2fe1.patch";
-      sha256 = "1v77b7ilgf8zy1npxxcyc06mq6lck6bi6lw4aksnq3mi61n5znmx";
-    })
-  ];
 
   nativeBuildInputs = [ cmake pkg-config wrapGAppsHook libxslt ];
 


### PR DESCRIPTION
###### Motivation for this change

3.7.5 segfaults a lot, I've been using 3.11.1 for a day and it hasn't crashed once

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
