### PR TITLE
wiimms-iso-tools: pull pending upstream inclusion fix for ncurses-6.3

### DIFF
--- a/pkgs/tools/filesystems/wiimms-iso-tools/default.nix
+++ b/pkgs/tools/filesystems/wiimms-iso-tools/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchurl, zlib, ncurses, fuse}:
+{lib, stdenv, fetchurl, fetchpatch, zlib, ncurses, fuse}:
 
 stdenv.mkDerivation rec {
   name = "wiimms-iso-tools";
@@ -11,7 +11,19 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ zlib ncurses fuse ];
 
-  patches = [ ./fix-paths.diff ];
+  patches = [
+    ./fix-paths.diff
+
+    # Pull pending upstream fix for ncurses-6.3:
+    #  https://github.com/Wiimm/wiimms-iso-tools/pull/14
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/Wiimm/wiimms-iso-tools/commit/3f1e84ec6915cc4f658092d33411985bd3eaf4e6.patch";
+      sha256 = "18cfri4y1082phg6fzh402gk5ri24wr8ff4zl8v5rlgjndh610im";
+      stripLen = 1;
+    })
+  ];
+
   postPatch = ''
     patchShebangs setup.sh
     patchShebangs gen-template.sh


### PR DESCRIPTION
Without the fix build on ncurses-6.3 fails as:

    src/lib-std.c:3623:32: error: format not a string literal and no format arguments [-Werror=format-security]
     3623 |             ERROR0(ERR_WARNING,errmsg);
          |                                ^~~~~~
