### PR TITLE
mesa: move llvmPackages to depsHostHost

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21808,7 +21808,6 @@ with pkgs;
   libGLU = mesa_glu;
 
   mesa = callPackage ../development/libraries/mesa {
-    llvmPackages = llvmPackages_latest;
     inherit (darwin.apple_sdk.frameworks) OpenGL;
     inherit (darwin.apple_sdk.libs) Xplugin;
   };


### PR DESCRIPTION
###### Motivation for this change

Mesa use LLVM for OpenCL, which is both running on and targeting hostPlatform, thus depsHostHost.

Consider nix-shell with crossSystem for cross platform development, and have some GUI nativeBuildInputs using mesa. These programs are expected to run on buildPlatform, and shouldn't depend on crossSystem, which is buildPackages.mesa's targetPlatform.

I discovered the issue when I put `qemu` in `nativeBuildInputs` of `shell.nix` for cross platform development. And it tries to rebuild `qemu` (build = host = x86_64, target = aarch64) with some aarch64 packages, which is incorrect. Since QEMU's host is x86_64 and it is running on x86_64 to simulate aarch64. No aarch64 artifacts is needed for QEMU and/or its dependency `mesa`.

This PR causes no rebuild for native or cross build. It only makes `pkgsCross.*.buildPackages.mesa == mesa` and `pkgsCross.*.some-pkg == some-pkg` where `some-pkg` relies on `mesa` but doesn't depend on targetPlatform, ~like `qemu`~. Unfortunately recent changes of `qemu` makes it still not target-agnostic, but that are future issues. 

cc: @Mindavi @sbruder  @primeos @vcunat

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
