### PR TITLE
nixos/pantheon: cleanup FAQ section

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/pantheon.xml
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.xml
@@ -107,12 +107,6 @@ switchboard-with-plugs.override {
      <para>
       AppCenter has been available since 20.03, but it is of little use. This is because there is no functioning PackageKit backend for Nix 2.0. The Flatpak backend will not work before <link xlink:href="https://github.com/elementary/appcenter/issues/1076">flag for Flatpak-only</link> is provided. See this <link xlink:href="https://github.com/NixOS/nixpkgs/issues/70214">issue</link>.
      </para>
-     <para>
-      To use AppCenter on NixOS, add <literal>pantheon.appcenter</literal> to <xref linkend="opt-environment.systemPackages" />, <link linkend="module-services-flatpak">enable Flatpak support</link> and optionally add the <literal>appcenter</literal> Flatpak remote:
-     </para>
-<screen>
-<prompt>$ </prompt>flatpak remote-add --if-not-exists appcenter https://flatpak.elementary.io/repo.flatpakrepo
-</screen>
     </listitem>
    </varlistentry>
   </variablelist>


### PR DESCRIPTION
###### Motivation for this change

As mentioned in FAQ, appcenter does not work currently, the installation instructions should be removed to avoid any confusion, I forgot to clean everything up when doing the 2021-10-27 update.

While it is possible to patch appcenter, I have to admit that maintaining that patch downstream is very hard. I am upstreaming my patch and hope it can be merged soon. I will update the docs again when there is an update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested building the manual
- [x] Checked the rendered content
