### PR TITLE
pantheon.wingpanel-indicator-sound: 6.0.0 -> 6.0.1

### DIFF
--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/sound/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/sound/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
-, fetchpatch
 , nix-update-script
 , pantheon
 , pkg-config
@@ -20,29 +20,14 @@
 
 stdenv.mkDerivation rec {
   pname = "wingpanel-indicator-sound";
-  version = "6.0.0";
+  version = "6.0.1";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "0cv97c0qrhqisyghy9a9qr4ffcx3g4bkswxm6rn4r2wfg4gvljri";
+    sha256 = "sha256-FHZ4YhGLqGTz5Po2XFJvnWuAi1eHKcT9zzgJFHic02E=";
   };
-
-  patches = [
-    # Upstream code not respecting our localedir
-    # https://github.com/elementary/wingpanel-indicator-sound/pull/216
-    (fetchpatch {
-      url = "https://github.com/elementary/wingpanel-indicator-sound/commit/df816104c15e4322c1077313b1f43114cdaf710e.patch";
-      sha256 = "029z7l467jz1ymxwrzrf874062r6xmskl7mldpq39jh110fijy5l";
-    })
-    # Fix build with vala 0.54
-    # https://github.com/elementary/wingpanel-indicator-sound/pull/221
-    (fetchpatch {
-      url = "https://github.com/elementary/wingpanel-indicator-sound/commit/398d181eabe3dd803dc0ba335ac629902ec5b5ab.patch";
-      sha256 = "1r2x3n6ws56jk7xcgk60am8mc5dgf8pz5ipsydxvmlrmipkjxyqi";
-    })
-  ];
 
   nativeBuildInputs = [
     libxml2


### PR DESCRIPTION
###### Motivation for this change

Part of Pantheon **6.0.4** updates.

For upcoming package update, please check https://github.com/orgs/elementary/projects/90#column-16673367

---

### About the backport workflow for 6.0.4 and 6.1

21.11 branch off is expected to happen before Pantheon 6.0.4 release cycle finishes. As mentioned in the [21.11 feature freeze](https://github.com/NixOS/nixpkgs/issues/140168#issuecomment-932658416) issue, I will start backporting changes to 21.11 as soon as branch off is done (so this PR does not need a backport obviously).

#### What I backport

I WILL backport Pantheon updates that fits [criteria for backporting changes](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#criteria-for-backporting-changes) before elementary shift their focus to Pantheon 7.

I WILL NOT backport updates for the following [unless necessary]:

- Pantheon updates that introduces breaking changes and/or critical bugs and/or major regressions.
- `gnome-settings-daemon` and `mutter` shipped by Pantheon
- upstream (GNOME) updates for `epiphany`, `file-roller`, `evince` [I WILL backport downstream (elementary) patch updates when possible]
- other non-Pantheon package updates

If you need a backport for these packages, please read the changes and test the update yourself when sending a PR, and make sure it fits criteria for backporting changes.

#### Why I backport

Seems that Pantheon is the only desktop in NixOS that backport feature updates so I add this section.

- (Most importantly) Fits [criteria for backporting changes](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#criteria-for-backporting-changes)
- The number of rebuild is very very small and it is easy to rebuild my system to test the change.
- Pantheon has feature updates every month which are also delivered to elementary OS 6 users.
- We already offered backports when NixOS 20.03 and 20.09 was stable release (not in 21.05 because Pantheon 6 is a major update).

#### How I backport

Updates on `master` is done daily as I live on nixos-unstable and testing something is easy. The PR will be titled as `pkg-name: from -> to` for single package updates or `Pantheon updates yyyy-mm-dd` for multiple packages updates. Unless major concerns are raised all PRs are expected to be tested and merged before I open the next PR.

Updates on `release-21.11` will be done monthly. When a release cycle (elementary) finishes, I will open a `[21.11] Pantheon 6.x.y` PR for all updates in the release cycle. The PR is expected to be tested and merged before the next elementary release cycle starts.

All untested PRs will be marked as draft.

#### Support for stable release

We do provide support for stable release. But due to current manpower, support on both stable release and unstable release is limited.

---

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).