### PR TITLE
flameshot: fix under KDE wayland

### DIFF
--- a/pkgs/tools/misc/flameshot/default.nix
+++ b/pkgs/tools/misc/flameshot/default.nix
@@ -21,7 +21,9 @@ mkDerivation rec {
   };
 
   patches = [
-    # Support for USE_LAUNCHER_ABSOLUTE_PATH.
+    # Use absolute install path for `Exec=` in the desktop file.
+    # This is required since KWin relies on absolute paths in `Exec=` to find a process'
+    # corresponding desktop file and check if it's allowed to take screenshot.
     # Should be removed when the next release comes out.
     (fetchpatch {
       url = "https://github.com/flameshot-org/flameshot/commit/1031980ed1e62d24d7f719998b7951d48801e3fa.patch";
@@ -43,9 +45,6 @@ mkDerivation rec {
 
   nativeBuildInputs = [ cmake qttools qtsvg ];
   buildInputs = [ qtbase ];
-
-  # Use relative path for the .desktop file.
-  cmakeFlags = [ "-DUSE_LAUNCHER_ABSOLUTE_PATH=OFF" ];
 
   meta = with lib; {
     description = "Powerful yet simple to use screenshot software";


### PR DESCRIPTION
###### Motivation for this change

KWin relies on absolute path in `Exec=` to find a process's corresponding desktop file and check if it's allowed to take screenshot. So we need to set `Exec=` to the absolute path instead of just `flameshot`.

KWin detail is discussed in https://github.com/flameshot-org/flameshot/issues/1380

For testers: you may need to install it to `environment.systemPackages` and re-login to make it work.

cc: @jansol @haizaar

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
