### PR TITLE
chromiumDev: 97.0.4692.20 -> 98.0.4710.4

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -31,15 +31,15 @@
     }
   },
   "dev": {
-    "version": "97.0.4692.20",
-    "sha256": "1njgfz3kz1pyyaaskqc47ldy2gzc3c9a8mjib81nalzrqbmd3372",
-    "sha256bin64": "06vsmzz8nvmx7hfqwvqfmq4h000dw22srxdrgrdfgh7mry0yvf4a",
+    "version": "98.0.4710.4",
+    "sha256": "0ay4bn9963k7bbv31wfc1iy2z6n6jjk1h2mn7m7893i81raisk8m",
+    "sha256bin64": "0n4kb6iiv9aih7yzrnr9m7znqb2p37grlj8by6gpjfikx3fxf5gg",
     "deps": {
       "gn": {
-        "version": "2021-11-03",
+        "version": "2021-11-16",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "90294ccdcf9334ed25a76ac9b67689468e506342",
-        "sha256": "0n0jml8s00ayy186jzrf207hbz70pxiq426znxwxd4gjcp60scsa"
+        "rev": "4aa9bdfa05b688c58d3d7d3e496f3f18cbb3d89e",
+        "sha256": "0jwjfbxlbqxlz7wm46vyrxn3pgwyyd03as6gy5mcvvk9aialqh9f"
       }
     }
   },

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -10,7 +10,6 @@
 , hunspellDicts, spellcheckerLanguage ? null # E.g. "de_DE"
 # For a full list of available languages:
 # $ cat pkgs/development/libraries/hunspell/dictionaries.nix | grep "dictFileName =" | awk '{ print $3 }'
-, sqlcipher
 }:
 
 let
@@ -23,39 +22,6 @@ let
       --set HUNSPELL_DICTIONARIES "${hunspellDicts.${hunspellDict}}/share/hunspell" \
       --set LC_MESSAGES "${spellcheckerLanguage}"'');
 
-  sqlcipher-signal = sqlcipher.overrideAttrs (_: {
-    # Using the same features as the upstream signal sqlcipher build
-    # https://github.com/signalapp/better-sqlite3/blob/2fa02d2484e9f9a10df5ac7ea4617fb2dff30006/deps/defines.gypi
-    CFLAGS = [
-      "-DSQLITE_LIKE_DOESNT_MATCH_BLOBS"
-      "-DSQLITE_THREADSAFE=2"
-      "-DSQLITE_USE_URI=0"
-      "-DSQLITE_DEFAULT_MEMSTATUS=0"
-      "-DSQLITE_OMIT_DEPRECATED"
-      "-DSQLITE_OMIT_GET_TABLE"
-      "-DSQLITE_OMIT_TCL_VARIABLE"
-      "-DSQLITE_OMIT_PROGRESS_CALLBACK"
-      "-DSQLITE_OMIT_SHARED_CACHE"
-      "-DSQLITE_TRACE_SIZE_LIMIT=32"
-      "-DSQLITE_DEFAULT_CACHE_SIZE=-16000"
-      "-DSQLITE_DEFAULT_FOREIGN_KEYS=1"
-      "-DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1"
-      "-DSQLITE_ENABLE_COLUMN_METADATA"
-      "-DSQLITE_ENABLE_UPDATE_DELETE_LIMIT"
-      "-DSQLITE_ENABLE_STAT4"
-      "-DSQLITE_ENABLE_FTS5"
-      "-DSQLITE_ENABLE_JSON1"
-      "-DSQLITE_ENABLE_RTREE"
-      "-DSQLITE_INTROSPECTION_PRAGMAS"
-
-      # SQLCipher-specific options
-      "-DSQLITE_HAS_CODEC"
-      "-DSQLITE_TEMP_STORE=2"
-      "-DSQLITE_SECURE_DELETE"
-    ];
-
-    LDFLAGS = [ "-lm" ];
-  });
 in stdenv.mkDerivation rec {
   pname = "signal-desktop";
   version = "5.23.1"; # Please backport all updates to the stable channel.
@@ -153,7 +119,6 @@ in stdenv.mkDerivation rec {
   preFixup = ''
     gappsWrapperArgs+=(
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc ] }"
-      --prefix LD_PRELOAD : "${sqlcipher-signal}/lib/libsqlcipher.so"
       ${customLanguageWrapperArgs}
     )
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Note: The Google Chrome startup for the VM test seems pretty broken but surprisingly the test passes.
Startup log:
```
machine: must succeed: su - alice -c 'ulimit -c unlimited; google-chrome-unstable file:///nix/store/0c2gy8gjbxir30g5izd7x3bbs4cn1skq-chromium-startup.html >&2 & disown'
machine # [   17.571420] su[986]: Successful su for alice by root
machine # [   17.576763] su[986]: pam_unix(su:session): session opened for user alice(uid=1000) by (uid=0)
machine # [   17.594024] su[986]: pam_unix(su:session): session closed for user alice
(0.07 seconds)
machine: waiting for Make Google Chrome the default browser to appear on screen
machine: sending monitor command: screendump /build/tmpqdcg8eie/ppm
machine # [989:1020:1120/162854.126964:ERROR:bus.cc(397)] Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
machine # [989:1020:1120/162854.137210:ERROR:bus.cc(397)] Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
machine # [989:1020:1120/162854.555940:ERROR:bus.cc(397)] Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
machine # [989:1020:1120/162854.556016:ERROR:bus.cc(397)] Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
machine # libva error: vaGetDriverNameByIndex() failed with unknown libva error, driver_name = (null)
machine # [1028:1028:1120/162855.446984:ERROR:viz_main_impl.cc(161)] Exiting GPU process due to errors during initialization
machine # [989:1059:1120/162855.747363:ERROR:object_proxy.cc(642)] Failed to call method: org.freedesktop.DBus.Properties.Get: object_path= /org/freedesktop/UPower: org.freedesktop.DBus.Error.ServiceUnknown: The name org.freedesktop.UPower was not provided by any .service files
machine # [989:1059:1120/162855.761554:ERROR:object_proxy.cc(642)] Failed to call method: org.freedesktop.UPower.GetDisplayDevice: object_path= /org/freedesktop/UPower: org.freedesktop.DBus.Error.ServiceUnknown: The name org.freedesktop.UPower was not provided by any .service files
machine # [989:1059:1120/162855.776996:ERROR:object_proxy.cc(642)] Failed to call method: org.freedesktop.UPower.EnumerateDevices: object_path= /org/freedesktop/UPower: org.freedesktop.DBus.Error.ServiceUnknown: The name org.freedesktop.UPower was not provided by any .service files
machine # libva error: vaGetDriverNameByIndex() failed with unknown libva error, driver_name = (null)
machine # [1058:1058:1120/162856.728976:ERROR:viz_main_impl.cc(161)] Exiting GPU process due to errors during initialization
machine # [1120/162857.060212:ERROR:process_memory_range.cc(75)] read out of range
machine # [1120/162857.062104:ERROR:file_io_posix.cc(144)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq: No such file or directory (2)
machine # [1120/162857.062133:ERROR:file_io_posix.cc(144)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq: No such file or directory (2)[   28.234688] show_signal: 91 callbacks suppressed
machine # [   28.234690] traps: chrome[1122] trap invalid opcode ip:7ff60e1a7c7a sp:7ffd1c229300 error:0 in libGLESv2.so[7ff60e048000+41f000]
machine #
machine # [   28.172040] systemd[1]: Created slice Slice /system/systemd-coredump.
machine # [   28.177222] systemd[1]: Started Process Core Dump (PID 1124/UID 0).
machine # [   28.598556] systemd-coredump[1125]: Process 1122 (chrome) of user 1000 dumped core.
machine # [989:989:1120/162857.551044:ERROR:gpu_process_host.cc(965)] GPU process exited unexpectedly: exit_code=132
machine # [   28.619231] systemd[1]: systemd-coredump@0-1124-0.service: Deactivated successfully.
machine # [1120/162857.592127:ERROR:process_memory_range.cc(75)] read out of range
machine # [1120/162857.593287:ERROR:file_io_posix.cc(144)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq: No such file or directory (2)
machine # [1120/162857.593313:ERROR:file_io_posix.cc(144)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq: No such file or directory (2)[   28.765924] traps: chrome[1128] trap invalid opcode ip:7ff60e1a7c7a sp:7ffd1c229300 error:0 in libGLESv2.so[7ff60e048000+41f000]
machine #
machine # [   28.693966] systemd[1]: Started Process Core Dump (PID 1134/UID 0).
machine: sending monitor command: screendump /build/tmp_lsaxwhn/ppm
machine # [   29.074933] systemd-coredump[1135]: Process 1128 (chrome) of user 1000 dumped core.
machine # [989:989:1120/162858.039690:ERROR:gpu_process_host.cc(965)] GPU process exited unexpectedly: exit_code=132
machine # [   29.110732] systemd[1]: systemd-coredump@1-1134-0.service: Deactivated successfully.
machine # [1120/162858.088102:ERROR:process_memory_range.cc(75)] read out of range[   29.270515] traps: chrome[1136] trap invalid opcode ip:7ff60e1a7c7a sp:7ffd1c229300 error:0 in libGLESv2.so[7ff60e048000+41f000]
machine #
machine # [1120/162858.100496:ERROR:file_io_posix.cc(144)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq: No such file or directory (2)
machine # [1120/162858.100522:ERROR:file_io_posix.cc(144)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq: No such file or directory (2)
machine # [   29.213403] systemd[1]: Started Process Core Dump (PID 1143/UID 0).
machine # [   29.562324] systemd-coredump[1144]: Process 1136 (chrome) of user 1000 dumped core.
machine # [989:989:1120/162858.517659:ERROR:gpu_process_host.cc(965)] GPU process exited unexpectedly: exit_code=132
machine # [   29.597448] systemd[1]: systemd-coredump@2-1143-0.service: Deactivated successfully.
machine # [1145:1145:1120/162858.572999:ERROR:gpu_init.cc(454)] Passthrough is not supported, GL is disabled, ANGLE is
machine: sending monitor command: screendump /build/tmp6raefv9s/ppm
(34.54 seconds)
machine: making screenshot /nix/store/vmvbdrl5635bv4grb45d9w4dlj0vb3i3-vm-test-run-chromium-chrome-dev/google_chrome_default_browser_prompt.png
machine: sending monitor command: screendump /nix/store/vmvbdrl5635bv4grb45d9w4dlj0vb3i3-vm-test-run-chromium-chrome-dev/google_chrome_default_browser_prompt.png.ppm
(0.06 seconds)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
