### PR TITLE
python3Packages.cirq-core: fix for aarch64

### DIFF
--- a/pkgs/development/python-modules/cirq-core/default.nix
+++ b/pkgs/development/python-modules/cirq-core/default.nix
@@ -3,6 +3,7 @@
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub
+, fetchpatch
 , duet
 , matplotlib
 , networkx
@@ -42,6 +43,22 @@ buildPythonPackage rec {
   };
 
   sourceRoot = "source/${pname}";
+
+  patches = [
+    # present in upstream master - remove after 0.13.1
+    (fetchpatch {
+      name = "fix-test-tolerances.part-1.patch";
+      url = "https://github.com/quantumlib/Cirq/commit/eb1d9031e55d3c8801ea44abbb6a4132b2fc5126.patch";
+      sha256 = "0ka24v6dfxnap9p07ni32z9zccbmw0lbrp5mcknmpsl12hza98xm";
+      stripLen = 1;
+    })
+    (fetchpatch {
+      name = "fix-test-tolerances.part-2.patch";
+      url = "https://github.com/quantumlib/Cirq/commit/a28d601b2bcfc393336375c53e5915fd16455395.patch";
+      sha256 = "0k2dqsm4ydn6556d40kc8j04jgjn59z4wqqg1jn1r916a7yxw493";
+      stripLen = 1;
+    })
+  ];
 
   postPatch = ''
     substituteInPlace requirements.txt \
@@ -84,10 +101,6 @@ buildPythonPackage rec {
   disabledTests = [
     "test_metadata_search_path" # tries to import flynt, which isn't in Nixpkgs
     "test_benchmark_2q_xeb_fidelities" # fails due pandas MultiIndex. Maybe issue with pandas version in nix?
-  ] ++ lib.optionals stdenv.hostPlatform.isAarch64 [
-    # Seem to fail due to math issues on aarch64?
-    "expectation_from_wavefunction"
-    "test_single_qubit_op_to_framed_phase_form_output_on_example_case"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
ZHF: #144627 @NixOS/nixos-release-managers

Another case of a responsive upstream fixing things (https://github.com/quantumlib/Cirq/issues/4379), in this case the tests' precision tolerances needed to be loosened.

This enables all the other `cirq` packages without other issues for me.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
