### PR TITLE
tgswitch: init at 0.5.378

### DIFF
--- a/pkgs/applications/networking/cluster/tgswitch/default.nix
+++ b/pkgs/applications/networking/cluster/tgswitch/default.nix
@@ -1,0 +1,21 @@
+{ buildGoPackage, lib, fetchFromGitHub }:
+buildGoPackage rec {
+  pname = "tgswitch";
+  version = "0.5.378";
+
+  src = fetchFromGitHub {
+    owner = "warrensbox";
+    repo = "tgswitch";
+    rev = version;
+    sha256 = "0q2aqh75acbpkmvkws0rl3d5dzq3sisy637c0x6cnc88h34g3n3i";
+  };
+
+  goPackagePath = "github.com/warrensbox/tgswitch";
+
+  meta = with lib; {
+    description = "A command line tool to switch between different versions of terragrunt";
+    homepage = "https://github.com/warrensbox/tgswitch";
+    license = licenses.mit;
+    maintainers = with maintainers; [ psibi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33011,6 +33011,8 @@ with pkgs;
 
   tfswitch = callPackage ../applications/networking/cluster/tfswitch {};
 
+  tgswitch = callPackage ../applications/networking/cluster/tgswitch {};
+
   tilt = callPackage ../applications/networking/cluster/tilt {};
 
   timeular = callPackage ../applications/office/timeular {};


### PR DESCRIPTION
Add tgswitch which allows to easily manage different terragrunt
versions for different projects.

Tested it locally on a NixOS machine:

```
❯ tgswitch --help

Usage: tgswitch [-hv] [-b value] [parameters ...]
 -b, --bin=value  Custom binary path. For example:
                  /Users/username/bin/terragrunt
 -h, --help       displays help message
 -v, --version    displays the version of tgswitch
Supply the terragrunt version as an argument, or choose from a menu
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
