### PR TITLE
nixos/rtsp-simple-server: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -898,6 +898,7 @@
   ./services/networking/unbound.nix
   ./services/networking/unifi.nix
   ./services/video/unifi-video.nix
+  ./services/video/rtsp-simple-server.nix
   ./services/networking/v2ray.nix
   ./services/networking/vsftpd.nix
   ./services/networking/wasabibackend.nix

--- a/nixos/modules/services/video/rtsp-simple-server.nix
+++ b/nixos/modules/services/video/rtsp-simple-server.nix
@@ -1,0 +1,80 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.rtsp-simple-server;
+  package = pkgs.rtsp-simple-server;
+  format = pkgs.formats.yaml {};
+in
+{
+  options = {
+    services.rtsp-simple-server = {
+      enable = mkEnableOption "RTSP Simple Server";
+
+      settings = mkOption {
+        description = ''
+          Settings for rtsp-simple-server.
+          Read more at <link xlink:href="https://github.com/aler9/rtsp-simple-server/blob/main/rtsp-simple-server.yml"/>
+        '';
+        type = format.type;
+
+        default = {
+          logLevel = "info";
+          logDestinations = [
+            "stdout"
+          ];
+          # we set this so when the user uses it, it just works (see LogsDirectory below). but it's not used by default.
+          logFile = "/var/log/rtsp-simple-server/rtsp-simple-server.log";
+        };
+
+        example = {
+          paths = {
+            cam = {
+              runOnInit = "ffmpeg -f v4l2 -i /dev/video0 -f rtsp rtsp://localhost:$RTSP_PORT/$RTSP_PATH";
+              runOnInitRestart = true;
+            };
+          };
+        };
+      };
+
+      env = mkOption {
+        type = with types; attrsOf anything;
+        description = "Extra environment variables for RTSP Simple Server";
+        default = {};
+        example = {
+          RTSP_CONFKEY = "mykey";
+        };
+      };
+    };
+  };
+
+  config = mkIf (cfg.enable) {
+    # NOTE: rtsp-simple-server watches this file and automatically reloads if it changes
+    environment.etc."rtsp-simple-server.yaml".source = format.generate "rtsp-simple-server.yaml" cfg.settings;
+
+    systemd.services.rtsp-simple-server = {
+      environment = cfg.env;
+
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      path = with pkgs; [
+        ffmpeg
+      ];
+
+      serviceConfig = {
+        DynamicUser = true;
+        User = "rtsp-simple-server";
+        Group = "rtsp-simple-server";
+
+        LogsDirectory = "rtsp-simple-server";
+
+        # user likely may want to stream cameras, can't hurt to add video group
+        SupplementaryGroups = "video";
+
+        ExecStart = "${package}/bin/rtsp-simple-server /etc/rtsp-simple-server.yaml";
+      };
+    };
+  };
+}

--- a/pkgs/servers/rtsp-simple-server/default.nix
+++ b/pkgs/servers/rtsp-simple-server/default.nix
@@ -5,16 +5,16 @@
 
 buildGoModule rec {
   pname = "rtsp-simple-server";
-  version = "0.17.3";
+  version = "0.17.8";
 
   src = fetchFromGitHub {
     owner = "aler9";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-9V6yblRnOAZBYuGChjeDyOTWjCCVhdFxljSndEr7GdY=";
+    hash = "sha256-wjF7XTiUw5lPSmNiHvqUz4ZswpzLBoYF9S25dL8VPMU=";
   };
 
-  vendorSha256 = "sha256-lFyRMoI+frzAa7sL8wIzUgzJRrCQjt9Ri8T9pHIpoug=";
+  vendorSha256 = "sha256-rntfePkwNGnyPjIzjLJhBYLTcndHP605Ah/xPcM6sRo=";
 
   # Tests need docker
   doCheck = false;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
