### PR TITLE
kodi.packages.libretro-mgba: init at 0.9.2.31

### DIFF
--- a/pkgs/applications/video/kodi-packages/libretro-mgba/default.nix
+++ b/pkgs/applications/video/kodi-packages/libretro-mgba/default.nix
@@ -1,0 +1,31 @@
+{ lib, rel, buildKodiBinaryAddon, fetchFromGitHub, libretro, mgba }:
+
+buildKodiBinaryAddon rec {
+  pname = "kodi-libretro-mgba";
+  namespace = "game.libretro.mgba";
+  version = "0.9.2.31";
+
+  src = fetchFromGitHub {
+    owner = "kodi-game";
+    repo = "game.libretro.mgba";
+    rev = "${version}-${rel}";
+    sha256 = "sha256-eZLuNhLwMTtzpLGkymc9cLC83FQJWZ2ZT0iyz4sY4EA=";
+  };
+
+  extraCMakeFlags = [
+    "-DMGBA_LIB=${mgba}/lib/retroarch/cores/mgba_libretro.so"
+  ];
+
+  extraBuildInputs = [ mgba ];
+  propagatedBuildInputs = [
+    libretro
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/kodi-game/game.libretro.mgba";
+    description = "mGBA for Kodi";
+    platforms = platforms.all;
+    license = licenses.gpl2Only;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -3,7 +3,7 @@
 with lib;
 
 let
-  inherit (libretro) genesis-plus-gx snes9x;
+  inherit (libretro) genesis-plus-gx mgba snes9x;
 in
 
 let self = rec {
@@ -75,6 +75,8 @@ let self = rec {
   libretro = callPackage ../applications/video/kodi-packages/libretro { };
 
   libretro-genplus = callPackage ../applications/video/kodi-packages/libretro-genplus { inherit genesis-plus-gx; };
+
+  libretro-mgba = callPackage ../applications/video/kodi-packages/libretro-mgba { inherit mgba; };
 
   libretro-snes9x = callPackage ../applications/video/kodi-packages/libretro-snes9x { inherit snes9x; };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
more core

~~TODO: test~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
