### PR TITLE
python3Packages.librouteros: 3.1.0 -> 3.2.0

### DIFF
--- a/pkgs/development/python-modules/librouteros/default.nix
+++ b/pkgs/development/python-modules/librouteros/default.nix
@@ -8,14 +8,16 @@
 
 buildPythonPackage rec {
   pname = "librouteros";
-  version = "3.1.0";
+  version = "3.2.0";
+  format = "setuptools";
+
   disabled = !isPy3k;
 
   src = fetchFromGitHub {
     owner = "luqasz";
     repo = pname;
     rev = version;
-    sha256 = "1skjwnqa3vcpq9gzgpw93wdmisq15fp0q07kzyq3fgx4yg7b6sql";
+    sha256 = "sha256-Zo9HCjYe9cCkqXhikAjDQKQXGkrMni3f+9KoqhZskNk=";
   };
 
   checkInputs = [
@@ -33,7 +35,9 @@ buildPythonPackage rec {
     "test_generator_ditch"
   ];
 
-  pythonImportsCheck = [ "librouteros" ];
+  pythonImportsCheck = [
+    "librouteros"
+  ];
 
   meta = with lib; {
     description = "Python implementation of the MikroTik RouterOS API";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream releae 3.2.0

Change log: https://github.com/luqasz/librouteros/blob/master/CHANGELOG.rst#320

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
