### PR TITLE
ncurses: 6.2 -> 6.3

### DIFF
--- a/pkgs/applications/audio/squishyball/default.nix
+++ b/pkgs/applications/audio/squishyball/default.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ flac libao libvorbis ncurses opusfile ];
 
-  NIX_CFLAGS_COMPILE = "-DNCURSES_INTERNALS";
-
   patches = [ ./gnu-screen.patch ];
 
   postInstall = ''

--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -14,7 +14,7 @@
 
 stdenv.mkDerivation rec {
   # Note the revision needs to be adjusted.
-  version = "6.2";
+  version = "6.3";
   name = "ncurses-${version}" + lib.optionalString (abiVersion == "5") "-abi5-compat";
 
   # We cannot use fetchFromGitHub (which calls fetchzip)
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
   in fetchurl {
     url = "https://github.com/mirror/ncurses/archive/${rev}.tar.gz";
-    sha256 = "15r2456g0mlq2q7gh2z52vl6zv6y0z8sdchrs80kg4idqd8sm8fd";
+    sha256 = "1mawdjhzl2na2j0dylwc37f5w95rhgyvlwnfhww5rz2r7fgkvayv";
   };
 
   outputs = [ "out" "dev" "man" ];

--- a/pkgs/games/rogue/default.nix
+++ b/pkgs/games/rogue/default.nix
@@ -15,9 +15,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ncurses ];
 
-  # Fix build for recent ncurses versions
-  NIX_CFLAGS_COMPILE = "-DNCURSES_INTERNALS=1";
-
   meta = with lib; {
     homepage = "http://rogue.rogueforge.net/rogue-5-4/";
     description = "The final version of the original Rogue game developed for the UNIX operating system";

--- a/pkgs/tools/misc/wyrd/default.nix
+++ b/pkgs/tools/misc/wyrd/default.nix
@@ -9,8 +9,6 @@ stdenv.mkDerivation rec {
     sha256 = "0zlrg602q781q8dij62lwdprpfliyy9j1rqfqcz8p2wgndpivddj";
   };
 
-  NIX_CFLAGS_COMPILE = "-DNCURSES_INTERNALS=1";
-
   preConfigure = ''
     substituteInPlace curses/curses.ml --replace 'pp gcc' "pp $CC"
   '';


### PR DESCRIPTION
The biggest nixpkgs-specific change is addition of printf()-style
attribute annotations for many ncurses APIs. -Werror=format-security
now flags parameter inconsistencies and fails the build.

The fixes are usually one-liners like adding "%s" format string for
non-literals or just using `hardeningDisable [ "format" ];` for software
where backporting or fixing is not practical.

Almost all of build failures are already sorted in `nixpkgs/master` (~60 changes).