### PR TITLE
signal-desktop: 5.23.1 -> 5.24.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -10,7 +10,6 @@
 , hunspellDicts, spellcheckerLanguage ? null # E.g. "de_DE"
 # For a full list of available languages:
 # $ cat pkgs/development/libraries/hunspell/dictionaries.nix | grep "dictFileName =" | awk '{ print $3 }'
-, sqlcipher
 }:
 
 let
@@ -23,42 +22,9 @@ let
       --set HUNSPELL_DICTIONARIES "${hunspellDicts.${hunspellDict}}/share/hunspell" \
       --set LC_MESSAGES "${spellcheckerLanguage}"'');
 
-  sqlcipher-signal = sqlcipher.overrideAttrs (_: {
-    # Using the same features as the upstream signal sqlcipher build
-    # https://github.com/signalapp/better-sqlite3/blob/2fa02d2484e9f9a10df5ac7ea4617fb2dff30006/deps/defines.gypi
-    CFLAGS = [
-      "-DSQLITE_LIKE_DOESNT_MATCH_BLOBS"
-      "-DSQLITE_THREADSAFE=2"
-      "-DSQLITE_USE_URI=0"
-      "-DSQLITE_DEFAULT_MEMSTATUS=0"
-      "-DSQLITE_OMIT_DEPRECATED"
-      "-DSQLITE_OMIT_GET_TABLE"
-      "-DSQLITE_OMIT_TCL_VARIABLE"
-      "-DSQLITE_OMIT_PROGRESS_CALLBACK"
-      "-DSQLITE_OMIT_SHARED_CACHE"
-      "-DSQLITE_TRACE_SIZE_LIMIT=32"
-      "-DSQLITE_DEFAULT_CACHE_SIZE=-16000"
-      "-DSQLITE_DEFAULT_FOREIGN_KEYS=1"
-      "-DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1"
-      "-DSQLITE_ENABLE_COLUMN_METADATA"
-      "-DSQLITE_ENABLE_UPDATE_DELETE_LIMIT"
-      "-DSQLITE_ENABLE_STAT4"
-      "-DSQLITE_ENABLE_FTS5"
-      "-DSQLITE_ENABLE_JSON1"
-      "-DSQLITE_ENABLE_RTREE"
-      "-DSQLITE_INTROSPECTION_PRAGMAS"
-
-      # SQLCipher-specific options
-      "-DSQLITE_HAS_CODEC"
-      "-DSQLITE_TEMP_STORE=2"
-      "-DSQLITE_SECURE_DELETE"
-    ];
-
-    LDFLAGS = [ "-lm" ];
-  });
 in stdenv.mkDerivation rec {
   pname = "signal-desktop";
-  version = "5.23.1"; # Please backport all updates to the stable channel.
+  version = "5.24.0"; # Please backport all updates to the stable channel.
   # All releases have a limited lifetime and "expire" 90 days after the release.
   # When releases "expire" the application becomes unusable until an update is
   # applied. The expiration date for the current release can be extracted with:
@@ -68,7 +34,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-    sha256 = "0scbnkkbaqyqiz6bfvhdrc0yqnccjsf66iggjpa7kjyk3cy61s6c";
+    sha256 = "1p19vs4wxlghv8cbsq5k4bl8h9fzr9izp4k4qs5fcnqiy1z92ycy";
   };
 
   nativeBuildInputs = [
@@ -153,7 +119,6 @@ in stdenv.mkDerivation rec {
   preFixup = ''
     gappsWrapperArgs+=(
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc ] }"
-      --prefix LD_PRELOAD : "${sqlcipher-signal}/lib/libsqlcipher.so"
       ${customLanguageWrapperArgs}
     )
 


### PR DESCRIPTION
Thanks to [0] we don't need the LD_PRELOAD hack anymore. Now, SQLCipher
will correctly get loaded without having to preload it. With version
5.23.1 this doesn't work (can be verified via the NixOS VM test).

[0]: https://github.com/signalapp/better-sqlite3/commit/917a6f5cf8b84d5ef4b8fe6dc0f4b8f59ca45bea

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Note: This should be fine but I don't plan to backport it to 21.05.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
