### PR TITLE
noto-fonts-cjk: add missing serif font

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -357,6 +357,18 @@
           <literal>~/.local/share/polymc/polymc.cfg</literal>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <literal>pkgs.noto-fonts-cjk</literal> is now deprecated in
+          favor of <literal>pkgs.noto-fonts-cjk-sans</literal> and
+          <literal>pkgs.noto-fonts-cjk-serif</literal> because they each
+          have different release schedules. To maintain compatibility
+          with prior releases of Nixpkgs,
+          <literal>pkgs.noto-fonts-cjk</literal> is currently an alias
+          of <literal>pkgs.noto-fonts-cjk-sans</literal> and doesn’t
+          include serif fonts.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-22.05-notable-changes">

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -111,6 +111,12 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - MultiMC has been replaced with the fork PolyMC due to upstream developers being hostile to 3rd party package maintainers. PolyMC removes all MultiMC branding and is aimed at providing proper 3rd party packages like the one contained in Nixpkgs. This change affects the data folder where game instances and other save and configuration files are stored. Users with existing installations should rename `~/.local/share/multimc` to `~/.local/share/polymc`. The main config file's path has also moved from `~/.local/share/multimc/multimc.cfg` to `~/.local/share/polymc/polymc.cfg`.
 
+- `pkgs.noto-fonts-cjk` is now deprecated in favor of `pkgs.noto-fonts-cjk-sans`
+  and `pkgs.noto-fonts-cjk-serif` because they each have different release
+  schedules. To maintain compatibility with prior releases of Nixpkgs,
+  `pkgs.noto-fonts-cjk` is currently an alias of `pkgs.noto-fonts-cjk-sans` and
+  doesn't include serif fonts.
+
 ## Other Notable Changes {#sec-release-22.05-notable-changes}
 
 - The option [services.redis.servers](#opt-services.redis.servers) was added

--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -3,7 +3,6 @@
 , lib
 , fetchFromGitHub
 , fetchurl
-, fetchzip
 , cairo
 , python3
 , pkg-config
@@ -61,6 +60,42 @@ let
         maintainers = with maintainers; [ mathnerd314 emily ];
       };
     };
+
+  mkNotoCJK = { typeface, version, rev, sha256 }:
+    stdenvNoCC.mkDerivation {
+      pname = "noto-fonts-cjk-${lib.toLower typeface}";
+      inherit version;
+
+      src = fetchFromGitHub {
+        owner = "googlefonts";
+        repo = "noto-cjk";
+        inherit rev sha256;
+      };
+
+      installPhase = ''
+        install -m444 -Dt $out/share/fonts/opentype/noto-cjk ${typeface}/Variable/OTC/*.otf.ttc
+      '';
+
+      meta = with lib; {
+        description = "Beautiful and free fonts for CJK languages";
+        homepage = "https://www.google.com/get/noto/help/cjk/";
+        longDescription = ''
+          Noto ${typeface} CJK is a ${lib.toLower typeface} typeface designed as
+          an intermediate style between the modern and traditional. It is
+          intended to be a multi-purpose digital font for user interface
+          designs, digital content, reading on laptops, mobile devices, and
+          electronic books. Noto ${typeface} CJK comprehensively covers
+          Simplified Chinese, Traditional Chinese, Japanese, and Korean in a
+          unified font family. It supports regional variants of ideographic
+          characters for each of the four languages. In addition, it supports
+          Japanese kana, vertical forms, and variant characters (itaiji); it
+          supports Korean hangeul — both contemporary and archaic.
+        '';
+        license = licenses.ofl;
+        platforms = platforms.all;
+        maintainers = with maintainers; [ mathnerd314 emily ];
+      };
+    };
 in
 
 {
@@ -74,39 +109,18 @@ in
     weights = "{Black,Condensed,Extra,Medium,Semi,Thin}*";
   };
 
-  noto-fonts-cjk = let zip = fetchzip {
-    url = let rev = "be6c059ac1587e556e2412b27f5155c8eb3ddbe6"; in
-      "https://raw.githubusercontent.com/googlefonts/noto-cjk/${rev}/NotoSansCJK.ttc.zip";
-    # __MACOSX...
-    stripRoot = false;
-    sha256 = "0ik4z2b15i0pghskgfm3adzb0h35fr4gyzvz3bq49hhkhn9h85vi";
-  }; in stdenvNoCC.mkDerivation {
-    pname = "noto-fonts-cjk";
-    version = "2.001";
+  noto-fonts-cjk-sans = mkNotoCJK {
+    typeface = "Sans";
+    version = "2.004";
+    rev = "9f7f3c38eab63e1d1fddd8d50937fe4f1eacdb1d";
+    sha256 = "sha256-BX4tcDcz+RGka8mtced1k3BopUJQ14t1BtAVqTjyPik=";
+  };
 
-    buildCommand = ''
-      install -m444 -Dt $out/share/fonts/opentype/noto-cjk ${zip}/*.ttc
-    '';
-
-    meta = with lib; {
-      description = "Beautiful and free fonts for CJK languages";
-      homepage = "https://www.google.com/get/noto/help/cjk/";
-      longDescription =
-      ''
-        Noto Sans CJK is a sans serif typeface designed as an intermediate style
-        between the modern and traditional. It is intended to be a multi-purpose
-        digital font for user interface designs, digital content, reading on laptops,
-        mobile devices, and electronic books. Noto Sans CJK comprehensively covers
-        Simplified Chinese, Traditional Chinese, Japanese, and Korean in a unified font
-        family. It supports regional variants of ideographic characters for each of the
-        four languages. In addition, it supports Japanese kana, vertical forms, and
-        variant characters (itaiji); it supports Korean hangeul — both contemporary and
-        archaic.
-      '';
-      license = licenses.ofl;
-      platforms = platforms.all;
-      maintainers = with maintainers; [ mathnerd314 emily ];
-    };
+  noto-fonts-cjk-serif = mkNotoCJK {
+    typeface = "Serif";
+    version = "2.000";
+    rev = "9f7f3c38eab63e1d1fddd8d50937fe4f1eacdb1d";
+    sha256 = "sha256-BX4tcDcz+RGka8mtced1k3BopUJQ14t1BtAVqTjyPik=";
   };
 
   noto-fonts-emoji = let

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -656,6 +656,7 @@ mapAliases ({
   nmap-unfree = nmap; # added 2021-04-06
   nologin = shadow; # added 2018-04-25
   nordic-polar = throw "nordic-polar was removed on 2021-05-27, now integrated in nordic"; # added 2021-05-27
+  noto-fonts-cjk = noto-fonts-cjk-sans; # added 2021-12-16
   now-cli = throw "now-cli has been replaced with nodePackages.vercel"; # added 2021-08-05
   nxproxy = nx-libs; # added 2019-02-15
   nylas-mail-bin = throw "nylas-mail-bin was deprecated on 2019-09-11: abandoned by upstream";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23719,7 +23719,12 @@ with pkgs;
   nordzy-cursor-theme = callPackage ../data/icons/nordzy-cursor-theme { };
 
   inherit (callPackages ../data/fonts/noto-fonts {})
-    noto-fonts noto-fonts-cjk noto-fonts-emoji noto-fonts-emoji-blob-bin noto-fonts-extra;
+    noto-fonts
+    noto-fonts-cjk-sans
+    noto-fonts-cjk-serif
+    noto-fonts-emoji
+    noto-fonts-emoji-blob-bin
+    noto-fonts-extra;
 
   nuclear = callPackage ../applications/audio/nuclear { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This adds the Noto Serif CJK fonts to the `noto-fonts-cjk` package. It should be included the package, but is currently missing.

Fixes #99940


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`) (Checked with a font viewer)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
