### PR TITLE
pngcheck: build on darwin and take ownership

### DIFF
--- a/pkgs/tools/graphics/pngcheck/default.nix
+++ b/pkgs/tools/graphics/pngcheck/default.nix
@@ -11,6 +11,10 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    substituteInPlace Makefile.unx --replace "gcc" "clang"
+  '';
+
   makefile = "Makefile.unx";
   makeFlags = [ "ZPATH=${zlib.static}/lib" ];
 
@@ -21,10 +25,10 @@ stdenv.mkDerivation rec {
     cp pngcheck $out/bin/pngcheck
   '';
 
-  meta = {
+  meta = with lib; {
     homepage = "http://pmt.sourceforge.net/pngcrush";
     description = "Verifies the integrity of PNG, JNG and MNG files";
-    license = lib.licenses.free;
-    platforms = with lib.platforms; linux;
+    license = licenses.free;
+    platforms = with platforms; [ unix ];
   };
 }

--- a/pkgs/tools/graphics/pngcheck/default.nix
+++ b/pkgs/tools/graphics/pngcheck/default.nix
@@ -30,5 +30,6 @@ stdenv.mkDerivation rec {
     description = "Verifies the integrity of PNG, JNG and MNG files";
     license = licenses.free;
     platforms = with platforms; [ unix ];
+    maintainers = with maintainers; [ starcraft66 ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

It was only building on linux

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
