### PR TITLE
kernel: enable core scheduling on 5.14+ kernels

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -859,6 +859,8 @@ let
 
       LIRC = mkMerge [ (whenOlder "4.16" module) (whenAtLeast "4.17" yes) ];
 
+      SCHED_CORE = whenAtLeast "5.14" yes;
+
     } // optionalAttrs (stdenv.hostPlatform.system == "x86_64-linux" || stdenv.hostPlatform.system == "aarch64-linux") {
       # Enable CPU/memory hotplug support
       # Allows you to dynamically add & remove CPUs/memory to a VM client running NixOS without requiring a reboot


### PR DESCRIPTION
###### Motivation for this change

Core scheduling is a recent innovation in newer kernels to help run
certain untrusted compute workloads more safely in the face of
vulnerabilities like Spectre. In short: it lets processes assign a
unique "cookie" to some group of processes to indicate they are allowed
to be scheduled together on the same SMT-capable core. This helps
mitigate attacks that rely on observing usage of CPU execution units by
cohabitated threads.

Some extra details are available via Linux Weekly News:

  "Core scheduling lands in 5.14", https://lwn.net/Articles/861251/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
