### PR TITLE
moka-icon-theme: 5.4.0 -> unstable-2019-05-29

### DIFF
--- a/pkgs/data/icons/moka-icon-theme/default.nix
+++ b/pkgs/data/icons/moka-icon-theme/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, meson, ninja, gtk3, python3, faba-icon-theme, hicolor-icon-theme }:
+{ lib, stdenv, fetchFromGitHub, meson, ninja, gtk3, python3, faba-icon-theme, hicolor-icon-theme, jdupes }:
 
 stdenv.mkDerivation rec {
   pname = "moka-icon-theme";
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
     ninja
     gtk3
     python3
+    jdupes
   ];
 
   propagatedBuildInputs = [
@@ -25,8 +26,17 @@ stdenv.mkDerivation rec {
 
   dontDropIconThemeCache = true;
 
+  # These fixup steps are slow and unnecessary for this package
+  dontPatchELF = true;
+  dontRewriteSymlinks = true;
+
   postPatch = ''
     patchShebangs meson/post_install.py
+  '';
+
+  postInstall = ''
+    # replace duplicate files with symlinks
+    jdupes -l -r $out/share/icons
   '';
 
   meta = with lib; {

--- a/pkgs/data/icons/moka-icon-theme/default.nix
+++ b/pkgs/data/icons/moka-icon-theme/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "moka-icon-theme";
-  version = "5.4.0";
+  version = "unstable-2019-05-29";
 
   src = fetchFromGitHub {
     owner = "snwh";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "015l02im4mha5z91dbchxf6xkp66d346bg3xskwg0rh3lglhjsrd";
+    rev = "c0355ea31e5cfdb6b44d8108f602d66817546a09";
+    sha256 = "0m4kfarkl94wdhsds2q1l9x5hfa9l3117l8j6j7qm7sf7yzr90c8";
   };
 
   nativeBuildInputs = [
@@ -30,9 +30,9 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "An icon theme designed with a minimal flat style using simple geometry and bright colours";
+    description = "Icon theme designed with a minimal flat style using simple geometry and bright colours";
     homepage = "https://snwh.org/moka";
-    license = with licenses; [ cc-by-sa-40 gpl3 ];
+    license = with licenses; [ cc-by-sa-40 gpl3Only ];
     # darwin cannot deal with file names differing only in case
     platforms = platforms.linux;
     maintainers = with maintainers; [ romildo ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Update the latest upstream commit
- Replace duplicate files with symlinks

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
