### PR TITLE
python3Packages.cvxpy: 1.1.13 -> 1.1.17, scs: 2.1.1 -> 3.0.0, python3Packages.scs: 2.1.1 -> 3.0.0

### DIFF
--- a/pkgs/development/libraries/science/math/scs/default.nix
+++ b/pkgs/development/libraries/science/math/scs/default.nix
@@ -4,13 +4,13 @@ assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation rec {
   pname = "scs";
-  version = "2.1.1";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "cvxgrp";
     repo = "scs";
     rev = version;
-    sha256 = "14g5m3lcvrbwpq1bq0liq00jh0gm1947lg3z4jfsp43f6p5alb20";
+    sha256 = "sha256-Lly28KDDZ5hJyiMOhiX/3VaKs0iPcSqizOurZevhfCo=";
   };
 
   # Actually link and add libgfortran to the rpath

--- a/pkgs/development/python-modules/cvxpy/default.nix
+++ b/pkgs/development/python-modules/cvxpy/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "cvxpy";
-  version = "1.1.13";
+  version = "1.1.17";
   format = "pyproject";
 
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "012avhf0a8n9xyy4g3xcr5z8z2a3m6rnqic6gfs9fq6p9bkq3ix9";
+    sha256 = "sha256-M5fTuJ13Dqnw/DWbHJs6/t5qDTvqHP8g4mU7E0Uc24o=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/qiskit-aer/default.nix
+++ b/pkgs/development/python-modules/qiskit-aer/default.nix
@@ -88,6 +88,7 @@ buildPythonPackage rec {
   ];
   # Slow tests
   disabledTests = [
+    "test_clifford" # fails on cvxpy >= 1.1.15. https://github.com/Qiskit/qiskit-aer/pull/1318. Remove in future.
     "test_snapshot" # TODO: these ~30 tests fail on setup due to pytest fixture issues?
     "test_initialize_2" # TODO: simulations appear incorrect, off by >10%.
 
@@ -111,7 +112,6 @@ buildPythonPackage rec {
     "_144"
     "test_sparse_output_probabilities"
     "test_reset_2_qubit"
-    # "test_clifford"
   ];
   checkInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/scs/default.nix
+++ b/pkgs/development/python-modules/scs/default.nix
@@ -5,25 +5,21 @@
 , lapack
 , numpy
 , scipy
-, scs
   # check inputs
-, nose
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
-  inherit (scs) pname version;
+  pname = "scs";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "bodono";
     repo = "scs-python";
-    rev = "f02abdc0e2e0a5851464e30f6766ccdbb19d73f0"; # need to choose commit manually, untagged
-    sha256 = "174b5s7cwgrn1m55jlrszdl403zhpzc4yl9acs6kjv9slmg1mmjr";
+    rev = version;
+    sha256 = "sha256-7OgqCo21S0FDev8xv6/8iGFXg8naVi93zd8v1f9iaWw=";
+    fetchSubmodules = true;
   };
-
-  preConfigure = ''
-    rm -r scs
-    ln -s ${scs.src} scs
-  '';
 
   buildInputs = [
     lapack
@@ -35,10 +31,7 @@ buildPythonPackage rec {
     scipy
   ];
 
-  checkInputs = [ nose ];
-  checkPhase = ''
-    nosetests
-  '';
+  checkInputs = [ pytestCheckHook ];
   pythonImportsCheck = [ "scs" ];
 
   meta = with lib; {
@@ -50,7 +43,7 @@ buildPythonPackage rec {
     '';
     homepage = "https://github.com/cvxgrp/scs"; # upstream C package
     downloadPage = "https://github.com/bodono/scs-python";
-    license = licenses.gpl3;
+    license = licenses.mit;
     maintainers = with maintainers; [ drewrisinger ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8426,7 +8426,7 @@ in {
 
   scikit-survival = callPackage ../development/python-modules/scikit-survival { };
 
-  scs = callPackage ../development/python-modules/scs { scs = pkgs.scs; };
+  scs = callPackage ../development/python-modules/scs { };
 
   sdnotify = callPackage ../development/python-modules/sdnotify { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update cvxpy, scs to latest versions.

- scs: 2.1.1 -> 3.0.0
- python3Packages.scs: 2.1.1 -> 3.0.0
- python3Packages.cvxpy: 1.1.13 -> 1.1.17
- python3Packages.qiskit-aer: disable failing test

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
