### PR TITLE
[staging] fetchurl: Support URLs with spaces in them

### DIFF
--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -118,19 +118,21 @@ let
     else if sha1   != "" then { outputHashAlgo = "sha1";   outputHash = sha1; }
     else if cacert != null then { outputHashAlgo = "sha256"; outputHash = ""; }
     else throw "fetchurl requires a hash for fixed-output derivation: ${lib.concatStringsSep ", " urls_}";
+
+  escapeUrl = builtins.replaceStrings [ " " ] [ "%20" ];
 in
 
 stdenvNoCC.mkDerivation {
   name =
     if showURLs then "urls"
     else if name != "" then name
-    else baseNameOf (toString (builtins.head urls_));
+    else escapeUrl (baseNameOf (toString (builtins.head urls_)));
 
   builder = ./builder.sh;
 
   nativeBuildInputs = [ curl ];
 
-  urls = urls_;
+  urls = lib.concatMapStringsSep "\n" escapeUrl urls_;
 
   # If set, prefer the content-addressable mirrors
   # (http://tarballs.nixos.org) over the original URLs.

--- a/pkgs/build-support/fetchurl/test-urls-with-spaces.nix
+++ b/pkgs/build-support/fetchurl/test-urls-with-spaces.nix
@@ -1,0 +1,11 @@
+{ fetchurl, invalidateFetcherByDrvHash, writeTextFile }:
+
+invalidateFetcherByDrvHash fetchurl {
+  name = "test";
+  url = "file://" + (writeTextFile {
+    name = "derivation-with-a-file-with-spaces";
+    text = "this is some content";
+    destination = "/file with spaces";
+  }) + "/file with spaces";
+  sha256 = "sha256:1jk4zjmgab4yh5ifzfnz43sapiv5mifjdblasid4z8vm0wqr6f9p";
+}

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -121,7 +121,7 @@ rec {
         allowSubstitutes = false;
       }
       ''
-        n=$out${destination}
+        n="$out${destination}"
         mkdir -p "$(dirname "$n")"
 
         if [ -e "$textPath" ]; then

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -61,5 +61,7 @@ with pkgs;
 
   writers = callPackage ../build-support/writers/test.nix {};
 
+  fetchurlWithSpaces = callPackage ../build-support/fetchurl/test-urls-with-spaces.nix;
+
   dhall = callPackage ./dhall { };
 }


### PR DESCRIPTION
This is accomplished by switching to arrays instead of using
space-separated strings.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Download URLs with spaces from mirrors

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
