### PR TITLE
retroArchCores: remove, retroarchFull: init, retroarch: use fixed paths on "libretro_info_path"

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -1365,6 +1365,17 @@ Superuser created successfully.
           <literal>gnat11</literal> instead of <literal>gnat9</literal>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <literal>retroArchCores</literal> has been removed. This means
+          that using <literal>nixpkgs.config.retroarch</literal> to
+          customize RetroArch cores is not supported anymore. Instead,
+          use package overrides, for example:
+          <literal>retroarch.override { cores = with libretro; [ citra snes9x ]; };</literal>.
+          Also, <literal>retroarchFull</literal> derivation is available
+          for those who want to have all RetroArch cores available.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-21.11-notable-changes">
@@ -1964,6 +1975,16 @@ Superuser created successfully.
           <literal>julia-lts</literal>. In practice this means it has
           been upgraded from <literal>1.0.4</literal> to
           <literal>1.5.4</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          RetroArch has been upgraded from version
+          <literal>1.8.5</literal> to <literal>1.9.13.2</literal>. Since
+          the previous release was quite old, if you’re having issues
+          after the upgrade, please delete your
+          <literal>$XDG_CONFIG_HOME/retroarch/retroarch.cfg</literal>
+          file.
         </para>
       </listitem>
     </itemizedlist>

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -407,6 +407,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 - The default GNAT version has been changed: The `gnat` attribute now points to `gnat11`
   instead of `gnat9`.
 
+- `retroArchCores` has been removed. This means that using `nixpkgs.config.retroarch` to customize RetroArch cores is not supported anymore. Instead, use package overrides, for example: `retroarch.override { cores = with libretro; [ citra snes9x ]; };`. Also, `retroarchFull` derivation is available for those who want to have all RetroArch cores available.
+
 ## Other Notable Changes {#sec-release-21.11-notable-changes}
 
 
@@ -539,3 +541,5 @@ In addition to numerous new and upgraded packages, this release has the followin
 - Loki has had another release. Some default values have been changed for the configuration and some configuration options have been renamed. For more details, please check [the upgrade guide](https://grafana.com/docs/loki/latest/upgrading/#240).
 
 - `julia` now refers to `julia-stable` instead of `julia-lts`. In practice this means it has been upgraded from `1.0.4` to `1.5.4`.
+
+- RetroArch has been upgraded from version `1.8.5` to `1.9.13.2`. Since the previous release was quite old, if you're having issues after the upgrade, please delete your `$XDG_CONFIG_HOME/retroarch/retroarch.cfg` file.

--- a/pkgs/misc/emulators/retroarch/0001-Disable-menu_show_core_updater.patch
+++ b/pkgs/misc/emulators/retroarch/0001-Disable-menu_show_core_updater.patch
@@ -1,0 +1,25 @@
+From 546b343294209abbb193883ab76b679b7f99c6d3 Mon Sep 17 00:00:00 2001
+From: Thiago Kenji Okada <thiagokokada@gmail.com>
+Date: Sat, 20 Nov 2021 16:03:50 -0300
+Subject: [PATCH 1/2] Disable "menu_show_core_updater"
+
+---
+ retroarch.cfg | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/retroarch.cfg b/retroarch.cfg
+index cdcb199c9f..ab72f3920f 100644
+--- a/retroarch.cfg
++++ b/retroarch.cfg
+@@ -681,7 +681,7 @@
+ # menu_show_online_updater = true
+ 
+ # If disabled, will hide the ability to update cores (and core info files) inside the menu.
+-# menu_show_core_updater = true
++menu_show_core_updater = false
+ 
+ # If disabled, the libretro core will keep running in the background when we
+ # are in the menu.
+-- 
+2.31.1
+

--- a/pkgs/misc/emulators/retroarch/0002-Use-fixed-paths-on-libretro_info_path.patch
+++ b/pkgs/misc/emulators/retroarch/0002-Use-fixed-paths-on-libretro_info_path.patch
@@ -1,0 +1,80 @@
+From 6788718299e1aba3ff8b31cd6ef012e8d3643bd3 Mon Sep 17 00:00:00 2001
+From: Thiago Kenji Okada <thiagokokada@gmail.com>
+Date: Sat, 20 Nov 2021 15:59:23 -0300
+Subject: [PATCH 2/2] Use fixed paths on "libretro_info_path"
+
+This patch sets "libretro_info_path" to `handle = false`, so instead of
+using the values from `retroarch.cfg`, it will always use the default.
+
+Also, it patches the default "libretro_info_path" to the
+`@libretro_info_path` string, so we can substitute it with the full path
+to it during build.
+---
+ configuration.c                    | 2 +-
+ frontend/drivers/platform_darwin.m | 9 ++-------
+ frontend/drivers/platform_unix.c   | 8 ++++----
+ 3 files changed, 7 insertions(+), 12 deletions(-)
+
+diff --git a/configuration.c b/configuration.c
+index e6a3841324..afb1d6e2ce 100644
+--- a/configuration.c
++++ b/configuration.c
+@@ -1456,7 +1456,7 @@ static struct config_path_setting *populate_settings_path(
+    SETTING_PATH("core_options_path",
+          settings->paths.path_core_options, false, NULL, true);
+    SETTING_PATH("libretro_info_path",
+-         settings->paths.path_libretro_info, false, NULL, true);
++         settings->paths.path_libretro_info, false, NULL, false);
+    SETTING_PATH("content_database_path",
+          settings->paths.path_content_database, false, NULL, true);
+    SETTING_PATH("cheat_database_path",
+diff --git a/frontend/drivers/platform_darwin.m b/frontend/drivers/platform_darwin.m
+index f922e50c55..52732f65ae 100644
+--- a/frontend/drivers/platform_darwin.m
++++ b/frontend/drivers/platform_darwin.m
+@@ -383,14 +383,9 @@ static void frontend_darwin_get_env(int *argc, char *argv[],
+          home_dir_buf, "shaders_glsl",
+          sizeof(g_defaults.dirs[DEFAULT_DIR_SHADER]));
+ #endif
+-#ifdef HAVE_UPDATE_CORES
+     fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE],
+-		    home_dir_buf, "cores", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE]));
+-#else
+-    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE],
+-		    bundle_path_buf, "modules", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE]));
+-#endif
+-   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE_INFO], home_dir_buf, "info", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE_INFO]));
++		    "@libretro_directory@", "", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE]));
++   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE_INFO], "@libretro_info_path@", "", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE_INFO]));
+    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_OVERLAY], home_dir_buf, "overlays", sizeof(g_defaults.dirs[DEFAULT_DIR_OVERLAY]));
+ #ifdef HAVE_VIDEO_LAYOUT
+    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_VIDEO_LAYOUT], home_dir_buf, "layouts", sizeof(g_defaults.dirs[DEFAULT_DIR_VIDEO_LAYOUT]));
+diff --git a/frontend/drivers/platform_unix.c b/frontend/drivers/platform_unix.c
+index 722e1c595c..d87e01cf12 100644
+--- a/frontend/drivers/platform_unix.c
++++ b/frontend/drivers/platform_unix.c
+@@ -1815,8 +1815,8 @@ static void frontend_unix_get_env(int *argc,
+       strcpy_literal(base_path, "retroarch");
+ #endif
+ 
+-   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE], base_path,
+-         "cores", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE]));
++   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE], "@libretro_directory@",
++         "", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE]));
+ #if defined(DINGUX)
+    /* On platforms that require manual core installation/
+     * removal, placing core info files in the same directory
+@@ -1825,8 +1825,8 @@ static void frontend_unix_get_env(int *argc,
+    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE_INFO], base_path,
+          "core_info", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE_INFO]));
+ #else
+-   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE_INFO], base_path,
+-         "cores", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE_INFO]));
++   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE_INFO], "@libretro_info_path@",
++         "", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE_INFO]));
+ #endif
+    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_AUTOCONFIG], base_path,
+          "autoconfig", sizeof(g_defaults.dirs[DEFAULT_DIR_AUTOCONFIG]));
+-- 
+2.31.1
+

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -91,6 +91,8 @@ let
             --add-flags "-L $COREDIR/${d2u core}_libretro${stdenv.hostPlatform.extensions.sharedLibrary} $@"
         '';
 
+        enableParallelBuilding = true;
+
         passthru = {
           inherit core;
           libretroCore = "/lib/retroarch/cores";
@@ -427,7 +429,6 @@ in
     core = "mame";
     description = "Port of MAME to libretro";
     license = with lib.licenses; [ bsd3 gpl2Plus ];
-
     extraBuildInputs = [ alsa-lib libGLU libGL portaudio python3 xorg.libX11 ];
     postPatch = ''
       # Prevent the failure during the parallel building of:
@@ -443,6 +444,7 @@ in
     license = "MAME";
     makefile = "Makefile";
     makeFlags = lib.optional (!stdenv.hostPlatform.isx86) "IS_X86=0";
+    enableParallelBuilding = false;
   };
 
   mame2003 = mkLibRetroCore {
@@ -450,6 +452,7 @@ in
     description = "Port of MAME ~2003 to libretro";
     license = "MAME";
     makefile = "Makefile";
+    enableParallelBuilding = false;
   };
 
   mame2003-plus = mkLibRetroCore {
@@ -457,6 +460,7 @@ in
     description = "Port of MAME ~2003+ to libretro";
     license = "MAME";
     makefile = "Makefile";
+    enableParallelBuilding = false;
   };
 
   mame2010 = mkLibRetroCore {
@@ -465,6 +469,7 @@ in
     license = "MAME";
     makefile = "Makefile";
     makeFlags = lib.optionals stdenv.hostPlatform.isAarch64 [ "PTR64=1" "ARM_ENABLED=1" "X86_SH2DRC=0" "FORCE_DRC_C_BACKEND=1" ];
+    enableParallelBuilding = false;
   };
 
   mame2015 = mkLibRetroCore {
@@ -474,6 +479,7 @@ in
     extraNativeBuildInputs = [ python27 ];
     extraBuildInputs = [ alsa-lib ];
     makefile = "Makefile";
+    enableParallelBuilding = false;
   };
 
   mame2016 = mkLibRetroCore {
@@ -494,6 +500,7 @@ in
       # make -C 3rdparty/genie/build/gmake.linux -f genie.make obj/Release/src/host/lua-5.3.0/src/lgc.o
       mkdir -p 3rdparty/genie/build/gmake.linux/obj/Release/src/host/lua-5.3.0/src
     '';
+    enableParallelBuilding = false;
   };
 
   mesen = mkLibRetroCore {
@@ -523,7 +530,6 @@ in
     src = getCoreSrc "mupen64plus";
     description = "Libretro port of Mupen64 Plus, GL only";
     license = lib.licenses.gpl3Only;
-
     extraBuildInputs = [ libGLU libGL libpng nasm xorg.libX11 ];
     makefile = "Makefile";
   };

--- a/pkgs/misc/emulators/retroarch/default.nix
+++ b/pkgs/misc/emulators/retroarch/default.nix
@@ -68,7 +68,8 @@ stdenv.mkDerivation rec {
       --replace "@libretro_info_path@" "$out/share/libretro/info"
   '';
 
-  nativeBuildInputs = [ pkg-config wayland ] ++
+  nativeBuildInputs = [ pkg-config ] ++
+    optional stdenv.isLinux wayland ++
     optional withVulkan makeWrapper;
 
   buildInputs = [ ffmpeg freetype libxml2 libGLU libGL python3 SDL2 which ] ++
@@ -109,5 +110,8 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     platforms = platforms.all;
     maintainers = with maintainers; [ MP2E edwtjo matthewbauer kolbycrouch thiagokokada ];
+    # FIXME: exits with error on macOS:
+    # No Info.plist file in application bundle or no NSPrincipalClass in the Info.plist file, exiting
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/misc/emulators/retroarch/default.nix
+++ b/pkgs/misc/emulators/retroarch/default.nix
@@ -55,18 +55,17 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    # FIXME: The `retroarch.cfg` file is created once in the first run and only
-    # updated when needed. However, the file may have out-of-date paths
-    # In case of issues (e.g.: cores are not loading), please delete the
-    # `$XDG_CONFIG_HOME/retroarch/retroarch.cfg` file
-    # See: https://github.com/libretro/RetroArch/issues/13251
-    ./fix-config.patch
+    ./0001-Disable-menu_show_core_updater.patch
+    ./0002-Use-fixed-paths-on-libretro_info_path.patch
   ];
 
   postPatch = ''
-    substituteInPlace retroarch.cfg \
+    substituteInPlace "frontend/drivers/platform_unix.c" \
       --replace "@libretro_directory@" "$out/lib" \
-      --replace "@libretro_info_path@" "$out/share/libretro/info" \
+      --replace "@libretro_info_path@" "$out/share/libretro/info"
+    substituteInPlace "frontend/drivers/platform_darwin.m" \
+      --replace "@libretro_directory@" "$out/lib" \
+      --replace "@libretro_info_path@" "$out/share/libretro/info"
   '';
 
   nativeBuildInputs = [ pkg-config wayland ] ++

--- a/pkgs/misc/emulators/retroarch/disable-menu-show-core-updater.patch
+++ b/pkgs/misc/emulators/retroarch/disable-menu-show-core-updater.patch
@@ -1,0 +1,13 @@
+diff --git a/retroarch.cfg b/retroarch.cfg
+index cdcb199c9f..ab72f3920f 100644
+--- a/retroarch.cfg
++++ b/retroarch.cfg
+@@ -681,7 +681,7 @@
+ # menu_show_online_updater = true
+ 
+ # If disabled, will hide the ability to update cores (and core info files) inside the menu.
+-# menu_show_core_updater = true
++menu_show_core_updater = false
+ 
+ # If disabled, the libretro core will keep running in the background when we
+ # are in the menu.

--- a/pkgs/misc/emulators/retroarch/fix-libretro-paths.patch
+++ b/pkgs/misc/emulators/retroarch/fix-libretro-paths.patch
@@ -1,0 +1,28 @@
+diff --git a/configuration.c b/configuration.c
+index e6a3841324..afb1d6e2ce 100644
+--- a/configuration.c
++++ b/configuration.c
+@@ -1456,7 +1456,7 @@ static struct config_path_setting *populate_settings_path(
+    SETTING_PATH("core_options_path",
+          settings->paths.path_core_options, false, NULL, true);
+    SETTING_PATH("libretro_info_path",
+-         settings->paths.path_libretro_info, false, NULL, true);
++         settings->paths.path_libretro_info, false, NULL, false);
+    SETTING_PATH("content_database_path",
+          settings->paths.path_content_database, false, NULL, true);
+    SETTING_PATH("cheat_database_path",
+diff --git a/frontend/drivers/platform_unix.c b/frontend/drivers/platform_unix.c
+index 722e1c595c..e7313ee038 100644
+--- a/frontend/drivers/platform_unix.c
++++ b/frontend/drivers/platform_unix.c
+@@ -1825,8 +1825,8 @@ static void frontend_unix_get_env(int *argc,
+    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE_INFO], base_path,
+          "core_info", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE_INFO]));
+ #else
+-   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE_INFO], base_path,
+-         "cores", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE_INFO]));
++   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE_INFO], "@libretro_info_path@",
++         "", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE_INFO]));
+ #endif
+    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_AUTOCONFIG], base_path,
+          "autoconfig", sizeof(g_defaults.dirs[DEFAULT_DIR_AUTOCONFIG]));

--- a/pkgs/misc/emulators/retroarch/kodi-advanced-launchers.nix
+++ b/pkgs/misc/emulators/retroarch/kodi-advanced-launchers.nix
@@ -1,6 +1,4 @@
-{ stdenv, pkgs, lib, cores, runtimeShell }:
-
-assert cores != [];
+{ stdenv, pkgs, lib, runtimeShell, cores ? [ ] }:
 
 let
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -787,9 +787,10 @@ mapAliases ({
   qt-3 = throw "qt-3 has been removed from nixpkgs, as it's unmaintained and insecure"; # added 2021-02-15
   rfkill = throw "rfkill has been removed, as it's included in util-linux"; # added 2020-08-23
   riak-cs = throw "riak-cs is not maintained anymore"; # added 2020-10-14
-  ring-daemon = jami-daemon; #added 2021-10-26
+  ring-daemon = jami-daemon; # added 2021-10-26
   radare2-cutter = cutter; # added 2021-03-30
   redkite = throw "redkite was archived by upstream"; # added 2021-04-12
+  retroArchCores = throw "retroArchCores has been removed. Please use overrides instead, e.g.: `retroarch.override { cores = with libretro; [ ... ]; }`"; # added 2021-11-19
   rkt = throw "rkt was archived by upstream"; # added 2020-05-16
   rpiboot-unstable = rpiboot; # added 2021-07-30
   rtv = throw "rtv was archived by upstream. Consider using tuir, an actively maintained fork"; # added 2021-08-08
@@ -992,6 +993,7 @@ mapAliases ({
   wireshark-gtk = throw "wireshark-gtk is not supported anymore. Use wireshark-qt or wireshark-cli instead."; # added 2019-11-18
   wireguard = wireguard-tools; # added 2018-05-19
   morituri = whipper; # added 2018-09-13
+  xbmc-retroarch-advanced-launchers = kodi-retroarch-advanced-launchers; # added 2021-11-19
   xp-pen-g430 = pentablet-driver; # added 2020-05-03
   xdg_utils = xdg-utils; # added 2021-02-01
   xfceUnstable = xfce4-14; # added 2019-09-17

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29126,94 +29126,6 @@ with pkgs;
 
   wp-cli = callPackage ../development/tools/wp-cli { };
 
-  retroArchCores =
-    let
-      cfg = config.retroarch or {};
-      inherit (lib) optional;
-    in with libretro;
-      ([ ]
-      ++ optional (cfg.enableAtari800 or false) atari800
-      ++ optional (cfg.enableBeetleGBA or false) beetle-gba
-      ++ optional (cfg.enableBeetleLynx or false) beetle-lynx
-      ++ optional (cfg.enableBeetleNGP or false) beetle-ngp
-      ++ optional (cfg.enableBeetlePCEFast or false) beetle-pce-fast
-      ++ optional (cfg.enableBeetlePCFX or false) beetle-pcfx
-      ++ optional (cfg.enableBeetlePSX or false) beetle-psx
-      ++ optional (cfg.enableBeetlePSXHW or false) beetle-psx-hw
-      ++ optional (cfg.enableBeetleSaturn or false) beetle-saturn
-      ++ optional (cfg.enableBeetleSaturnHW or false) beetle-saturn-hw
-      ++ optional (cfg.enableBeetleSNES or false) beetle-snes
-      ++ optional (cfg.enableBeetleSuperGrafx or false) beetle-supergrafx
-      ++ optional (cfg.enableBeetleWswan or false) beetle-wswan
-      ++ optional (cfg.enableBeetleVB or false) beetle-vb
-      ++ optional (cfg.enableBlueMSX or false) bluemsx
-      ++ optional (cfg.enableBsnesMercury or false) bsnes-mercury
-      ++ optional (cfg.enableCitra or false) citra
-      ++ optional (cfg.enableDesmume or false) desmume
-      ++ optional (cfg.enableDesmume2015 or false) desmume2015
-      ++ optional (cfg.enableDolphin or false) dolphin
-      ++ optional (cfg.enableDOSBox or false) dosbox
-      ++ optional (cfg.enableEightyOne or false) eightyone
-      ++ optional (cfg.enableFBAlpha2012 or false) fbalpha2012
-      ++ optional (cfg.enableFBNeo or false) fbneo
-      ++ optional (cfg.enableFceumm or false) fceumm
-      ++ optional (cfg.enableFlycast or false) flycast
-      ++ optional (cfg.enableFMSX or false) fmsx
-      ++ optional (cfg.enableFreeIntv or false) freeintv
-      ++ optional (cfg.enableGambatte or false) gambatte
-      ++ optional (cfg.enableGenesisPlusGX or false) genesis-plus-gx
-      ++ optional (cfg.enableGpsp or false) gpsp
-      ++ optional (cfg.enableGW or false) gw
-      ++ optional (cfg.enableHandy or false) handy
-      ++ optional (cfg.enableHatari or false) hatari
-      ++ optional (cfg.enableMAME or false) mame
-      ++ optional (cfg.enableMAME2000 or false) mame2000
-      ++ optional (cfg.enableMAME2003 or false) mame2003
-      ++ optional (cfg.enableMAME2003Plus or false) mame2003-plus
-      ++ optional (cfg.enableMAME2010 or false) mame2010
-      ++ optional (cfg.enableMAME2015 or false) mame2015
-      ++ optional (cfg.enableMAME2016 or false) mame2016
-      ++ optional (cfg.enableMesen or false) mesen
-      ++ optional (cfg.enableMeteor or false) meteor
-      ++ optional (cfg.enableMGBA or false) mgba
-      ++ optional (cfg.enableMupen64Plus or false) mupen64plus
-      ++ optional (cfg.enableNeoCD or false) neocd
-      ++ optional (cfg.enableNestopia or false) nestopia
-      ++ optional (cfg.enableNP2kai or false) np2kai
-      ++ optional (cfg.enableO2EM or false) o2em
-      ++ optional (cfg.enableOpera or false) opera
-      ++ optional (cfg.enableParallelN64 or false) parallel-n64
-      ++ optional (cfg.enablePCSXRearmed or false) pcsx_rearmed
-      ++ optional (cfg.enablePicodrive or false) picodrive
-      ++ optional (cfg.enablePlay or false) play
-      ++ optional (cfg.enablePPSSPP or false) ppsspp
-      ++ optional (cfg.enablePrboom or false) prboom
-      ++ optional (cfg.enableProSystem or false) prosystem
-      ++ optional (cfg.enableQuickNES or false) quicknes
-      ++ optional (cfg.enableSameBoy or false) sameboy
-      ++ optional (cfg.enableScummVM or false) scummvm
-      ++ optional (cfg.enableSMSPlusGX or false) smsplus-gx
-      ++ optional (cfg.enableSnes9x or false) snes9x
-      ++ optional (cfg.enableSnes9x2002 or false) snes9x2002
-      ++ optional (cfg.enableSnes9x2005 or false) snes9x2005
-      ++ optional (cfg.enableSnes9x2010 or false) snes9x2010
-      ++ optional (cfg.enableStella or false) stella
-      ++ optional (cfg.enableStella2014 or false) stella2014
-      ++ optional (cfg.enableTGBDual or false) tgbdual
-      ++ optional (cfg.enableThePowderToy or false) the-powder-toy
-      ++ optional (cfg.enableTIC80 or false) tic80
-      ++ optional (cfg.enableVbaNext or false) vba-next
-      ++ optional (cfg.enableVbaM or false) vba-m
-      ++ optional (cfg.enableVecx or false) vecx
-      ++ optional (cfg.enableVirtualJaguar or false) virtualjaguar
-      ++ optional (cfg.enableYabause or false) yabause
-      );
-
-  wrapRetroArch = { retroarch }: callPackage ../misc/emulators/retroarch/wrapper.nix {
-    inherit retroarch;
-    cores = retroArchCores;
-  };
-
   wsjtx = qt5.callPackage ../applications/radio/wsjtx { };
 
   wxhexeditor = callPackage ../applications/editors/wxhexeditor {
@@ -29293,10 +29205,7 @@ with pkgs;
   kodi-cli = callPackage ../tools/misc/kodi-cli { };
 
   kodi-retroarch-advanced-launchers =
-    callPackage ../misc/emulators/retroarch/kodi-advanced-launchers.nix {
-      cores = retroArchCores;
-  };
-  xbmc-retroarch-advanced-launchers = kodi-retroarch-advanced-launchers;
+    callPackage ../misc/emulators/retroarch/kodi-advanced-launchers.nix { };
 
   xca = libsForQt5.callPackage ../applications/misc/xca { };
 
@@ -32867,6 +32776,10 @@ with pkgs;
   retroarchBare = callPackage ../misc/emulators/retroarch {
     inherit (darwin) libobjc;
     inherit (darwin.apple_sdk.frameworks) AppKit Foundation;
+  };
+
+  wrapRetroArch = { retroarch }: callPackage ../misc/emulators/retroarch/wrapper.nix {
+    inherit retroarch;
   };
 
   retroarch = wrapRetroArch { retroarch = retroarchBare; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32784,6 +32784,10 @@ with pkgs;
 
   retroarch = wrapRetroArch { retroarch = retroarchBare; };
 
+  retroarchFull = retroarch.override {
+    cores = builtins.filter (c: c ? libretroCore) (builtins.attrValues libretro);
+  };
+
   libretro = recurseIntoAttrs (callPackage ../misc/emulators/retroarch/cores.nix {
     retroarch = retroarchBare;
   });


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`retroArchCores` is strange: it requires a global configuration on nixpkgs, as:

```nix
nixpkgs.config.retroarch = {
  enableDolphin = true;
  enableMGBA = true;
  enableMAME = true;
};
```

To do so, we ended up declaring all available emulators on `all-packages.nix`. Failing to do so would mean that the emulator wouldn't be available.

However, there is a mechanism on nixpkgs that also works: overrides. Overrides are similar on how other packages works, for example:

```nix
(retroarch.override { cores = with libretro; [ citra snes9x ]; });
```

So let's remove `retroArchCores` and leave the overrides mechanism instead.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
