### PR TITLE
nethogs: pull upstream fix for ncurses-6.3

### DIFF
--- a/pkgs/tools/networking/nethogs/default.nix
+++ b/pkgs/tools/networking/nethogs/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, ncurses, libpcap }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, ncurses, libpcap }:
 
 stdenv.mkDerivation rec {
   pname = "nethogs";
@@ -10,6 +10,16 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "0sn1sdp86akwlm4r1vmkxjjl50c0xaisk91bbz57z7kcsaphxna9";
   };
+
+  patches = [
+    # Pull upstream patch for ncurses-6.3 support:
+    #  https://github.com/raboof/nethogs/pull/210
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/raboof/nethogs/commit/455daf357da7f394763e5b93b11b3defe1f82ed1.patch";
+      sha256 = "0wkp0yr6qg1asgvmsn7blf7rq48sh5k4n3w0nxf5869hxvkhnnzs";
+    })
+  ];
 
   buildInputs = [ ncurses libpcap ];
 


### PR DESCRIPTION
Without the fix build on ncurses-6.3 fails as:

    cui.cpp: In function ‘void show_ncurses(Line**, int)’:
    cui.cpp:377:73: error: format not a string literal and no format arguments [-Werror=format-security]
      377 |   mvprintw(3 + 1 + i, cols - COLUMN_WIDTH_UNIT, desc_view_mode[viewMode]);
          |                                                                         ^
