### PR TITLE
psi-plus: 1.5.1556-2 -> 1.5.1576

### DIFF
--- a/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
@@ -40,43 +40,15 @@ assert builtins.elem (lib.toLower chatType) [
 
 assert enablePsiMedia -> enablePlugins;
 
-mkDerivation {
+mkDerivation rec {
   pname = "psi-plus";
-
-  # Version mask is “X.X.XXXX-R” where “X.X.XXXX” is a mandatory version of Psi
-  # and “-R” ending is optional revision number.
-  #
-  # The “psi-plus-snapshots” generally provides snapshots of these separate
-  # repositories glued together (there are also dependencies/libraries):
-  #
-  # 1. Psi
-  # 2. Plugins pack for Psi
-  # 3. “psimedia” plugin
-  # 4. Resources for Psi (icons, skins, sounds)
-  #
-  # “X.X.XXXX” is literally a version of Psi.
-  # So often when for instance plugins are updated separately a new snapshot is
-  # created. And that snapshot would also be linked to “X.X.XXXX” version.
-  # So many commits may have the same associated version of the snapshot.
-  # But mind that only one Git tag is created for “X.X.XXXX” version.
-  #
-  # It’s not yet defined in the Psi+ project what value to use as a version for
-  # any further releases that don’t change Psi version.
-  #
-  # Let’s do what Debian does for instance (appends “-R” where “R” is a revision
-  # number).
-  # E.g. https://tracker.debian.org/news/1226321/psi-plus-14554-5-migrated-to-testing/
-  #
-  # This has been communicated with the Psi+ main devs in this XMPP MUC chat:
-  # psi-dev@conference.jabber.ru
-  #
-  version = "1.5.1556-2";
+  version = "1.5.1576";
 
   src = fetchFromGitHub {
     owner = "psi-plus";
     repo = "psi-plus-snapshots";
-    rev = "635879010b6697f7041a7bbea1853a1f4673c7f7";
-    sha256 = "18xvljcm0a9swkyz4diwxi4xaj0w27jnhfgpi8fv5fj11j0g1b3a";
+    rev = version;
+    sha256 = "15iqa8hd4p968sp79zsi32g7bhamgg267pk2bxspl646viv91f6g";
   };
 
   cmakeFlags = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/psi-plus/psi-plus-snapshots/releases/tag/1.5.1576

There should be properly tagged releases now (for example: https://github.com/psi-plus/psi-plus-snapshots/releases/tag/1.5.1556.1), so no need for suffixes like `-2` anymore.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
