### PR TITLE
python3Packages.weasyprint: 52 -> 53.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9967,6 +9967,12 @@
     githubId = 592876;
     name = "Robert W. Pearce";
   };
+  rprecenth = {
+    email = "rasmus@precenth.eu";
+    github = "Prillan";
+    githubId = 1675190;
+    name = "Rasmus Précenth";
+  };
   rprospero = {
     email = "rprospero+nix@gmail.com";
     github = "rprospero";

--- a/pkgs/development/python-modules/pydyf/default.nix
+++ b/pkgs/development/python-modules/pydyf/default.nix
@@ -1,0 +1,48 @@
+{ lib,
+  buildPythonPackage,
+  fetchPypi,
+  isPy3k,
+  pytestCheckHook,
+  coverage,
+  ghostscript,
+  pillow,
+  pytest,
+  pytest-cov,
+  pytest-flake8,
+  pytest-isort
+}:
+
+buildPythonPackage rec {
+  pname = "pydyf";
+  version = "0.1.2";
+  disabled = !isPy3k;
+
+  pytestFlagsArray = [
+    # setup.py is auto-generated and doesn't pass the flake8 check
+    "--ignore=setup.py"
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    coverage
+    ghostscript
+    pillow
+    pytest
+    pytest-cov
+    pytest-flake8
+    pytest-isort
+  ];
+
+  src = fetchPypi {
+    inherit version;
+    pname = "pydyf";
+    sha256 = "sha256-Hi9d5IF09QXeAlp9HnzwG73ZQiyoq5RReCvwDuF4YCw=";
+  };
+
+  meta = with lib; {
+    homepage = "https://doc.courtbouillon.org/pydyf/stable/";
+    description = "Low-level PDF generator written in Python and based on PDF specification 1.7";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ rprecenth ];
+  };
+}

--- a/pkgs/development/python-modules/weasyprint/default.nix
+++ b/pkgs/development/python-modules/weasyprint/default.nix
@@ -1,17 +1,24 @@
 { buildPythonPackage,
   fetchPypi,
   fetchpatch,
+  pytestCheckHook,
+  brotli,
   cairosvg,
+  fonttools,
+  pydyf,
   pyphen,
   cffi,
   cssselect,
   lxml,
   html5lib,
   tinycss,
+  zopfli,
   glib,
+  harfbuzz,
   pango,
   fontconfig,
   lib, stdenv,
+  ghostscript,
   pytest,
   pytest-runner,
   pytest-isort,
@@ -23,35 +30,48 @@
 
 buildPythonPackage rec {
   pname = "weasyprint";
-  version = "52";
+  version = "53.4";
   disabled = !isPy3k;
 
-  # excluded test needs the Ahem font
-  checkPhase = ''
-    runHook preCheck
-    pytest -k 'not test_font_stretch'
-    runHook postCheck
-  '';
+  pytestFlagsArray = [
+    # setup.py is auto-generated and doesn't pass the flake8 check
+    "--ignore=setup.py"
+    # ffi.py is patched by us and doesn't pass the flake8 check
+    "--ignore=weasyprint/text/ffi.py"
+  ];
 
-  # ignore failing flake8-test
-  prePatch = ''
-    substituteInPlace setup.cfg \
-        --replace '[tool:pytest]' '[tool:pytest]\nflake8-ignore = E501'
-  '';
+  disabledTests = [
+    # test_font_stretch needs the Ahem font (fails on macOS)
+    "test_font_stretch"
+  ];
 
-  checkInputs = [ pytest pytest-runner pytest-isort pytest-flake8 pytest-cov ];
+  checkInputs = [
+    pytestCheckHook
+    ghostscript
+    pytest
+    pytest-runner
+    pytest-isort
+    pytest-flake8
+    pytest-cov
+  ];
 
   FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";
 
-  propagatedBuildInputs = [ cairosvg pyphen cffi cssselect lxml html5lib tinycss ];
+  propagatedBuildInputs = [
+    brotli
+    cairosvg
+    cffi
+    cssselect
+    fonttools
+    html5lib
+    lxml
+    pydyf
+    pyphen
+    tinycss
+    zopfli
+  ];
 
-  # 47043a1fd7e50a892b9836466f521df85d597c4.patch can be removed after next release of weasyprint, see:
-  # https://github.com/Kozea/WeasyPrint/issues/1333#issuecomment-818062970
   patches = [
-    (fetchpatch {
-      url = "https://github.com/Kozea/WeasyPrint/commit/47043a1fd7e50a892b9836466f521df85d597c44.patch";
-      sha256 = "0l9z0hrav3bcdajlg3vbzljq0lkw7hlj8ppzrq3v21hbj1il1nsb";
-    })
     (substituteAll {
       src = ./library-paths.patch;
       fontconfig = "${fontconfig.lib}/lib/libfontconfig${stdenv.hostPlatform.extensions.sharedLibrary}";
@@ -59,13 +79,14 @@ buildPythonPackage rec {
       gobject = "${glib.out}/lib/libgobject-2.0${stdenv.hostPlatform.extensions.sharedLibrary}";
       pango = "${pango.out}/lib/libpango-1.0${stdenv.hostPlatform.extensions.sharedLibrary}";
       pangocairo = "${pango.out}/lib/libpangocairo-1.0${stdenv.hostPlatform.extensions.sharedLibrary}";
+      harfbuzz = "${harfbuzz.out}/lib/libharfbuzz${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
   ];
 
   src = fetchPypi {
     inherit version;
-    pname = "WeasyPrint";
-    sha256 = "0rwf43111ws74m8b1alkkxzz57g0np3vmd8as74adwnxslfcg4gs";
+    pname = "weasyprint";
+    sha256 = "sha256-EMyxfVXHMJa98e3T7+WMuFWwfkwwfZutTryaPxP/RYA=";
   };
 
   meta = with lib; {

--- a/pkgs/development/python-modules/weasyprint/library-paths.patch
+++ b/pkgs/development/python-modules/weasyprint/library-paths.patch
@@ -1,38 +1,31 @@
-diff --git a/weasyprint/fonts.py b/weasyprint/fonts.py
-index 79e3b5b..4438eb4 100644
---- a/weasyprint/fonts.py
-+++ b/weasyprint/fonts.py
-@@ -45,11 +45,8 @@ else:
-     # with OSError: dlopen() failed to load a library: cairo / cairo-2
-     # So let's hope we find the same file as cairo already did ;)
-     # Same applies to pangocairo requiring pangoft2
--    fontconfig = dlopen(ffi, 'fontconfig', 'libfontconfig',
--                        'libfontconfig-1.dll',
--                        'libfontconfig.so.1', 'libfontconfig-1.dylib')
--    pangoft2 = dlopen(ffi, 'pangoft2-1.0', 'libpangoft2-1.0-0',
--                      'libpangoft2-1.0.so.0', 'libpangoft2-1.0.dylib')
-+    fontconfig = dlopen(ffi, '@fontconfig@')
-+    pangoft2 = dlopen(ffi, '@pangoft2@')
- 
-     ffi.cdef('''
-         // FontConfig
-diff --git a/weasyprint/text.py b/weasyprint/text.py
-index 1dc5e4d..b070bad 100644
---- a/weasyprint/text.py
-+++ b/weasyprint/text.py
-@@ -255,12 +255,9 @@ def dlopen(ffi, *names):
+diff --git a/weasyprint/text/ffi.py b/weasyprint/text/ffi.py
+index 0734cbea..22e31a5e 100644
+--- a/weasyprint/text/ffi.py
++++ b/weasyprint/text/ffi.py
+@@ -387,21 +387,11 @@ def _dlopen(ffi, *names):
      return ffi.dlopen(names[0])  # pragma: no cover
  
  
--gobject = dlopen(ffi, 'gobject-2.0', 'libgobject-2.0-0', 'libgobject-2.0.so.0',
--                 'libgobject-2.0.dylib')
--pango = dlopen(ffi, 'pango-1.0', 'libpango-1.0-0', 'libpango-1.0.so.0',
--               'libpango-1.0.dylib')
--pangocairo = dlopen(ffi, 'pangocairo-1.0', 'libpangocairo-1.0-0',
--                    'libpangocairo-1.0.so.0', 'libpangocairo-1.0.dylib')
-+gobject = dlopen(ffi, '@gobject@')
-+pango = dlopen(ffi, '@pango@')
-+pangocairo = dlopen(ffi, '@pangocairo@')
+-gobject = _dlopen(
+-    ffi, 'gobject-2.0-0', 'gobject-2.0', 'libgobject-2.0-0',
+-    'libgobject-2.0.so.0', 'libgobject-2.0.dylib')
+-pango = _dlopen(
+-    ffi, 'pango-1.0-0', 'pango-1.0', 'libpango-1.0-0', 'libpango-1.0.so.0',
+-    'libpango-1.0.dylib')
+-harfbuzz = _dlopen(
+-    ffi, 'harfbuzz', 'harfbuzz-0.0', 'libharfbuzz-0',
+-    'libharfbuzz.so.0', 'libharfbuzz.so.0', 'libharfbuzz.0.dylib')
+-fontconfig = _dlopen(
+-    ffi, 'fontconfig-1', 'fontconfig', 'libfontconfig', 'libfontconfig-1.dll',
+-    'libfontconfig.so.1', 'libfontconfig-1.dylib')
+-pangoft2 = _dlopen(
+-    ffi, 'pangoft2-1.0-0', 'pangoft2-1.0', 'libpangoft2-1.0-0',
+-    'libpangoft2-1.0.so.0', 'libpangoft2-1.0.dylib')
++gobject = _dlopen(ffi, '@gobject@')
++pango = _dlopen(ffi, '@pango@')
++harfbuzz = _dlopen(ffi, '@harfbuzz@')
++fontconfig = _dlopen(ffi, '@fontconfig@')
++pangoft2 = _dlopen(ffi, '@pangoft2@')
  
  gobject.g_type_init()
- 
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6346,6 +6346,8 @@ in {
 
   pydy = callPackage ../development/python-modules/pydy { };
 
+  pydyf = callPackage ../development/python-modules/pydyf { };
+
   pyechonest = callPackage ../development/python-modules/pyechonest { };
 
   pyeclib = callPackage ../development/python-modules/pyeclib { };


### PR DESCRIPTION
###### Motivation for this change

ZHF: #144627

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Notes

I have not tested this extensively, but the basic functionality in https://doc.courtbouillon.org/weasyprint/stable/first_steps.html works well.