### PR TITLE
multitail: pull pending upstream inclusion fix for ncurses-6.3

### DIFF
--- a/pkgs/tools/misc/multitail/default.nix
+++ b/pkgs/tools/misc/multitail/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, ncurses, pkg-config }:
+{ lib, stdenv, fetchurl, fetchpatch, ncurses, pkg-config }:
 
 stdenv.mkDerivation rec {
   version = "6.5.0";
@@ -8,6 +8,16 @@ stdenv.mkDerivation rec {
     url = "https://www.vanheusden.com/multitail/${pname}-${version}.tgz";
     sha256 = "1vd9vdxyxsccl64ilx542ya5vlw2bpg6gnkq1x8cfqy6vxvmx7dj";
   };
+
+  patches = [
+    # Fix pending upstream inclusion for ncurses-6.3:
+    #  https://github.com/halturin/multitail/pull/4
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/halturin/multitail/commit/d7d10f3bce261074c116eba9f924b61f43777662.patch";
+      sha256 = "0kyp9l6v92mz6d3h34j11gs5kh3sf2nv76mygqfxb800vd8r0cgg";
+    })
+  ];
 
   nativeBuildInputs = [ pkg-config ];
 
@@ -21,7 +31,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "http://www.vanheusden.com/multitail/";
+    homepage = "https://github.com/halturin/multitail";
     description = "tail on Steroids";
     maintainers = with lib.maintainers; [ matthiasbeyer ];
     platforms = lib.platforms.unix;


### PR DESCRIPTION
Without the fix build on ncurses-6.3 fails as:

    ui.c:1167:71: error: format not a string literal and no format arguments [-Werror=format-security]
     1167 |                                 mvwprintw(mywin -> win, 4 + loop, 42, dummy);
          |                                                                       ^~~~~
