### PR TITLE
flat-remix-gnome: 20211028 -> 20211113

### DIFF
--- a/pkgs/data/themes/flat-remix-gnome/default.nix
+++ b/pkgs/data/themes/flat-remix-gnome/default.nix
@@ -2,24 +2,30 @@
 , fetchFromGitHub
 , glib
 , lib
+, writeScriptBin
 }:
-
+let
+  # make install will use dconf to find desktop background file uri.
+  # consider adding an args to allow specify pictures manually.
+  # https://github.com/daniruiz/flat-remix-gnome/blob/20211113/Makefile#L38
+  fake-dconf = writeScriptBin "dconf" "echo -n";
+in
 stdenv.mkDerivation rec {
   pname = "flat-remix-gnome";
-  version = "20211028";
+  version = "20211113";
 
   src = fetchFromGitHub {
     owner = "daniruiz";
     repo = pname;
     rev = version;
-    hash = "sha256-sHJj81MmU9s5sUq5gaIT3leezuG0aVvgTD70Kho9Z0c=";
+    hash = "sha256-A9aiaS4CXRpr4+Y8+tyvWYRbR9STFS9TuplGksPfqtU=";
   };
 
-  nativeBuildInputs = [ glib ];
+  nativeBuildInputs = [ glib fake-dconf ];
   makeFlags = [ "PREFIX=$(out)" ];
   preInstall = ''
     # make install will back up this file, it will fail if the file doesn't exist.
-    # https://github.com/daniruiz/flat-remix-gnome/blob/20211028/Makefile#L54
+    # https://github.com/daniruiz/flat-remix-gnome/blob/20211113/Makefile#L56
     mkdir -p $out/share/gnome-shell/
     touch $out/share/gnome-shell/gnome-shell-theme.gresource
   '';


### PR DESCRIPTION
###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
