### PR TITLE
ogre, ogre1_9, ogre1_10: fix for aarch64

### DIFF
--- a/pkgs/development/libraries/ogre/1.10.x.nix
+++ b/pkgs/development/libraries/ogre/1.10.x.nix
@@ -16,6 +16,14 @@ stdenv.mkDerivation {
      sha256 = "1zwvlx5dz9nwjazhnrhzb0w8ilpa84r0hrxrmmy69pgr1p1yif5a";
   };
 
+  # fix for ARM. sys/sysctl.h has moved in later glibcs, and
+  # https://github.com/OGRECave/ogre-next/issues/132 suggests it isn't
+  # needed anyway.
+  postPatch = ''
+    substituteInPlace OgreMain/src/OgrePlatformInformation.cpp \
+      --replace '#include <sys/sysctl.h>' ""
+  '';
+
   cmakeFlags = [ "-DOGRE_BUILD_SAMPLES=${toString withSamples}" ]
     ++ map (x: "-DOGRE_BUILD_PLUGIN_${x}=on")
            ([ "BSP" "OCTREE" "PCZ" "PFX" ] ++ lib.optional withNvidiaCg "CG")

--- a/pkgs/development/libraries/ogre/1.9.x.nix
+++ b/pkgs/development/libraries/ogre/1.9.x.nix
@@ -19,6 +19,14 @@ stdenv.mkDerivation rec {
     sha256 = "11lfgzqaps3728dswrq3cbwk7aicigyz08q4hfyy6ikc6m35r4wg";
   };
 
+  # fix for ARM. sys/sysctl.h has moved in later glibcs, and
+  # https://github.com/OGRECave/ogre-next/issues/132 suggests it isn't
+  # needed anyway.
+  postPatch = ''
+    substituteInPlace OgreMain/src/OgrePlatformInformation.cpp \
+      --replace '#include <sys/sysctl.h>' ""
+  '';
+
   cmakeFlags = [ "-DOGRE_BUILD_SAMPLES=${toString withSamples}" ]
     ++ map (x: "-DOGRE_BUILD_PLUGIN_${x}=on")
            ([ "BSP" "OCTREE" "PCZ" "PFX" ] ++ lib.optional withNvidiaCg "CG")

--- a/pkgs/development/libraries/ogre/default.nix
+++ b/pkgs/development/libraries/ogre/default.nix
@@ -19,6 +19,14 @@ stdenv.mkDerivation rec {
      sha256 = "1iv6k0dwdzg5nnzw2mcgcl663q4f7p2kj7nhs8afnsikrzxxgsi4";
   };
 
+  # fix for ARM. sys/sysctl.h has moved in later glibcs, and
+  # https://github.com/OGRECave/ogre-next/issues/132 suggests it isn't
+  # needed anyway.
+  postPatch = ''
+    substituteInPlace OgreMain/src/OgrePlatformInformation.cpp \
+      --replace '#include <sys/sysctl.h>' ""
+  '';
+
   cmakeFlags = [ "-DOGRE_BUILD_DEPENDENCIES=OFF" "-DOGRE_BUILD_SAMPLES=${toString withSamples}" ]
     ++ map (x: "-DOGRE_BUILD_PLUGIN_${x}=on")
            ([ "BSP" "OCTREE" "PCZ" "PFX" ] ++ lib.optional withNvidiaCg "CG")


### PR DESCRIPTION
###### Motivation for this change
ZHF: #144627 @NixOS/nixos-release-managers

Turns out we don't actually need this header https://github.com/OGRECave/ogre-next/issues/132

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
