### PR TITLE
python3Packages.sentry-sdk: 1.4.3 -> 1.5.0

### DIFF
--- a/pkgs/development/python-modules/sentry-sdk/default.nix
+++ b/pkgs/development/python-modules/sentry-sdk/default.nix
@@ -1,4 +1,6 @@
-{ aiohttp
+{ lib
+, aiohttp
+, asttokens
 , blinker
 , botocore
 , bottle
@@ -7,41 +9,65 @@
 , certifi
 , chalice
 , django
+, executing
 , falcon
 , fetchPypi
 , flask
+, httpx
 , iana-etc
 , isPy3k
 , libredirect
+, pure-eval
 , pyramid
+, pyspark
 , rq
 , sanic
 , sqlalchemy
-, lib
 , tornado
-, urllib3
 , trytond
+, urllib3
 , werkzeug
-, executing
-, pure-eval
-, asttokens
 }:
 
 buildPythonPackage rec {
   pname = "sentry-sdk";
-  version = "1.4.3";
+  version = "1.5.0";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b9844751e40710e84a457c5bc29b21c383ccb2b63d76eeaad72f7f1c808c8828";
+    sha256 = "sha256-eJoRqHygJJGJbhIe/dZOj9kzJ7aejy99QvA+JWlkjog=";
   };
 
-  checkInputs = [ blinker botocore chalice django flask tornado bottle rq falcon sqlalchemy werkzeug trytond
-    executing pure-eval asttokens ]
-  ++ lib.optionals isPy3k [ celery pyramid sanic aiohttp ];
+  propagatedBuildInputs = [
+    certifi
+    urllib3
+  ];
 
-  propagatedBuildInputs = [ urllib3 certifi ];
-
+  checkInputs = [
+    asttokens
+    blinker
+    botocore
+    bottle
+    chalice
+    django
+    executing
+    falcon
+    flask
+    pure-eval
+    rq
+    sqlalchemy
+    tornado
+    trytond
+    werkzeug
+  ] ++ lib.optionals isPy3k [
+    aiohttp
+    celery
+    httpx
+    pyramid
+    pyspark
+    sanic
+  ];
 
   # The Sentry tests need access to `/etc/protocols` (the tests call
   # `socket.getprotobyname('tcp')`, which reads from this file). Normally
@@ -55,8 +81,11 @@ buildPythonPackage rec {
   postCheck = "unset NIX_REDIRECTS LD_PRELOAD";
 
   # no tests
-  doCheck = false;
-  pythonImportsCheck = [ "sentry_sdk" ];
+  doCheck = true;
+
+  pythonImportsCheck = [
+    "sentry_sdk"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/getsentry/sentry-python";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.5.0

Change log: https://github.com/getsentry/sentry-python/releases/tag/1.5.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
