### PR TITLE
nixos/systemd: disable systemd-gpt-auto-generator by default

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -117,6 +117,14 @@
           <literal>virtualisation.docker.daemon.settings</literal>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <literal>systemd-gpt-auto-generator</literal> is now disabled
+          by default due to conflicting with our declarative mount
+          management, Issue
+          <link xlink:href="https://github.com/NixOS/nixpkgs/issues/4002">#4002</link>.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-22.05-notable-changes">

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -43,6 +43,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - If you previously used `/etc/docker/daemon.json`, you need to incorporate the changes into the new option `virtualisation.docker.daemon.settings`.
 
+- `systemd-gpt-auto-generator` is now disabled by default due to conflicting with our declarative mount management, Issue [#4002](https://github.com/NixOS/nixpkgs/issues/4002).
+
 ## Other Notable Changes {#sec-release-22.05-notable-changes}
 
 - The option [services.redis.servers](#opt-services.redis.servers) was added

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -512,12 +512,14 @@ in
     systemd.generators = mkOption {
       type = types.attrsOf types.path;
       default = {};
-      example = { systemd-gpt-auto-generator = "/dev/null"; };
+      example = literalExpression ''{ systemd-gpt-auto-generator = "${config.systemd.package}/lib/systemd/system-generators/systemd-gpt-auto-generator"; };'';
       description = ''
         Definition of systemd generators.
         For each <literal>NAME = VALUE</literal> pair of the attrSet, a link is generated from
         <literal>/etc/systemd/system-generators/NAME</literal> to <literal>VALUE</literal>.
+        Note: systemd-gpt-auto-generator is disabled by default due to not being declarative.
       '';
+        # systemd-gpt-auto-generator issue https://github.com/NixOS/nixpkgs/issues/4002
     };
 
     systemd.shutdown = mkOption {
@@ -1053,7 +1055,7 @@ in
         '') config.system.build.etc.passthru.targets;
       }) + "/*";
 
-      "systemd/system-generators" = { source = hooks "generators" cfg.generators; };
+      "systemd/system-generators" = { source = hooks "generators" ({ systemd-gpt-auto-generator = "/dev/null"; } // cfg.generators); };
       "systemd/system-shutdown" = { source = hooks "shutdown" cfg.shutdown; };
     });
 


### PR DESCRIPTION
it is not declarative and breaks our declarative configuration sometimes

See: https://github.com/NixOS/nixpkgs/issues/4002

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Closes https://github.com/NixOS/nixpkgs/issues/4002

###### Things done
tested in a vm
```nix
{
  inputs = {
    #nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
    nixpkgs.url = "/home/artturin/nixgits/my-nixpkgs";
  };

  outputs = inputs@{ self, nixpkgs }: {

    nixosConfigurations.vm = nixpkgs.lib.nixosSystem {
      system = "x86_64-linux";
      specialArgs = { inherit inputs; };
      modules = [
        ({ pkgs, lib, config, ... }: {
          # try without the comment and with
          #systemd.generators = { systemd-gpt-auto-generator = "${config.systemd.package}/lib/systemd/system-generators/systemd-gpt-auto-generator"; };
        })

        ({ pkgs, lib, config, modulesPath, ... }: {
          documentation.enable = false;
          users.mutableUsers = false;
          users.users.root = {
            password = "root";
          };
          users.users.user = {
            password = "user";
            isNormalUser = true;
            extraGroups = [ "wheel" ];
          };

          imports = [
            #(modulesPath + "/profiles/minimal.nix")
          ];
        })
      ];
    };
    # So that we can just run 'nix run' instead of
    # 'nix build ".#nixosConfigurations.vm.config.system.build.vm" && ./result/bin/run-nixos-vm'
    defaultPackage.x86_64-linux = self.nixosConfigurations.vm.config.system.build.vm;
    defaultApp.x86_64-linux = {
      type = "app";
      program = "${self.defaultPackage.x86_64-linux}/bin/run-nixos-vm";
    };
  };
}
```
tested on my system
```nix
  disabledModules = [ "system/boot/systemd.nix" ];
  
  imports = let
    pkgsReview = builtins.fetchTarball {
      url = "https://github.com/artturin/nixpkgs/archive/systemd-gpt-autogen-disable.tar.gz";
    };
  in [
    (import "${pkgsReview}/nixos/modules/system/boot/systemd.nix")
  ];
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
