### PR TITLE
cbqn-standalone: fix installPhase on darwin

### DIFF
--- a/pkgs/development/interpreters/bqn/cbqn/default.nix
+++ b/pkgs/development/interpreters/bqn/cbqn/default.nix
@@ -52,8 +52,9 @@ stdenv.mkDerivation rec {
 
      mkdir -p $out/bin/
      cp BQN -t $out/bin/
-     ln -s $out/bin/BQN $out/bin/bqn
-     ln -s $out/bin/BQN $out/bin/cbqn
+     # note guard condition for case-insensitive filesystems
+     [ -e $out/bin/bqn ] || ln -s $out/bin/BQN $out/bin/bqn
+     [ -e $out/bin/cbqn ] || ln -s $out/bin/BQN $out/bin/cbqn
 
      runHook postInstall
   '';


### PR DESCRIPTION
###### Motivation for this change
ZHF: #144627 @NixOS/nixos-release-managers

I was extremely tempted to change the version string too to the standard `unstable-xxxx-xx-xx` but I'm sure it's weird for some reason. Problem is it includes characters that require escapes which is nasty.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
