### PR TITLE
quark: init at 2021-02-22

### DIFF
--- a/pkgs/servers/http/quark/default.nix
+++ b/pkgs/servers/http/quark/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, fetchgit, patches ? null }:
+
+stdenv.mkDerivation {
+  pname = "quark";
+  version = "unstable-2021-02-22";
+
+  src = fetchgit {
+    url = "git://git.suckless.org/quark";
+    rev = "68b4f733b2755762e43df90f73db5a6ec8d14104";
+    sha256 = "sha256-Jtu5zJfHd+6Oq572nVem5msMDCOjdqDNH4SQck8/O5A=";
+  };
+
+  inherit patches;
+
+  makeFlags = [ "CC:=$(CC)" ];
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    description = "Extremely small and simple HTTP GET/HEAD-only web server for static content";
+    homepage = "http://tools.suckless.org/quark";
+    license = licenses.isc;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21035,6 +21035,8 @@ with pkgs;
 
   pshs = callPackage ../servers/http/pshs { };
 
+  quark = callPackage ../servers/http/quark { };
+
   sympa = callPackage ../servers/mail/sympa { };
 
   system-sendmail = lowPrio (callPackage ../servers/mail/system-sendmail { });


### PR DESCRIPTION
###### Motivation for this change
[**quark**](http://tools.suckless.org/quark/) is an extremely small and simple HTTP GET/HEAD-only web server for static content.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
