### PR TITLE
meilisearch: 0.23.1 -> 0.24.0

### DIFF
--- a/pkgs/servers/search/meilisearch/default.nix
+++ b/pkgs/servers/search/meilisearch/default.nix
@@ -7,7 +7,7 @@
 , Foundation
 }:
 
-let version = "0.23.1";
+let version = "0.24.0";
 in
 rustPlatform.buildRustPackage {
   pname = "meilisearch";
@@ -16,14 +16,15 @@ rustPlatform.buildRustPackage {
     owner = "meilisearch";
     repo = "MeiliSearch";
     rev = "v${version}";
-    sha256 = "sha256-4F7noByC9ZgqYwPfkm8VE15QU2jbBvUAH4Idxa+J+Aw=";
+    sha256 = "sha256-0peKFNB/w8FDowiRo3v/dakxUSPnKbZi0ZA5ALoEzHQ=";
   };
+  cargoSha256 = "sha256-U9bIXDtE71vydfSyZDznQrRsYYny/jXo97gb2CAoXy4=";
   cargoPatches = [
     # feature mini-dashboard tries to download a file from the internet
     # feature analitycs should be opt-in
     ./remove-default-feature.patch
   ];
-  cargoSha256 = "sha256-dz+1IQZRSeMEagI2dnOtR3A8prg4UZ2Om0pd1BUhuhE=";
+  cargoBuildFlags = [ "--no-default-features" ];
   buildInputs = lib.optionals stdenv.isDarwin [ Security DiskArbitration Foundation ];
   meta = with lib; {
     description = "Powerful, fast, and an easy to use search engine ";

--- a/pkgs/servers/search/meilisearch/remove-default-feature.patch
+++ b/pkgs/servers/search/meilisearch/remove-default-feature.patch
@@ -1,13 +1,41 @@
 diff --git a/meilisearch-http/Cargo.toml b/meilisearch-http/Cargo.toml
-index de418cd4..ecc78d6f 100644
+index aab32113..8e48ad41 100644
 --- a/meilisearch-http/Cargo.toml
 +++ b/meilisearch-http/Cargo.toml
-@@ -92,7 +92,7 @@ mini-dashboard = [
+@@ -1,10 +1,11 @@
+ [package]
+ authors = ["Quentin de Quelen <quentin@dequelen.me>", "Clément Renault <clement@meilisearch.com>"]
+ description = "MeiliSearch HTTP server"
+-edition = "2018"
++edition = "2021"
+ license = "MIT"
+ name = "meilisearch-http"
+ version = "0.24.0"
++resolver = "2"
+ 
+ [[bin]]
+ name = "meilisearch"
+@@ -92,7 +93,7 @@ mini-dashboard = [
      "zip",
  ]
- analytics = ["whoami", "reqwest"]
+ analytics = ["segment"]
 -default = ["analytics", "mini-dashboard"]
 +default = []
  
  [target.'cfg(target_os = "linux")'.dependencies]
  tikv-jemallocator = "0.4.1"
+diff --git a/meilisearch-http/build.rs b/meilisearch-http/build.rs
+index 41f429ba..eedf113c 100644
+--- a/meilisearch-http/build.rs
++++ b/meilisearch-http/build.rs
+@@ -1,10 +1,6 @@
+ use vergen::{vergen, Config};
+ 
+ fn main() {
+-    if let Err(e) = vergen(Config::default()) {
+-        println!("cargo:warning=vergen: {}", e);
+-    }
+-
+     #[cfg(feature = "mini-dashboard")]
+     mini_dashboard::setup_mini_dashboard().expect("Could not load the mini-dashboard assets");
+ }


### PR DESCRIPTION
###### Motivation for this change

upstream update https://github.com/meilisearch/MeiliSearch/releases/tag/v0.24.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
