### PR TITLE
ubootRockPro64/ubootRock64: Combined SD/MMC image and SPI image

### DIFF
--- a/nixos/modules/installer/sd-card/sd-image-aarch64.nix
+++ b/nixos/modules/installer/sd-card/sd-image-aarch64.nix
@@ -14,9 +14,10 @@
   boot.consoleLogLevel = lib.mkDefault 7;
 
   # The serial ports listed here are:
+  # - ttyS2: for RockPro64 and Rock64 (1500000 baud to match the bootloader)
   # - ttyS0: for Tegra (Jetson TX1)
   # - ttyAMA0: for QEMU's -machine virt
-  boot.kernelParams = ["console=ttyS0,115200n8" "console=ttyAMA0,115200n8" "console=tty0"];
+  boot.kernelParams = [ "console=ttyS2,1500000n8" "console=ttyS0,115200n8" "console=ttyAMA0,115200n8" "console=tty0" ];
 
   sdImage = {
     populateFirmwareCommands = let

--- a/nixos/modules/installer/sd-card/sd-image-aarch64.nix
+++ b/nixos/modules/installer/sd-card/sd-image-aarch64.nix
@@ -14,10 +14,9 @@
   boot.consoleLogLevel = lib.mkDefault 7;
 
   # The serial ports listed here are:
-  # - ttyS2: for RockPro64 and Rock64 (1500000 baud to match the bootloader)
   # - ttyS0: for Tegra (Jetson TX1)
   # - ttyAMA0: for QEMU's -machine virt
-  boot.kernelParams = [ "console=ttyS2,1500000n8" "console=ttyS0,115200n8" "console=ttyAMA0,115200n8" "console=tty0" ];
+  boot.kernelParams = ["console=ttyS0,115200n8" "console=ttyAMA0,115200n8" "console=tty0"];
 
   sdImage = {
     populateFirmwareCommands = let

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -424,7 +424,6 @@ in {
   };
 
   ubootRockPro64 = buildUBoot {
-    extraMakeFlags = [ "all" "u-boot.itb" ];
     extraPatches = [
       # https://patchwork.ozlabs.org/project/uboot/list/?series=237654&archive=both&state=*
       (fetchpatch {
@@ -435,7 +434,7 @@ in {
     defconfig = "rockpro64-rk3399_defconfig";
     extraMeta.platforms = ["aarch64-linux"];
     BL31="${armTrustedFirmwareRK3399}/bl31.elf";
-    filesToInstall = [ "u-boot.itb" "idbloader.img"];
+    filesToInstall = [ "u-boot-rockchip.bin" "u-boot.itb" "idbloader.img" ];
   };
 
   ubootROCPCRK3399 = buildUBoot {

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -394,33 +394,12 @@ in {
     filesToInstall = ["u-boot.bin"];
   };
 
-  ubootRock64 = let
-    rkbin = fetchFromGitHub {
-      owner = "ayufan-rock64";
-      repo = "rkbin";
-      rev = "f79a708978232a2b6b06c2e4173c5314559e0d3a";
-      sha256 = "0h7xm4ck3p3380c6bqm5ixrkxwcx6z5vysqdwvfa7gcqx5d6x5zz";
-    };
-  in buildUBoot {
+  ubootRock64 = buildUBoot {
     extraMakeFlags = [ "all" "u-boot.itb" ];
     defconfig = "rock64-rk3328_defconfig";
-    extraMeta = {
-      platforms = [ "aarch64-linux" ];
-      license = lib.licenses.unfreeRedistributableFirmware;
-    };
+    extraMeta.platforms = [ "aarch64-linux" ];
     BL31="${armTrustedFirmwareRK3328}/bl31.elf";
     filesToInstall = [ "u-boot.itb" "idbloader.img"];
-    # Derive MAC address from cpuid
-    # Submitted upstream: https://patchwork.ozlabs.org/patch/1203686/
-    extraConfig = ''
-      CONFIG_MISC_INIT_R=y
-    '';
-    # Close to being blob free, but the U-Boot TPL causes random memory
-    # corruption
-    postBuild = ''
-      ./tools/mkimage -n rk3328 -T rksd -d ${rkbin}/rk33/rk3328_ddr_786MHz_v1.13.bin idbloader.img
-      cat spl/u-boot-spl.bin >> idbloader.img
-    '';
   };
 
   ubootRockPro64 = buildUBoot {

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -395,11 +395,10 @@ in {
   };
 
   ubootRock64 = buildUBoot {
-    extraMakeFlags = [ "all" "u-boot.itb" ];
     defconfig = "rock64-rk3328_defconfig";
     extraMeta.platforms = [ "aarch64-linux" ];
     BL31="${armTrustedFirmwareRK3328}/bl31.elf";
-    filesToInstall = [ "u-boot.itb" "idbloader.img"];
+    filesToInstall = [ "u-boot-rockchip.bin" "u-boot.itb" "idbloader.img" ];
   };
 
   ubootRockPro64 = buildUBoot {

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -434,7 +434,10 @@ in {
     defconfig = "rockpro64-rk3399_defconfig";
     extraMeta.platforms = ["aarch64-linux"];
     BL31="${armTrustedFirmwareRK3399}/bl31.elf";
-    filesToInstall = [ "u-boot-rockchip.bin" "u-boot.itb" "idbloader.img" ];
+    filesToInstall = [ "u-boot-rockchip.bin" "u-boot.itb" "idbloader.img" "spi-idbloader.img" ];
+    postBuild = ''
+      ./tools/mkimage -n rk3399 -T rkspi -d tpl/u-boot-tpl.bin:spl/u-boot-spl.bin spi-idbloader.img
+    '';
   };
 
   ubootROCPCRK3399 = buildUBoot {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- Install already-built `u-boot-rockchip.bin` combined SD/MMC U-Boot image for Rock64 and RockPro64, to make flashing easier (one image instead of two).
- Make SPI-compatible `spi-idbloader.img` for RockPro64. When flashed along with `uboot-itb`, a RockPro64 can boot the unmodified generic NixOS SD image.
  - Doing the same change for Rock64 didn't work (SPI flash is ignored when booting as though it didn't have the correct block ID header), so I'm just submitting the RockPro64 one for now.
- Add RockPro64/Rock64 console kernel command line to Aarch64 SD image, so the image is is usable out of the box on those boards.
  - I could only get a console if the `ttyS2` entry was first.
- Remove Rock64 config change that has been upstreamed.

See commit messages for more details and flashing instructions.

###### Things done

Testing done mostly with cross-compiled U-Boot.

- RockPro64: Flashed combined SD/MMC image to an SD card, boots fine.
- RockPro64: Flashed SPI image to the board, boots the current unstable latest-kernel Aarch64 generic NixOS SD image: https://hydra.nixos.org/build/158402880
  - You don't get a console unless you add a console line with `ttyS2` to the kernel command line, eg. `console=ttyS2,1500000n8`.
- RockPro64: Built U-Boot on-device (no cross compilation) and flashed resulting SPI images, booted fine.
- Rock64: Tested combined SD/MMC image, boots fine.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (via `pkgsCross.aarch64-multiplatform`)
  - [x] aarch64-linux (on a RockPro64)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
