### PR TITLE
python3Packages.restrictedpython: 5.1 -> 5.2

### DIFF
--- a/pkgs/development/python-modules/restrictedpython/default.nix
+++ b/pkgs/development/python-modules/restrictedpython/default.nix
@@ -1,34 +1,34 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-
-# Test dependencies
-, pytest, pytest-mock
+, pytest-mock
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
-  pname = "RestrictedPython";
-  version = "5.1";
+  pname = "restrictedpython";
+  version = "5.2";
+  format = "setuptools";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "9ae16e500782b41bd1abefd8554ccb26330817bba9ce090d385aa226f1ca83e8";
+    pname = "RestrictedPython";
+    inherit version;
+    sha256 = "sha256-Y02h9sXBIqJi9DOwg+49F6mgOfjxs3eFl++0dGHNNhs=";
   };
 
-  #propagatedBuildInputs = [ xmltodict requests ifaddr ];
-
   checkInputs = [
-    pytest pytest-mock
+    pytestCheckHook
+    pytest-mock
   ];
 
-  checkPhase = ''
-    pytest
-  '';
+  pythonImportsCheck = [
+    "RestrictedPython"
+  ];
 
-  meta = {
+  meta = with lib; {
+    description = "Restricted execution environment for Python to run untrusted code";
     homepage = "https://github.com/zopefoundation/RestrictedPython";
-    description = "A restricted execution environment for Python to run untrusted code";
-    license = lib.licenses.zpl21;
-    maintainers = with lib.maintainers; [ juaningan ];
+    license = licenses.zpl21;
+    maintainers = with maintainers; [ juaningan ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 5.2

Change log: https://github.com/zopefoundation/RestrictedPython/blob/master/CHANGES.rst#52-2021-11-19

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
