### PR TITLE
python3Packages.graphviz: 0.18 -> 0.18.1

### DIFF
--- a/pkgs/development/python-modules/graphviz/default.nix
+++ b/pkgs/development/python-modules/graphviz/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "graphviz";
-  version = "0.18";
+  version = "0.18.1";
 
   disabled = pythonOlder "3.6";
 
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "xflr6";
     repo = "graphviz";
     rev = version;
-    sha256 = "sha256-K98CwG+V+EFwzyawVjRwVhbX2FVfoX7dCAD5PXAWTq8=";
+    sha256 = "sha256-Y3w9btjYvKfcEQGuAzV+o6edJ9VmVcWhc+ICOqy87uM=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/graphviz/paths.patch
+++ b/pkgs/development/python-modules/graphviz/paths.patch
@@ -1,8 +1,8 @@
 diff --git a/graphviz/backend/dot_command.py b/graphviz/backend/dot_command.py
-index d1903e6..6470d11 100644
+index 1e123d1..41e19c2 100644
 --- a/graphviz/backend/dot_command.py
 +++ b/graphviz/backend/dot_command.py
-@@ -10,7 +10,7 @@ from . import parameters
+@@ -11,7 +11,7 @@ from . import _common
  __all__ = ['command']
  
  #: :class:`pathlib.Path` of layout command (``Path('dot')``).
@@ -38,48 +38,38 @@ index 6d4a4d1..2cc6cd8 100644
      kwargs = {'stderr': subprocess.DEVNULL} if quiet else {}
      subprocess.Popen(cmd, **kwargs)
 diff --git a/tests/_common.py b/tests/_common.py
-index ab93461..7eaca89 100644
+index 87b4cbd..4188beb 100644
 --- a/tests/_common.py
 +++ b/tests/_common.py
-@@ -10,7 +10,7 @@ __all__ = ['EXPECTED_DOT_BINARY', 'EXPECTED_DEFAULT_ENCODING',
+@@ -14,9 +14,9 @@ __all__ = ['EXPECTED_DOT_BINARY', 'EXPECTED_UNFLATTEN_BINARY',
             'as_cwd',
             'check_startupinfo', 'StartupinfoMatcher']
  
--EXPECTED_DOT_BINARY = pathlib.Path('dot')
-+EXPECTED_DOT_BINARY = pathlib.Path('@graphviz@/bin/dot')
+-EXPECTED_DOT_BINARY = _compat.make_subprocess_arg(pathlib.Path('dot'))
++EXPECTED_DOT_BINARY = _compat.make_subprocess_arg(pathlib.Path('@graphviz@/bin/dot'))
+ 
+-EXPECTED_UNFLATTEN_BINARY = _compat.make_subprocess_arg(pathlib.Path('unflatten'))
++EXPECTED_UNFLATTEN_BINARY = _compat.make_subprocess_arg(pathlib.Path('@graphviz@/bin/unflatten'))
  
  EXPECTED_DEFAULT_ENCODING = 'utf-8'
  
 diff --git a/tests/backend/test_execute.py b/tests/backend/test_execute.py
-index 05d6525..78484cb 100644
+index 2cb853a..8093dfe 100644
 --- a/tests/backend/test_execute.py
 +++ b/tests/backend/test_execute.py
-@@ -57,6 +57,7 @@ def test_run_check_input_lines_mocked(mocker, sentinel, mock_popen,
-     mock_sys_stderr.flush.assert_called_once_with()
+@@ -15,6 +15,7 @@ def empty_path(monkeypatch):
+     monkeypatch.setenv('PATH', '')
  
  
 +@pytest.mark.skip(reason='empty $PATH has no effect')
  @pytest.mark.usefixtures('empty_path')
  @pytest.mark.parametrize(
      'func, args',
-diff --git a/tests/backend/test_unflattening.py b/tests/backend/test_unflattening.py
-index 033a4d2..7d52689 100644
---- a/tests/backend/test_unflattening.py
-+++ b/tests/backend/test_unflattening.py
-@@ -8,7 +8,7 @@ import graphviz
- 
- import _common
- 
--EXPECTED_UNFLATTEN_BINARY = pathlib.Path('unflatten')
-+EXPECTED_UNFLATTEN_BINARY = pathlib.Path('@graphviz@/bin/unflatten')
- 
- 
- @pytest.mark.exe
 diff --git a/tests/backend/test_viewing.py b/tests/backend/test_viewing.py
-index f5acddb..6b34884 100644
+index 59a23d5..f73f905 100644
 --- a/tests/backend/test_viewing.py
 +++ b/tests/backend/test_viewing.py
-@@ -25,6 +25,6 @@ def test_view(mocker, mock_platform, mock_popen, mock_startfile, quiet):
+@@ -26,6 +26,6 @@ def test_view_mocked(mocker, mock_platform, mock_popen, mock_startfile, quiet):
      if mock_platform == 'darwin':
          mock_popen.assert_called_once_with(['open', 'nonfilepath'], **kwargs)
      elif mock_platform in ('linux', 'freebsd'):


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/xflr6/graphviz/blob/0.18.1/CHANGES.rst

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
