### PR TITLE
docopts: 0.6.3 -> 0.6.4

### DIFF
--- a/pkgs/development/tools/misc/docopts/default.nix
+++ b/pkgs/development/tools/misc/docopts/default.nix
@@ -2,13 +2,13 @@
 
 buildGoPackage rec {
   pname = "docopts";
-  version = "0.6.3-rc2";
+  version = "0.6.4-with-no-mangle-double-dash";
 
   src = fetchFromGitHub {
     owner = "docopt";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-PmsTkPT/sf70MKYLhHvjCDb2o3VQ1k7d++RUW7rcoAg=";
+    sha256 = "0zxax0kl8wqpkzmw9ij4qgfhjbk4r7996pjyp9xf5icyk8knp00q";
   };
 
   goPackagePath = "github.com/docopt/${pname}";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Superseed https://github.com/NixOS/nixpkgs/pull/144499

###### Motivation for this change

Version 0.6.3 was affected by a bug (https://github.com/docopt/docopts/issues/47) that has been resolved in 0.6.4.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).