### PR TITLE
mirrors: add kernel.org mirrors where appropriate

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -151,6 +151,7 @@
   cpan = [
     "https://cpan.metacpan.org/"
     "https://cpan.perl.org/"
+    "https://mirrors.kernel.org/CPAN/"
     "https://backpan.perl.org/"  # for old releases
   ];
 
@@ -171,6 +172,7 @@
   debian = [
     "https://httpredir.debian.org/debian/"
     "https://ftp.debian.org/debian/"
+    "https://mirrors.edge.kernel.org/debian/"
     "ftp://ftp.de.debian.org/debian/"
     "ftp://ftp.fr.debian.org/debian/"
     "ftp://ftp.nl.debian.org/debian/"
@@ -183,6 +185,7 @@
   ubuntu = [
     "https://nl.archive.ubuntu.com/ubuntu/"
     "https://old-releases.ubuntu.com/ubuntu/"
+    "https://mirrors.edge.kernel.org/ubuntu/"
     "http://de.archive.ubuntu.com/ubuntu/"
     "http://archive.ubuntu.com/ubuntu/"
   ];
@@ -206,6 +209,7 @@
     "https://ftp.funet.fi/pub/linux/mirrors/opensuse/distribution/"
     "https://ftp.opensuse.org/pub/opensuse/distribution/"
     "https://ftp5.gwdg.de/pub/opensuse/discontinued/distribution/"
+    "https://mirrors.edge.kernel.org/opensuse/distribution/"
     "http://ftp.hosteurope.de/mirror/ftp.opensuse.org/discontinued/"
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
