### PR TITLE
ory-hydra: init at 1.10.7

### DIFF
--- a/pkgs/applications/misc/ory-hydra/default.nix
+++ b/pkgs/applications/misc/ory-hydra/default.nix
@@ -1,0 +1,29 @@
+{ fetchFromGitHub, buildGoModule, lib, stdenv }:
+
+buildGoModule rec {
+  pname = "ory-hydra";
+  version = "1.10.7";
+
+  src = fetchFromGitHub {
+    owner = "ory";
+    repo = "hydra";
+    rev = "v${version}";
+    sha256 = "sha256-/cuzMTOMtju24tRO8KtW8yzztYFj9dSZRnYOMyAVMsk=";
+  };
+
+  vendorSha256 = "sha256-H3lAjlDpEcdQlFc5mwHOHhPjTSltUEleKIyZwUcXmtI=";
+
+  subPackages = [ "." ];
+
+  preBuild = ''
+    # patchShebangs doesn't work for this Makefile, do it manually
+    substituteInPlace Makefile --replace '/bin/bash' '${stdenv.shell}'
+  '';
+
+  meta = with lib; {
+    maintainers = with maintainers; [ cmcdragonkai StillerHarpo ];
+    homepage = "https://www.ory.sh/hydra/";
+    license = licenses.asl20;
+    description = "OpenID Certified OAuth 2.0 Server and OpenID Connect Provider optimized for low-latency, high throughput, and low resource consumption";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18918,6 +18918,8 @@ with pkgs;
 
   ortp = callPackage ../development/libraries/ortp { };
 
+  ory-hydra = callPackage ../applications/misc/ory-hydra { };
+
   openhmd = callPackage ../development/libraries/openhmd { };
 
   openrct2 = callPackage ../games/openrct2 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
