### PR TITLE
nheko: 0.8.2 -> 0.9.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/nheko/default.nix
+++ b/pkgs/applications/networking/instant-messengers/nheko/default.nix
@@ -21,6 +21,9 @@
 , olm
 , pkg-config
 , nlohmann_json
+, coeurl
+, libevent
+, curl
 , voipSupport ? true
 , gst_all_1
 , libnice
@@ -28,13 +31,13 @@
 
 mkDerivation rec {
   pname = "nheko";
-  version = "0.8.2";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "Nheko-Reborn";
     repo = "nheko";
     rev = "v${version}";
-    sha256 = "sha256-w4l91/W6F1FL+Q37qWSjYRHv4vad/10fxdKwfNeEwgw=";
+    sha256 = "1akhnngxkxbjwjkg5ispl6j5s2ylbcj92r3zxqqry4gbfxbjpx8k";
   };
 
   nativeBuildInputs = [
@@ -58,6 +61,9 @@ mkDerivation rec {
     qtquickcontrols2
     qtgraphicaleffects
     qtkeychain
+    coeurl
+    libevent
+    curl
   ] ++ lib.optional stdenv.isDarwin qtmacextras
     ++ lib.optionals voipSupport (with gst_all_1; [
       gstreamer

--- a/pkgs/development/libraries/coeurl/default.nix
+++ b/pkgs/development/libraries/coeurl/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, ninja
+, pkg-config
+, meson
+, libevent
+, curl
+, spdlog
+}:
+
+stdenv.mkDerivation rec {
+  pname = "coeurl";
+  version = "0.1.0";
+
+  src = fetchFromGitLab {
+    domain = "nheko.im";
+    owner = "nheko-reborn";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "10a5klr44m2xy6law8s3s5rynk1q268fa4pkhilbn52yyv0fwajq";
+  };
+
+  nativeBuildInputs = [ ninja pkg-config meson ];
+  buildInputs = [ libevent curl spdlog ];
+
+  meta = with lib; {
+    description = "A simple async wrapper around CURL for C++";
+    homepage = "https://nheko.im/nheko-reborn/coeurl";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ rnhmjoj ];
+  };
+}

--- a/pkgs/development/libraries/mtxclient/default.nix
+++ b/pkgs/development/libraries/mtxclient/default.nix
@@ -3,36 +3,36 @@
 , fetchpatch
 , cmake
 , pkg-config
-, boost17x
 , openssl
 , olm
 , spdlog
 , nlohmann_json
+, coeurl
+, libevent
+, curl
 }:
 
 stdenv.mkDerivation rec {
   pname = "mtxclient";
-  version = "0.5.1";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "Nheko-Reborn";
     repo = "mtxclient";
     rev = "v${version}";
-    sha256 = "sha256-UKroV1p7jYuNzCAFMsuUsYC/C9AZ1D4rhwpwuER39vc=";
+    sha256 = "0sxx7vj6a1n2d95c118pjq52707qwf16154fdvz5f4z1pq7c8dsi";
   };
 
-  # This patch should be obsolete and should stop applying the in next release.
-  patches = [ ./fix-compilation-with-olm-3.2.5.patch ];
+  postPatch = ''
+    # See https://github.com/gabime/spdlog/issues/1897
+    sed -i '1a add_compile_definitions(SPDLOG_FMT_EXTERNAL)' CMakeLists.txt
+  '';
 
   cmakeFlags = [
     # Network requiring tests can't be disabled individually:
     # https://github.com/Nheko-Reborn/mtxclient/issues/22
     "-DBUILD_LIB_TESTS=OFF"
     "-DBUILD_LIB_EXAMPLES=OFF"
-    "-Dnlohmann_json_DIR=${nlohmann_json}/lib/cmake/nlohmann_json"
-    # Can be removed once either https://github.com/NixOS/nixpkgs/pull/85254 or
-    # https://github.com/NixOS/nixpkgs/pull/73940 are merged
-    "-DBoost_NO_BOOST_CMAKE=TRUE"
   ];
 
   nativeBuildInputs = [
@@ -41,13 +41,16 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [
     spdlog
-    boost17x
+    nlohmann_json
     openssl
     olm
+    coeurl
+    libevent
+    curl
   ];
 
   meta = with lib; {
-    description = "Client API library for Matrix, built on top of Boost.Asio";
+    description = "Client API library for the Matrix protocol.";
     homepage = "https://github.com/Nheko-Reborn/mtxclient";
     license = licenses.mit;
     maintainers = with maintainers; [ fpletz pstn ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15883,6 +15883,8 @@ with pkgs;
 
   cmrt = callPackage ../development/libraries/cmrt { };
 
+  coeurl = callPackage ../development/libraries/coeurl { };
+
   cogl = callPackage ../development/libraries/cogl { };
 
   coin3d = callPackage ../development/libraries/coin3d { };


### PR DESCRIPTION
###### Motivation for this change

Version bump

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change
- [x] Tested basic functionality of all binary files
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
