### PR TITLE
stderred: init at unstable-2021-04-28

### DIFF
--- a/pkgs/development/tools/stderred/default.nix
+++ b/pkgs/development/tools/stderred/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "stderred";
+  version = "unstable-2021-04-28";
+
+  src = fetchFromGitHub {
+    owner = "sickill";
+    repo = "stderred";
+    rev = "b2238f7c72afb89ca9aaa2944d7f4db8141057ea";
+    sha256 = "k/EA327AsRHgUYu7QqSF5yzOyO6h5XcE9Uv4l1VcIPI=";
+  };
+
+  sourceRoot = "${src.name}/src";
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  meta = with lib; {
+    description = "stderr in red.";
+    longDescription = ''
+      stderred hooks on write() and a family of stream functions (fwrite, fprintf, error...) from libc in order to colorize all stderr output that goes to terminal thus making it distinguishable from stdout.
+      Basically it wraps text that goes to file with descriptor "2" with proper ANSI escape codes making text red.
+    '';
+    homepage = "https://github.com/sickill/stderred";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mkg20001 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9226,6 +9226,8 @@ with pkgs;
 
   sacd = callPackage ../tools/cd-dvd/sacd { };
 
+  stderred = callPackage ../development/tools/stderred { };
+
   safe = callPackage ../tools/security/safe { };
 
   safety-cli = with python3.pkgs; toPythonApplication safety;


### PR DESCRIPTION
Upstream hasn't seen a release in forever (2012)
so let's just go with unstable

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/123057

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
