### PR TITLE
checksec: add sed to PATH

### DIFF
--- a/pkgs/os-specific/linux/checksec/default.nix
+++ b/pkgs/os-specific/linux/checksec/default.nix
@@ -1,5 +1,14 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper, file, findutils
-, binutils-unwrapped, glibc, coreutils, sysctl, openssl
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
+, binutils-unwrapped
+, coreutils
+, file
+, findutils
+, glibc
+, openssl
+, sysctl
 }:
 
 stdenv.mkDerivation rec {
@@ -16,18 +25,24 @@ stdenv.mkDerivation rec {
   patches = [ ./0001-attempt-to-modprobe-config-before-checking-kernel.patch ];
   nativeBuildInputs = [ makeWrapper ];
 
-  installPhase = let
-    path = lib.makeBinPath [
-      findutils file binutils-unwrapped sysctl openssl
-    ];
-  in ''
-    mkdir -p $out/bin
-    install checksec $out/bin
-    substituteInPlace $out/bin/checksec --replace /lib/libc.so.6 ${glibc.out}/lib/libc.so.6
-    substituteInPlace $out/bin/checksec --replace "/usr/bin/id -" "${coreutils}/bin/id -"
-    wrapProgram $out/bin/checksec \
-      --prefix PATH : ${path}
-  '';
+  installPhase =
+    let
+      path = lib.makeBinPath [
+        binutils-unwrapped
+        findutils
+        file
+        openssl
+        sysctl
+      ];
+    in
+    ''
+      mkdir -p $out/bin
+      install checksec $out/bin
+      substituteInPlace $out/bin/checksec --replace /lib/libc.so.6 ${glibc.out}/lib/libc.so.6
+      substituteInPlace $out/bin/checksec --replace "/usr/bin/id -" "${coreutils}/bin/id -"
+      wrapProgram $out/bin/checksec \
+        --prefix PATH : ${path}
+    '';
 
   meta = with lib; {
     description = "A tool for checking security bits on executables";

--- a/pkgs/os-specific/linux/checksec/default.nix
+++ b/pkgs/os-specific/linux/checksec/default.nix
@@ -7,6 +7,7 @@
 , file
 , findutils
 , glibc
+, gnused
 , openssl
 , sysctl
 }:
@@ -31,6 +32,7 @@ stdenv.mkDerivation rec {
         binutils-unwrapped
         findutils
         file
+        gnused
         openssl
         sysctl
       ];
@@ -38,10 +40,11 @@ stdenv.mkDerivation rec {
     ''
       mkdir -p $out/bin
       install checksec $out/bin
-      substituteInPlace $out/bin/checksec --replace /lib/libc.so.6 ${glibc.out}/lib/libc.so.6
-      substituteInPlace $out/bin/checksec --replace "/usr/bin/id -" "${coreutils}/bin/id -"
-      wrapProgram $out/bin/checksec \
-        --prefix PATH : ${path}
+      substituteInPlace $out/bin/checksec \
+        --replace /lib/libc.so.6 ${glibc.out}/lib/libc.so.6 \
+        --replace "/usr/bin/id -" "${coreutils}/bin/id -" \
+        --replace " /bin/sed " " ${gnused}/bin/sed "
+      wrapProgram $out/bin/checksec --prefix PATH : ${path}
     '';
 
   meta = with lib; {

--- a/pkgs/os-specific/linux/checksec/default.nix
+++ b/pkgs/os-specific/linux/checksec/default.nix
@@ -38,8 +38,7 @@ stdenv.mkDerivation rec {
       ];
     in
     ''
-      mkdir -p $out/bin
-      install checksec $out/bin
+      install -D -t $out/bin checksec
       substituteInPlace $out/bin/checksec \
         --replace /lib/libc.so.6 ${glibc.out}/lib/libc.so.6 \
         --replace "/usr/bin/id -" "${coreutils}/bin/id -" \


### PR DESCRIPTION
###### Motivation for this change
checksec complains that `/bin/sed` is missing on every run, although probably harmless, this PR fixes that.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
