### PR TITLE
Support XDG-conformant paths for internal Nix files

### DIFF
--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -717,7 +717,7 @@ If set to `true`, the standard environment will enable debug information in C/C+
 For example, with GDB, you can add
 
 ```
-set debug-file-directory ~/.nix-profile/lib/debug
+set debug-file-directory ~/.local/share/nix/profile/lib/debug
 ```
 
 to `~/.gdbinit`. GDB will then be able to find debug information installed via `nix-env -i`.

--- a/doc/using/configuration.chapter.md
+++ b/doc/using/configuration.chapter.md
@@ -204,7 +204,7 @@ Using `packageOverrides`, it is possible to manage packages declaratively. This 
 }
 ```
 
-To install it into our environment, you can just run `nix-env -iA nixpkgs.myPackages`. If you want to load the packages to be built from a working copy of `nixpkgs` you just run `nix-env -f. -iA myPackages`. To explore what's been installed, just look through `~/.nix-profile/`. You can see that a lot of stuff has been installed. Some of this stuff is useful some of it isn't. Let's tell Nixpkgs to only link the stuff that we want:
+To install it into our environment, you can just run `nix-env -iA nixpkgs.myPackages`. If you want to load the packages to be built from a working copy of `nixpkgs` you just run `nix-env -f. -iA myPackages`. To explore what's been installed, just look through your user profile (`$XDG_DATA_HOME/nix/profile`, or a legacy location `~/.nix-profile/`). You can see that a lot of stuff has been installed. Some of this stuff is useful some of it isn't. Let's tell Nixpkgs to only link the stuff that we want:
 
 ```nix
 {
@@ -233,7 +233,7 @@ To install it into our environment, you can just run `nix-env -iA nixpkgs.myPack
 
 ### Getting documentation {#sec-getting-documentation}
 
-After building that new environment, look through `~/.nix-profile` to make sure everything is there that we wanted. Discerning readers will note that some files are missing. Look inside `~/.nix-profile/share/man/man1/` to verify this. There are no man pages for any of the Nix tools! This is because some packages like Nix have multiple outputs for things like documentation (see section 4). Let's make Nix install those as well.
+After building that new environment, look through `$XDG_DATA_HOME/nix/profile` (or, as noted above, `~/.nix-profile`) to make sure everything is there that we wanted. Discerning readers will note that some files are missing. Look inside `$XDG_DATA_HOME/nix/profile/share/man/man1/` to verify this. There are no man pages for any of the Nix tools! This is because some packages like Nix have multiple outputs for things like documentation (see section 4). Let's make Nix install those as well.
 
 ```nix
 {
@@ -264,8 +264,9 @@ This provides us with some useful documentation for using our packages.  However
 {
   packageOverrides = pkgs: with pkgs; rec {
     myProfile = writeText "my-profile" ''
-      export PATH=$HOME/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/sbin:/bin:/usr/sbin:/usr/bin
-      export MANPATH=$HOME/.nix-profile/share/man:/nix/var/nix/profiles/default/share/man:/usr/share/man
+      if [ -z "$XDG_DATA_HOME" ]; then XDG_DATA_HOME=$HOME/.local/share; fi
+      export PATH=$XDG_DATA_HOME/nix/profile/bin:/nix/var/nix/profiles/default/bin:/sbin:/bin:/usr/sbin:/usr/bin
+      export MANPATH=$XDG_DATA_HOME/nix/profile/share/man:/nix/var/nix/profiles/default/share/man:/usr/share/man
     '';
     myPackages = pkgs.buildEnv {
       name = "my-packages";
@@ -296,8 +297,9 @@ For this to work fully, you must also have this script sourced when you are logg
 
 ```ShellSession
 #!/bin/sh
-if [ -d $HOME/.nix-profile/etc/profile.d ]; then
-  for i in $HOME/.nix-profile/etc/profile.d/*.sh; do
+if [ -z "$XDG_DATA_HOME" ]; then XDG_DATA_HOME=$HOME/.local/share; fi
+if [ -d $XDG_DATA_HOME/nix/profile/etc/profile.d ]; then
+  for i in $XDG_DATA_HOME/nix/profile/etc/profile.d/*.sh; do
     if [ -r $i ]; then
       . $i
     fi
@@ -315,9 +317,10 @@ Configuring GNU info is a little bit trickier than man pages. To work correctly,
 {
   packageOverrides = pkgs: with pkgs; rec {
     myProfile = writeText "my-profile" ''
-      export PATH=$HOME/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/sbin:/bin:/usr/sbin:/usr/bin
-      export MANPATH=$HOME/.nix-profile/share/man:/nix/var/nix/profiles/default/share/man:/usr/share/man
-      export INFOPATH=$HOME/.nix-profile/share/info:/nix/var/nix/profiles/default/share/info:/usr/share/info
+      if [ -z "$XDG_DATA_HOME" ]; then XDG_DATA_HOME=$HOME/.local/share; fi
+      export PATH=$XDG_DATA_HOME/nix/profile/bin:/nix/var/nix/profiles/default/bin:/sbin:/bin:/usr/sbin:/usr/bin
+      export MANPATH=$XDG_DATA_HOME/nix/profile/share/man:/nix/var/nix/profiles/default/share/man:/usr/share/man
+      export INFOPATH=$XDG_DATA_HOME/nix/profile/share/info:/nix/var/nix/profiles/default/share/info:/usr/share/info
     '';
     myPackages = pkgs.buildEnv {
       name = "my-packages";

--- a/doc/using/configuration.chapter.md
+++ b/doc/using/configuration.chapter.md
@@ -264,7 +264,7 @@ This provides us with some useful documentation for using our packages.  However
 {
   packageOverrides = pkgs: with pkgs; rec {
     myProfile = writeText "my-profile" ''
-      if [ -z "$XDG_DATA_HOME" ]; then XDG_DATA_HOME=$HOME/.local/share; fi
+      XDG_DATA_HOME=${XDG_DATA_HOME:-$HOME/.local/share}
       export PATH=$XDG_DATA_HOME/nix/profile/bin:/nix/var/nix/profiles/default/bin:/sbin:/bin:/usr/sbin:/usr/bin
       export MANPATH=$XDG_DATA_HOME/nix/profile/share/man:/nix/var/nix/profiles/default/share/man:/usr/share/man
     '';
@@ -297,7 +297,7 @@ For this to work fully, you must also have this script sourced when you are logg
 
 ```ShellSession
 #!/bin/sh
-if [ -z "$XDG_DATA_HOME" ]; then XDG_DATA_HOME=$HOME/.local/share; fi
+XDG_DATA_HOME=${XDG_DATA_HOME:-$HOME/.local/share}
 if [ -d $XDG_DATA_HOME/nix/profile/etc/profile.d ]; then
   for i in $XDG_DATA_HOME/nix/profile/etc/profile.d/*.sh; do
     if [ -r $i ]; then
@@ -317,7 +317,7 @@ Configuring GNU info is a little bit trickier than man pages. To work correctly,
 {
   packageOverrides = pkgs: with pkgs; rec {
     myProfile = writeText "my-profile" ''
-      if [ -z "$XDG_DATA_HOME" ]; then XDG_DATA_HOME=$HOME/.local/share; fi
+      XDG_DATA_HOME=${XDG_DATA_HOME:-$HOME/.local/share}
       export PATH=$XDG_DATA_HOME/nix/profile/bin:/nix/var/nix/profiles/default/bin:/sbin:/bin:/usr/sbin:/usr/bin
       export MANPATH=$XDG_DATA_HOME/nix/profile/share/man:/nix/var/nix/profiles/default/share/man:/usr/share/man
       export INFOPATH=$XDG_DATA_HOME/nix/profile/share/info:/nix/var/nix/profiles/default/share/info:/usr/share/info

--- a/maintainers/scripts/nix-diff.sh
+++ b/maintainers/scripts/nix-diff.sh
@@ -81,9 +81,17 @@ if [ -n "$opt_profile" ]; then
         usage_tip
     fi
 else
-    opt_profile=$(readlink ~/.nix-profile)
+    NIX_LINK=$HOME/.nix-profile
+    if ! [ -e "$NIX_LINK" ]; then
+        if [ -n "$XDG_DATA_HOME" ]; then
+            NIX_LINK="$XDG_DATA_HOME/nix/profile"
+        else
+            NIX_LINK=$HOME/.local/share/nix/profile
+        fi
+    fi
+    opt_profile=$(readlink "$NIX_LINK")
     if (( $? != 0 )); then
-        echo 'error: unable to dereference `~/.nix-profile`' >&2
+        echo 'error: unable to dereference the user profile' >&2
         echo 'specify the profile manually with the `-p` flag' >&2
         usage_tip
     fi

--- a/maintainers/scripts/nix-diff.sh
+++ b/maintainers/scripts/nix-diff.sh
@@ -81,13 +81,9 @@ if [ -n "$opt_profile" ]; then
         usage_tip
     fi
 else
-    NIX_LINK=$HOME/.nix-profile
+    NIX_LINK="$HOME/.nix-profile"
     if ! [ -e "$NIX_LINK" ]; then
-        if [ -n "$XDG_DATA_HOME" ]; then
-            NIX_LINK="$XDG_DATA_HOME/nix/profile"
-        else
-            NIX_LINK=$HOME/.local/share/nix/profile
-        fi
+        NIX_LINK="${XDG_DATA_HOME:-$HOME/.local/share}/nix/profile"
     fi
     opt_profile=$(readlink "$NIX_LINK")
     if (( $? != 0 )); then

--- a/maintainers/scripts/update-channel-branches.sh
+++ b/maintainers/scripts/update-channel-branches.sh
@@ -66,8 +66,17 @@ if currentSystem=$(nixos-version 2>/dev/null); then
     updateRef current-system "$sha1"
 fi
 
-echo "Fetching channels from $HOME/.nix-defexpr:"
-for revFile in : $(find -L "$HOME/.nix-defexpr/" -maxdepth 4 -name svn-revision); do
+NIX_DEFEXPR="$HOME/.nix-defexpr"
+if ! [ -e "$NIX_DEFEXPR" ]; then
+    if [ -n "$XDG_DATA_HOME" ]; then
+        NIX_DEFEXPR="$XDG_DATA_HOME/nix/defexpr"
+    else
+        NIX_DEFEXPR="$HOME/.local/share/nix/defexpr"
+    fi
+fi
+
+echo "Fetching channels from $NIX_DEFEXPR"
+for revFile in : $(find -L "$NIX_DEFEXPR" -maxdepth 4 -name svn-revision); do
     test "$revFile" = : && continue;
 
     # Deconstruct a path such as, into:
@@ -78,7 +87,7 @@ for revFile in : $(find -L "$HOME/.nix-defexpr/" -maxdepth 4 -name svn-revision)
     #   /home/luke/.nix-defexpr/channels/nixpkgs/svn-revision
     #     channelName = nixpkgs
     #
-    user=${revFile#*.nix-defexpr/channels}
+    user=${revFile#$NIX_DEFEXPR/channels}
     repo=${user#*/}
     repo=${repo%%/*}
     user=${user%%/*}

--- a/nixos/doc/manual/configuration/user-mgmt.chapter.md
+++ b/nixos/doc/manual/configuration/user-mgmt.chapter.md
@@ -64,7 +64,7 @@ account named `alice`:
 
 To make all nix tools available to this new user use \`su - USER\` which
 opens a login shell (==shell that loads the profile) for given user.
-This will create the \~/.nix-defexpr symlink. So run:
+This will create the `$XDG_DATA_HOME/nix/defexpr` symlink. So run:
 
 ```ShellSession
 # su - alice -c "true"

--- a/nixos/doc/manual/development/sources.chapter.md
+++ b/nixos/doc/manual/development/sources.chapter.md
@@ -63,15 +63,16 @@ need to tell `nixos-rebuild` about them using the `-I` flag:
 If you want `nix-env` to use the expressions in `/my/sources`, use
 `nix-env -f
   /my/sources/nixpkgs`, or change the default by adding a symlink in
-`~/.nix-defexpr`:
+`$XDG_DATA_HOME/nix/defexpr` (or the legacy `~/.nix-defexpr`):
 
 ```ShellSession
-$ ln -s /my/sources/nixpkgs ~/.nix-defexpr/nixpkgs
+$ ln -s /my/sources/nixpkgs "$XDG_DATA_HOME/nix/defexpr"
 ```
 
-You may want to delete the symlink `~/.nix-defexpr/channels_root` to
-prevent root's NixOS channel from clashing with your own tree (this may
-break the command-not-found utility though). If you want to go back to
-the default state, you may just remove the `~/.nix-defexpr` directory
-completely, log out and log in again and it should have been recreated
-with a link to the root channels.
+You may want to delete the symlink
+`$XDG_DATA_HOME/nix/defexpr/channels_root` to prevent root's NixOS
+channel from clashing with your own tree (this may break the
+command-not-found utility though). If you want to go back to the
+default state, you may just remove the `$XDG_DATA_HOME/nix/defexpr`
+directory completely, log out and log in again and it should have been
+recreated with a link to the root channels.

--- a/nixos/doc/manual/from_md/configuration/user-mgmt.chapter.xml
+++ b/nixos/doc/manual/from_md/configuration/user-mgmt.chapter.xml
@@ -74,7 +74,8 @@ users.groups.students.gid = 1000;
   <para>
     To make all nix tools available to this new user use `su - USER`
     which opens a login shell (==shell that loads the profile) for given
-    user. This will create the ~/.nix-defexpr symlink. So run:
+    user. This will create the
+    <literal>$XDG_DATA_HOME/nix/defexpr</literal> symlink. So run:
   </para>
   <programlisting>
 # su - alice -c &quot;true&quot;

--- a/nixos/doc/manual/from_md/development/sources.chapter.xml
+++ b/nixos/doc/manual/from_md/development/sources.chapter.xml
@@ -72,19 +72,21 @@ $ git merge origin/nixos-17.03
     If you want <literal>nix-env</literal> to use the expressions in
     <literal>/my/sources</literal>, use
     <literal>nix-env -f /my/sources/nixpkgs</literal>, or change the
-    default by adding a symlink in <literal>~/.nix-defexpr</literal>:
+    default by adding a symlink in
+    <literal>$XDG_DATA_HOME/nix/defexpr</literal> (or the legacy
+    <literal>~/.nix-defexpr</literal>):
   </para>
   <programlisting>
-$ ln -s /my/sources/nixpkgs ~/.nix-defexpr/nixpkgs
+$ ln -s /my/sources/nixpkgs &quot;$XDG_DATA_HOME/nix/defexpr&quot;
 </programlisting>
   <para>
     You may want to delete the symlink
-    <literal>~/.nix-defexpr/channels_root</literal> to prevent root’s
-    NixOS channel from clashing with your own tree (this may break the
-    command-not-found utility though). If you want to go back to the
-    default state, you may just remove the
-    <literal>~/.nix-defexpr</literal> directory completely, log out and
-    log in again and it should have been recreated with a link to the
-    root channels.
+    <literal>$XDG_DATA_HOME/nix/defexpr/channels_root</literal> to
+    prevent root’s NixOS channel from clashing with your own tree (this
+    may break the command-not-found utility though). If you want to go
+    back to the default state, you may just remove the
+    <literal>$XDG_DATA_HOME/nix/defexpr</literal> directory completely,
+    log out and log in again and it should have been recreated with a
+    link to the root channels.
   </para>
 </chapter>

--- a/nixos/doc/manual/from_md/installation/installing-from-other-distro.section.xml
+++ b/nixos/doc/manual/from_md/installation/installing-from-other-distro.section.xml
@@ -40,7 +40,7 @@
       </para>
       <programlisting>
 $ curl -L https://nixos.org/nix/install | sh
-$ . $HOME/.nix-profile/etc/profile.d/nix.sh # …or open a fresh shell
+$ . $XDG_DATA_HOME/nix/profile/etc/profile.d/nix.sh # …or open a fresh shell
 </programlisting>
       <para>
         More details in the

--- a/nixos/doc/manual/installation/installing-from-other-distro.section.md
+++ b/nixos/doc/manual/installation/installing-from-other-distro.section.md
@@ -22,7 +22,7 @@ The first steps to all these are the same:
 
     ```ShellSession
     $ curl -L https://nixos.org/nix/install | sh
-    $ . $HOME/.nix-profile/etc/profile.d/nix.sh # …or open a fresh shell
+    $ . $XDG_DATA_HOME/nix/profile/etc/profile.d/nix.sh # …or open a fresh shell
     ```
 
     More details in the [ Nix

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -590,6 +590,8 @@ in {
 
     environment.profiles = [
       "$HOME/.nix-profile"
+      "$XDG_DATA_HOME/nix/profile"
+      "$HOME/.local/share/nix/profile"
       "/etc/profiles/per-user/$USER"
     ];
 

--- a/nixos/modules/installer/cd-dvd/channel.nix
+++ b/nixos/modules/installer/cd-dvd/channel.nix
@@ -40,6 +40,7 @@ in
         mkdir -p /nix/var/nix/profiles/per-user/root
         ${config.nix.package.out}/bin/nix-env -p /nix/var/nix/profiles/per-user/root/channels \
           -i ${channelSources} --quiet --option build-use-substitutes false
+        # Use a legacy location to stay compatible with old nix
         mkdir -m 0700 -p /root/.nix-defexpr
         ln -s /nix/var/nix/profiles/per-user/root/channels /root/.nix-defexpr/channels
         mkdir -m 0755 -p /var/lib/nixos

--- a/nixos/modules/installer/tools/nixos-install.sh
+++ b/nixos/modules/installer/tools/nixos-install.sh
@@ -178,6 +178,7 @@ if [[ -z $noChannelCopy ]]; then
         nix-env --store "$mountPoint" "${extraBuildFlags[@]}" --extra-substituters "$sub" \
                 -p "$mountPoint"/nix/var/nix/profiles/per-user/root/channels --set "$channelPath" --quiet \
                 "${verbosity[@]}"
+        # Use a legacy defexpr location to stay compatible with old nix
         install -m 0700 -d "$mountPoint"/root/.nix-defexpr
         ln -sfn /nix/var/nix/profiles/per-user/root/channels "$mountPoint"/root/.nix-defexpr/channels
     fi

--- a/nixos/modules/services/continuous-integration/gitlab-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitlab-runner.nix
@@ -273,7 +273,7 @@ in
               mkdir -p -m 1777 /nix/var/nix/gcroots/per-user
               mkdir -p -m 1777 /nix/var/nix/profiles/per-user
               mkdir -p -m 0755 /nix/var/nix/profiles/per-user/root
-              mkdir -p -m 0700 "$HOME/.nix-defexpr"
+              mkdir -p -m 0700 "$XDG_DATA_HOME/nix/defexpr"
 
               . ''${pkgs.nix}/etc/profile.d/nix.sh
 

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -636,7 +636,7 @@ in
         install -m 0755 -d /nix/var/nix/{gcroots,profiles}/per-user
 
         # Subscribe the root user to the NixOS channel by default.
-        if [ ! -e "/root/.nix-channels" ]; then
+        if [ ! -e "/root/.nix-channels" ] && [ ! -e /root/.local/share/nix/channels ]; then
             echo "${config.system.defaultChannel} nixos" > "/root/.nix-channels"
         fi
       '';

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -620,8 +620,17 @@ in
 
     environment.extraInit =
       ''
-        if [ -e "$HOME/.nix-defexpr/channels" ]; then
-          export NIX_PATH="$HOME/.nix-defexpr/channels''${NIX_PATH:+:$NIX_PATH}"
+        NIX_DEFEXPR="$HOME/.nix-defexpr"
+        if ! [ -e "$NIX_DEFEXPR" ]; then
+            if [ -n "$XDG_DATA_HOME" ]; then
+                NIX_DEFEXPR="$XDG_DATA_HOME/nix/defexpr"
+            else
+                NIX_DEFEXPR="$HOME/.local/share/nix/defexpr"
+            fi
+        fi
+
+        if [ -e "$NIX_DEFEXPR/channels" ]; then
+          export NIX_PATH="$NIX_DEFEXPR/channels''${NIX_PATH:+:$NIX_PATH}"
         fi
       '';
 

--- a/nixos/modules/virtualisation/amazon-init.nix
+++ b/nixos/modules/virtualisation/amazon-init.nix
@@ -37,6 +37,7 @@ let
         done < <(printf "%s\n" "$channels")
 
         if [[ -n "$channels" ]]; then
+          # We don't use the new XDG location here to stay compatible with old Nix
           printf "%s" "$channels" > /root/.nix-channels
           nix-channel --update
         fi

--- a/nixos/modules/virtualisation/digital-ocean-init.nix
+++ b/nixos/modules/virtualisation/digital-ocean-init.nix
@@ -70,6 +70,7 @@ in {
             done
 
             if [[ -n "$channels" ]]; then
+              # We don't use the new XDG location here to stay compatible with old Nix
               printf "%s" "$channels" > /root/.nix-channels
               nix-channel --update
             fi

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -160,7 +160,7 @@ let
 
       with subtest("Check whether the channel works"):
           machine.succeed("nix-env -iA nixos.procps >&2")
-          assert ".nix-profile" in machine.succeed("type -tP ps | tee /dev/stderr")
+          assert "nix/profile" in machine.succeed("type -tP ps | tee /dev/stderr")
 
       with subtest(
           "Check that the daemon works, and that non-root users can run builds "

--- a/pkgs/applications/misc/ulauncher/0001-Adjust-get_data_path-for-NixOS.patch
+++ b/pkgs/applications/misc/ulauncher/0001-Adjust-get_data_path-for-NixOS.patch
@@ -7,7 +7,7 @@ We construct the ulauncher data path from xdg_data_dirs
 and prevent it from being a nix store path or being xdg_data_home.
 We do this to prevent /nix/store paths being hardcoded to shortcuts.json.
 On NixOS this path will either be /run/current-system/sw/share/ulauncher
-or $HOME/.nix-profile/share/ulauncher if the user used nix-env.
+or $XDG_DATA_HOME/nix/profile/share/ulauncher if the user used nix-env.
 ---
  ulauncher/config.py | 27 ++++++++++++++++++---------
  1 file changed, 18 insertions(+), 9 deletions(-)

--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -26,8 +26,8 @@ assert lib.versionOlder "6.12" ghc.version || ghc.isGhcjs || ghc.isHaLVM;
 # A good way to import the environment set by the wrapper below into
 # your shell is to add the following snippet to your ~/.bashrc:
 #
-#   if [ -e ~/.nix-profile/bin/ghc ]; then
-#     eval $(grep export ~/.nix-profile/bin/ghc)
+#   if [ -e $XDG_DATA_HOME/nix/profile/bin/ghc ]; then
+#     eval $(grep export $XDG_DATA_HOME/nix/profile/bin/ghc)
 #   fi
 
 let

--- a/pkgs/development/libraries/aqbanking/gwenhywfar.nix
+++ b/pkgs/development/libraries/aqbanking/gwenhywfar.nix
@@ -7,6 +7,7 @@
 , pluginSearchPaths ? [
     "/run/current-system/sw/lib/gwenhywfar/plugins"
     ".nix-profile/lib/gwenhywfar/plugins"
+    "$XDG_DATA_HOME/nix/profile/lib/gwenhywfar/plugins"
   ]
 }:
 
@@ -39,13 +40,13 @@ in stdenv.mkDerivation rec {
     '';
 
   in ''
-    sed -i -e '/GWEN_PathManager_DefinePath.*GWEN_PM_PLUGINDIR/,/^#endif/ {
+    sed -i -e "/GWEN_PathManager_DefinePath.*GWEN_PM_PLUGINDIR/,/^#endif/ {
       /^#if/,/^#endif/ {
         H; /^#endif/ {
           ${lib.concatMapStrings mkSearchPath pluginSearchPaths}
         }
       }
-    }' src/gwenhywfar.c
+    }" src/gwenhywfar.c
 
     # Strip off the effective SO version from the path so that for example
     # "lib/gwenhywfar/plugins/60" becomes just "lib/gwenhywfar/plugins".

--- a/pkgs/development/libraries/fontconfig/make-fonts-conf.xsl
+++ b/pkgs/development/libraries/fontconfig/make-fonts-conf.xsl
@@ -35,9 +35,13 @@
         <xsl:text>&#0010;</xsl:text>
       </xsl:for-each>
 
-      <!-- nix user profile -->
+      <!-- nix user profile (legacy) -->
       <dir>~/.nix-profile/lib/X11/fonts</dir>
       <dir>~/.nix-profile/share/fonts</dir>
+
+      <!-- nix user profile -->
+      <dir prefix="xdg">nix/profile/lib/X11/fonts</dir>
+      <dir prefix="xdg">nix/profile/share/fonts</dir>
 
       <!-- FHS paths for non-NixOS platforms -->
       <dir>/usr/share/fonts</dir>

--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -69,8 +69,10 @@ Typical plugin files:
 Vim offers the :h rtp setting which works for most plugins. Thus adding
 this to your .vimrc should make most plugins work:
 
-  set rtp+=~/.nix-profile/share/vim-plugins/youcompleteme
-  " or for p in ["youcompleteme"] | exec 'set rtp+=~/.nix-profile/share/vim-plugins/'.p | endfor
+  set rtp+=~/.local/share/nix/profile/share/vim-plugins/youcompleteme
+  " or for p in ["youcompleteme"] | exec 'set rtp+=~/.local/share/nix/profile/share/vim-plugins/'.p | endfor
+
+(you may need to replace ~/.local/share with whatever your XDG_DATA_HOME is)
 
 which is what the [VAM]/pathogen solutions above basically do.
 

--- a/pkgs/servers/x11/xquartz/default.nix
+++ b/pkgs/servers/x11/xquartz/default.nix
@@ -38,7 +38,14 @@
 
 let
   installer = writeScript "xquartz-install" ''
-    NIX_LINK=$HOME/.nix-profile
+    NIX_LINK="$HOME/.nix-profile"
+    if ! [ -e "$NIX_LINK" ]; then
+        if [ -n "$XDG_DATA_HOME" ]; then
+            NIX_LINK="$XDG_DATA_HOME/nix/profile"
+        else
+            NIX_LINK="$HOME/.local/share/nix/profile"
+        fi
+    fi
 
     tmpdir=$(/usr/bin/mktemp -d $TMPDIR/xquartz-installer-XXXXXXXX)
     agentName=org.nixos.xquartz.startx.plist

--- a/pkgs/servers/x11/xquartz/default.nix
+++ b/pkgs/servers/x11/xquartz/default.nix
@@ -40,11 +40,7 @@ let
   installer = writeScript "xquartz-install" ''
     NIX_LINK="$HOME/.nix-profile"
     if ! [ -e "$NIX_LINK" ]; then
-        if [ -n "$XDG_DATA_HOME" ]; then
-            NIX_LINK="$XDG_DATA_HOME/nix/profile"
-        else
-            NIX_LINK="$HOME/.local/share/nix/profile"
-        fi
+        NIX_LINK="''${XDG_DATA_HOME:-$HOME/.local/share}/nix/profile"
     fi
 
     tmpdir=$(/usr/bin/mktemp -d $TMPDIR/xquartz-installer-XXXXXXXX)

--- a/pkgs/shells/zsh/zsh-git-prompt/default.nix
+++ b/pkgs/shells/zsh/zsh-git-prompt/default.nix
@@ -14,7 +14,7 @@
 #
 # Or if installed locally:
 #
-#   source ~/.nix-profile/share/zsh-git-prompt/zshrc.sh
+#   source $XDG_DATA_HOME/nix/profile/share/zsh-git-prompt/zshrc.sh
 #
 # Either way, you then have to set a prompt that incorporates
 # git_super_status, for example:

--- a/pkgs/tools/system/incron/default_path.patch
+++ b/pkgs/tools/system/incron/default_path.patch
@@ -12,7 +12,7 @@ index 11fd04b..a8681bd 100644
  
  PROC_MAP UserTable::s_procMap;
  
-@@ -597,12 +594,20 @@ void UserTable::RunAsUser(std::string cmd) const
+@@ -597,12 +594,22 @@ void UserTable::RunAsUser(std::string cmd) const
      if (clearenv() != 0)
        goto failed;
  
@@ -20,7 +20,9 @@ index 11fd04b..a8681bd 100644
 +    std::string DEFAULT_PATH;
 +    DEFAULT_PATH += "/run/wrappers/bin:";
 +    DEFAULT_PATH += pwd->pw_dir;
-+    DEFAULT_PATH += "/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:/etc/profiles/per-user/";
++    DEFAULT_PATH += "/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:/etc/profiles/per-user/:";
++    DEFAULT_PATH += pwd->pw_dir;
++    DEFAULT_PATH += "/.local/share/nix/bin:";
 +    DEFAULT_PATH += pwd->pw_name;
 +    DEFAULT_PATH += "/bin";
 +

--- a/pkgs/tools/typesetting/tex/tetex/environment.patch
+++ b/pkgs/tools/typesetting/tex/tetex/environment.patch
@@ -3,7 +3,7 @@ diff -rc --exclude=texmf.in tetex-src-3.0.orig/texk/kpathsea/texmf.in-teTeX tete
 --- tetex-src-3.0/texk/kpathsea/texmf.in-teTeX	2006-01-27 17:38:35.000000000 +0100
 ***************
 *** 104,109 ****
---- 104,115 ----
+--- 104,117 ----
   %   TEXMFCONFIG = @texmf@-config
   TEXMFCONFIG = $HOME/.texmf-config
   
@@ -11,7 +11,9 @@ diff -rc --exclude=texmf.in tetex-src-3.0.orig/texk/kpathsea/texmf.in-teTeX tete
 + % system to add trees during the build of nix-expressions.
 + 
 + % TEXMFNIXHOME, for packages in the user environment.
-+ TEXMFNIXHOME = $HOME/.nix-profile/share/texmf-nix
++ TEXMFNIXHOMELEGACY = $HOME/.nix-profile/share/texmf-nix
++ TEXMFNIXHOME = $XDG_DATA_HOME/nix/profile/share/texmf-nix
++ TEXMFNIXFALLBACK = ~/.local/share/nix/profile/share/texmf-nix
 + 
   % Now, list all the texmf trees. If you have multiple trees you can
   % use shell brace notation, like this:
@@ -29,7 +31,7 @@ diff -rc --exclude=texmf.in tetex-src-3.0.orig/texk/kpathsea/texmf.in-teTeX tete
   %
   % For texconfig to work properly, TEXMFCONGIG and TEXMFVAR should be named
   % explicitly and before all other trees.
-! TEXMF = {!!$TEXMFCONFIG,!!$TEXMFVAR,$TEXMFNIX,$TEXMFHOME,$TEXMFNIXHOME,!!$TEXMFSYSCONFIG,!!$TEXMFSYSVAR,!!$TEXMFMAIN,!!$TEXMFLOCAL,!!$TEXMFDIST}
+! TEXMF = {!!$TEXMFCONFIG,!!$TEXMFVAR,$TEXMFNIX,$TEXMFHOME,$TEXMFNIXHOME,$TEXMFNIXHOMEFALLBACK,$TEXMFNIXHOMELEGACY,!!$TEXMFSYSCONFIG,!!$TEXMFSYSVAR,!!$TEXMFMAIN,!!$TEXMFLOCAL,!!$TEXMFDIST}
   
   % The system trees.  These are the trees that are shared by all the users.
   SYSTEXMF = $TEXMFLOCAL;$TEXMFMAIN;$TEXMFDIST

--- a/pkgs/tools/wayland/swayr/icon-paths.patch
+++ b/pkgs/tools/wayland/swayr/icon-paths.patch
@@ -1,8 +1,16 @@
 diff --git a/src/config.rs b/src/config.rs
-index de7d04b..291114b 100644
+index 33bdcaa..5e79283 100644
 --- a/src/config.rs
 +++ b/src/config.rs
-@@ -197,6 +197,12 @@ impl Default for Format {
+@@ -195,6 +195,7 @@ impl Default for Menu {
+
+ impl Default for Format {
+     fn default() -> Self {
++        let data_home = std::env::var("XDG_DATA_HOME").unwrap_or("~/.local/share".to_string());
+         Format {
+             window_format: Some(
+                 "{urgency_start}<b>“{title}”</b>{urgency_end} \
+@@ -214,6 +215,15 @@ impl Default for Format {
              ),
              urgency_end: Some("</span>".to_string()),
              icon_dirs: Some(vec![
@@ -12,6 +20,9 @@ index de7d04b..291114b 100644
 +                "~/.nix-profile/share/icons/hicolor/scalable/apps".to_string(),
 +                "~/.nix-profile/share/icons/hicolor/48x48/apps".to_string(),
 +                "~/.nix-profile/share/pixmaps".to_string(),
++                format!("{}/nix/profile/share/icons/hicolor/scalable/apps", data_home),
++                format!("{}/nix/profile/share/icons/hicolor/48x48/apps", data_home),
++                format!("{}/nix/profile/share/pixmaps", data_home),
                  "/usr/share/icons/hicolor/scalable/apps".to_string(),
                  "/usr/share/icons/hicolor/48x48/apps".to_string(),
                  "/usr/share/pixmaps".to_string(),

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -16,6 +16,7 @@
   (add-to-list 'package-directory-list "/run/current-system/sw/share/emacs/site-lisp/elpa")
 
   ;; optional. use this if you install emacs packages to user profiles (with nix-env)
+  (add-to-list 'package-directory-list "~/.local/share/profile/nix/share/emacs/site-lisp/elpa")
   (add-to-list 'package-directory-list "~/.nix-profile/share/emacs/site-lisp/elpa")
 
   (package-initialize)


### PR DESCRIPTION
Ref: https://github.com/NixOS/nix/pull/5588

This searches in `$XDG_DATA_HOME/nix/profile` everywhere where
previously we only looked in `~/.nix-profile`, ditto for
`.nix-channels` and `.nix-defexpr`. This shouldn't break any
compatibility for now. It is highly recommended to use nixpkgs with
these changes if you want to use Nix with the XDG basedir PR, but not
doing so shouldn't result in any dramatic breakage -- in fact, NixOS
is perfectly usable without any user profile.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
