### PR TITLE
python3Packages.libversion: 1.2.3 -> 1.2.4

### DIFF
--- a/pkgs/development/python-modules/libversion/default.nix
+++ b/pkgs/development/python-modules/libversion/default.nix
@@ -1,23 +1,41 @@
-{ lib, buildPythonPackage, fetchPypi, pkg-config, libversion, pythonOlder }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, libversion
+, pkg-config
+, pythonOlder
+}:
 
 buildPythonPackage rec {
   pname = "libversion";
-  version = "1.2.3";
-
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "e6e903cc6307c3eda90401373eb81bfd0dd2dc93772ddab3d23705bed0c6f6e9";
-  };
-
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ libversion ];
+  version = "1.2.4";
+  format = "setuptools";
 
   disabled = pythonOlder "3.6";
 
+  src = fetchFromGitHub {
+    owner = "repology";
+    repo = "py-libversion";
+    rev = version;
+    sha256 = "sha256-p0wtSB+QXAERf+57MMb8cqWoy1bG3XaCpR9GPwYYvJM=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    libversion
+  ];
+
+  pythonImportsCheck = [
+    "libversion"
+  ];
+
   meta = with lib; {
-    homepage = "https://github.com/repology/py-libversion";
     description = "Python bindings for libversion, which provides fast, powerful and correct generic version string comparison algorithm";
+    homepage = "https://github.com/repology/py-libversion";
     license = licenses.mit;
-    maintainers = [ maintainers.ryantm ];
+    maintainers = with maintainers; [ ryantm ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.2.4

Change log: https://github.com/repology/py-libversion/releases/tag/1.2.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
