### PR TITLE
vc_0_7: fix darwin build

### DIFF
--- a/pkgs/development/libraries/vc/0.7.nix
+++ b/pkgs/development/libraries/vc/0.7.nix
@@ -11,6 +11,9 @@ stdenv.mkDerivation rec {
     sha256 = "190s4r2n3jsivl4j2m288j3rqmgjj6gl308hi9mzwyhcfn17q8br";
   };
 
+  # Avoid requesting an unreasonable intrinsic
+  patches = lib.optional stdenv.cc.isClang ./vc_0_7_clang_fix.patch;
+
   nativeBuildInputs = [ cmake ];
 
   postPatch = ''

--- a/pkgs/development/libraries/vc/vc_0_7_clang_fix.patch
+++ b/pkgs/development/libraries/vc/vc_0_7_clang_fix.patch
@@ -1,0 +1,28 @@
+diff -ur a/sse/intrinsics.h b/sse/intrinsics.h
+--- a/sse/intrinsics.h	2021-11-12 22:09:50.000000000 -0500
++++ b/sse/intrinsics.h	2021-11-12 22:14:08.000000000 -0500
+@@ -498,16 +498,6 @@
+         case 0:
+             f = _mm_cvtss_f32(v);
+             break;
+-#if defined VC_IMPL_SSE4_1 && !defined VC_MSVC
+-        default:
+-#ifdef VC_GCC
+-            f = __builtin_ia32_vec_ext_v4sf(static_cast<__v4sf>(v), (i));
+-#else
+-            // MSVC fails to compile this because it can't optimize i to an immediate
+-            _MM_EXTRACT_FLOAT(f, v, i);
+-#endif
+-            break;
+-#else
+         case 1:
+             f = _mm_cvtss_f32(_mm_castsi128_ps(_mm_srli_si128(_mm_castps_si128(v), 4)));
+             break;
+@@ -517,7 +507,6 @@
+         case 3:
+             f = _mm_cvtss_f32(_mm_castsi128_ps(_mm_srli_si128(_mm_castps_si128(v), 12)));
+             break;
+-#endif
+         }
+         return f;
+     }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
