### PR TITLE
znapzend: Arbitrary flags & rootExec flag support

### DIFF
--- a/nixos/modules/services/backup/znapzend.nix
+++ b/nixos/modules/services/backup/znapzend.nix
@@ -306,7 +306,7 @@ in
         type = types.listOf types.str;
         default = [];
         description = "Extra flags passed to the znapzend daemon.";
-        example = literalExample ''[ "--rootexec=sudo" ]'';
+        example = literalExpression ''[ "--rootexec=sudo" ]'';
       };
 
       features.oracleMode = mkEnableOption ''

--- a/nixos/modules/services/backup/znapzend.nix
+++ b/nixos/modules/services/backup/znapzend.nix
@@ -294,68 +294,19 @@ in
 {
   options = {
     services.znapzend = {
-      enable = mkEnableOption "ZnapZend ZFS backup daemon";
-
-      logLevel = mkOption {
-        default = "debug";
-        example = "warning";
-        type = enum ["debug" "info" "warning" "err" "alert"];
-        description = ''
-          The log level when logging to file. Any of debug, info, warning, err,
-          alert. Default in daemonized form is debug.
-        '';
-      };
-
-      logTo = mkOption {
-        type = str;
-        default = "syslog::daemon";
-        example = "/var/log/znapzend.log";
-        description = ''
-          Where to log to (syslog::&lt;facility&gt; or &lt;filepath&gt;).
-        '';
-      };
-
-      noDestroy = mkOption {
-        type = bool;
-        default = false;
-        description = "Does all changes to the filesystem except destroy.";
-      };
-
       autoCreation = mkOption {
         type = bool;
         default = false;
         description = "Automatically create the destination dataset if it does not exist.";
       };
 
-      zetup = mkOption {
-        type = attrsOf srcType;
-        description = "Znapzend configuration.";
-        default = {};
-        example = literalExpression ''
-          {
-            "tank/home" = {
-              # Make snapshots of tank/home every hour, keep those for 1 day,
-              # keep every days snapshot for 1 month, etc.
-              plan = "1d=>1h,1m=>1d,1y=>1m";
-              recursive = true;
-              # Send all those snapshots to john@example.com:rtank/john as well
-              destinations.remote = {
-                host = "john@example.com";
-                dataset = "rtank/john";
-              };
-            };
-          };
-        '';
-      };
+      enable = mkEnableOption "ZnapZend ZFS backup daemon";
 
-      pure = mkOption {
-        type = bool;
-        description = ''
-          Do not persist any stateful znapzend setups. If this option is
-          enabled, your previously set znapzend setups will be cleared and only
-          the ones defined with this module will be applied.
-        '';
-        default = false;
+      extraFlags = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = "Extra flags passed to the znapzend daemon.";
+        example = literalExample ''[ "--rootexec=sudo" ]'';
       };
 
       features.oracleMode = mkEnableOption ''
@@ -414,6 +365,67 @@ in
         that dataset tree... and a decent backup plan will ensure you have a lot
         of those), so you would benefit from requesting this feature.
       '';
+
+      logLevel = mkOption {
+        default = "debug";
+        example = "warning";
+        type = enum ["debug" "info" "warning" "err" "alert"];
+        description = ''
+          The log level when logging to file. Any of debug, info, warning, err,
+          alert. Default in daemonized form is debug.
+        '';
+      };
+
+      logTo = mkOption {
+        type = str;
+        default = "syslog::daemon";
+        example = "/var/log/znapzend.log";
+        description = ''
+          Where to log to (syslog::&lt;facility&gt; or &lt;filepath&gt;).
+        '';
+      };
+
+      noDestroy = mkOption {
+        type = bool;
+        default = false;
+        description = "Does all changes to the filesystem except destroy.";
+      };
+
+      pure = mkOption {
+        type = bool;
+        description = ''
+          Do not persist any stateful znapzend setups. If this option is
+          enabled, your previously set znapzend setups will be cleared and only
+          the ones defined with this module will be applied.
+        '';
+        default = false;
+      };
+
+      rootSudo = mkEnableOption ''
+        Executes commands that require root privilege on all configured remotes with the sudo command.
+        Please ensure that the /etc/sudoers file on the remote host is properly configured.
+      '';
+
+      zetup = mkOption {
+        type = attrsOf srcType;
+        description = "Znapzend configuration.";
+        default = {};
+        example = literalExpression ''
+          {
+            "tank/home" = {
+              # Make snapshots of tank/home every hour, keep those for 1 day,
+              # keep every days snapshot for 1 month, etc.
+              plan = "1d=>1h,1m=>1d,1y=>1m";
+              recursive = true;
+              # Send all those snapshots to john@example.com:rtank/john as well
+              destinations.remote = {
+                host = "john@example.com";
+                dataset = "rtank/john";
+              };
+            };
+          };
+        '';
+      };
     };
   };
 
@@ -426,7 +438,10 @@ in
         wantedBy    = [ "zfs.target" ];
         after       = [ "zfs.target" ];
 
-        path = with pkgs; [ zfs mbuffer openssh ];
+        # sudo is only added if rootSudo is configured
+        # note that this is required by znapzend itself as there is no finer grain control over where it uses the sudo command
+        # (i.e it will also run local superuser commands with sudo)
+        path = with pkgs; [ zfs mbuffer openssh ] ++ optional cfg.rootSudo sudo;
 
         preStart = optionalString cfg.pure ''
           echo Resetting znapzend zetups
@@ -448,15 +463,18 @@ in
           # make the service fail in that case.
           TimeoutStartSec = 180;
           # Needs to have write access to ZFS
+          # Currently only supports root but could theoretically support any user with the --rootExec=sudo flag
           User = "root";
           ExecStart = let
             args = concatStringsSep " " [
-              "--logto=${cfg.logTo}"
-              "--loglevel=${cfg.logLevel}"
-              (optionalString cfg.noDestroy "--nodestroy")
               (optionalString cfg.autoCreation "--autoCreation")
               (optionalString (enabledFeatures != [])
                 "--features=${concatStringsSep "," enabledFeatures}")
+              "--logto=${cfg.logTo}"
+              "--loglevel=${cfg.logLevel}"
+              (optionalString cfg.noDestroy "--nodestroy")
+              (optionalString cfg.rootSudo "--rootExec=sudo")
+              "${toString cfg.extraFlags}"
             ]; in "${pkgs.znapzend}/bin/znapzend ${args}";
           ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
           Restart = "on-failure";


### PR DESCRIPTION
###### Motivation for this change
`znapzend` supports a special mode called `rootExec` where commands that require root access can be executed with `sudo` prepended. This means that znapzend can run as a user with minimal permissions, only becoming superuser when required (usually for `zfs` commands).

This PR adds the new `znapzend.rootSudo` enable flag which activates this functionality, as well as an arbitrary `znapzend.extraFlags` array of strings for more advanced functionality.

I've also tidied the formatting of the module, making everything nice and alphabetised and a bit less all over the place.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
