### PR TITLE
gimp: fix build on darwin

### DIFF
--- a/pkgs/applications/graphics/gimp/default.nix
+++ b/pkgs/applications/graphics/gimp/default.nix
@@ -148,6 +148,8 @@ in stdenv.mkDerivation rec {
   # test-eevl.c:64:36: error: initializer element is not a compile-time constant
   doCheck = !stdenv.isDarwin;
 
+  NIX_CFLAGS_COMPILE = lib.optional stdenv.isDarwin "-DGDK_OSX_BIG_SUR=16";
+
   # Check if librsvg was built with --disable-pixbuf-loader.
   PKG_CONFIG_GDK_PIXBUF_2_0_GDK_PIXBUF_MODULEDIR = "${librsvg}/${gdk-pixbuf.moduleDir}";
 


### PR DESCRIPTION
###### Motivation for this change
ZHF: #144627 (@NixOS/nixos-release-managers)

gimp is currently failing to build on darwin:

```
gui.c:285:36: error: use of undeclared identifier 'GDK_OSX_BIG_SUR'; did you mean 'GDK_OSX_TIGER'?
  if (gdk_quartz_osx_version () >= GDK_OSX_BIG_SUR)
                                   ^~~~~~~~~~~~~~~
                                   GDK_OSX_TIGER
/nix/store/g7bkiccx10fg9v004n62rl7wh97ifd1y-gtk+-2.24.33-dev/include/gtk-2.0/gdk/gdkquartz.h:46:3: note: 'GDK_OSX_TIGER' declared here
  GDK_OSX_TIGER = 4,
  ^
1 error generated.
```

In #138410 and #138797 we figured this is due to a gtk2 that's missing the bug sur definition. We may or may not want to patch that back in with upstream patch https://gitlab.gnome.org/GNOME/gtk/-/commit/69135bcfe3c6e907e3dfed23d97eae9abfd782bc, but the additional problem is that gimp is using `GDK_OSX_BIG_SUR` rather than `GDK_OSX_BIGSUR`, so it looks like we'll have to hack in the definition for gimp anyway.

Edit: the alternative would be to patch gtk2 with the above and patch gimp with https://gitlab.gnome.org/GNOME/gimp/-/commit/5ff5d3898574bb346c8220e3ebde2edfea5a4b6a

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
