### PR TITLE
Fix evaluation after #143994

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/async-rpc-kernel.nix
+++ b/pkgs/development/ocaml-modules/janestreet/async-rpc-kernel.nix
@@ -3,7 +3,7 @@
  ppx_jane, sexplib, typerep, variantslib}:
 
 buildOcamlJane {
-  name = "async_rpc_kernel";
+  pname = "async_rpc_kernel";
   hash = "0pvys7giqix1nfidw1f4i3r94cf03ba1mvhadpm2zpdir3av91sw";
   propagatedBuildInputs = [ async_kernel bin_prot core_kernel fieldslib
     ppx_assert ppx_bench ppx_driver ppx_expect ppx_inline_test ppx_jane

--- a/pkgs/development/ocaml-modules/janestreet/bin_prot.nix
+++ b/pkgs/development/ocaml-modules/janestreet/bin_prot.nix
@@ -1,7 +1,7 @@
 {lib, buildOcamlJane, type_conv}:
 
 buildOcamlJane {
-  name = "bin_prot";
+  pname = "bin_prot";
   version = "113.33.03";
   minimumSupportedOcamlVersion = "4.02";
   hash = "0jlarpfby755j0kikz6vnl1l6q0ga09b9zrlw6i84r22zchnqdsh";

--- a/pkgs/development/ocaml-modules/janestreet/core_bench.nix
+++ b/pkgs/development/ocaml-modules/janestreet/core_bench.nix
@@ -6,7 +6,7 @@
 }:
 
 buildOcamlJane {
-  name = "core_bench";
+  pname = "core_bench";
   hash = "1d1ainpakgsf5rg8dvar12ksgilqcc4465jr8gf7fz5mmn0mlifj";
   propagatedBuildInputs =
     [ core core_extended textutils ];

--- a/pkgs/development/ocaml-modules/janestreet/fieldslib.nix
+++ b/pkgs/development/ocaml-modules/janestreet/fieldslib.nix
@@ -1,7 +1,7 @@
 { lib, type_conv, buildOcamlJane }:
 
 buildOcamlJane {
-  name = "fieldslib";
+  pname = "fieldslib";
   version = "113.33.03";
 
   minimumSupportedOcamlVersion = "4.02";

--- a/pkgs/development/ocaml-modules/janestreet/ppx-assert.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-assert.nix
@@ -2,7 +2,7 @@
  ppx_compare, ppx_core, ppx_driver, ppx_here, ppx_sexp_conv, ppx_tools, ppx_type_conv, sexplib}:
 
 buildOcamlJane {
-  name = "ppx_assert";
+  pname = "ppx_assert";
   hash = "0n7fa1j79ykbkhp8xz0ksg5096asri5d0msshsaqhw5fz18chvz4";
   propagatedBuildInputs =
     [ ppx_compare ppx_core ppx_driver ppx_here ppx_sexp_conv ppx_tools

--- a/pkgs/development/ocaml-modules/janestreet/ppx-bench.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-bench.nix
@@ -2,7 +2,7 @@
  ppx_core, ppx_driver, ppx_inline_test, ppx_tools}:
 
 buildOcamlJane {
-  name = "ppx_bench";
+  pname = "ppx_bench";
   minimumSupportedOcamlVersion = "4.02";
   hash = "1l5jlwy1d1fqz70wa2fkf7izngp6nx3g4s9bmnd6ca4dx1x5bksk";
 

--- a/pkgs/development/ocaml-modules/janestreet/ppx-bin-prot.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-bin-prot.nix
@@ -2,7 +2,7 @@
  ppx_core, ppx_tools, ppx_type_conv, bin_prot}:
 
 buildOcamlJane {
-  name = "ppx_bin_prot";
+  pname = "ppx_bin_prot";
   hash = "0kwmrrrybdkmphqczsr3lg3imsxcjb8iy41syvn44s3kcjfyyzbz";
   propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv bin_prot ];
 

--- a/pkgs/development/ocaml-modules/janestreet/ppx-compare.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-compare.nix
@@ -2,7 +2,7 @@
  ppx_core, ppx_driver, ppx_tools, ppx_type_conv}:
 
 buildOcamlJane {
-  name = "ppx_compare";
+  pname = "ppx_compare";
   hash = "05cnwxfxm8201lpfmcqkcqfy6plh5c2151jbj4qsnxhlvvjli459";
   propagatedBuildInputs =
     [ppx_core ppx_driver ppx_tools ppx_type_conv ];

--- a/pkgs/development/ocaml-modules/janestreet/ppx-custom-printf.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-custom-printf.nix
@@ -2,7 +2,7 @@
  ppx_core, ppx_driver, ppx_sexp_conv, ppx_tools}:
 
 buildOcamlJane {
-  name = "ppx_custom_printf";
+  pname = "ppx_custom_printf";
   hash = "06y85m6ky376byja4w7gdwd339di5ag0xrf0czkylzjsnylhdr85";
 
   propagatedBuildInputs = [ ppx_core ppx_driver ppx_sexp_conv ppx_tools ];

--- a/pkgs/development/ocaml-modules/janestreet/ppx-enumerate.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-enumerate.nix
@@ -2,7 +2,7 @@
  ppx_core, ppx_tools, ppx_type_conv}:
 
 buildOcamlJane {
-  name = "ppx_enumerate";
+  pname = "ppx_enumerate";
   hash = "0m11921q2pjzkwckf21fynd2qfy83n9jjsgks23yagdai8a7ym16";
   propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv ];
 

--- a/pkgs/development/ocaml-modules/janestreet/ppx-expect.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-expect.nix
@@ -4,7 +4,7 @@
  ppx_variants_conv, re, sexplib, variantslib, fieldslib}:
 
 buildOcamlJane {
-  name = "ppx_expect";
+  pname = "ppx_expect";
   hash = "0cwagb4cj3x1vsr19kyfa9pxlvaz9a5v863cahi5glinsh4mzgdx";
   propagatedBuildInputs =
     [ ppx_assert ppx_compare ppx_core ppx_custom_printf ppx_driver

--- a/pkgs/development/ocaml-modules/janestreet/ppx-fields-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-fields-conv.nix
@@ -2,7 +2,7 @@
  ppx_core, ppx_tools, ppx_type_conv}:
 
 buildOcamlJane {
-  name = "ppx_fields_conv";
+  pname = "ppx_fields_conv";
   hash = "11w9wfjgkv7yxv3rwlwi6m193zan6rhmi45q7n3ddi2s8ls3gra7";
   propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv ];
 

--- a/pkgs/development/ocaml-modules/janestreet/ppx-here.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-here.nix
@@ -2,7 +2,7 @@
  ppx_core, ppx_driver}:
 
 buildOcamlJane {
-  name = "ppx_here";
+  pname = "ppx_here";
   hash = "1mzdgn8k171zkwmbizf1a48l525ny0w3363c7gknpnifcinxniiw";
   propagatedBuildInputs = [ ppx_core ppx_driver ];
 

--- a/pkgs/development/ocaml-modules/janestreet/ppx-inline-test.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-inline-test.nix
@@ -2,7 +2,7 @@
  ppx_core, ppx_driver, ppx_tools}:
 
 buildOcamlJane {
-  name = "ppx_inline_test";
+  pname = "ppx_inline_test";
   hash = "0ygapa54i0wwcj3jcqwiimrc6z0b7aafgjhbk37h6vvclnm5n7f6";
   propagatedBuildInputs = [ ppx_core ppx_driver ppx_tools ];
 

--- a/pkgs/development/ocaml-modules/janestreet/ppx-jane.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-jane.nix
@@ -6,7 +6,7 @@
  ppx_sexp_value, ppx_typerep_conv, ppx_variants_conv}:
 
 buildOcamlJane {
-  name = "ppx_jane";
+  pname = "ppx_jane";
   hash  = "1la0rp8fhzfglwb15gqh1pl1ld8ls4cnidaw9mjc5q1hb0yj1qd9";
   propagatedBuildInputs =
     [ ppx_assert ppx_bench ppx_bin_prot ppx_compare ppx_custom_printf

--- a/pkgs/development/ocaml-modules/janestreet/ppx-let.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-let.nix
@@ -2,7 +2,7 @@
  ppx_core, ppx_driver}:
 
 buildOcamlJane {
-  name = "ppx_let";
+  pname = "ppx_let";
   hash = "0whnfq4rgkq4apfqnvc100wlk25pmqdyvy6s21dsn3fcm9hff467";
   propagatedBuildInputs = [ ppx_core ppx_driver ];
 

--- a/pkgs/development/ocaml-modules/janestreet/ppx-optcomp.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-optcomp.nix
@@ -2,7 +2,7 @@
  ppx_core, ppx_tools}:
 
 buildOcamlJane {
-  name = "ppx_optcomp";
+  pname = "ppx_optcomp";
   hash = "09m2x2a5ics4bz1j29n5slhh1rlyhcwdfmf44v1jfxcby3f0riwd";
   propagatedBuildInputs =
     [ ppx_core ppx_tools ];

--- a/pkgs/development/ocaml-modules/janestreet/ppx-pipebang.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-pipebang.nix
@@ -2,7 +2,7 @@
  ppx_core, ppx_driver, ppx_tools}:
 
 buildOcamlJane {
-  name = "ppx_pipebang";
+  pname = "ppx_pipebang";
   hash = "0k25bhj9ziiw89xvs4svz7cgazbbmprba9wbic2llffg55fp7acc";
   propagatedBuildInputs = [ ppx_core ppx_driver ppx_tools ];
 

--- a/pkgs/development/ocaml-modules/janestreet/ppx-sexp-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-sexp-conv.nix
@@ -2,7 +2,7 @@
  ppx_core, ppx_tools, ppx_type_conv, sexplib}:
 
 buildOcamlJane {
-  name = "ppx_sexp_conv";
+  pname = "ppx_sexp_conv";
   hash = "1kgbmlc11w5jhbhmy5n0f734l44zwyry48342dm5qydi9sfzcgq2";
   propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv sexplib];
 

--- a/pkgs/development/ocaml-modules/janestreet/ppx-sexp-message.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-sexp-message.nix
@@ -2,7 +2,7 @@
  ppx_core, ppx_driver, ppx_here, ppx_sexp_conv, ppx_tools}:
 
 buildOcamlJane {
-  name = "ppx_sexp_message";
+  pname = "ppx_sexp_message";
   hash = "0inbff25qii868p141jb1y8n3vjfyz66jpnsl9nma6nkkyjkp05j";
   propagatedBuildInputs = [ ppx_core ppx_driver ppx_here ppx_sexp_conv ppx_tools ];
 

--- a/pkgs/development/ocaml-modules/janestreet/ppx-sexp-value.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-sexp-value.nix
@@ -2,7 +2,7 @@
  ppx_core, ppx_driver, ppx_here, ppx_sexp_conv, ppx_tools}:
 
 buildOcamlJane {
-  name = "ppx_sexp_value";
+  pname = "ppx_sexp_value";
   hash = "04602ppqfwx33ghjywam00hlqqzsz4d99r60k9q0v1mynk9pjhj0";
   propagatedBuildInputs = [ ppx_core ppx_driver ppx_here ppx_sexp_conv ppx_tools ];
 

--- a/pkgs/development/ocaml-modules/janestreet/ppx-typerep-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-typerep-conv.nix
@@ -2,7 +2,7 @@
  ppx_core, ppx_tools, ppx_type_conv, typerep}:
 
 buildOcamlJane {
-  name = "ppx_typerep_conv";
+  pname = "ppx_typerep_conv";
   hash = "0dldlx73r07j6w0i7h4hxly0v678naa79na5rafsk2974gs5ih9g";
   propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv typerep ];
 

--- a/pkgs/development/ocaml-modules/janestreet/ppx-variants-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-variants-conv.nix
@@ -2,7 +2,7 @@
  ppx_core, ppx_tools, ppx_type_conv, sexplib, variantslib}:
 
 buildOcamlJane {
-  name = "ppx_variants_conv";
+  pname = "ppx_variants_conv";
   hash = "0kgal8b9yh7wrd75hllb9fyl6zbksfnr9k7pykpzdm3js98dirhn";
   propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv sexplib variantslib ];
 

--- a/pkgs/development/ocaml-modules/janestreet/sexplib.nix
+++ b/pkgs/development/ocaml-modules/janestreet/sexplib.nix
@@ -2,7 +2,7 @@
 
 buildOcamlJane {
   minimumSupportedOcamlVersion = "4.02";
-  name = "sexplib";
+  pname = "sexplib";
   version = "113.33.03";
 
   hash = "1klar4qw4s7bj47ig7kxz2m4j1q3c60pfppis4vxrxv15r0kfh22";

--- a/pkgs/development/ocaml-modules/janestreet/typerep.nix
+++ b/pkgs/development/ocaml-modules/janestreet/typerep.nix
@@ -1,7 +1,7 @@
 {lib, buildOcamlJane, type_conv}:
 
 buildOcamlJane {
-  name = "typerep";
+  pname = "typerep";
   version = "113.33.03";
 
   minimumSupportedOcamlVersion = "4.00";

--- a/pkgs/development/ocaml-modules/janestreet/variantslib.nix
+++ b/pkgs/development/ocaml-modules/janestreet/variantslib.nix
@@ -1,7 +1,7 @@
 {lib, buildOcamlJane, type_conv}:
 
 buildOcamlJane {
-  name = "variantslib";
+  pname = "variantslib";
   version = "113.33.03";
 
   minimumSupportedOcamlVersion = "4.00";


### PR DESCRIPTION
###### Motivation for this change

Evaluation is broken.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
