### PR TITLE
python3Packages.libcloud: 3.4.0 -> 3.4.1

### DIFF
--- a/pkgs/development/python-modules/libcloud/default.nix
+++ b/pkgs/development/python-modules/libcloud/default.nix
@@ -1,40 +1,49 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, isPy27
-, mock
 , pycrypto
+, pythonOlder
 , requests
-, pytest-runner
-, pytest
-, requests-mock
-, typing
 }:
 
 buildPythonPackage rec {
   pname = "apache-libcloud";
-  version = "3.4.0";
+  version = "3.4.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "17618ccbe3493f2be015db9e1efa35080ff34d470de723f1384d908ff126e51c";
+    sha256 = "sha256-iPGNoM8/rAr3I+dD+3QdnRviUYge2reloNFimVW1ARs=";
   };
 
-  checkInputs = [ mock pytest pytest-runner requests-mock ];
-  propagatedBuildInputs = [ pycrypto requests ] ++ lib.optionals isPy27 [ typing ];
+  propagatedBuildInputs = [
+    pycrypto
+    requests
+  ];
 
-  preConfigure = "cp libcloud/test/secrets.py-dist libcloud/test/secrets.py";
+  preConfigure = ''
+    cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
+  '';
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "setup_requires=pytest_runner," "setup_requires=[],"
+  '';
 
   # requires a certificates file
   doCheck = false;
 
-  pythonImportsCheck = [ "libcloud" ];
+  pythonImportsCheck = [
+    "libcloud"
+  ];
 
   meta = with lib; {
     description = "A unified interface to many cloud providers";
     homepage = "https://libcloud.apache.org/";
     changelog = "https://github.com/apache/libcloud/blob/v${version}/CHANGES.rst";
     license = licenses.asl20;
+    maintainers = with maintainers; [ ];
   };
-
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 3.4.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
