### PR TITLE
coreboot-toolchain: Add other target architectures

### DIFF
--- a/pkgs/development/tools/misc/coreboot-toolchain/default.nix
+++ b/pkgs/development/tools/misc/coreboot-toolchain/default.nix
@@ -63,4 +63,10 @@ let
   };
 in {
   i386 = common "i386";
+  x86_64 = common "x64";
+  arm = common "arm";
+  aarch64 = common "aarch64";
+  riscv = common "riscv";
+  ppc64 = common "ppc64";
+  nds32le = common "nds32le";
 }

--- a/pkgs/development/tools/misc/coreboot-toolchain/default.nix
+++ b/pkgs/development/tools/misc/coreboot-toolchain/default.nix
@@ -12,51 +12,55 @@
 , zlib
 }:
 
-stdenvNoCC.mkDerivation rec {
-  pname = "coreboot-toolchain";
-  version = "4.15";
+let
+  common = arch: stdenvNoCC.mkDerivation rec {
+    pname = "coreboot-toolchain-${arch}";
+    version = "4.15";
 
-  src = fetchgit {
-    url = "https://review.coreboot.org/coreboot";
-    rev = version;
-    sha256 = "1qsb2ca22h5f0iwc254qsfm7qcn8967ir8aybdxa1pakgmnfsyp9";
-    fetchSubmodules = false;
-    leaveDotGit = true;
-    postFetch = ''
-      patchShebangs $out/util/crossgcc/buildgcc
-      PATH=${lib.makeBinPath [ getopt ]}:$PATH $out/util/crossgcc/buildgcc -W > $out/.crossgcc_version
-      rm -rf $out/.git
+    src = fetchgit {
+      url = "https://review.coreboot.org/coreboot";
+      rev = version;
+      sha256 = "1qsb2ca22h5f0iwc254qsfm7qcn8967ir8aybdxa1pakgmnfsyp9";
+      fetchSubmodules = false;
+      leaveDotGit = true;
+      postFetch = ''
+        patchShebangs $out/util/crossgcc/buildgcc
+        PATH=${lib.makeBinPath [ getopt ]}:$PATH $out/util/crossgcc/buildgcc -W > $out/.crossgcc_version
+        rm -rf $out/.git
+      '';
+    };
+
+    nativeBuildInputs = [ bison curl git perl ];
+    buildInputs = [ flex gnat11 zlib ];
+
+    enableParallelBuilding = true;
+    dontConfigure = true;
+    dontInstall = true;
+
+    postPatch = ''
+      mkdir -p util/crossgcc/tarballs
+
+      ${lib.concatMapStringsSep "\n" (
+        file: "ln -s ${file.archive} util/crossgcc/tarballs/${file.name}"
+        ) (callPackage ./stable.nix { })
+      }
+
+      patchShebangs util/genbuild_h/genbuild_h.sh
     '';
+
+    buildPhase = ''
+      export CROSSGCC_VERSION=$(cat .crossgcc_version)
+      make crossgcc-${arch} CPUS=$NIX_BUILD_CORES DEST=$out
+    '';
+
+    meta = with lib; {
+      homepage = "https://www.coreboot.org";
+      description = "coreboot toolchain for ${arch} targets";
+      license = with licenses; [ bsd2 bsd3 gpl2 lgpl2Plus gpl3Plus ];
+      maintainers = with maintainers; [ felixsinger ];
+      platforms = platforms.linux;
+    };
   };
-
-  nativeBuildInputs = [ bison curl git perl ];
-  buildInputs = [ flex gnat11 zlib ];
-
-  enableParallelBuilding = true;
-  dontConfigure = true;
-  dontInstall = true;
-
-  postPatch = ''
-    mkdir -p util/crossgcc/tarballs
-
-    ${lib.concatMapStringsSep "\n" (
-      file: "ln -s ${file.archive} util/crossgcc/tarballs/${file.name}"
-      ) (callPackage ./stable.nix { })
-    }
-
-    patchShebangs util/genbuild_h/genbuild_h.sh
-  '';
-
-  buildPhase = ''
-    export CROSSGCC_VERSION=$(cat .crossgcc_version)
-    make crossgcc-i386 CPUS=$NIX_BUILD_CORES DEST=$out
-  '';
-
-  meta = with lib; {
-    homepage = "https://www.coreboot.org";
-    description = "coreboot toolchain";
-    license = with licenses; [ bsd2 bsd3 gpl2 lgpl2Plus gpl3Plus ];
-    maintainers = with maintainers; [ felixsinger ];
-    platforms = platforms.linux;
-  };
+in {
+  i386 = common "i386";
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12066,7 +12066,7 @@ with pkgs;
 
   pscid = nodePackages.pscid;
 
-  coreboot-toolchain = callPackage ../development/tools/misc/coreboot-toolchain { };
+  coreboot-toolchain = callPackages ../development/tools/misc/coreboot-toolchain { };
 
   remarkable-toolchain = callPackage ../development/tools/misc/remarkable/remarkable-toolchain { };
 


### PR DESCRIPTION
###### Motivation for this change
* Allow adding new architectures
* Add other target architectures

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
