### PR TITLE
ncdc: pull upstream ncurses-6.3 fix

### DIFF
--- a/pkgs/applications/networking/p2p/ncdc/default.nix
+++ b/pkgs/applications/networking/p2p/ncdc/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, ncurses, zlib, bzip2, sqlite, pkg-config, glib, gnutls }:
+{ lib, stdenv, fetchurl, fetchpatch, ncurses, zlib, bzip2, sqlite, pkg-config, glib, gnutls }:
 
 stdenv.mkDerivation rec {
   pname = "ncdc";
@@ -8,6 +8,15 @@ stdenv.mkDerivation rec {
     url = "https://dev.yorhel.nl/download/ncdc-${version}.tar.gz";
     sha256 = "1bdgqd07f026qk6vpbxqsin536znd33931m3b4z44prlm9wd6pyi";
   };
+
+  patches = [
+    # Upstream fix for ncurses-6.3 support:
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://g.blicky.net/ncdc.git/patch/?id=4126dd51e90deb9e22dfd139cc4518a7812fcad6";
+      sha256 = "13hqkmhmbazj6cllb5b2ccgf51vsn5lri7jqkqc5xwivgcisfrij";
+    })
+  ];
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ ncurses zlib bzip2 sqlite glib gnutls ];


### PR DESCRIPTION
Without the change the build fails on ncurses-6.3 as:

    src/uit_dl.c:227:25: error: format not a string literal
      and no format arguments [-Werror=format-security]
      227 |     mvprintw(bottom, 0, hash);
          |                         ^~~~
