### PR TITLE
retroarch: 1.9.2 -> 1.9.13.2

### DIFF
--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -435,6 +435,8 @@ in
       mkdir -p 3rdparty/genie/build/gmake.linux/obj/Release/src/host/lua-5.3.0/src
     '';
     makefile = "Makefile.libretro";
+
+    enableParallelBuilding = true;
   };
 
   mame2000 = mkLibRetroCore {
@@ -474,6 +476,7 @@ in
     extraNativeBuildInputs = [ python27 ];
     extraBuildInputs = [ alsa-lib ];
     makefile = "Makefile";
+    enableParallelBuilding = true;
   };
 
   mame2016 = mkLibRetroCore {
@@ -494,6 +497,7 @@ in
       # make -C 3rdparty/genie/build/gmake.linux -f genie.make obj/Release/src/host/lua-5.3.0/src/lgc.o
       mkdir -p 3rdparty/genie/build/gmake.linux/obj/Release/src/host/lua-5.3.0/src
     '';
+    enableParallelBuilding = true;
   };
 
   mesen = mkLibRetroCore {

--- a/pkgs/misc/emulators/retroarch/default.nix
+++ b/pkgs/misc/emulators/retroarch/default.nix
@@ -1,53 +1,101 @@
-{ lib, stdenv, fetchFromGitHub, which, pkg-config, makeWrapper
-, ffmpeg, libGLU, libGL, freetype, libxml2, python3
-, libobjc, AppKit, Foundation
-, alsa-lib ? null
-, libdrm ? null
-, libpulseaudio ? null
-, libv4l ? null
-, libX11 ? null
-, libXdmcp ? null
-, libXext ? null
-, libXxf86vm ? null
-, mesa ? null
-, SDL2 ? null
-, udev ? null
-, enableNvidiaCgToolkit ? false, nvidia_cg_toolkit ? null
-, withVulkan ? stdenv.isLinux, vulkan-loader ? null
-, wayland
+{ lib
+, stdenv
+, enableNvidiaCgToolkit ? false
+, withVulkan ? stdenv.isLinux
+, alsa-lib
+, AppKit
+, fetchFromGitHub
+, ffmpeg
+, Foundation
+, freetype
+, libdrm
+, libGL
+, libGLU
+, libobjc
+, libpulseaudio
+, libv4l
+, libX11
+, libXdmcp
+, libXext
 , libxkbcommon
+, libxml2
+, libXxf86vm
+, makeWrapper
+, mesa
+, nvidia_cg_toolkit
+, pkg-config
+, python3
+, SDL2
+, substituteAll
+, udev
+, vulkan-loader
+, wayland
+, which
 }:
 
 with lib;
 
+let
+  libretroSuperSrc = fetchFromGitHub {
+    owner = "libretro";
+    repo = "libretro-super";
+    sha256 = "sha256-4WB6/1DDec+smhMJKLCxWb4+LQlZN8v2ik69saKixkE=";
+    # Update it when cores is updated
+    rev = "fa70d9843838df719623094965bd447e4db0d1b4";
+  };
+in
 stdenv.mkDerivation rec {
   pname = "retroarch-bare";
-  # FIXME: retroarch >=1.9.3 doesn't load the cores
-  version = "1.9.2";
+  version = "1.9.13.2";
 
   src = fetchFromGitHub {
     owner = "libretro";
     repo = "RetroArch";
-    sha256 = "sha256-Dwv0hl+d99FbVMG4KnkjO1aYfAw0m4x+zvrbyb/wOX8=";
+    sha256 = "sha256-fehHchn+o9QM2wIK6zYamnbFvQda32Gw0rJk8Orx00U=";
     rev = "v${version}";
   };
 
-  nativeBuildInputs = [ pkg-config wayland ]
-                      ++ optional withVulkan makeWrapper;
+  patches = [
+    ./disable-core-updater.patch
+    ./fix-paths.patch
+  ];
 
-  buildInputs = [ ffmpeg freetype libxml2 libGLU libGL python3 SDL2 which ]
-                ++ optional enableNvidiaCgToolkit nvidia_cg_toolkit
-                ++ optional withVulkan vulkan-loader
-                ++ optionals stdenv.isDarwin [ libobjc AppKit Foundation ]
-                ++ optionals stdenv.isLinux [ alsa-lib libdrm libpulseaudio libv4l libX11
-                                              libXdmcp libXext libXxf86vm mesa udev
-                                              wayland libxkbcommon ];
+  postPatch = ''
+    substituteInPlace configuration.c \
+      --replace "@libretro_directory@" "$out/lib" \
+      --replace "@libretro_info_path@" "$out/share/libretro/info" \
+  '';
+
+  nativeBuildInputs = [ pkg-config wayland ] ++
+    optional withVulkan makeWrapper;
+
+  buildInputs = [ ffmpeg freetype libxml2 libGLU libGL python3 SDL2 which ] ++
+    optional enableNvidiaCgToolkit nvidia_cg_toolkit ++
+    optional withVulkan vulkan-loader ++
+    optionals stdenv.isDarwin [ libobjc AppKit Foundation ] ++
+    optionals stdenv.isLinux [
+      alsa-lib
+      libdrm
+      libpulseaudio
+      libv4l
+      libX11
+      libXdmcp
+      libXext
+      libXxf86vm
+      mesa
+      udev
+      wayland
+      libxkbcommon
+    ];
 
   enableParallelBuilding = true;
 
   configureFlags = lib.optionals stdenv.isLinux [ "--enable-kms" "--enable-egl" ];
 
   postInstall = optionalString withVulkan ''
+    mkdir -p $out/share/libretro/info
+    # TODO: ideally each core should have its own core information
+    cp -r ${libretroSuperSrc}/dist/info/* $out/share/libretro/info
     wrapProgram $out/bin/retroarch --prefix LD_LIBRARY_PATH ':' ${vulkan-loader}/lib
   '';
 

--- a/pkgs/misc/emulators/retroarch/disable-core-updater.patch
+++ b/pkgs/misc/emulators/retroarch/disable-core-updater.patch
@@ -1,0 +1,13 @@
+diff --git a/retroarch.cfg b/retroarch.cfg
+index cdcb199c9f..ab72f3920f 100644
+--- a/retroarch.cfg
++++ b/retroarch.cfg
+@@ -681,7 +681,7 @@
+ # menu_show_online_updater = true
+ 
+ # If disabled, will hide the ability to update cores (and core info files) inside the menu.
+-# menu_show_core_updater = true
++menu_show_core_updater = false
+ 
+ # If disabled, the libretro core will keep running in the background when we
+ # are in the menu.

--- a/pkgs/misc/emulators/retroarch/fix-paths.patch
+++ b/pkgs/misc/emulators/retroarch/fix-paths.patch
@@ -1,0 +1,19 @@
+diff --git a/configuration.c b/configuration.c
+index e6a3841324..5c6027dcea 100644
+--- a/configuration.c
++++ b/configuration.c
+@@ -2919,6 +2919,14 @@ void config_load(void *data)
+ #ifdef HAVE_CONFIGFILE
+    config_parse_file(global);
+ #endif
++   // Ignore config paths and use the values from /nix/store instead
++   settings_t *settings = config_st;
++   fill_pathname_expand_special(settings->paths.directory_libretro,
++         "@libretro_directory@",
++         sizeof(settings->paths.directory_libretro));
++   fill_pathname_expand_special(settings->paths.path_libretro_info,
++         "@libretro_info_path@",
++         sizeof(settings->paths.path_libretro_info));
+ }
+ 
+ #ifdef HAVE_CONFIGFILE


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR finally bumps retroarch to the latest version.

The issue of non-working cores on newer versions of RetroArch was caused by the missing core metadata that is available on [libretro/libretro-super](https://github.com/libretro/libretro-super) repo. This also allows RetroArch to works properly, for example there is no need to load a core before loading a content: RetroArch knows each emulator to load depending on the
available emulators and the file extension.

However, there were one issue (already presented on master) that if the config file was created only on the first run RetroArch. Subsequent runs could have out-of-date paths. Not a huge issue since if the path is invalid RetroArch will go back to its defaults, but the inclusion of metadata would make this issue worse since anyone that ever run RetroArch once will have an unworking RetroArch, unless they fixed their config to point to `libretro_info_path` to the correct path.

This commit also fixes it by ignoring the `libretro_directory` and `libretro_info_path` configuration, and just hard-coding it to the path on the `/nix/store`.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
