### PR TITLE
ares: init at 126

### DIFF
--- a/pkgs/misc/emulators/ares/default.nix
+++ b/pkgs/misc/emulators/ares/default.nix
@@ -1,0 +1,84 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, alsa-lib
+, gtksourceview3
+, libXv
+, openal
+, libpulseaudio
+, libao
+, udev
+, SDL2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ares";
+  version = "126";
+
+  src = fetchFromGitHub {
+    owner = "ares-emulator";
+    repo = "ares";
+    rev = "v${version}";
+    sha256 = "1rj4vmz8lvpmfc6wni7222kagnw9f6jda9rcb6qky2kpizlp2d24";
+  };
+
+  parallel-rdp = fetchFromGitHub {
+    owner = "Themaister";
+    repo = "parallel-rdp-standalone";
+    rev = "0dcebe11ee79288441e40e145c8f340d81f52316";
+    sha256 = "1avp4wyfkhk5yfjqx5w3jbqghn2mq5la7k9248kjmnp9n9lip6w9";
+  };
+
+  patches = [
+    ./fix-ruby.patch
+  ];
+
+  enableParallelBuilding = true;
+  dontConfigure = true;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    alsa-lib
+    gtksourceview3
+    libXv
+    openal
+    libpulseaudio
+    libao
+    udev
+    SDL2
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    rm -rf ares/n64/vulkan/parallel-rdp
+    ln -sf ${parallel-rdp} ares/n64/vulkan/parallel-rdp
+    make -C desktop-ui -j $NIX_BUILD_CORES openmp=true vulkan=true local=false hiro=gtk3
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share/{applications,ares,pixmaps}}
+    cp desktop-ui/out/ares $out/bin
+    cp desktop-ui/resource/ares.desktop $out/share/applications
+    cp desktop-ui/resource/{ares{.ico,.png},font.png} $out/share/pixmaps
+    cp -r ares/{Shaders,System} $out/share/ares
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://ares.dev";
+    description = "Open-source multi-system emulator with a focus on accuracy and preservation";
+    license = licenses.isc;
+    maintainers = with maintainers; [ Madouura ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/misc/emulators/ares/fix-ruby.patch
+++ b/pkgs/misc/emulators/ares/fix-ruby.patch
@@ -1,0 +1,27 @@
+diff --git a/ruby/GNUmakefile b/ruby/GNUmakefile
+index e85a51701..7fca89e0f 100644
+--- a/ruby/GNUmakefile
++++ b/ruby/GNUmakefile
+@@ -8,19 +8,9 @@ ifeq ($(ruby),)
+     ruby += audio.openal
+     ruby += input.quartz #input.carbon
+   else ifeq ($(platform),linux)
+-    pkg_check1 = $(if $(shell test -e /usr/lib/lib$1.so && echo 1),$2)
+-    pkg_check2 = $(if $(shell test -e /usr/lib/$(shell uname -m)-linux-gnu/lib$1.so && echo 1),$2)
+-    pkg_check = $(call pkg_check1,$1,$2) $(call pkg_check2,$1,$2)
+-    ruby += video.glx video.glx2 video.xshm
+-    ruby += $(call pkg_check,Xv,video.xvideo)
+-    ruby += audio.oss audio.alsa
+-    ruby += $(call pkg_check,openal,audio.openal)
+-    ruby += $(call pkg_check,pulse,audio.pulseaudio)
+-    ruby += $(call pkg_check,pulse-simple,audio.pulseaudiosimple)
+-    ruby += $(call pkg_check,ao,audio.ao)
+-    ruby += input.xlib
+-    ruby += $(call pkg_check,udev,input.udev)
+-    ruby += $(call pkg_check,SDL2,input.sdl)
++    ruby += video.glx video.glx2 video.xshm video.xvideo
++    ruby += audio.oss audio.alsa audio.openal audio.pulseaudio audio.pulseaudiosimple audio.ao
++    ruby += input.xlib input.udev input.sdl
+   else ifeq ($(platform),bsd)
+     pkg_check = $(if $(shell test -e /usr/local/lib/lib$1.so && echo 1),$2)
+     ruby += video.glx video.glx2 video.xshm

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32219,6 +32219,8 @@ with pkgs;
 
   antimicrox = libsForQt5.callPackage ../tools/misc/antimicrox { };
 
+  ares = callPackage ../misc/emulators/ares { };
+
   atari800 = callPackage ../misc/emulators/atari800 { };
 
   ataripp = callPackage ../misc/emulators/atari++ { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Newer Higan fork.
Semi-depends on https://github.com/NixOS/nixpkgs/pull/145199/commits/86630d9a5fbcecf04178e2d1f110f075ff3f8763 from #145199

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
