### PR TITLE
powertop: pull upstream fix for ncurses-6.3

### DIFF
--- a/pkgs/os-specific/linux/powertop/default.nix
+++ b/pkgs/os-specific/linux/powertop/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, gettext, libnl, ncurses, pciutils
+{ lib, stdenv, fetchFromGitHub, fetchpatch, gettext, libnl, ncurses, pciutils
 , pkg-config, zlib, autoreconfHook }:
 
 stdenv.mkDerivation rec {
@@ -11,6 +11,15 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "1zkr2y5nb1nr22nq8a3zli87iyfasfq6489p7h1k428pv8k45w4f";
   };
+
+  patches = [
+    # Pull upstream patch for ncurses-6.3 compatibility
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/fenrus75/powertop/commit/9ef1559a1582f23d599c149601c3a8e06809296c.patch";
+      sha256 = "0qx69f3bwhxgsga9nas8lgrclf1rxvr7fq7fd2n8dv3x4lsb46j1";
+    })
+  ];
 
   outputs = [ "out" "man" ];
 


### PR DESCRIPTION
Without the fix build on ncurses-6.3 fails as:

    lib.cpp:586:24: error: format not a string literal and no format arguments [Werror=format-security]
      586 |         mvprintw(1, 0, notify);
          |                        ^~~~~~
