### PR TITLE
mapnik: 3.1.0 -> unstable-2022-04-14

### DIFF
--- a/pkgs/development/libraries/mapnik/catch2-src.patch
+++ b/pkgs/development/libraries/mapnik/catch2-src.patch
@@ -1,0 +1,14 @@
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 0705ddce1..771291b88 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -7,8 +7,7 @@ include(FetchContent)
+ 
+ FetchContent_Declare(
+   Catch2
+-  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+-  GIT_TAG        v2.13.7)
++  SOURCE_DIR @catch2_src@)
+ FetchContent_MakeAvailable(Catch2)
+ 
+ if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.19.0") 

--- a/pkgs/development/libraries/mapnik/cmake-harfbuzz.patch
+++ b/pkgs/development/libraries/mapnik/cmake-harfbuzz.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f2dc1f02d..739b8ae99 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -153,19 +153,8 @@ endif()
+ 
+ mapnik_find_package(Freetype REQUIRED)
+ 
+-# try to find harfbuzz with the native configuration and fallback to our "own" FindHarfBuzz
+-mapnik_find_package(harfbuzz CONFIG QUIET)
+-if(harfbuzz_FOUND)
+-    message(STATUS "Found harfbuzz native cmake")
+-    list(APPEND MAPNIK_OPTIONAL_LIBS harfbuzz::harfbuzz)
+-else()
+-    # Use pkg-config when harfbuzz is not found. 
+-    # It might be possible that in future version harfbuzz could only be found via pkg-config.
+-    # harfbuzz related discussion: https://github.com/harfbuzz/harfbuzz/issues/2653
+-    message(STATUS "harfbuzz not found via cmake. Searching via pkg-config...")
+-    pkg_check_modules(harfbuzz REQUIRED IMPORTED_TARGET harfbuzz>=${HARFBUZZ_MIN_VERSION})
+-    list(APPEND MAPNIK_OPTIONAL_LIBS PkgConfig::harfbuzz)
+-endif()
++pkg_check_modules(harfbuzz REQUIRED IMPORTED_TARGET harfbuzz)
++list(APPEND MAPNIK_OPTIONAL_LIBS PkgConfig::harfbuzz)
+ 
+ if(USE_EXTERNAL_MAPBOX_GEOMETRY)
+     # this is used to provide a way to specify include dirs with CACHE VARIABLES

--- a/pkgs/development/libraries/mapnik/default.nix
+++ b/pkgs/development/libraries/mapnik/default.nix
@@ -1,111 +1,110 @@
-{ lib, stdenv, fetchzip
-, boost, cairo, freetype, gdal, harfbuzz, icu, libjpeg, libpng, libtiff
-, libwebp, libxml2, proj, python3, python ? python3, sqlite, zlib
-, sconsPackages
-
-# supply a postgresql package to enable the PostGIS input plugin
-, postgresql ? null
+{ lib
+, stdenv
+, fetchFromGitHub
+, buildPackages
+, cmake
+, pkg-config
+, substituteAll
+, boost
+, cairo
+, freetype
+, gdal
+, harfbuzz
+, icu
+, libjpeg
+, libpng
+, libtiff
+, libwebp
+, libxml2
+, proj
+, python3
+, sqlite
+, zlib
+, catch2
+, postgresql
 }:
 
-let
-  scons = sconsPackages.scons_3_0_1;
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "mapnik";
-  version = "3.1.0";
+  version = "unstable-2022-04-14";
 
-  src = fetchzip {
-    # this one contains all git submodules and is cheaper than fetchgit
-    url = "https://github.com/mapnik/mapnik/releases/download/v${version}/mapnik-v${version}.tar.bz2";
-    sha256 = "sha256-qqPqN4vs3ZsqKgnx21yQhX8OzHca/0O+3mvQ/vnC5EY=";
+  src = fetchFromGitHub {
+    owner = "mapnik";
+    repo = "mapnik";
+    rev = "1ba1278b4227ccd887a95880d1c75aa6446132fc";
+    sha256 = "sha256-dtu+PKpK/crO5cZje0aj+vB9beG0eU6fyT9GNtvvtbM=";
+    fetchSubmodules = true;
   };
 
   postPatch = ''
     substituteInPlace configure \
-      --replace '$PYTHON scons/scons.py' ${scons}/bin/scons
+      --replace '$PYTHON scons/scons.py' ${buildPackages.scons}/bin/scons
     rm -r scons
   '';
 
   # a distinct dev output makes python-mapnik fail
   outputs = [ "out" ];
 
-  nativeBuildInputs = [ scons ];
+  patches = [
+    # The lib/cmake/harfbuzz/harfbuzz-config.cmake file in harfbuzz.dev is faulty,
+    # as it provides the wrong libdir. The workaround is to just rely on
+    # pkg-config to locate harfbuzz shared object files.
+    # Upstream HarfBuzz wants to drop CMake support anyway.
+    # See discussion: https://github.com/mapnik/mapnik/issues/4265
+    ./cmake-harfbuzz.patch
+    # prevent CMake from trying to get libraries on the Internet
+    (substituteAll {
+      src = ./catch2-src.patch;
+      catch2_src = catch2.src;
+    })
+    ./include.patch
+  ];
+
+  nativeBuildInputs = [ cmake pkg-config ];
 
   buildInputs = [
-    boost cairo freetype gdal harfbuzz icu libjpeg libpng libtiff
-    libwebp proj python sqlite zlib
-
-    # optional inputs
+    boost
+    cairo
+    freetype
+    gdal
+    harfbuzz
+    icu
+    libjpeg
+    libpng
+    libtiff
+    libwebp
+    proj
+    python3
+    sqlite
+    zlib
+    libxml2
     postgresql
   ];
 
-  propagatedBuildInputs = [ libxml2 ];
+  cmakeFlags = [
+    # Would require qt otherwise.
+    "-DBUILD_DEMO_VIEWER=OFF"
+  ];
 
-  prefixKey = "PREFIX=";
-
-  preConfigure = ''
-    patchShebangs ./configure
+  # mapnik-config is currently not build with CMake. So we use the SCons for
+  # this one. We can't add SCons to nativeBuildInputs though, as stdenv would
+  # then try to build everything with scons.
+  preBuild = ''
+    cd ..
+    ${buildPackages.scons}/bin/scons utils/mapnik-config
+    cd build
   '';
 
-  # NOTE: 2021-05-06:
-  # Add -DACCEPT_USE_OF_DEPRECATED_PROJ_API_H=1 for backwards compatibility
-  # with major versions 6 and 7 of proj which are otherwise not compatible
-  # with mapnik 3.1.0. Note that:
-  #
-  # 1. Starting with proj version 8, this workaround will no longer be
-  #    supported by the upstream proj project.
-  #
-  # 2. Without the workaround, mapnik configures itself without proj support.
-  #
-  # 3. The master branch of mapnik (after 3.1.0) appears to add native support
-  #    for the proj 6 api, so this workaround is not likely to be needed in
-  #    subsequent mapnik releases. At that point, this block comment and the
-  #    NIX_CFLAGS_COMPILE expression can be removed.
-
-  NIX_CFLAGS_COMPILE =
-    if version != "3.1.0" && lib.versionAtLeast version "3.1.0"
-    then throw "The mapnik compatibility workaround for proj 6 may no longer be required. Remove workaround after checking."
-    else if lib.versionAtLeast (lib.getVersion proj) "8"
-    then throw ("mapnik currently requires a version of proj less than 8, but proj version is: " + (lib.getVersion proj))
-    else "-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H=1";
-
-  configureFlags = [
-    "BOOST_INCLUDES=${boost.dev}/include"
-    "BOOST_LIBS=${boost.out}/lib"
-    "CAIRO_INCLUDES=${cairo.dev}/include"
-    "CAIRO_LIBS=${cairo.out}/lib"
-    "FREETYPE_INCLUDES=${freetype.dev}/include"
-    "FREETYPE_LIBS=${freetype.out}/lib"
-    "GDAL_CONFIG=${gdal}/bin/gdal-config"
-    "HB_INCLUDES=${harfbuzz.dev}/include"
-    "HB_LIBS=${harfbuzz.out}/lib"
-    "ICU_INCLUDES=${icu.dev}/include"
-    "ICU_LIBS=${icu.out}/lib"
-    "JPEG_INCLUDES=${libjpeg.dev}/include"
-    "JPEG_LIBS=${libjpeg.out}/lib"
-    "PNG_INCLUDES=${libpng.dev}/include"
-    "PNG_LIBS=${libpng.out}/lib"
-    "PROJ_INCLUDES=${proj.dev}/include"
-    "PROJ_LIBS=${proj.out}/lib"
-    "SQLITE_INCLUDES=${sqlite.dev}/include"
-    "SQLITE_LIBS=${sqlite.out}/lib"
-    "TIFF_INCLUDES=${libtiff.dev}/include"
-    "TIFF_LIBS=${libtiff.out}/lib"
-    "WEBP_INCLUDES=${libwebp}/include"
-    "WEBP_LIBS=${libwebp}/lib"
-    "XMLPARSER=libxml2"
-  ];
-
-  buildFlags = [
-    "JOBS=$(NIX_BUILD_CORES)"
-  ];
+  preInstall = ''
+    mkdir -p $out/bin
+    cp ../utils/mapnik-config/mapnik-config $out/bin/mapnik-config
+  '';
 
   meta = with lib; {
     description = "An open source toolkit for developing mapping applications";
     homepage = "https://mapnik.org";
     maintainers = with maintainers; [ hrdinka erictapen ];
-    license = licenses.lgpl21;
+    license = licenses.lgpl21Plus;
     platforms = platforms.all;
-    # https://github.com/mapnik/mapnik/issues/4232
-    broken = lib.versionAtLeast proj.version "8.0.0";
   };
 }

--- a/pkgs/development/libraries/mapnik/include.patch
+++ b/pkgs/development/libraries/mapnik/include.patch
@@ -1,0 +1,11 @@
+diff --git a/benchmark/src/test_png_encoding2.cpp b/benchmark/src/test_png_encoding2.cpp
+index 19897d180..5791b139c 100644
+--- a/benchmark/src/test_png_encoding2.cpp
++++ b/benchmark/src/test_png_encoding2.cpp
+@@ -1,5 +1,6 @@
+ #include "bench_framework.hpp"
+ #include "compare_images.hpp"
++#include <memory>
+ 
+ class test : public benchmark::test_case
+ {

--- a/pkgs/development/python-modules/python-mapnik/default.nix
+++ b/pkgs/development/python-modules/python-mapnik/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
+, substituteAll
 , isPyPy
 , python
 , pillow
@@ -17,35 +19,43 @@
 , mapnik
 , proj
 , zlib
+, libxml2
+, sqlite
+, nose
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "python-mapnik";
-  version = "unstable-2020-02-24";
+  version = "unstable-2020-09-08";
 
   src = fetchFromGitHub {
     owner = "mapnik";
     repo = "python-mapnik";
-    rev = "7da019cf9eb12af8f8aa88b7d75789dfcd1e901b";
-    sha256 = "0snn7q7w1ab90311q8wgd1z64kw1svm5w831q0xd6glqhah86qc8";
+    rev = "a2c2a86eec954b42d7f00093da03807d0834b1b4";
+    hash = "sha256-GwDdrutJOHtW7pIWiUAiu1xucmRvp7YFYB3YSCrDsrY=";
+    # Only needed for test data
+    fetchSubmodules = true;
   };
 
-  disabled = isPyPy;
-  doCheck = false; # doesn't find needed test data files
-  preBuild = ''
-    export BOOST_PYTHON_LIB="boost_python${"${lib.versions.major python.version}${lib.versions.minor python.version}"}"
-    export BOOST_THREAD_LIB="boost_thread"
-    export BOOST_SYSTEM_LIB="boost_system"
-    export PYCAIRO=true
-  '';
+  patches = [
+    # https://github.com/mapnik/python-mapnik/issues/239
+    (fetchpatch {
+      url = "https://github.com/koordinates/python-mapnik/commit/318b1edac16f48a7f21902c192c1dd86f6210a44.patch";
+      sha256 = "sha256-cfU8ZqPPGCqoHEyGvJ8Xy/bGpbN2vSDct6A3N5+I8xM=";
+    })
+    ./find-pycairo-with-pkg-config.patch
+    # python-mapnik seems to depend on having the mapnik src directory
+    # structure available at build time. We just hardcode the paths.
+    (substituteAll {
+      src = ./find-libmapnik.patch;
+      libmapnik = "${mapnik}/lib";
+    })
+  ];
 
   nativeBuildInputs = [
     mapnik # for mapnik_config
     pkg-config
-  ];
-
-  patches = [
-    ./find-pycairo-with-pkg-config.patch
   ];
 
   buildInputs = [
@@ -60,9 +70,65 @@ buildPythonPackage rec {
     libwebp
     proj
     zlib
+    libxml2
+    sqlite
   ];
 
   propagatedBuildInputs = [ pillow pycairo ];
+
+  configureFlags = [
+    "XMLPARSER=libxml2"
+  ];
+
+  disabled = isPyPy;
+
+  preBuild = ''
+    export BOOST_PYTHON_LIB="boost_python${"${lib.versions.major python.version}${lib.versions.minor python.version}"}"
+    export BOOST_THREAD_LIB="boost_thread"
+    export BOOST_SYSTEM_LIB="boost_system"
+    export PYCAIRO=true
+    export XMLPARSER=libxml2
+  '';
+
+  checkInputs = [
+    nose
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    # import from $out
+    rm -r mapnik
+  '';
+
+  # https://github.com/mapnik/python-mapnik/issues/255
+  disabledTests = [
+    "test_adding_datasource_to_layer"
+    "test_compare_map"
+    "test_dataraster_coloring"
+    "test_dataraster_query_point"
+    "test_good_files"
+    "test_layer_init"
+    "test_load_save_map"
+    "test_loading_fontset_from_map"
+    "test_normalizing_definition"
+    "test_pdf_printing"
+    "test_proj_antimeridian_bbox"
+    "test_proj_transform_between_init_and_literal"
+    "test_pycairo_pdf_surface1"
+    "test_pycairo_svg_surface1"
+    "test_query_tolerance"
+    "test_raster_warping"
+    "test_raster_warping_does_not_overclip_source"
+    "test_render_points"
+    "test_render_with_scale_factor"
+    "test_style_level_image_filter"
+    "test_that_coordinates_do_not_overflow_and_polygon_is_rendered_csv"
+    "test_that_coordinates_do_not_overflow_and_polygon_is_rendered_memory"
+    "test_transparency_levels"
+    "test_visual_zoom_all_rendering1"
+    "test_visual_zoom_all_rendering2"
+    "test_wgs84_inverse_forward"
+  ];
 
   pythonImportsCheck = [ "mapnik" ];
 
@@ -70,6 +136,6 @@ buildPythonPackage rec {
     description = "Python bindings for Mapnik";
     maintainers = with maintainers; [ erictapen ];
     homepage = "https://mapnik.org";
-    license = licenses.lgpl21;
+    license = licenses.lgpl21Plus;
   };
 }

--- a/pkgs/development/python-modules/python-mapnik/find-libmapnik.patch
+++ b/pkgs/development/python-modules/python-mapnik/find-libmapnik.patch
@@ -1,0 +1,30 @@
+diff --git a/build.py b/build.py
+index 0f94826b6..3cceb4546 100644
+--- a/build.py
++++ b/build.py
+@@ -110,8 +110,8 @@ py_env.AppendUnique(LIBS='mapnik-wkt')
+ _mapnik = py_env.LoadableModule('mapnik/_mapnik', sources, LDMODULEPREFIX='', LDMODULESUFFIX='.so')
+ 
+ Depends(_mapnik, env.subst('../../src/%s' % env['MAPNIK_LIB_NAME']))
+-Depends(_mapnik, env.subst('../../src/json/libmapnik-json${LIBSUFFIX}'))
+-Depends(_mapnik, env.subst('../../src/wkt/libmapnik-wkt${LIBSUFFIX}'))
++Depends(_mapnik, env.subst('@libmapnik@/libmapnikjson${LIBSUFFIX}'))
++Depends(_mapnik, env.subst('@libmapnik@/libmapnikwkt${LIBSUFFIX}'))
+ 
+ if 'uninstall' not in COMMAND_LINE_TARGETS:
+     pymapniklib = env.Install(target_path,_mapnik)
+diff --git a/setup.py b/setup.py
+index 9985da5a2..5a03a1ec8 100755
+--- a/setup.py
++++ b/setup.py
+@@ -118,8 +118,8 @@ linkflags.extend(check_output([mapnik_config, '--libs']).split(' '))
+ linkflags.extend(check_output([mapnik_config, '--ldflags']).split(' '))
+ linkflags.extend(check_output([mapnik_config, '--dep-libs']).split(' '))
+ linkflags.extend([
+-'-lmapnik-wkt',
+-'-lmapnik-json',
++'-lmapnikwkt',
++'-lmapnikjson',
+ ] + ['-l%s' % i for i in get_boost_library_names()])
+ 
+ # Dynamically make the mapnik/paths.py file

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19937,15 +19937,11 @@ with pkgs;
   opencl-clang = callPackage ../development/libraries/opencl-clang { };
 
   mapnik = callPackage ../development/libraries/mapnik {
-    gdal = gdal.override {
-      libgeotiff = libgeotiff.override { proj = proj_7; };
-      libspatialite = libspatialite.override { proj = proj_7; };
-      proj = proj_7;
+    harfbuzz = harfbuzz.override {
+      withIcu = true;
     };
-    proj = proj_7;
     boost = boost175;
   };
-
 
   marisa = callPackage ../development/libraries/marisa {};
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8657,7 +8657,7 @@ in {
     inherit (pkgs) pkg-config cairo harfbuzz icu libjpeg libpng libtiff libwebp proj zlib;
     inherit boost;
     mapnik = pkgs.mapnik.override {
-      inherit python boost;
+      inherit boost;
     };
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8648,16 +8648,17 @@ in {
 
   python-manilaclient = callPackage ../development/python-modules/python-manilaclient { };
 
-  python-mapnik = let
+  python-mapnik = callPackage ../development/python-modules/python-mapnik rec {
+    inherit (pkgs) pkg-config cairo icu libjpeg libpng libtiff libwebp proj zlib;
     boost = pkgs.boost175.override {
       enablePython = true;
       inherit python;
     };
-  in callPackage ../development/python-modules/python-mapnik {
-    inherit (pkgs) pkg-config cairo harfbuzz icu libjpeg libpng libtiff libwebp proj zlib;
-    inherit boost;
+    harfbuzz = pkgs.harfbuzz.override {
+      withIcu = true;
+    };
     mapnik = pkgs.mapnik.override {
-      inherit boost;
+      inherit boost harfbuzz;
     };
   };
 


### PR DESCRIPTION

###### Motivation for this change

Mapnik is currently broken, so I don't see any other choice than to use current master. I also bumped python-mapnik to latest master and fixed the build.

It required some minor patches, that I'm willing to maintain for future releases.

###### Things done

```
    mapnik: 3.1.0 -> unstable-2021-11-02
    
    - use CMake. I just didn't got it to work with SCons.
    - patch cmake to find harfbuzz
    - prefetch catch2 for enabling tests
    - add myself as maintainer
    - build mapnik-config with scons, as it isn't build by cmake
    - use python3 exclusively
    - build with harfbuzz-icu
    - change license to lgpl21Plus
```

```
    python3Packages.python-mapnik: unstable-2020-02-24 -> unstable-2020-09-08
    
    Also:
    
    - use libxml2 for xml parsing
    - use newest boost
    - patch to find libmapnik{json,wkt}.a
    - fix license
    - add myself as maintainer
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
