### PR TITLE
laminar: 1.0 -> 1.1

### DIFF
--- a/pkgs/development/tools/continuous-integration/laminar/default.nix
+++ b/pkgs/development/tools/continuous-integration/laminar/default.nix
@@ -14,14 +14,9 @@ let
     url = "https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.12/vue.min.js";
     sha256 = "1hm5kci2g6n5ikrvp1kpkkdzimjgylv1xicg2vnkbvd9rb56qa99";
   };
-  js.vue-router = fetchurl {
-    url =
-      "https://cdnjs.cloudflare.com/ajax/libs/vue-router/3.4.8/vue-router.min.js";
-    sha256 = "0418waib896ywwxkxliip75zp94k3s9wld51afrqrcq70axld0c9";
-  };
   js.ansi_up = fetchurl {
-    url = "https://raw.githubusercontent.com/drudru/ansi_up/v1.3.0/ansi_up.js";
-    sha256 = "1993dywxqi2ylnxybwk7m0s0bg2bq7kfllpyr0s8ck6chd0p8i6r";
+    url = "https://raw.githubusercontent.com/drudru/ansi_up/v4.0.4/ansi_up.js";
+    sha256 = "1dx8wn38ds8d01kkih26fx1yrisg3kpz61qynjr4zil03ap0hrlr";
   };
   js.Chart = fetchurl {
     url = "https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.min.js";
@@ -29,10 +24,10 @@ let
   };
 in stdenv.mkDerivation rec {
   pname = "laminar";
-  version = "1.0";
+  version = "1.1";
   src = fetchurl {
     url = "https://github.com/ohwgiles/laminar/archive/${version}.tar.gz";
-    sha256 = "11m6h3rdmj2rsmsryy7r40gqccj4gg1cnqwy6blscs87gx4s423g";
+    sha256 = "1lzfmfjygmbdr2n1q49kwwffw8frz5y6iczhdz5skwmzwg0chbsf";
   };
   patches = [ ./patches/no-network.patch ];
   nativeBuildInputs = [ cmake pandoc ];
@@ -40,7 +35,6 @@ in stdenv.mkDerivation rec {
   preBuild = ''
     mkdir -p js css
     cp  ${js.vue}         js/vue.min.js
-    cp  ${js.vue-router}  js/vue-router.min.js
     cp  ${js.ansi_up}     js/ansi_up.js
     cp  ${js.Chart}       js/Chart.min.js
   '';

--- a/pkgs/development/tools/continuous-integration/laminar/patches/no-network.patch
+++ b/pkgs/development/tools/continuous-integration/laminar/patches/no-network.patch
@@ -4,25 +4,23 @@ does so unconditionally is twice as bad.
 Required files are downloaded as separate fixed-output derivations and
 put into correct location before build phase starts.
 
---- laminar-0.8/CMakeLists.txt
-+++ laminar-0.8-new/CMakeLists.txt
-@@ -82,15 +82,6 @@
+--- laminar-1.1/CMakeLists.txt
++++ laminar-1.1-new/CMakeLists.txt
+@@ -82,13 +82,6 @@
      COMMAND sh -c '( echo -n "\\#define INDEX_HTML_UNCOMPRESSED_SIZE " && wc -c < "${CMAKE_SOURCE_DIR}/src/resources/index.html" ) > index_html_size.h'
      DEPENDS src/resources/index.html)
  
 -# Download 3rd-party frontend JS libs...
 -file(DOWNLOAD https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.12/vue.min.js
 -	js/vue.min.js EXPECTED_MD5 fb192338844efe86ec759a40152fcb8e)
--file(DOWNLOAD https://cdnjs.cloudflare.com/ajax/libs/vue-router/3.4.8/vue-router.min.js
--	js/vue-router.min.js EXPECTED_MD5 5f51d4dbbf68fd6725956a5a2b865f3b)
--file(DOWNLOAD https://raw.githubusercontent.com/drudru/ansi_up/v1.3.0/ansi_up.js
--        js/ansi_up.js EXPECTED_MD5 158566dc1ff8f2804de972f7e841e2f6)
+-file(DOWNLOAD https://raw.githubusercontent.com/drudru/ansi_up/v4.0.4/ansi_up.js
+-        js/ansi_up.js EXPECTED_MD5 b31968e1a8fed0fa82305e978161f7f5)
 -file(DOWNLOAD https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.min.js
 -        js/Chart.min.js EXPECTED_MD5 f6c8efa65711e0cbbc99ba72997ecd0e)
  # ...and compile them
- generate_compressed_bins(${CMAKE_BINARY_DIR} js/vue-router.min.js js/vue.min.js
+ generate_compressed_bins(${CMAKE_BINARY_DIR} js/vue.min.js
      js/ansi_up.js js/Chart.min.js)
-@@ -141,12 +132,12 @@
+@@ -139,12 +132,12 @@
      target_link_libraries(laminar-tests ${GTEST_LIBRARY} capnp-rpc capnp kj-http kj-async kj pthread sqlite3 z)
  endif()
  


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Version update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
