### PR TITLE
tlaplus: 1.7.0 -> 1.7.1 base upon released jar file

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3908,6 +3908,12 @@
     githubId = 183879;
     name = "Florian Klink";
   };
+  florentc = {
+    email = "florentc@users.noreply.github.com";
+    github = "florentc";
+    githubId = 1149048;
+    name = "Florent Ch.";
+  };
   FlorianFranzen = {
     email = "Florian.Franzen@gmail.com";
     github = "FlorianFranzen";

--- a/pkgs/applications/science/logic/tlaplus/default.nix
+++ b/pkgs/applications/science/logic/tlaplus/default.nix
@@ -1,34 +1,30 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper
-, adoptopenjdk-bin, jre, ant
-}:
+{ lib, stdenv, fetchurl, makeWrapper, adoptopenjdk-bin, jre }:
 
 stdenv.mkDerivation rec {
   pname = "tlaplus";
-  version = "1.7.0";
+  version = "1.7.1";
 
-  src = fetchFromGitHub {
-    owner  = "tlaplus";
-    repo   = "tlaplus";
-    rev    = "refs/tags/v${version}";
-    sha256 = "1mm6r9bq79zks50yk0agcpdkw9yy994m38ibmgpb3bi3wkpq9891";
+  src = fetchurl {
+    url = "https://github.com/tlaplus/tlaplus/releases/download/v${version}/tla2tools.jar";
+    sha256 = "d532ba31aafe17afba1130f92410d9257454ff7393d1eb2fe032f0c07f352da5";
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ adoptopenjdk-bin ant ];
+  buildInputs = [ adoptopenjdk-bin ];
 
-  buildPhase = "ant -f tlatools/org.lamport.tlatools/customBuild.xml compile dist";
+  dontUnpack = true;
   installPhase = ''
     mkdir -p $out/share/java $out/bin
-    cp tlatools/org.lamport.tlatools/dist/*.jar $out/share/java
+    cp $src $out/share/java/tla2tools.jar
 
-    makeWrapper ${jre}/bin/java $out/bin/tlc2 \
-      --add-flags "-cp $out/share/java/tla2tools.jar tlc2.TLC"
-    makeWrapper ${jre}/bin/java $out/bin/tla2sany \
-      --add-flags "-cp $out/share/java/tla2tools.jar tla2sany.SANY"
+    makeWrapper ${jre}/bin/java $out/bin/tlc \
+      --add-flags "-XX:+UseParallelGC -cp $out/share/java/tla2tools.jar tlc2.TLC"
+    makeWrapper ${jre}/bin/java $out/bin/tlasany \
+      --add-flags "-XX:+UseParallelGC -cp $out/share/java/tla2tools.jar tla2sany.SANY"
     makeWrapper ${jre}/bin/java $out/bin/pcal \
-      --add-flags "-cp $out/share/java/tla2tools.jar pcal.trans"
-    makeWrapper ${jre}/bin/java $out/bin/tla2tex \
-      --add-flags "-cp $out/share/java/tla2tools.jar tla2tex.TLA"
+      --add-flags "-XX:+UseParallelGC -cp $out/share/java/tla2tools.jar pcal.trans"
+    makeWrapper ${jre}/bin/java $out/bin/tlatex \
+      --add-flags "-XX:+UseParallelGC -cp $out/share/java/tla2tools.jar tla2tex.TLA"
   '';
 
   meta = {
@@ -36,6 +32,6 @@ stdenv.mkDerivation rec {
     homepage    = "http://lamport.azurewebsites.net/tla/tla.html";
     license     = lib.licenses.mit;
     platforms   = lib.platforms.unix;
-    maintainers = [ lib.maintainers.thoughtpolice ];
+    maintainers = with lib.maintainers; [ florentc thoughtpolice ];
   };
 }


### PR DESCRIPTION


###### Motivation for this change

The current version is one year late compared to the latest stable release. In the previous tlaplus package, there was an issue with the tools when passing some command line arguments such as `-workers 4` for `tlc`. A java string method was not found and the program would not proceed correctly. 

###### Things done

This updates tlaplus to the most recent stable version and directly fetches the tlatools jar file from the official Github release page instead of building from the sources. This solves the command line arguments issue.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
