### PR TITLE
jnettop: pull pending upstream inclusion fix for ncurses-6.3

### DIFF
--- a/pkgs/tools/networking/jnettop/default.nix
+++ b/pkgs/tools/networking/jnettop/default.nix
@@ -18,6 +18,14 @@ stdenv.mkDerivation rec {
       url = "https://sources.debian.net/data/main/j/jnettop/0.13.0-1/debian/patches/0001-Use-64-bit-integers-for-byte-totals-support-bigger-u.patch";
       sha256 = "1b0alc12sj8pzcb66f8xslbqlbsvq28kz34v6jfhbb1q25hyr7jg";
     })
+
+    # Fix pending upstream inclusion for ncurses-6.3:
+    #  https://sourceforge.net/p/jnettop/patches/5/
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://sourceforge.net/p/jnettop/patches/5/attachment/jnettop-0.13.0-ncurses-6.3.patch";
+      sha256 = "1a0g3bal6f2fh1sq9q5kfwljrnskfvrhdzhjadcds34gzsr26v7x";
+    })
   ];
 
   preConfigure = "autoconf ";
@@ -31,7 +39,7 @@ stdenv.mkDerivation rec {
       by bandwidth they use.
     '';
 
-    homepage = "http://jnettop.kubs.info/";
+    homepage = "https://sourceforge.net/projects/jnettop/";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
   };


### PR DESCRIPTION
Without the fix build on ncurses-6.3 fails as:

    jcursesdisplay.c:111:17: error: format not a string literal and no format arguments [-Werror=format-security]
      111 |                 mvprintw(2, 0, statusMessage);
          |                 ^~~~~~~~
