### PR TITLE
apache-airflow: fix build on darwin

### DIFF
--- a/pkgs/development/python-modules/apache-airflow/default.nix
+++ b/pkgs/development/python-modules/apache-airflow/default.nix
@@ -199,6 +199,10 @@ buildPythonPackage rec {
 
     substituteInPlace tests/core/test_core.py \
       --replace "/bin/bash" "${stdenv.shell}"
+  '' + lib.optionalString stdenv.isDarwin ''
+    # Fix failing test on Hydra
+    substituteInPlace airflow/utils/db.py \
+      --replace "/tmp/sqlite_default.db" "$TMPDIR/sqlite_default.db"
   '';
 
   # allow for gunicorn processes to have access to python packages
@@ -218,6 +222,10 @@ buildPythonPackage rec {
 
   pytestFlagsArray = [
     "tests/core/test_core.py"
+  ];
+
+  disabledTests = lib.optionals stdenv.isDarwin [
+    "bash_operator_kill"  # psutil.AccessDenied
   ];
 
   postInstall = ''

--- a/pkgs/development/python-modules/apache-airflow/default.nix
+++ b/pkgs/development/python-modules/apache-airflow/default.nix
@@ -58,7 +58,7 @@
 , termcolor
 , unicodecsv
 , werkzeug
-, pytest
+, pytestCheckHook
 , freezegun
 , mkYarnPackage
 }:
@@ -171,7 +171,7 @@ buildPythonPackage rec {
 
   checkInputs = [
     freezegun
-    pytest
+    pytestCheckHook
   ];
 
   INSTALL_PROVIDERS_FROM_SOURCES = "true";
@@ -204,7 +204,7 @@ buildPythonPackage rec {
   # allow for gunicorn processes to have access to python packages
   makeWrapperArgs = [ "--prefix PYTHONPATH : $PYTHONPATH" ];
 
-  checkPhase = ''
+  preCheck = ''
    export HOME=$(mktemp -d)
    export AIRFLOW_HOME=$HOME
    export AIRFLOW__CORE__UNIT_TEST_MODE=True
@@ -214,9 +214,11 @@ buildPythonPackage rec {
    airflow version
    airflow db init
    airflow db reset -y
-
-   pytest tests/core/test_core.py
   '';
+
+  pytestFlagsArray = [
+    "tests/core/test_core.py"
+  ];
 
   postInstall = ''
     cp -rv ${airflow-frontend}/static/dist $out/lib/${python.libPrefix}/site-packages/airflow/www/static


### PR DESCRIPTION
###### Motivation for this change

Apache Airflow tests fail on Darwin: https://hydra.nixos.org/build/158846836

ZHF: #144627  (@NixOS/nixos-release-managers)

###### Things done

Disable a test that fails on Darwin (I don't know if it can be fixed):

    _______________________ TestCore.test_bash_operator_kill _______________________
    ...
    /nix/store/sg1d6cs4kswr8cjsasfhcbjmhi6gz2g1-python3.9-psutil-5.8.0/lib/python3.9/site-packages/psutil/_psosx.py:431: PermissionError
    ...
    E           psutil.AccessDenied: psutil.AccessDenied (pid=1)

And fix a test that is failing on Hydra because it tries to write to `/tmp`
    
    ________________________ TestCore.test_check_operators _________________________
    ...
    E           sqlite3.OperationalError: attempt to write a readonly database
    ...
    INFO     airflow.hooks.base:base.py:70 Using connection to: id: sqlite_default. Host: /tmp/sqlite_default.db, Port: None, Schema: None, Login: None, Password: None, extra: {}

Patch the database name to use `$TMPDIR` instead. It has been fixed in Apache Airflow 2.2.2 but the commit doesn't apply on top of 2.1.4, and I tried to update the package, but the 2.2.x tarballs (using `fetchFromGitHub`) do not contain any tests, so I gave up.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
