### PR TITLE
tree: fix build on darwin/others

### DIFF
--- a/pkgs/tools/system/tree/default.nix
+++ b/pkgs/tools/system/tree/default.nix
@@ -30,13 +30,15 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     sed -i Makefile -e 's|^OBJS=|OBJS=$(EXTRA_OBJS) |'
-    makeFlagsArray+=("CC=$CC")
+    makeFlagsArray+=(
+      ${systemFlags}
+      "CC=$CC"
+    )
   '';
 
   makeFlags = [
     "prefix=${placeholder "out"}"
     "MANDIR=${placeholder "out"}/share/man/man1"
-    systemFlags
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/145647 introduced a regression preventing this package from building on darwin and probably other obscure systems like cygwin and *bsd because these platforms have make flag strings specified. When passed in the `makeFlags` array, the CFLAGS string is incorrectly escaped causing an error like this:

```
> build flags: SHELL=/nix/store/wbwcrf1g7ywmmw2lllc26r0zcdvassiq-bash-5.1-p8/bin/bash prefix=/nix/store/iajwvfmjwf476bn
jzfi5mpkcmp1djxw3-tree-1.8.0 MANDIR=/nix/store/iajwvfmjwf476bnjzfi5mpkcmp1djxw3-tree-1.8.0/share/man/man1 CFLAGS=\"-O2 -Wall -
fomit-frame-pointer\" LDFLAGS= EXTRA_OBJS=strverscmp.o CC=clang 
       > make: omit-frame-pointer": No such file or directory
       > make: *** No rule to make target 'omit-frame-pointer"'.  Stop.
```

Reverting back to passing the extra make flags in `makeFlagsArray` fixes the build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
