### PR TITLE
mongodb: init at 4.4.10, init at 5.0.3, refactor and update tests

### DIFF
--- a/nixos/tests/mongodb.nix
+++ b/nixos/tests/mongodb.nix
@@ -37,6 +37,8 @@ import ./make-test-python.nix ({ pkgs, ... }:
           mongodb-3_6
           mongodb-4_0
           mongodb-4_2
+          mongodb-4_4
+          mongodb-5_1
         ];
       };
     };
@@ -48,6 +50,8 @@ import ./make-test-python.nix ({ pkgs, ... }:
       + runMongoDBTest pkgs.mongodb-3_6
       + runMongoDBTest pkgs.mongodb-4_0
       + runMongoDBTest pkgs.mongodb-4_2
+      + runMongoDBTest pkgs.mongodb-4_4
+      + runMongoDBTest pkgs.mongodb-5_0
       + ''
         node.shutdown()
       '';

--- a/pkgs/servers/nosql/mongodb/mongodb.nix
+++ b/pkgs/servers/nosql/mongodb/mongodb.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, sconsPackages, boost, gperftools, pcre-cpp, snappy, zlib, libyamlcpp
+{ xz, lib, stdenv, fetchurl, sconsPackages, boost, gperftools, pcre-cpp, snappy, zlib, libyamlcpp
 , sasl, openssl, libpcap, curl, Security, CoreFoundation, cctools }:
 
 # Note:
@@ -46,6 +46,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ variants.scons ];
   buildInputs = [
+    xz
     boost
     curl
     gperftools
@@ -59,6 +60,8 @@ in stdenv.mkDerivation rec {
     zlib
   ] ++ lib.optionals stdenv.isDarwin [ Security CoreFoundation cctools ];
 
+  makeFlags = [ "PREFIX=$(out)" ];
+  dontAddPrefix = true;
   # MongoDB keeps track of its build parameters, which tricks nix into
   # keeping dependencies to build inputs in the final output.
   # We remove the build flags from buildInfo data.
@@ -119,7 +122,7 @@ in stdenv.mkDerivation rec {
     runHook postInstallCheck
   '';
 
-  prefixKey = "--prefix=";
+  #prefixKey = "--prefix=";
 
   enableParallelBuilding = true;
 

--- a/pkgs/servers/nosql/mongodb/v4_4.nix
+++ b/pkgs/servers/nosql/mongodb/v4_4.nix
@@ -1,0 +1,18 @@
+{ stdenv, callPackage, lib, sasl, boost, Security, CoreFoundation, cctools }:
+
+let
+  buildMongoDB = callPackage ./mongodb.nix {
+    inherit sasl;
+    inherit boost;
+    inherit Security;
+    inherit CoreFoundation;
+    inherit cctools;
+  };
+in buildMongoDB {
+  version = "4.4.10";
+  sha256 = "sha256-3SLK/UoO6LzjotCnduCSuPD/GTvrp9Fxj2uKxfngyeY=";
+  patches =
+   [ ./forget-build-dependencies-4-2.patch ]
+   ++
+   lib.optionals stdenv.isDarwin [ ./asio-no-experimental-string-view-4-2.patch ];
+}

--- a/pkgs/servers/nosql/mongodb/v5_0.nix
+++ b/pkgs/servers/nosql/mongodb/v5_0.nix
@@ -1,0 +1,18 @@
+{ stdenv, callPackage, lib, sasl, boost, Security, CoreFoundation, cctools }:
+
+let
+  buildMongoDB = callPackage ./mongodb.nix {
+    inherit sasl;
+    inherit boost;
+    inherit Security;
+    inherit CoreFoundation;
+    inherit cctools;
+  };
+in buildMongoDB {
+  version = "5.0.3";
+  sha256 = "sha256-4Br6Q20Cdd55BwRJg37+NDpycUMs3PLttp6a5hrAN90=";
+  patches =
+   [ ./forget-build-dependencies-4-2.patch ]
+   ++
+   lib.optionals stdenv.isDarwin [ ./asio-no-experimental-string-view-4-2.patch ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21101,6 +21101,13 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };
 
+  mongodb-4_4 = callPackage ../servers/nosql/mongodb/v4_4.nix {
+    sasl = cyrus_sasl;
+    boost = boost169;
+    inherit (darwin) cctools;
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+  };
+
   nginx-sso = callPackage ../servers/nginx-sso { };
 
   percona-server56 = callPackage ../servers/sql/percona/5.6.x.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21108,6 +21108,13 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };
 
+  mongodb-5_0 = callPackage ../servers/nosql/mongodb/v5_0.nix {
+    sasl = cyrus_sasl;
+    boost = boost169;
+    inherit (darwin) cctools;
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+  };
+
   nginx-sso = callPackage ../servers/nginx-sso { };
 
   percona-server56 = callPackage ../servers/sql/percona/5.6.x.nix { };


### PR DESCRIPTION
###### Motivation for this change

- init release 4.4 at 4.4.10
- init release 5.0 at 5.0.3
- refactor for new releases introduced
- update tests to make use of the new package versions

This is a WIP since I can't make it build in this current state (it can affect the old releases too), also the workflow is a bit slow here since building mongo takes around an hour.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
