### PR TITLE
Add mani cli tool

### DIFF
--- a/pkgs/development/tools/mani/default.nix
+++ b/pkgs/development/tools/mani/default.nix
@@ -1,0 +1,45 @@
+{ buildGoModule, fetchFromGitHub, lib, installShellFiles, git, makeWrapper}:
+
+buildGoModule rec {
+  pname = "mani";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = "alajmo";
+    repo = "mani";
+    rev = "v${version}";
+    sha256 = "sha256-9rcgPeYFHdIN73K0zGPEHqFFLFkVYkNYRXJ+0/Zo4zI=";
+  };
+
+  vendorSha256 = "sha256-ZivzDfjx2djzS0Xm3GISK3zpB5fUUMgy2o4Ti1Z9wMM=";
+
+  nativeBuildInputs = [ installShellFiles makeWrapper ];
+
+  postInstall = ''
+    installShellCompletion --cmd mani \
+      --bash <($out/bin/mani completion bash) \
+      --fish <($out/bin/mani completion fish) \
+      --zsh <($out/bin/mani completion zsh)
+
+    wrapProgram $out/bin/mani \
+      --prefix PATH : ${lib.makeBinPath [ git ]}
+  '';
+
+  # Skip tests
+  # The repo's test folder has a README.md with detailed information. I don't
+  # know how to wrap the dependencies for these integration tests so skip for now.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "CLI tool to help you manage multiple repositories";
+    longDescription = ''
+      mani is a CLI tool that helps you manage multiple repositories. It's useful
+      when you are working with microservices, multi-project systems, many
+      libraries or just a bunch of repositories and want a central place for
+      pulling all repositories and running commands over them.
+    '';
+    homepage = "https://manicli.com/";
+    changelog = "https://github.com/alajmo/mani/releases/tag/v${version}";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6904,6 +6904,8 @@ with pkgs;
 
   makebootfat = callPackage ../tools/misc/makebootfat { };
 
+  mani = callPackage ../development/tools/mani { };
+
   mapcache = callPackage ../servers/mapcache { };
 
   mapserver = callPackage ../servers/mapserver { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add the mani cli tool

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [*] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


I don't really know much GO so I mostly copied and pasted. The tests were trying to create files and got permission denied so I just skipped them for now. The resulting binary seems to be working fine, haven't had any issues yet.