### PR TITLE
[Backport release-21.05] borgmatic: 1.5.12 -> 1.5.18

### DIFF
--- a/pkgs/tools/backup/borgmatic/default.nix
+++ b/pkgs/tools/backup/borgmatic/default.nix
@@ -2,30 +2,26 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "borgmatic";
-  version = "1.5.12";
+  version = "1.5.18";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "sha256-XLbBJvNRmH8W9SnOjF7zUbazRYFCMW6SEO2wKN/2VTY=";
+    sha256 = "sha256-dX1U1zza8zMhDiTLE+DgtN6RLRciLks4NDOukpKH/po=";
   };
 
   checkInputs = with python3Packages; [ flexmock pytestCheckHook pytest-cov ];
 
   # - test_borgmatic_version_matches_news_version
   # The file NEWS not available on the pypi source, and this test is useless
-  # - test_collect_configuration_run_summary_logs_outputs_merged_json_results
-  # Upstream fixed in the next version, see
-  # https://github.com/witten/borgmatic/commit/ea6cd53067435365a96786b006aec391714501c4
   disabledTests = [
     "test_borgmatic_version_matches_news_version"
-    "test_collect_configuration_run_summary_logs_outputs_merged_json_results"
   ];
 
   propagatedBuildInputs = with python3Packages; [
     borgbackup
     colorama
-    pykwalify
-    ruamel_yaml
+    jsonschema
+    ruamel-yaml
     requests
     setuptools
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The systemd service in 1.5.12 not working properly, see #146441

Auto backport failed https://github.com/NixOS/nixpkgs/pull/137463#issuecomment-973270231 so I manually merge the change in this PR

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
