### PR TITLE
rose-pine-gtk-theme: init at unstable-2021-02-22

### DIFF
--- a/pkgs/data/themes/rose-pine-gtk/default.nix
+++ b/pkgs/data/themes/rose-pine-gtk/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, fetchFromGitHub
+, lib
+, gnome-themes-extra
+, gtk-engine-murrine
+, gtk_engines
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rose-pine-gtk-theme";
+  version = "unstable-2021-02-22";
+
+  src = fetchFromGitHub {
+    owner = "rose-pine";
+    repo = "gtk";
+    rev = "9cd2dd449f911973ec549231a57a070d256da9fd";
+    sha256 = "0lqx8dmv754ix3xbg7h440x964n0bg4lb06vbzvsydnbx79h7lvy";
+  };
+
+  buildInputs = [
+    gnome-themes-extra # adwaita engine for Gtk2
+    gtk_engines # pixmap engine for Gtk2
+  ];
+
+  propagatedUserEnvPkgs = [
+    gtk-engine-murrine # murrine engine for Gtk2
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/themes
+    cp -a Rose-Pine $out/share/themes
+    rm $out/share/themes/*/LICENSE
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Rosé Pine theme for GTK";
+    homepage = "https://github.com/rose-pine/gtk";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23488,6 +23488,8 @@ with pkgs;
 
   rime-data = callPackage ../data/misc/rime-data { };
 
+  rose-pine-gtk-theme = callPackage ../data/themes/rose-pine-gtk { };
+
   route159 = callPackage ../data/fonts/route159 { };
 
   sampradaya = callPackage ../data/fonts/sampradaya { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add [Rosé Pine](https://rosepinetheme.com) for [GTK](https://github.com/rose-pine/gtk)

Fixes https://github.com/NixOS/nixpkgs/issues/145776

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
