### PR TITLE
rsyscall: init at 0.0.3

### DIFF
--- a/pkgs/development/libraries/librsyscall/default.nix
+++ b/pkgs/development/libraries/librsyscall/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, stdenv
+, autoreconfHook
+, pkg-config
+, glibc
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "librsyscall";
+  version = "0.0.1";
+  src = fetchFromGitHub {
+    owner = "catern";
+    repo = "rsyscall";
+    rev = "v${version}";
+    sha256 = "1a89gg6aysyymn1wvaxrgf93334cz1y1zarr5nhxg0vjly8v91pg";
+  };
+  sourceRoot = "source/c";
+
+  # librsyscall builds some static bootstrap binaries;
+  # both static and dynamic libraries will be installed, which is fine.
+  dontDisableStatic = true;
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  buildInputs = [ glibc glibc.static ];
+
+  meta = with lib; {
+    description = "Make syscalls remotely";
+    homepage = "https://github.com/catern/rsyscall";
+    platforms = ["x86_64-linux"];
+    license = licenses.mit;
+    maintainers = with maintainers; [ catern ];
+  };
+}

--- a/pkgs/development/python-modules/nixdeps/default.nix
+++ b/pkgs/development/python-modules/nixdeps/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "nixdeps";
+  version = "1.0.0";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0rjwjz3qzifp6kh11p7whgs4dm44d07n28phw03gwfisqi4k2h43";
+  };
+
+  pythonImportsCheck = [ "nixdeps.setuptools" ];
+  propagatedBuildInputs = [ setuptools ];
+
+  meta = with lib; {
+    description = "A setuptools entrypoint to store dependencies on Nix packages at build-time";
+    homepage = "https://github.com/catern/rsyscall/tree/master/nixdeps";
+    license = licenses.mit;
+    maintainers = with maintainers; [ catern ];
+  };
+}
+

--- a/pkgs/development/python-modules/rsyscall/default.nix
+++ b/pkgs/development/python-modules/rsyscall/default.nix
@@ -1,0 +1,75 @@
+{ lib
+, buildPythonPackage
+, cffi
+, trio
+, typeguard
+, pyroute2
+, outcome
+, nixdeps
+, pytestCheckHook
+, typing-extensions
+, pythonOlder
+, fetchPypi
+, librsyscall
+, nix
+, socat
+, pkg-config
+, openssh
+, coreutils
+}:
+
+buildPythonPackage rec {
+  pname = "rsyscall";
+  version = "0.0.3";
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1wvviglibnkkh332f27hqzjyz7ipbp6h3p845h0x77y1vlsf4gxk";
+  };
+
+  buildInputs = [
+    cffi
+    librsyscall
+  ];
+  nativeBuildInputs = [
+    pkg-config
+  ];
+  propagatedBuildInputs = [
+    trio
+    typeguard
+    pyroute2
+    outcome
+    nixdeps
+  ];
+  # rsyscall uses these to build containers on the fly
+  exportReferencesGraph = [
+    "nix" nix
+    "librsyscall" librsyscall
+    "openssh" openssh
+    "coreutils" coreutils
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    typing-extensions
+    socat
+  ];
+  disabledTests = [
+    "ssh"    # the build user's login shell is /noshell
+    "net"    # /dev/net/tun doesn't exist
+    "nix"    # can't use Nix in the build sandbox
+    "pgid"   # /proc/sys/kernel/ns_last_pid doesn't exist
+    "fuse"   # /dev/fuse doesn't exist
+  ];
+  # pytestCheckHook runs against the source tree rather than the installed version by default,
+  # but we need to test against the installed version because there's a compiled extension.
+  preCheck = "cd $out";
+
+  meta = with lib; {
+    description = "A library for making system calls remotely, through another process";
+    homepage = "https://github.com/catern/rsyscall";
+    license = licenses.mit;
+    maintainers = with maintainers; [ catern ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7216,6 +7216,8 @@ with pkgs;
 
   libraspberrypi = callPackage ../development/libraries/libraspberrypi { };
 
+  librsyscall = callPackage ../development/libraries/librsyscall { };
+
   libsidplayfp = callPackage ../development/libraries/libsidplayfp { };
 
   libspf2 = callPackage ../development/libraries/libspf2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5108,6 +5108,8 @@ in {
     inherit (pkgs) nix;
   };
 
+  nixdeps = callPackage ../development/python-modules/nixdeps { };
+
   nixpkgs = callPackage ../development/python-modules/nixpkgs { };
 
   nixpkgs-pytools = callPackage ../development/python-modules/nixpkgs-pytools { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8258,6 +8258,8 @@ in {
 
   rstcheck = callPackage ../development/python-modules/rstcheck { };
 
+  rsyscall = callPackage ../development/python-modules/rsyscall { };
+
   rtmidi-python = callPackage ../development/python-modules/rtmidi-python { };
 
   rtoml = callPackage ../development/python-modules/rtoml { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I use this package and plan on packaging other things which depend on it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
