### PR TITLE
mindustry: unbreak

### DIFF
--- a/pkgs/games/mindustry/default.nix
+++ b/pkgs/games/mindustry/default.nix
@@ -191,8 +191,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.x86_64;
     # Hash mismatch on darwin:
     # https://github.com/NixOS/nixpkgs/pull/105590#issuecomment-737120293
-    broken = stdenv.isDarwin
-    # does not work with any maintained java version (https://github.com/Anuken/Mindustry/issues/5114)
-      || true;
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/games/mindustry/default.nix
+++ b/pkgs/games/mindustry/default.nix
@@ -4,7 +4,7 @@
 , copyDesktopItems
 , fetchFromGitHub
 , gradle_6
-, jdk11
+, jdk
 , perl
 
 # for arc
@@ -87,8 +87,7 @@ let
     popd
   '';
 
-  jdk = jdk11;
-  gradle = (gradle_6.override (old: { java = jdk11; }));
+  gradle = (gradle_6.override (old: { java = jdk; }));
 
   # fake build to pre-download deps into fixed-output derivation
   deps = stdenv.mkDerivation {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30294,6 +30294,7 @@ with pkgs;
   mindustry-wayland = callPackage ../games/mindustry { jdk = adoptopenjdk-hotspot-bin-15; glew = glew-egl; };
 
   mindustry-server = callPackage ../games/mindustry {
+    jdk = adoptopenjdk-hotspot-bin-15;
     enableClient = false;
     enableServer = true;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30290,8 +30290,13 @@ with pkgs;
 
   methane = callPackage ../games/methane { };
 
-  mindustry = callPackage ../games/mindustry { jdk = adoptopenjdk-hotspot-bin-15; };
-  mindustry-wayland = callPackage ../games/mindustry { jdk = adoptopenjdk-hotspot-bin-15; glew = glew-egl; };
+  mindustry = callPackage ../games/mindustry {
+    jdk = adoptopenjdk-hotspot-bin-15;
+  };
+  mindustry-wayland = callPackage ../games/mindustry {
+    jdk = adoptopenjdk-hotspot-bin-15;
+    glew = glew-egl;
+  };
 
   mindustry-server = callPackage ../games/mindustry {
     jdk = adoptopenjdk-hotspot-bin-15;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30290,8 +30290,8 @@ with pkgs;
 
   methane = callPackage ../games/methane { };
 
-  mindustry = callPackage ../games/mindustry { };
-  mindustry-wayland = callPackage ../games/mindustry { glew = glew-egl; };
+  mindustry = callPackage ../games/mindustry { jdk = adoptopenjdk-hotspot-bin-15; };
+  mindustry-wayland = callPackage ../games/mindustry { jdk = adoptopenjdk-hotspot-bin-15; glew = glew-egl; };
 
   mindustry-server = callPackage ../games/mindustry {
     enableClient = false;


### PR DESCRIPTION
###### Motivation for this change

This should fix:
- https://github.com/NixOS/nixpkgs/issues/128929 (but then for 21.11)
- https://github.com/NixOS/nixpkgs/issues/109798.

jdk15 is not supported anymore by oracle / openjdk, but since it's just a game, I don't expect that's a big issue in practice.

I _think_ propagating it like this is the right way to go about it, but please let me know if that seems wrong (and I'd like to hear the proper solution too then). I might have misunderstood how it works, but this seems like a good workaround to me.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
