### PR TITLE
python3Packages.johnnycanencrypt: fix build with newer maturin

### DIFF
--- a/pkgs/development/python-modules/johnnycanencrypt/default.nix
+++ b/pkgs/development/python-modules/johnnycanencrypt/default.nix
@@ -13,6 +13,7 @@
 , pytestCheckHook
 , pythonOlder
 , PCSC
+, libiconv
 }:
 
 buildPythonPackage rec {
@@ -55,7 +56,10 @@ buildPythonPackage rec {
   buildInputs = [
     pcsclite
     nettle
-  ] ++ lib.optionals stdenv.isDarwin [ PCSC ];
+  ] ++ lib.optionals stdenv.isDarwin [
+    PCSC
+    libiconv
+  ];
 
   # Needed b/c need to check AFTER python wheel is installed (using Rust Build, not buildPythonPackage)
   doCheck = false;
@@ -70,6 +74,8 @@ buildPythonPackage rec {
   # for compatibility with maturin 0.9.0.
   postPatch = ''
     sed '/project-url = /d' -i Cargo.toml
+    substituteInPlace pyproject.toml \
+      --replace 'manylinux = "off"' 'skip-auditwheel = true'
   '';
 
   preCheck = ''


### PR DESCRIPTION
###### Motivation for this change
ZHF: #144627 @NixOS/nixos-release-managers

Fixes build on nixos x86_64 and macos 10.15, but **not** linux aarch64. There is an unusual error there:

```
🍹 Building a mixed python/rust project
🔗 Found pyo3 bindings

💥 maturin failed
  Caused by: Finding python interpreters failed
  Caused by: Trying to get metadata from the python interpreter 'python3.7' failed
```

This is from a `python38Packages` build - I'm not sure where it's getting python 3.7 from. Open invitation to fix it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
