### PR TITLE
nixos/etcd: refactor, tests and bumps

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -97,6 +97,16 @@
       </listitem>
       <listitem>
         <para>
+          etcd now defaults to 3.5, updated from 3.3, which brings some
+          deprecations. See the etcd dos on
+          <link xlink:href="https://etcd.io/docs/v3.6/upgrades/upgrade_3_4/">upgrade
+          etcd from 3.3 to 3.4</link> and
+          <link xlink:href="https://etcd.io/docs/v3.3/upgrades/upgrade_3_5/">upgrade
+          etcd from 3.4 to 3.5</link> for more details.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <literal>hardware.nvidia</literal> has a new option
           <literal>open</literal> that can be used to opt in the
           opensource version of NVIDIA kernel driver. Note that the

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -46,6 +46,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - PHP now defaults to PHP 8.1, updated from 8.0.
 
+- etcd now defaults to 3.5, updated from 3.3, which brings some deprecations. See the etcd dos on [upgrade etcd from 3.3 to 3.4](https://etcd.io/docs/v3.6/upgrades/upgrade_3_4/) and [upgrade etcd from 3.4 to 3.5](https://etcd.io/docs/v3.3/upgrades/upgrade_3_5/) for more details.
+
 - `hardware.nvidia` has a new option `open` that can be used to opt in the opensource version of NVIDIA kernel driver. Note that the driver's support for GeForce and Workstation GPUs is still alpha quality, see [NVIDIA Releases Open-Source GPU Kernel Modules](https://developer.nvidia.com/blog/nvidia-releases-open-source-gpu-kernel-modules/) for the official announcement.
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/services/misc/etcd.nix
+++ b/nixos/modules/services/misc/etcd.nix
@@ -186,7 +186,7 @@ in {
 
       serviceConfig = {
         Type = "notify";
-        ExecStart = "${pkgs.etcd}/bin/etcd";
+        ExecStart = "${cfg.package}/bin/etcd";
         User = "etcd";
         LimitNOFILE = 40000;
       };

--- a/nixos/modules/services/misc/etcd.nix
+++ b/nixos/modules/services/misc/etcd.nix
@@ -15,6 +15,12 @@ in {
       type = types.bool;
     };
 
+    package = mkOption {
+      description = "Which etcd derivation to use.";
+      default = pkgs.etcd;
+      type = types.package;
+    };
+
     name = mkOption {
       description = "Etcd unique node name.";
       default = config.networking.hostName;
@@ -192,7 +198,7 @@ in {
       };
     };
 
-    environment.systemPackages = [ pkgs.etcd ];
+    environment.systemPackages = [ cfg.package ];
 
     users.users.etcd = {
       isSystemUser = true;

--- a/nixos/modules/services/misc/etcd.nix
+++ b/nixos/modules/services/misc/etcd.nix
@@ -17,8 +17,8 @@ in {
 
     package = mkOption {
       description = "Which etcd derivation to use.";
-      default = pkgs.etcd;
       type = types.package;
+      example = literalExpression "pkgs.etcd_3_5";
     };
 
     name = mkOption {

--- a/nixos/modules/services/misc/etcd.nix
+++ b/nixos/modules/services/misc/etcd.nix
@@ -156,6 +156,15 @@ in {
   };
 
   config = mkIf cfg.enable {
+     services.etcd.package =
+     # Note: when changing the default, make it conditional on
+     # ‘system.stateVersion’ to maintain compatibility with existing
+     # systems!
+     # Remember to change the default version at pkgs/top-level/all-packages.nix too between NixOS versions
+     mkDefault (if versionAtLeast config.system.stateVersion "22.11" then pkgs.etcd_3_5
+           else if versionAtLeast config.system.stateVersion "22.05" then pkgs.etcd_3_3
+           else throw "please set your desired package for state version ${config.system.stateVersion}");
+
     systemd.tmpfiles.rules = [
       "d '${cfg.dataDir}' 0700 etcd - - -"
     ];

--- a/nixos/tests/etcd-cluster.nix
+++ b/nixos/tests/etcd-cluster.nix
@@ -86,10 +86,11 @@ import ./make-test-python.nix ({ pkgs, ... } : let
     };
 
     environment.variables = {
-      ETCDCTL_CERT_FILE = "${etcd_client_cert}";
-      ETCDCTL_KEY_FILE = "${etcd_client_key}";
-      ETCDCTL_CA_FILE = "${ca_pem}";
+      ETCDCTL_CERT = "${etcd_client_cert}";
+      ETCDCTL_KEY = "${etcd_client_key}";
+      ETCDCTL_CACERT = "${ca_pem}";
       ETCDCTL_PEERS = "https://127.0.0.1:2379";
+      ETCDCTL_API = "3";
     };
 
     networking.firewall.allowedTCPPorts = [ 2380 ];

--- a/nixos/tests/etcd.nix
+++ b/nixos/tests/etcd.nix
@@ -10,7 +10,7 @@ import ./make-test-python.nix ({ pkgs, ... } : {
   nodes = {
     node = { ... }: {
       services.etcd.enable = true;
-      services.etcd.package = pkgs.etcd_3_4;
+      services.etcd.package = pkgs.etcd;
     };
   };
 

--- a/nixos/tests/etcd.nix
+++ b/nixos/tests/etcd.nix
@@ -10,7 +10,6 @@ import ./make-test-python.nix ({ pkgs, ... } : {
   nodes = {
     node = { ... }: {
       services.etcd.enable = true;
-      services.etcd.package = pkgs.etcd;
     };
   };
 

--- a/nixos/tests/etcd.nix
+++ b/nixos/tests/etcd.nix
@@ -10,6 +10,7 @@ import ./make-test-python.nix ({ pkgs, ... } : {
   nodes = {
     node = { ... }: {
       services.etcd.enable = true;
+      services.etcd.package = pkgs.etcd_3_4;
     };
   };
 
@@ -19,7 +20,7 @@ import ./make-test-python.nix ({ pkgs, ... } : {
         node.wait_for_unit("etcd.service")
 
     with subtest("should write and read some values to etcd"):
-        node.succeed("etcdctl set /foo/bar 'Hello world'")
+        node.succeed("etcdctl put /foo/bar 'Hello world'")
         node.succeed("etcdctl get /foo/bar | grep 'Hello world'")
   '';
 })

--- a/pkgs/servers/etcd/3.3.nix
+++ b/pkgs/servers/etcd/3.3.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoPackage, fetchFromGitHub, nixosTests }:
+{ lib, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
   pname = "etcd";
@@ -23,8 +23,6 @@ buildGoPackage rec {
   installPhase = ''
     install -Dm755 bin/* bin/functional/cmd/* -t $out/bin
   '';
-
-  passthru.tests = { inherit (nixosTests) etcd etcd-cluster; };
 
   meta = with lib; {
     description = "Distributed reliable key-value store for the most critical data of a distributed system";

--- a/pkgs/servers/etcd/3.5.nix
+++ b/pkgs/servers/etcd/3.5.nix
@@ -39,8 +39,6 @@ let
     ldflags = [ "-X go.etcd.io/etcd/api/v3/version.GitSHA=GitNotFound" ];
 
     meta = commonMeta;
-
-    passthru.tests = { inherit (nixosTests) etcd etcd-cluster; };
   };
 
   etcdutl = buildGoModule rec {
@@ -75,6 +73,8 @@ symlinkJoin {
   name = "etcd";
   version = etcdVersion;
   meta = commonMeta;
+
+  passthru.tests = { inherit (nixosTests) etcd etcd-cluster; };
 
   paths = [
     etcdserver

--- a/pkgs/servers/etcd/3.5.nix
+++ b/pkgs/servers/etcd/3.5.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, symlinkJoin }:
+{ lib, buildGoModule, fetchFromGitHub, symlinkJoin, nixosTests }:
 
 let
   etcdVersion = "3.5.4";
@@ -39,6 +39,8 @@ let
     ldflags = [ "-X go.etcd.io/etcd/api/v3/version.GitSHA=GitNotFound" ];
 
     meta = commonMeta;
+
+    passthru.tests = { inherit (nixosTests) etcd etcd-cluster; };
   };
 
   etcdutl = buildGoModule rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22141,7 +22141,7 @@ with pkgs;
 
   ergochat = callPackage ../servers/irc/ergochat { };
 
-  etcd = etcd_3_3;
+  etcd = etcd_3_5;
   etcd_3_3 = callPackage ../servers/etcd/3.3.nix { };
   etcd_3_4 = callPackage ../servers/etcd/3.4.nix { };
   etcd_3_5 = callPackage ../servers/etcd/3.5.nix { };


### PR DESCRIPTION
###### Motivation for this change

Part 2 of PR #145795.

- update default etcd package (3.4 or 3.5?)
- refactor tests for new etcd version (maybe do it in matrix like https://github.com/NixOS/nixpkgs/blob/master/nixos/tests/mongodb.nix)
- update module to use different packages

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
