### PR TITLE
chromium: update.py: Download files from the main repository

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/update.py
+++ b/pkgs/applications/networking/browsers/chromium/update.py
@@ -5,6 +5,7 @@
 via upstream-info.json."""
 # Usage: ./update.py [--commit]
 
+import base64
 import csv
 import json
 import re
@@ -48,9 +49,10 @@ def nix_prefetch_git(url, rev):
 
 def get_file_revision(revision, file_path):
     """Fetches the requested Git revision of the given Chromium file."""
-    url = f'https://raw.githubusercontent.com/chromium/chromium/{revision}/{file_path}'
+    url = f'https://chromium.googlesource.com/chromium/src/+/refs/tags/{revision}/{file_path}?format=TEXT'
     with urlopen(url) as http_response:
-        return http_response.read()
+        resp = http_response.read()
+        return base64.b64decode(resp)
 
 
 def get_matching_chromedriver(version):


### PR DESCRIPTION
The tag 98.0.4710.4 is missing on the official GitHub mirror. As a
result the download of the DEPS file was failing (HTTP Error 404: Not
Found). Using the upstream repository is obviously better anyway, it's
just less obvious how to fetch a file from there (?format=TEXT).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes:
```
$ pkgs/applications/networking/browsers/chromium/update.py
GET https://omahaproxy.appspot.com/history?os=linux
nix-prefetch-url https://commondatastorage.googleapis.com/chromium-browser-official/chromium-98.0.4710.4.tar.xz
path is '/nix/store/3fjcmb5f923f72hwyf7wdaywsgw5k7mb-chromium-98.0.4710.4.tar.xz'
nix-prefetch-url https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-unstable/google-chrome-unstable_98.0.4710.4-1_amd64.deb
path is '/nix/store/qgg94h57ndsy1ng6957wqg7s6z5f094h-google-chrome-unstable_98.0.4710.4-1_amd64.deb'
Traceback (most recent call last):
  File "/var/tmp/michael/nixpkgs/pkgs/applications/networking/browsers/chromium/update.py", line 200, in <module>
    channel['deps'] = get_channel_dependencies(channel['version'])
  File "/var/tmp/michael/nixpkgs/pkgs/applications/networking/browsers/chromium/update.py", line 76, in get_channel_dependencies
    deps = get_file_revision(version, 'DEPS')
  File "/var/tmp/michael/nixpkgs/pkgs/applications/networking/browsers/chromium/update.py", line 53, in get_file_revision
    with urlopen(url) as http_response:
  File "/nix/store/fkzla307l4mlcvfyshsrccwl7szihx2z-python3-3.9.6/lib/python3.9/urllib/request.py", line 214, in urlopen
    return opener.open(url, data, timeout)
  File "/nix/store/fkzla307l4mlcvfyshsrccwl7szihx2z-python3-3.9.6/lib/python3.9/urllib/request.py", line 523, in open
    response = meth(req, response)
  File "/nix/store/fkzla307l4mlcvfyshsrccwl7szihx2z-python3-3.9.6/lib/python3.9/urllib/request.py", line 632, in http_response
    response = self.parent.error(
  File "/nix/store/fkzla307l4mlcvfyshsrccwl7szihx2z-python3-3.9.6/lib/python3.9/urllib/request.py", line 561, in error
    return self._call_chain(*args)
  File "/nix/store/fkzla307l4mlcvfyshsrccwl7szihx2z-python3-3.9.6/lib/python3.9/urllib/request.py", line 494, in _call_chain
    result = func(*args)
  File "/nix/store/fkzla307l4mlcvfyshsrccwl7szihx2z-python3-3.9.6/lib/python3.9/urllib/request.py", line 641, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 404: Not Found
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
