### PR TITLE
lscolors: 0.8.0 -> 0.8.1

### DIFF
--- a/pkgs/applications/misc/lscolors/default.nix
+++ b/pkgs/applications/misc/lscolors/default.nix
@@ -2,19 +2,22 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "lscolors";
-  version = "0.8.0";
+  version = "0.8.1";
 
   src = fetchCrate {
     inherit version pname;
-    sha256 = "sha256-dwtrs9NlhJ+km2/146HMnDirWRB5Ur5LTmWdKAK03v0=";
+    sha256 = "sha256-74KNnERhyiZamVyS9yzDNVf33KMqDiSfPb5BCTKFuHA=";
   };
 
-  cargoSha256 = "sha256-vQnrLt+VSDPr61VMkYFtjSDnEt+NmWBZUd4qLzPzQBU=";
+  cargoSha256 = "sha256-mjGZ/q9BByndwfnFGk6k5KD9ctY0X0/oaEugiOJY8Ms=";
+
+  # setid is not allowed in the sandbox
+  checkFlags = [ "--skip=tests::style_for_setid" ];
 
   meta = with lib; {
     description = "Rust library and tool to colorize paths using LS_COLORS";
     homepage = "https://github.com/sharkdp/lscolors";
-    license = with licenses; [ asl20 mit ];
+    license = with licenses; [ asl20 /* or */ mit ];
     maintainers = with maintainers; [ SuperSandro2000 ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Updates lscolors to 0.8.1: https://github.com/sharkdp/lscolors/releases/tag/v0.8.1

Disables tests since they now attempt to create and set permissions on temporary files: https://github.com/sharkdp/lscolors/blob/c6e191b91f637058ba932a4f7b065f2e19d8a1ba/src/lib.rs#L577

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
