### PR TITLE
qvge: enable on darwin

### DIFF
--- a/pkgs/applications/graphics/qvge/default.nix
+++ b/pkgs/applications/graphics/qvge/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , substituteAll
 , qmake
+, qtsvg
 , qtx11extras
 , graphviz
 }:
@@ -27,13 +28,13 @@ mkDerivation rec {
 
   nativeBuildInputs = [ qmake ];
 
-  buildInputs = [ qtx11extras ];
+  buildInputs = if stdenv.isDarwin then [ qtsvg ] else [ qtx11extras ];
 
   meta = with lib; {
     description = "Qt Visual Graph Editor";
     homepage = "https://github.com/ArsMasiuk/qvge";
     license = licenses.mit;
     maintainers = with maintainers; [ sikmir ];
-    platforms = with platforms; linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/graphics/qvge/default.nix
+++ b/pkgs/applications/graphics/qvge/default.nix
@@ -1,14 +1,15 @@
 { lib
-, mkDerivation
+, stdenv
 , fetchFromGitHub
 , substituteAll
+, wrapQtAppsHook
 , qmake
 , qtsvg
 , qtx11extras
 , graphviz
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "qvge";
   version = "0.6.3";
 
@@ -26,7 +27,7 @@ mkDerivation rec {
     inherit graphviz;
   });
 
-  nativeBuildInputs = [ qmake ];
+  nativeBuildInputs = [ wrapQtAppsHook qmake ];
 
   buildInputs = if stdenv.isDarwin then [ qtsvg ] else [ qtx11extras ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
