### PR TITLE
ookla-speedtest: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/tools/networking/ookla-speedtest/default.nix
+++ b/pkgs/tools/networking/ookla-speedtest/default.nix
@@ -2,16 +2,16 @@
 
 let
   pname = "ookla-speedtest";
-  version = "1.0.0";
+  version = "1.1.0";
 
   srcs = {
     x86_64-linux = fetchurl {
       url = "https://install.speedtest.net/app/cli/${pname}-${version}-x86_64-linux.tgz";
-      sha256 = "sha256-X+ICjw1EJ+T0Ix2fnPcOZpG7iQpwY211Iy/k2XBjMWg=";
+      sha256 = "sha256-/NWN8G6uqokjchSnNcC3FU1qDsOjt4Jh2kCnZc5B9H8=";
     };
     aarch64-linux = fetchurl {
       url = "https://install.speedtest.net/app/cli/${pname}-${version}-aarch64-linux.tgz";
-      sha256 = "sha256-BzaE3DSQUIygGwTFhV4Ez9eX/tM/bqam7cJt+8b2qp4=";
+      sha256 = "sha256-kyOrChC3S8kn4ArO5IylFIstS/N3pXxBVx4ZWI600oU=";
     };
   };
 in


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Updated to latest version, also tested the functionality of the program.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
