### PR TITLE
nfstrace: pull pending upstream inclusion fix for ncurses-6.3

### DIFF
--- a/pkgs/tools/networking/nfstrace/default.nix
+++ b/pkgs/tools/networking/nfstrace/default.nix
@@ -22,11 +22,22 @@ stdenv.mkDerivation rec {
       url = "https://github.com/epam/nfstrace/commit/4562a895ed3ac0e811bdd489068ad3ebe4d7b501.patch";
       sha256 = "1fbicbllyykjknik7asa81x0ixxmbwqwkiz74cnznagv10jlkj3p";
     })
+
+    # Fix pending upstream inclusion for ncurses-6.3 support:
+    #  https://github.com/epam/nfstrace/pull/50
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/epam/nfstrace/commit/29c7c415f5412df1aae9b1e6ed3a2760d2c227a0.patch";
+      sha256 = "134709w6bld010jx3xdy9imcjzal904a84n9f8vv0wnas5clxdmx";
+    })
   ];
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
       --replace "-Wno-braced-scalar-init" ""
+    # -Wall -Wextra -Werror fails on clang and newer gcc
+    substituteInPlace CMakeLists.txt \
+      --replace "-Werror" ""
   '';
 
   buildInputs = [ json_c libpcap ncurses libtirpc ];

--- a/pkgs/tools/networking/nfstrace/default.nix
+++ b/pkgs/tools/networking/nfstrace/default.nix
@@ -33,10 +33,9 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
+   # -Wall -Wextra -Werror fails on clang and newer gcc
     substituteInPlace CMakeLists.txt \
-      --replace "-Wno-braced-scalar-init" ""
-    # -Wall -Wextra -Werror fails on clang and newer gcc
-    substituteInPlace CMakeLists.txt \
+      --replace "-Wno-braced-scalar-init" "" \
       --replace "-Werror" ""
   '';
 


### PR DESCRIPTION
Without the fix build on ncurses-6.3 fails as:

    nfstrace/analyzers/src/watch/nc_windows/header_window.cpp:77:82:
      error: format '%d' expects argument of type 'int', but argument 5 has type 'time_t' {aka 'long int'} [-Werror=format=]
       77 |     mvwprintw(_window, HEADER::ELAPSED_LINE, FIRST_CHAR_POS, "Elapsed time:  \t %d days; %d:%d:%d times",
          |                                                                                 ~^
          |                                                                                  int
          |                                                                                 %ld

While at it dropped blanket -Werror that fails on gcc-12 and clang-12.