### PR TITLE
kotlin-language-server: init at 1.1.2

### DIFF
--- a/pkgs/development/tools/kotlin-language-server/default.nix
+++ b/pkgs/development/tools/kotlin-language-server/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, fetchurl, unzip, openjdk11, gradle }:
+
+stdenv.mkDerivation rec {
+  pname = "kotlin-language-server";
+  version = "1.1.2";
+  src = fetchurl {
+    url = "https://github.com/fwcd/kotlin-language-server/releases/download/${version}/server.zip";
+    sha256 = "d8850ee2be8c49e5e642c4a41f52304098ae0bcce009e4d91531a9aeecd64916";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/lib
+    mkdir -p $out/bin
+    cp -r lib/* $out/lib
+    cp -r bin/* $out/bin
+  '';
+
+  nativeBuildInputs = [ unzip gradle ];
+  buildInputs = [ openjdk11 gradle ];
+
+  meta = {
+    description = "kotlin language server";
+    longDescription = ''
+      About Kotlin code completion, linting and more for any editor/IDE
+      using the Language Server Protocol Topics'';
+    homepage = "https://github.com/fwcd/kotlin-language-server";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12385,6 +12385,8 @@ with pkgs;
   kotlin = callPackage ../development/compilers/kotlin { };
   kotlin-native = callPackage ../development/compilers/kotlin/native.nix { };
 
+  kotlin-language-server = callPackage ../development/tools/kotlin-language-server {};
+
   lazarus = callPackage ../development/compilers/fpc/lazarus.nix {
     fpc = fpc;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
