### PR TITLE
asusctl: init and nixos/asusd: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7051,6 +7051,12 @@
     githubId = 4032;
     name = "Kristoffer Thømt Ravneberg";
   };
+  kravemir = {
+    email = "kravec.miroslav@gmail.com";
+    github = "kravemir";
+    githubId = 1643935;
+    name = "Miroslav Kravec";
+  };
   kritnich = {
     email = "kritnich@kritni.ch";
     github = "Kritnich";

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -121,6 +121,14 @@
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://gitlab.com/asus-linux/asusctl">asusd</link>,
+          a service to allow control of such as fan speeds, keyboard
+          LEDs, graphics modes for Asus ROG laptops. Available as
+          <link linkend="opt-services.asusd.enable">services.asusd</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://dragonflydb.io/">dragonflydb</link>,
           a modern replacement for Redis and Memcached. Available as
           <link linkend="opt-services.dragonflydb.enable">services.dragonflydb</link>.

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -54,6 +54,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [appvm](https://github.com/jollheef/appvm), Nix based app VMs. Available as [virtualisation.appvm](options.html#opt-virtualisation.appvm.enable).
 
+- [asusd](https://gitlab.com/asus-linux/asusctl), a service to allow control of such as fan speeds, keyboard LEDs, graphics modes for Asus ROG laptops. Available as [services.asusd](#opt-services.asusd.enable).
+
 - [dragonflydb](https://dragonflydb.io/), a modern replacement for Redis and Memcached. Available as [services.dragonflydb](#opt-services.dragonflydb.enable).
 
 - [infnoise](https://github.com/leetronics/infnoise), a hardware True Random Number Generator dongle.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -537,6 +537,7 @@
   ./services/misc/airsonic.nix
   ./services/misc/ankisyncd.nix
   ./services/misc/apache-kafka.nix
+  ./services/misc/asusd.nix
   ./services/misc/autofs.nix
   ./services/misc/autorandr.nix
   ./services/misc/bazarr.nix

--- a/nixos/modules/services/misc/asusd.nix
+++ b/nixos/modules/services/misc/asusd.nix
@@ -1,0 +1,76 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.services.asusd;
+  tomlFormat = pkgs.formats.toml {};
+in
+{
+  options = {
+    services.asusd = {
+      enable = mkEnableOption ''
+        an interface for rootless control of system functions for Asus ROG-like laptops.
+
+        This will allow usage of <code>asusctl</code> to control hardware such as fan speeds, keyboard LEDs and graphics modes
+      '';
+      ledmodes = mkOption {
+        type = tomlFormat.type;
+        description = ''
+          <filename>asusd-ledmodes.toml</filename> as a Nix attribute set.
+          See <link xlink:href="https://gitlab.com/asus-linux/asusctl/-/blob/main/data/asusd-ledmodes.toml">asusd-ledmodes.toml</link> for examples.
+        '';
+        default = {};
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Set the ledmodes to the packaged ledmodes by default.
+    services.asusd.ledmodes = mkDefault (
+      let
+        # Convert packaged asusd-ledmodes.toml to JSON.
+        json = pkgs.runCommand "asusd-ledmodes.json" {
+            nativeBuildInputs = [ pkgs.remarshal ];
+          } ''
+            toml2json "${pkgs.asusctl}/etc/asusd/asusd-ledmodes.toml" "$out"
+          '';
+        # Convert JSON to Nix attribute-set.
+        attrs = builtins.fromJSON (builtins.readFile json);
+      in attrs
+    );
+
+    environment.systemPackages = with pkgs; [ asusctl ];
+    services.dbus.packages = with pkgs; [ asusctl ];
+
+    # Avoiding adding udev rules file of asusctl as-is due to the reference to systemd.
+    # services.udev.packages = with pkgs; [ asusctl ];
+
+    # See ${pkgs.asusctl}/lib/udev/rules.d/99-asusd.rules
+    services.udev.extraRules = ''
+      ACTION=="add|change", SUBSYSTEM=="input", ENV{ID_VENDOR_ID}=="0b05", ENV{ID_MODEL_ID}=="1[89][a-zA-Z0-9][a-zA-Z0-9]|193b", ENV{ID_TYPE}=="hid", TAG+="systemd", ENV{SYSTEMD_WANTS}="asusd.service"
+      ACTION=="add|remove", SUBSYSTEM=="input", ENV{ID_VENDOR_ID}=="0b05", ENV{ID_MODEL_ID}=="1[89][a-zA-Z0-9][a-zA-Z0-9]|193b", RUN+="${pkgs.systemd}/bin/systemctl restart asusd.service"
+    '';
+
+    environment.etc."asusd/asusd-ledmodes.toml".source = tomlFormat.generate "asusd-ledmodes.toml" cfg.ledmodes;
+
+    systemd.services.asusd = {
+      description = "Asus Control Daemon";
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "dbus.socket" ];
+      environment.IS_SERVICE = "1";
+      unitConfig = {
+        StartLimitInterval = 200;
+        StartLimitBurst = 2;
+      };
+      serviceConfig = {
+        Type = "dbus";
+        BusName = "org.asuslinux.Daemon";
+        SELinuxContext = "system_u:system_r:unconfined_t:s0";
+        ExecStart = "${pkgs.asusctl}/bin/asusd";
+        ConfigurationDirectory = "asusd";
+        Restart = "always";
+        RestartSec = "1s";
+      };
+    };
+  };
+}

--- a/pkgs/os-specific/linux/asusctl/default.nix
+++ b/pkgs/os-specific/linux/asusctl/default.nix
@@ -1,0 +1,41 @@
+{ lib, fetchFromGitLab, rustPlatform
+, pkg-config
+, udev
+}:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  pname = "asusctl";
+  version = "4.3.0";
+
+  src = fetchFromGitLab {
+    owner = "asus-linux";
+    repo = "asusctl";
+    rev = version;
+    hash = "sha256-s0y5oK079Mwg9RTbSbcW1jGjhRH0X/GnSPI1e/G8m1c=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ udev ];
+
+  cargoHash = "sha256-lKviCcwuJaLx+H9Qu6XXUFM3L99A4kgP1vR46hBhVRE=";
+
+  preInstall = ''
+    # Install the data.
+    # Let buildRustPackage handle installing build output in installPhase.
+    make install \
+      DESTDIR="$out" \
+      INSTALL_PROGRAM=true \
+      INSTALL_DATA="install -D -m 0444" \
+      prefix=""
+  '';
+
+  meta = with lib; {
+    description = "A control daemon, CLI tools, and a collection of crates for interacting with ASUS ROG laptops.";
+    homepage = https://gitlab.com/asus-linux/asusctl;
+    license = with licenses; [ mpl20 ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ bobvanderlinden  ];
+  };
+}

--- a/pkgs/os-specific/linux/asusctl/default.nix
+++ b/pkgs/os-specific/linux/asusctl/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchFromGitLab, rustPlatform
 , pkg-config
-, udev
+, udev, e2fsprogs
 }:
 
 with rustPlatform;
@@ -15,6 +15,19 @@ buildRustPackage rec {
     rev = version;
     hash = "sha256-s0y5oK079Mwg9RTbSbcW1jGjhRH0X/GnSPI1e/G8m1c=";
   };
+
+  prePatch = ''
+    for file in \
+      daemon-user/src/user_config.rs \
+      daemon/src/ctrl_anime/config.rs
+    do
+      substituteInPlace $file \
+        --replace /usr/share/ $out/share/
+    done
+
+    substituteInPlace daemon/src/ctrl_rog_bios.rs \
+      --replace /usr/bin/chattr ${e2fsprogs}/bin/chattr
+  '';
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ udev ];

--- a/pkgs/os-specific/linux/asusctl/default.nix
+++ b/pkgs/os-specific/linux/asusctl/default.nix
@@ -36,6 +36,6 @@ buildRustPackage rec {
     homepage = https://gitlab.com/asus-linux/asusctl;
     license = with licenses; [ mpl20 ];
     platforms = platforms.linux;
-    maintainers = with maintainers; [ bobvanderlinden  ];
+    maintainers = with maintainers; [ bobvanderlinden kravemir ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4687,6 +4687,8 @@ with pkgs;
 
   asunder = callPackage ../applications/audio/asunder { };
 
+  asusctl = callPackage ../os-specific/linux/asusctl { };
+
   autossh = callPackage ../tools/networking/autossh { };
 
   assh = callPackage ../tools/networking/assh { };


### PR DESCRIPTION
###### Motivation for this change

Asus ROG laptops (and some non-Asus laptops) require non-standard methods to control its hardware like fan speeds, keyboard LEDs and graphics modes.
`asusctl` is a project that allows such control. It uses a daemon `asusd` to instruct the kernel and allows controlling of the daemon without root using dbus and `asusctl`.

I don't have a Asus laptop on which I can test this, but this was blocking a coworker from using Nix, so hopefully this will work for him. If you want to give this a try, use:

```
services.asusd.enable = true;
```

and run:

```
nixos-rebuild -I nixpkgs=https://github.com/bobvanderlinden/nixpkgs/archive/pr-asusctl.tar.gz test
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
