### PR TITLE
lispPackages.magicl: init at v0.9.1

### DIFF
--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/abstract-classes.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/abstract-classes.nix
@@ -1,0 +1,28 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "abstract-classes";
+  version = "cl-20190307-hg";
+
+  description = "Extends the MOP to allow `abstract` and `final` classes.";
+
+  deps = [ args."closer-mop" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/cl-abstract-classes/2019-03-07/cl-abstract-classes-20190307-hg.tgz";
+    sha256 = "0p0ml54j049anzjhdp54q36p3pbwqdikvyi9rk9jv6kxrgd07qdx";
+  };
+
+  packageName = "abstract-classes";
+
+  asdFilesToKeep = ["abstract-classes.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM abstract-classes DESCRIPTION
+    Extends the MOP to allow `abstract` and `final` classes. SHA256
+    0p0ml54j049anzjhdp54q36p3pbwqdikvyi9rk9jv6kxrgd07qdx URL
+    http://beta.quicklisp.org/archive/cl-abstract-classes/2019-03-07/cl-abstract-classes-20190307-hg.tgz
+    MD5 9f70affac8015d8fc4e29f16c642890e NAME abstract-classes FILENAME
+    abstract-classes DEPS ((NAME closer-mop FILENAME closer-mop)) DEPENDENCIES
+    (closer-mop) VERSION cl-20190307-hg SIBLINGS (singleton-classes) PARASITES
+    NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cffi-libffi.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cffi-libffi.nix
@@ -1,0 +1,33 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "cffi-libffi";
+  version = "cffi_0.24.1";
+
+  description = "Foreign structures by value";
+
+  deps = [ args."alexandria" args."babel" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."trivial-features" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/cffi/2021-04-11/cffi_0.24.1.tgz";
+    sha256 = "1ir8a4rrnilj9f8rv1hh6fhkg2wp8z8zcf9hiijcix50pabxq8qh";
+  };
+
+  packageName = "cffi-libffi";
+
+  asdFilesToKeep = ["cffi-libffi.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM cffi-libffi DESCRIPTION Foreign structures by value SHA256
+    1ir8a4rrnilj9f8rv1hh6fhkg2wp8z8zcf9hiijcix50pabxq8qh URL
+    http://beta.quicklisp.org/archive/cffi/2021-04-11/cffi_0.24.1.tgz MD5
+    c3df5c460e00e5af8b8bd2cd03a4b5cc NAME cffi-libffi FILENAME cffi-libffi DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
+     (NAME cffi FILENAME cffi) (NAME cffi-grovel FILENAME cffi-grovel)
+     (NAME cffi-toolchain FILENAME cffi-toolchain)
+     (NAME trivial-features FILENAME trivial-features))
+    DEPENDENCIES
+    (alexandria babel cffi cffi-grovel cffi-toolchain trivial-features) VERSION
+    cffi_0.24.1 SIBLINGS
+    (cffi-examples cffi-grovel cffi-tests cffi-toolchain cffi-uffi-compat cffi)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/interface.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/interface.nix
@@ -1,0 +1,28 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "interface";
+  version = "20190307-hg";
+
+  description = "A system for defining interfaces.";
+
+  deps = [ args."alexandria" args."global-vars" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/interface/2019-03-07/interface-20190307-hg.tgz";
+    sha256 = "0h9i6vmc89yaiba2l3yh47gq8vnj7lmfky8g1pp96ky53h043608";
+  };
+
+  packageName = "interface";
+
+  asdFilesToKeep = ["interface.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM interface DESCRIPTION A system for defining interfaces. SHA256
+    0h9i6vmc89yaiba2l3yh47gq8vnj7lmfky8g1pp96ky53h043608 URL
+    http://beta.quicklisp.org/archive/interface/2019-03-07/interface-20190307-hg.tgz
+    MD5 2171f1127f13b79c82c56302b629c18b NAME interface FILENAME interface DEPS
+    ((NAME alexandria FILENAME alexandria)
+     (NAME global-vars FILENAME global-vars))
+    DEPENDENCIES (alexandria global-vars) VERSION 20190307-hg SIBLINGS NIL
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/magicl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/magicl.nix
@@ -1,0 +1,44 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "magicl";
+  version = "v0.9.1";
+
+  parasites = [ "magicl/core" "magicl/ext" "magicl/ext-blas" "magicl/ext-expokit" "magicl/ext-lapack" ];
+
+  description = "Matrix Algebra proGrams In Common Lisp";
+
+  deps = [ args."abstract-classes" args."alexandria" args."babel" args."cffi" args."cffi-grovel" args."cffi-libffi" args."cffi-toolchain" args."closer-mop" args."global-vars" args."interface" args."policy-cond" args."trivial-features" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/magicl/2021-04-11/magicl-v0.9.1.tgz";
+    sha256 = "1vsi82l7w1ijp3f7f8hi9pm91www3a9fb8nnljiwypnjrjbrkwld";
+  };
+
+  packageName = "magicl";
+
+  asdFilesToKeep = ["magicl.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM magicl DESCRIPTION Matrix Algebra proGrams In Common Lisp SHA256
+    1vsi82l7w1ijp3f7f8hi9pm91www3a9fb8nnljiwypnjrjbrkwld URL
+    http://beta.quicklisp.org/archive/magicl/2021-04-11/magicl-v0.9.1.tgz MD5
+    5b28a64d6577cc9b97b7719a82ae4d1c NAME magicl FILENAME magicl DEPS
+    ((NAME abstract-classes FILENAME abstract-classes)
+     (NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
+     (NAME cffi FILENAME cffi) (NAME cffi-grovel FILENAME cffi-grovel)
+     (NAME cffi-libffi FILENAME cffi-libffi)
+     (NAME cffi-toolchain FILENAME cffi-toolchain)
+     (NAME closer-mop FILENAME closer-mop)
+     (NAME global-vars FILENAME global-vars)
+     (NAME interface FILENAME interface)
+     (NAME policy-cond FILENAME policy-cond)
+     (NAME trivial-features FILENAME trivial-features))
+    DEPENDENCIES
+    (abstract-classes alexandria babel cffi cffi-grovel cffi-libffi
+     cffi-toolchain closer-mop global-vars interface policy-cond
+     trivial-features)
+    VERSION v0.9.1 SIBLINGS
+    (magicl-examples magicl-gen magicl-tests magicl-transcendental) PARASITES
+    (magicl/core magicl/ext magicl/ext-blas magicl/ext-expokit
+     magicl/ext-lapack)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/policy-cond.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/policy-cond.nix
@@ -1,0 +1,26 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "policy-cond";
+  version = "20200427-git";
+
+  description = "Tools to insert code based on compiler policy.";
+
+  deps = [ ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/policy-cond/2020-04-27/policy-cond-20200427-git.tgz";
+    sha256 = "10cyb84grz306wkz2wmhf6njvgav51yn3fk0fg3fp1q2xzcnq7y1";
+  };
+
+  packageName = "policy-cond";
+
+  asdFilesToKeep = ["policy-cond.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM policy-cond DESCRIPTION
+    Tools to insert code based on compiler policy. SHA256
+    10cyb84grz306wkz2wmhf6njvgav51yn3fk0fg3fp1q2xzcnq7y1 URL
+    http://beta.quicklisp.org/archive/policy-cond/2020-04-27/policy-cond-20200427-git.tgz
+    MD5 c62090127d03b788518ac1257f49eda2 NAME policy-cond FILENAME policy-cond
+    DEPS NIL DEPENDENCIES NIL VERSION 20200427-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
@@ -305,6 +305,16 @@ $out/lib/common-lisp/query-fs"
   magicl = x: {
     parasites = [ "magicl/core" "magicl/ext" "magicl/ext-blas" "magicl/ext-lapack" "magicl/ext-expokit" ];
     propagatedBuildInputs = [ pkgs.gfortran pkgs.openblas pkgs.libffi ];
+    overrides = y: (x.overrides y) // {
+      postPatch = ''
+        # Fix relative path of Fortran output
+        patch -p1 < ${
+          pkgs.fetchurl {
+            url = "https://github.com/quil-lang/magicl/commit/fd9aebbb3b1c60562174cca14a00d6348b4079e0.diff";
+            sha256 = "0cwp2a8h2b0fq1wwcdkvis7w0brdgl1rwmy2vfcjwfv9w7avwg6j";
+          }}
+      '';
+    };
   };
   uax-15 = x: {
     overrides = y: (x.overrides y) // {

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
@@ -113,7 +113,17 @@ $out/lib/common-lisp/query-fs"
       '';
     };
   };
-  cffi = addNativeLibs [pkgs.libffi];
+  cffi-libffi = x: {
+    # Current upstream version only finds libffi.so.7 not libffi.so.8...
+    propagatedBuildInputs = [ (pkgs.libffi.overrideAttrs (oldAttrs: rec {
+      version = "3.3";
+      src = pkgs.fetchurl {
+        url = "https://sourceware.org/pub/libffi/libffi-3.3.tar.gz";
+        sha256 = "0mi0cpf8aa40ljjmzxb7im6dbj45bb0kllcd09xgmp834y9agyvj";
+      };
+    })
+    )];
+  };
   cl-mysql = x: {
     propagatedBuildInputs = [pkgs.libmysqlclient];
     overrides = y: (x.overrides y) // {
@@ -292,6 +302,10 @@ $out/lib/common-lisp/query-fs"
     };
   };
   lla = addNativeLibs [ pkgs.openblas ];
+  magicl = x: {
+    parasites = [ "magicl/core" "magicl/ext" "magicl/ext-blas" "magicl/ext-lapack" "magicl/ext-expokit" ];
+    propagatedBuildInputs = [ pkgs.gfortran pkgs.openblas pkgs.libffi ];
+  };
   uax-15 = x: {
     overrides = y: (x.overrides y) // {
       postPatch = ''

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
@@ -165,6 +165,7 @@ local-time
 log4cl
 lparallel
 lquery
+magicl
 marshal
 md5
 metabang-bind

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -277,6 +277,47 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "policy-cond" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."policy-cond" or (x: {}))
+       (import ./quicklisp-to-nix-output/policy-cond.nix {
+         inherit fetchurl;
+       }));
+
+
+  "interface" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."interface" or (x: {}))
+       (import ./quicklisp-to-nix-output/interface.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "global-vars" = quicklisp-to-nix-packages."global-vars";
+       }));
+
+
+  "cffi-libffi" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."cffi-libffi" or (x: {}))
+       (import ./quicklisp-to-nix-output/cffi-libffi.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "babel" = quicklisp-to-nix-packages."babel";
+           "cffi" = quicklisp-to-nix-packages."cffi";
+           "cffi-grovel" = quicklisp-to-nix-packages."cffi-grovel";
+           "cffi-toolchain" = quicklisp-to-nix-packages."cffi-toolchain";
+           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
+       }));
+
+
+  "abstract-classes" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."abstract-classes" or (x: {}))
+       (import ./quicklisp-to-nix-output/abstract-classes.nix {
+         inherit fetchurl;
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+       }));
+
+
   "cl-num-utils" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."cl-num-utils" or (x: {}))
@@ -2621,6 +2662,26 @@ let quicklisp-to-nix-packages = rec {
        (qlOverrides."marshal" or (x: {}))
        (import ./quicklisp-to-nix-output/marshal.nix {
          inherit fetchurl;
+       }));
+
+
+  "magicl" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."magicl" or (x: {}))
+       (import ./quicklisp-to-nix-output/magicl.nix {
+         inherit fetchurl;
+           "abstract-classes" = quicklisp-to-nix-packages."abstract-classes";
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "babel" = quicklisp-to-nix-packages."babel";
+           "cffi" = quicklisp-to-nix-packages."cffi";
+           "cffi-grovel" = quicklisp-to-nix-packages."cffi-grovel";
+           "cffi-libffi" = quicklisp-to-nix-packages."cffi-libffi";
+           "cffi-toolchain" = quicklisp-to-nix-packages."cffi-toolchain";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "global-vars" = quicklisp-to-nix-packages."global-vars";
+           "interface" = quicklisp-to-nix-packages."interface";
+           "policy-cond" = quicklisp-to-nix-packages."policy-cond";
+           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
        }));
 
 

--- a/pkgs/development/lisp-modules/shell.nix
+++ b/pkgs/development/lisp-modules/shell.nix
@@ -5,7 +5,8 @@ self = rec {
   name = "ql-to-nix";
   env = buildEnv { name = name; paths = buildInputs; };
   buildInputs = [
-    gcc stdenv
+    gfortran stdenv
+    pkg-config libffi
     openssl fuse libuv libmysqlclient libfixposix libev sqlite
     freetds
     lispPackages.quicklisp-to-nix lispPackages.quicklisp-to-nix-system-info
@@ -22,6 +23,7 @@ self = rec {
       gobject-introspection
       gtk3
       libev
+      libffi
       libfixposix
       libmysqlclient
       libuv


### PR DESCRIPTION
Help!

This branch attempts to add the Lisp package [MAGICL](https://github.com/quil-lang/magicl) but currently it only compiles and doesn't load.

More specifically, the Nix package for MAGICL builds fine but when it is then loaded into SBCL with REQUIRE then ASDF tries and fails to recompile a Fortran source file. The reason it fails is simply that the package has moved into the read-only Nix store and we can't write to it anymore. The part I don't understand though is, why does ASDF try to compile this file at all, given that the binary output it wants already exists in the store?

If anyone can shed light on this I would be most grateful!

I've spent some time tracing ASDF internals but I'm none the wiser. I don't see any obvious problem in the [magicl.asd](https://github.com/quil-lang/magicl/blob/master/magicl.asd#L130-L187) file definition although I am not an expert.

Here's a transcript showing the load failing to build `libexpokit.so` when it already exists

```
[luke@snowy:~/git/nixpkgs]$ nix-shell --pure -p sbcl lispPackages.magicl --run "common-lisp.sh --eval '(require :magicl)'"
This is SBCL 2.1.9.nixos, an implementation of ANSI Common Lisp.
More information about SBCL is available at <http://www.sbcl.org/>.

SBCL is free software, provided as is, with absolutely no warranty.
It is mostly in the public domain; some portions are provided under
BSD-style licenses.  See the CREDITS and COPYING files in the
distribution for more information.
ASDF could not load magicl because
Subprocess #<UIOP/LAUNCH-PROGRAM::PROCESS-INFO {1003B45EA3}>
 with command ("gfortran" "-fPIC" "-std=legacy" "-c"
               "/nix/store/14h7avnk675ydvjjfy3pppkv6qdbfffx-lisp-magicl-v0.9.1/lib/common-lisp/magicl/expokit/expokit.f"
               "-o"
               "/nix/store/14h7avnk675ydvjjfy3pppkv6qdbfffx-lisp-magicl-v0.9.1/lib/common-lisp/magicl/expokit/expokit.o")
 exited with error code 1.

debugger invoked on a UIOP/RUN-PROGRAM:SUBPROCESS-ERROR in thread
#<THREAD "main thread" RUNNING {1004AC01F3}>:
  Subprocess #<UIOP/LAUNCH-PROGRAM::PROCESS-INFO {1003B45EA3}>
 with command ("gfortran" "-fPIC" "-std=legacy" "-c"
               "/nix/store/14h7avnk675ydvjjfy3pppkv6qdbfffx-lisp-magicl-v0.9.1/lib/common-lisp/magicl/expokit/expokit.f"
               "-o"
               "/nix/store/14h7avnk675ydvjjfy3pppkv6qdbfffx-lisp-magicl-v0.9.1/lib/common-lisp/magicl/expokit/expokit.o")
 exited with error code 1

Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [CONTINUE                     ] IGNORE-ERROR-STATUS
  1: [RETRY                        ] Retry
                                     compiling #<F->SO "magicl/ext-expokit" "expokit" "expokit">.
  2: [ACCEPT                       ] Continue, treating
                                     compiling #<F->SO "magicl/ext-expokit" "expokit" "expokit">
                                     as having been successful.
  3:                                 Retry ASDF operation.
  4: [CLEAR-CONFIGURATION-AND-RETRY] Retry ASDF operation after resetting the
                                     configuration.
  5:                                 Retry ASDF operation.
  6:                                 Retry ASDF operation after resetting the
                                     configuration.
  7:                                 Ignore runtime option --eval "(require :magicl)".
  8: [ABORT                        ] Skip rest of --eval and --load options.
  9:                                 Skip to toplevel READ/EVAL/PRINT loop.
 10: [EXIT                         ] Exit SBCL (calling #'EXIT, killing the process).

(UIOP/RUN-PROGRAM::%CHECK-RESULT 1 :COMMAND ("gfortran" "-fPIC" "-std=legacy" "-c" "/nix/store/14h7avnk675ydvjjfy3pppkv6qdbfffx-lisp-magicl-v0.9.1/lib/common-lisp/magicl/expokit/expokit.f" "-o" "/nix/store/14h7avnk675ydvjjfy3pppkv6qdbfffx-lisp-magicl-v0.9.1/lib/common-lisp/magicl/expokit/expokit.o") :PROCESS #<UIOP/LAUNCH-PROGRAM::PROCESS-INFO {1003B45EA3}> :IGNORE-ERROR-STATUS NIL)
   source: (CERROR "IGNORE-ERROR-STATUS" 'SUBPROCESS-ERROR :COMMAND COMMAND
                   :CODE EXIT-CODE :PROCESS PROCESS)
0] 
; 
; compilation unit aborted
;   caught 1 fatal ERROR condition
* 

# See that the output file already exists
[luke@snowy:~/git/nixpkgs]$ ls /nix/store/14h7avnk675ydvjjfy3pppkv6qdbfffx-lisp-magicl-v0.9.1/lib/common-lisp/magicl/expokit
expokit.f  libexpokit.so  LICENSE-expokit.txt

# Manually run the failing command
[luke@snowy:~/git/nixpkgs]$ nix-shell --pure -p sbcl lispPackages.magicl --run "gfortran -fPIC -std=legacy -c /nix/store/14h7avnk675ydvjjfy3pppkv6qdbfffx-lisp-magicl-v0.9.1/lib/common-lisp/magicl/expokit/expokit.f -o /nix/store/14h7avnk675ydvjjfy3pppkv6qdbfffx-lisp-magicl-v0.9.1/lib/common-lisp/magicl/expokit/expokit.o"
[...]
Assembler messages:
Fatal error: can't create /nix/store/14h7avnk675ydvjjfy3pppkv6qdbfffx-lisp-magicl-v0.9.1/lib/common-lisp/magicl/expokit/expokit.o: Read-only file system
```
