### PR TITLE
treewide: refactor isi686 && isx86_64 -> isx86

### DIFF
--- a/nixos/lib/make-zfs-image.nix
+++ b/nixos/lib/make-zfs-image.nix
@@ -241,7 +241,7 @@ let
     pkgs.vmTools.override {
       rootModules =
         [ "zfs" "9p" "9pnet_virtio" "virtio_pci" "virtio_blk" ] ++
-          (pkgs.lib.optional (pkgs.stdenv.isi686 || pkgs.stdenv.isx86_64) "rtc_cmos");
+          (pkgs.lib.optional pkgs.stdenv.hostPlatform.isx86 "rtc_cmos");
       kernel = modulesTree;
     }
   ).runInLinuxVM (

--- a/nixos/lib/qemu-common.nix
+++ b/nixos/lib/qemu-common.nix
@@ -17,7 +17,7 @@ rec {
       ''-netdev vde,id=vlan${toString nic},sock="$QEMU_VDE_SOCKET_${toString net}"''
     ];
 
-  qemuSerialDevice = if pkgs.stdenv.isi686 || pkgs.stdenv.isx86_64 then "ttyS0"
+  qemuSerialDevice = if pkgs.stdenv.hostPlatform.isx86 then "ttyS0"
         else if (with pkgs.stdenv.hostPlatform; isAarch32 || isAarch64 || isPower) then "ttyAMA0"
         else throw "Unknown QEMU serial device for system '${pkgs.stdenv.hostPlatform.system}'";
 

--- a/nixos/modules/hardware/all-firmware.nix
+++ b/nixos/modules/hardware/all-firmware.nix
@@ -83,7 +83,7 @@ in {
         b43Firmware_5_1_138
         b43Firmware_6_30_163_46
         b43FirmwareCutter
-      ] ++ optional (pkgs.stdenv.hostPlatform.isi686 || pkgs.stdenv.hostPlatform.isx86_64) facetimehd-firmware;
+      ] ++ optional pkgs.stdenv.hostPlatform.isx86 facetimehd-firmware;
     })
     (mkIf cfg.wirelessRegulatoryDatabase {
       hardware.firmware = [ pkgs.wireless-regdb ];

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -467,7 +467,7 @@ let
       throw "Unsupported architecture";
 
   # Syslinux (and isolinux) only supports x86-based architectures.
-  canx86BiosBoot = pkgs.stdenv.isi686 || pkgs.stdenv.isx86_64;
+  canx86BiosBoot = pkgs.stdenv.hostPlatform.isx86;
 
 in
 

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -243,7 +243,7 @@ in
             "hid_generic" "hid_lenovo" "hid_apple" "hid_roccat"
             "hid_logitech_hidpp" "hid_logitech_dj" "hid_microsoft"
 
-          ] ++ optionals (pkgs.stdenv.isi686 || pkgs.stdenv.isx86_64) [
+          ] ++ optionals pkgs.stdenv.hostPlatform.isx86 [
             # Misc. x86 keyboard stuff.
             "pcips2" "atkbd" "i8042"
 

--- a/nixos/modules/virtualisation/azure-agent.nix
+++ b/nixos/modules/virtualisation/azure-agent.nix
@@ -76,7 +76,7 @@ in
 
   config = mkIf cfg.enable {
     assertions = [ {
-      assertion = pkgs.stdenv.isi686 || pkgs.stdenv.isx86_64;
+      assertion = pkgs.stdenv.hostPlatform.isx86;
       message = "Azure not currently supported on ${pkgs.stdenv.hostPlatform.system}";
     } {
       assertion = config.networking.networkmanager.enable == false;

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -97,7 +97,7 @@ let
     imap1 (idx: drive: drive // { device = driveDeviceName idx; });
 
   efiPrefix =
-    if (pkgs.stdenv.isi686 || pkgs.stdenv.isx86_64) then "${pkgs.OVMF.fd}/FV/OVMF"
+    if pkgs.stdenv.hostPlatform.isx86 then "${pkgs.OVMF.fd}/FV/OVMF"
     else if pkgs.stdenv.isAarch64 then "${pkgs.OVMF.fd}/FV/AAVMF"
     else throw "No EFI firmware available for platform";
   efiFirmware = "${efiPrefix}_CODE.fd";
@@ -833,7 +833,7 @@ in
 
     # FIXME: Consolidate this one day.
     virtualisation.qemu.options = mkMerge [
-      (mkIf (pkgs.stdenv.isi686 || pkgs.stdenv.isx86_64) [
+      (mkIf pkgs.stdenv.hostPlatform.isx86 [
         "-usb" "-device usb-tablet,bus=usb-bus.0"
       ])
       (mkIf (pkgs.stdenv.isAarch32 || pkgs.stdenv.isAarch64) [

--- a/nixos/modules/virtualisation/virtualbox-guest.nix
+++ b/nixos/modules/virtualisation/virtualbox-guest.nix
@@ -33,7 +33,7 @@ in
 
   config = mkIf cfg.enable (mkMerge [{
     assertions = [{
-      assertion = pkgs.stdenv.isi686 || pkgs.stdenv.isx86_64;
+      assertion = pkgs.stdenv.hostPlatform.isx86;
       message = "Virtualbox not currently supported on ${pkgs.stdenv.hostPlatform.system}";
     }];
 

--- a/nixos/modules/virtualisation/vmware-guest.nix
+++ b/nixos/modules/virtualisation/vmware-guest.nix
@@ -23,7 +23,7 @@ in
 
   config = mkIf cfg.enable {
     assertions = [ {
-      assertion = pkgs.stdenv.isi686 || pkgs.stdenv.isx86_64;
+      assertion = pkgs.stdenv.hostPlatform.isx86;
       message = "VMWare guest is not currently supported on ${pkgs.stdenv.hostPlatform.system}";
     } ];
 

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -70,7 +70,7 @@ let
     let iface = if grubVersion == 1 then "ide" else "virtio";
         isEfi = bootLoader == "systemd-boot" || (bootLoader == "grub" && grubUseEfi);
         bios  = if pkgs.stdenv.isAarch64 then "QEMU_EFI.fd" else "OVMF.fd";
-    in if !isEfi && !(pkgs.stdenv.isi686 || pkgs.stdenv.isx86_64) then
+    in if !isEfi && !pkgs.stdenv.hostPlatform.isx86 then
       throw "Non-EFI boot methods are only supported on i686 / x86_64"
     else ''
       def assemble_qemu_flags():

--- a/pkgs/applications/graphics/krita/generic.nix
+++ b/pkgs/applications/graphics/krita/generic.nix
@@ -32,7 +32,7 @@ mkDerivation rec {
     openjpeg opencolorio_1 poppler curl ilmbase
     qtmultimedia qtx11extras quazip
     python3Packages.pyqt5
-  ] ++ lib.optional (stdenv.hostPlatform.isi686 || stdenv.hostPlatform.isx86_64) vc;
+  ] ++ lib.optional stdenv.hostPlatform.isx86 vc;
 
   NIX_CFLAGS_COMPILE = [ "-I${ilmbase.dev}/include/OpenEXR" ]
     ++ lib.optional stdenv.cc.isGNU "-Wno-deprecated-copy";

--- a/pkgs/applications/science/logic/monosat/default.nix
+++ b/pkgs/applications/science/logic/monosat/default.nix
@@ -31,7 +31,7 @@ let
   # source behind __linux__ check assumes system is also x86 and
   # tries to disable x86/x87-specific extended precision mode
   # https://github.com/sambayless/monosat/issues/33
-  commonPostPatch = lib.optionalString (!(stdenv.isi686 || stdenv.isx86_64)) ''
+  commonPostPatch = lib.optionalString (!stdenv.hostPlatform.isx86) ''
     substituteInPlace src/monosat/Main.cc \
       --replace 'defined(__linux__)' '0'
   '';

--- a/pkgs/applications/video/mplayer/default.nix
+++ b/pkgs/applications/video/mplayer/default.nix
@@ -174,7 +174,7 @@ stdenv.mkDerivation rec {
          (useUnfreeCodecs && codecs != null && !crossBuild)
          "--codecsdir=${codecs}"
     ++ optional
-         ((stdenv.hostPlatform.isi686 || stdenv.hostPlatform.isx86_64) && !crossBuild)
+         (stdenv.hostPlatform.isx86 && !crossBuild)
          "--enable-runtime-cpudetection"
     ++ optional fribidiSupport "--enable-fribidi"
     ++ optional stdenv.isLinux "--enable-vidix"

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -5,7 +5,7 @@
 , storeDir ? builtins.storeDir
 , rootModules ?
     [ "virtio_pci" "virtio_mmio" "virtio_blk" "virtio_balloon" "virtio_rng" "ext4" "unix" "9p" "9pnet_virtio" "crc32c_generic" ]
-      ++ pkgs.lib.optional (pkgs.stdenv.isi686 || pkgs.stdenv.isx86_64) "rtc_cmos"
+      ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isx86 "rtc_cmos"
 }:
 
 let

--- a/pkgs/desktops/gnome/core/gnome-software/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-software/default.nix
@@ -37,7 +37,7 @@
 }:
 
 let
-  withFwupd = stdenv.isx86_64 || stdenv.isi686;
+  withFwupd = stdenv.hostPlatform.isx86;
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/compilers/ocaml/ber-metaocaml.nix
+++ b/pkgs/development/compilers/ocaml/ber-metaocaml.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-   useX11 = stdenv.isi686 || stdenv.isx86_64;
+   useX11 = stdenv.hostPlatform.isx86;
    x11deps = [ libX11 xorgproto ];
    inherit (lib) optionals;
 

--- a/pkgs/development/compilers/sbcl/common.nix
+++ b/pkgs/development/compilers/sbcl/common.nix
@@ -2,8 +2,8 @@
 
 { lib, stdenv, fetchurl, fetchpatch, writeText, sbclBootstrap
 , sbclBootstrapHost ? "${sbclBootstrap}/bin/sbcl --disable-debugger --no-userinit --no-sysinit"
-, threadSupport ? (stdenv.isi686 || stdenv.isx86_64 || "aarch64-linux" == stdenv.hostPlatform.system || "aarch64-darwin" == stdenv.hostPlatform.system)
-, linkableRuntime ? (stdenv.isi686 || stdenv.isx86_64)
+, threadSupport ? (stdenv.hostPlatform.isx86 || "aarch64-linux" == stdenv.hostPlatform.system || "aarch64-darwin" == stdenv.hostPlatform.system)
+, linkableRuntime ? stdenv.hostPlatform.isx86
 , disableImmobileSpace ? false
   # Meant for sbcl used for creating binaries portable to non-NixOS via save-lisp-and-die.
   # Note that the created binaries still need `patchelf --set-interpreter ...`

--- a/pkgs/development/interpreters/clisp/default.nix
+++ b/pkgs/development/interpreters/clisp/default.nix
@@ -9,8 +9,8 @@
 , libffcall
 , coreutils
 # build options
-, threadSupport ? (stdenv.isi686 || stdenv.isx86_64)
-, x11Support ? (stdenv.isi686 || stdenv.isx86_64)
+, threadSupport ? stdenv.hostPlatform.isx86
+, x11Support ? stdenv.hostPlatform.isx86
 , dllSupport ? true
 , withModules ? [
     "pcre"

--- a/pkgs/development/interpreters/clisp/hg.nix
+++ b/pkgs/development/interpreters/clisp/hg.nix
@@ -8,8 +8,8 @@
 , libffi, libffcall, automake
 , coreutils
 # build options
-, threadSupport ? (stdenv.isi686 || stdenv.isx86_64)
-, x11Support ? (stdenv.isi686 || stdenv.isx86_64)
+, threadSupport ? stdenv.hostPlatform.isx86
+, x11Support ? stdenv.hostPlatform.isx86
 , dllSupport ? true
 , withModules ? [
     "pcre"

--- a/pkgs/development/libraries/SDL2_gfx/default.nix
+++ b/pkgs/development/libraries/SDL2_gfx/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ SDL2 ]
     ++ lib.optional stdenv.isDarwin darwin.libobjc;
 
-  configureFlags = [(if stdenv.isi686 || stdenv.isx86_64 then "--enable-mmx" else "--disable-mmx")]
+  configureFlags = [(if stdenv.hostPlatform.isx86 then "--enable-mmx" else "--disable-mmx")]
      ++ lib.optional stdenv.isDarwin "--disable-sdltest";
 
   meta = with lib; {

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -161,7 +161,7 @@ stdenv.mkDerivation ({
       "--enable-bind-now"
       (lib.withFeatureAs withLinuxHeaders "headers" "${linuxHeaders}/include")
       (lib.enableFeature profilingLibraries "profile")
-    ] ++ lib.optionals (stdenv.hostPlatform.isx86_64 || stdenv.hostPlatform.isi686 || stdenv.hostPlatform.isAarch64) [
+    ] ++ lib.optionals (stdenv.hostPlatform.isx86 || stdenv.hostPlatform.isAarch64) [
       # This feature is currently supported on
       # i386, x86_64 and x32 with binutils 2.29 or later,
       # and on aarch64 with binutils 2.30 or later.

--- a/pkgs/development/libraries/libimagequant/default.nix
+++ b/pkgs/development/libraries/libimagequant/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     patchShebangs ./configure
   '';
 
-  configureFlags = lib.optionals (!stdenv.isi686 && !stdenv.isx86_64) [ "--disable-sse" ];
+  configureFlags = lib.optionals (!stdenv.hostPlatform.isx86) [ "--disable-sse" ];
 
   meta = with lib; {
     homepage = "https://pngquant.org/lib/";

--- a/pkgs/development/libraries/opencolorio/1.x.nix
+++ b/pkgs/development/libraries/opencolorio/1.x.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     # External libyamlcpp 0.6.* not compatible: https://github.com/imageworks/OpenColorIO/issues/517
     "-DUSE_EXTERNAL_YAML=OFF"
   ] ++ lib.optional stdenv.isDarwin "-DOCIO_USE_BOOST_PTR=ON"
-    ++ lib.optional (!stdenv.hostPlatform.isi686 && !stdenv.hostPlatform.isx86_64) "-DOCIO_USE_SSE=OFF";
+    ++ lib.optional (!stdenv.hostPlatform.isx86) "-DOCIO_USE_SSE=OFF";
 
   postInstall = ''
     mkdir -p $bin/bin; mv $out/bin $bin/

--- a/pkgs/development/libraries/pcl/default.nix
+++ b/pkgs/development/libraries/pcl/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   # remove attempt to prevent (x86/x87-specific) extended precision use
   # when SSE not detected
-  postPatch = lib.optionalString (!(stdenv.isi686 || stdenv.isx86_64)) ''
+  postPatch = lib.optionalString (!stdenv.hostPlatform.isx86) ''
     sed -i '/-ffloat-store/d' cmake/pcl_find_sse.cmake
   '';
 

--- a/pkgs/development/libraries/x264/default.nix
+++ b/pkgs/development/libraries/x264/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional (!stdenv.isi686) "--enable-pic"
     ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "--cross-prefix=${stdenv.cc.targetPrefix}";
 
-  nativeBuildInputs = lib.optional (stdenv.hostPlatform.isx86_64 || stdenv.hostPlatform.isi686) nasm;
+  nativeBuildInputs = lib.optional stdenv.hostPlatform.isx86 nasm;
 
   meta = with lib; {
     description = "Library for encoding H264/AVC video streams";

--- a/pkgs/development/python-modules/pyqtgraph/default.nix
+++ b/pkgs/development/python-modules/pyqtgraph/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
     export FONTCONFIG_FILE=${fontsConf}
   '';
 
-  disabledTests = lib.optionals (!(stdenv.isi686 || stdenv.isx86_64)) [
+  disabledTests = lib.optionals (!stdenv.hostPlatform.isx86) [
     # small precision-related differences on other architectures,
     # upstream doesn't consider it serious.
     # https://github.com/pyqtgraph/pyqtgraph/issues/2110

--- a/pkgs/os-specific/linux/fbterm/default.nix
+++ b/pkgs/os-specific/linux/fbterm/default.nix
@@ -9,7 +9,7 @@ let
       sha256 = "0pciv5by989vzvjxsv1jsv4bdp4m8j0nfbl29jm5fwi12w4603vj";
     };
   buildInputs = [ gpm freetype fontconfig ncurses ]
-    ++ lib.optional (stdenv.isi686 || stdenv.isx86_64) libx86;
+    ++ lib.optional stdenv.hostPlatform.isx86 libx86;
 in
 stdenv.mkDerivation {
   inherit (s) pname version;

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -58,7 +58,7 @@ let
     setuptools
   ]);
 
-  isx86 = stdenv.isx86_64 || stdenv.isi686;
+  isx86 = stdenv.hostPlatform.isx86;
 
   # Dell isn't supported on Aarch64
   haveDell = isx86;

--- a/pkgs/os-specific/linux/read-edid/default.nix
+++ b/pkgs/os-specific/linux/read-edid/default.nix
@@ -10,9 +10,9 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = lib.optional (stdenv.isi686 || stdenv.isx86_64) libx86;
+  buildInputs = lib.optional stdenv.hostPlatform.isx86 libx86;
 
-  cmakeFlags = [ "-DCLASSICBUILD=${if stdenv.isi686 || stdenv.isx86_64 then "ON" else "OFF"}" ];
+  cmakeFlags = [ "-DCLASSICBUILD=${if stdenv.hostPlatform.isx86 then "ON" else "OFF"}" ];
 
   patchPhase = ''
     substituteInPlace CMakeLists.txt --replace 'COPYING' 'LICENSE'

--- a/pkgs/os-specific/linux/rtl8812au/default.nix
+++ b/pkgs/os-specific/linux/rtl8812au/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   makeFlags = [
     "ARCH=${stdenv.hostPlatform.linuxArch}"
     "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
-    ("CONFIG_PLATFORM_I386_PC=" + (if (stdenv.hostPlatform.isi686 || stdenv.hostPlatform.isx86_64) then "y" else "n"))
+    ("CONFIG_PLATFORM_I386_PC=" + (if stdenv.hostPlatform.isx86 then "y" else "n"))
     ("CONFIG_PLATFORM_ARM_RPI=" + (if (stdenv.hostPlatform.isAarch32 || stdenv.hostPlatform.isAarch64) then "y" else "n"))
   ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) [
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"

--- a/pkgs/tools/graphics/pngquant/default.nix
+++ b/pkgs/tools/graphics/pngquant/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   preConfigure = "patchShebangs .";
 
-  configureFlags = lib.optionals (!stdenv.isi686 && !stdenv.isx86_64) [ "--disable-sse" ];
+  configureFlags = lib.optionals (!stdenv.hostPlatform.isx86) [ "--disable-sse" ];
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libpng zlib lcms2 ];

--- a/pkgs/tools/misc/ipxe/default.nix
+++ b/pkgs/tools/misc/ipxe/default.nix
@@ -9,7 +9,7 @@ let
     "bin-x86_64-efi/ipxe.efi" = null;
     "bin-x86_64-efi/ipxe.efirom" = null;
     "bin-x86_64-efi/ipxe.usb" = "ipxe-efi.usb";
-  } // lib.optionalAttrs (stdenv.isi686 || stdenv.isx86_64) {
+  } // lib.optionalAttrs stdenv.hostPlatform.isx86 {
     "bin/ipxe.dsk" = null;
     "bin/ipxe.usb" = null;
     "bin/ipxe.iso" = null;
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   pname = "ipxe";
   version = "1.21.1";
 
-  nativeBuildInputs = [ perl cdrkit xz openssl gnu-efi mtools ] ++ lib.optional (stdenv.isi686 || stdenv.isx86_64) syslinux;
+  nativeBuildInputs = [ perl cdrkit xz openssl gnu-efi mtools ] ++ lib.optional stdenv.hostPlatform.isx86 syslinux;
 
   src = fetchFromGitHub {
     owner = "ipxe";
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
 
   makeFlags =
     [ "ECHO_E_BIN_ECHO=echo" "ECHO_E_BIN_ECHO_E=echo" # No /bin/echo here.
-    ] ++ lib.optionals (stdenv.isi686 || stdenv.isx86_64) [
+    ] ++ lib.optionals stdenv.hostPlatform.isx86 [
       "ISOLINUX_BIN_LIST=${syslinux}/share/syslinux/isolinux.bin"
       "LDLINUX_C32=${syslinux}/share/syslinux/ldlinux.c32"
     ] ++ lib.optional (embedScript != null) "EMBED=${embedScript}";

--- a/pkgs/tools/networking/fastd/default.nix
+++ b/pkgs/tools/networking/fastd/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   ];
 
   # some options are only available on x86
-  mesonFlags = lib.optionals (!stdenv.isx86_64 && !stdenv.isi686) [
+  mesonFlags = lib.optionals (!stdenv.hostPlatform.isx86) [
     "-Dcipher_salsa20_xmm=disabled"
     "-Dcipher_salsa2012_xmm=disabled"
     "-Dmac_ghash_pclmulqdq=disabled"

--- a/pkgs/tools/security/mkp224o/default.nix
+++ b/pkgs/tools/security/mkp224o/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
       variants = [
         { suffix = "ref10";         configureFlags = ["--enable-ref10"]; }
         { suffix = "donna";         configureFlags = ["--enable-donna"]; }
-      ] ++ lib.optionals (stdenv.isi686 || stdenv.isx86_64) [
+      ] ++ lib.optionals stdenv.hostPlatform.isx86 [
         { suffix = "donna-sse2";    configureFlags = ["--enable-donna-sse2"]; }
       ] ++ lib.optionals stdenv.isx86_64 [
         { suffix = "amd64-51-30k";  configureFlags = ["--enable-amd64-51-30k"]; }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11607,7 +11607,7 @@ with pkgs;
     if ccWrapper.isGNU then ccWrapper.overrideAttrs(old: {
       cc = old.cc.override {
         reproducibleBuild = false;
-        profiledCompiler = with stdenv; (!isDarwin && (isi686 || isx86_64));
+        profiledCompiler = with stdenv; (!isDarwin && hostPlatform.isx86);
       };
     }) else ccWrapper;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
