### PR TITLE
python3Packages.spectral-cube: upgrade and fix build

### DIFF
--- a/pkgs/development/python-modules/casa-formats-io/default.nix
+++ b/pkgs/development/python-modules/casa-formats-io/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, astropy
+, dask
+, numpy
+}:
+
+buildPythonPackage rec {
+  pname = "casa-formats-io";
+  version = "0.1";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "16rypj65wdfxxrilxfhbk563lxv86if4vvs9zfq3f8bkzdr8xl9s";
+  };
+
+  propagatedBuildInputs = [ astropy dask numpy ];
+
+  # Tests require a large (800 Mb) dataset
+  doCheck = false;
+
+  pythonImportsCheck = [ "casa_formats_io" ];
+
+  meta = {
+    description = "Dask-based reader for CASA data";
+    homepage = "http://radio-astro-tools.github.io";
+    license = lib.licenses.lgpl2Only;
+    maintainers = with lib.maintainers; [ smaret ];
+  };
+}
+

--- a/pkgs/development/python-modules/spectral-cube/default.nix
+++ b/pkgs/development/python-modules/spectral-cube/default.nix
@@ -1,10 +1,11 @@
 { lib
+, stdenv
 , fetchPypi
-, fetchpatch
 , buildPythonPackage
 , aplpy
 , joblib
 , astropy
+, casa-formats-io
 , radio_beam
 , six
 , dask
@@ -15,26 +16,22 @@
 
 buildPythonPackage rec {
   pname = "spectral-cube";
-  version = "0.5.0";
+  version = "0.6.0";
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "17zisr26syfb8kn89xj17lrdycm0hsmy5yp5zrn236wgd8rjriki";
+    sha256 = "1c0pp82wgl680w2vcwlrrz46sy83z1qs74w5bd691wg0512hv2jx";
   };
 
-  patches = [
-    # Fix compatibility with radio_beam >= 0.3.3. Will be included
-    # in the next release of spectral cube > 0.5.0
-    (fetchpatch {
-      url = "https://github.com/radio-astro-tools/spectral-cube/commit/bbe4295ebef7dfa6fe4474275a29acd6cb0cb544.patch";
-    sha256 = "1qddfm3364kc34yf6wd9nd6rxh4qc2v5pqilvz9adwb4a50z28bf";
-    })
-  ];
-
-  nativeBuildInputs = [ astropy-helpers ];
-  propagatedBuildInputs = [ astropy radio_beam joblib six dask ];
+  propagatedBuildInputs = [ astropy casa-formats-io radio_beam joblib six dask ];
   checkInputs = [ pytestCheckHook aplpy pytest-astropy ];
+
+  # On x86_darwin, this test fails with "Fatal Python error: Aborted"
+  # when sandbox = true.
+  disabledTestPaths = lib.optionals stdenv.isDarwin [
+    "spectral_cube/tests/test_visualization.py"
+  ];
 
   meta = {
     description = "Library for reading and analyzing astrophysical spectral data cubes";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1383,6 +1383,8 @@ in {
 
   cartopy = callPackage ../development/python-modules/cartopy { };
 
+  casa-formats-io = callPackage ../development/python-modules/casa-formats-io { };
+
   casbin = callPackage ../development/python-modules/casbin { };
 
   case = callPackage ../development/python-modules/case { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I noticed it was broken in #144276. Upgrade to the latest upstream and fix the build.

ZHF: #144627

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
