### PR TITLE
gnomeExtensions.customize-ibus: init at 78

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4717,6 +4717,12 @@
     githubId = 896431;
     name = "Chris Hodapp";
   };
+  hollowman6 = {
+    email = "hollowman@hollowman.ml";
+    github = "HollowMan6";
+    githubId = 43995067;
+    name = "Songlin Jiang";
+  };
   holymonson = {
     email = "holymonson@gmail.com";
     github = "holymonson";

--- a/pkgs/desktops/gnome/extensions/customize-ibus/default.nix
+++ b/pkgs/desktops/gnome/extensions/customize-ibus/default.nix
@@ -1,0 +1,41 @@
+{ lib, stdenv, fetchFromGitHub, gnome, gettext, glib, ibus }:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-extension-customize-ibus";
+  version = "78";
+
+  src = fetchFromGitHub {
+    owner = "openSUSE";
+    repo = "Customize-IBus";
+    rev = "v${version}";
+    sha256 = "1hnnsjriq7xaakk8biwz55mn077lnm9nsmi4wz5zk7clgxmasvq9";
+  };
+
+  passthru = {
+    extensionUuid = "customize-ibus@hollowman.ml";
+    extensionPortalSlug = "customize-ibus";
+  };
+
+  nativeBuildInputs = [ gettext glib ];
+
+  buildPhase = ''
+    runHook preBuild
+    make _build VERSION=${version}
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/share/gnome-shell/extensions/"
+    cp -r _build "$out/share/gnome-shell/extensions/customize-ibus@hollowman.ml"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Full customization of appearance, behavior, system tray and input source indicator for IBus";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ hollowman6 ];
+    homepage = "https://github.com/openSUSE/Customize-IBus";
+    broken = versionOlder gnome.gnome-shell.version "3.34";
+  };
+}

--- a/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
+++ b/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
@@ -3,6 +3,7 @@
   "arcmenu@arcmenu.com" = callPackage ./arcmenu { };
   "caffeine@patapon.info" = callPackage ./caffeine { };
   "clock-override@gnomeshell.kryogenix.org" = callPackage ./clock-override { };
+  "customize-ibus@hollowman.ml" = callPackage ./customize-ibus { };
   "dash-to-panel@jderose9.github.com" = callPackage ./dash-to-panel { };
   "drop-down-terminal@gs-extensions.zzrough.org" = callPackage ./drop-down-terminal { };
   "EasyScreenCast@iacopodeenosee.gmail.com" = callPackage ./EasyScreenCast { };


### PR DESCRIPTION
###### Motivation for this change
Add Customize IBus as manually packaged GNOME Shell extension since it depends on IBus.

###### Things done

gnomeExtensions.customize-ibus: set to manually package
Also Add myself as the mantainer

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
