### PR TITLE
blitz: fix build for darwin

### DIFF
--- a/pkgs/development/libraries/blitz/default.nix
+++ b/pkgs/development/libraries/blitz/default.nix
@@ -1,13 +1,20 @@
-{ stdenv, lib, fetchFromGitHub, pkg-config, gfortran, texinfo, python, boost
-# Select SIMD alignment width (in bytes) for vectorization.
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, gfortran
+, texinfo
+, python
+, boost
+  # Select SIMD alignment width (in bytes) for vectorization.
 , simdWidth ? 1
-# Pad arrays to simdWidth by default?
-# Note: Only useful if simdWidth > 1
+  # Pad arrays to simdWidth by default?
+  # Note: Only useful if simdWidth > 1
 , enablePadding ? false
-# Activate serialization through Boost.Serialize?
+  # Activate serialization through Boost.Serialize?
 , enableSerialization ? true
-# Activate test-suite?
-# WARNING: Some of the tests require up to 1700MB of memory to compile.
+  # Activate test-suite?
+  # WARNING: Some of the tests require up to 1700MB of memory to compile.
 , doCheck ? true
 }:
 
@@ -29,7 +36,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ gfortran texinfo boost ];
 
   configureFlags =
-    [ "--enable-shared"
+    [
+      "--enable-shared"
       "--disable-static"
       "--enable-fortran"
       "--enable-optimize"
@@ -44,6 +52,9 @@ stdenv.mkDerivation rec {
     ] ++ optional enablePadding "--enable-array-length-padding"
     ++ optional enableSerialization "--enable-serialization"
     ++ optional stdenv.is64bit "--enable-64bit";
+
+  # skip broken library name detection
+  ax_boost_user_serialization_lib = lib.optionalString stdenv.isDarwin "boost_serialization";
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF: #144627

Fix blitz on darwin.

This is complicated enough that it bears a more thorough explanation. It appears the library has switched from autoconf to cmake between versions 1.0.1 (current nixpkgs release) and 1.0.2 (latest release). The release notes say that the autoconf build has been left in for the most recent release, but it had some odd symlinks in it that I didn't know how to fix for the standard build process. I was not confident that the cmake-based build provided the same level of customizability, and perhaps it didn't need to, but that is beyond my understanding.

I was able to pinpoint the failure to an outdated configure script which is included as part of the release, so I believe the best and most conservative course of action is to provide a patch with nixpkgs, because I'm not sure what contributing it back upstream would look like. I would be happy to assist users or maintainers to work on this as they see fit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
