### PR TITLE
python39: backport patch to accomodate system library changes in Big Sur

### DIFF
--- a/pkgs/development/interpreters/python/cpython/3.9/bpo-44689-ctypes.util.find_library-now-finds-macOS-1.patch
+++ b/pkgs/development/interpreters/python/cpython/3.9/bpo-44689-ctypes.util.find_library-now-finds-macOS-1.patch
@@ -1,0 +1,84 @@
+From 4b55837e7c747e0f3bd2df1b5c8996ce86c6f60a Mon Sep 17 00:00:00 2001
+From: "Miss Islington (bot)"
+ <31488909+miss-islington@users.noreply.github.com>
+Date: Mon, 30 Aug 2021 02:08:16 -0700
+Subject: [PATCH] bpo-44689: ctypes.util.find_library() now finds macOS 11+
+ system libraries when built on older macOS systems (GH-27251) (GH-28053)
+
+Previously, when built on older macOS systems, `find_library` was not able to find macOS system libraries when running on Big Sur due to changes in how system libraries are stored.
+(cherry picked from commit 71853a73024a98aa38a3c0444fe364dbd9709134)
+
+Co-authored-by: Tobias Bergkvist <tobias@bergkv.ist>
+---
+ .../2021-07-20-22-27-01.bpo-44689.mmT_xH.rst  |  5 ++++
+ Modules/_ctypes/callproc.c                    | 29 +++++++++++++++++--
+ 2 files changed, 31 insertions(+), 3 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/macOS/2021-07-20-22-27-01.bpo-44689.mmT_xH.rst
+
+diff --git a/Misc/NEWS.d/next/macOS/2021-07-20-22-27-01.bpo-44689.mmT_xH.rst b/Misc/NEWS.d/next/macOS/2021-07-20-22-27-01.bpo-44689.mmT_xH.rst
+new file mode 100644
+index 0000000000..b1e878d1ee
+--- /dev/null
++++ b/Misc/NEWS.d/next/macOS/2021-07-20-22-27-01.bpo-44689.mmT_xH.rst
+@@ -0,0 +1,5 @@
++ :meth:`ctypes.util.find_library` now works correctly on macOS 11 Big Sur
++ even if Python is built on an older version of macOS.  Previously, when
++ built on older macOS systems, ``find_library`` was not able to find
++ macOS system libraries when running on Big Sur due to changes in
++ how system libraries are stored.
+diff --git a/Modules/_ctypes/callproc.c b/Modules/_ctypes/callproc.c
+index 18984d15ab..b0f1e0bd04 100644
+--- a/Modules/_ctypes/callproc.c
++++ b/Modules/_ctypes/callproc.c
+@@ -1449,14 +1449,37 @@ copy_com_pointer(PyObject *self, PyObject *args)
+     return r;
+ }
+ #else
+-
++#ifdef __APPLE__
+ #ifdef HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH
++#define HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH_RUNTIME \
++    __builtin_available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
++#else
++// Support the deprecated case of compiling on an older macOS version
++static void *libsystem_b_handle;
++static bool (*_dyld_shared_cache_contains_path)(const char *path);
++
++__attribute__((constructor)) void load_dyld_shared_cache_contains_path(void) {
++    libsystem_b_handle = dlopen("/usr/lib/libSystem.B.dylib", RTLD_LAZY);
++    if (libsystem_b_handle != NULL) {
++        _dyld_shared_cache_contains_path = dlsym(libsystem_b_handle, "_dyld_shared_cache_contains_path");
++    }
++}
++
++__attribute__((destructor)) void unload_dyld_shared_cache_contains_path(void) {
++    if (libsystem_b_handle != NULL) {
++        dlclose(libsystem_b_handle);
++    }
++}
++#define HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH_RUNTIME \
++    _dyld_shared_cache_contains_path != NULL
++#endif
++
+ static PyObject *py_dyld_shared_cache_contains_path(PyObject *self, PyObject *args)
+ {
+      PyObject *name, *name2;
+      char *name_str;
+ 
+-     if (__builtin_available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)) {
++     if (HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH_RUNTIME) {
+          int r;
+ 
+          if (!PyArg_ParseTuple(args, "O", &name))
+@@ -1999,7 +2022,7 @@ PyMethodDef _ctypes_module_methods[] = {
+     {"dlclose", py_dl_close, METH_VARARGS, "dlclose a library"},
+     {"dlsym", py_dl_sym, METH_VARARGS, "find symbol in shared library"},
+ #endif
+-#ifdef HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH
++#ifdef __APPLE__
+      {"_dyld_shared_cache_contains_path", py_dyld_shared_cache_contains_path, METH_VARARGS, "check if path is in the shared cache"},
+ #endif
+     {"alignment", align_func, METH_O, alignment_doc},
+-- 
+2.33.1
+

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -240,6 +240,9 @@ in with passthru; stdenv.mkDerivation {
   ] ++ optionals (pythonAtLeast "3.9" && stdenv.isDarwin) [
     # Stop checking for TCL/TK in global macOS locations
     ./3.9/darwin-tcl-tk.patch
+    # ctypes.util.find_library() now finds macOS 11+ system libraries when built on older macOS systems
+    # https://github.com/python/cpython/pull/28053
+    ./3.9/bpo-44689-ctypes.util.find_library-now-finds-macOS-1.patch
   ] ++ optionals (isPy3k && hasDistutilsCxxPatch) [
     # Fix for http://bugs.python.org/issue1222585
     # Upstream distutils is calling C compiler to compile C++ code, which


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Backports https://github.com/python/cpython/pull/28053

@bergkvist Can you test this change?

Depending on when we merge #145752 I need to rebase this once more. But this should be backported to 21.11 if it indeed fixes python3.9 stuff on recent MacOS releases.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
