### PR TITLE
online-judge-tools: init at 11.5.1

### DIFF
--- a/pkgs/development/python-modules/online-judge-api-client/default.nix
+++ b/pkgs/development/python-modules/online-judge-api-client/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, appdirs
+, beautifulsoup4
+, buildPythonPackage
+, colorlog
+, fetchFromGitHub
+, git
+, jsonschema
+, lxml
+, markdown
+, python
+, requests
+, substituteAll
+, toml
+}:
+
+let
+  # NOTE This is needed to download & run another Python program internally in
+  #      order to generate test cases for library-checker problems.
+  pythonEnv = python.withPackages (ps: with ps; [ colorlog jinja2 markdown toml ]);
+in buildPythonPackage rec {
+  pname = "online-judge-api-client";
+  version = "10.10.0";
+
+  src = fetchFromGitHub {
+    owner = "online-judge-tools";
+    repo = "api-client";
+    rev = "v${version}";
+    sha256 = "0lmryqi0bv82v9k9kf1rzzq9zr83smpmy8ivzw4fk31hvpczp4fn";
+  };
+
+  patches = [ ./fix-paths.patch ];
+  postPatch = ''
+    substituteInPlace onlinejudge/service/library_checker.py \
+      --subst-var-by git               ${git} \
+      --subst-var-by pythonInterpreter ${pythonEnv.interpreter}
+  '';
+
+  propagatedBuildInputs = [
+    appdirs
+    beautifulsoup4
+    colorlog
+    jsonschema
+    lxml
+    requests
+    toml
+  ];
+
+  # Requires internet access
+  doCheck = false;
+
+  pythonImportsCheck = [ "onlinejudge" "onlinejudge_api" ];
+
+  meta = with lib; {
+    description = "API client to develop tools for competitive programming";
+    homepage = "https://github.com/online-judge-tools/api-client";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sei40kr ];
+  };
+}

--- a/pkgs/development/python-modules/online-judge-api-client/fix-paths.patch
+++ b/pkgs/development/python-modules/online-judge-api-client/fix-paths.patch
@@ -1,0 +1,39 @@
+diff --git a/onlinejudge/service/library_checker.py b/onlinejudge/service/library_checker.py
+index b63c7b7..e062490 100644
+--- a/onlinejudge/service/library_checker.py
++++ b/onlinejudge/service/library_checker.py
+@@ -51,7 +51,7 @@ class LibraryCheckerService(onlinejudge.type.Service):
+             return
+ 
+         try:
+-            subprocess.check_call(['git', '--version'], stdout=sys.stderr, stderr=sys.stderr)
++            subprocess.check_call(['@git@/bin/git', '--version'], stdout=sys.stderr, stderr=sys.stderr)
+         except FileNotFoundError:
+             logger.error('git command not found')
+             raise
+@@ -60,12 +60,12 @@ class LibraryCheckerService(onlinejudge.type.Service):
+         if not path.exists():
+             # init the problem repository
+             url = 'https://github.com/yosupo06/library-checker-problems'
+-            logger.info('$ git clone %s %s', url, path)
+-            subprocess.check_call(['git', 'clone', url, str(path)], stdout=sys.stderr, stderr=sys.stderr)
++            logger.info('$ @git@/bin/git clone %s %s', url, path)
++            subprocess.check_call(['@git@/bin/git', 'clone', url, str(path)], stdout=sys.stderr, stderr=sys.stderr)
+         else:
+             # sync the problem repository
+-            logger.info('$ git -C %s pull', str(path))
+-            subprocess.check_call(['git', '-C', str(path), 'pull'], stdout=sys.stderr, stderr=sys.stderr)
++            logger.info('$ @git@/bin/git -C %s pull', str(path))
++            subprocess.check_call(['@git@/bin/git', '-C', str(path), 'pull'], stdout=sys.stderr, stderr=sys.stderr)
+ 
+         cls.is_repository_updated = True
+ 
+@@ -100,7 +100,7 @@ class LibraryCheckerProblem(onlinejudge.type.Problem):
+             logger.warning("generate.py may not work on Windows")
+ 
+         problem_spec = str(self._get_problem_directory_path() / 'info.toml')
+-        command = [sys.executable, str(path / 'generate.py'), problem_spec]
++        command = ['@pythonInterpreter@', str(path / 'generate.py'), problem_spec]
+         if compile_checker:
+             command.append('--compile-checker')
+         logger.info('$ %s', ' '.join(command))

--- a/pkgs/development/python-modules/online-judge-tools/default.nix
+++ b/pkgs/development/python-modules/online-judge-tools/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, colorama
+, fetchFromGitHub
+, online-judge-api-client
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "online-judge-tools";
+  version = "11.5.1";
+
+  src = fetchFromGitHub {
+    owner = "online-judge-tools";
+    repo = "oj";
+    rev = "v${version}";
+    sha256 = "0zkzmmjgjb6lyrzq1ip54cpnp7al9a7mcyjyi5vx58bvnx3q0c6m";
+  };
+
+  propagatedBuildInputs = [ colorama online-judge-api-client requests ];
+
+  # Requires internet access
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Tools for various online judges. Download sample cases, generate additional test cases, test your code, and submit it.";
+    homepage = "https://github.com/online-judge-tools/oj";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sei40kr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3506,6 +3506,8 @@ with pkgs;
 
   oneshot = callPackage ../tools/networking/oneshot { };
 
+  online-judge-tools = with python3.pkgs; toPythonApplication online-judge-tools;
+
   xkbd = callPackage ../applications/misc/xkbd { };
 
   libpsm2 = callPackage ../os-specific/linux/libpsm2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5566,6 +5566,10 @@ in {
 
   onkyo-eiscp = callPackage ../development/python-modules/onkyo-eiscp { };
 
+  online-judge-api-client = callPackage ../development/python-modules/online-judge-api-client { };
+
+  online-judge-tools = callPackage ../development/python-modules/online-judge-tools { };
+
   onlykey-solo-python = callPackage ../development/python-modules/onlykey-solo-python { };
 
   onnx = callPackage ../development/python-modules/onnx { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR adds [online-judge-tools](https://github.com/online-judge-tools/oj).

One of its dependency `online-judge-api-client` clones/updates `library-checker-problems` by internally invoking `git` command, and then run `generate.py` in the repository.
~So I added those dependencies to the `PATH/PYTHONPATH`.~
So I created another Python environment to run `generate.py`.

https://github.com/online-judge-tools/api-client/blob/master/onlinejudge/service/library_checker.py#L48-L70
https://github.com/online-judge-tools/api-client/blob/master/onlinejudge/service/library_checker.py#L93-L111
https://github.com/yosupo06/library-checker-problems/blob/master/requirements.txt

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
