### PR TITLE
vaultwarden: fix the build for rustc 1.56

### DIFF
--- a/pkgs/tools/security/vaultwarden/default.nix
+++ b/pkgs/tools/security/vaultwarden/default.nix
@@ -19,12 +19,20 @@ in rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-ViXpoPkBznB0o/dc/l1r3m0y+z2w58wqlU8/cg8u7tI=";
 
+  postPatch = ''
+    # Upstream specifies 1.57; nixpkgs has 1.56 which also produces a working
+    # vaultwarden when using RUSTC_BOOTSTRAP=1
+    sed -ri 's/^rust-version = .*//g' Cargo.toml
+  '';
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = with lib; [ openssl ]
     ++ optionals stdenv.isDarwin [ libiconv Security CoreServices ]
     ++ optional (dbBackend == "mysql") libmysqlclient
     ++ optional (dbBackend == "postgresql") postgresql;
 
+  # vaultwarden depends on rocket v0.5.0-dev, which requires nightly features.
+  # This may be removed if https://github.com/dani-garcia/vaultwarden/issues/712 is fixed.
   RUSTC_BOOTSTRAP = 1;
 
   cargoBuildFlags = [ featuresFlag ];
@@ -42,6 +50,6 @@ in rustPlatform.buildRustPackage rec {
     description = "Unofficial Bitwarden compatible server written in Rust";
     homepage = "https://github.com/dani-garcia/vaultwarden";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ msteen ];
+    maintainers = with maintainers; [ msteen ivan ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This fixes https://github.com/NixOS/nixpkgs/issues/146215

rustc 1.55 was ignoring vaultwarden's `rust-version = 1.57`, causing
the build to succeed. rustc 1.56 was erroring out because it does not
ignore the minimum `rust-version`.

Patch out the `rust-version` because we do not really need 1.57;
rustc 1.56 with RUSTC_BOOTSTRAP=1 produces a working vaultwarden.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc maintainer @msteen 

It seems to build, ~~but I still need to confirm that vaultwarden is working properly.~~