### PR TITLE
gmid: fix cross-compilation

### DIFF
--- a/pkgs/servers/gemini/gmid/default.nix
+++ b/pkgs/servers/gemini/gmid/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, bison, libressl, libevent }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, bison, libressl, libevent }:
 
 stdenv.mkDerivation rec {
   pname = "gmid";
@@ -10,6 +10,14 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-BBd0AL5jRRslxzDnxcTZRR+8J5D23NAQ7mp9K+leXAQ=";
   };
+
+  patches = [
+    # Fix cross-compilation
+    (fetchpatch {
+      url = "https://github.com/omar-polo/gmid/commit/eb77afa8d308a2f4f422df2ff19f023b5b2cc591.patch";
+      sha256 = "sha256-rTTZUpfXOg7X0Ad0Y9evyU7k+aVYpJ0t9SEkNA/sSdk=";
+    })
+  ];
 
   nativeBuildInputs = [ bison ];
 


### PR DESCRIPTION
###### Motivation for this change
fix cross-compilation

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
