### PR TITLE
etcd_3_5: init at 3.5.1

### DIFF
--- a/pkgs/servers/etcd/3.5.nix
+++ b/pkgs/servers/etcd/3.5.nix
@@ -1,0 +1,36 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "etcd";
+  version = "3.5.1";
+
+  vendorSha256 = "sha256-ad89jDLLeAJizQMmO0lPH8N9GdaBrn9NyXGCxVT3fHE=";
+
+  doCheck = false;
+
+  src = fetchFromGitHub {
+    owner = "etcd-io";
+    repo = "etcd";
+    rev = "v${version}";
+    sha256 = "sha256-Ip7JAWbZBZcc8MXd+Sw05QmTs448fQXpQ5XXo6RW+Gs=";
+  };
+
+  buildPhase = ''
+    patchShebangs .
+    ./build
+    ./functional/build
+  '';
+
+  installPhase = ''
+    install -Dm755 bin/* bin/functional/cmd/* -t $out/bin
+  '';
+
+
+  meta = with lib; {
+    description = "Distributed reliable key-value store for the most critical data of a distributed system";
+    license = licenses.asl20;
+    homepage = "https://etcd.io/";
+    maintainers = with maintainers; [ offline zowoq ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20639,6 +20639,7 @@ with pkgs;
 
   etcd = callPackage ../servers/etcd { };
   etcd_3_4 = callPackage ../servers/etcd/3.4.nix { };
+  etcd_3_5 = callPackage ../servers/etcd/3.5.nix { };
 
   ejabberd = callPackage ../servers/xmpp/ejabberd { };
 


### PR DESCRIPTION
###### Motivation for this change

Init etcd latest release as continuation of PR #145795.

WIP since it does not build yet per https://github.com/NixOS/nixpkgs/pull/145795#issuecomment-968139317 comment.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
