### PR TITLE
libasyncns: fix build for darwin

### DIFF
--- a/pkgs/development/libraries/libasyncns/default.nix
+++ b/pkgs/development/libraries/libasyncns/default.nix
@@ -9,6 +9,11 @@ stdenv.mkDerivation rec {
     sha256 = "0x5b6lcic4cd7q0bx00x93kvpyzl7n2abbgvqbrlzrfb8vknc6jg";
   };
 
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    substituteInPlace libasyncns/asyncns.c \
+      --replace '<arpa/nameser.h>' '<arpa/nameser_compat.h>'
+  '';
+
   configureFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "ac_cv_func_malloc_0_nonnull=yes"
     "ac_cv_func_realloc_0_nonnull=yes"

--- a/pkgs/development/python-modules/libasyncns/default.nix
+++ b/pkgs/development/python-modules/libasyncns/default.nix
@@ -1,5 +1,10 @@
-{ lib, buildPythonPackage, fetchurl
-, libasyncns, pkg-config }:
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchurl
+, libasyncns
+, pkg-config
+}:
 
 buildPythonPackage rec {
   pname = "libasyncns-python";
@@ -11,6 +16,11 @@ buildPythonPackage rec {
   };
 
   patches = [ ./libasyncns-fix-res-consts.patch ];
+
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    substituteInPlace resquery.c \
+      --replace '<arpa/nameser.h>' '<arpa/nameser_compat.h>'
+  '';
 
   buildInputs = [ libasyncns ];
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/python-modules/libasyncns/default.nix
+++ b/pkgs/development/python-modules/libasyncns/default.nix
@@ -26,6 +26,8 @@ buildPythonPackage rec {
   nativeBuildInputs = [ pkg-config ];
   doCheck = false; # requires network access
 
+  pythonImportsCheck = [ "libasyncns" ];
+
   meta = with lib; {
     description = "libasyncns-python is a python binding for the asynchronous name service query library";
     license = licenses.lgpl21;


### PR DESCRIPTION
###### Motivation for this change
ZHF #144627 @NixOS/nixos-release-managers

Also fix `python3Packages.libasyncns` and add `pythonImportsCheck` for it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
