### PR TITLE
meson: 0.57.1 -> 0.60.1

### DIFF
--- a/pkgs/development/tools/build-managers/meson/boost-Do-not-add-system-paths-on-nix.patch
+++ b/pkgs/development/tools/build-managers/meson/boost-Do-not-add-system-paths-on-nix.patch
@@ -1,26 +1,11 @@
-From 536108b10271f2f42d41c7d9ddb4ce2ea1851f4f Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?Niklas=20Hamb=C3=BCchen?= <mail@nh2.me>
-Date: Sat, 17 Oct 2020 19:27:08 +0200
-Subject: [PATCH] boost: Do not add system paths on nix
-
----
- mesonbuild/dependencies/boost.py | 17 +----------------
- 1 file changed, 1 insertion(+), 16 deletions(-)
-
 diff --git a/mesonbuild/dependencies/boost.py b/mesonbuild/dependencies/boost.py
-index 907c0c275..ecaf11b18 100644
+index aadf3f833..9296b951c 100644
 --- a/mesonbuild/dependencies/boost.py
 +++ b/mesonbuild/dependencies/boost.py
-@@ -643,22 +643,7 @@ class BoostDependency(ExternalDependency):
-             roots += [x for x in candidates if x.name.lower().startswith('boost') and x.is_dir()]
+@@ -682,16 +682,7 @@ class BoostDependency(SystemDependency):
          else:
              tmp = []  # type: T.List[Path]
--
--            # Homebrew
--            brew_boost = Path('/usr/local/Cellar/boost')
--            if brew_boost.is_dir():
--                tmp += [x for x in brew_boost.iterdir()]
--
+ 
 -            # Add some default system paths
 -            tmp += [Path('/opt/local')]
 -            tmp += [Path('/usr/local/opt/boost')]
@@ -33,8 +18,5 @@ index 907c0c275..ecaf11b18 100644
 -            roots += tmp
 +            # Do not add any non-explicit paths on nix
  
-         return roots
+         self.check_and_set_roots(roots, use_system=True)
  
--- 
-2.25.4
-

--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -9,11 +9,11 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "meson";
-  version = "0.57.1";
+  version = "0.60.1";
 
   src = python3.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "19n8alcpzv6npgp27iqljkmvdmr7s2c7zm8y997j1nlvpa1cgqbj";
+    hash = "sha256-Wt14nJU9mEtQCFiyhR7j163QRgzxpvhS8Kchrxc4ThM=";
   };
 
   patches = [

--- a/pkgs/development/tools/build-managers/meson/gir-fallback-path.patch
+++ b/pkgs/development/tools/build-managers/meson/gir-fallback-path.patch
@@ -1,8 +1,10 @@
+diff --git a/mesonbuild/modules/gnome.py b/mesonbuild/modules/gnome.py
+index 1c6952df7..ed7d198bc 100644
 --- a/mesonbuild/modules/gnome.py
 +++ b/mesonbuild/modules/gnome.py
-@@ -807,6 +807,13 @@ class GnomeModule(ExtensionModule):
-         if fatal_warnings:
-             scan_command.append('--warn-error')
+@@ -925,6 +925,13 @@ class GnomeModule(ExtensionModule):
+ 
+         generated_files = [f for f in libsources if isinstance(f, (GeneratedList, CustomTarget, CustomTargetIndex))]
  
 +        if len(set([girtarget.get_custom_install_dir()[0] for girtarget in girtargets])) > 1:
 +            raise MesonException('generate_gir tries to build multiple libraries with different install_dir at once: {}'.format(','.join([str(girtarget) for girtarget in girtargets])))
@@ -11,6 +13,6 @@
 +        if fallback_libpath is not None and isinstance(fallback_libpath, str) and len(fallback_libpath) > 0 and fallback_libpath[0] == "/":
 +            scan_command += ['--fallback-library-path=' + fallback_libpath]
 +
-         scan_target = self._make_gir_target(state, girfile, scan_command, depends, kwargs)
+         scan_target = self._make_gir_target(state, girfile, scan_command, generated_files, depends, kwargs)
  
-         typelib_output = '%s-%s.typelib' % (ns, nsversion)
+         typelib_output = f'{ns}-{nsversion}.typelib'

--- a/pkgs/development/tools/build-managers/meson/more-env-vars.patch
+++ b/pkgs/development/tools/build-managers/meson/more-env-vars.patch
@@ -1,13 +1,16 @@
 diff --git a/mesonbuild/environment.py b/mesonbuild/environment.py
-index 756dd8193..a5cc6ef8b 100644
+index 5635c8a76..93f25da43 100644
 --- a/mesonbuild/environment.py
 +++ b/mesonbuild/environment.py
-@@ -151,7 +151,7 @@ def _get_env_var(for_machine: MachineChoice, is_cross: bool, var_name: str) -> T
+@@ -68,9 +68,9 @@ def _get_env_var(for_machine: MachineChoice, is_cross: bool, var_name: str) -> T
          # compiling we fall back on the unprefixed host version. This
          # allows native builds to never need to worry about the 'BUILD_*'
          # ones.
 -        ([var_name + '_FOR_BUILD'] if is_cross else [var_name]),
 +        [var_name + '_FOR_BUILD'] + ([] if is_cross else [var_name]),
-         # Always just the unprefixed host verions
-         [var_name]
+         # Always just the unprefixed host versions
+-        [var_name]
++        [var_name],
      )[for_machine]
+     for var in candidates:
+         value = os.environ.get(var)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updated all patches that failed to apply, would very much like a second pair of eyes on that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
