### PR TITLE
zsh-vi-mode: init at 0.8.5

### DIFF
--- a/pkgs/shells/zsh/zsh-vi-mode/default.nix
+++ b/pkgs/shells/zsh/zsh-vi-mode/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "zsh-vi-mode";
+  version = "0.8.5";
+
+  src = fetchFromGitHub {
+    owner = "jeffreytse";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "EOYqHh0rcgoi26eopm6FTl81ehak5kXMmzNcnJDH8/E=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/share/${pname}
+    cp *.zsh $out/share/${pname}/
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/jeffreytse/zsh-vi-mode";
+    license = licenses.mit;
+    description = "A better and friendly vi(vim) mode plugin for ZSH.";
+    maintainers = with maintainers; [ kyleondy ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11088,6 +11088,8 @@ with pkgs;
 
   zsh-command-time = callPackage ../shells/zsh/zsh-command-time { };
 
+  zsh-vi-mode = callPackage ../shells/zsh/zsh-vi-mode {};
+
   zsh-you-should-use = callPackage ../shells/zsh/zsh-you-should-use { };
 
   zsh-z = callPackage ../shells/zsh/zsh-z { };


### PR DESCRIPTION
Adding [zsh-vi-mode] at version `0.8.5`.

[zsh-vi-mode]: https://github.com/jeffreytse/zsh-vi-mod

###### Motivation for this change

Upstreaming the [`zsh-vi-mode` package derivation](https://github.com/KyleOndy/dotfiles/blob/9c27dcb0bd160bfcb846c7c0d2c824219aa96261/pkgs/zsh-vi-mode/default.nix) I've been using locally for a while.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
