### PR TITLE
python3Packages.mypy: 0.812 -> unstable-2021-11-14

### DIFF
--- a/pkgs/development/python-modules/hydra-check/default.nix
+++ b/pkgs/development/python-modules/hydra-check/default.nix
@@ -6,6 +6,7 @@
 , requests
 , beautifulsoup4
 , mypy
+, types-requests
 }:
 
 buildPythonPackage rec {
@@ -26,14 +27,17 @@ buildPythonPackage rec {
     beautifulsoup4
   ];
 
-  checkInputs = [ mypy ];
+  checkInputs = [
+    mypy
+    types-requests
+  ];
 
   checkPhase = ''
     echo -e "\x1b[32m## run mypy\x1b[0m"
     mypy hydracheck
   '';
 
-  meta = with lib;{
+  meta = with lib; {
     description = "check hydra for the build status of a package";
     homepage = "https://github.com/nix-community/hydra-check";
     license = licenses.mit;

--- a/pkgs/development/python-modules/mypy/default.nix
+++ b/pkgs/development/python-modules/mypy/default.nix
@@ -12,6 +12,12 @@ buildPythonPackage rec {
     sha256 = "069i9qnfanp7dn8df1vspnqb0flvsszzn22v00vj08nzlnd061yd";
   };
 
+  # remove pin with mypy>=0.920
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "typed_ast >= 1.4.0, < 1.5.0" "typed_ast >= 1.4.0, < 2"
+  '';
+
   propagatedBuildInputs = [ typed-ast psutil mypy-extensions typing-extensions ];
 
   # Tests not included in pip package.

--- a/pkgs/development/python-modules/mypy/default.nix
+++ b/pkgs/development/python-modules/mypy/default.nix
@@ -1,34 +1,63 @@
-{ lib, stdenv, fetchPypi, buildPythonPackage, typed-ast, psutil, isPy3k
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, buildPythonPackage
 , mypy-extensions
+, python
+, pythonOlder
+, typed-ast
 , typing-extensions
+, tomli
+, types-typed-ast
 }:
+
 buildPythonPackage rec {
   pname = "mypy";
-  version = "0.812";
-  disabled = !isPy3k;
+  version = "unstable-2021-11-14";
+  disabled = pythonOlder "3.6";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "069i9qnfanp7dn8df1vspnqb0flvsszzn22v00vj08nzlnd061yd";
+  src = fetchFromGitHub {
+    owner = "python";
+    repo = "mypy";
+    rev = "053a1beb94ee4e5b3260725594315d1b6776e42f";
+    sha256 = "sha256-q2ntj3y3GgXrw4v+yMvcqWFv4y/6YwunIj3bNzU9CH0=";
   };
 
-  # remove pin with mypy>=0.920
+  patches = [
+    # FIXME: Remove patch after upstream has decided the proper solution.
+    #        https://github.com/python/mypy/pull/11143
+    (fetchpatch {
+      url = "https://github.com/python/mypy/commit/f1755259d54330cd087cae763cd5bbbff26e3e8a.patch";
+      sha256 = "sha256-5gPahX2X6+/qUaqDQIGJGvh9lQ2EDtks2cpQutgbOHk=";
+    })
+  ];
+
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "typed_ast >= 1.4.0, < 1.5.0" "typed_ast >= 1.4.0, < 2"
+      --replace "tomli>=1.1.0,<1.2.0" "tomli"
   '';
 
-  propagatedBuildInputs = [ typed-ast psutil mypy-extensions typing-extensions ];
+  buildInputs = [
+    types-typed-ast
+  ];
+
+  propagatedBuildInputs = [
+    mypy-extensions
+    tomli
+    typed-ast
+    typing-extensions
+  ];
 
   # Tests not included in pip package.
   doCheck = false;
 
   pythonImportsCheck = [
     "mypy"
-    "mypy.types"
     "mypy.api"
     "mypy.fastparse"
     "mypy.report"
+    "mypy.types"
     "mypyc"
     "mypyc.analysis"
   ];
@@ -38,10 +67,13 @@ buildPythonPackage rec {
   # is64bit: unfortunately the build would exhaust all possible memory on i686-linux.
   MYPY_USE_MYPYC = stdenv.buildPlatform.is64bit;
 
+  # when testing reduce optimisation level to drastically reduce build time
+  MYPYC_OPT_LEVEL = 1;
+
   meta = with lib; {
     description = "Optional static typing for Python";
-    homepage    = "http://www.mypy-lang.org";
-    license     = licenses.mit;
-    maintainers = with maintainers; [ martingms lnl7 ];
+    homepage = "http://www.mypy-lang.org";
+    license = licenses.mit;
+    maintainers = with maintainers; [ martingms lnl7 SuperSandro2000 ];
   };
 }

--- a/pkgs/development/python-modules/mypy/extensions.nix
+++ b/pkgs/development/python-modules/mypy/extensions.nix
@@ -13,12 +13,12 @@ buildPythonPackage rec {
     sha256 = "2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8";
   };
 
-  propagatedBuildInputs = if pythonOlder "3.5" then [ typing ] else [ ];
+  propagatedBuildInputs = lib.optional (pythonOlder "3.5") typing;
 
   meta = with lib; {
     description = "Experimental type system extensions for programs checked with the mypy typechecker";
-    homepage    = "http://www.mypy-lang.org";
-    license     = licenses.mit;
-    maintainers = with maintainers; [ martingms lnl7 ];
+    homepage = "http://www.mypy-lang.org";
+    license = licenses.mit;
+    maintainers = with maintainers; [ martingms lnl7 SuperSandro2000 ];
   };
 }

--- a/pkgs/development/python-modules/pylsp-mypy/default.nix
+++ b/pkgs/development/python-modules/pylsp-mypy/default.nix
@@ -20,9 +20,15 @@ buildPythonPackage rec {
     sha256 = "1d119csj1k5m9j0f7wdvpvnd02h548css6ybxqah92nk2v0rjscr";
   };
 
+  disabledTests = [
+    "test_multiple_workspaces"
+  ];
+
   checkInputs = [ pytestCheckHook mock ];
 
   propagatedBuildInputs = [ mypy python-lsp-server ];
+
+  pythonImportsCheck = [ "pylsp_mypy" ];
 
   meta = with lib; {
     homepage = "https://github.com/Richardk2n/pylsp-mypy";

--- a/pkgs/development/python-modules/python-language-server/default.nix
+++ b/pkgs/development/python-modules/python-language-server/default.nix
@@ -84,6 +84,8 @@ buildPythonPackage rec {
     homepage = "https://github.com/palantir/python-language-server";
     description = "An implementation of the Language Server Protocol for Python";
     license = licenses.mit;
+    # not compatible with jedi 0.18.0
+    broken = true;
     maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/tomli/default.nix
+++ b/pkgs/development/python-modules/tomli/default.nix
@@ -7,7 +7,7 @@
 
 buildPythonPackage rec {
   pname = "tomli";
-  version = "1.2.1";
+  version = "1.2.2";
   format = "pyproject";
 
   outputs = [
@@ -19,8 +19,13 @@ buildPythonPackage rec {
     owner = "hukkin";
     repo = pname;
     rev = version;
-    sha256 = "sha256-30AQ9MQmclcjl1d83mIoxFXzaJn1OFKQlVxayqC5NxY=";
+    sha256 = "sha256-oDjpNzWxTaCC1+WyBKrkR6kp90ZomcZQfyW+xKddDoM=";
   };
+
+  patches = [
+    # required for mypy
+    ./fix-backwards-compatibility-load.patch
+  ];
 
   nativeBuildInputs = [ flit-core ];
 

--- a/pkgs/development/python-modules/tomli/fix-backwards-compatibility-load.patch
+++ b/pkgs/development/python-modules/tomli/fix-backwards-compatibility-load.patch
@@ -1,0 +1,21 @@
+diff --git a/tomli/_parser.py b/tomli/_parser.py
+index 89e81c3..6fb1bfd 100644
+--- a/tomli/_parser.py
++++ b/tomli/_parser.py
+@@ -1,6 +1,6 @@
+ import string
+ from types import MappingProxyType
+-from typing import Any, BinaryIO, Dict, FrozenSet, Iterable, NamedTuple, Optional, Tuple
++from typing import IO, Union, Any, BinaryIO, Dict, FrozenSet, Iterable, NamedTuple, Optional, Tuple
+ import warnings
+ 
+ from tomli._re import (
+@@ -48,7 +48,7 @@ class TOMLDecodeError(ValueError):
+     """An error raised if a document is not valid TOML."""
+ 
+ 
+-def load(fp: BinaryIO, *, parse_float: ParseFloat = float) -> Dict[str, Any]:
++def load(fp: Union[IO, BinaryIO], *, parse_float: ParseFloat = float) -> Dict[str, Any]:
+     """Parse TOML from a binary file object."""
+     s_bytes = fp.read()
+     try:

--- a/pkgs/development/python-modules/typed-ast/default.nix
+++ b/pkgs/development/python-modules/typed-ast/default.nix
@@ -1,12 +1,12 @@
 { buildPythonPackage, fetchFromGitHub, lib, pythonOlder, pytest }:
 buildPythonPackage rec {
   pname = "typed-ast";
-  version = "1.4.3";
+  version = "1.5.0";
   src = fetchFromGitHub {
     owner = "python";
     repo = "typed_ast";
     rev = version;
-    sha256 = "16mn9snwik5n2ib65sw2xcaqdm02j8ps21zgjxf8kyy7qnx2mx4w";
+    sha256 = "sha256-z3l5gMG1Jp6EI7SnGn5ABVXVBi+bK///iJBqEWn4d+s=";
   };
   # Only works with Python 3.3 and newer;
   disabled = pythonOlder "3.3";

--- a/pkgs/development/python-modules/typed-ast/default.nix
+++ b/pkgs/development/python-modules/typed-ast/default.nix
@@ -1,15 +1,16 @@
 { buildPythonPackage, fetchFromGitHub, lib, pythonOlder, pytest }:
+
 buildPythonPackage rec {
   pname = "typed-ast";
   version = "1.5.0";
+  disabled = pythonOlder "3.3";
+
   src = fetchFromGitHub {
     owner = "python";
     repo = "typed_ast";
     rev = version;
     sha256 = "sha256-z3l5gMG1Jp6EI7SnGn5ABVXVBi+bK///iJBqEWn4d+s=";
   };
-  # Only works with Python 3.3 and newer;
-  disabled = pythonOlder "3.3";
 
   pythonImportsCheck = [
     "typed_ast"
@@ -21,6 +22,7 @@ buildPythonPackage rec {
   checkInputs = [
     pytest
   ];
+
   checkPhase = ''
     runHook preCheck
 
@@ -32,9 +34,10 @@ buildPythonPackage rec {
     runHook postCheck
   '';
 
-  meta = {
+  meta = with lib; {
     homepage = "https://github.com/python/typed_ast";
     description = "Python 2 and 3 ast modules with type comment support";
-    license = lib.licenses.asl20;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ SuperSandro2000 ];
   };
 }

--- a/pkgs/development/python-modules/types-typed-ast/default.nix
+++ b/pkgs/development/python-modules/types-typed-ast/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "types-typed-ast";
+  version = "1.4.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "ffa0471e0ba19c4ea0cba0436d660871b5f5215854ea9ead3cb5b60f525af75a";
+  };
+
+  # Module doesn't have tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "typed_ast-stubs" ];
+
+  meta = with lib; {
+    description = "Typing stubs for typed-ast";
+    homepage = "https://github.com/python/typeshed";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ superherointj veehaitch ];
+  };
+}

--- a/pkgs/development/python-modules/types-typed-ast/default.nix
+++ b/pkgs/development/python-modules/types-typed-ast/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "types-typed-ast";
-  version = "1.4.4";
+  version = "1.5.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ffa0471e0ba19c4ea0cba0436d660871b5f5215854ea9ead3cb5b60f525af75a";
+    sha256 = "sha256-2Op5y/vFIL6Nm8jeSHL0SzQtvbwJFmfi8hsDu9eWkVA=";
   };
 
   # Module doesn't have tests
@@ -21,6 +21,6 @@ buildPythonPackage rec {
     description = "Typing stubs for typed-ast";
     homepage = "https://github.com/python/typeshed";
     license = licenses.asl20;
-    maintainers = with maintainers; [ superherointj veehaitch ];
+    maintainers = with maintainers; [ SuperSandro2000 veehaitch ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9534,6 +9534,8 @@ in {
 
   types-toml = callPackage ../development/python-modules/types-toml { };
 
+  types-typed-ast = callPackage ../development/python-modules/types-typed-ast { };
+
   typesentry = callPackage ../development/python-modules/typesentry { };
 
   typesystem = callPackage ../development/python-modules/typesystem { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
mypy 0.900 introduced a breaking change and no longer ships types with it https://mypy-lang.blogspot.com/2021/06/mypy-0900-released.html .

We need a patch to allow loading types via sys.path in packages that use mypy. All hunks of the patch only apply on commits after the latest release which is why I decided to fetch the latest commit of mypy due to no time for backporting that patch.

The tomli update is needed to resolve an infinite import recursion in their type hints. https://github.com/hukkin/tomli/blob/master/CHANGELOG.md#122

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
