### PR TITLE
010-editor: init at 12.0.1

### DIFF
--- a/pkgs/applications/editors/010-editor/default.nix
+++ b/pkgs/applications/editors/010-editor/default.nix
@@ -1,0 +1,83 @@
+{ lib, stdenv, fetchFromGitHub, fetchurl, makeDesktopItem, autoPatchelfHook, copyDesktopItems, perlPackages, zlib, fontconfig, freetype, libxkbcommon, cups, ... }:
+
+let
+  extract = fetchFromGitHub {
+    owner = "lod";
+    repo = "unpack-install-jammer";
+    rev = "41faa5a8c7925db4ff7ca665cca478979d177de4";
+    sha256 = "1gvx7nkg4spz245hnmzcshiy0k3qvslqlzp4if7ngdqi2pfjrn4q";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "010-editor";
+  version = "12.0.1";
+
+  src = fetchurl {
+    url = "https://download.sweetscape.com/010EditorLinux64Installer${version}.tar.gz";
+    sha256 = "0ln8qxy1mij8qnnn8dxwnvmkx69l0f0w6xnb615ihx8wyhvlmfzh";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    copyDesktopItems
+  ] ++ (with perlPackages; [
+    perl
+    ModernPerl
+    CompressRawLzma
+    CompressRawZlib
+    FileHomeDir
+    TermProgressBar
+    DataDump
+  ]);
+
+  buildInputs = [
+    zlib
+    freetype
+    fontconfig
+    libxkbcommon
+    cups
+  ];
+
+  # Archive does not have a subdirectory
+  setSourceRoot = "sourceRoot=$PWD";
+
+  # Use shipped Qt5 libs
+  runtimeDependencies = [ "$out" ];
+
+  postUnpack = ''
+    perl ${extract}/extract.pl -s Home=/ 010EditorLinux64Installer
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -ra install_dir/010editor $out
+
+    mkdir $out/bin
+    ln -s ../010editor $out/bin/010editor
+
+    mkdir -p $out/share/pixmaps
+    mv $out/010_icon_128x128.png $out/share/pixmaps/010-editor.png
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      desktopName = "010 Editor";
+      comment = meta.description;
+      exec = "010editor";
+      icon = pname;
+      categories = "Utility;Development";
+    })
+  ];
+
+  meta = with lib; {
+    description = "Professional text editor and hex editor";
+    homepage = "https://www.sweetscape.com/010editor/";
+    maintainers = with maintainers; [ ius ];
+    license = licenses.unfree;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23918,6 +23918,8 @@ with pkgs;
 
   ### APPLICATIONS
 
+  _010-editor = callPackage ../applications/editors/010-editor { };
+
   _2bwm = callPackage ../applications/window-managers/2bwm {
     patches = config."2bwm".patches or [];
   };


### PR DESCRIPTION
###### Motivation for this change

010 Editor is a powerful hex editor.

~~This PR also adds me as a nixpkgs maintainer.~~

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
