### PR TITLE
httping: pull upstream fix for ncurses-6.3

### DIFF
--- a/pkgs/tools/networking/httping/default.nix
+++ b/pkgs/tools/networking/httping/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, gettext, libintl, ncurses, openssl
+{ lib, stdenv, fetchurl, fetchpatch, gettext, libintl, ncurses, openssl
 , fftw ? null }:
 
 stdenv.mkDerivation rec {
@@ -9,6 +9,15 @@ stdenv.mkDerivation rec {
     url = "https://vanheusden.com/httping/${pname}-${version}.tgz";
     sha256 = "1y7sbgkhgadmd93x1zafqc4yp26ssiv16ni5bbi9vmvvdl55m29y";
   };
+
+  patches = [
+    # Upstream fix for ncurses-6.3.
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/folkertvanheusden/HTTPing/commit/4ea9d5b78540c972e3fe1bf44db9f7b3f87c0ad0.patch";
+      sha256 = "0w3kdkq6c6hz1d9jjnw0ldvd6dy39yamj8haf0hvcyb1sb67qjmp";
+    })
+  ];
 
   buildInputs = [ fftw libintl ncurses openssl ];
   nativeBuildInputs = [ gettext ];


### PR DESCRIPTION
Without the fix build on ncurses-6.3 fails as:

    nc.c:238:17: error: format not a string literal and no format arguments [-Werror=format-security]
      238 |                 wprintw(w, what);
          |                 ^~~~~~~
