### PR TITLE
python3Packages.fiona: skip some tests failing on aarch64

### DIFF
--- a/pkgs/development/python-modules/fiona/default.nix
+++ b/pkgs/development/python-modules/fiona/default.nix
@@ -51,6 +51,12 @@ buildPythonPackage rec {
     "http" "https" "wheel"
     # Assert not true
     "test_no_append_driver_cannot_append"
+  ] ++ lib.optionals stdenv.isAarch64 [
+    # https://github.com/Toblerity/Fiona/issues/1012 the existence of this
+    # as a bug hasn't been challenged and other distributors seem to also
+    # be skipping these tests on aarch64, so this is not unique to nixpkgs.
+    "test_write_or_driver_error"
+    "test_append_or_driver_error"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
ZHF: #144627 @NixOS/nixos-release-managers 

https://github.com/Toblerity/Fiona/issues/1012 the existence of this as a bug hasn't been challenged and other distributors seem to also be skipping these tests on aarch64, so this is not unique to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
