### PR TITLE
python3Packages.envisage: disable tests of broken optional feature

### DIFF
--- a/pkgs/development/python-modules/envisage/default.nix
+++ b/pkgs/development/python-modules/envisage/default.nix
@@ -1,7 +1,7 @@
 { lib, fetchPypi, isPy27
 , buildPythonPackage
 , traits, apptools, pytestCheckHook
-, ipykernel, ipython, setuptools
+, ipython, setuptools
 }:
 
 buildPythonPackage rec {
@@ -15,6 +15,8 @@ buildPythonPackage rec {
     sha256 = "8864c29aa344f7ac26eeb94788798f2d0cc791dcf95c632da8d79ebc580e114c";
   };
 
+  # for the optional dependency ipykernel, only versions < 6 are
+  # supported, so it's not included in the tests, and not propagated
   propagatedBuildInputs = [ traits apptools setuptools ];
 
   preCheck = ''
@@ -22,7 +24,7 @@ buildPythonPackage rec {
   '';
 
   checkInputs = [
-    ipykernel ipython pytestCheckHook
+    ipython pytestCheckHook
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/envisage/default.nix
+++ b/pkgs/development/python-modules/envisage/default.nix
@@ -1,7 +1,12 @@
-{ lib, fetchPypi, isPy27
+{ lib
+, fetchPypi
+, isPy27
 , buildPythonPackage
-, traits, apptools, pytestCheckHook
-, ipython, setuptools
+, traits
+, apptools
+, pytestCheckHook
+, ipython
+, setuptools
 }:
 
 buildPythonPackage rec {
@@ -24,7 +29,8 @@ buildPythonPackage rec {
   '';
 
   checkInputs = [
-    ipython pytestCheckHook
+    ipython
+    pytestCheckHook
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Only ipykernel < 6 is supported, disable tests for it.

[test suite fails with ipykernel 6](https://github.com/enthought/envisage/issues/448)
[Require ipykernel<6](https://github.com/enthought/envisage/pull/449)

ZHF #144627

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
