### PR TITLE
fcft: 2.4.6 -> 2.5.0

### DIFF
--- a/pkgs/development/libraries/fcft/default.nix
+++ b/pkgs/development/libraries/fcft/default.nix
@@ -1,38 +1,53 @@
 { stdenv, lib, fetchFromGitea, pkg-config, meson, ninja, scdoc
 , freetype, fontconfig, pixman, tllist, check
-, withHarfBuzz ? true
-, harfbuzz
+# Text shaping methods to enable, empty list disables all text shaping.
+# See `availableShapingTypes` or upstream meson_options.txt for available types.
+, withShapingTypes ? [ "grapheme" "run" ]
+, harfbuzz, utf8proc
+, fcft # for passthru.tests
 }:
 
 let
+  # Needs to be reflect upstream meson_options.txt
+  availableShapingTypes = [
+    "grapheme"
+    "run"
+  ];
+
   # Courtesy of sternenseemann and FRidh, commit c9a7fdfcfb420be8e0179214d0d91a34f5974c54
   mesonFeatureFlag = opt: b: "-D${opt}=${if b then "enabled" else "disabled"}";
 in
 
 stdenv.mkDerivation rec {
   pname = "fcft";
-  version = "2.4.5";
+  version = "2.5.0";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "dnkl";
     repo = "fcft";
     rev = version;
-    sha256 = "0z4bqap88pydkgcxrsvm3fmcyhi9x7z8knliarvdcvqlk7qnyzfh";
+    sha256 = "0agqldh68hn898d3f6k99kjbz8had5j5k0jyvi71d4k9vhx8cy7c";
   };
 
   depsBuildBuild = [ pkg-config ];
   nativeBuildInputs = [ pkg-config meson ninja scdoc ];
   buildInputs = [ freetype fontconfig pixman tllist ]
-    ++ lib.optional withHarfBuzz harfbuzz;
+    ++ lib.optionals (withShapingTypes != []) [ harfbuzz ]
+    ++ lib.optionals (builtins.elem "run" withShapingTypes) [ utf8proc ];
   checkInputs = [ check ];
 
   mesonBuildType = "release";
-  mesonFlags = [
-    (mesonFeatureFlag "text-shaping" withHarfBuzz)
-  ];
+  mesonFlags = builtins.map (t:
+    mesonFeatureFlag "${t}-shaping" (lib.elem t withShapingTypes)
+  ) availableShapingTypes;
 
   doCheck = true;
+
+  passthru.tests = {
+    noShaping = fcft.override { withShapingTypes = []; };
+    onlyGraphemeShaping = fcft.override { withShapingTypes = [ "grapheme" ]; };
+  };
 
   meta = with lib; {
     homepage = "https://codeberg.org/dnkl/fcft";


### PR DESCRIPTION
Replace withHarfBuzz with withShapingTypes which allows us to more
accurately represent the current feature flag situation upstream.
Additionally test all non-default configurations via passthru.tests.

Settings for shapingType:

* `[ "grapheme" ]`: depend on HarfBuzz, like withHarfBuzz before
* `[ "grapheme" "run" ]`: depend on HarfBuzz and utf8proc. This is
  the same as `[ "run" ]` at the moment which may change in the
  future.
* `[]`: No text shaping support, no additional dependencies

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
