### PR TITLE
megapixels: 1.3.0 -> 1.4.0

### DIFF
--- a/pkgs/applications/graphics/megapixels/default.nix
+++ b/pkgs/applications/graphics/megapixels/default.nix
@@ -1,10 +1,10 @@
 { stdenv
 , lib
-, fetchFromSourcehut
+, fetchFromGitLab
+, glib
 , meson
 , ninja
 , pkg-config
-, glib
 , wrapGAppsHook
 , epoxy
 , gtk4
@@ -27,20 +27,20 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "megapixels";
-  version = "1.3.0";
+  version = "1.4.0";
 
-  src = fetchFromSourcehut {
-    owner = "~martijnbraam";
+  src = fetchFromGitLab {
+    owner = "postmarketOS";
     repo = "megapixels";
     rev = version;
-    sha256 = "0dagp1sh5whnnllrydk7ijjid0hmvcbdm8kkzq2g168khdfn80jm";
+    sha256 = "sha256-I7eevbIg+DEY9hnvat65J4Kem1FFNZc4XzaQQaewP/4=";
   };
 
   nativeBuildInputs = [
+    glib
     meson
     ninja
     pkg-config
-    glib
     wrapGAppsHook
   ];
 
@@ -62,8 +62,8 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "GTK4 camera application that knows how to deal with the media request api";
-    homepage = "https://sr.ht/~martijnbraam/Megapixels";
-    changelog = "https://git.sr.ht/~martijnbraam/megapixels/refs/${version}";
+    homepage = "https://gitlab.com/postmarketOS/megapixels";
+    changelog = "https://gitlab.com/postmarketOS/megapixels/-/tags/${version}";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ OPNA2608 dotlambda ];
     platforms = platforms.linux;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
