### PR TITLE
oil: compile from source

### DIFF
--- a/pkgs/shells/oil/default.nix
+++ b/pkgs/shells/oil/default.nix
@@ -95,6 +95,7 @@ stdenv.mkDerivation {
   '';
 
   buildPhase = ''
+    build/dev.sh yajl
     make _bin/oil.ovm-dbg -J$NIX_BUILD_CORES
     make _release/oil.tar -J$NIX_BUILD_CORES
   '';

--- a/pkgs/shells/oil/default.nix
+++ b/pkgs/shells/oil/default.nix
@@ -1,42 +1,148 @@
-{ stdenv, lib, fetchurl, withReadline ? true, readline }:
+{ lib
+, stdenv
+, python27Packages
+, callPackage
+, fetchFromGitHub
+, makeWrapper
+, # re2c deps
+  autoreconfHook
+, # py-yajl deps
+  git
+, # oil deps
+  readline
+, cmark
+, file
+, glibcLocales
+, withReadline ? true
+, darwin
+, which
+, cmake
+, python27Full
+}:
 
-stdenv.mkDerivation rec {
-  pname = "oil";
+let
   version = "0.9.3";
+  # rev == present HEAD of release/0.9.3
+  rev = "20d23eed7949548bc897ddcf7701f720c81f438e";
+  src = fetchFromGitHub {
+    owner = "oilshell";
+    repo = "oil";
+    inherit rev;
+    hash = "sha256-wyjydQv7xHY2hNsG/msfHdztFLD40atXM3X2Ib6cl3Q=";
+    fetchSubmodules = true;
 
-  src = fetchurl {
-    url = "https://www.oilshell.org/download/oil-${version}.tar.xz";
-    sha256 = "sha256-YvNgcvafM3jgO3nY1SVcHRNglOwRQQ208W7oLxZg79o=";
+    /*
+      It's not critical to drop most of these; the primary target is
+      the vendored fork of Python-2.7.13, which is ~ 55M and over 3200
+      files, dozens of which get interpreter script patches in fixup.
+
+      Note: -f is necessary to keep it from being a pain to update
+      hash on rev updates. Command will fail w/o and not print hash.
+    */
+    # extraPostFetch = ''
+    #   rm -rf benchmarks metrics py-yajl rfc gold web testdata services demo devtools cpp
+    # '';
   };
+  re2c = stdenv.mkDerivation rec {
+    pname = "re2c";
+    version = "1.0.3";
+    sourceRoot = "${src.name}/re2c";
+    src = fetchFromGitHub {
+      owner = "skvadrik";
+      repo = "re2c";
+      rev = version;
+      sha256 = "0grx7nl9fwcn880v5ssjljhcb9c5p2a6xpwil7zxpmv0rwnr3yqi";
+    };
+    nativeBuildInputs = [ autoreconfHook ];
+    preCheck = ''
+      patchShebangs run_tests.sh
+    '';
+  };
+  patchSrc = fetchFromGitHub {
+    owner = "abathur";
+    repo = "nix-py-dev-oil";
+    rev = "v0.8.12.1";
+    hash = "sha256-7JVnosdcvmVFN3h6SIeeqcJFcyFkai//fFuzi7ThNMY=";
+  };
+in
 
-  postPatch = ''
-    patchShebangs build
+  /*
+    Upstream isn't interested in packaging this as a library
+    (or accepting all of the patches we need to do so).
+    This creates one without disturbing upstream too much.
+  */
+stdenv.mkDerivation {
+  pname = "oil";
+  inherit version src;
+
+  # patch to support a python package, pass tests on macOS, etc.
+  patches = [
+    "${patchSrc}/0004-disable-internal-py-yajl-for-nix-built.patch"
+    "${patchSrc}/0006-disable_failing_libc_tests.patch"
+  ];
+
+  # TODO substitue the naked python2 call instead of having python27 as a dependency
+  # TODO fix pythonpath to include py-yajl
+  buildInputs = [ readline cmark cmake python27Full ] ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Carbon ];
+
+  nativeBuildInputs = [ re2c file makeWrapper ];
+
+  configurePhase = ''
+    build/dev.sh yajl-release
+    build/prepare.sh configure
+    build/prepare.sh build-python
+    build/dev.sh all
   '';
 
-  preInstall = ''
-    mkdir -p $out/bin
+  buildPhase = ''
+    make _bin/oil.ovm-dbg -J$NIX_BUILD_CORES
+    make _release/oil.tar -J$NIX_BUILD_CORES
   '';
 
-  buildInputs = lib.optional withReadline readline;
-  configureFlags = lib.optional withReadline "--with-readline";
-
-  # Stripping breaks the bundles by removing the zip file from the end.
-  dontStrip = true;
+  _NIX_SHELL_LIBCMARK = "${cmark}/lib/libcmark${stdenv.hostPlatform.extensions.sharedLibrary}";
 
   meta = {
     description = "A new unix shell";
     homepage = "https://www.oilshell.org/";
-
     license = with lib.licenses; [
       psfl # Includes a portion of the python interpreter and standard library
       asl20 # Licence for Oil itself
     ];
-
     maintainers = with lib.maintainers; [ lheckemann alva ];
     changelog = "https://www.oilshell.org/release/${version}/changelog.html";
   };
-
   passthru = {
     shellPath = "/bin/osh";
   };
 }
+# python27Packages.buildPythonPackage {
+#   pname = "oil";
+#   inherit version src;
+
+
+#   propagatedBuildInputs = with python27Packages; [ six typing ];
+
+#   doCheck = true;
+
+#   preBuild = ''
+#     devtools/release.sh quick-oil-tarball
+#   '';
+
+#   postPatch = ''
+#     patchShebangs asdl build core doctools frontend native oil_lang
+#   '';
+
+#   /*
+#     We did convince oil to upstream an env for specifying
+#     this to support a shell.nix. Would need a patch if they
+#     later drop this support. See:
+#     https://github.com/oilshell/oil/blob/46900310c7e4a07a6223eb6c08e4f26460aad285/doctools/cmark.py#L30-L34
+#   */
+
+#   # See earlier note on glibcLocales TODO: verify needed?
+#   LOCALE_ARCHIVE = lib.optionalString (stdenv.buildPlatform.libc == "glibc") "${glibcLocales}/lib/locale/locale-archive";
+
+#   # not exhaustive; just a spot-check for now
+#   pythonImportsCheck = [ "oil" "oil._devbuild" ];
+
+# }


### PR DESCRIPTION
###### Motivation for this change

In order to determine if we can switch the default nixpkgs shell to be oil (or osh), oil (and osh) need to be built from source and not just from a release tarball.

On linux I get the following problems
- After the python build, there are the following warning messages
```
gcc -pthread -shared build/temp.linux-x86_64-2.7/tmp/nix-build-oil-cpython-2.7.13.drv-0/Python-2.7.13/Modu
les/cryptmodule.o -L/nix/store/n3f2dv2kzzl3s79v9w3q0qdi1c8n0z9r-oil-cpython-2.7.13/lib -o build/lib.linux-
x86_64-2.7/crypt.so
*** WARNING: renaming "crypt" since importing it failed: build/lib.linux-x86_64-2.7/crypt.so: undefined sy
mbol: crypt

Python build finished, but the necessary bits to build these modules were not found:
_bsddb             _curses            _curses_panel
_sqlite3           _ssl               _tkinter
bsddb185           bz2                dbm
dl                 gdbm               imageop
nis                readline           sunaudiodev
zlib
To find the necessary bits, look in setup.py in detect_modules() for the module's name.


Failed to build these modules:
crypt
```
- After the preceding warning, the build actually fails with
```
make: *** No rule to make target 'Misc/python-config.in', needed by 'python-config'.  Stop.
```

On darwin, the python build does not even succeed, having a problem with '_CF'. (which is related to corefoundation framework from darwin. I have no idea how to tell the cpython build to find the corefoundation. I checked the NIX_CFLAGS and NIX_LDFLAGS and those include the corefoundation framework headers.

@andychu Here is the explanation of what is happening here. Nix needs to build each dependency of the project separately. As I understand it, there are 3 (re2c, py-yajl, and python-2.7.13). re2c and py-yajl build correctly, however I am getting errors when building python 2.7.13. My understanding is that it needs to be built first.
Looking at the build script in build/prepare.sh it is just calling make. This is what I am doing here. There must be something to do with the python-config.in

Some feedback on the docs: They are good at describing the high level view of what is happening. However, in this case, since those build scripts need to be examined and broken down into their components, the only way is to just read those. Some more detailed explanation would be amazing. (I am happy to try to redact a draft after we have had the introduction call).

@abathur I added you as a reviewer, but it's just in case you see something that is obviously wrong. No stress or obligation here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
