### PR TITLE
czkawka: 3.2.0 -> 3.3.0

### DIFF
--- a/pkgs/tools/misc/czkawka/default.nix
+++ b/pkgs/tools/misc/czkawka/default.nix
@@ -12,16 +12,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "czkawka";
-  version = "3.2.0";
+  version = "3.3.0";
 
   src = fetchFromGitHub {
     owner = "qarmin";
-    repo = pname;
+    repo = "czkawka";
     rev = version;
-    sha256 = "sha256-OBe6nk5C3kO5Lkas9+G+VY3xAzY7SWx8W5CkSbaYJ9Y=";
+    sha256 = "0mikgnsqxj8dgapr2k7i9i8mmsza15kp4nasyd6l1vp2cqy8aki6";
   };
 
-  cargoSha256 = "sha256-Jghkf1mX5ic7zB2KmtOZbSxgF8C6KjRdGG1Yt+dzylI=";
+  cargoSha256 = "009zfy4lk8y51h1wi71mrjp6kc7xnk3r8jlbxvhyqslhqd9w10fv";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/tools/misc/czkawka/default.nix
+++ b/pkgs/tools/misc/czkawka/default.nix
@@ -8,6 +8,8 @@
 , gdk-pixbuf
 , atk
 , gtk3
+, testVersion
+, czkawka
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -35,6 +37,11 @@ rustPlatform.buildRustPackage rec {
     atk
     gtk3
   ];
+
+  passthru.tests.version = testVersion {
+    package = czkawka;
+    command = "czkawka_cli --version";
+  };
 
   meta = with lib; {
     description = "A simple, fast and easy to use app to remove unnecessary files from your computer";

--- a/pkgs/tools/misc/czkawka/default.nix
+++ b/pkgs/tools/misc/czkawka/default.nix
@@ -40,6 +40,6 @@ rustPlatform.buildRustPackage rec {
     description = "A simple, fast and easy to use app to remove unnecessary files from your computer";
     homepage = "https://github.com/qarmin/czkawka";
     license = with licenses; [ mit ];
-    maintainers = with maintainers; [ yanganto ];
+    maintainers = with maintainers; [ yanganto _0x4A6F ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- Upgrade to [3.3.0](https://github.com/qarmin/czkawka/releases/tag/3.3.0) incorporating these [changes](https://github.com/qarmin/czkawka/compare/3.2.0...3.3.0).
- Adding myself as maintainer
- Add installCheck

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
