### PR TITLE
fluxus: switch to racket_7_9

### DIFF
--- a/pkgs/applications/graphics/fluxus/default.nix
+++ b/pkgs/applications/graphics/fluxus/default.nix
@@ -17,7 +17,7 @@
 , ode
 , openal
 , openssl
-, racket
+, racket_7_9
 , sconsPackages
 , zlib
 }:
@@ -42,6 +42,7 @@ let
     openssl
     zlib
   ];
+  racket = racket_7_9;
 in
 stdenv.mkDerivation rec {
   pname = "fluxus";
@@ -67,7 +68,7 @@ stdenv.mkDerivation rec {
     ode
     openal
     openssl.dev
-    racket
+    racket_7_9
   ];
   nativeBuildInputs = [ sconsPackages.scons_3_1_2 ];
 

--- a/pkgs/development/interpreters/racket/racket_7_9.nix
+++ b/pkgs/development/interpreters/racket/racket_7_9.nix
@@ -1,0 +1,111 @@
+{ lib, stdenv, fetchurl, makeFontsConf
+, cacert
+, cairo, coreutils, fontconfig, freefont_ttf
+, glib, gmp
+, gtk3
+, libedit, libffi
+, libiconv
+, libGL
+, libGLU
+, libjpeg
+, libpng, libtool, mpfr, openssl, pango, poppler
+, readline, sqlite
+, disableDocs ? false
+, CoreFoundation
+, gsettings-desktop-schemas
+, wrapGAppsHook
+}:
+
+let
+
+  fontsConf = makeFontsConf {
+    fontDirectories = [ freefont_ttf ];
+  };
+
+  libPath = lib.makeLibraryPath [
+    cairo
+    fontconfig
+    glib
+    gmp
+    gtk3
+    gsettings-desktop-schemas
+    libedit
+    libGL
+    libGLU
+    libjpeg
+    libpng
+    mpfr
+    openssl
+    pango
+    poppler
+    readline
+    sqlite
+  ];
+
+in
+
+stdenv.mkDerivation rec {
+  pname = "racket";
+  version = "7.9"; # always change at once with ./minimal.nix
+
+  src = (lib.makeOverridable ({ name, sha256 }:
+    fetchurl {
+      url = "https://mirror.racket-lang.org/installers/${version}/${name}-src.tgz";
+      inherit sha256;
+    }
+  )) {
+    name = "${pname}-${version}";
+    sha256 = "0gmp2ahmfd97nn9bwpfx9lznjmjkd042slnrrbdmyh59cqh98y2m";
+  };
+
+  FONTCONFIG_FILE = fontsConf;
+  LD_LIBRARY_PATH = libPath;
+  NIX_LDFLAGS = lib.concatStringsSep " " [
+    (lib.optionalString (stdenv.cc.isGNU && ! stdenv.isDarwin) "-lgcc_s")
+    (lib.optionalString stdenv.isDarwin "-framework CoreFoundation")
+  ];
+
+  nativeBuildInputs = [ cacert wrapGAppsHook ];
+
+  buildInputs = [ fontconfig libffi libtool sqlite gsettings-desktop-schemas gtk3 ]
+    ++ lib.optionals stdenv.isDarwin [ libiconv CoreFoundation ];
+
+  preConfigure = ''
+    unset AR
+    for f in src/lt/configure src/cs/c/configure src/bc/src/string.c; do
+      substituteInPlace "$f" --replace /usr/bin/uname ${coreutils}/bin/uname
+    done
+    mkdir src/build
+    cd src/build
+
+    gappsWrapperArgs+=("--prefix" "LD_LIBRARY_PATH" ":" ${LD_LIBRARY_PATH})
+  '';
+
+  shared = if stdenv.isDarwin then "dylib" else "shared";
+  configureFlags = [ "--enable-${shared}"  "--enable-lt=${libtool}/bin/libtool" ]
+                   ++ lib.optional disableDocs [ "--disable-docs" ]
+                   ++ lib.optional stdenv.isDarwin [ "--enable-xonx" ];
+
+  configureScript = "../configure";
+
+  enableParallelBuilding = false;
+
+
+  meta = with lib; {
+    description = "A programmable programming language";
+    longDescription = ''
+      Racket is a full-spectrum programming language. It goes beyond
+      Lisp and Scheme with dialects that support objects, types,
+      laziness, and more. Racket enables programmers to link
+      components written in different dialects, and it empowers
+      programmers to create new, project-specific dialects. Racket's
+      libraries support applications from web servers and databases to
+      GUIs and charts.
+    '';
+    homepage = "https://racket-lang.org/";
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = with maintainers; [ kkallio henrytill vrthra ];
+    platforms = [ "x86_64-darwin" "x86_64-linux" "aarch64-linux" ];
+    broken = stdenv.isDarwin; # No support yet for setting FFI lookup path
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13611,6 +13611,10 @@ with pkgs;
     stdenv = if stdenv.isDarwin then stdenv else gcc7Stdenv;
     inherit (darwin.apple_sdk.frameworks) CoreFoundation;
   };
+  racket_7_9 = callPackage ../development/interpreters/racket/racket_7_9.nix {
+    stdenv = if stdenv.isDarwin then stdenv else gcc7Stdenv;
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation;
+  };
   racket-minimal = callPackage ../development/interpreters/racket/minimal.nix { };
 
   rakudo = callPackage ../development/interpreters/rakudo {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fluxus did not build with racket 8.3 because racket 8.3 has dropped some libraries.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

[#zhfmsk](https://nixhax.github.io/zhf-21.11/index.en.html)