### PR TITLE
Tuned: init at 2.16.0 

### DIFF
--- a/nixos/modules/services/hardware/tuned.nix
+++ b/nixos/modules/services/hardware/tuned.nix
@@ -1,0 +1,22 @@
+{ config, pkgs, lib, ... }:
+let
+  cfg = config.services.tuned;
+  p = pkgs.python39Packages.tuned;
+in
+{
+  options.services.tuned = {
+    enable = lib.mkEnableOption "tuned, a performance tuning daemon";
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ p ];
+    environment.etc.tuned = {
+      source = "${p}/etc/tuned";
+      mode = "0600";
+    };
+    systemd.packages = [ p ];
+    systemd.tmpfiles.packages = [ p ];
+    services.dbus.packages = [ p ];
+
+  };
+}

--- a/pkgs/tools/misc/tuned/default.nix
+++ b/pkgs/tools/misc/tuned/default.nix
@@ -1,0 +1,101 @@
+{ lib
+, python
+, fetchFromGitHub
+, installShellFiles
+, pyudev
+, python-linux-procfs
+, pyperf
+, pygobject3
+, configobj
+, dbus-python
+, gtk3
+, wrapGAppsHook
+, ethtool
+, gawk
+, hdparm
+}:
+python.pkgs.buildPythonApplication rec{
+  pname = "tuned";
+  version = "2.16.0";
+  src = fetchFromGitHub {
+    owner = "redhat-performance";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-v4U4GtTJnINmd390T0H1Bh4v7uw+SYWHpOdnML9lE3I=";
+  };
+
+  outputs = [ "out" "man" ]; #TODO:separate GUI output
+
+  propagatedBuildInputs = [
+    gawk
+    hdparm
+    ethtool
+    dbus-python
+    pyudev
+    python-linux-procfs
+    pyperf
+    pygobject3
+    configobj
+    gtk3
+    wrapGAppsHook
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  binNames = [ "tuned" "tuned-adm" "powertop2tuned" ];
+  libexecNames = [ "defirqaffinity.py" "pmqos-static.py" ]; #TODO: tuned-gui
+  postPatch = ''
+    cp ${./setup.py} setup.py
+    scripts='${builtins.toJSON
+      ((map (e: "bin/${e}") binNames)
+      ++ (map (e: "libexec/${e}") libexecNames))}' \
+      substituteAllInPlace setup.py
+    cp experiments/powertop2tuned.py .
+    for i in $binNames
+    do
+      install -D $i.py bin/$i
+      chmod a+x bin/$i
+    done
+  '';
+
+  postInstall = ''
+    installShellCompletion tuned-adm.bash
+    installManPage man/*
+
+    install -Dt $out/lib/systemd/system tuned.service
+    sed -i "s:/usr/sbin:$out/bin:g" $out/lib/systemd/system/tuned.service
+    install -Dt $out/lib/tmpfiles.d tuned.tmpfiles
+    install -Dt $out/share/polkit-1/actions com.redhat.tuned.policy
+    install -Dt $out/share/icons/hicolor/scalable/apps icons/tuned.svg
+    install -D dbus.conf $out/share/dbus-1/system.d/tuned.conf
+    install -D modules.conf $out/etc/modprobe.d/tuned.conf
+
+    mkdir -p $out/libexec/tuned
+    for i in $libexecNames
+    do
+      mv $out/bin/$i $out/libexec/tuned
+    done
+
+    etcTuned=$out/etc/tuned
+    install -Dt $etcTuned bootcmdline
+
+    libTuned=$out/lib/tuned
+    mv profiles $libTuned
+    mv $libTuned/{realtime/realtime,realtime-virtual-guest/realtime-virtual-guest,realtime-virtual-host/realtime-virtual-host,cpu-partitioning/cpu-partitioning}-variables.conf $etcTuned
+    install -D recommend.conf $libTuned/recommend.d/50-tuned.conf
+
+    #RHEL renamed pyperf to python-perf
+    ln -s ${pyperf}/${python.sitePackages}/pyperf $out/${python.sitePackages}/perf
+  '';
+
+  doCheck = false; # cannot import gimport.GTK
+
+  meta = with lib; {
+    description = " Tuning Profile Delivery Mechanism for Linux ";
+    homepage = "https://tuned-project.org/";
+    license = licenses.gpl2Only;
+    maintainers = [ maintainers.pasqui23 ];
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/tools/misc/tuned/default.nix
+++ b/pkgs/tools/misc/tuned/default.nix
@@ -56,6 +56,10 @@ python.pkgs.buildPythonApplication rec{
       install -D $i.py bin/$i
       chmod a+x bin/$i
     done
+    for f in tuned/consts.py tuned-adm.bash man/* profiles/*/*
+    do
+      substituteInPlace $f --replace /usr/lib $out/lib
+    done
   '';
 
   postInstall = ''
@@ -68,7 +72,6 @@ python.pkgs.buildPythonApplication rec{
     install -Dt $out/share/polkit-1/actions com.redhat.tuned.policy
     install -Dt $out/share/icons/hicolor/scalable/apps icons/tuned.svg
     install -D dbus.conf $out/share/dbus-1/system.d/tuned.conf
-    install -D modules.conf $out/etc/modprobe.d/tuned.conf
 
     mkdir -p $out/libexec/tuned
     for i in $libexecNames
@@ -82,6 +85,7 @@ python.pkgs.buildPythonApplication rec{
     libTuned=$out/lib/tuned
     mv profiles $libTuned
     mv $libTuned/{realtime/realtime,realtime-virtual-guest/realtime-virtual-guest,realtime-virtual-host/realtime-virtual-host,cpu-partitioning/cpu-partitioning}-variables.conf $etcTuned
+    touch $etcTuned/tuned-main.conf
     install -D recommend.conf $libTuned/recommend.d/50-tuned.conf
 
     #RHEL renamed pyperf to python-perf

--- a/pkgs/tools/misc/tuned/setup.py
+++ b/pkgs/tools/misc/tuned/setup.py
@@ -1,0 +1,10 @@
+import setuptools
+
+setuptools.setup(
+    name="@pname@",
+    version="@version@",
+    package_dir={"": "."},
+    packages=setuptools.find_packages(where="."),
+    python_requires=">=3.6",
+    scripts=@scripts@
+)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9408,6 +9408,8 @@ in {
   ttp = callPackage ../development/python-modules/ttp { };
 
   tubes = callPackage ../development/python-modules/tubes { };
+  
+  tuned = callPackage ../tools/misc/tuned/default.nix { };
 
   tunigo = callPackage ../development/python-modules/tunigo { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Tuned is a performance tuning daemon developed by red hat.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
