### PR TITLE
treewide: remove unused args

### DIFF
--- a/pkgs/misc/arm-trusted-firmware/default.nix
+++ b/pkgs/misc/arm-trusted-firmware/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, openssl, pkgsCross, buildPackages }:
+{ lib, stdenv, fetchFromGitHub, openssl, pkgsCross, buildPackages }:
 
 let
   buildArmTrustedFirmware = { filesToInstall

--- a/pkgs/misc/drivers/hplip/3.16.11.nix
+++ b/pkgs/misc/drivers/hplip/3.16.11.nix
@@ -2,7 +2,7 @@
 , pkg-config
 , cups, libjpeg, libusb1, python2Packages, sane-backends, dbus, usbutils
 , net-snmp, openssl, nettools
-, bash, coreutils, util-linux
+, bash, util-linux
 , qtSupport ? true
 , withPlugin ? false
 }:

--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -3,7 +3,7 @@
 , cups, zlib, libjpeg, libusb1, python3Packages, sane-backends
 , dbus, file, ghostscript, usbutils
 , net-snmp, openssl, perl, nettools, avahi
-, bash, coreutils, util-linux
+, bash, util-linux
 # To remove references to gcc-unwrapped
 , removeReferencesTo, qt5
 , withQt5 ? true

--- a/pkgs/misc/drivers/utsushi/default.nix
+++ b/pkgs/misc/drivers/utsushi/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, writeScriptBin, fetchFromGitLab, autoreconfHook, pkg-config
 , autoconf-archive, libxslt, boost , gtkmm2 , imagemagick, sane-backends
-, tesseract4, udev, libusb1, gnum4 }:
+, tesseract4, udev, libusb1 }:
 
 
 let

--- a/pkgs/misc/emulators/commanderx16/run.nix
+++ b/pkgs/misc/emulators/commanderx16/run.nix
@@ -1,6 +1,4 @@
-{ lib
-, stdenv
-, runtimeShell
+{ runtimeShell
 , symlinkJoin
 , writeTextFile
 }:

--- a/pkgs/misc/emulators/dgen-sdl/default.nix
+++ b/pkgs/misc/emulators/dgen-sdl/default.nix
@@ -1,7 +1,6 @@
 { lib, stdenv
 , fetchurl
 , libarchive
-, doxygen
 , SDL
 }:
 

--- a/pkgs/misc/emulators/mgba/default.nix
+++ b/pkgs/misc/emulators/mgba/default.nix
@@ -9,7 +9,6 @@
 , libedit
 , libelf
 , libzip
-, copyDesktopItems
 , makeDesktopItem
 , minizip
 , pkg-config

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, fetchgit, fetchFromGitHub, fetchFromGitLab, fetchpatch, cmake, pkg-config, makeWrapper, python27, python3, retroarch
-, alsa-lib, fluidsynth, curl, hidapi, libGLU, gettext, glib, gtk2, portaudio, SDL, SDL_net, SDL2, SDL2_image, libGL
+{ lib, stdenv, fetchgit, fetchFromGitHub, fetchpatch, cmake, pkg-config, makeWrapper, python27, python3, retroarch
+, alsa-lib, fluidsynth, curl, hidapi, libGLU, gettext, portaudio, SDL, SDL2, libGL
 , ffmpeg, pcre, libevdev, libpng, libjpeg, libzip, udev, libvorbis, snappy, which, hexdump
-, miniupnpc, sfml, xorg, zlib, nasm, libpcap, boost, icu, openssl
+, sfml, xorg, zlib, nasm, libpcap, boost, icu, openssl
 , buildPackages }:
 
 let

--- a/pkgs/misc/emulators/retroarch/default.nix
+++ b/pkgs/misc/emulators/retroarch/default.nix
@@ -14,7 +14,6 @@
 , udev ? null
 , enableNvidiaCgToolkit ? false, nvidia_cg_toolkit ? null
 , withVulkan ? stdenv.isLinux, vulkan-loader ? null
-, fetchurl
 , wayland
 , libxkbcommon
 }:

--- a/pkgs/misc/ghostscript/test-corpus-render.nix
+++ b/pkgs/misc/ghostscript/test-corpus-render.nix
@@ -1,5 +1,4 @@
-{ lib
-, stdenv
+{ stdenv
 , fetchgit
 , ghostscript
 }:

--- a/pkgs/misc/scrcpy/default.nix
+++ b/pkgs/misc/scrcpy/default.nix
@@ -2,7 +2,6 @@
 , meson
 , ninja
 , pkg-config
-, fetchpatch
 
 , platform-tools
 , ffmpeg

--- a/pkgs/misc/vscode-extensions/cpptools/default.nix
+++ b/pkgs/misc/vscode-extensions/cpptools/default.nix
@@ -1,6 +1,5 @@
 { lib, vscode-utils
-, fetchurl, unzip
-, mono, writeScript, runtimeShell
+, fetchurl, mono, writeScript, runtimeShell
 , jq, clang-tools
 , gdbUseFixed ? true, gdb # The gdb default setting will be fixed to specified. Use version from `PATH` otherwise.
 }:

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -1,6 +1,5 @@
 { config
 , lib
-, buildEnv
 , fetchurl
 , callPackage
 , vscode-utils

--- a/pkgs/misc/vscode-extensions/wakatime/default.nix
+++ b/pkgs/misc/vscode-extensions/wakatime/default.nix
@@ -1,5 +1,5 @@
 { lib
-, wakatime, vscode-utils }:
+, vscode-utils }:
 
 let
   inherit (vscode-utils) buildVscodeMarketplaceExtension;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The misc subtree had a few derivations with unused arguments in the derivation inputs.
The cleanup was done manually with a bit of ad-hoc scripting.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
