### PR TITLE
openssh: add patch from debian to display ssh-keygen command when hos…

### DIFF
--- a/pkgs/tools/networking/openssh/common.nix
+++ b/pkgs/tools/networking/openssh/common.nix
@@ -42,6 +42,11 @@ stdenv.mkDerivation rec {
       url = "https://salsa.debian.org/ssh-team/openssh/-/raw/debian/1%258.7p1-2/debian/patches/mention-ssh-keygen-on-keychange.patch";
       sha256 = "sha256-K2IPgh2cGmZU3+bXFHgueBTw2SFtUFrdWKv7MJ5+ltc=";
     })
+    # improve scp filenames with spaces in verbose
+    (fetchpatch {
+      url = "https://salsa.debian.org/ssh-team/openssh/-/raw/debian/1%258.7p1-2/debian/patches/scp-quoting.patch";
+      sha256 = "sha256-oMHG9ELMQa+agA937QJKvj1HAkjmFaPMbxfRO34u09U=";
+    })
   ] ++ extraPatches;
 
   postPatch =

--- a/pkgs/tools/networking/openssh/common.nix
+++ b/pkgs/tools/networking/openssh/common.nix
@@ -36,6 +36,12 @@ stdenv.mkDerivation rec {
 
     # See discussion in https://github.com/NixOS/nixpkgs/pull/16966
     ./dont_create_privsep_path.patch
+
+    # display ssh-keygen command to remove offending entry from known-host when ssh host key changed
+    (fetchpatch {
+      url = "https://salsa.debian.org/ssh-team/openssh/-/raw/debian/1%258.7p1-2/debian/patches/mention-ssh-keygen-on-keychange.patch";
+      sha256 = "sha256-K2IPgh2cGmZU3+bXFHgueBTw2SFtUFrdWKv7MJ5+ltc=";
+    })
   ] ++ extraPatches;
 
   postPatch =


### PR DESCRIPTION
…tkey changed

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I want this message

```
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!
Someone could be eavesdropping on you right now (man-in-the-middle attack)!
It is also possible that a host key has just been changed.
The fingerprint for the ED25519 key sent by the remote host is
SHA256:.........
Please contact your system administrator.
Add correct host key in /home/user/.ssh/known_hosts to get rid of this message.
Offending ED25519 key in /home/user/.ssh/known_hosts:1
remove with:
ssh-keygen -f "/home/user/.ssh/known_hosts" -R "host"
Host key for magnesium has changed and you have requested strict checking.
Host key verification failed.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
