### PR TITLE
python39Packages.{pydyf,weasyprint}: remove extra pytest, remove linting only tests, format to standard pythonPackages layout

### DIFF
--- a/pkgs/development/python-modules/pydyf/default.nix
+++ b/pkgs/development/python-modules/pydyf/default.nix
@@ -1,15 +1,11 @@
-{ lib,
-  buildPythonPackage,
-  fetchPypi,
-  isPy3k,
-  pytestCheckHook,
-  coverage,
-  ghostscript,
-  pillow,
-  pytest,
-  pytest-cov,
-  pytest-flake8,
-  pytest-isort
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+, pytestCheckHook
+, coverage
+, ghostscript
+, pillow
 }:
 
 buildPythonPackage rec {
@@ -17,27 +13,23 @@ buildPythonPackage rec {
   version = "0.1.2";
   disabled = !isPy3k;
 
-  pytestFlagsArray = [
-    # setup.py is auto-generated and doesn't pass the flake8 check
-    "--ignore=setup.py"
-  ];
+  src = fetchPypi {
+    inherit version;
+    pname = "pydyf";
+    sha256 = "sha256-Hi9d5IF09QXeAlp9HnzwG73ZQiyoq5RReCvwDuF4YCw=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace "--isort --flake8 --cov --no-cov-on-fail" ""
+  '';
 
   checkInputs = [
     pytestCheckHook
     coverage
     ghostscript
     pillow
-    pytest
-    pytest-cov
-    pytest-flake8
-    pytest-isort
   ];
-
-  src = fetchPypi {
-    inherit version;
-    pname = "pydyf";
-    sha256 = "sha256-Hi9d5IF09QXeAlp9HnzwG73ZQiyoq5RReCvwDuF4YCw=";
-  };
 
   meta = with lib; {
     homepage = "https://doc.courtbouillon.org/pydyf/stable/";

--- a/pkgs/development/python-modules/weasyprint/default.nix
+++ b/pkgs/development/python-modules/weasyprint/default.nix
@@ -1,31 +1,27 @@
-{ buildPythonPackage,
-  fetchPypi,
-  fetchpatch,
-  pytestCheckHook,
-  brotli,
-  cairosvg,
-  fonttools,
-  pydyf,
-  pyphen,
-  cffi,
-  cssselect,
-  lxml,
-  html5lib,
-  tinycss,
-  zopfli,
-  glib,
-  harfbuzz,
-  pango,
-  fontconfig,
-  lib, stdenv,
-  ghostscript,
-  pytest,
-  pytest-runner,
-  pytest-isort,
-  pytest-flake8,
-  pytest-cov,
-  isPy3k,
-  substituteAll
+{ buildPythonPackage
+, fetchPypi
+, fetchpatch
+, pytestCheckHook
+, brotli
+, cairosvg
+, fonttools
+, pydyf
+, pyphen
+, cffi
+, cssselect
+, lxml
+, html5lib
+, tinycss
+, zopfli
+, glib
+, harfbuzz
+, pango
+, fontconfig
+, lib
+, stdenv
+, ghostscript
+, isPy3k
+, substituteAll
 }:
 
 buildPythonPackage rec {
@@ -33,26 +29,25 @@ buildPythonPackage rec {
   version = "53.4";
   disabled = !isPy3k;
 
-  pytestFlagsArray = [
-    # setup.py is auto-generated and doesn't pass the flake8 check
-    "--ignore=setup.py"
-    # ffi.py is patched by us and doesn't pass the flake8 check
-    "--ignore=weasyprint/text/ffi.py"
-  ];
+  src = fetchPypi {
+    inherit version;
+    pname = "weasyprint";
+    sha256 = "sha256-EMyxfVXHMJa98e3T7+WMuFWwfkwwfZutTryaPxP/RYA=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace "--isort --flake8 --cov --no-cov-on-fail" ""
+  '';
 
   disabledTests = [
-    # test_font_stretch needs the Ahem font (fails on macOS)
+    # needs the Ahem font (fails on macOS)
     "test_font_stretch"
   ];
 
   checkInputs = [
     pytestCheckHook
     ghostscript
-    pytest
-    pytest-runner
-    pytest-isort
-    pytest-flake8
-    pytest-cov
   ];
 
   FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";
@@ -82,12 +77,6 @@ buildPythonPackage rec {
       harfbuzz = "${harfbuzz.out}/lib/libharfbuzz${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
   ];
-
-  src = fetchPypi {
-    inherit version;
-    pname = "weasyprint";
-    sha256 = "sha256-EMyxfVXHMJa98e3T7+WMuFWwfkwwfZutTryaPxP/RYA=";
-  };
 
   meta = with lib; {
     homepage = "https://weasyprint.org/";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

make python-unstable easier by not relying on linters for tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
