### PR TITLE
libresprite: init at 1.0

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -230,6 +230,7 @@ in
   leaps = handleTest ./leaps.nix {};
   libinput = handleTest ./libinput.nix {};
   libreddit = handleTest ./libreddit.nix {};
+  libresprite = handleTest ./libresprite.nix {};
   libreswan = handleTest ./libreswan.nix {};
   lidarr = handleTest ./lidarr.nix {};
   lightdm = handleTest ./lightdm.nix {};

--- a/nixos/tests/libresprite.nix
+++ b/nixos/tests/libresprite.nix
@@ -1,0 +1,30 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "libresprite";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ fgaz ];
+  };
+
+  machine = { config, pkgs, ... }: {
+    imports = [
+      ./common/x11.nix
+    ];
+
+    services.xserver.enable = true;
+    environment.systemPackages = [
+      pkgs.imagemagick
+      pkgs.libresprite
+    ];
+  };
+
+  enableOCR = true;
+
+  testScript =
+    ''
+      machine.wait_for_x()
+      machine.succeed("convert -font DejaVu-Sans +antialias label:'IT WORKS' image.png")
+      machine.execute("libresprite image.png >&2 &")
+      machine.wait_for_window("LibreSprite v${pkgs.libresprite.version}")
+      machine.wait_for_text("IT WORKS")
+      machine.screenshot("screen")
+    '';
+})

--- a/pkgs/applications/editors/libresprite/default.nix
+++ b/pkgs/applications/editors/libresprite/default.nix
@@ -1,0 +1,105 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+
+, cmake
+, pkg-config
+, ninja
+, gtest
+
+, curl
+, freetype
+, giflib
+, libjpeg
+, libpng
+, libwebp
+, pixman
+, tinyxml
+, zlib
+, SDL2
+, SDL2_image
+, lua
+, AppKit
+, Cocoa
+, Foundation
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libresprite";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "LibreSprite";
+    repo = "LibreSprite";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "sha256-d8GmVHYomDb74iSeEhJEVTHvbiVXggXg7xSqIKCUSzY=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    ninja
+    gtest
+  ];
+
+  buildInputs = [
+    curl
+    freetype
+    giflib
+    libjpeg
+    libpng
+    libwebp
+    pixman
+    tinyxml
+    zlib
+    SDL2
+    SDL2_image
+    lua
+    # no v8 due to missing libplatform and libbase
+  ] ++ lib.optionals stdenv.isDarwin [
+    AppKit
+    Cocoa
+    Foundation
+  ];
+
+  cmakeFlags = [
+    "-DWITH_DESKTOP_INTEGRATION=ON"
+    "-DWITH_WEBP_SUPPORT=ON"
+  ];
+
+  hardeningDisable = lib.optional stdenv.isDarwin "format";
+
+  # Install mime icons. Note that the mimetype is still "x-aseprite"
+  postInstall = ''
+    src="$out/share/libresprite/data/icons"
+    for size in 16 32 48 64; do
+      dst="$out"/share/icons/hicolor/"$size"x"$size"
+      install -Dm644 "$src"/doc"$size".png "$dst"/mimetypes/aseprite.png
+    done
+  '';
+
+  meta = with lib; {
+    homepage = "https://libresprite.github.io/";
+    description = "Animated sprite editor & pixel art tool, fork of Aseprite";
+    license = licenses.gpl2Only;
+    longDescription =
+      ''LibreSprite is a program to create animated sprites. Its main features are:
+
+          - Sprites are composed by layers & frames (as separated concepts).
+          - Supported color modes: RGBA, Indexed (palettes up to 256 colors), and Grayscale.
+          - Load/save sequence of PNG files and GIF animations (and FLC, FLI, JPG, BMP, PCX, TGA).
+          - Export/import animations to/from Sprite Sheets.
+          - Tiled drawing mode, useful to draw patterns and textures.
+          - Undo/Redo for every operation.
+          - Real-time animation preview.
+          - Multiple editors support.
+          - Pixel-art specific tools like filled Contour, Polygon, Shading mode, etc.
+          - Onion skinning.
+      '';
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+    # https://github.com/LibreSprite/LibreSprite/issues/308
+    broken = stdenv.isDarwin && stdenv.isAarch64;
+  };
+}

--- a/pkgs/applications/editors/libresprite/default.nix
+++ b/pkgs/applications/editors/libresprite/default.nix
@@ -22,6 +22,8 @@
 , AppKit
 , Cocoa
 , Foundation
+
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -78,6 +80,10 @@ stdenv.mkDerivation rec {
       install -Dm644 "$src"/doc"$size".png "$dst"/mimetypes/aseprite.png
     done
   '';
+
+  passthru.tests = {
+    libresprite-can-open-png = nixosTests.libresprite;
+  };
 
   meta = with lib; {
     homepage = "https://libresprite.github.io/";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26421,6 +26421,10 @@ with pkgs;
   });
   libreoffice-still-unwrapped = libreoffice-still.libreoffice;
 
+  libresprite = callPackage ../applications/editors/libresprite {
+    inherit (darwin.apple_sdk.frameworks) AppKit Cocoa Foundation;
+  };
+
   libvmi = callPackage ../development/libraries/libvmi { };
 
   libutp = callPackage ../applications/networking/p2p/libutp { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
