### PR TITLE
mockobjects: remove builder.sh

### DIFF
--- a/pkgs/development/libraries/java/mockobjects/builder.sh
+++ b/pkgs/development/libraries/java/mockobjects/builder.sh
@@ -1,6 +1,0 @@
-set -e
-source $stdenv/setup
-
-tar xvf $src
-mkdir -p $out
-mv * $out

--- a/pkgs/development/libraries/java/mockobjects/default.nix
+++ b/pkgs/development/libraries/java/mockobjects/default.nix
@@ -2,12 +2,23 @@
 
 stdenv.mkDerivation {
   name = "mockobjects-0.09";
-  builder = ./builder.sh;
 
   src = fetchurl {
     url = "mirror://sourceforge/mockobjects/mockobjects-bin-0.09.tar";
     sha256 = "18rnyqfcyh0s3dwkkaszdd50ssyjx5fa1y3ii309ldqg693lfgnz";
   };
+
+  # Work around the "unpacker appears to have produced no directories"
+  setSourceRoot = "sourceRoot=`pwd`";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/java
+    cp mockobjects-*.jar $out/share/java
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "Generic unit testing framework and methodology for testing any kind of code";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
"builder.sh" should be deprecated.

Additionally I think the output is different. It used to output directly without the folders "/share/java"

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
