### PR TITLE
mongodb-compass: 1.25.0 -> 1.29.4

### DIFF
--- a/pkgs/tools/misc/mongodb-compass/default.nix
+++ b/pkgs/tools/misc/mongodb-compass/default.nix
@@ -1,9 +1,40 @@
-{ lib, stdenv, fetchurl, dpkg
-, alsa-lib, at-spi2-atk, at-spi2-core, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, glib
-, gnome2, gdk-pixbuf, gtk3, pango, libnotify, libsecret, libuuid, libxcb, nspr, nss, systemd, xorg, wrapGAppsHook }:
+{
+alsa-lib,
+at-spi2-atk,
+at-spi2-core,
+atk,
+cairo,
+cups,
+curl,
+dbus,
+dpkg,
+expat,
+fetchurl,
+fontconfig,
+freetype,
+gdk-pixbuf,
+glib,
+gnome2,
+gtk3,
+lib,
+libdrm,
+libnotify,
+libsecret,
+libuuid,
+libxcb,
+libxkbcommon,
+mesa,
+nspr,
+nss,
+pango,
+stdenv,
+systemd,
+wrapGAppsHook,
+xorg,
+}:
 
 let
-  version = "1.25.0";
+  version = "1.29.4";
 
   rpath = lib.makeLibraryPath [
     alsa-lib
@@ -17,22 +48,24 @@ let
     expat
     fontconfig
     freetype
+    gdk-pixbuf
     glib
     gnome2.GConf
-    gdk-pixbuf
     gtk3
-    pango
+    libdrm
     libnotify
     libsecret
     libuuid
     libxcb
+    libxkbcommon
+    mesa
     nspr
     nss
+    pango
     stdenv.cc.cc
     systemd
-
-    xorg.libxkbfile
     xorg.libX11
+    xorg.libXScrnSaver
     xorg.libXcomposite
     xorg.libXcursor
     xorg.libXdamage
@@ -42,14 +75,16 @@ let
     xorg.libXrandr
     xorg.libXrender
     xorg.libXtst
-    xorg.libXScrnSaver
-  ] + ":${stdenv.cc.cc.lib}/lib64";
+    xorg.libxkbfile
+    xorg.libxshmfence
+    (lib.getLib stdenv.cc.cc)
+  ];
 
   src =
     if stdenv.hostPlatform.system == "x86_64-linux" then
       fetchurl {
         url = "https://downloads.mongodb.com/compass/mongodb-compass_${version}_amd64.deb";
-        sha256 = "sha256-998/voQ04fLj3KZCy6BueUoI1v++4BoGRTGJT7Nsv40=";
+        sha256 = "sha256-CqC6BrRhMfjxamSwC6ub1u3+FtDuIq3/OMNdUZgpCAQ=";
       }
     else
       throw "MongoDB compass is not supported on ${stdenv.hostPlatform.system}";
@@ -94,8 +129,9 @@ in stdenv.mkDerivation {
 
   meta = with lib; {
     description = "The GUI for MongoDB";
+    maintainers = with maintainers; [ bryanasdev000 ];
     homepage = "https://www.mongodb.com/products/compass";
-    license = licenses.unfree;
+    license = licenses.sspl;
     platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

mongodb-compass: 1.25.0 -> 1.29.4

Also add myself as maintainer and set new license.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
