### PR TITLE
python3Packages.m3u8: bump and fix build on Hydra (x86_64-darwin)

### DIFF
--- a/pkgs/development/python-modules/m3u8/default.nix
+++ b/pkgs/development/python-modules/m3u8/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub, requests, iso8601, bottle, pytest, pytest-cov }:
+{ lib, buildPythonPackage, fetchFromGitHub, requests, iso8601, bottle, pytestCheckHook }:
 
 buildPythonPackage rec {
   pname = "m3u8";
@@ -11,13 +11,15 @@ buildPythonPackage rec {
     sha256 = "0cmg993icpsa1b19kljxvjwhs167bsqrs0ad4wnwsi8qq6na5d4p";
   };
 
-  checkInputs = [ bottle pytest pytest-cov ];
-
-  checkPhase = ''
-    pytest tests/test_{parser,model,variant_m3u8}.py
-  '';
+  checkInputs = [ bottle pytestCheckHook ];
 
   propagatedBuildInputs = [ requests iso8601 ];
+
+  pytestFlagsArray = [
+    "tests/test_parser.py"
+    "tests/test_model.py"
+    "tests/test_variant_m3u8.py"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/globocom/m3u8";

--- a/pkgs/development/python-modules/m3u8/default.nix
+++ b/pkgs/development/python-modules/m3u8/default.nix
@@ -21,6 +21,11 @@ buildPythonPackage rec {
     "tests/test_variant_m3u8.py"
   ];
 
+  preCheck = ''
+    # Fix test on Hydra
+    substituteInPlace tests/test_model.py --replace "/tmp/d.m3u8" "$TMPDIR/d.m3u8"
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/globocom/m3u8";
     description = "Python m3u8 parser";

--- a/pkgs/development/python-modules/m3u8/default.nix
+++ b/pkgs/development/python-modules/m3u8/default.nix
@@ -2,18 +2,18 @@
 
 buildPythonPackage rec {
   pname = "m3u8";
-  version = "0.6.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "globocom";
     repo = pname;
     rev = version;
-    sha256 = "0cmg993icpsa1b19kljxvjwhs167bsqrs0ad4wnwsi8qq6na5d4p";
+    sha256 = "sha256-EfHhmV2otEgEy2OVohS+DF7dk97GFdWZ4cFCERZBmlA=";
   };
 
-  checkInputs = [ bottle pytestCheckHook ];
-
   propagatedBuildInputs = [ requests iso8601 ];
+
+  checkInputs = [ bottle pytestCheckHook ];
 
   pytestFlagsArray = [
     "tests/test_parser.py"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Darwin build works locally but [fails on Hydra](https://hydra.nixos.org/build/157643942):

```
>       with open(filename, 'w') as fileobj:
E       PermissionError: [Errno 13] Permission denied: '/tmp/d.m3u8'
```

ZHF: #144627  (@NixOS/nixos-release-managers)

###### Things done

Patch a test that needs write access to `/tmp` to use `$TMPDIR` instead.

The package has not been updated in 18 months so bump it to latest version too.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
