### PR TITLE
kdash: init at 0.3.1

### DIFF
--- a/pkgs/development/tools/kdash/default.nix
+++ b/pkgs/development/tools/kdash/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv
+, fetchFromGitHub
+, rustPlatform
+, pkg-config
+, perl
+, python3
+, openssl
+, xorg
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "kdash";
+  version = "0.2.4";
+
+  src = fetchFromGitHub {
+    owner = "kdash-rs";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "09f9qkab2scass4p2vxkhyqslcf32kvpxi1zfa23p72v681jp0c8";
+  };
+
+  nativeBuildInputs = [ perl python3 pkg-config ];
+
+  buildInputs = [ openssl xorg.xcbutil ];
+
+  cargoSha256 = "0jbyvjgxcjw610nd2i6d3jfmhv1lwsl8ss4fd3kwczsms28frx5c";
+
+  meta = with lib; {
+    description = "A simple and fast dashboard for Kubernetes";
+    homepage = "https://github.com/kdash-rs/kdash";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ matthiasbeyer ];
+  };
+}

--- a/pkgs/development/tools/kdash/default.nix
+++ b/pkgs/development/tools/kdash/default.nix
@@ -10,20 +10,20 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "kdash";
-  version = "0.2.4";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "kdash-rs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "09f9qkab2scass4p2vxkhyqslcf32kvpxi1zfa23p72v681jp0c8";
+    sha256 = "08ca638kvs98xhbc9g1szw0730cjk9g01qqaja8j413n2h1pr8yq";
   };
 
   nativeBuildInputs = [ perl python3 pkg-config ];
 
   buildInputs = [ openssl xorg.xcbutil ];
 
-  cargoSha256 = "0jbyvjgxcjw610nd2i6d3jfmhv1lwsl8ss4fd3kwczsms28frx5c";
+  cargoSha256 = "0nb554y8r7gvw7ls6gnrg98xxbws0mc6zdsc6ss3p2x9z8xwx204";
 
   meta = with lib; {
     description = "A simple and fast dashboard for Kubernetes";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6686,6 +6686,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) AppKit;
   };
 
+  kdash = callPackage ../development/tools/kdash { };
+
   kdbplus = pkgsi686Linux.callPackage ../applications/misc/kdbplus { };
 
   keepalived = callPackage ../tools/networking/keepalived { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
