### PR TITLE
Fix certificate validation on Fedora/RHEL

### DIFF
--- a/nixos/tests/custom-ca.nix
+++ b/nixos/tests/custom-ca.nix
@@ -82,7 +82,7 @@ in
       # chromium-based browsers refuse to run as root
       test-support.displayManager.auto.user = "alice";
       # browsers may hang with the default memory
-      virtualisation.memorySize = 500;
+      virtualisation.memorySize = 600;
 
       networking.hosts."127.0.0.1" = [ "good.example.com" "bad.example.com" ];
       security.pki.certificateFiles = [ "${example-good-cert}/ca.crt" ];
@@ -162,7 +162,7 @@ in
         browser = command.split()[0]
         with subtest("Good certificate is trusted in " + browser):
             execute_as(
-                "alice", f"env P11_KIT_DEBUG=trust {command} https://good.example.com & >&2"
+                "alice", f"{command} https://good.example.com >&2 &"
             )
             wait_for_window_as("alice", browser)
             machine.wait_for_text("It works!")
@@ -170,9 +170,9 @@ in
             execute_as("alice", "xdotool key ctrl+w")  # close tab
 
         with subtest("Unknown CA is untrusted in " + browser):
-            execute_as("alice", f"{command} https://bad.example.com & >&2")
+            execute_as("alice", f"{command} https://bad.example.com >&2 &")
             machine.wait_for_text(error)
             machine.screenshot("bad" + browser)
-            machine.succeed("pkill " + browser)
+            machine.succeed("pkill -f " + browser)
   '';
 })

--- a/pkgs/development/libraries/gnutls/default.nix
+++ b/pkgs/development/libraries/gnutls/default.nix
@@ -51,8 +51,10 @@ stdenv.mkDerivation rec {
 
   preConfigure = "patchShebangs .";
   configureFlags =
-    lib.optional stdenv.isLinux "--with-default-trust-store-file=/etc/ssl/certs/ca-certificates.crt"
-  ++ [
+    lib.optionals stdenv.isLinux [
+    "--with-default-trust-store-file=/etc/ssl/certs/ca-certificates.crt"
+    "--with-default-trust-store-pkcs11=pkcs11:"
+  ] ++ [
     "--disable-dependency-tracking"
     "--enable-fast-install"
     "--with-unbound-root-key-file=${dns-root-data}/root.key"

--- a/pkgs/development/libraries/p11-kit/default.nix
+++ b/pkgs/development/libraries/p11-kit/default.nix
@@ -31,7 +31,11 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--sysconfdir=/etc"
     "--localstatedir=/var"
-    "--with-trust-paths=/etc/ssl/trust-source:/etc/ssl/certs/ca-certificates.crt"
+    "--with-trust-paths=${lib.concatStringsSep ":" [
+      "/etc/ssl/trust-source"               # p11-kit trust source
+      "/etc/ssl/certs/ca-certificates.crt"  # NixOS + Debian/Ubuntu/Arch/Gentoo...
+      "/etc/pki/tls/certs/ca-bundle.crt"    # Fedora/CentOS
+    ]}"
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

Fix certificate validation on Fedora and RHEL.
Also see this [thread](https://discourse.nixos.org/t/certificate-validation-broken-in-all-electron-chromium-apps-and-browsers/15962/11) and the commit messages.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via `nixosTests.custom-ca` after unlinking `/etc/ssl`.
- [ ] Tested compilation of all packages that depend on this change
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).