### PR TITLE
libretro.dolphin: 2020-03-06 -> 2021-11-01

### DIFF
--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -8,11 +8,11 @@ let
 
   d2u = lib.replaceChars ["-"] ["_"];
 
-  mkLibRetroCore = { core, src, description, license, broken ? false, ... }@a:
+  mkLibRetroCore = { core, src, description, license, broken ? false, version ? "2020-03-06", ... }@a:
   lib.makeOverridable stdenv.mkDerivation ((rec {
 
     name = "libretro-${a.core}-${version}";
-    version = "2020-03-06";
+    inherit version;
     inherit (a) src;
 
     buildInputs = [ zlib ] ++ a.extraBuildInputs or [];

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -334,10 +334,11 @@ in with lib.licenses;
 
   dolphin = mkLibRetroCore {
     core = "dolphin";
+    version = "2021-11-01";
     src = fetchRetro {
       repo = "dolphin";
-      rev = "1fbd59911d1b718c142d6448dee3ede98152e395";
-      sha256 = "1rymsvs034l1hbxc3w8zi9lhmgka2qaj3jynjy152dccd480nnd4";
+      rev = "3370f7693be95c23ac779e5172ff52b7eb2861a7";
+      sha256 = "0ylxi25kbv0h2p24aid7z4i0w6drf7h92q02hjdl3h3gni98lk9i";
     };
     description = "Port of Dolphin to libretro";
     license = gpl2Plus;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Updates libretro.dolphin. Fixes libretro.dolphin building. ([failing hydra job](https://hydra.nixos.org/build/157293440)).

ZHF: #144627



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
