### PR TITLE
lunatic: fix build, mark broken on darwin

### DIFF
--- a/pkgs/development/interpreters/lunatic/default.nix
+++ b/pkgs/development/interpreters/lunatic/default.nix
@@ -1,4 +1,4 @@
-{ cmake, fetchFromGitHub, lib, rustPlatform }:
+{ lib, rustPlatform, fetchFromGitHub, fetchpatch, cmake }:
 
 rustPlatform.buildRustPackage rec {
   pname = "lunatic";
@@ -11,7 +11,17 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1dz8v19jw9v55p3mz4932v6z24ihp6wk238n4d4lx9xj91mf3g6r";
   };
 
-  cargoSha256 = "1rkxl27l6ydmcq3flc6qbnd7zmpkfmyc86b8q4pi7dwhqnd5g70g";
+  cargoPatches = [
+    # NOTE: remove on next update
+    # update dependencies to resolve incompatibility with rust 1.56
+    (fetchpatch {
+      name = "update-wasmtime.patch";
+      url = "https://github.com/lunatic-solutions/lunatic/commit/cd8db51732712c19a8114db290882d1bb6b928c0.patch";
+      sha256 = "sha256-eyoIOTqGSU/XNfF55FG+WrQPSMvt9L/S/KBsUQB5z1k=";
+    })
+  ];
+
+  cargoSha256 = "sha256-yoG4gCk+nHE8pBqV6ND9NCegx4bxbdGEU5hY5JauloM=";
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/development/interpreters/lunatic/default.nix
+++ b/pkgs/development/interpreters/lunatic/default.nix
@@ -1,4 +1,4 @@
-{ lib, rustPlatform, fetchFromGitHub, fetchpatch, cmake }:
+{ lib, rustPlatform, fetchFromGitHub, fetchpatch, cmake, stdenv }:
 
 rustPlatform.buildRustPackage rec {
   pname = "lunatic";
@@ -30,5 +30,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://lunatic.solutions";
     license = with licenses; [ mit /* or */ asl20 ];
     maintainers = with maintainers; [ figsoda ];
+    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

hydra failure: https://hydra.nixos.org/log/8y6hpjdnbgzwjyyhr8427vpl3q6gq6gm-lunatic-0.6.2.drv

darwin build is still failing: https://github.com/figsoda/nixpkgs-test/runs/4212308704

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
