### PR TITLE
python3Packages.cozy: fix dependency name

### DIFF
--- a/pkgs/development/python-modules/cozy/default.nix
+++ b/pkgs/development/python-modules/cozy/default.nix
@@ -1,5 +1,15 @@
-{ buildPythonPackage, isPy3k, fetchFromGitHub, lib,
-  z3, ply, igraph, oset, ordered-set, dictionaries, setuptools }:
+{ buildPythonPackage
+, isPy3k
+, fetchFromGitHub
+, lib
+, z3
+, ply
+, igraph
+, oset
+, ordered-set
+, dictionaries
+, setuptools
+}:
 
 buildPythonPackage {
   pname = "cozy";
@@ -7,7 +17,13 @@ buildPythonPackage {
   disabled = !isPy3k;
 
   propagatedBuildInputs = [
-    setuptools z3 ply igraph oset ordered-set dictionaries
+    setuptools
+    z3
+    ply
+    igraph
+    oset
+    ordered-set
+    dictionaries
   ];
 
   src = fetchFromGitHub {
@@ -37,10 +53,10 @@ buildPythonPackage {
   '';
 
 
-  meta = {
+  meta = with lib; {
     description = "The collection synthesizer";
     homepage = "https://cozy.uwplse.org/";
-    license = lib.licenses.asl20;
-    maintainers = [ lib.maintainers.MostAwesomeDude ];
+    license = licenses.asl20;
+    maintainers = with maintainers; [ MostAwesomeDude ];
   };
 }

--- a/pkgs/development/python-modules/cozy/default.nix
+++ b/pkgs/development/python-modules/cozy/default.nix
@@ -17,9 +17,14 @@ buildPythonPackage {
     sha256 = "1jhr5gzihj8dkg0yc5dmi081v2isxharl0ph7v2grqj0bwqzl40j";
   };
 
-  # Yoink the Z3 dependency name, because our Z3 package doesn't provide it.
+  # - yoink the Z3 dependency name, because our Z3 package doesn't provide it.
+  # - remove "dictionaries" version bound
+  # - patch igraph package name
   postPatch = ''
-    sed -i -e '/z3-solver/d' -e 's/^dictionaries.*$/dictionaries/' requirements.txt
+    sed -i -e '/z3-solver/d' \
+           -e 's/^dictionaries.*$/dictionaries/' \
+           -e 's/python-igraph/igraph/' \
+            requirements.txt
   '';
 
   # Tests are not correctly set up in the source tree.


### PR DESCRIPTION
###### Motivation for this change

`python-igraph` was recently renamed to `igraph`

ZHF #144627 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
