### PR TITLE
python3Packages.ledgerwallet: fix build

### DIFF
--- a/pkgs/development/python-modules/ledgerwallet/default.nix
+++ b/pkgs/development/python-modules/ledgerwallet/default.nix
@@ -25,6 +25,13 @@ buildPythonPackage rec {
     sha256 = "0fb93h2wxm9as9rsywlgz2ng4wrlbjphn6mgbhj6nls2i86rrdxk";
   };
 
+  patches = [
+    # Fix removed function in construct library
+    # https://github.com/LedgerHQ/ledgerctl/issues/17
+    # https://github.com/construct/construct/commit/8915512f53552b1493afdbce5bbf8bb6f2aa4411
+    ./remove-iterateints.patch
+  ];
+
   buildInputs = lib.optionals stdenv.isDarwin [ AppKit ];
   propagatedBuildInputs = [
     cryptography click construct ecdsa hidapi intelhex pillow protobuf requests tabulate

--- a/pkgs/development/python-modules/ledgerwallet/remove-iterateints.patch
+++ b/pkgs/development/python-modules/ledgerwallet/remove-iterateints.patch
@@ -1,0 +1,19 @@
+--- a/ledgerwallet/params.py	2021-11-17 20:31:10.488954050 -0300
++++ b/ledgerwallet/params.py	2021-11-17 20:31:30.619477930 -0300
+@@ -19,7 +19,6 @@
+ )
+ from construct.core import (
+     byte2int,
+-    iterateints,
+     singleton,
+     stream_read,
+     stream_write,
+@@ -40,7 +39,7 @@
+         num_bytes = byte & 0x80
+         encoded_len = stream_read(stream, num_bytes)
+         num = 0
+-        for len_byte in iterateints(encoded_len):
++        for len_byte in encoded_len:
+             num = num << 8 + len_byte
+         return num
+ 


### PR DESCRIPTION
The 'construct' library removed a function and the build started to fail
because of it.

Upstream pinned the version of the 'construct' library to a previous
release, but we can solve it with a simple patch.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF: #144627 (@NixOS/nixos-release-managers)

###### Things done

Add a simple patch to fix the build.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
