### PR TITLE
qt512: Make apps work on macOS Big Sur

### DIFF
--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -74,6 +74,17 @@ let
         # Ensure -I${includedir} is added to Cflags in pkg-config files.
         # See https://github.com/NixOS/nixpkgs/issues/52457
         ./qtbase.patch.d/0014-qtbase-pkg-config.patch
+
+        # Make Qt applications work on macOS Big Sur even if they're
+        # built with an older version of the macOS SDK (<10.14). This
+        # issue is fixed in 5.12.11, but it requires macOS SDK 10.13 to
+        # build. See https://bugreports.qt.io/browse/QTBUG-87014 for
+        # more info.
+        (fetchpatch {
+          name = "big_sur_layer_backed_views.patch";
+          url = "https://codereview.qt-project.org/gitweb?p=qt/qtbase.git;a=patch;h=c5d904639dbd690a36306e2b455610029704d821";
+          sha256 = "0crkw3j1iwdc1pbf5dhar0b4q3h5gs2q1sika8m12y02yk3ns697";
+        })
       ];
     qtdeclarative = [ ./qtdeclarative.patch ];
     qtlocation = [ ./qtlocation-gcc-9.patch ];


### PR DESCRIPTION
###### Motivation for this change
Backport of #145473 

Make Qt applications work on macOS Big Sur even if they're built with an older version of the macOS SDK (<10.14 - we're currently using 10.12). This issue is fixed in 5.12.11, but it requires macOS SDK 10.13 to build. See https://bugreports.qt.io/browse/QTBUG-87014 for more info.

(cherry picked from commit 39ce18a7ecb76d15f646d735fd65257b8ad5aa27)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
