### PR TITLE
libopenmpt: fix build on gcc-12

### DIFF
--- a/pkgs/applications/audio/libopenmpt/default.nix
+++ b/pkgs/applications/audio/libopenmpt/default.nix
@@ -1,4 +1,4 @@
-{ config, lib, stdenv, fetchurl, zlib, pkg-config, mpg123, libogg, libvorbis, portaudio, libsndfile, flac
+{ config, lib, stdenv, fetchurl, fetchpatch, zlib, pkg-config, mpg123, libogg, libvorbis, portaudio, libsndfile, flac
 , usePulseAudio ? config.pulseaudio or stdenv.isLinux, libpulseaudio }:
 
 stdenv.mkDerivation rec {
@@ -11,6 +11,16 @@ stdenv.mkDerivation rec {
     url = "https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-${version}+release.autotools.tar.gz";
     sha256 = "1c54lldr2imjzhlhq5lvwhj7d5794xm97cby9pznr5wdjjay0sa4";
   };
+
+  patches = [
+    # Fix pending upstream inclusion for gcc-12 include headers:
+    #  https://github.com/OpenMPT/openmpt/pull/8
+    (fetchpatch {
+      name = "gcc-12.patch";
+      url = "https://github.com/OpenMPT/openmpt/commit/6e7a43190ef2f9ba0b3efc19b9527261b69ec8f7.patch";
+      sha256 = "081m1rf09bbrlg52aihaajmld5dcnwbp6y7zpyik92mm332r330h";
+    })
+  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
`gcc-12` cleaned up implicit header includes and now requires
explicit '<memory>' for 'std::unique_ptr<>':

    openmpt123/openmpt123.cpp:194:14: error: 'unique_ptr' in namespace 'std' does not name a template type
      194 |         std::unique_ptr<file_audio_stream_base> impl;
          |              ^~~~~~~~~~
    openmpt123/openmpt123.cpp:109:1: note: 'std::unique_ptr' is defined in header '<memory>'; did you forget to '#include <memory>'?
      108 | #include "openmpt123_waveout.hpp"
      +++ |+#include <memory>
      109 |
