### PR TITLE
python3Packages.nbclient: 0.5.8 -> 0.5.9, fix build

### DIFF
--- a/pkgs/development/python-modules/nbclient/default.nix
+++ b/pkgs/development/python-modules/nbclient/default.nix
@@ -6,24 +6,17 @@
 
 buildPythonPackage rec {
   pname = "nbclient";
-  version = "0.5.8";
+  version = "0.5.9";
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-NPUsycuDGl2MzXAxU341THXcYaJEh/mYcS0Sid4yCiU=";
+    sha256 = "sha256-meRt2vrNC4YSk78kb+2FQKGErfo6p9ZB+JAx7AcHAeA=";
   };
 
   inherit doCheck;
   checkInputs = [ pytest xmltodict nbconvert ipywidgets ];
   propagatedBuildInputs = [ async_generator traitlets nbformat nest-asyncio jupyter-client ];
-
-  postFixup =  ''
-    # Remove until fixed by upstream
-    # https://github.com/jupyter/nbclient/pull/173#issuecomment-968760082
-    rm $out/bin/.jupyter-run-wrapped
-    rm $out/bin/jupyter-run
-  '';
 
   meta = with lib; {
     homepage = "https://github.com/jupyter/nbclient";


### PR DESCRIPTION
This also fixes the build failure introduced in https://github.com/NixOS/nixpkgs/pull/146151, as for some reason the bin directory is empty when doCheck = true and then the postFixup failed.

0.5.9 contains https://github.com/jupyter/nbclient/pull/173 so no need for the `postFixup` anymore.

This should also close https://github.com/NixOS/nixpkgs/issues/146277.
The original issue was https://github.com/NixOS/nixpkgs/issues/145968.

Run

```
nix build --impure --expr "let pkgs = import ./. {}; in pkgs.python3.withPackages (ps: [ ps.jupyterlab ])"
```

for testing.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
