### PR TITLE
profanity: pull upstream fixes for ncurses-6.3

### DIFF
--- a/pkgs/applications/networking/instant-messengers/profanity/default.nix
+++ b/pkgs/applications/networking/instant-messengers/profanity/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , autoconf-archive
 , autoreconfHook
 , cmocka
@@ -46,6 +47,23 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./patches/packages-osx.patch
+
+    # pullupstream fixes for ncurses-6.3
+    (fetchpatch {
+      name = "ncurses-6.3-p1.patch";
+      url = "https://github.com/profanity-im/profanity/commit/e5b6258c997d4faf36e2ffb8a47b386c5629b4eb.patch";
+      sha256 = "sha256-4rwpvsgfIQ60GcLS0O7Hyn7ZidREjYT+dVND54z0zrw=";
+    })
+    (fetchpatch {
+      name = "ncurses-6.3-p2.patch";
+      url = "https://github.com/profanity-im/profanity/commit/fd9ccec8dc604902bbb1d444dba4223ccee0a092.patch";
+      sha256 = "sha256-4gZaXoDNulBIR+e6y/9bJKXVactCHWS8H8lPJaJwVwE=";
+    })
+    (fetchpatch {
+      name = "ncurses-6.3-p3.patch";
+      url = "https://github.com/profanity-im/profanity/commit/242696f09a49c8446ba6aef8bdad65fb58a77715.patch";
+      sha256 = "sha256-BOYHkae9aIA7HaVM23Yu25TTK9e3SuV+u0FEi7Sn62I=";
+    })
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Without the patches the build will fail on ncurses-6.3 as:

    src/ui/statusbar.c:500:9: error: format not a string literal and no format arguments [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat-security-Werror=format-security8;;]
      500 |         mvwprintw(statusbar_win, 0, pos, statusbar->fulljid);
          |         ^~~~~~~~~
