### PR TITLE
crd2pulumi: init at 1.0.10

### DIFF
--- a/pkgs/development/tools/crd2pulumi/default.nix
+++ b/pkgs/development/tools/crd2pulumi/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "crd2pulumi";
+  version = "1.0.10";
+
+  src = fetchFromGitHub {
+    owner = "pulumi";
+    repo = "crd2pulumi";
+    rev = "v${version}";
+    sha256 = "1xzr63brzqysvhm3fqj246c7s84kchpcm6wad3mvxcxjcab6xd1f";
+  };
+
+  vendorSha256 = "0xi5va2fy4nrxp3qgyzcw20a2089sbz8h1hvqx2ryxijr61wd93d";
+
+  ldflags = [ "-s" "-w" "-X github.com/pulumi/crd2pulumi/gen.Version=${src.rev}" ];
+
+  subPackages = [ "." ];
+
+  meta = with lib; {
+    description = "Generate typed CustomResources from a Kubernetes CustomResourceDefinition";
+    homepage = "https://github.com/pulumi/crd2pulumi";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ flokli ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4283,6 +4283,8 @@ with pkgs;
 
   crackxls = callPackage ../tools/security/crackxls { };
 
+  crd2pulumi = callPackage ../development/tools/crd2pulumi { };
+
   create-cycle-app = nodePackages.create-cycle-app;
 
   createrepo_c = callPackage ../tools/package-management/createrepo_c { };


### PR DESCRIPTION
###### Motivation for this change
Being able to generate typed CustomResources from a Kubernetes CustomResourceDefinition for Pulumi.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
