### PR TITLE
[DRAFT] popcorntime: init at 0.4.6

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27638,6 +27638,8 @@ with pkgs;
 
   ponymix = callPackage ../applications/audio/ponymix { };
 
+  popcorntime-bin = callPackage ../applications/video/popcorntime {};
+
   portfolio-filemanager = callPackage ../applications/misc/portfolio-filemanager { };
 
   pothos = libsForQt5.callPackage ../applications/radio/pothos { };


### PR DESCRIPTION
###### Motivation for this change
Packaging [Popcorn Time](https://github.com/popcorn-official/popcorn-desktop) version 0.4.6.

Since building PopcornTime from source is very complex, this package uses the binary deb-tarball.

Unfortunately it doesn't start yet:

``` 
$ Popcorn-Time
[1120/175141.865069:ERROR:icu_util.cc(194)] Couldn't mmap icu data file
[1120/175141.865172:FATAL:content_main_delegate.cc(50)] Check failed: false. 
#0 0x7f114a956db9 <unknown>

fish: Job 1, 'Popcorn-Time' terminated by signal SIGABRT (Abort)
```

And somehow the linking to glibc seems to fail:
```
ldd /nix/store/1ddjn2ynr4gnlyf8wab179h01xmg2kp4-popcorntime-bin-0.4.6/Popcorn-Time
/nix/store/1ddjn2ynr4gnlyf8wab179h01xmg2kp4-popcorntime-bin-0.4.6/Popcorn-Time: /nix/store/jsp3h3wpzc842j0rz61m5ly71ak6qgdn-glibc-2.32-54/lib/libc.so.6: version `GLIBC_2.33' not found (required by /nix/store/nmrpvmrkvcs65x4lvs41fb8aazy1da9l-glib-2.70.1/lib/libglib-2.0.so.0)
/nix/store/1ddjn2ynr4gnlyf8wab179h01xmg2kp4-popcorntime-bin-0.4.6/Popcorn-Time: /nix/store/jsp3h3wpzc842j0rz61m5ly71ak6qgdn-glibc-2.32-54/lib/libc.so.6: version `GLIBC_2.33' not found (required by /nix/store/qhv5ccl3v1y8hz3nvmiajvidgryqqdmp-nss-3.71/lib/libnssutil3.so)
/nix/store/1ddjn2ynr4gnlyf8wab179h01xmg2kp4-popcorntime-bin-0.4.6/Popcorn-Time: /nix/store/jsp3h3wpzc842j0rz61m5ly71ak6qgdn-glibc-2.32-54/lib/libc.so.6: version `GLIBC_2.33' not found (required by /nix/store/xbkfidqmzl37li0ya1cwh3j4vv1x5yzf-nspr-4.32/lib/libnspr4.so)
/nix/store/1ddjn2ynr4gnlyf8wab179h01xmg2kp4-popcorntime-bin-0.4.6/Popcorn-Time: /nix/store/jsp3h3wpzc842j0rz61m5ly71ak6qgdn-glibc-2.32-54/lib/libc.so.6: version `GLIBC_2.33' not found (required by /nix/store/jz78aw3aimdc6gfqwlgwary7vm5kg0dh-libX11-1.7.2/lib/libX11.so.6)
[...]
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
