### PR TITLE
etcd: 3.4.16 -> 3.4.18, 3.3.25 -> 3.3.27, init 3.5.1

### DIFF
--- a/nixos/modules/services/misc/etcd.nix
+++ b/nixos/modules/services/misc/etcd.nix
@@ -184,7 +184,7 @@ in {
 
       serviceConfig = {
         Type = "notify";
-        ExecStart = "${pkgs.etcd}/bin/etcd";
+        ExecStart = "${cfg.package}/bin/etcd";
         User = "etcd";
         LimitNOFILE = 40000;
       };

--- a/nixos/modules/services/misc/etcd.nix
+++ b/nixos/modules/services/misc/etcd.nix
@@ -14,6 +14,12 @@ in {
       type = types.bool;
     };
 
+    package = mkOption {
+      description = "Which etcd derivation to use.";
+      default = pkgs.etcd;
+      type = types.package;
+    };
+
     name = mkOption {
       description = "Etcd unique node name.";
       default = config.networking.hostName;
@@ -184,7 +190,7 @@ in {
       };
     };
 
-    environment.systemPackages = [ pkgs.etcd ];
+    environment.systemPackages = [ cfg.package ];
 
     users.users.etcd = {
       isSystemUser = true;

--- a/pkgs/servers/etcd/3.4.nix
+++ b/pkgs/servers/etcd/3.4.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "etcd";
-  version = "3.4.16";
+  version = "3.4.18";
 
   deleteVendor = true;
   vendorSha256 = null;
@@ -13,7 +13,7 @@ buildGoModule rec {
     owner = "etcd-io";
     repo = "etcd";
     rev = "v${version}";
-    sha256 = "sha256-mTQwa9dYc0U0tjum1vR8Dbe/xLRHFUthcklA+Ye6/jw=";
+    sha256 = "sha256-/bXcW5g8mNFEjvfg+1loLFi8+IaWdcTE/lUPsHzEaIo=";
   };
 
   buildPhase = ''

--- a/pkgs/servers/etcd/3.5.nix
+++ b/pkgs/servers/etcd/3.5.nix
@@ -1,0 +1,36 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "etcd";
+  version = "3.5.1";
+
+  vendorSha256 = "sha256-ad89jDLLeAJizQMmO0lPH8N9GdaBrn9NyXGCxVT3fHE=";
+
+  doCheck = false;
+
+  src = fetchFromGitHub {
+    owner = "etcd-io";
+    repo = "etcd";
+    rev = "v${version}";
+    sha256 = "sha256-Ip7JAWbZBZcc8MXd+Sw05QmTs448fQXpQ5XXo6RW+Gs=";
+  };
+
+  buildPhase = ''
+    patchShebangs .
+    ./build
+    ./functional/build
+  '';
+
+  installPhase = ''
+    install -Dm755 bin/* bin/functional/cmd/* -t $out/bin
+  '';
+
+
+  meta = with lib; {
+    description = "Distributed reliable key-value store for the most critical data of a distributed system";
+    license = licenses.asl20;
+    homepage = "https://etcd.io/";
+    maintainers = with maintainers; [ offline zowoq ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/servers/etcd/default.nix
+++ b/pkgs/servers/etcd/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   pname = "etcd";
-  version = "3.3.25";
+  version = "3.3.27";
 
   goPackagePath = "github.com/coreos/etcd";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner = "etcd-io";
     repo = "etcd";
     rev = "v${version}";
-    sha256 = "10cyy6jr2xzmla5yyn850cv323ixrk70fjpk8lxjjjvy0ffmb6hj";
+    sha256 = "sha256-zO+gwzaTgeFHhlkY/3AvRTEA4Yltlp+NqdlDe4dLJYg=";
   };
 
   buildPhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20561,6 +20561,7 @@ with pkgs;
 
   etcd = callPackage ../servers/etcd { };
   etcd_3_4 = callPackage ../servers/etcd/3.4.nix { };
+  etcd_3_5 = callPackage ../servers/etcd/3.5.nix { };
 
   ejabberd = callPackage ../servers/xmpp/ejabberd { };
 


### PR DESCRIPTION
###### Motivation for this change

Update etcd versions

WIP on 3.5.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
