### PR TITLE
mp3blaster: pull pending upstream inclusion fix for ncurses-6.3

### DIFF
--- a/pkgs/applications/audio/mp3blaster/default.nix
+++ b/pkgs/applications/audio/mp3blaster/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, ncurses, libvorbis, SDL }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, ncurses, libvorbis, SDL }:
 
 stdenv.mkDerivation rec {
   pname = "mp3blaster";
@@ -10,6 +10,16 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "0pzwml3yhysn8vyffw9q9p9rs8gixqkmg4n715vm23ib6wxbliqs";
   };
+
+  patches = [
+    # Fix pending upstream inclusion for ncurses-6.3 support:
+    #  https://github.com/stragulus/mp3blaster/pull/8
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/stragulus/mp3blaster/commit/62168cba5eaba6ffe56943552837cf033cfa96ed.patch";
+      sha256 = "088l27kl1l58lwxfnw5x2n64sdjy925ycphni3icwag7zvpj0xz1";
+    })
+  ];
 
   buildInputs = [
     ncurses


### PR DESCRIPTION
Without the fix build on ncurses-6.3 fails as:

    nmixer.cc:219:26: error: format not a string literal and no format arguments [-Werror=format-security]
      219 |                 mvwprintw(mixwin, my_y - 1, my_x, (char*)source);
          |                 ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
