### PR TITLE
python3Packages.vulcan-api: init at 2.0.3

### DIFF
--- a/pkgs/development/python-modules/related/default.nix
+++ b/pkgs/development/python-modules/related/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, attrs
+, buildPythonPackage
+, fetchPypi
+, future
+, pytestCheckHook
+, python-dateutil
+, pythonOlder
+, pyyaml
+}:
+
+buildPythonPackage rec {
+  pname = "related";
+  version = "0.7.2";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "w0XmNWh1xF08qitH22lQgTRNqO6qyYrYd2dc6x3Fop0=";
+  };
+
+  propagatedBuildInputs = [
+    attrs
+    future
+    python-dateutil
+    pyyaml
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    # Remove outdated setup.cfg
+    rm setup.cfg
+    substituteInPlace setup.py \
+      --replace "'pytest-runner'," ""
+  '';
+
+  disabledTests = [
+    # Source tarball doesn't contains all needed files
+    "test_compose_from_yml"
+    "test_yaml_roundtrip_with_empty_values"
+    "test_compose_from_yml"
+    "test_store_data_from_json"
+  ];
+
+  pythonImportsCheck = [
+    "related"
+  ];
+
+  meta = with lib; {
+    description = "Nested Object Models in Python";
+    homepage = "https://github.com/genomoncology/related";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/uonet-request-signer-hebe/default.nix
+++ b/pkgs/development/python-modules/uonet-request-signer-hebe/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, pyopenssl
+}:
+
+buildPythonPackage rec {
+  pname = "uonet-request-signer-hebe";
+  version = "0.1.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "fidopnpAt5CXPsLbx+V8wrJCQQ/WIO6AqxpsYLDv8qM=";
+  };
+
+  propagatedBuildInputs = [
+    pyopenssl
+  ];
+
+  # Source is not tagged
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "uonet_request_signer_hebe"
+  ];
+
+  meta = with lib; {
+    description = "UONET+ (hebe) request signer for Python";
+    homepage = "https://github.com/wulkanowy/uonet-request-signer";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/vulcan-api/default.nix
+++ b/pkgs/development/python-modules/vulcan-api/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, aenum
+, aiodns
+, aiohttp
+, buildPythonPackage
+, cchardet
+, fetchFromGitHub
+, pyopenssl
+, pythonOlder
+, pytz
+, related
+, requests
+, uonet-request-signer-hebe
+, yarl
+}:
+
+buildPythonPackage rec {
+  pname = "vulcan-api";
+  version = "2.0.3";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "kapi2289";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "YLt9yufOBlWRyo+le7HcaFD/s7V5WpvhMUrHJqyC3pY=";
+  };
+
+  propagatedBuildInputs = [
+    aenum
+    aiodns
+    aiohttp
+    cchardet
+    pyopenssl
+    pytz
+    related
+    requests
+    uonet-request-signer-hebe
+    yarl
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "vulcan"
+  ];
+
+  meta = with lib; {
+    description = "Python library for UONET+ e-register API";
+    homepage = "https://vulcan-api.readthedocs.io/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8090,6 +8090,8 @@ in {
 
   reikna = callPackage ../development/python-modules/reikna { };
 
+  related = callPackage ../development/python-modules/related { };
+
   relatorio = callPackage ../development/python-modules/relatorio { };
 
   remarshal = callPackage ../development/python-modules/remarshal { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9811,6 +9811,8 @@ in {
     enablePython = true;
   });
 
+  vulcan-api = callPackage ../development/python-modules/vulcan-api { };
+
   vultr = callPackage ../development/python-modules/vultr { };
 
   vulture = callPackage ../development/python-modules/vulture { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9636,6 +9636,8 @@ in {
 
   untokenize = callPackage ../development/python-modules/untokenize { };
 
+  uonet-request-signer-hebe = callPackage ../development/python-modules/uonet-request-signer-hebe { };
+
   upass = callPackage ../development/python-modules/upass { };
 
   upb-lib = callPackage ../development/python-modules/upb-lib { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library for UONET+ e-register API

https://vulcan-api.readthedocs.io

This could become a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
