### PR TITLE
cardpeek: fix build on darwin

### DIFF
--- a/pkgs/applications/misc/cardpeek/default.nix
+++ b/pkgs/applications/misc/cardpeek/default.nix
@@ -1,29 +1,50 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, autoreconfHook,
-  glib, gtk3, pcsclite, lua5_2, curl, readline }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, autoreconfHook
+, glib
+, gtk3
+, pcsclite
+, lua5_2
+, curl
+, readline
+, PCSC
+, xcbuild
+}:
 let
   version = "0.8.4";
 in
-  stdenv.mkDerivation {
-    pname = "cardpeek";
-    inherit version;
+stdenv.mkDerivation {
+  pname = "cardpeek";
+  inherit version;
 
-    src = fetchFromGitHub {
-      owner = "L1L1";
-      repo = "cardpeek";
-      rev = "cardpeek-${version}";
-      sha256 = "1ighpl7nvcvwnsd6r5h5n9p95kclwrq99hq7bry7s53yr57l6588";
-    };
+  src = fetchFromGitHub {
+    owner = "L1L1";
+    repo = "cardpeek";
+    rev = "cardpeek-${version}";
+    sha256 = "1ighpl7nvcvwnsd6r5h5n9p95kclwrq99hq7bry7s53yr57l6588";
+  };
 
-    nativeBuildInputs = [ pkg-config autoreconfHook ];
-    buildInputs = [ glib gtk3 pcsclite lua5_2 curl readline ];
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    # replace xcode check and hard-coded PCSC framework path
+    substituteInPlace configure.ac \
+      --replace 'if test ! -e "/Applications/Xcode.app/"; then' 'if test yes != yes; then' \
+      --replace 'PCSC_HEADERS=`ls -d /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/*.sdk/System/Library/Frameworks/PCSC.framework/Versions/Current/Headers/ | sort | head -1`' 'PCSC_HEADERS=${PCSC}/Library/Frameworks/PCSC.framework/Headers'
+  '';
 
-    enableParallelBuilding = true;
+  nativeBuildInputs = [ pkg-config autoreconfHook ];
+  buildInputs = [ glib gtk3 lua5_2 curl readline ]
+    ++ lib.optional stdenv.isDarwin PCSC
+    ++ lib.optional stdenv.isLinux pcsclite;
 
-    meta = with lib; {
-      homepage = "https://github.com/L1L1/cardpeek";
-      description = "A tool to read the contents of ISO7816 smart cards";
-      license = licenses.gpl3Plus;
-      platforms = with platforms; linux ++ darwin;
-      maintainers = with maintainers; [ embr ];
-    };
-  }
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/L1L1/cardpeek";
+    description = "A tool to read the contents of ISO7816 smart cards";
+    license = licenses.gpl3Plus;
+    platforms = with platforms; linux ++ darwin;
+    maintainers = with maintainers; [ embr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2377,7 +2377,7 @@ with pkgs;
 
   catclock = callPackage ../applications/misc/catclock { };
 
-  cardpeek = callPackage ../applications/misc/cardpeek { };
+  cardpeek = callPackage ../applications/misc/cardpeek { inherit (darwin.apple_sdk.frameworks) PCSC; };
 
   cawbird = callPackage ../applications/networking/cawbird { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF: #144627

###### Things done

Use native PCSC framework on darwin and strip out checks for Xcode.app.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
