### PR TITLE
p2pool: init at 1.4

### DIFF
--- a/pkgs/applications/misc/p2pool/default.nix
+++ b/pkgs/applications/misc/p2pool/default.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, cmake
+, fetchFromGitHub
+, gss
+, hwloc
+, lib
+, libsodium
+, libuv
+, openssl
+, pkg-config
+, zeromq
+}:
+
+stdenv.mkDerivation rec {
+  pname = "p2pool";
+  version = "1.4";
+
+  src = fetchFromGitHub {
+    owner = "SChernykh";
+    repo = "p2pool";
+    rev = "v${version}";
+    sha256 = "sha256-syeVRweQJTNzKVl9FuIQl36WwzoI/oV2ULZbSGiDkv0=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ libuv zeromq libsodium gss hwloc openssl ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -vD p2pool $out/bin/p2pool
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Decentralized pool for Monero mining";
+    homepage = "https://github.com/SChernykh/p2pool";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ ratsclub ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25762,6 +25762,8 @@ with pkgs;
 
   musikcube = callPackage ../applications/audio/musikcube {};
 
+  p2pool = callPackage ../applications/misc/p2pool { };
+
   pass2csv = python3Packages.callPackage ../tools/security/pass2csv {};
 
   pass-secret-service = callPackage ../applications/misc/pass-secret-service { };


### PR DESCRIPTION
###### Motivation for this change

This PR adds [p2pool](https://github.com/SChernykh/p2pool) (decentralized pool for Monero mining) package and service. It also adds the `zmqPubAddress` to the `monero` service because `p2pool` uses this to receive notifications.
 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
