### PR TITLE
nixos/qemu-vm: default memorySize 384 -> 1024

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -296,7 +296,7 @@ in
     virtualisation.memorySize =
       mkOption {
         type = types.ints.positive;
-        default = 384;
+        default = 1024;
         description =
           ''
             The memory size in megabytes of the virtual machine.

--- a/nixos/tests/airsonic.nix
+++ b/nixos/tests/airsonic.nix
@@ -11,10 +11,6 @@ import ./make-test-python.nix ({ pkgs, ... }: {
         enable = true;
         maxMemory = 800;
       };
-
-      # Airsonic is a Java application, and unfortunately requires a significant
-      # amount of memory.
-      virtualisation.memorySize = 1024;
     };
 
   testScript = ''

--- a/nixos/tests/cage.nix
+++ b/nixos/tests/cage.nix
@@ -17,7 +17,6 @@ import ./make-test-python.nix ({ pkgs, ...} :
       program = "${pkgs.xterm}/bin/xterm -cm -pc -fa Monospace -fs 24";
     };
 
-    virtualisation.memorySize = 1024;
     # Need to switch to a different GPU driver than the default one (-vga std) so that Cage can launch:
     virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
   };

--- a/nixos/tests/cagebreak.nix
+++ b/nixos/tests/cagebreak.nix
@@ -35,7 +35,6 @@ in
     programs.xwayland.enable = true;
     environment.systemPackages = [ pkgs.cagebreak pkgs.wayland-utils ];
 
-    virtualisation.memorySize = 1024;
     # Need to switch to a different GPU driver than the default one (-vga std) so that Cagebreak can launch:
     virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
   };

--- a/nixos/tests/cassandra.nix
+++ b/nixos/tests/cassandra.nix
@@ -41,7 +41,6 @@ let
       ];
     };
     services.cassandra = cassandraCfg ipAddress // extra;
-    virtualisation.memorySize = 1024;
   };
 in
 {

--- a/nixos/tests/ceph-multi-node.nix
+++ b/nixos/tests/ceph-multi-node.nix
@@ -37,7 +37,6 @@ let
 
   generateHost = { pkgs, cephConfig, networkConfig, ... }: {
     virtualisation = {
-      memorySize = 1024;
       emptyDiskImages = [ 20480 ];
       vlans = [ 1 ];
     };

--- a/nixos/tests/ceph-single-node-bluestore.nix
+++ b/nixos/tests/ceph-single-node-bluestore.nix
@@ -34,7 +34,6 @@ let
 
   generateHost = { pkgs, cephConfig, networkConfig, ... }: {
     virtualisation = {
-      memorySize = 1024;
       emptyDiskImages = [ 20480 20480 20480 ];
       vlans = [ 1 ];
     };

--- a/nixos/tests/ceph-single-node.nix
+++ b/nixos/tests/ceph-single-node.nix
@@ -34,7 +34,6 @@ let
 
   generateHost = { pkgs, cephConfig, networkConfig, ... }: {
     virtualisation = {
-      memorySize = 1024;
       emptyDiskImages = [ 20480 20480 20480 ];
       vlans = [ 1 ];
     };

--- a/nixos/tests/common/wayland-cage.nix
+++ b/nixos/tests/common/wayland-cage.nix
@@ -8,7 +8,6 @@
   };
 
   virtualisation = {
-    memorySize = 1024;
     qemu.options = [ "-vga virtio" ];
   };
 }

--- a/nixos/tests/containers-bridge.nix
+++ b/nixos/tests/containers-bridge.nix
@@ -15,7 +15,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     { pkgs, ... }:
     { imports = [ ../modules/installer/cd-dvd/channel.nix ];
       virtualisation.writableStore = true;
-      virtualisation.memorySize = 768;
 
       networking.bridges = {
         br0 = {

--- a/nixos/tests/containers-ephemeral.nix
+++ b/nixos/tests/containers-ephemeral.nix
@@ -5,7 +5,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
   };
 
   machine = { pkgs, ... }: {
-    virtualisation.memorySize = 768;
     virtualisation.writableStore = true;
 
     containers.webserver = {

--- a/nixos/tests/containers-extra_veth.nix
+++ b/nixos/tests/containers-extra_veth.nix
@@ -8,7 +8,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     { pkgs, ... }:
     { imports = [ ../modules/installer/cd-dvd/channel.nix ];
       virtualisation.writableStore = true;
-      virtualisation.memorySize = 768;
       virtualisation.vlans = [];
 
       networking.useDHCP = false;

--- a/nixos/tests/containers-hosts.nix
+++ b/nixos/tests/containers-hosts.nix
@@ -7,7 +7,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
   machine =
     { lib, ... }:
     {
-      virtualisation.memorySize = 256;
       virtualisation.vlans = [];
 
       networking.bridges.br0.interfaces = [];

--- a/nixos/tests/containers-imperative.nix
+++ b/nixos/tests/containers-imperative.nix
@@ -14,7 +14,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
       nix.binaryCaches = []; # don't try to access cache.nixos.org
 
       virtualisation.writableStore = true;
-      virtualisation.memorySize = 1024;
       # Make sure we always have all the required dependencies for creating a
       # container available within the VM, because we don't have network access.
       virtualisation.additionalPaths = let

--- a/nixos/tests/containers-ip.nix
+++ b/nixos/tests/containers-ip.nix
@@ -22,7 +22,6 @@ in import ./make-test-python.nix ({ pkgs, lib, ... }: {
       imports = [ ../modules/installer/cd-dvd/channel.nix ];
       virtualisation = {
         writableStore = true;
-        memorySize = 768;
       };
 
       containers.webserver4 = webserverFor "10.231.136.1" "10.231.136.2";

--- a/nixos/tests/containers-macvlans.nix
+++ b/nixos/tests/containers-macvlans.nix
@@ -15,7 +15,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     machine1 =
       { lib, ... }:
       {
-        virtualisation.memorySize = 256;
         virtualisation.vlans = [ 1 ];
 
         # To be able to ping containers from the host, it is necessary
@@ -55,7 +54,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     machine2 =
       { ... }:
       {
-        virtualisation.memorySize = 256;
         virtualisation.vlans = [ 1 ];
       };
 

--- a/nixos/tests/containers-physical_interfaces.nix
+++ b/nixos/tests/containers-physical_interfaces.nix
@@ -7,7 +7,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
   nodes = {
     server = { ... }:
       {
-        virtualisation.memorySize = 256;
         virtualisation.vlans = [ 1 ];
 
         containers.server = {
@@ -23,7 +22,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
         };
       };
     bridged = { ... }: {
-      virtualisation.memorySize = 128;
       virtualisation.vlans = [ 1 ];
 
       containers.bridged = {
@@ -41,7 +39,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     };
 
     bonded = { ... }: {
-      virtualisation.memorySize = 128;
       virtualisation.vlans = [ 1 ];
 
       containers.bonded = {
@@ -62,7 +59,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     };
 
     bridgedbond = { ... }: {
-      virtualisation.memorySize = 128;
       virtualisation.vlans = [ 1 ];
 
       containers.bridgedbond = {

--- a/nixos/tests/containers-portforward.nix
+++ b/nixos/tests/containers-portforward.nix
@@ -15,7 +15,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     { pkgs, ... }:
     { imports = [ ../modules/installer/cd-dvd/channel.nix ];
       virtualisation.writableStore = true;
-      virtualisation.memorySize = 768;
 
       containers.webserver =
         { privateNetwork = true;

--- a/nixos/tests/containers-tmpfs.nix
+++ b/nixos/tests/containers-tmpfs.nix
@@ -8,7 +8,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     { pkgs, ... }:
     { imports = [ ../modules/installer/cd-dvd/channel.nix ];
       virtualisation.writableStore = true;
-      virtualisation.memorySize = 768;
 
       containers.tmpfs =
         {

--- a/nixos/tests/custom-ca.nix
+++ b/nixos/tests/custom-ca.nix
@@ -81,8 +81,6 @@ in
 
       # chromium-based browsers refuse to run as root
       test-support.displayManager.auto.user = "alice";
-      # browsers may hang with the default memory
-      virtualisation.memorySize = 500;
 
       networking.hosts."127.0.0.1" = [ "good.example.com" "bad.example.com" ];
       security.pki.certificateFiles = [ "${example-good-cert}/ca.crt" ];

--- a/nixos/tests/enlightenment.nix
+++ b/nixos/tests/enlightenment.nix
@@ -19,7 +19,6 @@ import ./make-test-python.nix ({ pkgs, ...} :
       };
     };
     hardware.pulseaudio.enable = true; # needed for the factl test, /dev/snd/* exists without them but udev doesn't care then
-    virtualisation.memorySize = 1024;
     environment.systemPackages = [ pkgs.xdotool ];
     services.acpid.enable = true;
     services.connman.enable = true;

--- a/nixos/tests/fcitx/default.nix
+++ b/nixos/tests/fcitx/default.nix
@@ -11,7 +11,6 @@ import ../make-test-python.nix (
           ...
         }:
           {
-            virtualisation.memorySize = 1024;
 
             imports = [
               ../common/user-account.nix

--- a/nixos/tests/fenics.nix
+++ b/nixos/tests/fenics.nix
@@ -38,7 +38,6 @@ in
         gcc
         (python3.withPackages (ps: with ps; [ fenics ]))
       ];
-      virtualisation.memorySize = 512;
     };
   };
   testScript =

--- a/nixos/tests/firefox.nix
+++ b/nixos/tests/firefox.nix
@@ -13,9 +13,6 @@ import ./make-test-python.nix ({ pkgs, firefoxPackage, ... }: {
         pkgs.xdotool
       ];
 
-      # Need some more memory to record audio.
-      virtualisation.memorySize = 500;
-
       # Create a virtual sound device, with mixing
       # and all, for recording audio.
       boot.kernelModules = [ "snd-aloop" ];

--- a/nixos/tests/gerrit.nix
+++ b/nixos/tests/gerrit.nix
@@ -18,7 +18,6 @@ in {
       { config, pkgs, ... }: {
         networking.firewall.allowedTCPPorts = [ 80 2222 ];
 
-        virtualisation.memorySize = 1024;
 
         services.gerrit = {
           enable = true;

--- a/nixos/tests/gnome-xorg.nix
+++ b/nixos/tests/gnome-xorg.nix
@@ -40,7 +40,6 @@ import ./make-test-python.nix ({ pkgs, lib, ...} : {
         };
       };
 
-      virtualisation.memorySize = 1024;
     };
 
   testScript = { nodes, ... }: let

--- a/nixos/tests/gnome.nix
+++ b/nixos/tests/gnome.nix
@@ -45,7 +45,6 @@ import ./make-test-python.nix ({ pkgs, lib, ...} : {
         };
       };
 
-      virtualisation.memorySize = 1024;
     };
 
   testScript = { nodes, ... }: let

--- a/nixos/tests/graphite.nix
+++ b/nixos/tests/graphite.nix
@@ -4,7 +4,6 @@ import ./make-test-python.nix ({ pkgs, ... } :
   nodes = {
     one =
       { ... }: {
-        virtualisation.memorySize = 1024;
         time.timeZone = "UTC";
         services.graphite = {
           web = {

--- a/nixos/tests/hadoop/hadoop.nix
+++ b/nixos/tests/hadoop/hadoop.nix
@@ -95,7 +95,6 @@ import ../make-test-python.nix ({pkgs, ...}: {
 
     # YARN cluster
     rm1 = {pkgs, options, ...}: {
-      virtualisation.memorySize = 1024;
       services.hadoop = {
         inherit package coreSite hdfsSite;
         yarnSite = options.services.hadoop.yarnSite.default // yarnSiteHA;
@@ -103,7 +102,6 @@ import ../make-test-python.nix ({pkgs, ...}: {
       };
     };
     rm2 = {pkgs, options, ...}: {
-      virtualisation.memorySize = 1024;
       services.hadoop = {
         inherit package coreSite hdfsSite;
         yarnSite = options.services.hadoop.yarnSite.default // yarnSiteHA;

--- a/nixos/tests/hadoop/hdfs.nix
+++ b/nixos/tests/hadoop/hdfs.nix
@@ -2,7 +2,6 @@
 import ../make-test-python.nix ({...}: {
   nodes = {
     namenode = {pkgs, ...}: {
-      virtualisation.memorySize = 1024;
       services.hadoop = {
         package = pkgs.hadoop;
         hdfs = {

--- a/nixos/tests/installed-tests/fwupd.nix
+++ b/nixos/tests/installed-tests/fwupd.nix
@@ -7,6 +7,5 @@ makeInstalledTest {
     services.fwupd.enable = true;
     services.fwupd.disabledPlugins = lib.mkForce []; # don't disable test plugin
     services.fwupd.enableTestRemote = true;
-    virtualisation.memorySize = 768;
   };
 }

--- a/nixos/tests/jitsi-meet.nix
+++ b/nixos/tests/jitsi-meet.nix
@@ -8,7 +8,6 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     client = { nodes, pkgs, ... }: {
     };
     server = { config, pkgs, ... }: {
-      virtualisation.memorySize = 512;
       services.jitsi-meet = {
         enable = true;
         hostName = "server";

--- a/nixos/tests/kafka.nix
+++ b/nixos/tests/kafka.nix
@@ -19,7 +19,6 @@ let
         };
 
         networking.firewall.allowedTCPPorts = [ 2181 ];
-        virtualisation.memorySize = 1024;
       };
       kafka = { ... }: {
         services.apache-kafka = {

--- a/nixos/tests/keycloak.nix
+++ b/nixos/tests/keycloak.nix
@@ -17,7 +17,6 @@ let
 
       nodes = {
         keycloak = { ... }: {
-          virtualisation.memorySize = 1024;
 
           security.pki.certificateFiles = [
             certs.ca.cert

--- a/nixos/tests/lxd-image.nix
+++ b/nixos/tests/lxd-image.nix
@@ -46,8 +46,6 @@ in {
 
   machine = { lib, ... }: {
     virtualisation = {
-      # OOMs otherwise
-      memorySize = 1024;
       # disk full otherwise
       diskSize = 2048;
 

--- a/nixos/tests/metabase.nix
+++ b/nixos/tests/metabase.nix
@@ -7,7 +7,6 @@ import ./make-test-python.nix ({ pkgs, ... }: {
   nodes = {
     machine = { ... }: {
       services.metabase.enable = true;
-      virtualisation.memorySize = 1024;
     };
   };
 

--- a/nixos/tests/mysql/mysql.nix
+++ b/nixos/tests/mysql/mysql.nix
@@ -64,10 +64,6 @@ in
       {
         imports = [ users ];
 
-        # prevent oom:
-        # Kernel panic - not syncing: Out of memory: compulsory panic_on_oom is enabled
-        virtualisation.memorySize = 1024;
-
         services.mysql.enable = true;
         services.mysql.initialDatabases = [
           { name = "testdb3"; schema = ./testdb.sql; }

--- a/nixos/tests/networking-proxy.nix
+++ b/nixos/tests/networking-proxy.nix
@@ -8,7 +8,6 @@ let default-config = {
 
         services.xserver.enable = false;
 
-        virtualisation.memorySize = 128;
       };
 in import ./make-test-python.nix ({ pkgs, ...} : {
   name = "networking-proxy";

--- a/nixos/tests/nginx-etag.nix
+++ b/nixos/tests/nginx-etag.nix
@@ -37,7 +37,6 @@ import ./make-test-python.nix {
     };
 
     client = { pkgs, lib, ... }: {
-      virtualisation.memorySize = 512;
       environment.systemPackages = let
         testRunner = pkgs.writers.writePython3Bin "test-runner" {
           libraries = [ pkgs.python3Packages.selenium ];

--- a/nixos/tests/nixops/default.nix
+++ b/nixos/tests/nixops/default.nix
@@ -26,7 +26,6 @@ let
         nix.binaryCaches = lib.mkForce [ ];
         users.users.person.isNormalUser = true;
         virtualisation.writableStore = true;
-        virtualisation.memorySize = 1024 /*MiB*/;
         virtualisation.additionalPaths = [
           pkgs.hello
           pkgs.figlet

--- a/nixos/tests/opensmtpd-rspamd.nix
+++ b/nixos/tests/opensmtpd-rspamd.nix
@@ -39,7 +39,6 @@ import ./make-test-python.nix {
 
     smtp2 = { pkgs, ... }: {
       imports = [ common/user-account.nix ];
-      virtualisation.memorySize = 512;
       networking = {
         firewall.allowedTCPPorts = [ 25 143 ];
         useDHCP = false;

--- a/nixos/tests/pantheon.nix
+++ b/nixos/tests/pantheon.nix
@@ -15,7 +15,6 @@ import ./make-test-python.nix ({ pkgs, lib, ...} :
     services.xserver.enable = true;
     services.xserver.desktopManager.pantheon.enable = true;
 
-    virtualisation.memorySize = 1024;
   };
 
   enableOCR = true;

--- a/nixos/tests/paperless-ng.nix
+++ b/nixos/tests/paperless-ng.nix
@@ -8,7 +8,6 @@ import ./make-test-python.nix ({ lib, ... }: {
       enable = true;
       passwordFile = builtins.toFile "password" "admin";
     };
-    virtualisation.memorySize = 1024;
   };
 
   testScript = ''

--- a/nixos/tests/plasma5-systemd-start.nix
+++ b/nixos/tests/plasma5-systemd-start.nix
@@ -21,7 +21,6 @@ import ./make-test-python.nix ({ pkgs, ...} :
         user = "alice";
       };
     };
-    virtualisation.memorySize = 1024;
   };
 
   testScript = { nodes, ... }: let

--- a/nixos/tests/plasma5.nix
+++ b/nixos/tests/plasma5.nix
@@ -19,7 +19,6 @@ import ./make-test-python.nix ({ pkgs, ...} :
       user = "alice";
     };
     hardware.pulseaudio.enable = true; # needed for the factl test, /dev/snd/* exists without them but udev doesn't care then
-    virtualisation.memorySize = 1024;
   };
 
   testScript = { nodes, ... }: let

--- a/nixos/tests/pleroma.nix
+++ b/nixos/tests/pleroma.nix
@@ -202,7 +202,6 @@ import ./make-test-python.nix ({ pkgs, ... }:
       security.pki.certificateFiles = [ "${tls-cert}/cert.pem" ];
       networking.extraHosts = hosts nodes;
       networking.firewall.enable = false;
-      virtualisation.memorySize = 512;
       environment.systemPackages = with pkgs; [
         provision-db
         provision-secrets

--- a/nixos/tests/privacyidea.nix
+++ b/nixos/tests/privacyidea.nix
@@ -8,7 +8,6 @@ import ./make-test-python.nix ({ pkgs, ...} : rec {
 
   machine = { ... }: {
     virtualisation.cores = 2;
-    virtualisation.memorySize = 512;
 
     services.privacyidea = {
       enable = true;

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -464,7 +464,6 @@ let
         extraFlags = [ "--lnd.network=regtest" ];
       };
       metricProvider = {
-        virtualisation.memorySize = 1024;
         systemd.services.prometheus-lnd-exporter.serviceConfig.RestartSec = 15;
         systemd.services.prometheus-lnd-exporter.after = [ "lnd.service" ];
         services.bitcoind.regtest = {
@@ -953,7 +952,6 @@ let
       };
       metricProvider = {
         services.rspamd.enable = true;
-        virtualisation.memorySize = 1024;
       };
       exporterTest = ''
         wait_for_unit("rspamd.service")

--- a/nixos/tests/prometheus.nix
+++ b/nixos/tests/prometheus.nix
@@ -188,7 +188,6 @@ in import ./make-test-python.nix {
       # Minio requires at least 1GiB of free disk space to run.
       virtualisation = {
         diskSize = 2 * 1024;
-        memorySize = 1024;
       };
       networking.firewall.allowedTCPPorts = [ minioPort ];
 

--- a/nixos/tests/rspamd.nix
+++ b/nixos/tests/rspamd.nix
@@ -25,7 +25,6 @@ let
     machine = {
       services.rspamd.enable = true;
       networking.enableIPv6 = enableIPv6;
-      virtualisation.memorySize = 1024;
     };
     testScript = ''
       start_all()
@@ -69,7 +68,6 @@ in
           group = "rspamd";
         }];
       };
-      virtualisation.memorySize = 1024;
     };
 
     testScript = ''
@@ -118,7 +116,6 @@ in
           '';
         };
       };
-      virtualisation.memorySize = 1024;
     };
 
     testScript = ''
@@ -224,7 +221,6 @@ in
           rspamd_logger.infox(rspamd_config, 'Work dammit!!!')
         '';
       };
-      virtualisation.memorySize = 1024;
     };
     testScript = ''
       ${initMachine}
@@ -291,7 +287,6 @@ in
         postfix.enable = true;
         workers.rspamd_proxy.type = "rspamd_proxy";
       };
-      virtualisation.memorySize = 1024;
     };
     testScript = ''
       ${initMachine}

--- a/nixos/tests/seafile.nix
+++ b/nixos/tests/seafile.nix
@@ -1,7 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }:
   let
     client = { config, pkgs, ... }: {
-      virtualisation.memorySize = 256;
       environment.systemPackages = [ pkgs.seafile-shared pkgs.curl ];
     };
   in {
@@ -12,7 +11,6 @@ import ./make-test-python.nix ({ pkgs, ... }:
 
     nodes = {
       server = { config, pkgs, ... }: {
-        virtualisation.memorySize = 512;
         services.seafile = {
           enable = true;
           ccnetSettings.General.SERVICE_URL = "http://server";

--- a/nixos/tests/signal-desktop.nix
+++ b/nixos/tests/signal-desktop.nix
@@ -29,7 +29,6 @@ in {
     environment.systemPackages = with pkgs; [
       signal-desktop file sqlite sqlcipher-signal
     ];
-    virtualisation.memorySize = 1024;
   };
 
   enableOCR = true;

--- a/nixos/tests/spark/default.nix
+++ b/nixos/tests/spark/default.nix
@@ -3,7 +3,6 @@ import ../make-test-python.nix ({...}: {
 
   nodes = {
     worker = { nodes, pkgs, ... }: {
-      virtualisation.memorySize = 1024;
       services.spark.worker = {
         enable = true;
         master = "master:7077";

--- a/nixos/tests/sway.nix
+++ b/nixos/tests/sway.nix
@@ -44,7 +44,6 @@ import ./make-test-python.nix ({ pkgs, lib, ...} :
     # To test pinentry via gpg-agent:
     programs.gnupg.agent.enable = true;
 
-    virtualisation.memorySize = 1024;
     # Need to switch to a different GPU driver than the default one (-vga std) so that Sway can launch:
     virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
   };

--- a/nixos/tests/sympa.nix
+++ b/nixos/tests/sympa.nix
@@ -5,7 +5,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
   machine =
     { ... }:
     {
-      virtualisation.memorySize = 1024;
 
       services.sympa = {
         enable = true;

--- a/nixos/tests/systemd-cryptenroll.nix
+++ b/nixos/tests/systemd-cryptenroll.nix
@@ -8,7 +8,6 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     environment.systemPackages = [ pkgs.cryptsetup ];
     virtualisation = {
       emptyDiskImages = [ 512 ];
-      memorySize = 1024;
       qemu.options = [
         "-chardev socket,id=chrtpm,path=/tmp/swtpm-sock"
         "-tpmdev emulator,id=tpm0,chardev=chrtpm"

--- a/nixos/tests/systemd.nix
+++ b/nixos/tests/systemd.nix
@@ -5,7 +5,6 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     imports = [ common/user-account.nix common/x11.nix ];
 
     virtualisation.emptyDiskImages = [ 512 512 ];
-    virtualisation.memorySize = 1024;
 
     environment.systemPackages = [ pkgs.cryptsetup ];
 

--- a/nixos/tests/vault-postgresql.nix
+++ b/nixos/tests/vault-postgresql.nix
@@ -12,7 +12,6 @@ import ./make-test-python.nix ({ pkgs, ... }:
     maintainers = [ lnl7 roberth ];
   };
   machine = { lib, pkgs, ... }: {
-    virtualisation.memorySize = 512;
     environment.systemPackages = [ pkgs.vault ];
     environment.variables.VAULT_ADDR = "http://127.0.0.1:8200";
     services.vault.enable = true;

--- a/nixos/tests/vault.nix
+++ b/nixos/tests/vault.nix
@@ -8,7 +8,6 @@ import ./make-test-python.nix ({ pkgs, ... }:
     environment.systemPackages = [ pkgs.vault ];
     environment.variables.VAULT_ADDR = "http://127.0.0.1:8200";
     services.vault.enable = true;
-    virtualisation.memorySize = 512;
   };
 
   testScript =

--- a/nixos/tests/vaultwarden.nix
+++ b/nixos/tests/vaultwarden.nix
@@ -140,7 +140,6 @@ let
               in
               [ pkgs.firefox-unwrapped pkgs.geckodriver testRunner ];
 
-            virtualisation.memorySize = 768;
           }
         ];
 

--- a/nixos/tests/xfce.nix
+++ b/nixos/tests/xfce.nix
@@ -23,7 +23,6 @@ import ./make-test-python.nix ({ pkgs, ...} : {
 
       hardware.pulseaudio.enable = true; # needed for the factl test, /dev/snd/* exists without them but udev doesn't care then
 
-      virtualisation.memorySize = 1024;
     };
 
   testScript = { nodes, ... }: let


### PR DESCRIPTION
the default hasn't been changed since 2009
this can improve our test performances

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
