### PR TITLE
paper-icon-theme: 2018-06-24 -> unstable-2020-03-12

### DIFF
--- a/pkgs/data/icons/paper-icon-theme/default.nix
+++ b/pkgs/data/icons/paper-icon-theme/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, meson, ninja, gtk3, gnome, gnome-icon-theme, hicolor-icon-theme }:
+{ lib, stdenv, fetchFromGitHub, meson, ninja, gtk3, gnome, gnome-icon-theme, hicolor-icon-theme, jdupes }:
 
 stdenv.mkDerivation rec {
   pname = "paper-icon-theme";
@@ -15,6 +15,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     gtk3
+    jdupes
   ];
 
   propagatedBuildInputs = [
@@ -25,9 +26,16 @@ stdenv.mkDerivation rec {
 
   dontDropIconThemeCache = true;
 
+  # These fixup steps are slow and unnecessary for this package
+  dontPatchELF = true;
+  dontRewriteSymlinks = true;
+
   postInstall = ''
     # The cache for Paper-Mono-Dark is missing
     gtk-update-icon-cache "$out"/share/icons/Paper-Mono-Dark;
+
+    # replace duplicate files with symlinks
+    jdupes -l -r $out/share/icons
   '';
 
   meta = with lib; {

--- a/pkgs/data/icons/paper-icon-theme/default.nix
+++ b/pkgs/data/icons/paper-icon-theme/default.nix
@@ -1,21 +1,20 @@
-{ lib, stdenv, fetchFromGitHub, meson, ninja, gtk3, python3, gnome, gnome-icon-theme, hicolor-icon-theme }:
+{ lib, stdenv, fetchFromGitHub, meson, ninja, gtk3, gnome, gnome-icon-theme, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   pname = "paper-icon-theme";
-  version = "2018-06-24";
+  version = "unstable-2020-03-12";
 
   src = fetchFromGitHub {
     owner = "snwh";
     repo = pname;
-    rev = "c7cd013fba06dd8fd5cdff9f885520e2923266b8";
-    sha256 = "0x45zkjnmbz904df63ph06npbm3phpgck4xwyymx8r8jgrfplk6v";
+    rev = "aa3e8af7a1f0831a51fd7e638a4acb077a1e5188";
+    sha256 = "0x6qzch4rrc8firb1dcf926j93gpqxvd7h6dj5wwczxbvxi5bd77";
   };
 
   nativeBuildInputs = [
     meson
     ninja
     gtk3
-    python3
   ];
 
   propagatedBuildInputs = [
@@ -25,10 +24,6 @@ stdenv.mkDerivation rec {
   ];
 
   dontDropIconThemeCache = true;
-
-  postPatch = ''
-    patchShebangs meson/post_install.py
-  '';
 
   postInstall = ''
     # The cache for Paper-Mono-Dark is missing


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Update the latest upstream commit, and fixes https://github.com/NixOS/nixpkgs/issues/145840
- Replace duplicate files with symlinks 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
