### PR TITLE
python3Packages.typeguard: 2.12.1 -> 2.13.0

### DIFF
--- a/pkgs/development/python-modules/typeguard/default.nix
+++ b/pkgs/development/python-modules/typeguard/default.nix
@@ -1,43 +1,46 @@
-{ buildPythonPackage
+{ lib
+, buildPythonPackage
 , fetchPypi
+, pytestCheckHook
 , pythonOlder
-, lib
 , setuptools-scm
-, pytest
 , typing-extensions
-, glibcLocales
 }:
 
 buildPythonPackage rec {
   pname = "typeguard";
-  version = "2.12.1";
+  version = "2.13.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "c2af8b9bdd7657f4bd27b45336e7930171aead796711bc4cfc99b4731bb9d051";
+    sha256 = "sha256-BOOPkutZQQyTddO+I99l4KdkPy6Ly9QhQj2AjS+emd8=";
   };
 
-  buildInputs = [ setuptools-scm ];
-  nativeBuildInputs = [ glibcLocales ];
+  buildInputs = [
+    setuptools-scm
+  ];
 
-  LC_ALL="en_US.utf-8";
+  checkInputs = [
+    pytestCheckHook
+    typing-extensions
+  ];
 
-  postPatch = ''
-    substituteInPlace setup.cfg --replace " --cov" ""
-  '';
+  disabledTestPaths = [
+    # mypy tests aren't passing with latest mypy
+    "tests/mypy"
+  ];
 
-  checkInputs = [ pytest typing-extensions ];
-
-  # mypy tests aren't passing with latest mypy
-  checkPhase = ''
-    py.test . --ignore=tests/mypy
-  '';
-
-  disabled = pythonOlder "3.3";
+  pythonImportsCheck = [
+    "typeguard"
+  ];
 
   meta = with lib; {
-    description = "This library provides run-time type checking for functions defined with argument type annotations";
+    description = "Python library which provides run-time type checking for functions defined with argument type annotations";
     homepage = "https://github.com/agronholm/typeguard";
     license = licenses.mit;
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.13.0

Change log: https://typeguard.readthedocs.io/en/latest/versionhistory.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
