### PR TITLE
monosat, python3Packages.monosat: fix for non-x86

### DIFF
--- a/pkgs/applications/science/logic/monosat/default.nix
+++ b/pkgs/applications/science/logic/monosat/default.nix
@@ -28,9 +28,18 @@ let
     })
   ];
 
+  # source behind __linux__ check assumes system is also x86 and
+  # tries to disable x86/x87-specific extended precision mode
+  # https://github.com/sambayless/monosat/issues/33
+  commonPostPatch = lib.optionalString (!(stdenv.isi686 || stdenv.isx86_64)) ''
+    substituteInPlace src/monosat/Main.cc \
+      --replace 'defined(__linux__)' '0'
+  '';
+
   core = stdenv.mkDerivation {
     name = "${pname}-${version}";
     inherit src patches;
+    postPatch = commonPostPatch;
     nativeBuildInputs = [ cmake ];
     buildInputs = [ zlib gmp jdk8 ];
 
@@ -66,7 +75,7 @@ let
 
     # After patching src, move to where the actually relevant source is. This could just be made
     # the sourceRoot if it weren't for the patch.
-    postPatch = ''
+    postPatch = commonPostPatch + ''
       cd src/monosat/api/python
     '' +
     # The relative paths here don't make sense for our Nix build


### PR DESCRIPTION
###### Motivation for this change
ZHF: #144627 @NixOS/nixos-release-managers

Raised upstream @ https://github.com/sambayless/monosat/issues/33

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
