### PR TITLE
vimpc: pull pending upstream inclusion fix for ncurses-6.3

### DIFF
--- a/pkgs/applications/audio/vimpc/default.nix
+++ b/pkgs/applications/audio/vimpc/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , autoreconfHook
 , libmpdclient
 , ncurses
@@ -20,6 +21,16 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "0lswzkap2nm7v5h7ppb6a64cb35rajysd09nb204rxgrkij4m6nx";
   };
+
+  patches = [
+    # Pull fix pending upstream inclusion for ncurses-6.3:
+    #  https://github.com/boysetsfrog/vimpc/pull/100
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/boysetsfrog/vimpc/commit/055ecdce0720fdfc9ec2528c520b6c33da36271b.patch";
+      sha256 = "01p858jjxm0bf8hnk1z8h45j8c1y9i995mafa6ff3vg9vlak61pv";
+    })
+  ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ libmpdclient ncurses pcre taglib curl ];


### PR DESCRIPTION
Without the fix build on ncurses-6.3 fails as:

    src/window/listwindow.cpp:120:16:
      error: format not a string literal and no format arguments [-Werror=format-security]
      120 |       mvwprintw(window, line, 0, BlankLine.c_str());
          |       ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
