### PR TITLE
Fix Darwin build for cmigemo and skk-dict

### DIFF
--- a/pkgs/tools/inputmethods/skk/skk-dicts/default.nix
+++ b/pkgs/tools/inputmethods/skk/skk-dicts/default.nix
@@ -25,6 +25,8 @@ let
     url = "https://raw.githubusercontent.com/skk-dev/dict/8b35d07a7d2044d48b063d2774d9f9d00bb7cb48/SKK-JISYO.assoc";
     sha256 = "1smcbyv6srrhnpl7ic9nqds9nz3g2dgqngmhzkrdlwmvcpvakp1v";
   };
+
+  iconvBin = if stdenv.isDarwin then libiconv else  buildPackages.stdenv.cc.libc;
 in
 
 stdenv.mkDerivation {
@@ -49,7 +51,7 @@ stdenv.mkDerivation {
     for src in $srcs; do
       dst=$out/share/$(dictname $src)
       echo ";;; -*- coding: utf-8 -*-" > $dst  # libskk requires this on the first line
-      ${lib.getBin buildPackages.stdenv.cc.libc}/bin/iconv \
+      ${lib.getBin iconvBin}/bin/iconv \
         -f EUC-JP -t UTF-8 $src | skkdic-expr2 >> $dst
     done
 

--- a/pkgs/tools/text/cmigemo/default.nix
+++ b/pkgs/tools/text/cmigemo/default.nix
@@ -3,6 +3,9 @@
 , skk-dicts
 }:
 
+let
+  iconvBin = if stdenv.isDarwin then libiconv else  buildPackages.stdenv.cc.libc;
+in
 stdenv.mkDerivation {
   pname = "cmigemo";
   version = "1.3e";
@@ -25,7 +28,7 @@ stdenv.mkDerivation {
   makeFlags = [ "INSTALL=install" ];
 
   preBuild = ''
-    makeFlagsArray+=(FILTER_UTF8="${lib.getBin buildPackages.stdenv.cc.libc}/bin/iconv -t utf-8 -f cp932")
+    makeFlagsArray+=(FILTER_UTF8="${lib.getBin iconvBin}/bin/iconv -t utf-8 -f cp932")
   '';
 
   buildFlags = [ (if stdenv.isDarwin then "osx-all" else "gcc-all") ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes incorrect path to the `iconv` command.

ZHF: #144627

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
