### PR TITLE
l2md: unstable-2020-07-31 -> unstable-2021-10-27

### DIFF
--- a/pkgs/tools/text/l2md/default.nix
+++ b/pkgs/tools/text/l2md/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "l2md";
-  version = "unstable-2020-07-31";
+  version = "unstable-2021-10-27";
 
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/linux/kernel/git/dborkman/l2md.git";
-    rev = "2b9fae141fc2129940e0337732a35a3fc1c33455";
-    sha256 = "PNNoD3a+rJwKH6wbOkvVU1IW4+xF7+zQaLFAlyLlYOI=";
+    rev = "9db252bc1716ebaf0abd3a47a59ea78e4e6253d6";
+    sha256 = "sha256-H/leDUwQM55akyXsmTnI2YsnG4i1KQtf4bBt1fizy8E=";
   };
 
   buildInputs = [ libgit2 ];


### PR DESCRIPTION
###### Motivation for this change

ZHF: #144627  (@NixOS/nixos-release-managers)

###### Things done

Update to the [latest revision](https://git.kernel.org/pub/scm/linux/kernel/git/dborkman/l2md.git/commit/?id=9db252bc1716ebaf0abd3a47a59ea78e4e6253d6), which makes the project build on darwin.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
