### PR TITLE
python3Packages.typed-ast: 1.5.0 -> 1.5.1

### DIFF
--- a/pkgs/development/python-modules/typed-ast/default.nix
+++ b/pkgs/development/python-modules/typed-ast/default.nix
@@ -1,23 +1,23 @@
-{ buildPythonPackage, fetchFromGitHub, lib, pythonOlder, pytest }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytest
+, pythonOlder
+}:
 
 buildPythonPackage rec {
   pname = "typed-ast";
-  version = "1.5.0";
-  disabled = pythonOlder "3.3";
+  version = "1.5.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "python";
     repo = "typed_ast";
     rev = version;
-    sha256 = "sha256-z3l5gMG1Jp6EI7SnGn5ABVXVBi+bK///iJBqEWn4d+s=";
+    hash = "sha256-qfXMT+rSf/WcWHpkg4VZXZMYj/5IKQWAKRsxQ0TRzPU=";
   };
-
-  pythonImportsCheck = [
-    "typed_ast"
-    "typed_ast.ast27"
-    "typed_ast.ast3"
-    "typed_ast.conversions"
-  ];
 
   checkInputs = [
     pytest
@@ -34,9 +34,16 @@ buildPythonPackage rec {
     runHook postCheck
   '';
 
+  pythonImportsCheck = [
+    "typed_ast"
+    "typed_ast.ast27"
+    "typed_ast.ast3"
+    "typed_ast.conversions"
+  ];
+
   meta = with lib; {
+    description = "Python AST modules with type comment support";
     homepage = "https://github.com/python/typed_ast";
-    description = "Python 2 and 3 ast modules with type comment support";
     license = licenses.asl20;
     maintainers = with maintainers; [ SuperSandro2000 ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.50

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
