### PR TITLE
lightly: init at 0.4.1

### DIFF
--- a/pkgs/desktops/plasma-5/3rdparty/lightly/default.nix
+++ b/pkgs/desktops/plasma-5/3rdparty/lightly/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, cmake
+, extra-cmake-modules
+, kdecoration
+, kcoreaddons
+, kguiaddons
+, kconfigwidgets
+, kwindowsystem
+, kiconthemes
+, qtx11extras
+}:
+
+mkDerivation rec{
+  pname = "lightly";
+  version = "0.4.1";
+  src = fetchFromGitHub {
+    owner = "Luwx";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "k1fEZbhzluNlAmj5s/O9X20aCVQxlWQm/Iw/euX7cmI=";
+  };
+
+  extraCmakeFlags=["-DBUILD_TESTING=OFF"];
+
+  nativeBuildInputs = [ cmake extra-cmake-modules ];
+
+  buildInputs = [
+    kcoreaddons
+    kguiaddons
+    kconfigwidgets
+    kwindowsystem
+    kiconthemes
+    qtx11extras
+    kdecoration
+  ];
+
+  meta = with lib; {
+    description = "A modern style for qt applications";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ pasqui23 ];
+    homepage = "https://github.com/Luwx/Lightly/";
+    inherit (kwindowsystem.meta) platforms;
+  };
+}

--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -160,6 +160,7 @@ let
         kwin-tiling = callPackage ./3rdparty/kwin/scripts/tiling.nix { };
         krohnkite = callPackage ./3rdparty/kwin/scripts/krohnkite.nix { };
         krunner-symbols = callPackage ./3rdparty/addons/krunner-symbols.nix { };
+        lightly = callPackage ./3rdparty/lightly { };
         parachute = callPackage ./3rdparty/kwin/scripts/parachute.nix { };
       };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
###### Things done
OK I was dumb and did not understand nixos' model.

<del>
At the moment XDG_DATA_DIRS is not set correctly,despite building correctly

```
nix shell .#plasma5Packages.thirdParty.lightly
echo $XDG_DATA_DIRS|grep lightly
nix shell .#plasma5Packages.thirdParty.lightly
tree result
result
├── lib
│   ├── cmake
│   │   └── Lightly
│   │       ├── LightlyConfig.cmake
│   │       └── LightlyConfigVersion.cmake
│   ├── kconf_update_bin
│   │   └── kde4lightly
│   ├── liblightlycommon5.so.5 -> liblightlycommon5.so.5.19.4
│   ├── liblightlycommon5.so.5.19.4
│   └── qt-5.15.3
│       └── plugins
│           ├── kstyle_lightly_config.so
│           ├── org.kde.kdecoration2
│           │   └── lightlydecoration.so
│           └── styles
│               └── lightly.so
└── share
    ├── color-schemes
    │   └── Lightly.colors
    ├── kconf_update
    │   └── kde4lightly.upd
    ├── kservices5
    │   ├── lightlydecorationconfig.desktop
    │   └── lightlystyleconfig.desktop
    └── kstyle
        └── themes
            └── lightly.themerc
```
</del>

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
