### PR TITLE
neovide: fix build on darwin

### DIFF
--- a/pkgs/applications/editors/neovim/neovide/default.nix
+++ b/pkgs/applications/editors/neovim/neovide/default.nix
@@ -20,7 +20,18 @@
 , stdenv
 , enableWayland ? stdenv.isLinux
 , wayland
+, xcbuild
 , xorg
+# Apple frameworks
+, AppKit
+, ApplicationServices
+, Carbon
+, CoreFoundation
+, CoreGraphics
+, CoreVideo
+, Foundation
+, OpenGL
+, QuartzCore
 }:
 rustPlatform.buildRustPackage rec {
   pname = "neovide";
@@ -73,6 +84,8 @@ rustPlatform.buildRustPackage rec {
     makeWrapper
     python2 # skia-bindings
     llvmPackages.clang # skia
+  ] ++ lib.optionals stdenv.isDarwin [
+    xcbuild
   ];
 
   # All tests passes but at the end cargo prints for unknown reason:
@@ -96,6 +109,16 @@ rustPlatform.buildRustPackage rec {
         }))
       ];
     }))
+  ] ++ lib.optionals stdenv.isDarwin [
+    AppKit
+    ApplicationServices
+    Carbon
+    CoreFoundation
+    CoreGraphics
+    CoreVideo
+    Foundation
+    OpenGL
+    QuartzCore
   ];
 
   postFixup = let

--- a/pkgs/build-support/rust/default-crate-overrides.nix
+++ b/pkgs/build-support/rust/default-crate-overrides.nix
@@ -212,6 +212,10 @@ in
     buildInputs = [ freetype ];
   };
 
+  skia-bindings = attrs: {
+    nativeBuildInputs = lib.optionals stdenv.isDarwin [ xcbuild ];
+  };
+
   thrussh-libsodium = attrs: {
     nativeBuildInputs = [ pkg-config ];
     buildInputs = [ libsodium ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28673,7 +28673,18 @@ with pkgs;
 
   gnvim = callPackage ../applications/editors/neovim/gnvim/wrapper.nix { };
 
-  neovide = callPackage ../applications/editors/neovim/neovide { };
+  neovide = callPackage ../applications/editors/neovim/neovide {
+    inherit (darwin.apple_sdk.frameworks)
+      AppKit
+      ApplicationServices
+      Carbon
+      CoreFoundation
+      CoreGraphics
+      CoreVideo
+      Foundation
+      OpenGL
+      QuartzCore;
+  };
 
   neovim-remote = callPackage ../applications/editors/neovim/neovim-remote.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

Part of fixing the build on `aarch64-darwin`: https://github.com/NixOS/nixpkgs/issues/145523

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
