### PR TITLE
beeper: init at 2.16.32

### DIFF
--- a/pkgs/applications/networking/instant-messengers/beeper/default.nix
+++ b/pkgs/applications/networking/instant-messengers/beeper/default.nix
@@ -1,0 +1,38 @@
+{ lib, fetchurl, appimageTools }:
+appimageTools.wrapType2 rec {
+  name = "beeper";
+  version = "2.16.32";
+
+  src = fetchurl {
+    url = "https://download.beeper.com/linux/appimage/x64";
+    sha256 = "sha256-YkvRsdiKgm9hlcepzuSiOi3B7yV0cgeCodmACKfZbAk=";
+  };
+
+  extraInstallCommands =
+    let
+      appimageContents = appimageTools.extractType2 { inherit name src; };
+      installIcon = size: ''
+        install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/${size}x${size}/apps/beeper.png \
+          $out/share/icons/hicolor/${size}x${size}/apps/beeper.png
+      '';
+    in
+    ''
+      install -Dm444 ${appimageContents}/beeper.desktop -t $out/share/applications
+      substituteInPlace $out/share/applications/beeper.desktop \
+        --replace 'Exec=AppRun --no-sandbox' 'Exec=${name}'
+      ${lib.concatMapStringsSep "\n" installIcon (map toString [16 32 48 64 128 256 512 1024 ])}
+    '';
+
+  meta = with lib; {
+    homepage = "https://www.beeper.com/";
+    description = "Unified chat app";
+    longDescription = ''
+      A single app to chat on iMessage, WhatsApp, and 13 other networks. You
+      can search, prioritize, and mute messages. And with a unified inbox,
+      you'll never miss a message again.
+    '';
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ sumnerevans ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23982,6 +23982,8 @@ with pkgs;
 
   bchoppr = callPackage ../applications/audio/bchoppr { };
 
+  beeper = callPackage ../applications/networking/instant-messengers/beeper { };
+
   berry = callPackage ../applications/window-managers/berry { };
 
   bespokesynth = callPackage ../applications/audio/bespokesynth { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
