### PR TITLE
ibus-theme-tools: init at 4.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4717,6 +4717,12 @@
     githubId = 896431;
     name = "Chris Hodapp";
   };
+  hollowman6 = {
+    email = "hollowman@hollowman.ml";
+    github = "HollowMan6";
+    githubId = 43995067;
+    name = "Songlin Jiang";
+  };
   holymonson = {
     email = "holymonson@gmail.com";
     github = "holymonson";

--- a/pkgs/tools/misc/ibus-theme-tools/default.nix
+++ b/pkgs/tools/misc/ibus-theme-tools/default.nix
@@ -1,0 +1,26 @@
+{ lib, python3Packages, fetchFromGitHub, gettext }:
+
+python3Packages.buildPythonPackage rec {
+  pname = "ibus-theme-tools";
+  version = "4.2.0";
+  disabled = python3Packages.pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "openSUSE";
+    repo = "IBus-Theme-Tools";
+    rev = "v${version}";
+    sha256 = "0i8vwnikwd1bfpv4xlgzc51gn6s18q58nqhvcdiyjzcmy3z344c2";
+  };
+
+  propagatedBuildInputs = [ python3Packages.tinycss2 python3Packages.pygobject3 gettext ];
+
+  # No test.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Generate the IBus GTK or GNOME Shell theme from existing themes";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ hollowman6 ];
+    homepage = "https://github.com/openSUSE/IBus-Theme-Tools";
+  };
+}

--- a/pkgs/tools/misc/ibus-theme-tools/default.nix
+++ b/pkgs/tools/misc/ibus-theme-tools/default.nix
@@ -3,7 +3,6 @@
 python3Packages.buildPythonApplication rec {
   pname = "ibus-theme-tools";
   version = "4.2.0";
-  disabled = python3Packages.pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "openSUSE";
@@ -12,12 +11,14 @@ python3Packages.buildPythonApplication rec {
     sha256 = "0i8vwnikwd1bfpv4xlgzc51gn6s18q58nqhvcdiyjzcmy3z344c2";
   };
 
-  BuildInputs = [ gettext ];
+  buildInputs = [ gettext ];
 
   propagatedBuildInputs = with python3Packages; [ tinycss2 pygobject3 ];
 
   # No test.
   doCheck = false;
+
+  pythonImportsCheck = [ "ibus_theme_tools" ];
 
   meta = with lib; {
     description = "Generate the IBus GTK or GNOME Shell theme from existing themes";

--- a/pkgs/tools/misc/ibus-theme-tools/default.nix
+++ b/pkgs/tools/misc/ibus-theme-tools/default.nix
@@ -1,6 +1,6 @@
 { lib, python3Packages, fetchFromGitHub, gettext }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonApplication rec {
   pname = "ibus-theme-tools";
   version = "4.2.0";
   disabled = python3Packages.pythonOlder "3.6";
@@ -12,7 +12,9 @@ python3Packages.buildPythonPackage rec {
     sha256 = "0i8vwnikwd1bfpv4xlgzc51gn6s18q58nqhvcdiyjzcmy3z344c2";
   };
 
-  propagatedBuildInputs = [ python3Packages.tinycss2 python3Packages.pygobject3 gettext ];
+  BuildInputs = [ gettext ];
+
+  propagatedBuildInputs = with python3Packages; [ tinycss2 pygobject3 ];
 
   # No test.
   doCheck = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4157,6 +4157,8 @@ with pkgs;
 
   ibus-with-plugins = callPackage ../tools/inputmethods/ibus/wrapper.nix { };
 
+  ibus-theme-tools = callPackage ../tools/misc/ibus-theme-tools { };
+
   interception-tools = callPackage ../tools/inputmethods/interception-tools { };
   interception-tools-plugins = {
     caps2esc = callPackage ../tools/inputmethods/interception-tools/caps2esc.nix { };


### PR DESCRIPTION
###### Motivation for this change

Add IBus Theme Tools for Generating IBus Themes that can be used in #146353

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
