### PR TITLE
fprintd-tod: fix the build

### DIFF
--- a/pkgs/tools/security/fprintd/tod.nix
+++ b/pkgs/tools/security/fprintd/tod.nix
@@ -3,15 +3,13 @@
 , libfprint-tod
 }:
 
-fprintd.overrideAttrs (oldAttrs:
+(fprintd.override { libfprint = libfprintd-tod; }).overrideAttrs (oldAttrs:
   let
     pname = "fprintd-tod";
     version = "1.90.9";
-
-    libfprint = libfprint-tod;
   in
   {
-    inherit pname version libfprint;
+    inherit pname version;
 
     src = fetchFromGitLab {
       domain = "gitlab.freedesktop.org";

--- a/pkgs/tools/security/fprintd/tod.nix
+++ b/pkgs/tools/security/fprintd/tod.nix
@@ -1,0 +1,23 @@
+{ fetchFromGitLab
+, fprintd
+, libfprint-tod
+}:
+
+fprintd.overrideAttrs (oldAttrs:
+  let
+    pname = "fprintd-tod";
+    version = "1.90.9";
+
+    libfprint = libfprint-tod;
+  in
+  {
+    inherit pname version libfprint;
+
+    src = fetchFromGitLab {
+      domain = "gitlab.freedesktop.org";
+      owner = "libfprint";
+      repo = "${oldAttrs.pname}";
+      rev = "v${version}";
+      sha256 = "sha256-rOTVThHOY/Q2IIu2RGiv26UE2V/JFfWWnfKZQfKl5Mg=";
+    };
+  })

--- a/pkgs/tools/security/fprintd/tod.nix
+++ b/pkgs/tools/security/fprintd/tod.nix
@@ -3,7 +3,7 @@
 , libfprint-tod
 }:
 
-(fprintd.override { libfprint = libfprintd-tod; }).overrideAttrs (oldAttrs:
+(fprintd.override { libfprint = libfprint-tod; }).overrideAttrs (oldAttrs:
   let
     pname = "fprintd-tod";
     version = "1.90.9";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5307,9 +5307,7 @@ with pkgs;
 
   fprintd = callPackage ../tools/security/fprintd { };
 
-  fprintd-tod = callPackage ../tools/security/fprintd {
-    libfprint = libfprint-tod;
-  };
+  fprintd-tod = callPackage ../tools/security/fprintd/tod.nix { };
 
   ferdi = callPackage ../applications/networking/instant-messengers/ferdi {
     mkFranzDerivation = callPackage ../applications/networking/instant-messengers/franz/generic.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#144627
#144843 
[#zhfmsk](https://nixhax.github.io/zhf-21.11/index.en.html)

Pin  `fprintd-tod` to `1.90.9` until [libfprint-tod-vfs0090](https://gitlab.freedesktop.org/3v1n0/libfprint-tod-vfs0090) supports newer version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
