### PR TITLE
fetchgitlab: fix unexpected argument

### DIFF
--- a/pkgs/build-support/fetchgitlab/default.nix
+++ b/pkgs/build-support/fetchgitlab/default.nix
@@ -10,7 +10,7 @@ let
   slug = lib.concatStringsSep "/" ((lib.optional (group != null) group) ++ [ owner repo ]);
   escapedSlug = lib.replaceStrings [ "." "/" ] [ "%2E" "%2F" ] slug;
   escapedRev = lib.replaceStrings [ "+" "%" "/" ] [ "%2B" "%25" "%2F" ] rev;
-  passthruAttrs = removeAttrs args [ "domain" "owner" "group" "repo" "rev" ];
+  passthruAttrs = removeAttrs args [ "protocol" "domain" "owner" "group" "repo" "rev" ];
 
   useFetchGit = deepClone || fetchSubmodules || leaveDotGit;
   fetcher = if useFetchGit then fetchgit else fetchzip;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix error `called with unexpected argument 'protocol'` with explicit argument `protocol = "http"`.
An example of full error message:
```
error: anonymous function at /nix/store/jjx3dkasgziw9c2gh138pvf5q95q0jzm-nixos-21.11pre328987.c935f5e0add/nixos/pkgs/build-support/fetchurl/default.nix:40:1 called with unexpected argument 'protocol', at /nix/store/jjx3dkasgziw9c2gh138pvf5q95q0jzm-nixos-21.11pre328987.c935f5e0add/nixos/pkgs/build-support/fetchzip/default.nix:22:2
```
Explicit `protocol` parameter is passed to `fetchzip` that doesn't have it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - ~~[NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~
  - ~~and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)~~
  - ~~or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)~~
  - ~~made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages~~
  - tested with corporate gitlab server via http:
```
nix-build -I nixpkgs=/home/igor/nixpkgs -E 'with import <nixpkgs> {}; fetchFromGitLab { protocol = "http"; domain = "xxxx"; owner = "oooo"; repo = "pppp"; rev = "master"; curlOpts = "--header PRIVATE-TOKEN:XXXXX"; hash = "sha256-22teu3GFyGyBexfP2QXVh8qWsRze9J/Yd2q89qyQqwk="; }'
this derivation will be built:
  /nix/store/yhqbxjln50dfaqd1sgrd45iiban7qiw7-source.drv
building '/nix/store/yhqbxjln50dfaqd1sgrd45iiban7qiw7-source.drv'...

trying http://xxxx/api/v4/projects/oooo%2Fpppp/repository/archive.tar.gz?sha=master
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  347k  100  347k    0     0   963k      0 --:--:-- --:--:-- --:--:--  962k
unpacking source archive /build/archive.tar.gz?sha=master
/nix/store/19v4cy7dgv93zkkmz6xxw4mvcqr5r18k-source
```
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
