### PR TITLE
lifelines: pull pending upstream inclusion fix for ncurses-6.3

### DIFF
--- a/pkgs/applications/misc/lifelines/default.nix
+++ b/pkgs/applications/misc/lifelines/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, gettext, libiconv, bison, ncurses, perl, autoreconfHook }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, gettext, libiconv, bison, ncurses, perl, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   pname = "lifelines";
@@ -10,6 +10,16 @@ stdenv.mkDerivation rec {
     rev = "43f29285ed46fba322b6a14322771626e6b02c59";
     sha256 = "1agszzlmkxmznpc1xj0vzxkskrcfagfjvqsdyw1yp5yg6bsq272y";
   };
+
+  patches = [
+    # Fix pending upstream inclusion for ncurses-6.3 support:
+    #  https://github.com/lifelines/lifelines/pull/437
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/lifelines/lifelines/commit/e04ce2794d458c440787c191877fbbc0784447bd.patch";
+      sha256 = "1smnz4z5hfjas79bfvlnpw9x8199a5g0p9cvhf17zpcnz1432kg7";
+    })
+  ];
 
   buildInputs = [
     gettext


### PR DESCRIPTION
Without the fix build on ncurses-6.3 fails as:

    screen.c:430:17: error: format not a string literal and no format arguments [-Werror=format-security]
      430 |                 wprintw(win, _(qSdbrdonly));
          |                 ^~~~~~~
