### PR TITLE
Downgrade llvmPackages_latest to 12 on Darwin

### DIFF
--- a/pkgs/development/compilers/llvm/12/default.nix
+++ b/pkgs/development/compilers/llvm/12/default.nix
@@ -75,22 +75,20 @@ let
 
     clang-unwrapped = tools.libclang.out // { outputSpecified = false; };
 
-    # disabled until recommonmark supports sphinx 3
-    #Llvm-manpages = lowPrio (tools.libllvm.override {
-    #  enableManpages = true;
-    #  python3 = pkgs.python3;  # don't use python-boot
-    #});
+    llvm-manpages = lowPrio (tools.libllvm.override {
+      enableManpages = true;
+      python3 = pkgs.python3;  # don't use python-boot
+    });
 
     clang-manpages = lowPrio (tools.libclang.override {
       enableManpages = true;
       python3 = pkgs.python3;  # don't use python-boot
     });
 
-    # disabled until recommonmark supports sphinx 3
-    # lldb-manpages = lowPrio (tools.lldb.override {
-    #   enableManpages = true;
-    #   python3 = pkgs.python3;  # don't use python-boot
-    # });
+    lldb-manpages = lowPrio (tools.lldb.override {
+      enableManpages = true;
+      python3 = pkgs.python3;  # don't use python-boot
+    });
 
     clang = if stdenv.cc.isGNU then tools.libstdcxxClang else tools.libcxxClang;
 

--- a/pkgs/development/tools/analysis/clang-analyzer/0001-LLVM12-Fix-scan-build-to-use-NIX_CFLAGS_COMPILE.patch
+++ b/pkgs/development/tools/analysis/clang-analyzer/0001-LLVM12-Fix-scan-build-to-use-NIX_CFLAGS_COMPILE.patch
@@ -1,0 +1,34 @@
+From 40239d92957f1969652cdd41d6d2749c41ac4338 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
+Date: Fri, 31 Jul 2020 09:22:03 +0100
+Subject: [PATCH] [PATCH] Fix scan-build to use NIX_CFLAGS_COMPILE
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
+---
+ tools/scan-build/libexec/ccc-analyzer | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/tools/scan-build/libexec/ccc-analyzer b/tools/scan-build/libexec/ccc-analyzer
+index 800f38b5..0fb50fb3 100755
+--- a/tools/scan-build/libexec/ccc-analyzer
++++ b/tools/scan-build/libexec/ccc-analyzer
+@@ -246,6 +246,14 @@ sub Analyze {
+       push @Args, "-target", $AnalyzerTarget;
+     }
+ 
++    # Add Nix flags to analysis
++    if (defined $ENV{'NIX_CFLAGS_COMPILE'}) {
++      my @nixArgs = split(/\s+/, $ENV{'NIX_CFLAGS_COMPILE'});
++      foreach my $nixArg (@nixArgs) {
++        push @Args, $nixArg;
++      }
++    }
++
+     my $AnalysisArgs = GetCCArgs($HtmlDir, "--analyze", \@Args);
+     @CmdArgs = @$AnalysisArgs;
+   }
+-- 
+2.27.0

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12524,7 +12524,9 @@ with pkgs;
     stdenv = gcc7Stdenv;
   }));
 
-  llvmPackages_latest = llvmPackages_13;
+  # FIXME: llvmPackages_13.libcxx is currently broken on Darwin, leaving Clang
+  # to be broken too.
+  llvmPackages_latest = if stdenv.isDarwin then llvmPackages_12 else llvmPackages_13;
 
   llvmPackages_rocm = recurseIntoAttrs (callPackage ../development/compilers/llvm/rocm { });
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The recent upgrade of `llvmPackages_latest` to `llvmPackages_13` broke a number of packages that depend on it, due to `llmvPackages_13.libcxx` (and by extension, `llvmPackages_13.clang`) being marked as broken. This reverts those changes on Darwin. It should fix the builds of the following packages:

* clang-analyzer
* clang-tools
* lldb
* ccls

Relates to: #140783, #140783
ZHF: #144627

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Since building from the staging branch triggered an overwhelming amount of local builds, I've tested on the `master` branched and rebased against `staging`.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
