### PR TITLE
 python3Packages.tweepy: 4.0.1 -> 4.3.0 

### DIFF
--- a/pkgs/applications/networking/instant-messengers/turses/default.nix
+++ b/pkgs/applications/networking/instant-messengers/turses/default.nix
@@ -1,7 +1,30 @@
-{ lib, fetchpatch, python3Packages }:
+{ lib
+, fetchpatch
+, fetchFromGitHub
+, python3
+}:
 
-with lib;
-with python3Packages;
+let
+  py = python3.override {
+    packageOverrides = self: super: {
+
+      # Support for later tweepy releases is missing
+      # https://github.com/louipc/turses/issues/12
+      tweepy = super.tweepy.overridePythonAttrs (oldAttrs: rec {
+        version = "3.10.0";
+
+        src = fetchFromGitHub {
+          owner = "tweepy";
+          repo = "tweepy";
+          rev = "v${version}";
+          sha256 = "0k4bdlwjna6f1k19jki4xqgckrinkkw8b9wihzymr1l04rwd05nw";
+        };
+        doCheck = false;
+      });
+    };
+  };
+in
+with py.pkgs;
 
 buildPythonPackage rec {
   pname = "turses";
@@ -12,8 +35,18 @@ buildPythonPackage rec {
     sha256 = "15mkhm3b5ka42h8qph0mhh8izfc1200v7651c62k7ldcs50ib9j6";
   };
 
-  checkInputs = [ mock pytest coverage tox ];
-  propagatedBuildInputs = [ urwid tweepy future ];
+  propagatedBuildInputs = with py.pkgs; [
+    urwid
+    tweepy
+    future
+  ];
+
+  checkInputs = with py.pkgs; [
+    mock
+    pytest
+    coverage
+    tox
+  ];
 
   LC_ALL = "en_US.UTF-8";
 
@@ -29,6 +62,17 @@ buildPythonPackage rec {
     })
   ];
 
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "urwid==1.3.0" "urwid" \
+      --replace "future==0.14.3" "future" \
+      --replace "tweepy==3.3.0" "tweepy"
+    substituteInPlace tests/test_config.py \
+      --replace "config.generate_config_file.assert_called_once()" "assert config.generate_config_file.call_count == 1"
+    substituteInPlace tests/test_meta.py \
+      --replace "self.observer.update.assert_called_once()" "assert self.observer.update.call_count == 1"
+  '';
+
   checkPhase = ''
     TMP_TURSES=`echo turses-$RANDOM`
     mkdir $TMP_TURSES
@@ -36,18 +80,10 @@ buildPythonPackage rec {
     rm -rf $TMP_TURSES
   '';
 
-  postPatch = ''
-    sed -i -e 's|urwid==1.3.0|urwid==${getVersion urwid}|' setup.py
-    sed -i -e "s|future==0.14.3|future==${getVersion future}|" setup.py
-    sed -i -e "s|tweepy==3.3.0|tweepy==${getVersion tweepy}|" setup.py
-    sed -i -e "s|config.generate_config_file.assert_called_once()|assert config.generate_config_file.call_count == 1|" tests/test_config.py
-    sed -i -e "s|self.observer.update.assert_called_once()|assert self.observer.update.call_count == 1|" tests/test_meta.py
-  '';
-
   meta = with lib; {
-    homepage = "https://github.com/louipc/turses";
     description = "A Twitter client for the console";
-    license = licenses.gpl3;
+    homepage = "https://github.com/louipc/turses";
+    license = licenses.gpl3Only;
     maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };

--- a/pkgs/development/python-modules/tweepy/default.nix
+++ b/pkgs/development/python-modules/tweepy/default.nix
@@ -1,20 +1,48 @@
-{ lib, buildPythonPackage, fetchPypi, requests, six, requests_oauthlib }:
+{ lib
+, aiohttp
+, buildPythonPackage
+, fetchFromGitHub
+, oauthlib
+, requests
+, pythonOlder
+, vcrpy
+, pytestCheckHook
+, requests_oauthlib
+}:
 
 buildPythonPackage rec {
   pname = "tweepy";
-  version = "4.0.1";
+  version = "4.3.0";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "3bbb14a0ddef1ca8c9e8686ab2f647163afa02a6bab83507335ce647e9653a90";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-lS/98DRpJH1UGGNzwqVVUJOeul+BX+I3e+ysmC0oL3I=";
   };
 
-  doCheck = false;
-  propagatedBuildInputs = [ requests six requests_oauthlib ];
+  propagatedBuildInputs = [
+    aiohttp
+    oauthlib
+    requests
+    requests_oauthlib
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    vcrpy
+  ];
+
+  pythonImportsCheck = [
+    "tweepy"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/tweepy/tweepy";
-    description = "Twitter library for python";
+    description = "Twitter library for Python";
     license = licenses.mit;
     maintainers = with maintainers; [ ];
   };

--- a/pkgs/tools/security/ioccheck/default.nix
+++ b/pkgs/tools/security/ioccheck/default.nix
@@ -3,7 +3,29 @@
 , python3
 }:
 
-python3.pkgs.buildPythonApplication rec {
+let
+  py = python3.override {
+    packageOverrides = self: super: {
+
+      # Support for later tweepy releases is missing
+      # https://github.com/ranguli/ioccheck/issues/70
+      tweepy = super.tweepy.overridePythonAttrs (oldAttrs: rec {
+        version = "3.10.0";
+
+        src = fetchFromGitHub {
+          owner = "tweepy";
+          repo = "tweepy";
+          rev = "v${version}";
+          sha256 = "0k4bdlwjna6f1k19jki4xqgckrinkkw8b9wihzymr1l04rwd05nw";
+        };
+        doCheck = false;
+      });
+    };
+  };
+in
+with py.pkgs;
+
+buildPythonApplication rec {
   pname = "ioccheck";
   version = "unstable-2021-09-29";
   format = "pyproject";
@@ -15,11 +37,11 @@ python3.pkgs.buildPythonApplication rec {
     sha256 = "0lgqypcd5lzb2yqd5lr02pba24m26ghly4immxgz13svi8f6vzm9";
   };
 
-  nativeBuildInputs = with python3.pkgs; [
+  nativeBuildInputs = with py.pkgs; [
     poetry-core
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = with py.pkgs; [
     backoff
     click
     emoji
@@ -34,7 +56,7 @@ python3.pkgs.buildPythonApplication rec {
     vt-py
   ];
 
-  checkInputs = with python3.pkgs; [
+  checkInputs = with py.pkgs; [
     pytestCheckHook
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 4.3.0

Change log:
- https://github.com/tweepy/tweepy/releases/tag/v4.3.0
- https://github.com/tweepy/tweepy/releases/tag/v4.2.0
- https://github.com/tweepy/tweepy/releases/tag/v4.1.0

Fix build failure detected in https://github.com/NixOS/nixpkgs/pull/145691

- https://hydra.nixos.org/build/158062124
- https://hydra.nixos.org/build/158017499

ZHF: #144627

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
