### PR TITLE
firefox: fix crash, enable debug symbols and clean up

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -27,7 +27,9 @@
 , ltoSupport ? (stdenv.isLinux && stdenv.is64bit), overrideCC, buildPackages
 , gssSupport ? true, libkrb5
 , pipewireSupport ? waylandSupport && webrtcSupport, pipewire
-, jemallocSupport ? true, jemalloc
+# Workaround: disabled since currently jemalloc causes crashes with LLVM 13.
+# https://bugzilla.mozilla.org/show_bug.cgi?id=1741454
+, jemallocSupport ? false, jemalloc
 
 ## privacy-related options
 

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -174,10 +174,6 @@ buildStdenv.mkDerivation ({
                                           AVFoundation MediaToolbox CoreLocation
                                           Foundation libobjc AddressBook cups ];
 
-  NIX_LDFLAGS = lib.optionalString ltoSupport ''
-    -rpath ${llvmPackages.libunwind.out}/lib
-  '';
-
   MACH_USE_SYSTEM_PYTHON = "1";
 
   postPatch = ''
@@ -297,14 +293,7 @@ buildStdenv.mkDerivation ({
     cd obj-*
   '';
 
-  makeFlags = lib.optionals ltoSupport [
-    "AR=${buildStdenv.cc.bintools.bintools}/bin/llvm-ar"
-    "LLVM_OBJDUMP=${buildStdenv.cc.bintools.bintools}/bin/llvm-objdump"
-    "NM=${buildStdenv.cc.bintools.bintools}/bin/llvm-nm"
-    "RANLIB=${buildStdenv.cc.bintools.bintools}/bin/llvm-ranlib"
-    "STRIP=${buildStdenv.cc.bintools.bintools}/bin/llvm-strip"
-  ]
-  ++ extraMakeFlags;
+  makeFlags = extraMakeFlags;
 
   enableParallelBuilding = true;
   doCheck = false; # "--disable-tests" above

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -273,7 +273,7 @@ buildStdenv.mkDerivation ({
   #   https://bugzilla.mozilla.org/show_bug.cgi?id=1538724
   # elf-hack is broken when using clang+lld:
   #   https://bugzilla.mozilla.org/show_bug.cgi?id=1482204
-  ++ lib.optional ltoSupport "--enable-lto"
+  ++ lib.optional ltoSupport "--enable-lto=cross" # Cross-language LTO.
   ++ lib.optional (ltoSupport && (buildStdenv.isAarch32 || buildStdenv.isi686 || buildStdenv.isx86_64)) "--disable-elf-hack"
   ++ lib.optional (ltoSupport && !buildStdenv.isDarwin) "--enable-linker=lld"
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

1. Fix #146382 by disabling jemalloc by default.
   It's caused by jemalloc violates clang's alignment assumption of `malloc` from LLVM 13. Check details in https://bugzilla.mozilla.org/show_bug.cgi?id=1741454

   Try [this POC](https://buckley310.github.io/nixos_firefox_webp_poc/index.html) to confirm it's actually fixed by this PR.
2. Enable separated debug symbols by default for easy debugging.
3. Clean up unnecessary `makeFlags` and `NIX_LDFLAGS` since we're now using LLVM stdenv.
4. Use `--enable-lto=cross`. I add this to make our configure flags closer to [Arch's](https://github.com/archlinux/svntogit-packages/blob/05508c68eb851b292f07b344a19d8b104b8b0cac/trunk/PKGBUILD#L137), and potentially make it more optimized.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
