### PR TITLE
pkgs.development.python-modules: remove unused args

### DIFF
--- a/pkgs/development/python-modules/cirq-core/default.nix
+++ b/pkgs/development/python-modules/cirq-core/default.nix
@@ -1,5 +1,4 @@
 { lib
-, stdenv
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub

--- a/pkgs/development/python-modules/h5py/default.nix
+++ b/pkgs/development/python-modules/h5py/default.nix
@@ -1,5 +1,5 @@
-{ lib, fetchPypi, isPy27, python, buildPythonPackage, pythonOlder
-, numpy, hdf5, cython, six, pkgconfig, unittest2, fetchpatch
+{ lib, fetchPypi, isPy27, buildPythonPackage, pythonOlder
+, numpy, hdf5, cython, six, pkgconfig, unittest2
 , mpi4py ? null, openssh, pytestCheckHook, cached-property }:
 
 assert hdf5.mpiSupport -> mpi4py != null && hdf5.mpi == mpi4py.mpi;

--- a/pkgs/development/python-modules/jaxlib/default.nix
+++ b/pkgs/development/python-modules/jaxlib/default.nix
@@ -13,7 +13,7 @@
 #   * https://github.com/google/jax/issues/971#issuecomment-508216439
 #   * https://github.com/google/jax/issues/5723#issuecomment-913038780
 
-{ addOpenGLRunpath, autoPatchelfHook, buildPythonPackage, config, fetchPypi
+{ addOpenGLRunpath, autoPatchelfHook, buildPythonPackage, config
 , fetchurl, isPy39, lib, stdenv
 # propagatedBuildInputs
 , absl-py, flatbuffers, scipy, cudatoolkit_11

--- a/pkgs/development/python-modules/jupyter-repo2docker/default.nix
+++ b/pkgs/development/python-modules/jupyter-repo2docker/default.nix
@@ -1,7 +1,5 @@
 { lib
-, bash
 , buildPythonPackage
-, chardet
 , docker
 , entrypoints
 , escapism

--- a/pkgs/development/python-modules/lexid/default.nix
+++ b/pkgs/development/python-modules/lexid/default.nix
@@ -1,4 +1,4 @@
-{ lib, python, pythonOlder, buildPythonPackage, fetchPypi, pytestCheckHook, click }:
+{ lib, pythonOlder, buildPythonPackage, fetchPypi, pytestCheckHook, click }:
 
 buildPythonPackage rec {
   pname = "lexid";

--- a/pkgs/development/python-modules/pynest2d/default.nix
+++ b/pkgs/development/python-modules/pynest2d/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchFromGitHub, python3, cmake
-, pythonOlder, libnest2d, sip_4, clipper }:
+, libnest2d, sip_4, clipper }:
 
 buildPythonPackage rec {
   version = "4.10.0";

--- a/pkgs/development/python-modules/pytest-trio/default.nix
+++ b/pkgs/development/python-modules/pytest-trio/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchFromGitHub, pythonOlder
-, trio, python, async_generator, hypothesis, outcome, pytest }:
+, trio, async_generator, hypothesis, outcome, pytest }:
 
 buildPythonPackage rec {
   pname = "pytest-trio";

--- a/pkgs/development/python-modules/pytest/5.nix
+++ b/pkgs/development/python-modules/pytest/5.nix
@@ -1,16 +1,13 @@
 { lib, buildPythonPackage, pythonOlder, fetchPypi, isPy3k, isPyPy
 , atomicwrites
 , attrs
-, funcsigs
 , hypothesis
-, mock
 , more-itertools
 , packaging
 , pathlib2
 , pluggy
 , py
 , pygments
-, python
 , setuptools
 , setuptools-scm
 , six

--- a/pkgs/development/python-modules/python-nest/default.nix
+++ b/pkgs/development/python-modules/python-nest/default.nix
@@ -1,4 +1,4 @@
-{ buildPythonPackage, fetchPypi, lib, python, python-dateutil, requests
+{ buildPythonPackage, fetchPypi, lib, python-dateutil, requests
 , six, sseclient-py }:
 
 buildPythonPackage rec {

--- a/pkgs/development/python-modules/sh/default.nix
+++ b/pkgs/development/python-modules/sh/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, fetchpatch, python, coverage, lsof, glibcLocales, coreutils }:
+{ lib, buildPythonPackage, fetchPypi, python, coverage, lsof, glibcLocales, coreutils }:
 
 buildPythonPackage rec {
   pname = "sh";

--- a/pkgs/development/python-modules/spacy/default.nix
+++ b/pkgs/development/python-modules/spacy/default.nix
@@ -11,7 +11,6 @@
 , jsonschema
 , murmurhash
 , numpy
-, pathlib
 , preshed
 , requests
 , setuptools

--- a/pkgs/development/python-modules/stestr/tests.nix
+++ b/pkgs/development/python-modules/stestr/tests.nix
@@ -1,9 +1,5 @@
-{ stdenv
-, buildPythonPackage
-, ddt
-, sqlalchemy
+{  buildPythonPackage
 , stestr
-, subunit2sql
 }:
 
 buildPythonPackage rec {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The python subtree had a lot of derivations with unused arguments in the derivation inputs.
The cleanup was done manually with a bit of ad-hoc scripting.
This is a follow up to https://github.com/NixOS/nixpkgs/pull/145676

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
