### PR TITLE
marktext: 0.16.2 -> 0.16.3

### DIFF
--- a/pkgs/applications/misc/marktext/default.nix
+++ b/pkgs/applications/misc/marktext/default.nix
@@ -2,15 +2,20 @@
 
 let
   pname = "marktext";
-  version = "v0.16.2";
-in
-appimageTools.wrapType2 rec {
+  version = "v0.16.3";
   name = "${pname}-${version}-binary";
 
   src = fetchurl {
     url = "https://github.com/marktext/marktext/releases/download/${version}/marktext-x86_64.AppImage";
-    sha256 = "0ivf9lvv2jk7dvxmqprzcsxgya3617xmx5bppjvik44z14b5x8r7";
+    sha256 = "0s93c79vy2vsi7b6xq4hvsvjjad8bdkhl1q135vp98zmbf7bvm9b";
   };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit name src;
+  };
+in
+appimageTools.wrapType2 rec {
+  inherit name src;
 
   profile = ''
     export LC_ALL=C.UTF-8
@@ -28,8 +33,16 @@ appimageTools.wrapType2 rec {
     p.xorg.libxkbfile
   ];
 
-  # Strip version from binary name.
-  extraInstallCommands = "mv $out/bin/${name} $out/bin/${pname}";
+  extraInstallCommands = ''
+    # Strip version from binary name.
+    mv $out/bin/${name} $out/bin/${pname}
+
+    install -m 444 -D ${appimageContents}/marktext.desktop $out/share/applications/marktext.desktop
+    substituteInPlace $out/share/applications/marktext.desktop \
+      --replace "Exec=AppRun" "Exec=${pname} --"
+
+    cp -r ${appimageContents}/usr/share/icons $out/share
+  '';
 
   meta = with lib; {
     description = "A simple and elegant markdown editor, available for Linux, macOS and Windows";


### PR DESCRIPTION
Add .desktop file, icons in the process.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
