### PR TITLE
androidenv: fix emulator build on Linux

### DIFF
--- a/pkgs/development/mobile/androidenv/emulator.nix
+++ b/pkgs/development/mobile/androidenv/emulator.nix
@@ -3,7 +3,7 @@
 deployAndroidPackage {
   inherit package os;
   buildInputs = [ autoPatchelfHook makeWrapper ]
-  ++ lib.optional (os == "linux") [
+  ++ lib.optionals (os == "linux") [
     pkgs.glibc
     pkgs.xorg.libX11
     pkgs.xorg.libXext
@@ -18,6 +18,7 @@ deployAndroidPackage {
     pkgs.libcxx
     pkgs.libGL
     pkgs.libpulseaudio
+    pkgs.libuuid
     pkgs.zlib
     pkgs.ncurses5
     pkgs.stdenv.cc.cc


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

androidenv emulator was not building on Linux because the file uses `lib.optional` instead of `lib.optionals` and doesn't include `libuuid` in buildInputs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
