### PR TITLE
treewide: use buildFeatures and checkFeatures for rust packages

### DIFF
--- a/pkgs/applications/audio/librespot/default.nix
+++ b/pkgs/applications/audio/librespot/default.nix
@@ -15,23 +15,17 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "1sal85gsbnrabxi39298w9njdc08csnwl40akd6k9fsc0fmpn1b0";
 
-  cargoBuildFlags = with lib; [
-    "--no-default-features"
-    "--features"
-    (concatStringsSep "," (filter (x: x != "") [
-      (optionalString withRodio "rodio-backend")
-      (optionalString withALSA "alsa-backend")
-      (optionalString withPulseAudio "pulseaudio-backend")
-      (optionalString withPortAudio "portaudio-backend")
-
-    ]))
-  ];
-
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ openssl ] ++ lib.optional withALSA alsa-lib
     ++ lib.optional withPulseAudio libpulseaudio
     ++ lib.optional withPortAudio portaudio;
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = lib.optional withRodio "rodio-backend"
+    ++ lib.optional withALSA "alsa-backend"
+    ++ lib.optional withPulseAudio "pulseaudio-backend"
+    ++ lib.optional withPortAudio "portaudio-backend";
 
   doCheck = false;
 

--- a/pkgs/applications/audio/spotifyd/default.nix
+++ b/pkgs/applications/audio/spotifyd/default.nix
@@ -20,12 +20,6 @@ rustPackages.rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "07dxfc0csrnfl01p9vdrqvca9f574svlf37dk3dz8p6q08ki0n1z";
 
-  cargoBuildFlags = [
-    "--no-default-features"
-    "--features"
-    "${lib.optionalString withALSA "alsa_backend,"}${lib.optionalString withPulseAudio "pulseaudio_backend,"}${lib.optionalString withPortAudio "portaudio_backend,"}${lib.optionalString withMpris "dbus_mpris,"}${lib.optionalString withKeyring "dbus_keyring,"}"
-  ];
-
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ openssl ]
@@ -33,6 +27,13 @@ rustPackages.rustPlatform.buildRustPackage rec {
     ++ lib.optional withPulseAudio libpulseaudio
     ++ lib.optional withPortAudio portaudio
     ++ lib.optional (withMpris || withKeyring) dbus;
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = lib.optional withALSA "alsa_backend"
+    ++ lib.optional withPulseAudio "pulseaudio_backend"
+    ++ lib.optional withPortAudio "portaudio_backend"
+    ++ lib.optional withMpris "dbus_mpris"
+    ++ lib.optional withKeyring "dbus_keyring";
 
   doCheck = false;
 

--- a/pkgs/applications/blockchains/alfis/default.nix
+++ b/pkgs/applications/blockchains/alfis/default.nix
@@ -14,12 +14,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "1n7kb1lyghpkgdgd58pw8ldvfps30rnv5niwx35pkdg74h59hqgj";
 
-  cargoBuildFlags = [ "--no-default-features" ]
-    ++ lib.optional withGui "--features webgui";
-
-  cargoTestFlags = [ "--no-default-features" ]
-    ++ lib.optional withGui "--features webgui";
-
   checkFlags = [
     # these want internet access, disable them
     "--skip=dns::client::tests::test_tcp_client"
@@ -29,6 +23,9 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [ pkg-config makeWrapper ];
   buildInputs = lib.optional (withGui && stdenv.isLinux) webkitgtk
     ++ lib.optionals (withGui && stdenv.isDarwin) [ Cocoa WebKit ];
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = lib.optional withGui "webgui";
 
   postInstall = lib.optionalString (withGui && stdenv.isLinux) ''
     wrapProgram $out/bin/alfis \

--- a/pkgs/applications/blockchains/openethereum/default.nix
+++ b/pkgs/applications/blockchains/openethereum/default.nix
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage rec {
     ++ lib.optionals stdenv.isLinux [ systemd ]
     ++ lib.optionals stdenv.isDarwin [ darwin.Security ];
 
-  cargoBuildFlags = [ "--features final" ];
+  buildFeatures = [ "final" ];
 
   # Fix tests by preventing them from writing to /homeless-shelter.
   preCheck = ''

--- a/pkgs/applications/graphics/menyoki/default.nix
+++ b/pkgs/applications/graphics/menyoki/default.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = lib.optionals stdenv.isLinux [ libX11 libXrandr ];
 
-  cargoBuildFlags = lib.optional (!withSki) "--no-default-features";
+  buildNoDefaultFeatures = !withSki;
 
   postInstall = ''
     installManPage man/*

--- a/pkgs/applications/misc/clipcat/default.nix
+++ b/pkgs/applications/misc/clipcat/default.nix
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage rec {
   ];
   buildInputs = [ xorg.libxcb ];
 
-  cargoBuildFlags = [ "--features=all" ];
+  buildFeatures = [ "all" ];
 
   postInstall = ''
     installShellCompletion --bash completions/bash-completion/completions/*

--- a/pkgs/applications/misc/todiff/default.nix
+++ b/pkgs/applications/misc/todiff/default.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "0vrn1vc3rwabv6l2r1qb7mkcxbp75q79bfl3rxhyi51ra3ij507r";
 
-  checkPhase = "cargo test --features=integration_tests";
+  checkFeatures = [ "integration_tests" ];
 
   meta = with lib; {
     description = "Human-readable diff for todo.txt files";

--- a/pkgs/applications/networking/irc/tiny/default.nix
+++ b/pkgs/applications/networking/irc/tiny/default.nix
@@ -21,10 +21,10 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "05q3f1wp48mwkz8n0102rwb6jzrgpx3dlbxzf3zcw8r1mblgzim1";
 
-  cargoBuildFlags = lib.optionals stdenv.isLinux [ "--features=desktop-notifications" ];
-
   nativeBuildInputs = lib.optional stdenv.isLinux pkg-config;
   buildInputs = lib.optionals stdenv.isLinux [ dbus openssl ] ++ lib.optional stdenv.isDarwin Foundation;
+
+  buildFeatures = lib.optional stdenv.isLinux "desktop-notifications";
 
   meta = with lib; {
     description = "A console IRC client";

--- a/pkgs/applications/networking/mailreaders/meli/default.nix
+++ b/pkgs/applications/networking/mailreaders/meli/default.nix
@@ -25,13 +25,13 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-ZE653OtXyZ9454bKPApmuL2kVko/hGBWEAya1L1KIoc=";
 
-  cargoBuildFlags = lib.optional withNotmuch "--features=notmuch";
-
   nativeBuildInputs = [ pkg-config gzip makeWrapper ];
 
   buildInputs = [ openssl dbus sqlite ] ++ lib.optional withNotmuch notmuch;
 
   checkInputs = [ file ];
+
+  buildFeatures = lib.optional withNotmuch [ "notmuch" ];
 
   postInstall = ''
     mkdir -p $out/share/man/man1

--- a/pkgs/applications/science/logic/elan/default.nix
+++ b/pkgs/applications/science/logic/elan/default.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [ curl zlib openssl ]
     ++ lib.optional stdenv.isDarwin libiconv;
 
-  cargoBuildFlags = [ "--features no-self-update" ];
+  buildFeatures = [ "no-self-update" ];
 
   patches = lib.optionals stdenv.isLinux [
     # Run patchelf on the downloaded binaries.

--- a/pkgs/applications/science/machine-learning/finalfusion-utils/default.nix
+++ b/pkgs/applications/science/machine-learning/finalfusion-utils/default.nix
@@ -22,12 +22,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-/rLv2/bcVsmWw+ZfyumDcj0ptHPQBCCYR9O/lVlV+G0=";
 
-  # Enables build against a generic BLAS.
-  cargoBuildFlags = [
-    "--features"
-    "netlib"
-  ];
-
   nativeBuildInputs = [ installShellFiles ];
 
   buildInputs = [
@@ -37,6 +31,9 @@ rustPlatform.buildRustPackage rec {
   ] ++ lib.optionals stdenv.isDarwin [
     Security
   ];
+
+  # Enables build against a generic BLAS.
+  buildFeatures = [ "netlib" ];
 
   postInstall = ''
     # Install shell completions

--- a/pkgs/applications/version-management/git-and-tools/lucky-commit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/lucky-commit/default.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = lib.optional withOpenCL (if stdenv.isDarwin then OpenCL else ocl-icd);
 
-  cargoBuildFlags = lib.optional (!withOpenCL) "--no-default-features";
+  buildNoDefaultFeatures = !withOpenCL;
 
   # disable tests that require gpu
   checkNoDefaultFeatures = true;

--- a/pkgs/applications/version-management/pijul/default.nix
+++ b/pkgs/applications/version-management/pijul/default.nix
@@ -22,8 +22,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-j9xf97qPdhtakIwhAql0/Go5fPxlyWKAVLk5CMBfAbs=";
 
-  cargoBuildFlags = lib.optional gitImportSupport "--features=git";
-
   doCheck = false;
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl libsodium xxHash zstd ]
@@ -31,6 +29,8 @@ rustPlatform.buildRustPackage rec {
     ++ (lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
       CoreServices Security SystemConfiguration
     ]));
+
+  buildFeatures = lib.optional gitImportSupport "git";
 
   meta = with lib; {
     description = "A distributed version control system";

--- a/pkgs/applications/window-managers/eww/default.nix
+++ b/pkgs/applications/window-managers/eww/default.nix
@@ -25,10 +25,10 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ gtk3 ] ++ lib.optional withWayland gtk-layer-shell;
 
-  cargoBuildFlags = [ "--bin" "eww" ] ++ lib.optionals withWayland [
-    "--no-default-features"
-    "--features=wayland"
-  ];
+  buildNoDefaultFeatures = withWayland;
+  buildFeatures = lib.optional withWayland "wayland";
+
+  cargoBuildFlags = [ "--bin" "eww" ];
 
   cargoTestFlags = cargoBuildFlags;
 

--- a/pkgs/applications/window-managers/i3/status-rust.nix
+++ b/pkgs/applications/window-managers/i3/status-rust.nix
@@ -27,10 +27,10 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ dbus libpulseaudio notmuch openssl ];
 
-  cargoBuildFlags = [
-    "--features=notmuch"
-    "--features=maildir"
-    "--features=pulseaudio"
+  buildFeatures = [
+    "notmuch"
+    "maildir"
+    "pulseaudio"
   ];
 
   prePatch = ''

--- a/pkgs/applications/window-managers/i3/wmfocus.nix
+++ b/pkgs/applications/window-managers/i3/wmfocus.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage rec {
   # For now, this is the only available featureset. This is also why the file is
   # in the i3 folder, even though it might be useful for more than just i3
   # users.
-  cargoBuildFlags = [ "--features i3" ];
+  buildFeatures = [ "i3" ];
 
   meta = with lib; {
     description = "Visually focus windows by label";

--- a/pkgs/development/interpreters/wasmer/default.nix
+++ b/pkgs/development/interpreters/wasmer/default.nix
@@ -22,20 +22,18 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ cmake pkg-config ];
 
+  # cranelift+jit works everywhere, see:
+  # https://github.com/wasmerio/wasmer/blob/master/Makefile#L22
+  buildFeatures = [ "cranelift" "jit" ];
   cargoBuildFlags = [
-    # cranelift+jit works everywhere, see:
-    # https://github.com/wasmerio/wasmer/blob/master/Makefile#L22
-    "--features" "cranelift,jit"
     # must target manifest and desired output bin, otherwise output is empty
     "--manifest-path" "lib/cli/Cargo.toml"
     "--bin" "wasmer"
   ];
 
-  cargoTestFlags = [
-    "--features" "test-cranelift"
-    # Can't use test-jit :
-    # error: Package `wasmer-workspace v2.0.0 (/build/source)` does not have the feature `test-jit`
-  ];
+  # Can't use test-jit:
+  # error: Package `wasmer-workspace v2.0.0 (/build/source)` does not have the feature `test-jit`
+  checkFeatures = [ "test-cranelift" ];
 
   LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
 

--- a/pkgs/development/tools/diesel-cli/default.nix
+++ b/pkgs/development/tools/diesel-cli/default.nix
@@ -21,9 +21,6 @@ assert lib.assertMsg (sqliteSupport == true || postgresqlSupport == true || mysq
 
 let
   inherit (lib) optional optionals optionalString;
-  features = optional sqliteSupport "sqlite"
-    ++ optional postgresqlSupport "postgres"
-    ++ optional mysqlSupport "mysql";
 in
 
 rustPlatform.buildRustPackage rec {
@@ -36,7 +33,6 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-mRdDc4fHMkwkszY+2l8z1RSNMEQnrWI5/Y0Y2W+guQE=";
   };
 
-  cargoBuildFlags = [ "--no-default-features" "--features" "${lib.concatStringsSep "," features}" ];
   cargoSha256 = "sha256-sQ762Ss31sA5qALHzwkvwbfRXo00cCtqzQyoz3/zf6I=";
 
   nativeBuildInputs = [ installShellFiles pkg-config ];
@@ -47,6 +43,11 @@ rustPlatform.buildRustPackage rec {
     ++ optional sqliteSupport sqlite
     ++ optional postgresqlSupport postgresql
     ++ optionals mysqlSupport [ mariadb zlib ];
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = optional sqliteSupport "sqlite"
+    ++ optional postgresqlSupport "postgres"
+    ++ optional mysqlSupport "mysql";
 
   checkPhase = ''
     runHook preCheck

--- a/pkgs/development/tools/knightos/regenkfs/default.nix
+++ b/pkgs/development/tools/knightos/regenkfs/default.nix
@@ -12,7 +12,8 @@ rustPlatform.buildRustPackage {
   };
 
   cargoSha256 = "sha256-05VmQdop4vdzw2XEvVdp9+RNmyZvay1Q7gKN2n8rDEQ=";
-  cargoBuildFlags = [ "--features=c-undef" ];
+
+  buildFeatures = [ "c-undef" ];
 
   meta = with lib; {
     description = "Reimplementation of genkfs in Rust";

--- a/pkgs/development/tools/misc/sccache/default.nix
+++ b/pkgs/development/tools/misc/sccache/default.nix
@@ -13,10 +13,10 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "1f42cqaqnjwi9k4ihqil6z2dqh5dnf76x54gk7mndzkrfg3rl573";
 
-  cargoBuildFlags = lib.optionals (!stdenv.isDarwin) [ "--features=dist-client,dist-server" ];
-
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ] ++ lib.optional stdenv.isDarwin Security;
+
+  buildFeatures = lib.optionals (!stdenv.isDarwin) [ "dist-client" "dist-server" ];
 
   # Tests fail because of client server setup which is not possible inside the pure environment,
   # see https://github.com/mozilla/sccache/issues/460

--- a/pkgs/development/tools/misc/tokei/default.nix
+++ b/pkgs/development/tools/misc/tokei/default.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   # enable all output formats
-  cargoBuildFlags = [ "--features" "all" ];
+  buildFeatures = [ "all" ];
 
   meta = with lib; {
     description = "A program that allows you to count your code, quickly";

--- a/pkgs/development/tools/rust/cargo-deny/default.nix
+++ b/pkgs/development/tools/rust/cargo-deny/default.nix
@@ -28,9 +28,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [ openssl ]
     ++ lib.optionals stdenv.isDarwin [ curl Security ];
 
-  cargoBuildFlags = [ "--no-default-features" ];
-
-  cargoTestFlags = cargoBuildFlags;
+  buildNoDefaultFeatures = true;
 
   meta = with lib; {
     description = "Cargo plugin to generate list of all licenses for a crate";

--- a/pkgs/development/tools/rust/cargo-embed/default.nix
+++ b/pkgs/development/tools/rust/cargo-embed/default.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [ pkg-config rustfmt ];
   buildInputs = [ libusb1 libftdi1 ] ++ lib.optionals stdenv.isDarwin [ AppKit ];
 
-  cargoBuildFlags = [ "--features=ftdi" ];
+  buildFeatures = [ "ftdi" ];
 
   meta = with lib; {
     description = "A cargo extension for working with microcontrollers";

--- a/pkgs/development/tools/rust/rust-analyzer/default.nix
+++ b/pkgs/development/tools/rust/rust-analyzer/default.nix
@@ -56,15 +56,14 @@ rustPlatform.buildRustPackage rec {
 
   buildAndTestSubdir = "crates/rust-analyzer";
 
-  cargoBuildFlags = lib.optional useMimalloc "--features=mimalloc";
-  cargoTestFlags = lib.optional useMimalloc "--features=mimalloc";
-
   nativeBuildInputs = lib.optional useMimalloc cmake;
 
   buildInputs = lib.optionals stdenv.isDarwin [
     CoreServices
     libiconv
   ];
+
+  buildFeatures = lib.optional useMimalloc "mimalloc";
 
   RUST_ANALYZER_REV = version;
 

--- a/pkgs/development/tools/rust/rustup/default.nix
+++ b/pkgs/development/tools/rust/rustup/default.nix
@@ -40,7 +40,9 @@ rustPlatform.buildRustPackage rec {
     zlib
   ] ++ lib.optionals stdenv.isDarwin [ CoreServices Security libiconv xz ];
 
-  cargoBuildFlags = [ "--features no-self-update" ];
+  buildFeatures = [ "no-self-update" ];
+
+  checkFeatures = [ ];
 
   patches = lib.optionals stdenv.isLinux [
     (runCommand "0001-dynamically-patchelf-binaries.patch" { CC = stdenv.cc; patchelf = patchelf; libPath = "$ORIGIN/../lib:${libPath}"; } ''

--- a/pkgs/development/tools/selene/default.nix
+++ b/pkgs/development/tools/selene/default.nix
@@ -26,9 +26,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = lib.optional robloxSupport openssl
     ++ lib.optional (robloxSupport && stdenv.isDarwin) Security;
 
-  cargoBuildFlags = lib.optional (!robloxSupport) "--no-default-features";
-
-  cargoTestFlags = cargoBuildFlags;
+  buildNoDefaultFeatures = !robloxSupport;
 
   meta = with lib; {
     description = "A blazing-fast modern Lua linter written in Rust";

--- a/pkgs/development/tools/stylua/default.nix
+++ b/pkgs/development/tools/stylua/default.nix
@@ -19,8 +19,8 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-/4ZW1FIfK51ak2EIV6dYY3XpucPPR+OZySPWwcKP4v0=";
 
-  cargoBuildFlags = lib.optionals lua52Support [ "--features" "lua52" ]
-    ++ lib.optionals luauSupport [ "--features" "luau" ];
+  buildFeatures = lib.optional lua52Support "lua52"
+    ++ lib.optional luauSupport "luau";
 
   # test_standard fails on darwin
   doCheck = !stdenvNoCC.isDarwin;

--- a/pkgs/misc/vscode-extensions/vscode-lldb/default.nix
+++ b/pkgs/misc/vscode-extensions/vscode-lldb/default.nix
@@ -31,10 +31,11 @@ let
 
     buildAndTestSubdir = "adapter";
 
+    buildFeatures = [ "weak-linkage" ];
+
     cargoBuildFlags = [
       "--lib"
       "--bin=codelldb"
-      "--features=weak-linkage"
     ];
 
     # Tests are linked to liblldb but it is not available here.

--- a/pkgs/servers/routinator/default.nix
+++ b/pkgs/servers/routinator/default.nix
@@ -20,9 +20,8 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = lib.optionals stdenv.isDarwin [ Security ];
 
-  cargoBuildFlags = [ "--no-default-features" "--features=socks" ];
-
-  cargoTestFlags = cargoBuildFlags;
+  buildNoDefaultFeatures = true;
+  buildFeatures = [ "socks" ];
 
   meta = with lib; {
     description = "An RPKI Validator written in Rust";

--- a/pkgs/shells/nushell/default.nix
+++ b/pkgs/shells/nushell/default.nix
@@ -37,7 +37,7 @@ rustPlatform.buildRustPackage rec {
     ++ lib.optionals (withExtraFeatures && stdenv.isLinux) [ xorg.libX11 ]
     ++ lib.optionals (withExtraFeatures && stdenv.isDarwin) [ AppKit nghttp2 libgit2 ];
 
-  cargoBuildFlags = lib.optional withExtraFeatures "--features=extra";
+  buildFeatures = lib.optional withExtraFeatures "extra";
 
   # Since 0.34, nu has an indirect dependency on `zstd-sys` (via `polars` and
   # `parquet`, for dataframe support), which by default has an impure build

--- a/pkgs/tools/X11/xidlehook/default.nix
+++ b/pkgs/tools/X11/xidlehook/default.nix
@@ -25,11 +25,13 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1pl7f8fhxfcy0c6c08vkagp0x1ak96vc5wgamigrk1nkd6l371lb";
   };
 
-  cargoBuildFlags = lib.optionals (!stdenv.isLinux) [ "--no-default-features" "--features" "pulse" ];
   cargoSha256 = "1y7m61j07gvqfqz97mda39nc602sv7a826c06m8l22i7z380xfms";
 
   buildInputs = [ xlibsWrapper xorg.libXScrnSaver libpulseaudio ] ++ lib.optional stdenv.isDarwin Security;
   nativeBuildInputs = [ pkg-config patchelf python3 ];
+
+  buildNoDefaultFeatures = !stdenv.isLinux;
+  buildFeatures = lib.optional (!stdenv.isLinux) "pulse";
 
   postFixup = lib.optionalString stdenv.isLinux ''
     RPATH="$(patchelf --print-rpath $out/bin/xidlehook)"

--- a/pkgs/tools/compression/ouch/default.nix
+++ b/pkgs/tools/compression/ouch/default.nix
@@ -27,9 +27,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ bzip2 xz zlib zstd ];
 
-  cargoBuildFlags = [ "--features" "zstd/pkg-config" ];
-
-  cargoTestFlags = cargoBuildFlags;
+  buildFeatures = [ "zstd/pkg-config" ];
 
   postInstall = ''
     help2man $out/bin/ouch > ouch.1

--- a/pkgs/tools/misc/termplay/default.nix
+++ b/pkgs/tools/misc/termplay/default.nix
@@ -11,7 +11,6 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1w7hdqgqr1jgxid3k7f2j52wz31gv8bzr9rsm6xzp7nnihp6i45p";
   };
 
-  cargoBuildFlags = ["--features" "bin"];
   cargoSha256 = "08ip6x4kink244majlk595yh551c2ap3ry58wly994mh8wf6ifwb";
 
   nativeBuildInputs = [ makeWrapper ];
@@ -23,6 +22,8 @@ rustPlatform.buildRustPackage rec {
     gst_all_1.gst-plugins-bad
     libsixel
   ];
+
+  buildFeatures = [ "bin" ];
 
   postInstall = ''
     wrapProgram $out/bin/termplay --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"

--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -22,8 +22,8 @@
 , features ? ([ "sinks" "sources" "transforms" ]
     # the second feature flag is passed to the rdkafka dependency
     # building on linux fails without this feature flag (both x86_64 and AArch64)
-    ++ (lib.optionals enableKafka [ "rdkafka-plain" "rdkafka/dynamic_linking" ])
-    ++ (lib.optional stdenv.targetPlatform.isUnix "unix"))
+    ++ lib.optionals enableKafka [ "rdkafka-plain" "rdkafka/dynamic_linking" ]
+    ++ lib.optional stdenv.targetPlatform.isUnix "unix")
 }:
 
 let
@@ -51,24 +51,28 @@ rustPlatform.buildRustPackage {
   RUSTONIG_SYSTEM_LIBONIG = true;
   LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
 
-  cargoBuildFlags = [ "--no-default-features" "--features" (lib.concatStringsSep "," features) ];
+  TZDIR = "${tzdata}/share/zoneinfo";
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = features;
+
   # TODO investigate compilation failure for tests
   # dev dependency includes httpmock which depends on iashc which depends on curl-sys with http2 feature enabled
   # compilation fails because of a missing http2 include
   doCheck = !stdenv.isDarwin;
-  # healthcheck_grafana_cloud is trying to make a network access
-  # test_stream_errors is flaky on linux-aarch64
-  # tcp_with_tls_intermediate_ca is flaky on linux-x86_64
-  checkPhase = ''
-    TZDIR=${tzdata}/share/zoneinfo cargo test \
-      --no-default-features \
-      --features ${lib.concatStringsSep "," features} \
-      -- --test-threads 1 \
-      --skip=sinks::loki::tests::healthcheck_grafana_cloud \
-      --skip=kubernetes::api_watcher::tests::test_stream_errors \
-      --skip=sources::socket::test::tcp_with_tls_intermediate_ca \
-      --skip=sources::host_metrics::cgroups::tests::generates_cgroups_metrics
-  '';
+
+  checkFlags = [
+    # tries to make a network access
+    "--skip=sinks::loki::tests::healthcheck_grafana_cloud"
+
+    # flaky on linux-aarch64
+    "--skip=kubernetes::api_watcher::tests::test_stream_errors"
+
+    # flaky on linux-x86_64
+    "--skip=sources::socket::test::tcp_with_tls_intermediate_ca"
+
+    "--skip=sources::host_metrics::cgroups::tests::generates_cgroups_metrics"
+  ];
 
   # recent overhauls of DNS support in 0.9 mean that we try to resolve
   # vector.dev during the checkPhase, which obviously isn't going to work.

--- a/pkgs/tools/misc/websocat/default.nix
+++ b/pkgs/tools/misc/websocat/default.nix
@@ -12,12 +12,13 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-jwoWxK4phBqhIeo3+oRnpGsfvtn9gTR1ryd4N+0Lmbw=";
   };
 
-  cargoBuildFlags = [ "--features=ssl" ];
   cargoSha256 = "sha256-+3SG1maarY4DJ4+QiYGwltGLksOoOhKtcqstRwgzi2k=";
 
   nativeBuildInputs = [ pkg-config makeWrapper ];
   buildInputs = [ openssl ]
     ++ lib.optionals stdenv.isDarwin [ libiconv Security ];
+
+  buildFeatures = [ "ssl" ];
 
   # Needed to get openssl-sys to use pkg-config.
   OPENSSL_NO_VENDOR=1;

--- a/pkgs/tools/misc/xxv/default.nix
+++ b/pkgs/tools/misc/xxv/default.nix
@@ -25,7 +25,8 @@ rustPlatform.buildRustPackage rec {
 
   # I'm picking pancurses for Windows simply because that's the example given in Cursive's
   # documentation for picking an alternative backend. We could just as easily pick crossterm.
-  cargoBuildFlags = lib.optionals (!useNcurses) [ "--no-default-features" "--features pancurses-backend" ];
+  buildNoDefaultFeatures = !useNcurses;
+  buildFeatures = lib.optional (!useNcurses) "pancurses-backend";
 
   meta = with lib; {
     description = "A visual hex viewer for the terminal";

--- a/pkgs/tools/networking/bore/default.nix
+++ b/pkgs/tools/networking/bore/default.nix
@@ -15,7 +15,9 @@ rustPlatform.buildRustPackage rec {
   cargoBuildFlags = "-p ${pname}";
 
   # FIXME can’t test --all-targets and --doc in a single invocation
-  cargoTestFlags = "--features std --all-targets --workspace";
+  checkFeatures = [ "std" ];
+
+  cargoTestFlags = [ "--all-targets" "--workspace" ];
 
   nativeBuildInputs = [ installShellFiles ]
     ++ lib.optional stdenv.isDarwin llvmPackages.libclang;

--- a/pkgs/tools/nix/statix/default.nix
+++ b/pkgs/tools/nix/statix/default.nix
@@ -15,9 +15,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-e20POz9ZvuT0S+YG+9x7hcudhXQpOR4rVSFJbz76OI0=";
 
-  cargoBuildFlags = lib.optionals withJson [ "--features" "json" ];
-
-  cargoCheckFlags = cargoBuildFlags;
+  buildFeatures = lib.optional withJson "json";
 
   meta = with lib; {
     description = "Lints and suggestions for the nix programming language";

--- a/pkgs/tools/package-management/cargo-audit/default.nix
+++ b/pkgs/tools/package-management/cargo-audit/default.nix
@@ -32,8 +32,7 @@ rustPlatform.buildRustPackage rec {
     Security
   ];
 
-  # enables `cargo audit fix`
-  cargoBuildFlags = [ "--features fix" ];
+  buildFeatures = [ "fix" ];
 
   # The tests require network access which is not available in sandboxed Nix builds.
   doCheck = false;

--- a/pkgs/tools/security/sheesy-cli/default.nix
+++ b/pkgs/tools/security/sheesy-cli/default.nix
@@ -14,11 +14,15 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "159a5ph1gxwcgahyr8885lq3c1w76nxzfrfdpyqixqrr7jzx2rd3";
   cargoDepsName = pname;
 
-  cargoBuildFlags = [ "--bin sy" "--features" "vault,extract,completions,substitute,process" ];
-
   nativeBuildInputs = [ libgpg-error gpgme gettext installShellFiles ];
 
   buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security ];
+
+  buildFeatures = [ "vault" "extract" "completions" "substitute" "process" ];
+
+  checkFeatures = [ ];
+
+  cargoBuildFlags = [ "--bin" "sy" ];
 
   postInstall = ''
     installShellCompletion --cmd sy \

--- a/pkgs/tools/security/vaultwarden/default.nix
+++ b/pkgs/tools/security/vaultwarden/default.nix
@@ -3,10 +3,7 @@
 , libiconv, Security, CoreServices
 , dbBackend ? "sqlite", libmysqlclient, postgresql }:
 
-let
-  featuresFlag = "--features ${dbBackend}";
-
-in rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage rec {
   pname = "vaultwarden";
   version = "1.23.0";
 
@@ -35,14 +32,7 @@ in rustPlatform.buildRustPackage rec {
   # This may be removed if https://github.com/dani-garcia/vaultwarden/issues/712 is fixed.
   RUSTC_BOOTSTRAP = 1;
 
-  cargoBuildFlags = [ featuresFlag ];
-
-  checkPhase = ''
-    runHook preCheck
-    echo "Running cargo cargo test ${featuresFlag} -- ''${checkFlags} ''${checkFlagsArray+''${checkFlagsArray[@]}}"
-    cargo test ${featuresFlag} -- ''${checkFlags} ''${checkFlagsArray+"''${checkFlagsArray[@]}"}
-    runHook postCheck
-  '';
+  buildFeatures = dbBackend;
 
   passthru.tests = nixosTests.vaultwarden;
 

--- a/pkgs/tools/system/zenith/default.nix
+++ b/pkgs/tools/system/zenith/default.nix
@@ -18,11 +18,12 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1bn364rmp0q86rd7vgv4n7x09cdf9m4njcaq92jnk85ni6h147ax";
   };
 
-  cargoBuildFlags = lib.optionals nvidiaSupport [ "--features" "nvidia" ];
   cargoSha256 = "0c2mk2bcz4qjyqmf11yqhnhy4pqxr77b3c1gvr5jfmjshx4ff7v2";
 
   nativeBuildInputs = lib.optional nvidiaSupport makeWrapper;
   buildInputs = lib.optionals stdenv.isDarwin [ IOKit ];
+
+  buildFeatures = lib.optional nvidiaSupport "nvidia";
 
   postInstall = lib.optionalString nvidiaSupport ''
     wrapProgram $out/bin/zenith \

--- a/pkgs/tools/text/ripgrep/default.nix
+++ b/pkgs/tools/text/ripgrep/default.nix
@@ -22,12 +22,12 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "1kfdgh8dra4jxgcdb0lln5wwrimz0dpp33bq3h7jgs8ngaq2a9wp";
 
-  cargoBuildFlags = lib.optional withPCRE2 "--features pcre2";
-
   nativeBuildInputs = [ asciidoctor installShellFiles ]
     ++ lib.optional withPCRE2 pkg-config;
   buildInputs = lib.optional withPCRE2 pcre2
     ++ lib.optional stdenv.isDarwin Security;
+
+  buildFeatures = lib.optional withPCRE2 "pcre2";
 
   preFixup = ''
     installManPage $releaseDir/build/ripgrep-*/out/rg.1


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Follow up to #143069

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
