### PR TITLE
ion3: fix src url

### DIFF
--- a/pkgs/applications/window-managers/ion-3/default.nix
+++ b/pkgs/applications/window-managers/ion-3/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "3-20090110";
 
   src = fetchurl {
-    url = "http://tuomov.iki.fi/software/dl/ion-${version}.tar.gz";
+    url = "https://tuomov.iki.fi/software/ion/dl/ion-${version}.tar.gz";
     sha256 = "1nkks5a95986nyfkxvg2rik6zmwx0lh7szd5fji7yizccwzc9xns";
   };
 


### PR DESCRIPTION
###### Motivation for this change

Found this when reviewing #142834.
http://tuomov.iki.fi/software/dl/ion-3-20090110.tar.gz gave me 404.
I guess it should be https://tuomov.iki.fi/software/ion/dl/ion-3-20090110.tar.gz

###### Things done

- [x] `nix-prefetch ion3 -I nixpkgs=.`
- [x] Confirm that the sha256 is still correct