### PR TITLE
fetchPypi -> fetchFromPyPI

### DIFF
--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -40,6 +40,7 @@ with pkgs;
               isPy27 isPy35 isPy36 isPy37 isPy38 isPy39 isPy310 isPy3k isPyPy pythonAtLeast pythonOlder
               python bootstrapped-pip buildPythonPackage buildPythonApplication
               fetchPypi
+              fetchFromPyPI
               hasPythonModule requiredPythonModules makePythonPath disabledIf
               toPythonModule toPythonApplication
               buildSetupcfg

--- a/pkgs/development/interpreters/python/fetchfrompypi.nix
+++ b/pkgs/development/interpreters/python/fetchfrompypi.nix
@@ -1,4 +1,4 @@
-# `fetchPypi` function for fetching artifacts from PyPI.
+# `fetchFromPyPI` function for fetching artifacts from PyPI.
 { fetchurl
 , makeOverridable
 }:

--- a/pkgs/development/interpreters/python/update-python-libraries/update-python-libraries.py
+++ b/pkgs/development/interpreters/python/update-python-libraries/update-python-libraries.py
@@ -232,6 +232,7 @@ def _get_latest_version_github(package, extension, current_version, target):
 
 FETCHERS = {
     'fetchFromGitHub'   :   _get_latest_version_github,
+    'fetchFromPyPI'     :   _get_latest_version_pypi,
     'fetchPypi'         :   _get_latest_version_pypi,
     'fetchurl'          :   _get_latest_version_pypi,
 }
@@ -263,11 +264,11 @@ def _determine_extension(text, fetcher):
     """Determine what extension is used in the expression.
 
     If we use:
-    - fetchPypi, we check if format is specified.
+    - fetchFromPyPI or fetchPypi, we check if format is specified.
     - fetchurl, we determine the extension from the url.
     - fetchFromGitHub we simply use `.tar.gz`.
     """
-    if fetcher == 'fetchPypi':
+    if fetcher == 'fetchFromPyPI' or fetcher == 'fetchPypi' :
         try:
             src_format = _get_unique_value('format', text)
         except ValueError as e:

--- a/pkgs/development/python-modules/3to2/default.nix
+++ b/pkgs/development/python-modules/3to2/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromPyPI
 , pytest
 }:
 
@@ -8,7 +8,7 @@ buildPythonPackage rec {
   pname = "py3to2";
   version = "1.1.1";
 
-  src = fetchPypi {
+  src = fetchFromPyPI {
     inherit version;
     pname = "3to2";
     extension = "zip";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -56,7 +56,8 @@ let
   # See build-setupcfg/default.nix for documentation.
   buildSetupcfg = import ../build-support/build-setupcfg self;
 
-  fetchPypi = callPackage ../development/interpreters/python/fetchpypi.nix { };
+  fetchPypi = fetchFromPyPI;
+  fetchFromPyPI = callPackage ../development/interpreters/python/fetchfrompypi.nix { };
 
   # Check whether a derivation provides a Python module.
   hasPythonModule = drv: drv?pythonModule && drv.pythonModule == python;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Since the Python Package Index works as a package index, it is more intuitive to
call the function that fetches packages from it `fetchFromPyPI`, following the
unwritten rule for sources obtained from a "repository" like fetchFrom{GitHub,
Gitlab, Bitbucket, ...}

For now, this commit will act as a placeholder for the new fetchFromPyPI
function, while the old one will act as a safe alias.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
