### PR TITLE
kitsas: 3.0 → 3.1.1, enable on darwin

### DIFF
--- a/pkgs/applications/office/kitsas/default.nix
+++ b/pkgs/applications/office/kitsas/default.nix
@@ -1,44 +1,39 @@
-{ lib, mkDerivation, fetchFromGitHub, qmake, qtsvg, qtcreator, poppler, libzip, pkg-config }:
+{ lib, stdenv, fetchFromGitHub, qmake, qtbase, qtsvg, poppler, libzip, pkg-config, wrapQtAppsHook }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "kitsas";
-  version = "3.0";
+  version = "3.1.1";
 
   src = fetchFromGitHub {
     owner = "artoh";
     repo = "kitupiikki";
     rev = "v${version}";
-    sha256 = "sha256-UH2bFJZd83APRjlv6JR+Uy+ng4DWnnLmavAgjgSOiRo=";
+    sha256 = "sha256-nmlGLrVsTQawYHNgaax9EiutL4xgFdOD34Q4/rnB/D0=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  # QList::swapItemsAt was introduced in Qt 5.13
+  patches = lib.optional (lib.versionOlder qtbase.version "5.13") ./qt-512.patch;
 
-  buildInputs = [ qmake qtsvg poppler libzip ];
+  nativeBuildInputs = [ pkg-config qmake wrapQtAppsHook ];
+
+  buildInputs = [ qtsvg poppler libzip ];
 
   # We use a separate build-dir as otherwise ld seems to get confused between
   # directory and executable name on buildPhase.
   preConfigure = ''
-    mkdir build-linux
-    cd build-linux
+    mkdir build && cd build
   '';
 
-  qmakeFlags = [
-    "../kitsas/kitsas.pro"
-    "-spec"
-    "linux-g++"
-    "CONFIG+=release"
-  ];
+  qmakeFlags = [ "../kitsas/kitsas.pro" ];
 
-  preFixup = ''
-    make clean
-    rm Makefile
-  '';
-
-  installPhase = ''
-    mkdir -p $out/bin $out/share/applications
-    cp kitsas $out/bin
-    cp $src/kitsas.png $out/share/applications
-    cp $src/kitsas.desktop $out/share/applications
+  installPhase = if stdenv.isDarwin then ''
+    mkdir -p $out/Applications
+    mv kitsas.app $out/Applications
+  '' else ''
+    install -Dm755 kitsas -t $out/bin
+    install -Dm644 ../kitsas.svg -t $out/share/icons/hicolor/scalable/apps
+    install -Dm644 ../kitsas.png -t $out/share/icons/hicolor/256x256/apps
+    install -Dm644 ../kitsas.desktop -t $out/share/applications
   '';
 
   meta = with lib; {
@@ -46,6 +41,6 @@ mkDerivation rec {
     description = "An accounting tool suitable for Finnish associations and small business";
     maintainers = with maintainers; [ gspia ];
     license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/office/kitsas/qt-512.patch
+++ b/pkgs/applications/office/kitsas/qt-512.patch
@@ -1,0 +1,24 @@
+diff --git i/kitsas/apuri/siirtoapuri.cpp w/kitsas/apuri/siirtoapuri.cpp
+index 9a2c51f3..9565200f 100644
+--- i/kitsas/apuri/siirtoapuri.cpp
++++ w/kitsas/apuri/siirtoapuri.cpp
+@@ -25,6 +25,7 @@
+ #include "db/tositetyyppimodel.h"
+ #include "tiliote/tiliotekirjaaja.h"
+ 
++#include <QtAlgorithms>
+ #include <QDebug>
+ 
+ SiirtoApuri::SiirtoApuri(QWidget *parent, Tosite *tosite) :
+@@ -361,8 +362,9 @@ void SiirtoApuri::laskunmaksu()
+         TositeVienti eka = lista.at(0).toMap();        
+         tosite()->asetaPvm(eka.pvm());
+         tosite()->asetaOtsikko( eka.selite() );
+-        if( eka.kreditEuro() )
+-            lista.swapItemsAt(0,1);
++        if( eka.kreditEuro() ) {
++            qSwap(lista.begin()[0], lista.begin()[1]);
++        }
+         tosite()->viennit()->asetaViennit(lista);
+         reset();
+ 


### PR DESCRIPTION
###### Motivation for this change
* [changelog](https://github.com/artoh/kitupiikki/releases)
* enable on darwin

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
