### PR TITLE
libdeltachat: 1.64.0 -> 1.65.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/deltachat-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/deltachat-desktop/default.nix
@@ -3,6 +3,7 @@
 , electron
 , esbuild
 , fetchFromGitHub
+, fetchpatch
 , libdeltachat
 , makeDesktopItem
 , makeWrapper
@@ -14,6 +15,33 @@
 }:
 
 let
+  libdeltachat' = libdeltachat.overrideAttrs (old: rec {
+    version = "1.60.0";
+    src = fetchFromGitHub {
+      owner = "deltachat";
+      repo = "deltachat-core-rust";
+      rev = version;
+      sha256 = "1agm5xyaib4ynmw4mhgmkhh4lnxs91wv0q9i1zfihv2vkckfm2s2";
+    };
+    cargoDeps = rustPlatform.fetchCargoTarball {
+      inherit src;
+      name = "${old.pname}-${version}";
+      sha256 = "09d3mw2hb1gmqg7smaqwnfm7izw40znl0h1dz7s2imms2cnkjws1";
+    };
+    patches = [
+      # https://github.com/deltachat/deltachat-core-rust/pull/2589
+      (fetchpatch {
+        url = "https://github.com/deltachat/deltachat-core-rust/commit/408467e85d04fbbfd6bed5908d84d9e995943487.patch";
+        sha256 = "1j2ywaazglgl6370js34acrg0wrh0b7krqg05dfjf65n527lzn59";
+      })
+      ./no-static-lib.patch
+      # https://github.com/deltachat/deltachat-core-rust/pull/2660
+      (fetchpatch {
+        url = "https://github.com/deltachat/deltachat-core-rust/commit/8fb5e038a97d8ae68564c885d61b93127a68366d.patch";
+        sha256 = "088pzfrrkgfi4646dc72404s3kykcpni7hgkppalwlzg0p4is41x";
+      })
+    ];
+  });
   electronExec = if stdenv.isDarwin then
     "${electron}/Applications/Electron.app/Contents/MacOS/Electron"
   else
@@ -38,7 +66,7 @@ in nodePackages.deltachat-desktop.override rec {
   ];
 
   buildInputs = [
-    libdeltachat
+    libdeltachat'
   ] ++ lib.optionals stdenv.isDarwin [
     CoreServices
   ];

--- a/pkgs/applications/networking/instant-messengers/deltachat-desktop/no-static-lib.patch
+++ b/pkgs/applications/networking/instant-messengers/deltachat-desktop/no-static-lib.patch
@@ -1,0 +1,39 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fe7abe08..acdbe0d6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -13,7 +13,6 @@ find_program(CARGO cargo)
+ 
+ add_custom_command(
+ 	OUTPUT
+-	"target/release/libdeltachat.a"
+ 	"target/release/libdeltachat.${DYNAMIC_EXT}"
+ 	"target/release/pkgconfig/deltachat.pc"
+         COMMAND
+@@ -38,13 +37,11 @@ add_custom_target(
+ 	lib_deltachat
+ 	ALL
+ 	DEPENDS
+-	"target/release/libdeltachat.a"
+ 	"target/release/libdeltachat.${DYNAMIC_EXT}"
+ 	"target/release/pkgconfig/deltachat.pc"
+ )
+ 
+ include(GNUInstallDirs)
+ install(FILES "deltachat-ffi/deltachat.h" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+-install(FILES "target/release/libdeltachat.a" DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ install(FILES "target/release/libdeltachat.${DYNAMIC_EXT}" DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ install(FILES "target/release/pkgconfig/deltachat.pc" DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+diff --git a/deltachat-ffi/Cargo.toml b/deltachat-ffi/Cargo.toml
+index a34a27ba..cf354abb 100644
+--- a/deltachat-ffi/Cargo.toml
++++ b/deltachat-ffi/Cargo.toml
+@@ -12,7 +12,7 @@ categories = ["cryptography", "std", "email"]
+ 
+ [lib]
+ name = "deltachat"
+-crate-type = ["cdylib", "staticlib"]
++crate-type = ["cdylib"]
+ 
+ [dependencies]
+ deltachat = { path = "../", default-features = false }

--- a/pkgs/applications/networking/instant-messengers/deltachat-desktop/update.sh
+++ b/pkgs/applications/networking/instant-messengers/deltachat-desktop/update.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i bash -p curl jq nix-prefetch
+#! nix-shell -i bash -p coreutils curl gnused jq moreutils nix-prefetch
 
 set -euo pipefail
 cd "$(dirname "$0")"
@@ -13,7 +13,7 @@ rev=$(
     jq 'map(select(.prerelease | not)) | .[0].tag_name' --raw-output
 )
 ver=$(echo "$rev" | sed 's/^v//')
-old_ver=$(sed -n 's/.*\bversion = "\(.*\)".*/\1/p' default.nix)
+old_ver=$(tac default.nix | sed -n 's/.*\bversion = "\(.*\)".*/\1/p' | head -1)
 if [ "$ver" = "$old_ver" ]; then
     echo "Up to date: $ver"
     exit
@@ -21,9 +21,12 @@ fi
 echo "$old_ver -> $ver"
 
 sha256=$(nix-prefetch -f "$nixpkgs" deltachat-desktop --rev "$rev")
-sed -e "s#\\bversion = \".*\"#version = \"$ver\"#" \
-    -e "s#\\bsha256 = \".*\"#sha256 = \"$sha256\"#" \
-    -i default.nix
+tac default.nix \
+    | sed -e "0,/version = \".*\"/s//version = \"$ver\"/" \
+          -e "0,/sha256 = \".*\"/s//sha256 = \"$sha256\"/" \
+    | tac \
+    | sponge default.nix
+
 src=$(nix-build "$nixpkgs" -A deltachat-desktop.src --no-out-link)
 
 jq '{ name, version, dependencies: (.dependencies + (.devDependencies | del(.["@typescript-eslint/eslint-plugin","@typescript-eslint/parser","esbuild","electron-builder","electron-devtools-installer","electron-notarize","esbuild","eslint","eslint-config-prettier","eslint-plugin-react-hooks","hallmark","prettier","tape","testcafe","testcafe-browser-provider-electron","testcafe-react-selectors","walk"]))) }' \

--- a/pkgs/development/libraries/libdeltachat/default.nix
+++ b/pkgs/development/libraries/libdeltachat/default.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libdeltachat";
-  version = "1.64.0";
+  version = "1.65.0";
 
   src = fetchFromGitHub {
     owner = "deltachat";
     repo = "deltachat-core-rust";
     rev = version;
-    sha256 = "04a1ncikapx53jjrx0ac1qi907wlj6javylz4aksg4nfbph6y9j4";
+    sha256 = "1k906pll4k8bc2xc9qd9g7q10rikbij2sy0w2wg9mf335rfym6z4";
   };
 
   patches = [
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     name = "${pname}-${version}";
-    sha256 = "0skrzxn99c1gqil7z0dv0xhg883k98v6mh96nycf7whl2d25965x";
+    sha256 = "0jc9kyn5h3cn2ni5h3km47sfprpxr7hc96ca01yal2zyksm7zqxn";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/deltachat/deltachat-core-rust/blob/1.65.0/CHANGELOG.md


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
