### PR TITLE
krane: 2.3.1 → 2.3.2

### DIFF
--- a/pkgs/applications/networking/cluster/krane/Gemfile.lock
+++ b/pkgs/applications/networking/cluster/krane/Gemfile.lock
@@ -61,7 +61,7 @@ GEM
       multi_json
       to_regexp (~> 0.2.1)
     jwt (2.3.0)
-    krane (2.3.1)
+    krane (2.3.2)
       activesupport (>= 5.0)
       colorize (~> 0.8)
       concurrent-ruby (~> 1.1)
@@ -77,7 +77,7 @@ GEM
       recursive-open-struct (~> 1.1, >= 1.1.1)
       rest-client (~> 2.0)
     memoist (0.16.2)
-    mime-types (3.4.0)
+    mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.1115)
     minitest (5.14.4)

--- a/pkgs/applications/networking/cluster/krane/gemset.nix
+++ b/pkgs/applications/networking/cluster/krane/gemset.nix
@@ -276,10 +276,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0k1lwg0d2phs9n9zdx7nv5rv2p2vipm9jgzalr8x9nrq1is6wgvr";
+      sha256 = "0x908645i92w012xglc07lb6k2irn1zpzwgn1n99h2x54qk1pz4v";
       type = "gem";
     };
-    version = "2.3.1";
+    version = "2.3.2";
   };
   kubeclient = {
     dependencies = ["http" "recursive-open-struct" "rest-client"];
@@ -308,10 +308,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1wvbwlkf6i17xvxx70cffw26ijvcc400vfhpbnvd8mmx556cnb4g";
+      sha256 = "0ipw892jbksbxxcrlx9g5ljq60qx47pm24ywgfbyjskbcl78pkvb";
       type = "gem";
     };
-    version = "3.4.0";
+    version = "3.4.1";
   };
   mime-types-data = {
     groups = ["default"];


### PR DESCRIPTION
###### Motivation for this change
Update to the latest version: https://github.com/Shopify/krane/releases/tag/v2.3.2

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).