### PR TITLE
airsonic-advanced: init at 11.0.0-SNAPSHOT.20211116202136

### DIFF
--- a/nixos/tests/airsonic-advanced.nix
+++ b/nixos/tests/airsonic-advanced.nix
@@ -1,0 +1,29 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "airsonic";
+  meta = with pkgs.lib.maintainers; { maintainers = [ sumnerevans ]; };
+
+  machine = { pkgs, ... }: {
+    services.airsonic = {
+      enable = true;
+      maxMemory = 800;
+      war = "${pkgs.airsonic-advanced}/webapps/airsonic.war";
+    };
+
+    # Airsonic is a Java application, and unfortunately requires a significant
+    # amount of memory.
+    virtualisation.memorySize = 1024;
+  };
+
+  testScript = ''
+    def airsonic_is_up(_) -> bool:
+        return machine.succeed("curl --fail http://localhost:4040/login")
+
+
+    machine.start()
+    machine.wait_for_unit("airsonic.service")
+    machine.wait_for_open_port(4040)
+
+    with machine.nested("Waiting for UI to work"):
+        retry(airsonic_is_up)
+  '';
+})

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -25,6 +25,7 @@ in
   acme = handleTest ./acme.nix {};
   agda = handleTest ./agda.nix {};
   airsonic = handleTest ./airsonic.nix {};
+  airsonic-advanced = handleTest ./airsonic-advanced.nix {};
   amazon-init-shell = handleTest ./amazon-init-shell.nix {};
   apparmor = handleTest ./apparmor.nix {};
   atd = handleTest ./atd.nix {};

--- a/pkgs/servers/misc/airsonic-advanced/default.nix
+++ b/pkgs/servers/misc/airsonic-advanced/default.nix
@@ -21,7 +21,7 @@ stdenvNoCC.mkDerivation rec {
   meta = with lib; {
     description = "Personal media streamer";
     homepage = "https://github.com/airsonic-advanced/airsonic-advanced";
-    license = lib.licenses.gpl3;
+    license = licenses.gpl3;
     platforms = platforms.all;
     maintainers = with maintainers; [ disassembler pinpox ];
   };

--- a/pkgs/servers/misc/airsonic-advanced/default.nix
+++ b/pkgs/servers/misc/airsonic-advanced/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, nixosTests }:
+{ lib, stdenvNoCC, fetchurl, nixosTests }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "airsonic-advanced";

--- a/pkgs/servers/misc/airsonic-advanced/default.nix
+++ b/pkgs/servers/misc/airsonic-advanced/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchurl, nixosTests }:
+
+stdenv.mkDerivation rec {
+  pname = "airsonic-advanced";
+  version = "11.0.0-SNAPSHOT.20211116202136";
+
+  src = fetchurl {
+    url = "https://github.com/airsonic/airsonic-advanced/releases/tag/${version}/airsonic.war";
+    sha256 = "0la7px07gw1s4hfbw4x22nd31x2ddqbpr3kfkg6f4i2grh3218mh";
+  };
+
+  buildCommand = ''
+    mkdir -p "$out/webapps"
+    cp "$src" "$out/webapps/airsonic.war"
+  '';
+
+  passthru.tests = {
+    airsonic-starts = nixosTests.airsonic-advanced;
+  };
+
+  meta = with lib; {
+    description = "Personal media streamer";
+    homepage = "https://github.com/airsonic-advanced/airsonic-advanced";
+    license = lib.licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ disassembler pinpox ];
+  };
+}

--- a/pkgs/servers/misc/airsonic-advanced/default.nix
+++ b/pkgs/servers/misc/airsonic-advanced/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/airsonic-advanced/airsonic-advanced/releases/download/${version}/airsonic.war";
-    sha256 = "0la7px07gw1s4hfbw4x22nd31x2ddqbpr3kfkg6f4i2grh3218mh";
+    sha256 = "sha256-soLnjltoATjqNHRpcVcqiTSQGJwSSzxwKEMk/cr42YU=";
   };
 
   buildCommand = ''

--- a/pkgs/servers/misc/airsonic-advanced/default.nix
+++ b/pkgs/servers/misc/airsonic-advanced/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "11.0.0-SNAPSHOT.20211116202136";
 
   src = fetchurl {
-    url = "https://github.com/airsonic/airsonic-advanced/releases/tag/${version}/airsonic.war";
+    url = "https://github.com/airsonic-advanced/airsonic-advanced/releases/download/${version}/airsonic.war";
     sha256 = "0la7px07gw1s4hfbw4x22nd31x2ddqbpr3kfkg6f4i2grh3218mh";
   };
 

--- a/pkgs/servers/misc/airsonic-advanced/default.nix
+++ b/pkgs/servers/misc/airsonic-advanced/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, nixosTests }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "airsonic-advanced";
   version = "11.0.0-SNAPSHOT.20211116202136";
 

--- a/pkgs/servers/misc/airsonic-advanced/default.nix
+++ b/pkgs/servers/misc/airsonic-advanced/default.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation rec {
     sha256 = "sha256-soLnjltoATjqNHRpcVcqiTSQGJwSSzxwKEMk/cr42YU=";
   };
 
-  buildCommand = ''
+  installPhase = ''
     mkdir -p "$out/webapps"
     cp "$src" "$out/webapps/airsonic.war"
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -919,6 +919,8 @@ with pkgs;
 
   airsonic = callPackage ../servers/misc/airsonic { };
 
+  airsonic-advanced = callPackage ../servers/misc/airsonic-advanced { };
+
   airspy = callPackage ../applications/radio/airspy { };
 
   airspyhf = callPackage ../applications/radio/airspyhf { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The already present package `airsonic` is packaging a no longer maintained application. On their [github page](https://github.com/airsonic/airsonic) airsonic advises users to migrate to the newer fork `airsonic-advanced` which is being developed on.

I added a new package and test, instead of changing the existing one in case someone still is explicetily using the old fork. Let me know if you would prefer to replace the `airsonic` package instead. @disassembler since you are the maintainer of the `airsonic` package, should I add you as maintainer for the `airsonic-advanced` package aswell?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
