### PR TITLE
bespokesynth: mark unfree

### DIFF
--- a/pkgs/applications/audio/bespokesynth/default.nix
+++ b/pkgs/applications/audio/bespokesynth/default.nix
@@ -106,7 +106,13 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Software modular synth with controllers support, scripting and VST";
     homepage = "https://github.com/awwbees/BespokeSynth";
-    license = licenses.gpl3Plus;
+    license = with licenses; [
+      gpl3Plus
+      
+      # This package is unfree and not distributable due to the license of VST2.
+      # see #145607
+      unfree
+    ];
     maintainers = with maintainers; [ astro ];
     platforms = platforms.all;
   };

--- a/pkgs/applications/audio/bespokesynth/default.nix
+++ b/pkgs/applications/audio/bespokesynth/default.nix
@@ -108,7 +108,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/awwbees/BespokeSynth";
     license = with licenses; [
       gpl3Plus
-      
+
       # This package is unfree and not distributable due to the license of VST2.
       # see #145607
       unfree


### PR DESCRIPTION
Binaries of VST2 cannot be distributed without upstream permission
which we don't have and cant get. Until VST2 support can be
teased out more carefully, let's mark the package us unfree.

cc @astro re #145607 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
