### PR TITLE
python3Packages.roombapy: 1.6.3 -> 1.6.4

### DIFF
--- a/pkgs/development/python-modules/roombapy/default.nix
+++ b/pkgs/development/python-modules/roombapy/default.nix
@@ -11,20 +11,25 @@
 
 buildPythonPackage rec {
   pname = "roombapy";
-  version = "1.6.3";
+  version = "1.6.4";
   format = "pyproject";
+
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "pschmitt";
     repo = "roombapy";
     rev = version;
-    sha256 = "sha256-GkDfIC2jx4Mpguk/Wu45pZw0czhabJwTz58WYSLCOV8=";
+    sha256 = "sha256-EN+em+lULAUplXlhcU409ZVPk9BfMmD2oNwO0ETuqoA=";
   };
 
-  nativeBuildInputs = [ poetry-core ];
+  nativeBuildInputs = [
+    poetry-core
+  ];
 
-  propagatedBuildInputs = [ paho-mqtt ];
+  propagatedBuildInputs = [
+    paho-mqtt
+  ];
 
   checkInputs = [
     amqtt
@@ -37,12 +42,19 @@ buildPythonPackage rec {
     "tests/test_discovery.py"
   ];
 
-  pythonImportsCheck = [ "roombapy" ];
+  disabledTests = [
+    # Test want to connect to a local MQTT broker
+    "test_roomba_connect"
+  ];
+
+  pythonImportsCheck = [
+    "roombapy"
+  ];
 
   meta = with lib; {
-    homepage = "https://github.com/pschmitt/roombapy";
     description = "Python program and library to control Wi-Fi enabled iRobot Roombas";
-    maintainers = with maintainers; [ justinas ];
+    homepage = "https://github.com/pschmitt/roombapy";
     license = licenses.mit;
+    maintainers = with maintainers; [ justinas ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.6.4

Change log: https://github.com/pschmitt/roombapy/releases/tag/1.6.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
