### PR TITLE
trafficserver: pull upstream fix for ncurses-6.3

### DIFF
--- a/pkgs/servers/http/trafficserver/default.nix
+++ b/pkgs/servers/http/trafficserver/default.nix
@@ -63,6 +63,13 @@ stdenv.mkDerivation rec {
       url = "https://github.com/apache/trafficserver/commit/19d3af481cf74c91fbf713fc9d2f8b138ed5fbaf.diff";
       sha256 = "0z1ikgpp00rzrrcqh97931586yn9wbksgai9xlkcjd5cg8gq0150";
     })
+
+    # Fix build against ncurses-6.3:
+    #  https://github.com/apache/trafficserver/pull/8437
+    (fetchpatch {
+      url = "https://github.com/apache/trafficserver/commit/66c86c6b082903a92b9db33c60e3ed947e77d540.patch";
+      sha256 = "1hgpp80xnnjr4k5i6gcllrb7dw4q4xcdrkwxpc1xk2np5cbyxd16";
+    })
   ];
 
   # NOTE: The upstream README indicates that flex is needed for some features,


### PR DESCRIPTION
Without this change the build fails on ncurses-6.3 as:

    traffic_top/traffic_top.cc:146:13:
        error: format not a string literal and no format arguments [-Werror=format-security]
      146 |     mvprintw(my_y, x, prettyName.c_str());
          |     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
