### PR TITLE
selinux-python: fix cross; strict deps

### DIFF
--- a/pkgs/os-specific/linux/selinux-python/default.nix
+++ b/pkgs/os-specific/linux/selinux-python/default.nix
@@ -4,7 +4,6 @@
 # this is python3 only because setools only supports python3
 
 with lib;
-with python3.pkgs;
 
 stdenv.mkDerivation rec {
   pname = "selinux-python";
@@ -17,9 +16,11 @@ stdenv.mkDerivation rec {
     sha256 = "1pjzsyay5535cxcjag7y7k193ajry0s0xc3dqv5905qd7cwval1n";
   };
 
-  nativeBuildInputs = [ wrapPython ];
-  buildInputs = [ libsepol python3 ];
-  propagatedBuildInputs = [ libselinux libsemanage setools ipy ];
+  strictDeps = true;
+
+  nativeBuildInputs = [ python3 python3.pkgs.wrapPython ];
+  buildInputs = [ libsepol ];
+  propagatedBuildInputs = [ libselinux libsemanage setools python3.pkgs.ipy ];
 
   postPatch = ''
     substituteInPlace sepolicy/Makefile --replace "echo --root" "echo --prefix"
@@ -32,7 +33,7 @@ stdenv.mkDerivation rec {
     "LOCALEDIR=$(out)/share/locale"
     "BASHCOMPLETIONDIR=$(out)/share/bash-completion/completions"
     "PYTHON=python"
-    "PYTHONLIBDIR=$(out)/${python.sitePackages}"
+    "PYTHONLIBDIR=$(out)/${python3.sitePackages}"
     "LIBSEPOLA=${lib.getLib libsepol}/lib/libsepol.a"
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
