### PR TITLE
python3Packages.nessclient: init at 0.9.16b2

### DIFF
--- a/pkgs/development/python-modules/justbackoff/default.nix
+++ b/pkgs/development/python-modules/justbackoff/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "justbackoff";
+  version = "0.6.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "alexferl";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "097j6jxgl4b3z46x9y9z10643vnr9v831vhagrxzrq6nviil2z6l";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "pytest-runner>=5.2" ""
+  '';
+
+  pythonImportsCheck = [
+    "justbackoff"
+  ];
+
+  meta = with lib; {
+    description = "Simple backoff algorithm in Python";
+    homepage = "https://github.com/alexferl/justbackoff";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/nessclient/default.nix
+++ b/pkgs/development/python-modules/nessclient/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, click
+, fetchFromGitHub
+, justbackoff
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "nessclient";
+  version = "0.9.16b2";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "nickw444";
+    repo = pname;
+    rev = version;
+    sha256 = "1g3q9bv1nn1b8n6bklc05k8pac4cndzfxfr7liky0gnnbri15k81";
+  };
+
+  propagatedBuildInputs = [
+    justbackoff
+    click
+  ];
+
+  # Tests are not shipped
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "nessclient"
+  ];
+
+  meta = with lib; {
+    description = "Python implementation/abstraction of the Ness D8x / D16x Serial Interface ASCII protocol";
+    homepage = "https://github.com/nickw444/nessclient";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/nessclient/default.nix
+++ b/pkgs/development/python-modules/nessclient/default.nix
@@ -1,9 +1,12 @@
 { lib
+, asynctest
 , buildPythonPackage
 , click
 , fetchFromGitHub
 , justbackoff
 , pythonOlder
+, pytest-asyncio
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -25,15 +28,18 @@ buildPythonPackage rec {
     click
   ];
 
-  # Tests are not shipped
-  doCheck = false;
+  checkInputs = [
+    asynctest
+    pytest-asyncio
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [
     "nessclient"
   ];
 
   meta = with lib; {
-    description = "Python implementation/abstraction of the Ness D8x / D16x Serial Interface ASCII protocol";
+    description = "Python implementation/abstraction of the Ness D8x/D16x Serial Interface ASCII protocol";
     homepage = "https://github.com/nickw444/nessclient";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -559,7 +559,7 @@
     "nanoleaf" = ps: with ps; [ aionanoleaf ];
     "neato" = ps: with ps; [ aiohttp-cors pybotvac ];
     "nederlandse_spoorwegen" = ps: with ps; [ nsapi ];
-    "ness_alarm" = ps: with ps; [ ]; # missing inputs: nessclient
+    "ness_alarm" = ps: with ps; [ nessclient ];
     "nest" = ps: with ps; [ aiohttp-cors ha-ffmpeg python-nest ]; # missing inputs: google-nest-sdm
     "netatmo" = ps: with ps; [ pyturbojpeg aiohttp-cors hass-nabucasa pyatmo ];
     "netdata" = ps: with ps; [ netdata ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -535,6 +535,7 @@ in with py.pkgs; buildPythonApplication rec {
     "nam"
     "namecheapdns"
     "neato"
+    "ness_alarm"
     "netatmo"
     "nexia"
     "no_ip"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5054,6 +5054,8 @@ in {
 
   neo = callPackage ../development/python-modules/neo { };
 
+  nessclient = callPackage ../development/python-modules/nessclient { };
+
   nest-asyncio = callPackage ../development/python-modules/nest-asyncio { };
 
   nestedtext = callPackage ../development/python-modules/nestedtext { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4093,6 +4093,8 @@ in {
 
   jupytext = callPackage ../development/python-modules/jupytext { };
 
+  justbackoff = callPackage ../development/python-modules/justbackoff { };
+
   jwcrypto = callPackage ../development/python-modules/jwcrypto { };
 
   jxmlease = callPackage ../development/python-modules/jxmlease { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python implementation/abstraction of the Ness D8x / D16x Serial Interface ASCII protocol

https://github.com/nickw444/nessclient

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
