### PR TITLE
afterstep: fix build on upcoming binutils-2.36

### DIFF
--- a/pkgs/applications/window-managers/afterstep/default.nix
+++ b/pkgs/applications/window-managers/afterstep/default.nix
@@ -22,6 +22,14 @@ stdenv.mkDerivation rec {
       url = "https://salsa.debian.org/debian/afterstep/raw/master/debian/patches/44-Fix-build-with-gcc-5.patch";
       sha256 = "1vipy2lzzd2gqrsqk85pwgcdhargy815fxlbn57hsm45zglc3lj4";
     })
+
+    # Fix pending upstream inclusion for binutils-2.36 support:
+    #  https://github.com/afterstep/afterstep/pull/7
+    (fetchpatch {
+      name = "binutils-2.36.patch";
+      url = "https://github.com/afterstep/afterstep/commit/5e9e897cf8c455390dd6f5b27fec49707f6b9088.patch";
+      sha256 = "1kk97max05r2p1a71pvpaza79ff0klz32rggik342p7ki3516qv8";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
Without the change build fails on binutils-2.36 as:

    ar clq libAfterBase.a ashash.o ...
    ar: libdeps specified more than once
