### PR TITLE
scrcpy: 1.19 -> 1.20

### DIFF
--- a/pkgs/misc/scrcpy/default.nix
+++ b/pkgs/misc/scrcpy/default.nix
@@ -6,14 +6,15 @@
 
 , platform-tools
 , ffmpeg
+, libusb1
 , SDL2
 }:
 
 let
-  version = "1.19";
+  version = "1.20";
   prebuilt_server = fetchurl {
     url = "https://github.com/Genymobile/scrcpy/releases/download/v${version}/scrcpy-server-v${version}";
-    sha256 = "sha256-h2+TIhguaqxqWNsTNPQiWFXvOhfq68gKq2YB2dHsuGc=";
+    sha256 = "sha256-sgruSVH5mwYMSkQAC6lN6XP5YEdY72K+slOzcarT3zQ=";
   };
 in
 stdenv.mkDerivation rec {
@@ -24,7 +25,7 @@ stdenv.mkDerivation rec {
     owner = "Genymobile";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-IR4FTbVtHp9rRm0U4d1zkl0u+oR5FeElJ91NIspSKWg=";
+    sha256 = "sha256-yj/hpndVC1oInrYmCSKQix1kNWy/GpAlmO/6o3vvQQE=";
   };
 
   # postPatch:
@@ -38,7 +39,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper meson ninja pkg-config ];
 
-  buildInputs = [ ffmpeg SDL2 ];
+  buildInputs = [ ffmpeg SDL2 ] ++ lib.optionals stdenv.isLinux [
+    libusb1
+  ];
 
   # Manually install the server jar to prevent Meson from "fixing" it
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change

Updates `scrcpy` from 1.19 to 1.12: https://github.com/Genymobile/scrcpy/releases/tag/v1.20

This release adds a new icon and support for HID keyboards, which adds the new dependency on `libusb`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
