### PR TITLE
musikcube: pull pending upstream inclusion fix for ncurses-6.3

### DIFF
--- a/pkgs/applications/audio/musikcube/default.nix
+++ b/pkgs/applications/audio/musikcube/default.nix
@@ -4,6 +4,7 @@
 , boost
 , curl
 , fetchFromGitHub
+, fetchpatch
 , ffmpeg
 , lame
 , libev
@@ -25,6 +26,16 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "1y00vwn1h10cfflxrm5bk271ak9gilhjycgi44hlkkhmf5bdgn35";
   };
+
+  patches = [
+    # Fix pending upstream inclusion for ncuurses-6.3 support:
+    #  https://github.com/clangen/musikcube/pull/474
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/clangen/musikcube/commit/1240720e27232fdb199a4da93ca6705864442026.patch";
+      sha256 = "0bhjgwnj6d24wb1m9xz1vi1k9xk27arba1absjbcimggn54pinid";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
Without the fix build on ncurses-6.3 fails as:

    musikcube/cursespp/cursespp/curses_config.h:54:36:
     error: format not a string literal and no format arguments [-Werror=format-security]
       54 |     if (window && format) { wprintw(window, format, ##__VA_ARGS__); }
          |                             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    musikcube/src/musikcube/app/window/TransportWindow.cpp:640:5: note: in expansion of macro 'checked_wprintw'
      640 |     checked_wprintw(c, shuffleLabel.c_str(
