### PR TITLE
kristall: fix build on darwin

### DIFF
--- a/pkgs/applications/networking/browsers/kristall/default.nix
+++ b/pkgs/applications/networking/browsers/kristall/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     sed -i '1i #include <errno.h>' src/browsertab.cpp
   '';
 
-  nativeBuildInputs = [ qmake ];
+  nativeBuildInputs = [ wrapQtAppsHook qmake ];
 
   buildInputs = [ qtmultimedia ];
 

--- a/pkgs/applications/networking/browsers/kristall/default.nix
+++ b/pkgs/applications/networking/browsers/kristall/default.nix
@@ -1,31 +1,44 @@
-{ lib, mkDerivation, fetchFromGitHub, qtbase, qtmultimedia }:
+{ lib, stdenv, mkDerivation, fetchFromGitHub, qmake, qtmultimedia }:
 
 mkDerivation rec {
   pname = "kristall";
   version = "0.3";
+
   src = fetchFromGitHub {
     owner = "MasterQ32";
     repo = "kristall";
-    rev = "V" + version;
+    rev = "V${version}";
     sha256 = "07nf7w6ilzs5g6isnvsmhh4qa1zsprgjyf0zy7rhpx4ikkj8c8zq";
   };
 
-  buildInputs = [ qtbase qtmultimedia ];
+  postPatch = lib.optionalString stdenv.cc.isClang ''
+    sed -i '1i #include <errno.h>' src/browsertab.cpp
+  '';
+
+  nativeBuildInputs = [ qmake ];
+
+  buildInputs = [ qtmultimedia ];
 
   qmakeFlags = [ "src/kristall.pro" ];
 
-  installPhase = ''
+  installPhase = if stdenv.isDarwin then ''
+    mkdir -p $out/Applications
+    mv kristall.app $out/Applications
+  '' else ''
     install -Dt $out/bin kristall
     install -D Kristall.desktop $out/share/applications/net.random-projects.kristall.desktop
+    install -D src/icons/kristall.svg $out/share/icons/hicolor/scalable/apps/net.random-projects.kristall.svg
+    for size in 16 32 64 128; do
+      install -D src/icons/kristall-''${size}.png $out/share/icons/hicolor/''${size}x''${size}/apps/net.random-projects.kristall.png
+    done
   '';
 
-  meta = with lib;
-    src.meta // {
-      description =
-        "Graphical small-internet client, supports gemini, http, https, gopher, finger";
-      homepage = "https://random-projects.net/projects/kristall.gemini";
-      maintainers = with maintainers; [ ehmry ];
-      license = licenses.gpl3;
-      inherit (qtmultimedia.meta) platforms;
-    };
+  meta = with lib; {
+    description =
+      "Graphical small-internet client, supports gemini, http, https, gopher, finger";
+    homepage = "https://random-projects.net/projects/kristall.gemini";
+    maintainers = with maintainers; [ ehmry ];
+    license = licenses.gpl3Only;
+    inherit (qtmultimedia.meta) platforms;
+  };
 }

--- a/pkgs/applications/networking/browsers/kristall/default.nix
+++ b/pkgs/applications/networking/browsers/kristall/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, qmake, qtmultimedia }:
+{ lib, stdenv, fetchFromGitHub, wrapQtAppsHook, qmake, qtmultimedia }:
 
 stdenv.mkDerivation rec {
   pname = "kristall";

--- a/pkgs/applications/networking/browsers/kristall/default.nix
+++ b/pkgs/applications/networking/browsers/kristall/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, mkDerivation, fetchFromGitHub, qmake, qtmultimedia }:
+{ lib, stdenv, fetchFromGitHub, qmake, qtmultimedia }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "kristall";
   version = "0.3";
 


### PR DESCRIPTION
###### Motivation for this change
ZHF: #144627 (@NixOS/nixos-release-managers)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
