### PR TITLE
Revert "vim-utils: create less symlinks"

### DIFF
--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -198,8 +198,8 @@ let
     '';
 
     linkVimlPlugin = plugin: packageName: dir: ''
-      mkdir -p $out/pack/${packageName}/${dir}
-      ln -sf ${plugin}/${rtpPath} $out/pack/${packageName}/${dir}/${lib.getName plugin}
+      mkdir -p $out/pack/${packageName}/${dir}/${lib.getName plugin}
+      ln -sf ${plugin}/${rtpPath}/* $out/pack/${packageName}/${dir}/${lib.getName plugin}
     '';
 
     link = pluginPath: if hasLuaModule pluginPath


### PR DESCRIPTION
Reverts NixOS/nixpkgs#145105

(Potentially) closes #145980

Pinging these people because they're involved in either the PR that broke vim or the issue:

@sandhose @jlesquembre @teto 