### PR TITLE
Revert "libfprint-tod: 1.90.7 -> 1.94.1"

### DIFF
--- a/pkgs/development/libraries/libfprint-tod/default.nix
+++ b/pkgs/development/libraries/libfprint-tod/default.nix
@@ -6,7 +6,7 @@
 # for the curious, "tod" means "Touch OEM Drivers" meaning it can load
 # external .so's.
 libfprint.overrideAttrs ({ postPatch ? "", mesonFlags ? [], ... }: let
-  version = "1.94.1+tod1";
+  version = "1.90.7+git20210222+tod1";
 in  {
   pname = "libfprint-tod";
   inherit version;
@@ -16,7 +16,7 @@ in  {
     owner = "3v1n0";
     repo = "libfprint";
     rev = "v${version}";
-    sha256 = "sha256-IVeTQlZjea4xgbG/N7OTHAj6RT4WutfvQhV8qFEvkKo=";
+    sha256 = "0cj7iy5799pchyzqqncpkhibkq012g3bdpn18pfb19nm43svhn4j";
   };
 
   mesonFlags = mesonFlags ++ [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#146673

https://github.com/NixOS/nixpkgs/pull/144843