### PR TITLE
yambar: build with dual support, both wayland and x11

### DIFF
--- a/pkgs/applications/misc/yambar/default.nix
+++ b/pkgs/applications/misc/yambar/default.nix
@@ -18,6 +18,7 @@
 , wayland-protocols
 , waylandSupport ? false
 # Xorg backend
+, x11Support ? true
 , libxcb
 , xcbutil
 , xcbutilcursor
@@ -61,7 +62,7 @@ stdenv.mkDerivation rec {
     udev
     wayland
     wayland-protocols
-  ] ++ lib.optionals (!waylandSupport) [
+  ] ++ lib.optionals (x11Support) [
     xcbutil
     xcbutilcursor
     xcbutilerrors
@@ -71,7 +72,7 @@ stdenv.mkDerivation rec {
   mesonBuildType = "release";
 
   mesonFlags = [
-    (mesonFeatureFlag "backend-x11" (!waylandSupport))
+    (mesonFeatureFlag "backend-x11" (x11Support))
     (mesonFeatureFlag "backend-wayland" waylandSupport)
   ];
 

--- a/pkgs/applications/misc/yambar/default.nix
+++ b/pkgs/applications/misc/yambar/default.nix
@@ -1,5 +1,5 @@
-{ stdenv
-, lib
+{ lib
+, stdenv
 , fetchFromGitea
 , alsa-lib
 , fcft

--- a/pkgs/applications/misc/yambar/default.nix
+++ b/pkgs/applications/misc/yambar/default.nix
@@ -16,7 +16,7 @@
 , wayland
 , wayland-scanner
 , wayland-protocols
-, waylandSupport ? false
+, waylandSupport ? true
 # Xorg backend
 , x11Support ? true
 , libxcb
@@ -60,6 +60,7 @@ stdenv.mkDerivation rec {
     pixman
     tllist
     udev
+  ] ++ lib.optionals (waylandSupport) [
     wayland
     wayland-protocols
   ] ++ lib.optionals (x11Support) [

--- a/pkgs/applications/misc/yambar/default.nix
+++ b/pkgs/applications/misc/yambar/default.nix
@@ -1,36 +1,34 @@
 { stdenv
 , lib
 , fetchFromGitea
-, pkg-config
-, meson
-, ninja
-, scdoc
 , alsa-lib
 , fcft
 , json_c
 , libmpdclient
+, libxcb
 , libyaml
+, meson
+, ninja
 , pixman
+, pkg-config
+, scdoc
 , tllist
 , udev
 , wayland
-, wayland-scanner
 , wayland-protocols
-, waylandSupport ? true
-# Xorg backend
-, x11Support ? true
-, libxcb
+, wayland-scanner
 , xcbutil
 , xcbutilcursor
 , xcbutilerrors
 , xcbutilwm
+, waylandSupport ? true
+, x11Support ? true
 }:
 
 let
-  # Courtesy of sternenseemann and FRidh, commit c9a7fdfcfb420be8e0179214d0d91a34f5974c54
+  # Courtesy of sternenseemann and FRidh
   mesonFeatureFlag = opt: b: "-D${opt}=${if b then "enabled" else "disabled"}";
 in
-
 stdenv.mkDerivation rec {
   pname = "yambar";
   version = "1.7.0";
@@ -73,7 +71,7 @@ stdenv.mkDerivation rec {
   mesonBuildType = "release";
 
   mesonFlags = [
-    (mesonFeatureFlag "backend-x11" (x11Support))
+    (mesonFeatureFlag "backend-x11" x11Support)
     (mesonFeatureFlag "backend-wayland" waylandSupport)
   ];
 
@@ -86,9 +84,9 @@ stdenv.mkDerivation rec {
       X11 and Wayland, that goes to great lengths to be both CPU and battery
       efficient - polling is only done when absolutely necessary.
 
-      It has a number of modules that provide information in the form of
-      tags. For example, the clock module has a date tag that contains the
-      current date.
+      It has a number of modules that provide information in the form of tags.
+      For example, the clock module has a date tag that contains the current
+      date.
 
       The modules do not know how to present the information though. This is
       instead done by particles. And the user, you, decides which particles (and

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26985,9 +26985,7 @@ with pkgs;
     i3GapsSupport = false;
   };
 
-  yambar = callPackage ../applications/misc/yambar { x11Support = true; waylandSupport = false; };
-
-  yambar-wayland = callPackage ../applications/misc/yambar { x11Support = false; waylandSupport = true; };
+  yambar = callPackage ../applications/misc/yambar { x11Support = true; waylandSupport = true; };
 
   polyphone = libsForQt514.callPackage ../applications/audio/polyphone { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26985,7 +26985,7 @@ with pkgs;
     i3GapsSupport = false;
   };
 
-  yambar = callPackage ../applications/misc/yambar { x11Support = true; waylandSupport = true; };
+  yambar = callPackage ../applications/misc/yambar { };
 
   polyphone = libsForQt514.callPackage ../applications/audio/polyphone { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26985,9 +26985,9 @@ with pkgs;
     i3GapsSupport = false;
   };
 
-  yambar = callPackage ../applications/misc/yambar { };
+  yambar = callPackage ../applications/misc/yambar { x11Support = true; waylandSupport = false; };
 
-  yambar-wayland = callPackage ../applications/misc/yambar { waylandSupport = true; };
+  yambar-wayland = callPackage ../applications/misc/yambar { x11Support = false; waylandSupport = true; };
 
   polyphone = libsForQt514.callPackage ../applications/audio/polyphone { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The current nix derivation for yambar compiled it with X11 support only, although you could change a flag and get wayland support only. I have modified it so you can have both X11 and wayland support by default.

###### Things done

Note: I tested the change by using yambar with sway+wayland, xmonad+x11, and river+wayland.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
