### PR TITLE
python3Packages.python-crontab: skip test `test_03_usage`

### DIFF
--- a/pkgs/development/python-modules/python-crontab/default.nix
+++ b/pkgs/development/python-modules/python-crontab/default.nix
@@ -10,7 +10,11 @@ buildPythonPackage rec {
   };
 
   checkInputs = [ pytestCheckHook ];
-  disabledTests = [ "test_07_non_posix_shell"];
+  disabledTests = [
+    "test_07_non_posix_shell"
+    # doctest that assumes /tmp is writeable, awkward to patch
+    "test_03_usage"
+  ];
 
   propagatedBuildInputs = [ python-dateutil ];
 


### PR DESCRIPTION
###### Motivation for this change
ZHF #144627 @NixOS/nixos-release-managers 

A bit of a weird test, essentially a doctest - but it assumes `/tmp` is writable, which is a Bad Thing. Technically it only causes trouble on darwin, but I think I should just disable it universally as I don't think it covers anything not otherwise covered. Since the test is in the actual package's docstring I don't really want to patch it to e.g. read `os.environ["TEMPDIR"]` or use `tempfile` or otherwise add distracting complication to it.

Could also use a `libredirect` trick too but that seems a bit much.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
