### PR TITLE
qtile: set PYTHONPATH before launching command

### DIFF
--- a/pkgs/applications/window-managers/qtile/default.nix
+++ b/pkgs/applications/window-managers/qtile/default.nix
@@ -63,10 +63,20 @@ let
       maintainers = with maintainers; [ kamilchm ];
     };
   };
+
+  # restore qtile name
+  env = (python3.withPackages (ps: [ unwrapped ])).overrideAttrs (_: {
+    # otherwise will be exported as "env", this restores `nix search` behavior
+    name = "${unwrapped.pname}-${unwrapped.version}";
+    # export underlying qtile package
+    passthru = { inherit unwrapped; };
+  });
+
+  # allow for qtile subprocesses to also find site packages
+  wrapped = env.override({
+    makeWrapperArgs = [
+      "--suffix PYTHONPATH : $out/${python3.sitePackages}"
+    ];
+  });
 in
-(python3.withPackages (_: [ unwrapped ])).overrideAttrs (_: {
-  # otherwise will be exported as "env", this restores `nix search` behavior
-  name = "${unwrapped.pname}-${unwrapped.version}";
-  # export underlying qtile package
-  passthru = { inherit unwrapped; };
-})
+  wrapped


### PR DESCRIPTION
###### Motivation for this change

This is to allow subprocesses launched through qtile are
able to find the site-packages as well. Otherwise
`qtile check` which launches mypy will be unable to find
required modules

should close: #146281
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
