### PR TITLE
mongodb: 3.6.13 -> 3.6.23, 4.0.12 -> 4.0.27, 4.2.8 -> 4.2.17

### DIFF
--- a/pkgs/servers/nosql/mongodb/v3_6.nix
+++ b/pkgs/servers/nosql/mongodb/v3_6.nix
@@ -9,8 +9,8 @@ let
     inherit cctools;
   };
 in buildMongoDB {
-  version = "3.6.13";
-  sha256 = "1mbvk4bmabrswjdm01jssxcygjpq5799zqyx901nsi12vlcymwg4";
+  version = "3.6.23";
+  sha256 = "sha256-EJpIerW4zcGJvHfqJ65fG8yNsLRlUnRkvYfC+jkoFJ4=";
   patches = [ ./forget-build-dependencies.patch ]
     ++ lib.optionals stdenv.isDarwin [ ./asio-no-experimental-string-view.patch ];
 }

--- a/pkgs/servers/nosql/mongodb/v4_0.nix
+++ b/pkgs/servers/nosql/mongodb/v4_0.nix
@@ -9,8 +9,8 @@ let
     inherit cctools;
   };
 in buildMongoDB {
-  version = "4.0.12";
-  sha256 = "1j8dqa4jr623y87jrdanyib9r7x18srrvdx952q4azcc8zrdwci1";
+  version = "4.0.27";
+  sha256 = "sha256-ct33mnK4pszhYM4Is7j0GZQRyi8i8Qmy0wcklyq5LjM=";
   patches =
     [ ./forget-build-dependencies.patch ./mozjs-45_fix-3-byte-opcode.patch ]
     ++ lib.optionals stdenv.isDarwin [ ./asio-no-experimental-string-view.patch ];

--- a/pkgs/servers/nosql/mongodb/v4_2.nix
+++ b/pkgs/servers/nosql/mongodb/v4_2.nix
@@ -9,8 +9,8 @@ let
     inherit cctools;
   };
 in buildMongoDB {
-  version = "4.2.8";
-  sha256 = "13yvhi1258skdni00bh6ph609whqsmhiimhyqy1gs2liwdvh5278";
+  version = "4.2.17";
+  sha256 = "sha256-4ynvImVjN674VdD/bJ55Vy/IrOlMN8iZb2PAhxwbv1A=";
   patches =
     [ ./forget-build-dependencies-4-2.patch ]
     ++ lib.optionals stdenv.isDarwin [ ./asio-no-experimental-string-view-4-2.patch ];


### PR DESCRIPTION
###### Motivation for this change

Update releases 3.6, 4.0 and 4.2.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
