### PR TITLE
python3Packages.databricks-connect. Split into major versions

### DIFF
--- a/pkgs/development/python-modules/databricks-connect/default.nix
+++ b/pkgs/development/python-modules/databricks-connect/default.nix
@@ -40,6 +40,11 @@ in {
     sha256 = "sha256-JtsmcvvseJYPm/AAgKCvwvTPaxOd6srb2zHKTJVwgDQ=";
   };
 
+  databricks-connect_8 = mkDatabricks {
+    version = "8.1.14";
+    sha256 = "sha256-jxEJVaGlDkbcA9vZaah2W5STJoFT3hZwR2eyJuT+GG4=";
+  };
+
   databricks-connect_9 = mkDatabricks {
     version = "9.1.3";
     sha256 = "sha256-awA8zX6a4n2CkWSrfG9bE+QKUyVBAQae2k+deBeErX8=";

--- a/pkgs/development/python-modules/databricks-connect/default.nix
+++ b/pkgs/development/python-modules/databricks-connect/default.nix
@@ -1,37 +1,42 @@
 { lib, jdk8, buildPythonPackage, fetchPypi, six, py4j }:
+let
+  mkDatabricks = { version, sha256 }: buildPythonPackage rec {
+    pname = "databricks-connect";
+    inherit version;
 
-buildPythonPackage rec {
-  pname = "databricks-connect";
-  version = "9.1.2";
+    src = fetchPypi {
+      inherit pname version sha256;
+    };
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "9672aae60b299de58a527f320df45769cadf436398e21f4ce73424a25badb7a7";
+    sourceRoot = ".";
+
+    propagatedBuildInputs = [ py4j six jdk8 ];
+
+    # requires network access
+    doCheck = false;
+
+    prePatch = ''
+      substituteInPlace setup.py \
+        --replace "py4j==0.10.9" "py4j"
+    '';
+
+    preFixup = ''
+      substituteInPlace "$out/bin/find-spark-home" \
+        --replace find_spark_home.py .find_spark_home.py-wrapped
+    '';
+
+    pythonImportsCheck = [ "pyspark" "six" "py4j" ];
+
+    meta = with lib; {
+      description = "Client for connecting to remote Databricks clusters";
+      homepage = "https://pypi.org/project/databricks-connect";
+      license = licenses.databricks;
+      maintainers = with maintainers; [ kfollesdal ];
+    };
   };
-
-  sourceRoot = ".";
-
-  propagatedBuildInputs = [ py4j six jdk8 ];
-
-  # requires network access
-  doCheck = false;
-
-  prePatch = ''
-    substituteInPlace setup.py \
-      --replace "py4j==0.10.9" "py4j"
-  '';
-
-  preFixup = ''
-    substituteInPlace "$out/bin/find-spark-home" \
-      --replace find_spark_home.py .find_spark_home.py-wrapped
-  '';
-
-  pythonImportsCheck = [ "pyspark" "six" "py4j" ];
-
-  meta = with lib; {
-    description = "Client for connecting to remote Databricks clusters";
-    homepage = "https://pypi.org/project/databricks-connect";
-    license = licenses.databricks;
-    maintainers = with maintainers; [ kfollesdal ];
+in {
+  databricks-connect_9 = mkDatabricks {
+    version = "9.1.2";
+    sha256 = "9672aae60b299de58a527f320df45769cadf436398e21f4ce73424a25badb7a7";
   };
 }

--- a/pkgs/development/python-modules/databricks-connect/default.nix
+++ b/pkgs/development/python-modules/databricks-connect/default.nix
@@ -35,6 +35,11 @@ let
     };
   };
 in {
+  databricks-connect_7 = mkDatabricks {
+    version = "7.3.28";
+    sha256 = "sha256-JtsmcvvseJYPm/AAgKCvwvTPaxOd6srb2zHKTJVwgDQ=";
+  };
+
   databricks-connect_9 = mkDatabricks {
     version = "9.1.3";
     sha256 = "sha256-awA8zX6a4n2CkWSrfG9bE+QKUyVBAQae2k+deBeErX8=";

--- a/pkgs/development/python-modules/databricks-connect/default.nix
+++ b/pkgs/development/python-modules/databricks-connect/default.nix
@@ -36,7 +36,7 @@ let
   };
 in {
   databricks-connect_9 = mkDatabricks {
-    version = "9.1.2";
-    sha256 = "9672aae60b299de58a527f320df45769cadf436398e21f4ce73424a25badb7a7";
+    version = "9.1.3";
+    sha256 = "sha256-awA8zX6a4n2CkWSrfG9bE+QKUyVBAQae2k+deBeErX8=";
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1910,6 +1910,10 @@ in {
 
   databricks-connect = (callPackage ../development/python-modules/databricks-connect { }).databricks-connect_9;
 
+  inherit (callPackage ../development/python-modules/databricks-connect { })
+    databricks-connect_9
+  ;
+
   dataclasses = callPackage ../development/python-modules/dataclasses { };
 
   dataclasses-json = callPackage ../development/python-modules/dataclasses-json { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1912,6 +1912,7 @@ in {
 
   inherit (callPackage ../development/python-modules/databricks-connect { })
     databricks-connect_7
+    databricks-connect_8
     databricks-connect_9
   ;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1908,7 +1908,7 @@ in {
 
   databricks-cli = callPackage ../development/python-modules/databricks-cli { };
 
-  databricks-connect = callPackage ../development/python-modules/databricks-connect { };
+  databricks-connect = (callPackage ../development/python-modules/databricks-connect { }).databricks-connect_9;
 
   dataclasses = callPackage ../development/python-modules/dataclasses { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1911,6 +1911,7 @@ in {
   databricks-connect = (callPackage ../development/python-modules/databricks-connect { }).databricks-connect_9;
 
   inherit (callPackage ../development/python-modules/databricks-connect { })
+    databricks-connect_7
     databricks-connect_9
   ;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Until now we have only had one databricks-connect package following latest version on pypi. But Databricks have three major versions that still is in use 7, 8 and 9. Rewrite code so we get the following packages: 
- python3Packages.databricks-connect_7
- python3Packages.databricks-connect_8
- python3Packages.databricks-connect_9
- python3Packages.databricks-connect = python3Packages.databricks-connect_9

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
