### PR TITLE
linuxKernel.kernels.linux_xanmod: 5.14.16 -> 5.15.2

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-xanmod.nix
+++ b/pkgs/os-specific/linux/kernel/linux-xanmod.nix
@@ -1,9 +1,9 @@
 { lib, stdenv, buildLinux, fetchFromGitHub, ... } @ args:
 
 let
-  version = "5.14.16";
+  version = "5.15.2";
   release = "1";
-  suffix = "xanmod${release}-cacule";
+  suffix = "xanmod${release}-tt";
 in
 buildLinux (args // rec {
   inherit version;
@@ -13,19 +13,32 @@ buildLinux (args // rec {
     owner = "xanmod";
     repo = "linux";
     rev = modDirVersion;
-    sha256 = "sha256-ro7WnN0BPxW/8sajUyGTnvmbemKJEadSBcFmjZ+Wtrs=";
+    sha256 = "sha256-3tIwj+4xf/I5srEAqECbfH343J5nzCWViq1ZnidZI24=";
   };
 
   structuredExtraConfig = with lib.kernel; {
+    # removed options
+    CFS_BANDWIDTH = lib.mkForce (option no);
+    RT_GROUP_SCHED = lib.mkForce (option no);
+    SCHED_AUTOGROUP = lib.mkForce (option no);
+
+    # AMD P-state driver
+    X86_AMD_PSTATE = yes;
+
+    # Linux RNG framework
+    LRNG = yes;
+
+    # Paragon's NTFS3 driver
+    NTFS3_FS = module;
+    NTFS3_LZX_XPRESS = yes;
+    NTFS3_FS_POSIX_ACL = yes;
+
     # Preemptive Full Tickless Kernel at 500Hz
+    SCHED_CORE = lib.mkForce (option no);
     PREEMPT_VOLUNTARY = lib.mkForce no;
     PREEMPT = lib.mkForce yes;
     NO_HZ_FULL = yes;
     HZ_500 = yes;
-
-    # Google's Multigenerational LRU Framework
-    LRU_GEN = yes;
-    LRU_GEN_ENABLED = yes;
 
     # Google's BBRv2 TCP congestion Control
     TCP_CONG_BBR2 = yes;
@@ -46,14 +59,12 @@ buildLinux (args // rec {
     ANDROID_BINDER_DEVICES = freeform "binder,hwbinder,vndbinder";
 
     # Futex WAIT_MULTIPLE implementation for Wine / Proton Fsync.
-    # Futex2 interface compatible w/ latest Wine / Proton Fsync.
     FUTEX = yes;
-    FUTEX2 = yes;
     FUTEX_PI = yes;
   };
 
   extraMeta = {
-    branch = "5.14-cacule";
+    branch = "5.15-tt";
     maintainers = with lib.maintainers; [ fortuneteller2k lovesegfault ];
     description = "Built with custom settings and new features built to provide a stable, responsive and smooth desktop experience";
     broken = stdenv.isAarch64;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix: #145911 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
