### PR TITLE
vala: 0.54.2 → 0.54.3

### DIFF
--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -134,8 +134,8 @@ in rec {
   };
 
   vala_0_54 = generic {
-    version = "0.54.2";
-    sha256 = "iE3nRTF9TVbk6M7emT3I8E1Qz8o2z2DS8vJ4wwwrExE=";
+    version = "0.54.3";
+    sha256 = "7R1f5MvAzShF0N5PH/77Fa+waJLSMMfMppV4FnLo+2A=";
   };
 
   vala = vala_0_54;


### PR DESCRIPTION
###### Motivation for this change

I guess this has been reviewed in https://github.com/NixOS/nixpkgs/pull/145211#issuecomment-964284639 but was dropped later?

https://ftp.gnome.org/pub/GNOME/sources/vala/0.54/vala-0.54.3.news
https://gitlab.gnome.org/GNOME/vala/-/compare/0.54.2...0.54.3

* Various improvements and bug fixes:
  - codegen: Actually free data when using "remove(_all)"
    on GLib.Queue/(S)List [<a href="https://gitlab.gnome.org/GNOME/vala/issues/1238">#1238</a>]
  - vala:
    + Parameter following ellipsis parameter is not allowed [<a href="https://gitlab.gnome.org/GNOME/vala/issues/1237">#1237</a>]
    + More thorough check of ValueType and set CodeNode.error on failure
    + Really check compatiblity of error types for delegate symbol
    + Correctly output signature of callable throwing error
    + Report error for non ErrorType in throws
    + Implement CodeWriter.visit_foreach_statement()/visit_catch_clause()
  - parser: Make sure ErrorCodes are accessible as needed
  - girparser: Add support for "ref_/ref_sink_/unref_function"
    metadata for classes [<a href="https://gitlab.gnome.org/GNOME/vala/issues/1233">#1233</a>]

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).