### PR TITLE
gigedit: use old pangomm version

### DIFF
--- a/pkgs/applications/audio/gigedit/default.nix
+++ b/pkgs/applications/audio/gigedit/default.nix
@@ -1,7 +1,24 @@
-{ lib, stdenv, fetchurl, autoconf, automake, intltool, libtool, pkg-config, which
-, docbook_xml_dtd_45, docbook_xsl, gtkmm2, libgig, libsndfile, libxslt
+{ lib
+, stdenv
+, fetchurl
+, autoconf
+, automake
+, intltool
+, libtool
+, pkg-config
+, which
+, docbook_xml_dtd_45
+, docbook_xsl
+, gtkmm2
+, pangomm_2_42
+, libgig
+, libsndfile
+, libxslt
 }:
 
+let
+  gtkmm2_with_pango242 = gtkmm2.override { pangomm = pangomm_2_42; };
+in
 stdenv.mkDerivation rec {
   pname = "gigedit";
   version = "1.1.1";
@@ -15,7 +32,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoconf automake intltool libtool pkg-config which ];
 
-  buildInputs = [ docbook_xml_dtd_45 docbook_xsl gtkmm2 libgig libsndfile libxslt ];
+  buildInputs = [ docbook_xml_dtd_45 docbook_xsl gtkmm2_with_pango242 libgig libsndfile libxslt ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/pangomm/2.42.nix
+++ b/pkgs/development/libraries/pangomm/2.42.nix
@@ -1,0 +1,45 @@
+{ lib, stdenv, fetchurl, pkg-config, meson, ninja, python3, pango, glibmm, cairomm, gnome
+, ApplicationServices }:
+
+stdenv.mkDerivation rec {
+  pname = "pangomm";
+  version= "2.42.2";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "sha256-GyTJJiSuEnXMtXdYF10198Oa0zQtjAtLpg8NmEnS0Io=";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [ pkg-config meson ninja python3 ] ++ lib.optionals stdenv.isDarwin [
+    ApplicationServices
+  ];
+  propagatedBuildInputs = [ pango glibmm cairomm ];
+
+  doCheck = true;
+
+  passthru = {
+    updateScript = gnome.updateScript {
+      packageName = pname;
+      versionPolicy = "odd-unstable";
+      freeze = true;
+    };
+  };
+
+  meta = with lib; {
+    description = "C++ interface to the Pango text rendering library";
+    homepage    = "https://www.pango.org/";
+    license     = with licenses; [ lgpl2 lgpl21 ];
+    maintainers = with maintainers; [ lovek323 raskin ];
+    platforms   = platforms.unix;
+
+    longDescription = ''
+      Pango is a library for laying out and rendering of text, with an
+      emphasis on internationalization.  Pango can be used anywhere
+      that text layout is needed, though most of the work on Pango so
+      far has been done in the context of the GTK widget toolkit.
+      Pango forms the core of text and font handling for GTK.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16729,6 +16729,10 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) ApplicationServices;
   };
 
+  pangomm_2_42 = callPackage ../development/libraries/pangomm/2.42.nix {
+    inherit (darwin.apple_sdk.frameworks) ApplicationServices;
+  };
+
   gdata-sharp = callPackage ../development/libraries/gdata-sharp { };
 
   gdk-pixbuf = callPackage ../development/libraries/gdk-pixbuf { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Gigedit needs old version of pangomm to build

[#zhfmsk](https://nixhax.github.io/zhf-21.11/index.en.html)

###### Things done

pangomm_2.42 re-created and gtkmm overridden with it as an input. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
