### PR TITLE
_7zz: 22.00 -> 22.01; build on macOS

### DIFF
--- a/pkgs/tools/archivers/7zz/default.nix
+++ b/pkgs/tools/archivers/7zz/default.nix
@@ -2,9 +2,9 @@
 , lib
 , fetchurl
 
-  # Only used for x86/x86_64
+  # Only used for Linux's x86/x86_64
 , uasm
-, useUasm ? stdenv.hostPlatform.isx86
+, useUasm ? (stdenv.isLinux && stdenv.hostPlatform.isx86)
 
   # RAR code is under non-free unRAR license
   # see the meta.license section below for more details
@@ -16,13 +16,13 @@
 }:
 
 let
-  inherit (stdenv.hostPlatform) system;
-  platformSuffix = {
-    aarch64-linux = "_arm64";
-    i686-linux = "_x86";
-    x86_64-linux = "_x64";
-  }.${system} or
-    (builtins.trace "`platformSuffix` not available for `${system}.` Making a generic `7zz` build." "");
+  makefile = {
+    aarch64-darwin = "../../cmpl_mac_arm64.mak";
+    x86_64-darwin = "../../cmpl_mac_x64.mak";
+    aarch64-linux = "../../cmpl_gcc_arm64.mak";
+    i686-linux = "../../cmpl_gcc_x86.mak";
+    x86_64-linux = "../../cmpl_gcc_x64.mak";
+  }.${stdenv.hostPlatform.system} or "../../cmpl_gcc.mak"; # generic build
 in
 stdenv.mkDerivation rec {
   pname = "7zz";
@@ -51,27 +51,40 @@ stdenv.mkDerivation rec {
     '';
   };
 
-  sourceRoot = "CPP/7zip/Bundles/Alone2";
+  sourceRoot = ".";
+
+  patches = [ ./fix-build-on-darwin.patch ];
+  patchFlags = [ "-p0" ];
+
+  NIX_CFLAGS_COMPILE = lib.optionals stdenv.isDarwin [
+    "-Wno-deprecated-copy-dtor"
+  ];
+
+  inherit makefile;
 
   makeFlags =
     [
       "CC=${stdenv.cc.targetPrefix}cc"
       "CXX=${stdenv.cc.targetPrefix}c++"
-    ] ++
-    lib.optionals useUasm [ "MY_ASM=uasm" ] ++
+    ]
+    ++ lib.optionals useUasm [ "MY_ASM=uasm" ]
+    # We need at minimum 10.13 here because of utimensat, however since
+    # we need a bump anyway, let's set the same minimum version as the one in
+    # aarch64-darwin so we don't need additional changes for it
+    ++ lib.optionals stdenv.isDarwin [ "MACOSX_DEPLOYMENT_TARGET=10.16" ]
     # it's the compression code with the restriction, see DOC/License.txt
-    lib.optionals (!enableUnfree) [ "DISABLE_RAR_COMPRESS=true" ];
-
-  makefile = "../../cmpl_gcc${platformSuffix}.mak";
+    ++ lib.optionals (!enableUnfree) [ "DISABLE_RAR_COMPRESS=true" ];
 
   nativeBuildInputs = lib.optionals useUasm [ uasm ];
 
   enableParallelBuilding = true;
 
+  preBuild = "cd CPP/7zip/Bundles/Alone2";
+
   installPhase = ''
     runHook preInstall
 
-    install -Dm555 -t $out/bin b/g${platformSuffix}/7zz
+    install -Dm555 -t $out/bin b/*/7zz
     install -Dm444 -t $out/share/doc/${pname} ../../../../DOC/*.txt
 
     runHook postInstall
@@ -96,7 +109,7 @@ stdenv.mkDerivation rec {
       # the unRAR compression code is disabled by default
       lib.optionals enableUnfree [ unfree ];
     maintainers = with maintainers; [ anna328p peterhoeg jk ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     mainProgram = "7zz";
   };
 }

--- a/pkgs/tools/archivers/7zz/default.nix
+++ b/pkgs/tools/archivers/7zz/default.nix
@@ -26,13 +26,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "7zz";
-  version = "22.00";
+  version = "22.01";
 
   src = fetchurl {
     url = "https://7-zip.org/a/7z${lib.replaceStrings [ "." ] [ "" ] version}-src.tar.xz";
     hash = {
-      free = "sha256-QzGZgPxHobGwstFfVRtb4V+hqMM7dMIy2/EZcJ2aZe8=";
-      unfree = "sha256-QJafYB6Gr/Saqgug31zm/Tl89+JoOoS1kbAIHkYe9nU=";
+      free = "sha256-mp3cFXOEiVptkUdD1+X8XxwoJhBGs+Ns5qk3HBByfLg=";
+      unfree = "sha256-OTCYcwxwBCOSr4CJF+dllF3CQ33ueq48/MSWbrkg+8U=";
     }.${if enableUnfree then "unfree" else "free"};
     downloadToTemp = (!enableUnfree);
     # remove the unRAR related code from the src drv

--- a/pkgs/tools/archivers/7zz/fix-build-on-darwin.patch
+++ b/pkgs/tools/archivers/7zz/fix-build-on-darwin.patch
@@ -1,0 +1,24 @@
+diff -Naur CPP/7zip/Common/FileStreams.cpp CPP/7zip/Common/FileStreams.cpp
+--- CPP/7zip/Common/FileStreams.cpp
++++ CPP/7zip/Common/FileStreams.cpp
+@@ -12,7 +12,7 @@
+ #include <pwd.h>
+ 
+ // for major()/minor():
+-#if defined(__FreeBSD__) || defined(BSD)
++#if defined(__FreeBSD__) || defined(BSD) || defined(__APPLE__)
+ #include <sys/types.h>
+ #else
+ #include <sys/sysmacros.h>
+diff -Naur CPP/7zip/UI/Common/UpdateCallback.cpp CPP/7zip/UI/Common/UpdateCallback.cpp
+--- CPP/7zip/UI/Common/UpdateCallback.cpp
++++ CPP/7zip/UI/Common/UpdateCallback.cpp
+@@ -9,7 +9,7 @@
+ // #include <pwd.h>
+ 
+ // for major()/minor():
+-#if defined(__FreeBSD__) || defined(BSD)
++#if defined(__FreeBSD__) || defined(BSD) || defined(__APPLE__)
+ #include <sys/types.h>
+ #else
+ #include <sys/sysmacros.h>

--- a/pkgs/tools/archivers/7zz/update.sh
+++ b/pkgs/tools/archivers/7zz/update.sh
@@ -1,13 +1,14 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i bash -p coreutils gnused curl jq
+#! nix-shell -i bash -p coreutils gnused curl jq nix-prefetch
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 DRV_DIR="$PWD"
 
 OLD_VERSION="$(sed -nE 's/\s*version = "(.*)".*/\1/p' ./default.nix)"
-
-NEW_VERSION="$(curl "https://sourceforge.net/projects/sevenzip/best_release.json" | jq '.platform_releases.linux.filename' -r | cut -d/ -f3)"
+# The best_release.json is not always up-to-date
+# In those cases you can force the version by calling `./update.sh <newer_version>`
+NEW_VERSION="${1:-$(curl 'https://sourceforge.net/projects/sevenzip/best_release.json' | jq '.platform_releases.linux.filename' -r | cut -d/ -f3)}"
 
 echo "comparing versions $OLD_VERSION => $NEW_VERSION"
 if [[ "$OLD_VERSION" == "$NEW_VERSION" ]]; then

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -995,7 +995,7 @@ with pkgs;
 
   _6tunnel = callPackage ../tools/networking/6tunnel { };
 
-  _7zz = callPackage ../tools/archivers/7zz { };
+  _7zz = darwin.apple_sdk_11_0.callPackage ../tools/archivers/7zz { };
 
   _9pfs = callPackage ../tools/filesystems/9pfs { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

~~Right now it fails on `x86_64-darwin` with the following error:~~

```
../../../Windows/FileDir.cpp:1009:10: error: use of undeclared identifier 'utimensat'
  return utimensat(AT_FDCWD, path, times, flags) == 0
```

~~According to this [issue](https://gitlab.kitware.com/cmake/cmake/-/issues/17101), `utimensat` is only available on macOS SDK 10.13+.~~

~~So we probably need to wait until this issue is fixed: https://github.com/NixOS/nixpkgs/issues/101229~~

~~Maybe this works in `aarch64-darwin` though, since we use a newer SDK for it? If someone is interested to test, you're welcome.~~

Edit: working fine after the introduction of `darwin.apple_sdk_11_0.callPackage`, and also some additional patching.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
