### PR TITLE
jupyter_server: Patch unicode test for Darwin

### DIFF
--- a/pkgs/development/python-modules/jupyter_server/default.nix
+++ b/pkgs/development/python-modules/jupyter_server/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , buildPythonPackage
+, fetchpatch
 , fetchPypi
 , pythonOlder
 , pytestCheckHook
@@ -33,6 +34,13 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "c1f32e0c1807ab2de37bf70af97a36b4436db0bc8af3124632b1f4441038bf95";
   };
+
+  patches = [ (fetchpatch
+    { name = "Normalize-file-name-and-path.patch";
+      url = "https://github.com/jupyter-server/jupyter_server/pull/608/commits/345e26cdfd78651954b68708fa44119c2ac0dbd5.patch";
+      sha256 = "1kqz3dyh2w0h1g1fbvqa13q17hb6y32694rlaasyg213mq6g4k32";
+    })
+  ];
 
   propagatedBuildInputs = [
     argon2_cffi


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The test relies on creating and then reading files with unicode names
to/from disk. Apple's HFS+, the default file system until recently, is
unicode-normalizing with normal form D (NFD). So not all unicode file
names round-trip. This patch implements one imperfect solution.

ZHF: #144627

I've opened [a PR to implement this upstream](https://github.com/jupyter-server/jupyter_server/pull/608) to see if they're ok with this solution or would prefer an alternative but I haven't received a response yet. If upstream ends up deciding on a different solution I will update this PR or open a new one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
