### PR TITLE
retroarch: 1.9.2 -> 1.9.13.2

### DIFF
--- a/pkgs/misc/emulators/retroarch/fix-config.patch
+++ b/pkgs/misc/emulators/retroarch/fix-config.patch
@@ -1,0 +1,26 @@
+diff --git a/retroarch.cfg b/retroarch.cfg
+index cdcb199c9f..08b9b1cf10 100644
+--- a/retroarch.cfg
++++ b/retroarch.cfg
+@@ -681,7 +681,7 @@
+ # menu_show_online_updater = true
+ 
+ # If disabled, will hide the ability to update cores (and core info files) inside the menu.
+-# menu_show_core_updater = true
++menu_show_core_updater = false
+ 
+ # If disabled, the libretro core will keep running in the background when we
+ # are in the menu.
+@@ -823,10 +823,10 @@
+ # rgui_browser_directory =
+ 
+ # Core directory for libretro core implementations.
+-# libretro_directory =
++libretro_directory = @libretro_directory@
+ 
+ # Core info directory for libretro core information.
+-# libretro_info_path =
++libretro_info_path = @libretro_info_path@
+ 
+ # Path to content database directory.
+ # content_database_path =


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The issue of non-working cores on newer versions of RetroArch was caused by the missing core metadata that is available on [libretro/libretro-super](https://github.com/libretro/libretro-super) repo. This PR includes them, fixing the issue and also allows RetroArch to works properly. For example there is no need to load a core before loading a content: RetroArch knows each emulator to load depending on the available emulators and the file extension.

To load the metadata from `/nix/store`, we need to patch the `retroarch.cfg`. Sadly this file is only updated when needed, for example, it will update if the path that it is pointing doesn't exist anymore. However, before this PR it pointed to a file located in the HOME directory, so if someone used RetroArch before they will probably have issues while loading the file.

I tried to patch the configuration loader directly but the code is kinda messy and this seems very prone to breakage (while the `retroarch.cfg` file seems an stable interface). One better solution will probably be the introduction of a module that can generate `retroarch.cfg` file (since retroarch supports loading a config from `/etc/retroarch.cfg`).

But this will come in a future PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
