### PR TITLE
btcpayserver: 1.3.3 -> 1.3.6

### DIFF
--- a/pkgs/applications/blockchains/btcpayserver/default.nix
+++ b/pkgs/applications/blockchains/btcpayserver/default.nix
@@ -3,13 +3,13 @@
 
 buildDotnetModule rec {
   pname = "btcpayserver";
-  version = "1.3.3";
+  version = "1.3.6";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-IBdQlVZx7Bt4y7B7FvHJihHUWO15a89hs+SGwcobDqY=";
+    sha256 = "sha256-8SWbbdPx/cC7EWTkSbB/YqR13jaL76fFIjHPGL4rFyk=";
   };
 
   projectFile = "BTCPayServer/BTCPayServer.csproj";

--- a/pkgs/applications/blockchains/btcpayserver/deps.nix
+++ b/pkgs/applications/blockchains/btcpayserver/deps.nix
@@ -31,8 +31,8 @@
   })
   (fetchNuGet {
     name = "BTCPayServer.Lightning.All";
-    version = "1.2.14";
-    sha256 = "0avb0jlisx1nv0ary2nc82aamn95qmrrqshwbk8szzjqgvxzv4k2";
+    version = "1.2.16";
+    sha256 = "1dq8xzvg51iskvak28ishxm98b5r1qlybh2r36a079764vl5prn1";
   })
   (fetchNuGet {
     name = "BTCPayServer.Lightning.Charge";
@@ -51,13 +51,13 @@
   })
   (fetchNuGet {
     name = "BTCPayServer.Lightning.Eclair";
-    version = "1.2.7";
-    sha256 = "1h15gic45wps4nvmxyfmfils9nicbz3xkli705hq69g0mafy0f23";
+    version = "1.2.8";
+    sha256 = "01462fjc0zmgafqk7w0cl880wir9mah90r68xyw607ij28pdc2zf";
   })
   (fetchNuGet {
     name = "BTCPayServer.Lightning.LND";
-    version = "1.2.10";
-    sha256 = "10m8kw7598l9ap6y17znvm43cz5ca6qxbrh105knyb6hfzpsyqwp";
+    version = "1.2.12";
+    sha256 = "1dqg682lxv61rfwxxqqlc5fal8y5sz7dmf7p70rg7l9csgzgn67r";
   })
   (fetchNuGet {
     name = "BTCPayServer.Lightning.Ptarmigan";
@@ -778,6 +778,11 @@
     name = "NBitcoin";
     version = "6.0.15";
     sha256 = "038dcl2k88w4cijws3pdnjflgy4lmqx70z0l7yqz355kmxjz8ain";
+  })
+  (fetchNuGet {
+    name = "NBitcoin";
+    version = "6.0.17";
+    sha256 = "1dl3rmmx33041sd0lsj54lk19mzyd8j2nngjmbnn8s4gsdnzd7z1";
   })
   (fetchNuGet {
     name = "NBitcoin";

--- a/pkgs/applications/blockchains/nbxplorer/default.nix
+++ b/pkgs/applications/blockchains/nbxplorer/default.nix
@@ -2,13 +2,13 @@
 
 buildDotnetModule rec {
   pname = "nbxplorer";
-  version = "2.2.16";
+  version = "2.2.18";
 
   src = fetchFromGitHub {
     owner = "dgarage";
     repo = "NBXplorer";
     rev = "v${version}";
-    sha256 = "sha256-6nq5oCEVADZbzQJaEizzt6Lag11bZYLKGMTl2snZob8=";
+    sha256 = "sha256-zjSHgMdK417bm1Z/B2kvloDnPTqzM9jEVkZvoKeBkzM=";
   };
 
   projectFile = "NBXplorer/NBXplorer.csproj";

--- a/pkgs/applications/blockchains/nbxplorer/deps.nix
+++ b/pkgs/applications/blockchains/nbxplorer/deps.nix
@@ -195,6 +195,11 @@
     sha256 = "038dcl2k88w4cijws3pdnjflgy4lmqx70z0l7yqz355kmxjz8ain";
   })
   (fetchNuGet {
+    name = "NBitcoin";
+    version = "6.0.18";
+    sha256 = "1dr669h68cx6yfzr3n97yzzwbgnsv5g2008diyxngdjm55nh3q9s";
+  })
+  (fetchNuGet {
     name = "NETStandard.Library";
     version = "1.6.1";
     sha256 = "1z70wvsx2d847a2cjfii7b83pjfs34q05gb037fdjikv5kbagml8";


### PR DESCRIPTION
Things done:
- Tested with the [nix-bitcoin VM test](https://gist.github.com/45e634d575ceba290676d138a1bc7029).

Notes for reviewers:
You can verify GPG signatures with `refetch=1 pkgs/applications/blockchains/btcpayserver/update.sh`.

cc @prusnak @nixbitcoin