### PR TITLE
krane: 2.3.0 → 2.3.1

### DIFF
--- a/pkgs/applications/networking/cluster/krane/Gemfile.lock
+++ b/pkgs/applications/networking/cluster/krane/Gemfile.lock
@@ -55,13 +55,13 @@ GEM
     http-form_data (2.3.0)
     http-parser (1.2.3)
       ffi-compiler (>= 1.0, < 2.0)
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     jsonpath (0.9.9)
       multi_json
       to_regexp (~> 0.2.1)
     jwt (2.3.0)
-    krane (2.3.0)
+    krane (2.3.1)
       activesupport (>= 5.0)
       colorize (~> 0.8)
       concurrent-ruby (~> 1.1)
@@ -77,15 +77,15 @@ GEM
       recursive-open-struct (~> 1.1, >= 1.1.1)
       rest-client (~> 2.0)
     memoist (0.16.2)
-    mime-types (3.3.1)
+    mime-types (3.4.0)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0901)
+    mime-types-data (3.2021.1115)
     minitest (5.14.4)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     netrc (0.11.0)
-    oj (3.13.8)
-    os (1.1.1)
+    oj (3.13.9)
+    os (1.1.4)
     public_suffix (4.0.6)
     rake (13.0.6)
     recursive-open-struct (1.1.3)
@@ -108,7 +108,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8)
-    zeitwerk (2.4.2)
+    zeitwerk (2.5.1)
 
 PLATFORMS
   ruby
@@ -117,4 +117,4 @@ DEPENDENCIES
   krane
 
 BUNDLED WITH
-   2.2.20
+   2.2.24

--- a/pkgs/applications/networking/cluster/krane/gemset.nix
+++ b/pkgs/applications/networking/cluster/krane/gemset.nix
@@ -244,10 +244,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0g2fnag935zn2ggm5cn6k4s4xvv53v2givj1j90szmvavlpya96a";
+      sha256 = "0vdd1kii40qhbr9n8qx71k2gskq6rkl8ygy8hw5hfj8bb5a364xf";
       type = "gem";
     };
-    version = "1.8.10";
+    version = "1.8.11";
   };
   jsonpath = {
     dependencies = ["multi_json" "to_regexp"];
@@ -276,10 +276,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1r4sfyapdqcgqns4skxwkxd9v7a4f0h7y7zrgyz7za1p56jmx9sr";
+      sha256 = "0k1lwg0d2phs9n9zdx7nv5rv2p2vipm9jgzalr8x9nrq1is6wgvr";
       type = "gem";
     };
-    version = "2.3.0";
+    version = "2.3.1";
   };
   kubeclient = {
     dependencies = ["http" "recursive-open-struct" "rest-client"];
@@ -308,20 +308,20 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1zj12l9qk62anvk9bjvandpa6vy4xslil15wl6wlivyf51z773vh";
+      sha256 = "1wvbwlkf6i17xvxx70cffw26ijvcc400vfhpbnvd8mmx556cnb4g";
       type = "gem";
     };
-    version = "3.3.1";
+    version = "3.4.0";
   };
   mime-types-data = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1z5wvk6qi4ws1kjh7xn1rfirqw5m72bwvqacck1fjpbh33pcrwxv";
+      sha256 = "03m3fkix2haah20kvh1jgv262yg9jlzn6wq0y31kafxk8fysfy27";
       type = "gem";
     };
-    version = "3.2021.0901";
+    version = "3.2021.1115";
   };
   minitest = {
     groups = ["default"];
@@ -368,20 +368,20 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1wk5vk0py65aqp3xrs8s8qkj8pw6xny5z5p9dx16qdx6j3zw5a6g";
+      sha256 = "1hcmczbp9afxijzg0gvp9milyzk15phfmbpmmsj5ppmziwkdls16";
       type = "gem";
     };
-    version = "3.13.8";
+    version = "3.13.9";
   };
   os = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "12fli64wz5j9868gpzv5wqsingk1jk457qyqksv9ksmq9b0zpc9x";
+      sha256 = "0gwd20smyhxbm687vdikfh1gpi96h8qb1x28s2pdcysf6dm6v0ap";
       type = "gem";
     };
-    version = "1.1.1";
+    version = "1.1.4";
   };
   public_suffix = {
     groups = ["default"];
@@ -512,9 +512,9 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1746czsjarixq0x05f7p3hpzi38ldg6wxnxxw74kbjzh1sdjgmpl";
+      sha256 = "18l4r6layck0d80ydc692mv1lxak5xbf6w2paj1x7m2ggbggzxgj";
       type = "gem";
     };
-    version = "2.4.2";
+    version = "2.5.1";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update to the latest version: https://github.com/Shopify/krane/releases/tag/v2.3.1

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).