### PR TITLE
stdenv/check-meta: add note for Flake usage

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -119,13 +119,20 @@ let
         }
     '';
 
+    # flakeNote will be printed in the remediation messages below.
+    flakeNote = "
+ Note: For `nix shell`, `nix build`, `nix develop` or any other Nix 2.4+
+ (Flake) command, `--impure` must be passed in order to read this
+ environment variable.
+    ";
+
   remediate_allowlist = allow_attr: rebuild_amendment: attrs:
     ''
       a) To temporarily allow ${remediation_phrase allow_attr}, you can use an environment variable
          for a single invocation of the nix tools.
 
            $ export ${remediation_env_var allow_attr}=1
-
+           ${flakeNote}
       b) For `nixos-rebuild` you can set
         { nixpkgs.config.allow${allow_attr} = true; }
       in configuration.nix to override this.
@@ -148,7 +155,7 @@ let
            variable for a single invocation of the nix tools:
 
              $ export NIXPKGS_ALLOW_INSECURE=1
-
+             ${flakeNote}
         b) for `nixos-rebuild` you can add ‘${getName attrs}’ to
            `nixpkgs.config.permittedInsecurePackages` in the configuration.nix,
            like so:


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Flake users that use a command like `nix build nixpkgs#hello` on a
broken/insecure package will not be able to use an environment variable
to override that behavior, unless they pass `--impure` to the command.
This commit adds a conditional string that appears only if they are in
pure evaluation mode, thereby signalling that they are using Flake
commands.

Here is an example of how the message looks:

```
user: matthew swordfish in nixpkgs on  add-flake-note [$] 
❯ nix build .#linuxPackages_latest-libre.rtl88xxau-aircrack
error: Package ‘rtl88xxau-aircrack-5.15.1-3a6433’ in /nix/store/abygh3wk0w039hg29x9y0ikdv9r11g1h-source/pkgs/os-specific/linux/rtl88xxau-aircrack/default.nix:46 is marked as broken, refusing to evaluate.

       a) To temporarily allow broken packages, you can use an environment variable
          for a single invocation of the nix tools.

            $ export NIXPKGS_ALLOW_BROKEN=1

          Note: For `nix shell`, `nix build`, `nix develop` or any other Nix 2.4+
          (Flake) command, `--impure` must be passed in order to read this
          environment variable.

       b) For `nixos-rebuild` you can set
         { nixpkgs.config.allowBroken = true; }
       in configuration.nix to override this.

       c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
         { allowBroken = true; }
       to ~/.config/nixpkgs/config.nix.
(use '--show-trace' to show detailed location information)
```

Co-authored-by: pkharvey <kayharvey@protonmail.com>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
