### PR TITLE
jboss-mysql-jdbc: remove build.sh

### DIFF
--- a/pkgs/servers/http/jboss/jdbc/mysql/builder.sh
+++ b/pkgs/servers/http/jboss/jdbc/mysql/builder.sh
@@ -1,5 +1,0 @@
-buildInputs="$mysql_jdbc"
-source $stdenv/setup
-
-mkdir -p $out/server/default/lib
-ln -s $mysql_jdbc/share/java/mysql-connector-java.jar $out/server/default/lib/mysql-connector-java.jar

--- a/pkgs/servers/http/jboss/jdbc/mysql/default.nix
+++ b/pkgs/servers/http/jboss/jdbc/mysql/default.nix
@@ -2,13 +2,21 @@
 
 stdenv.mkDerivation {
   pname = "jboss-mysql-jdbc";
+  inherit (mysql_jdbc) version;
 
-  builder = ./builder.sh;
+  dontUnpack = true;
 
-  inherit mysql_jdbc;
-  version = mysql_jdbc.version;
+  installPhase = ''
+    runHook preInstall
 
-  meta = {
-    platforms = lib.platforms.unix;
+    mkdir -p $out/server/default/lib
+    ln -s $mysql_jdbc/share/java/mysql-connector-java.jar $out/server/default/lib/mysql-connector-java.jar
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    inherit (mysql_jdbc.meta) description license platforms homepage;
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
"builder.sh" should be deprecated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
