### PR TITLE
stdenv: let overrideAttrs accept attrset OR function

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -378,7 +378,12 @@ in
 lib.extendDerivation
   validity.handled
   ({
-     overrideAttrs = f: stdenv.mkDerivation (attrs // (f attrs));
+      overrideAttrs = f: let
+        f' =
+          if builtins.typeOf f == "set"
+          then (if lib.hasAttr "__functor" f then f else (_: f))
+          else f;
+      in stdenv.mkDerivation (attrs // (f' attrs));
 
      # A derivation that always builds successfully and whose runtime
      # dependencies are the original derivations build time dependencies


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Thanks to @adisbladis for this code.

Makes `overrideAttrs` usable in the same way that `override` can be used.
It allows the first argument of `overrideAttrs` to be either a function
or an attrset, instead of only a function:

```
hello.overrideAttrs (old: { postBuild = "echo hello"; })
hello.overrideAttrs { postBuild = "echo hello"; }
```

Previously only the first example was possible.

###### Repl Example

```
nix-repl> :lf .                                                                                     
warning: Git tree '/home/matthew/git/nixpkgs' is dirty
Added 13 variables.

nix-repl> :b outputs.legacyPackages.x86_64-linux.hello.overrideAttrs { postBuild = "echo test"; }   
warning: error: plugin-files set after plugins were loaded, you may need to move the flag before the subcommand

this derivation produced the following outputs:
  out -> /nix/store/svnf0a99ilivfc6hpw29z382fwmnpfkr-hello-2.10

nix-repl> :b outputs.legacyPackages.x86_64-linux.hello.overrideAttrs (old: { postBuild = "echo test"; })  
warning: error: plugin-files set after plugins were loaded, you may need to move the flag before the subcommand

this derivation produced the following outputs:
  out -> /nix/store/svnf0a99ilivfc6hpw29z382fwmnpfkr-hello-2.10
```

Co-authored-by: adisbladis <adisbladis@gmail.com>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
