### PR TITLE
Fix eval with `nix-env -qas`

### DIFF
--- a/pkgs/os-specific/darwin/apple-sdk/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/default.nix
@@ -271,7 +271,7 @@ in rec {
 
   overrides = super: {
     AppKit = lib.overrideDerivation super.AppKit (drv: {
-      __propagatedImpureHostDeps = drv.__propagatedImpureHostDeps ++ [
+      __propagatedImpureHostDeps = drv.__propagatedImpureHostDeps or [] ++ [
         "/System/Library/PrivateFrameworks/"
       ];
     });
@@ -285,13 +285,13 @@ in rec {
     });
 
     CoreMedia = lib.overrideDerivation super.CoreMedia (drv: {
-      __propagatedImpureHostDeps = drv.__propagatedImpureHostDeps ++ [
+      __propagatedImpureHostDeps = drv.__propagatedImpureHostDeps or [] ++ [
         "/System/Library/Frameworks/CoreImage.framework"
       ];
     });
 
     CoreMIDI = lib.overrideDerivation super.CoreMIDI (drv: {
-      __propagatedImpureHostDeps = drv.__propagatedImpureHostDeps ++ [
+      __propagatedImpureHostDeps = drv.__propagatedImpureHostDeps or [] ++ [
         "/System/Library/PrivateFrameworks/"
       ];
       setupHook = ./private-frameworks-setup-hook.sh;


### PR DESCRIPTION
###### Motivation for this change
At least on NixOS, it fails to evaluate as follows:

	$ nix-env -qaPs -f .
	error: attribute '__propagatedImpureHostDeps' missing

cc @NixOS/darwin-maintainers 