### PR TITLE
rocksdb: reintroduce rocksdb 6.23.3 as rocksdb_6_23

### DIFF
--- a/pkgs/applications/blockchains/electrs/default.nix
+++ b/pkgs/applications/blockchains/electrs/default.nix
@@ -24,12 +24,9 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [ llvmPackages.clang ];
   LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
 
-  # temporarily disable dynamic linking, which broke with rocksdb update 6.23.3 -> 6.25.3
-  # https://github.com/NixOS/nixpkgs/pull/143524#issuecomment-955053331
-  #
   # link rocksdb dynamically
-  # ROCKSDB_INCLUDE_DIR = "${rocksdb}/include";
-  # ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+  ROCKSDB_INCLUDE_DIR = "${rocksdb}/include";
+  ROCKSDB_LIB_DIR = "${rocksdb}/lib";
 
   buildInputs = lib.optionals stdenv.isDarwin [ Security ];
 

--- a/pkgs/applications/blockchains/electrs/default.nix
+++ b/pkgs/applications/blockchains/electrs/default.nix
@@ -3,10 +3,13 @@
 , rustPlatform
 , fetchFromGitHub
 , llvmPackages
-, rocksdb
+, rocksdb_6_23
 , Security
 }:
 
+let
+  rocksdb = rocksdb_6_23;
+in
 rustPlatform.buildRustPackage rec {
   pname = "electrs";
   version = "0.9.2";

--- a/pkgs/servers/blockbook/default.nix
+++ b/pkgs/servers/blockbook/default.nix
@@ -5,13 +5,16 @@
 , pkg-config
 , bzip2
 , lz4
-, rocksdb
+, rocksdb_6_23
 , snappy
 , zeromq
 , zlib
 , nixosTests
 }:
 
+let
+  rocksdb = rocksdb_6_23;
+in
 buildGoModule rec {
   pname = "blockbook";
   version = "0.3.6";

--- a/pkgs/servers/blockbook/default.nix
+++ b/pkgs/servers/blockbook/default.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , buildGoModule
 , fetchFromGitHub
-, packr
 , pkg-config
 , bzip2
 , lz4
@@ -14,22 +14,19 @@
 
 buildGoModule rec {
   pname = "blockbook";
-  version = "0.3.4";
-  commit = "eb4e10a";
+  version = "0.3.6";
+  commit = "5f8cf45";
 
   src = fetchFromGitHub {
     owner = "trezor";
     repo = "blockbook";
     rev = "v${version}";
-    sha256 = "0da1kav5x2xcmwvdgfk1q70l1k0sqqj3njgx2xx885d40m6qbnrs";
+    sha256 = "1jb195chy3kbspmv9vyg7llw6kgykkmvz3znd97mxf24f4q622jv";
   };
 
-  runVend = true;
-  vendorSha256 = "0p7vyw61nwvmaz7gz2bdh9fi6wp62i2vnzw6iz2r8cims4sbz53b";
+  vendorSha256 = "0d17qaqn33wi7lzw4hlym56d9v4qnmvs6plpm5jiby2g5yckq0mz";
 
-  doCheck = false;
-
-  nativeBuildInputs = [ packr pkg-config ];
+  nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ bzip2 lz4 rocksdb snappy zeromq zlib ];
 
@@ -39,11 +36,14 @@ buildGoModule rec {
     "-X github.com/trezor/blockbook/common.buildDate=unknown"
   ];
 
+  tags = [ "rocksdb_6_16" ];
+
   preBuild = lib.optionalString stdenv.isDarwin ''
     ulimit -n 8192
   '' + ''
     export CGO_LDFLAGS="-L${stdenv.cc.cc.lib}/lib -lrocksdb -lz -lbz2 -lsnappy -llz4 -lm -lstdc++"
-    packr clean && packr
+    buildFlagsArray+=("-tags=${lib.concatStringsSep " " tags}")
+    buildFlagsArray+=("-ldflags=${lib.concatStringsSep " " ldflags}")
   '';
 
   subPackages = [ "." ];
@@ -64,8 +64,5 @@ buildGoModule rec {
     license = licenses.agpl3;
     maintainers = with maintainers; [ mmahut _1000101 ];
     platforms = platforms.unix;
-    # go dependency tecbot/gorocksdb requires rocksdb 5.x but nixpkgs has only rocksdb 6.x
-    # issue in upstream can be tracked here: https://github.com/trezor/blockbook/issues/617
-    broken = true;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19300,6 +19300,17 @@ with pkgs;
 
   rocksdb_lite = rocksdb.override { enableLite = true; };
 
+  rocksdb_6_23 = rocksdb.overrideAttrs (old: rec {
+    pname = "rocksdb";
+    version = "6.23.3";
+    src = fetchFromGitHub {
+      owner = "facebook";
+      repo = pname;
+      rev = "v${version}";
+     sha256 = "sha256-SsDqhjdCdtIGNlsMj5kfiuS3zSGwcxi4KV71d95h7yk=";
+   };
+  });
+
   rotate-backups = callPackage ../tools/backup/rotate-backups { };
 
   rote = callPackage ../development/libraries/rote { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- it seems that at least 2 packages (blockbook, electrs) got broken when rocksdb was updated past 6.23.3 in https://github.com/NixOS/nixpkgs/pull/143524
- this PR fixes that by reintroducing rocksdb 6.23.3 as rocksdb_6_23 and patching these two packages to use that

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
