### PR TITLE
7zz: don't depend on p7zip for build

### DIFF
--- a/pkgs/tools/archivers/7zz/default.nix
+++ b/pkgs/tools/archivers/7zz/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, p7zip }:
+{ stdenv, lib, fetchurl, unar }:
 
 # https://sourceforge.net/p/sevenzip/discussion/45797/thread/7fe6c21efa/
 stdenv.mkDerivation rec {
@@ -6,9 +6,11 @@ stdenv.mkDerivation rec {
   version = "21.04";
 
   src = fetchurl {
-    url = "https://7-zip.org/a/7z${lib.replaceStrings ["." ] [""] version}-src.7z";
+    url = "https://7-zip.org/a/7z${lib.replaceStrings [ "." ] [ "" ] version}-src.7z";
     sha256 = "sha256-XmuEyIJAJQM0ZbgrW02lQ2rp4KFDBjLXKRaTfY+VCOg=";
   };
+
+  unpackCmd = "unar $src -D";
 
   sourceRoot = "CPP/7zip/Bundles/Alone2";
 
@@ -19,7 +21,7 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = [ "-Wno-error=maybe-uninitialized" ];
 
-  nativeBuildInputs = [ p7zip ];
+  nativeBuildInputs = [ unar ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`p7zip` is not maintained anymore, it was last updated on 2017-08-28.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
