### PR TITLE
ueforth: init

### DIFF
--- a/pkgs/development/interpreters/ueforth/default.nix
+++ b/pkgs/development/interpreters/ueforth/default.nix
@@ -1,0 +1,42 @@
+{ lib, stdenv, fetchFromGitHub
+, nodejs, python
+}:
+let
+  REVISION = "830e6b40d7d3a4c67302c65359c4989e2ff5a5de";
+in stdenv.mkDerivation {
+  name = "ueforth";
+  inherit REVISION;
+  src = fetchFromGitHub {
+    owner = "flagxor";
+    repo = "eforth";
+    rev = REVISION;
+    sha256 = "0xc5s3vyq3h5xjkvdxrq3fklg6pq1xsq7gy1p7aih937x4vcrlgh";
+  };
+
+  postUnpack = ''
+    sourceRoot=$sourceRoot/ueforth
+  '';
+
+  patchPhase = ''
+    sed -i 's_/usr/bin/env nodejs_${nodejs}/bin/node_' **/*.js
+    sed -i 's_/usr/bin/env python_${python}/bin/python_' **/*.py
+  '';
+
+  buildPhase = ''
+    make "REVISION=$REVISION" out/posix/ueforth
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/ueforth
+    cp out/posix/ueforth $out/bin
+    cp -R common posix $out/share/ueforth/
+  '';
+
+  meta = {
+    description = "µEforth, an EForth inspired Forth bootstraped from a minimalist C kernel";
+    homepage = "https://github.com/flagxor/eforth/tree/main/ueforth";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.all;
+  };
+
+}

--- a/pkgs/development/interpreters/ueforth/default.nix
+++ b/pkgs/development/interpreters/ueforth/default.nix
@@ -1,15 +1,14 @@
 { lib, stdenv, fetchFromGitHub
 , nodejs, python
 }:
-let
-  REVISION = "830e6b40d7d3a4c67302c65359c4989e2ff5a5de";
-in stdenv.mkDerivation {
-  name = "ueforth";
-  inherit REVISION;
+
+stdenv.mkDerivation rec {
+  pname = "ueforth";
+  version = "unstable-2021-09-20";
   src = fetchFromGitHub {
     owner = "flagxor";
     repo = "eforth";
-    rev = REVISION;
+    rev = "830e6b40d7d3a4c67302c65359c4989e2ff5a5de";
     sha256 = "0xc5s3vyq3h5xjkvdxrq3fklg6pq1xsq7gy1p7aih937x4vcrlgh";
   };
 
@@ -17,13 +16,13 @@ in stdenv.mkDerivation {
     sourceRoot=$sourceRoot/ueforth
   '';
 
-  patchPhase = ''
+  postPatch = ''
     sed -i 's_/usr/bin/env nodejs_${nodejs}/bin/node_' **/*.js
     sed -i 's_/usr/bin/env python_${python}/bin/python_' **/*.py
   '';
 
   buildPhase = ''
-    make "REVISION=$REVISION" out/posix/ueforth
+    make "REVISION=${src.rev}" out/posix/ueforth
   '';
 
   installPhase = ''

--- a/pkgs/development/interpreters/ueforth/default.nix
+++ b/pkgs/development/interpreters/ueforth/default.nix
@@ -1,6 +1,4 @@
-{ lib, stdenv, fetchFromGitHub
-, nodejs, python
-}:
+{ lib, stdenv, fetchFromGitHub, nodejs, python }:
 
 stdenv.mkDerivation rec {
   pname = "ueforth";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15371,6 +15371,8 @@ with pkgs;
 
   uefi-firmware-parser = callPackage ../development/tools/analysis/uefi-firmware-parser { };
 
+  ueforth = callPackage ../development/interpreters/ueforth { };
+
   uhd3_5 = callPackage ../applications/radio/uhd/3.5.nix { };
   uhd = callPackage ../applications/radio/uhd {
     boost = boost17x;


### PR DESCRIPTION
###### Motivation for this change

ueforth is a neat little C-embedded forth based on [X Macros] https://en.wikipedia.org/wiki/X_Macro

this builds the posix target

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
