### PR TITLE
mame: 0.226 -> 0.237

### DIFF
--- a/pkgs/misc/emulators/mame/default.nix
+++ b/pkgs/misc/emulators/mame/default.nix
@@ -1,12 +1,26 @@
-{ lib, stdenv, mkDerivation, fetchFromGitHub, makeDesktopItem, makeWrapper
-, python, pkg-config, SDL2, SDL2_ttf, alsa-lib, which, qtbase, libXinerama
-, libpcap, CoreAudioKit, ForceFeedback
-, installShellFiles }:
+{ lib
+, stdenv
+, alsa-lib
+, CoreAudioKit
+, fetchFromGitHub
+, fontconfig
+, ForceFeedback
+, installShellFiles
+, libpcap
+, libpulseaudio
+, libXi
+, libXinerama
+, makeDesktopItem
+, makeWrapper
+, pkg-config
+, python3
+, qtbase
+, SDL2
+, SDL2_ttf
+, which
+}:
 
 let
-  majorVersion = "0";
-  minorVersion = "226";
-
   desktopItem = makeDesktopItem {
     name = "MAME";
     exec = "mame${lib.optionalString stdenv.is64bit "64"}";
@@ -16,15 +30,16 @@ let
   };
 
   dest = "$out/opt/mame";
-in mkDerivation {
+in
+stdenv.mkDerivation rec {
   pname = "mame";
-  version = "${majorVersion}.${minorVersion}";
+  version = "0.237";
 
   src = fetchFromGitHub {
     owner = "mamedev";
     repo = "mame";
-    rev = "mame${majorVersion}${minorVersion}";
-    sha256 = "0pnsvz4vkjkqb1ac5wzwz31vx0iknyg5ffly90nhl13kcr656jrj";
+    rev = "mame${builtins.replaceStrings [ "." ] [ "" ] version}";
+    sha256 = "sha256-0GOzpE8YP32ixz+c4dtDur9K0Szf7cl/dkWzPcJRFAM=";
   };
 
   hardeningDisable = [ "fortify" ];
@@ -33,18 +48,19 @@ in mkDerivation {
   makeFlags = [
     "TOOLS=1"
     "USE_LIBSDL=1"
-  ]
-  ++ lib.optionals stdenv.cc.isClang [ "CC=clang" "CXX=clang++" ]
-  ;
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "CXX=${stdenv.cc.targetPrefix}c++"
+  ];
 
   dontWrapQtApps = true;
 
+  # https://docs.mamedev.org/initialsetup/compilingmame.html
   buildInputs =
-    [ SDL2 SDL2_ttf qtbase libXinerama ]
-    ++ lib.optional stdenv.isLinux alsa-lib
-    ++ lib.optionals stdenv.isDarwin [ libpcap CoreAudioKit ForceFeedback ]
-    ;
-  nativeBuildInputs = [ python pkg-config which makeWrapper installShellFiles ];
+    [ SDL2 SDL2_ttf qtbase ]
+    ++ lib.optionals stdenv.isLinux [ alsa-lib libpulseaudio libXinerama libXi fontconfig ]
+    ++ lib.optionals stdenv.isDarwin [ libpcap CoreAudioKit ForceFeedback ];
+
+  nativeBuildInputs = [ python3 pkg-config which makeWrapper installShellFiles ];
 
   # by default MAME assumes that paths with stock resources
   # are relative and that you run MAME changing to
@@ -75,13 +91,15 @@ in mkDerivation {
     ln -s ${desktopItem}/share/applications $out/share
   '';
 
+  enableParallelBuilding = true;
+
   meta = with lib; {
     description = "Is a multi-purpose emulation framework";
     homepage = "https://www.mamedev.org/";
     license = with licenses; [ bsd3 gpl2Plus ];
     platforms = platforms.unix;
-    # makefile needs fixes for install target
-    badPlatforms = [ "aarch64-linux" ];
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ thiagokokada ];
+    # macOS needs more time to build
+    timeout = 24 * 3600;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32356,6 +32356,12 @@ with pkgs;
 
   mame = libsForQt514.callPackage ../misc/emulators/mame {
     inherit (darwin.apple_sdk.frameworks) CoreAudioKit ForceFeedback;
+    # TODO: remove it on mame 0.238
+    stdenv =
+      if stdenv.cc.isClang then
+        overrideCC stdenv clang_6
+      else
+        stdenv;
   };
 
   martyr = callPackage ../development/libraries/martyr { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Our MAME derivation got kinda old, so bumping it.

As a bonus, one less program depending on Python 2 to build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
