### PR TITLE
zsa-udev-rules: unstable-2020-12-16 -> 2.1.3

### DIFF
--- a/nixos/modules/hardware/keyboard/zsa.nix
+++ b/nixos/modules/hardware/keyboard/zsa.nix
@@ -5,7 +5,6 @@ let
   cfg = config.hardware.keyboard.zsa;
 in
 {
-  # TODO: make group configurable like in https://github.com/NixOS/nixpkgs/blob/0b2b4b8c4e729535a61db56468809c5c2d3d175c/pkgs/tools/security/nitrokey-app/udev-rules.nix ?
   options.hardware.keyboard.zsa = {
     enable = mkOption {
       type = types.bool;
@@ -14,7 +13,6 @@ in
         Enables udev rules for keyboards from ZSA like the ErgoDox EZ, Planck EZ and Moonlander Mark I.
         You need it when you want to flash a new configuration on the keyboard
         or use their live training in the browser.
-        Access to the keyboard is granted to users in the "plugdev" group.
         You may want to install the wally-cli package.
       '';
     };
@@ -22,6 +20,5 @@ in
 
   config = mkIf cfg.enable {
     services.udev.packages = [ pkgs.zsa-udev-rules ];
-    users.groups.plugdev = {};
   };
 }

--- a/pkgs/os-specific/linux/zsa-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/zsa-udev-rules/default.nix
@@ -1,18 +1,17 @@
 { lib, stdenv, fetchFromGitHub }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "zsa-udev-rules";
-  version = "unstable-2020-12-16";
+  version = "2.1.3";
 
-  # TODO: use version and source from nixpkgs/pkgs/development/tools/wally-cli/default.nix after next release
   src = fetchFromGitHub {
     owner = "zsa";
     repo = "wally";
-    rev = "e5dde3c700beab39fb941c6941e55535bf9b2af6";
-    sha256 = "0pkybi32r1hrmpa1mc8qlzhv7xy5n5rr5ah25lbr0cipp1bda417";
+    rev = "${version}-linux";
+    sha256 = "mZzXKFKlO/jAitnqzfvmIHp46A+R3xt2gOhVC3qN6gM=";
   };
 
-  # it only installs files
+  # Only copies udevs rules
   dontConfigure = true;
   dontBuild = true;
   dontFixup = true;


### PR DESCRIPTION
###### Motivation for this change

This update the ZSA's udev rules to the latest version, which instead of a custom `plugdev` group uses systemd's uaccess mechanism instead. 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
