### PR TITLE
raylib: 3.7.0 -> 4.0.0

### DIFF
--- a/pkgs/development/libraries/raylib/default.nix
+++ b/pkgs/development/libraries/raylib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, cmake,
+{ stdenv, lib, fetchFromGitHub, cmake,
   mesa, libGLU, glfw,
   libX11, libXi, libXcursor, libXrandr, libXinerama,
   alsaSupport ? stdenv.hostPlatform.isLinux, alsa-lib,
@@ -9,22 +9,14 @@
 
 stdenv.mkDerivation rec {
   pname = "raylib";
-  version = "3.7.0";
+  version = "4.0.0";
 
   src = fetchFromGitHub {
     owner = "raysan5";
     repo = pname;
     rev = version;
-    sha256 = "1w8v747hqy0ils6zmy8sm056f24ybjhn9bamqzlxvbqhvh9vvly1";
+    sha256 = "1mszf5v7qy38cv1fisq6xd9smb765hylhkv1ms9y7shmdl2ni6b7";
   };
-
-  patches = [
-    # fixes incorrect version being set by cmake
-    (fetchpatch {
-      url = "https://github.com/raysan5/raylib/commit/204aa4c46fdd6986aa0130eeba658562c540759f.patch";
-      sha256 = "10pl7828iy4kadach0wy4fs95vr7k08z3mxw90j8dm9xak1ri8fz";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [


### PR DESCRIPTION

###### Motivation for this change
I've removed a patch that doesn't seem to be required anymore.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
