### PR TITLE
pacvim: pull pending upstream inclusion fix for ncurses-6.3

### DIFF
--- a/pkgs/games/pacvim/default.nix
+++ b/pkgs/games/pacvim/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, ncurses }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, ncurses }:
 
 stdenv.mkDerivation {
   pname = "pacvim";
@@ -9,6 +9,15 @@ stdenv.mkDerivation {
     rev = "ca7c8833c22c5fe97974ba5247ef1fcc00cedb8e";
     sha256 = "1kq6j7xmsl5qfl1246lyglkb2rs9mnb2rhsdrp18965dpbj2mhx2";
   };
+  patches = [
+    # Fix pending upstream inclusion for ncurses-6.3 support:
+    #   https://github.com/jmoon018/PacVim/pull/53
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/jmoon018/PacVim/commit/760682824cdbb328af616ff43bf822ade23924f7.patch";
+      sha256 = "1y3928dc2nkfldqhpiqk0blbx7qj8ar35f1w7fb92qwxrj8p4i6g";
+    })
+  ];
 
   buildInputs = [ ncurses ];
   makeFlags = [ "PREFIX=$(out)" ];


### PR DESCRIPTION
Without the fix build on ncurses-6.3 fails as:

    src/helperFns.cpp:103:17:
      error: format not a string literal and no format arguments [-Werror=format-security]
      103 |         mvprintw(TOP+5, 0, (x).c_str());
          |         ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
