### PR TITLE
la-capitaine-icon-theme: init at 0.6.2

### DIFF
--- a/pkgs/data/icons/la-capitaine-icon-theme/default.nix
+++ b/pkgs/data/icons/la-capitaine-icon-theme/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, breeze-icons
+, elementary-icon-theme
+, gnome-icon-theme
+, hicolor-icon-theme
+}:
+
+stdenv.mkDerivation rec {
+  pname = "la-capitaine-icon-theme";
+  version = "0.6.2";
+
+  src = fetchFromGitHub {
+    owner = "keeferrourke";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0id2dddx6rl71472l47vafx968wnklmq6b980br68w82kcvqczzs";
+  };
+
+  propagatedBuildInputs = [
+    breeze-icons
+    elementary-icon-theme
+    gnome-icon-theme
+    hicolor-icon-theme
+  ];
+
+  dontDropIconThemeCache = true;
+
+  postPatch = ''
+    patchShebangs configure
+
+    substituteInPlace configure \
+      --replace 'DISTRO=$(format "$(lsb_release -si 2>/dev/null)")' 'DISTRO=nixos'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/icons/$pname
+    cp -a * $out/share/icons/$pname
+    rm $out/share/icons/$pname/{configure,COPYING,LICENSE,*.md}
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Icon theme inspired by macOS and Google's Material Design";
+    homepage = "https://github.com/keeferrourke/la-capitaine-icon-theme";
+    license = with licenses; [ gpl3Plus mit ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23179,6 +23179,11 @@ with pkgs;
 
   kreative-square-fonts = callPackage ../data/fonts/kreative-square-fonts { };
 
+  la-capitaine-icon-theme = callPackage ../data/icons/la-capitaine-icon-theme {
+    inherit (plasma5Packages) breeze-icons;
+    inherit (pantheon) elementary-icon-theme;
+  };
+
   layan-gtk-theme = callPackage ../data/themes/layan-gtk-theme { };
 
   lato = callPackage ../data/fonts/lato {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add [la-capitaine-icon-theme](https://github.com/keeferrourke/la-capitaine-icon-theme).

> La Capitaine is an icon pack designed to integrate with most desktop environments. The set of icons takes inspiration from the latest iterations of macOS and Google's Material Design.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
