### PR TITLE
keen4: Fix ShellCheck lints

### DIFF
--- a/pkgs/games/keen4/builder.sh
+++ b/pkgs/games/keen4/builder.sh
@@ -1,4 +1,5 @@
 
+# shellcheck source=/dev/null
 source "$stdenv"/setup
 
 mkdir -p "$out"/share/keen4

--- a/pkgs/games/keen4/builder.sh
+++ b/pkgs/games/keen4/builder.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 
 # shellcheck source=/dev/null
 source "$stdenv"/setup

--- a/pkgs/games/keen4/builder.sh
+++ b/pkgs/games/keen4/builder.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 
+set -o nounset
+
 # shellcheck source=/dev/null
-source "$stdenv"/setup
+source "${stdenv}/setup"
 
-mkdir -p "$out"/share/keen4
-unzip -j "$dist" -d "$out"/share/keen4
+mkdir -p "${out}/share/keen4"
+unzip -j "$dist" -d "${out}/share/keen4"
 
-mkdir -p "$out"/bin
-cat > "$out"/bin/keen4 <<EOF
+mkdir -p "${out}/bin"
+cat > "${out}/bin/keen4" <<EOF
 #! $SHELL -e
 if test -z "\$HOME"; then
     echo "HOME directory not set"
@@ -20,9 +22,9 @@ fi
 mkdir -p \$HOME/.keen4
 cd \$HOME/.keen4
 
-ln -sf "$out"/share/keen4/* .
+ln -sf "${out}/share/keen4/"* .
 
-"$dosbox"/bin/dosbox ./KEEN4E.EXE -fullscreen -exit || true
+"${dosbox}/bin/dosbox" ./KEEN4E.EXE -fullscreen -exit || true
 
 # Cleanup the symlinks.
 for i in *; do
@@ -31,4 +33,4 @@ for i in *; do
     fi
 done
 EOF
-chmod +x "$out"/bin/keen4
+chmod +x "${out}/bin/keen4"

--- a/pkgs/games/keen4/builder.sh
+++ b/pkgs/games/keen4/builder.sh
@@ -1,10 +1,11 @@
-source $stdenv/setup
 
-mkdir -p $out/share/keen4
-unzip -j $dist -d $out/share/keen4
+source "$stdenv"/setup
 
-mkdir -p $out/bin
-cat > $out/bin/keen4 <<EOF
+mkdir -p "$out"/share/keen4
+unzip -j "$dist" -d "$out"/share/keen4
+
+mkdir -p "$out"/bin
+cat > "$out"/bin/keen4 <<EOF
 #! $SHELL -e
 if test -z "\$HOME"; then
     echo "HOME directory not set"
@@ -17,9 +18,9 @@ fi
 mkdir -p \$HOME/.keen4
 cd \$HOME/.keen4
 
-ln -sf $out/share/keen4/* .
+ln -sf "$out"/share/keen4/* .
 
-$dosbox/bin/dosbox ./KEEN4E.EXE -fullscreen -exit || true
+"$dosbox"/bin/dosbox ./KEEN4E.EXE -fullscreen -exit || true
 
 # Cleanup the symlinks.
 for i in *; do
@@ -28,4 +29,4 @@ for i in *; do
     fi
 done
 EOF
-chmod +x $out/bin/keen4
+chmod +x "$out"/bin/keen4


### PR DESCRIPTION
###### Motivation for this change

Existing issues requesting ShellCheck compliance: #133088, #21166.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file)) N/A
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
