### PR TITLE
mono: add licensing details

### DIFF
--- a/pkgs/development/compilers/mono/generic.nix
+++ b/pkgs/development/compilers/mono/generic.nix
@@ -81,6 +81,15 @@ stdenv.mkDerivation rec {
     description = "Cross platform, open source .NET development framework";
     platforms = with platforms; darwin ++ linux;
     maintainers = with maintainers; [ thoughtpolice obadz vrthra ];
-    license = licenses.free; # Combination of LGPL/X11/GPL ?
+    license = with licenses; [
+      /* runtime, compilers, tools and most class libraries licensed */ mit
+      /* runtime includes some code licensed */ bsd3
+      /* mcs/class/I18N/mklist.sh marked GPLv2 and others just GPL */ gpl2Only
+      /* RabbitMQ.Client class libraries dual licensed */ mpl20 asl20
+      /* mcs/class/System.Core/System/TimeZoneInfo.Android.cs */ asl20
+      /* some documentation */ mspl
+      # https://www.mono-project.com/docs/faq/licensing/
+      # https://github.com/mono/mono/blob/main/LICENSE
+    ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

It'd be nice to have mono built and cached so I've tried to add more accurate licensing.

The [LICENSE](https://github.com/mono/mono/blob/main/LICENSE) file is quite the mess but the [FAQ](https://www.mono-project.com/docs/faq/licensing) asserts the key licenses are mit bsd3 and asl20

One other matter is they say "api-documentation" is CC BY 4.0 but IDK if the manpages count towards that

I think with the statements in the FAQ we can safely build and distribute mono at the very least until notified otherwise.
We can also post an issue to get this double checked by the mono maintainers if we want a second pair of eyes

Some other concerns are, do the licenses vary depending on mono versions? why does the arch release list it as `GPL, LGPL2.1, MPL`.
Debian has a very detailed copyright and license analysis so we could use some license details from this? https://metadata.ftp-master.debian.org/changelogs//main/m/mono/mono_6.8.0.105+dfsg-3.2_copyright

cc: @thoughtpolice @obadz @vrthra

---

I've gone with a `/* explanation */ license` format which is quite non-standard and `nixpkgs-fmt` doesn't like it (although `nixpkgs-fmt` doesn't like other parts of the file either). I can fix this to be as below if required:

```
# explanation
license
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
