### PR TITLE
lapack: include lapacke_utils.h in alternatives/lapack 

### DIFF
--- a/pkgs/build-support/alternatives/lapack/default.nix
+++ b/pkgs/build-support/alternatives/lapack/default.nix
@@ -89,7 +89,7 @@ EOF
     ln -s $out/lib/liblapacke.so.3 $out/lib/liblapacke.so
   fi
 
-  cp ${lib.getDev lapack-reference}/include/lapacke{,_mangling,_config}.h $dev/include
+  cp ${lib.getDev lapack-reference}/include/lapacke{,_mangling,_config,_utils}.h $dev/include
 
   cat <<EOF > $dev/lib/pkgconfig/lapacke.pc
 Name: lapacke

--- a/pkgs/development/libraries/libsurvive/default.nix
+++ b/pkgs/development/libraries/libsurvive/default.nix
@@ -3,9 +3,9 @@
 , cmake
 , pkg-config
 , freeglut
-, liblapack
+, lapack
 , libusb1
-, openblas
+, blas
 , zlib
 }:
 
@@ -24,9 +24,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     freeglut
-    liblapack
+    lapack
     libusb1
-    openblas
+    blas
     zlib
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Although not present in our (old) version of libsurvive, there's an
upcoming issue
(https://gitlab.freedesktop.org/monado/monado/-/issues/130) which can be
worked around by using mkl as a lapack implementation.

This isn't a fix, but it makes things a little easier for those
overriding to a newer version, and it's the correct thing to do anyway.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).