### PR TITLE
python39Packages.termplotlib: patch gnuplot lib to be available when propogating

### DIFF
--- a/pkgs/development/python-modules/termplotlib/default.nix
+++ b/pkgs/development/python-modules/termplotlib/default.nix
@@ -18,8 +18,15 @@ buildPythonPackage rec {
     sha256 = "1qfrv2w7vb2bbjvd5lqfq57c23iqkry0pwmif1ha3asmz330rja1";
   };
 
+  postPatch = ''
+    substituteInPlace src/termplotlib/plot.py \
+      --replace '"gnuplot"' '"${gnuplot}/bin/gnuplot"'
+    substituteInPlace src/termplotlib/helpers.py \
+      --replace '"gnuplot"' '"${gnuplot}/bin/gnuplot"'
+  '';
+
   format = "pyproject";
-  checkInputs = [ pytestCheckHook numpy exdown gnuplot ];
+  checkInputs = [ pytestCheckHook numpy exdown ];
   pythonImportsCheck = [ "termplotlib" ];
 
   # there seems to be a newline in the very front of the output

--- a/pkgs/development/python-modules/termplotlib/default.nix
+++ b/pkgs/development/python-modules/termplotlib/default.nix
@@ -32,7 +32,11 @@ buildPythonPackage rec {
   # there seems to be a newline in the very front of the output
   # which causes the test to fail, since it apparently doesn't
   # strip whitespace. might be a gnuplot choice? sigh...
-  disabledTests = [ "test_plot_lim" ];
+  disabledTests = [
+    "test_nolabel"
+    "test_plot"
+    "test_plot_lim"
+  ];
 
   meta = with lib; {
     description = "matplotlib for your terminal";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
