### PR TITLE
elan: wrap embedded linker

### DIFF
--- a/pkgs/applications/science/logic/elan/0001-dynamically-patchelf-binaries.patch
+++ b/pkgs/applications/science/logic/elan/0001-dynamically-patchelf-binaries.patch
@@ -1,24 +1,19 @@
 diff --git a/src/elan-dist/src/component/package.rs b/src/elan-dist/src/component/package.rs
-index c51e76d..d0a26d7 100644
+index c51e76d..ae8159e 100644
 --- a/src/elan-dist/src/component/package.rs
 +++ b/src/elan-dist/src/component/package.rs
-@@ -56,11 +56,35 @@ fn unpack_without_first_dir<R: Read>(archive: &mut tar::Archive<R>, path: &Path)
+@@ -56,6 +56,30 @@ fn unpack_without_first_dir<R: Read>(archive: &mut tar::Archive<R>, path: &Path)
          entry
              .unpack(&full_path)
              .chain_err(|| ErrorKind::ExtractingPackage)?;
-+        nix_patchelf_if_needed(&full_path);
-     }
- 
-     Ok(())
- }
- 
-+fn nix_patchelf_if_needed(dest_path: &Path) {
-+    let (is_bin, is_lib) = if let Some(p) = dest_path.parent() {
-+        (p.ends_with("bin"), p.ends_with("lib"))
-+    } else {
-+        (false, false)
-+    };
++        nix_patch_if_needed(&full_path)?;
++    }
 +
++    Ok(())
++}
++
++fn nix_patch_if_needed(dest_path: &Path) -> Result<()> {
++    let is_bin = matches!(dest_path.parent(), Some(p) if p.ends_with("bin"));
 +    if is_bin {
 +        let _ = ::std::process::Command::new("@patchelf@/bin/patchelf")
 +            .arg("--set-interpreter")
@@ -26,15 +21,15 @@ index c51e76d..d0a26d7 100644
 +            .arg(dest_path)
 +            .output();
 +    }
-+    else if is_lib {
-+        let _ = ::std::process::Command::new("@patchelf@/bin/patchelf")
-+            .arg("--set-rpath")
-+            .arg("@libPath@")
-+            .arg(dest_path)
-+            .output();
-+    }
-+}
 +
- #[derive(Debug)]
- pub struct ZipPackage<'a>(temp::Dir<'a>);
++    if dest_path.extension() == Some(::std::ffi::OsStr::new("lld")) {
++        use std::os::unix::fs::PermissionsExt;
++        let new_path = dest_path.with_extension("orig");
++        ::std::fs::rename(dest_path, &new_path)?;
++        ::std::fs::write(dest_path, format!(r#"#! @shell@
++exec -a "$0" {} "$@" --dynamic-linker=@dynamicLinker@
++"#, new_path.to_str().unwrap()))?;
++        ::std::fs::set_permissions(dest_path, ::std::fs::Permissions::from_mode(0o755))?;
+     }
  
+     Ok(())


### PR DESCRIPTION
###### Motivation for this change

Lean 4 will soon start shipping its own toolchain including lld: https://github.com/leanprover/lean4/pull/795. This change is in preparation of that by wrapping the embedded `ld.lld` (Linux)/`ld64.lld` (macOS) in order to pass the correct interpreter. While we're at it, we drop the old GMP wrapper that has not been necessary for a long time, if at all.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
