### PR TITLE
lrzip: enable asm on x86 and fix build on darwin

### DIFF
--- a/pkgs/tools/compression/lrzip/default.nix
+++ b/pkgs/tools/compression/lrzip/default.nix
@@ -1,15 +1,19 @@
-{ lib, stdenv, fetchurl, zlib, lzo, bzip2, lz4, nasm, perl }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, zlib, lzo, bzip2, lz4, nasm, perl }:
 
 stdenv.mkDerivation rec {
   pname = "lrzip";
   version = "0.641";
 
-  src = fetchurl {
-    url = "http://ck.kolivas.org/apps/lrzip/${pname}-${version}.tar.xz";
-    sha256 = "0ziyanspd96dc3lp2qdcylc7aq8dhb511jhqrhxvlp502fjqjqrc";
+  src = fetchFromGitHub {
+    owner = "ckolivas";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-253CH6TiHWyr13C76y9PXjyB7gj2Bhd2VRgJ5r+cm/g=";
   };
 
-  buildInputs = [ zlib lzo bzip2 lz4 nasm perl ];
+  nativeBuildInputs = [ autoreconfHook nasm perl ];
+
+  buildInputs = [ zlib lzo bzip2 lz4 ];
 
   configureFlags = [
     "--disable-asm"


### PR DESCRIPTION
###### Motivation for this change

ZHF: #144627  (@NixOS/nixos-release-managers)

###### Things done

Patch a Makefile to fix the build on darwin.

While on it, I re-enabled compilation of native assembly code on x86 instead of keeping it disabled for all systems.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
