### PR TITLE
osmscout-server: Remove optional dependency mapnik

### DIFF
--- a/pkgs/applications/misc/osmscout-server/default.nix
+++ b/pkgs/applications/misc/osmscout-server/default.nix
@@ -1,6 +1,6 @@
 { lib, mkDerivation, fetchFromGitHub, fetchpatch, pkg-config
 , qmake, qttools, kirigami2, qtquickcontrols2, qtlocation
-, libosmscout, mapnik, valhalla, libpostal, osrm-backend, protobuf
+, libosmscout, valhalla, libpostal, osrm-backend, protobuf
 , libmicrohttpd_0_9_70, sqlite, marisa, kyotocabinet, boost
 }:
 
@@ -41,7 +41,7 @@ mkDerivation rec {
   nativeBuildInputs = [ qmake pkg-config qttools ];
   buildInputs = [
     kirigami2 qtquickcontrols2 qtlocation
-    mapnik valhalla libosmscout osrm-backend libmicrohttpd_0_9_70
+    valhalla libosmscout osrm-backend libmicrohttpd_0_9_70
     libpostal sqlite marisa kyotocabinet boost protobuf date
   ];
 
@@ -52,8 +52,10 @@ mkDerivation rec {
     mv data/valhalla.json-3.1 data/valhalla.json
   '';
 
-  # Choose to build the kirigami UI variant
-  qmakeFlags = [ "SCOUT_FLAVOR=kirigami" ];
+  qmakeFlags = [
+    "SCOUT_FLAVOR=kirigami" # Choose to build the kirigami UI variant
+    "CONFIG+=disable_mapnik" # Disable the optional mapnik backend
+  ];
 
   meta = with lib; {
     description = "Maps server providing tiles, geocoder, and router";


### PR DESCRIPTION
Mapnik keeps breaking and is not the main backend used by
osmscout-server.

###### Motivation for this change

Mapnik and its dependencies keep getting broken. It is an optional dependency of osmscout-server which was mostly kept as a historical legacy backend. By removing this dependency, we fix osmscout-server and hopefully avoid it breaking so often in the future.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

ZHF: #144627

Ping @NixOS/nixos-release-managers