### PR TITLE
cups-brother-hll2350dw: init at 4.0.0-1

### DIFF
--- a/pkgs/misc/cups/drivers/hll2350dw/default.nix
+++ b/pkgs/misc/cups/drivers/hll2350dw/default.nix
@@ -1,0 +1,94 @@
+{ lib
+, stdenv
+, fetchurl
+, dpkg
+, autoPatchelfHook
+, makeWrapper
+, perl
+, gnused
+, ghostscript
+, file
+, coreutils
+, gnugrep
+, which
+}:
+
+let
+  arches = [ "x86_64" "i686" "armv7l" ];
+
+  runtimeDeps = [
+    ghostscript
+    file
+    gnused
+    gnugrep
+    coreutils
+    which
+  ];
+in
+
+stdenv.mkDerivation rec {
+  pname = "cups-brother-hll2350dw";
+  version = "4.0.0-1";
+
+  nativeBuildInputs = [ dpkg makeWrapper autoPatchelfHook ];
+  buildInputs = [ perl ];
+
+  dontUnpack = true;
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf103566/hll2350dwpdrv-${version}.i386.deb";
+    sha256 = "0b7hhln105agc3rwpi7cjlx5nf4d2yk9iksahdv3725nnd06lg46";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    dpkg-deb -x $src $out
+
+    # delete unnecessary files for the current architecture
+  '' + lib.concatMapStrings (arch: ''
+    echo Deleting files for ${arch}
+    rm -r "$out/opt/brother/Printers/HLL2350DW/lpd/${arch}"
+  '') (builtins.filter (arch: arch != stdenv.hostPlatform.linuxArch) arches) + ''
+
+      # bundled scripts don't understand the arch subdirectories for some reason
+      ln -s \
+        "$out/opt/brother/Printers/HLL2350DW/lpd/${stdenv.hostPlatform.linuxArch}/"* \
+        "$out/opt/brother/Printers/HLL2350DW/lpd/"
+
+      # Fix global references and replace auto discovery mechanism with hardcoded values
+      substituteInPlace $out/opt/brother/Printers/HLL2350DW/lpd/lpdfilter \
+        --replace /opt "$out/opt" \
+        --replace "my \$BR_PRT_PATH =" "my \$BR_PRT_PATH = \"$out/opt/brother/Printers/HLL2350DW\"; #" \
+        --replace "PRINTER =~" "PRINTER = \"HLL2350DW\"; #"
+
+      # Make sure all executables have the necessary runtime dependencies available
+      find "$out" -executable -and -type f | while read file; do
+        wrapProgram "$file" --prefix PATH : "${lib.makeBinPath runtimeDeps}"
+      done
+
+      # Symlink filter and ppd into a location where CUPS will discover it
+      mkdir -p $out/lib/cups/filter
+      mkdir -p $out/share/cups/model
+
+      ln -s \
+        $out/opt/brother/Printers/HLL2350DW/lpd/lpdfilter \
+        $out/lib/cups/filter/brother_lpdwrapper_HLL2350DW
+
+      ln -s \
+        $out/opt/brother/Printers/HLL2350DW/cupswrapper/brother-HLL2350DW-cups-en.ppd \
+        $out/share/cups/model/
+
+      runHook postInstall
+    '';
+
+  meta = with lib; {
+    homepage = "http://www.brother.com/";
+    description = "Brother HL-L2350DW printer driver";
+    license = licenses.unfree;
+    platforms = builtins.map (arch: "${arch}-linux") arches;
+    downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=us_ot&lang=en&prod=hll2350dw_us_eu_as&os=128";
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32095,6 +32095,8 @@ with pkgs;
 
   cups-brother-hll2340dw = pkgsi686Linux.callPackage  ../misc/cups/drivers/hll2340dw { };
 
+  cups-brother-hll2350dw = callPackage  ../misc/cups/drivers/hll2350dw { };
+
   cups-drv-rastertosag-gdi = callPackage ../misc/cups/drivers/cups-drv-rastertosag-gdi { };
 
   # this driver ships with pre-compiled 32-bit binary libraries


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

makes my dumb wifi printer do things.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
