### PR TITLE
sngrep: pull upstream fix for ncurses-6.3

### DIFF
--- a/pkgs/applications/networking/sniffers/sngrep/default.nix
+++ b/pkgs/applications/networking/sniffers/sngrep/default.nix
@@ -3,6 +3,7 @@
 , autoconf
 , automake
 , fetchFromGitHub
+, fetchpatch
 , libpcap
 , ncurses
 , openssl
@@ -19,6 +20,16 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-92wPRDFSoIOYFv3XKdsuYH8j3D8kXyg++q6VpIIMGDg=";
   };
+
+  patches = [
+    # Pull fix pending upstream inclusion for ncurses-6.3 support:
+    #  https://github.com/irontec/sngrep/pull/382
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/irontec/sngrep/commit/d09e1c323dbd7fc899e8985899baec568f045601.patch";
+      sha256 = "sha256-nY5i3WQh/oKboEAh4wvxF5Imf2BHYEKdFj+WF1M3SSA=";
+    })
+  ];
 
   nativeBuildInputs = [
     autoconf


### PR DESCRIPTION
Without the fix build on ncurses-6.3 fails as:

    curses/ui_msg_diff.c: In function 'msg_diff_draw_message':
    curses/ui_msg_diff.c:190:5: error: format not a string literal and no format arguments [-Werror=format-security]
      190 |     mvwprintw(win, 0, 0, sip_get_msg_header(msg, header));
          |     ^~~~~~~~~
