### PR TITLE
droopy: Fix Python 3.9 compatiblity

### DIFF
--- a/pkgs/applications/networking/droopy/default.nix
+++ b/pkgs/applications/networking/droopy/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
     })
     (pkgs.fetchpatch {
       url = "https://patch-diff.githubusercontent.com/raw/stackp/Droopy/pull/31.patch";
-      sha256 = "1dn8wym9378d8kiz32snvl6cksp7ydrg0c5pgm2mp46nmnz45r6i";
+      sha256 = "1ig054rxn5r0ph4w4fhmrxlh158c97iqqc7dbnc819adn9nw96l5";
     })
   ];
 

--- a/pkgs/applications/networking/droopy/default.nix
+++ b/pkgs/applications/networking/droopy/default.nix
@@ -18,6 +18,10 @@ stdenv.mkDerivation {
       url = "https://patch-diff.githubusercontent.com/raw/stackp/Droopy/pull/30.patch";
       sha256 = "Y6jBraKvVQAiScbvLwezSKeWY3vaAbhaNXEGNaItigQ=";
     })
+    (pkgs.fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/stackp/Droopy/pull/31.patch";
+      sha256 = "1dn8wym9378d8kiz32snvl6cksp7ydrg0c5pgm2mp46nmnz45r6i";
+    })
   ];
 
   nativeBuildInputs = [ wrapPython ];

--- a/pkgs/applications/networking/droopy/default.nix
+++ b/pkgs/applications/networking/droopy/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
       url = "https://patch-diff.githubusercontent.com/raw/stackp/Droopy/pull/30.patch";
       sha256 = "Y6jBraKvVQAiScbvLwezSKeWY3vaAbhaNXEGNaItigQ=";
     })
-    (pkgs.fetchpatch {
+    (fetchpatch {
       url = "https://patch-diff.githubusercontent.com/raw/stackp/Droopy/pull/31.patch";
       sha256 = "1ig054rxn5r0ph4w4fhmrxlh158c97iqqc7dbnc819adn9nw96l5";
     })


### PR DESCRIPTION
###### Motivation for this change

Droopy has been broken since the update to Python 3.9. This change brings in the fairly trivial unmerged PR at https://github.com/stackp/Droopy/pull/31, which adds compatibility.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).