### PR TITLE
farbfeld,ii,sic,slock,slstatus,wmname: fix cross-compilation

### DIFF
--- a/pkgs/applications/misc/slstatus/default.nix
+++ b/pkgs/applications/misc/slstatus/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libX11 ];
 
+  makeFlags = [ "CC:=$(CC)" ];
+
   installFlags = [ "PREFIX=$(out)" ];
 
   meta = {

--- a/pkgs/applications/misc/wmname/default.nix
+++ b/pkgs/applications/misc/wmname/default.nix
@@ -9,9 +9,15 @@ stdenv.mkDerivation rec {
     sha256 = "559ad188b2913167dcbb37ecfbb7ed474a7ec4bbcb0129d8d5d08cb9208d02c5";
   };
 
+  postPatch = ''
+    substituteInPlace Makefile --replace "@strip" "#@strip"
+  '';
+
   buildInputs = [ libX11 ];
 
-  preConfigure = ''sed -i "s@PREFIX = /usr/local@PREFIX = $out@g" config.mk'';
+  makeFlags = [ "CC:=$(CC)" ];
+
+  installFlags = [ "PREFIX=$(out)" ];
 
   meta = {
     description = "Prints or set the window manager name property of the root window";

--- a/pkgs/applications/networking/irc/ii/default.nix
+++ b/pkgs/applications/networking/irc/ii/default.nix
@@ -9,9 +9,9 @@ stdenv.mkDerivation rec {
     sha256 = "1lk8vjl7i8dcjh4jkg8h8bkapcbs465sy8g9c0chfqsywbmf3ndr";
   };
 
-  installPhase = ''
-    make install PREFIX=$out
-  '';
+  makeFlags = [ "CC:=$(CC)" ];
+
+  installFlags = [ "PREFIX=$(out)" ];
 
   meta = {
     homepage = "https://tools.suckless.org/ii/";

--- a/pkgs/applications/networking/irc/sic/default.nix
+++ b/pkgs/applications/networking/irc/sic/default.nix
@@ -4,11 +4,14 @@ stdenv.mkDerivation rec {
   pname = "sic";
   version = "1.2";
 
-  makeFlags = [ "PREFIX=$(out)" ];
   src = fetchurl {
     url = "https://dl.suckless.org/tools/sic-${version}.tar.gz";
     sha256 = "ac07f905995e13ba2c43912d7a035fbbe78a628d7ba1c256f4ca1372fb565185";
   };
+
+  makeFlags = [ "CC:=$(CC)" ];
+
+  installFlags = [ "PREFIX=$(out)" ];
 
   meta = {
     description = "Simple IRC client";

--- a/pkgs/development/libraries/farbfeld/default.nix
+++ b/pkgs/development/libraries/farbfeld/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ libpng libjpeg ];
   nativeBuildInputs = [ makeWrapper ];
 
+  makeFlags = [ "CC:=$(CC)" ];
+
   installFlags = [ "PREFIX=$(out)" ];
   postInstall = ''
     wrapProgram "$out/bin/2ff" --prefix PATH : "${file}/bin"

--- a/pkgs/misc/screensavers/slock/default.nix
+++ b/pkgs/misc/screensavers/slock/default.nix
@@ -16,13 +16,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ xorgproto libX11 libXext libXrandr ];
 
-  installFlags = [ "DESTDIR=\${out}" "PREFIX=" ];
+  installFlags = [ "PREFIX=$(out)" ];
 
   postPatch = "sed -i '/chmod u+s/d' Makefile";
 
   preBuild = optionalString (conf != null) ''
     cp ${writeText "config.def.h" conf} config.def.h
   '';
+
+  makeFlags = [ "CC:=$(CC)" ];
 
   meta = {
     homepage = "https://tools.suckless.org/slock";


### PR DESCRIPTION
###### Motivation for this change
fix cross-compilation of some [suckless](https://suckless.org/) utils (farbfeld, ii, sic, slock, slstatus, wmname)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
