### PR TITLE
pythonPackages.termplotlib: fix build

### DIFF
--- a/pkgs/development/python-modules/termplotlib/default.nix
+++ b/pkgs/development/python-modules/termplotlib/default.nix
@@ -1,4 +1,5 @@
 { lib
+, substituteAll
 , buildPythonPackage
 , fetchFromGitHub
 , pytestCheckHook
@@ -19,13 +20,28 @@ buildPythonPackage rec {
   };
 
   format = "pyproject";
-  checkInputs = [ pytestCheckHook numpy exdown gnuplot ];
+  checkInputs = [
+    pytestCheckHook
+    exdown
+  ];
   pythonImportsCheck = [ "termplotlib" ];
 
-  # there seems to be a newline in the very front of the output
-  # which causes the test to fail, since it apparently doesn't
-  # strip whitespace. might be a gnuplot choice? sigh...
-  disabledTests = [ "test_plot_lim" ];
+  propagatedBuildInputs = [ numpy ];
+
+  patches = [
+    (substituteAll {
+      src = ./gnuplot-subprocess.patch;
+      gnuplot = "${gnuplot.out}/bin/gnuplot";
+    })
+  ];
+
+  # The current gnuplot version renders slightly different test
+  # graphs, with emphasis on slightly. The plots are still correct.
+  # Tests pass on gnuplot 5.4.1, but fail on 5.4.2.
+  disabledTests = [
+    "test_plot"
+    "test_nolabel"
+  ];
 
   meta = with lib; {
     description = "matplotlib for your terminal";

--- a/pkgs/development/python-modules/termplotlib/gnuplot-subprocess.patch
+++ b/pkgs/development/python-modules/termplotlib/gnuplot-subprocess.patch
@@ -1,0 +1,26 @@
+diff --git a/src/termplotlib/helpers.py b/src/termplotlib/helpers.py
+index 4b67fd0..38a2242 100644
+--- a/src/termplotlib/helpers.py
++++ b/src/termplotlib/helpers.py
+@@ -32,7 +32,7 @@ def is_unicode_standard_output():
+ 
+ 
+ def get_gnuplot_version():
+-    out = subprocess.check_output(["gnuplot", "--version"]).decode()
++    out = subprocess.check_output(["@gnuplot@", "--version"]).decode()
+     m = re.match("gnuplot (\\d).(\\d) patchlevel (\\d)\n", out)
+     if m is None:
+         raise RuntimeError("Couldn't get gnuplot version")
+diff --git a/src/termplotlib/plot.py b/src/termplotlib/plot.py
+index 0f46b87..1418fd1 100644
+--- a/src/termplotlib/plot.py
++++ b/src/termplotlib/plot.py
+@@ -17,7 +17,7 @@ def plot(
+     ticks_scale: int = 0,
+ ):
+     p = subprocess.Popen(
+-        ["gnuplot"],
++        ["@gnuplot@"],
+         stdout=subprocess.PIPE,
+         stdin=subprocess.PIPE,
+         stderr=subprocess.PIPE,


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF #144627

Fixes:
1. New tests are failing with gnuplot 5.4.2
2. Propagate gnuplot and numpy


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
