### PR TITLE
isl: isl.gforge.inria.fr has been taken offline

### DIFF
--- a/pkgs/development/libraries/isl/0.14.1.nix
+++ b/pkgs/development/libraries/isl/0.14.1.nix
@@ -4,7 +4,10 @@ stdenv.mkDerivation rec {
   name = "isl-0.14.1";
 
   src = fetchurl {
-    url = "http://isl.gforge.inria.fr/${name}.tar.xz";
+    urls = [
+      "mirror://sourceforge/libisl/${name}.tar.xz"
+      "https://libisl.sourceforge.io/${name}.tar.xz"
+    ];
     sha256 = "0xa6xagah5rywkywn19rzvbvhfvkmylhcxr6z9z7bz29cpiwk0l8";
   };
 

--- a/pkgs/development/libraries/isl/0.17.1.nix
+++ b/pkgs/development/libraries/isl/0.17.1.nix
@@ -4,7 +4,10 @@ stdenv.mkDerivation rec {
   name = "isl-0.17.1";
 
   src = fetchurl {
-    url = "http://isl.gforge.inria.fr/${name}.tar.xz";
+    urls = [
+      "mirror://sourceforge/libisl/${name}.tar.xz"
+      "https://libisl.sourceforge.io/${name}.tar.xz"
+    ];
     sha256 = "be152e5c816b477594f4c6194b5666d8129f3a27702756ae9ff60346a8731647";
   };
 

--- a/pkgs/development/libraries/isl/0.20.0.nix
+++ b/pkgs/development/libraries/isl/0.20.0.nix
@@ -4,7 +4,11 @@ stdenv.mkDerivation rec {
   name = "isl-0.20";
 
   src = fetchurl {
-    url = "http://isl.gforge.inria.fr/${name}.tar.xz";
+    urls = [
+      "mirror://sourceforge/libisl/${name}.tar.xz"
+      "https://libisl.sourceforge.io/${name}.tar.xz"
+    ];
+
     sha256 = "1akpgq0rbqbah5517blg2zlnfvjxfcl9cjrfc75nbcx5p2gnlnd5";
   };
 


### PR DESCRIPTION
###### Motivation for this change

isl.gforge.inria.fr has been taken offline

https://issues.guix.gnu.org/42162
https://github.com/dockcross/dockcross/issues/606
https://groups.google.com/g/isl-development/c/JGaMo2VUu_8
https://giters.com/coq/opam-coq-archive/issues/1298?amp=1

It does not look like there is any permanent solution yet. I provided every mirror I could find in the URLs.

Hashes didn't change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
