### PR TITLE
beyond-identity: init at 2.45.0-0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6184,6 +6184,12 @@
     email = "tierpluspluslists@gmail.com";
     name = "Karn Kallio";
   };
+  klden = {
+    name = "Kenzyme Le";
+    email = "kl@kenzymele.com";
+    github = "klDen";
+    githubId = 5478260;
+  };
   klntsky = {
     email = "klntsky@gmail.com";
     name = "Vladimir Kalnitsky";

--- a/pkgs/tools/security/beyond-identity/default.nix
+++ b/pkgs/tools/security/beyond-identity/default.nix
@@ -1,0 +1,89 @@
+{ lib, stdenv, fetchurl, dpkg, buildFHSUserEnv
+, glibc, glib, openssl, tpm2-tss
+, gtk3, gnome, polkit, polkit_gnome
+}:
+
+let
+  pname = "beyond-identity";
+  version = "2.45.0-0";
+  libPath = lib.makeLibraryPath ([ glib glibc openssl tpm2-tss gtk3 gnome.gnome-keyring polkit polkit_gnome ]);
+  meta = with lib; {
+    description = "Passwordless MFA identities for workforces, customers, and developers";
+    homepage = "https://www.beyondidentity.com";
+    downloadPage = "https://app.byndid.com/downloads";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ klden ];
+    platforms = [ "x86_64-linux" ];
+  };
+
+  beyond-identity = stdenv.mkDerivation {
+    inherit pname version meta;
+
+    src = fetchurl {
+      url = "https://packages.beyondidentity.com/public/linux-authenticator/deb/ubuntu/pool/focal/main/b/be/${pname}_${version}/${pname}_${version}_amd64.deb";
+      sha512 = "852689d473b7538cdca60d264295f39972491b5505accad897fd924504189f0a6d8b6481cc0520ee762d4642e0f4fd664a03b5741f9ea513ec46ab16b05158f2";
+    };
+
+    nativeBuildInputs = [
+      dpkg
+    ];
+
+    unpackPhase = ''
+      dpkg -x $src .
+    '';
+
+    installPhase = ''
+      mkdir -p $out/opt/beyond-identity
+
+      rm -rf usr/share/doc
+
+      # https://github.com/NixOS/nixpkgs/issues/42117
+      sed -i -e 's/auth_self/yes/g' usr/share/polkit-1/actions/com.beyondidentity.endpoint.stepup.policy
+
+      cp -ar usr/{bin,share} $out
+      cp -ar opt/beyond-identity/bin $out/opt/beyond-identity
+
+      ln -s $out/opt/beyond-identity/bin/* $out/bin/
+    '';
+
+    postFixup = ''
+      substituteInPlace \
+        $out/share/applications/com.beyondidentity.endpoint.BeyondIdentity.desktop \
+        --replace /usr/bin/ $out/bin/
+      substituteInPlace \
+        $out/share/applications/com.beyondidentity.endpoint.webserver.BeyondIdentity.desktop \
+        --replace /opt/ $out/opt/
+      substituteInPlace \
+        $out/opt/beyond-identity/bin/byndid-web \
+        --replace /opt/ $out/opt/
+      substituteInPlace \
+        $out/bin/beyond-identity \
+        --replace /opt/ $out/opt/ \
+        --replace /usr/bin/gtk-launch ${gtk3}/bin/gtk-launch
+
+      patchelf \
+        --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        --set-rpath "${libPath}" \
+        --force-rpath \
+        $out/bin/byndid
+    '';
+  };
+# /usr/bin/pkcheck is hardcoded in binary - we need FHS
+in buildFHSUserEnv {
+   inherit meta;
+   name = pname;
+
+   targetPkgs = pkgs: [
+     beyond-identity
+     glib glibc openssl tpm2-tss
+     gtk3 gnome.gnome-keyring
+     polkit polkit_gnome
+   ];
+
+   extraInstallCommands = ''
+     ln -s ${beyond-identity}/share $out
+   '';
+
+   runScript = "beyond-identity";
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -206,6 +206,8 @@ with pkgs;
 
   bakelite = callPackage ../tools/backup/bakelite { };
 
+  beyond-identity = callPackage ../tools/security/beyond-identity {};
+
   breakpad = callPackage ../development/misc/breakpad { };
 
   buf = callPackage ../development/tools/buf { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Port [Beyond Identity](https://www.beyondidentity.com/) .deb to NixOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
