### PR TITLE
[staging-next] python3Packages.hypothesis: 6.23.2 → 6.24.5

### DIFF
--- a/pkgs/development/python-modules/hypothesis/default.nix
+++ b/pkgs/development/python-modules/hypothesis/default.nix
@@ -18,14 +18,14 @@ buildPythonPackage rec {
   # If you need these, you can just add them to your environment.
 
   pname = "hypothesis";
-  version = "6.23.2";
+  version = "6.24.5";
 
   # Use github tarballs that includes tests
   src = fetchFromGitHub {
     owner = "HypothesisWorks";
     repo = "hypothesis-python";
     rev = "hypothesis-python-${version}";
-    sha256 = "1mdygyq6ra4kysi0y2g3a4bgpqrcb8ci2061117zyms419qwwh4l";
+    sha256 = "+pPnMgbLdYbh0xqPewNOJRaL7VtxeN73wbHHuK0fNYo=";
   };
 
   postUnpack = "sourceRoot=$sourceRoot/hypothesis-python";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Targetting: #146259

Could not reproduce [hydra error](https://hydra.nixos.org/build/158498090/nixlog/1) locally, regardless changed from:

```
============================= slowest 20 durations =============================
15.26s call     hypothesis-python/tests/cover/test_targeting.py::test_targeting_with_following_empty
5.68s call     hypothesis-python/tests/cover/test_statistical_events.py::test_stateful_with_one_of_bundles_states_are_deduped
5.51s call     hypothesis-python/tests/cover/test_searchstrategy.py::test_example_raises_unsatisfiable_when_too_filtered
[..]
XPASS tests/cover/test_lookup.py::test_resolves_weird_types[typ0] 
XPASS tests/cover/test_lookup_py38.py::test_simple_optional_key_is_optional 
XPASS tests/cover/test_lookup_py38.py::test_layered_optional_key_is_optional 
====== 2586 passed, 3 skipped, 1 xfailed, 3 xpassed in 323.29s (0:05:23) =======
Finished executing pytestCheckPhase
pytestcachePhase
pytestRemoveBytecodePhase
```

to

```
============================= slowest 20 durations =============================
8.38s call     hypothesis-python/tests/cover/test_targeting.py::test_targeting_with_following_empty
6.45s call     hypothesis-python/tests/cover/test_statistical_events.py::test_stateful_with_one_of_bundles_states_are_deduped
5.42s call     hypothesis-python/tests/cover/test_searchstrategy.py::test_example_raises_unsatisfiable_when_too_filtered
[..]
============ 2589 passed, 3 skipped, 1 xfailed in 309.59s (0:05:09) ============
Finished executing pytestCheckPhase
pytestcachePhase
pytestRemoveBytecodePhase
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
