### PR TITLE
fluent-bit: fix build on darwin

### DIFF
--- a/pkgs/tools/misc/fluent-bit/default.nix
+++ b/pkgs/tools/misc/fluent-bit/default.nix
@@ -11,13 +11,16 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-b+MZuZQB/sl0HcioU1KCxH3TNiXYSPBfC9dBKqCVeXk=";
   };
 
+  patches = lib.optionals stdenv.isDarwin [
+    ./fix-cmetrics-darwin.patch
+    ./fix-luajit-darwin.patch
+  ];
+
   nativeBuildInputs = [ cmake flex bison ];
 
   buildInputs = lib.optionals stdenv.isLinux [ systemd ];
 
   cmakeFlags = [ "-DFLB_METRICS=ON" "-DFLB_HTTP_SERVER=ON" ];
-
-  patches = lib.optionals stdenv.isDarwin [ ./fix-luajit-darwin.patch ];
 
   # _FORTIFY_SOURCE requires compiling with optimization (-O)
   NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isGNU "-O";

--- a/pkgs/tools/misc/fluent-bit/fix-cmetrics-darwin.patch
+++ b/pkgs/tools/misc/fluent-bit/fix-cmetrics-darwin.patch
@@ -1,0 +1,23 @@
+diff --git i/lib/cmetrics/src/cmt_time.c w/lib/cmetrics/src/cmt_time.c
+--- i/lib/cmetrics/src/cmt_time.c
++++ w/lib/cmetrics/src/cmt_time.c
+@@ -20,7 +20,7 @@
+ #include <cmetrics/cmt_info.h>
+ 
+ /* MacOS */
+-#ifdef FLB_HAVE_CLOCK_GET_TIME
++#ifdef CMT_HAVE_CLOCK_GET_TIME
+ #include <mach/clock.h>
+ #include <mach/mach.h>
+ #endif
+@@ -41,8 +41,8 @@
+     mach_timespec_t mts;
+     host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+     clock_get_time(cclock, &mts);
+-    tm->tv_sec = mts.tv_sec;
+-    tm->tv_nsec = mts.tv_nsec;
++    tm.tv_sec = mts.tv_sec;
++    tm.tv_nsec = mts.tv_nsec;
+     mach_port_deallocate(mach_task_self(), cclock);
+ #else /* __STDC_VERSION__ */
+     clock_gettime(CLOCK_REALTIME, &tm);

--- a/pkgs/tools/misc/fluent-bit/fix-luajit-darwin.patch
+++ b/pkgs/tools/misc/fluent-bit/fix-luajit-darwin.patch
@@ -1,14 +1,29 @@
 diff -Naur fluent-bit.old/cmake/luajit.cmake fluent-bit.new/cmake/luajit.cmake
 --- fluent-bit.old/cmake/luajit.cmake
 +++ fluent-bit.new/cmake/luajit.cmake
-@@ -11,10 +11,6 @@
- set(LUAJIT_SRC ${CMAKE_CURRENT_SOURCE_DIR}/${FLB_PATH_LIB_LUAJIT})
+@@ -12,15 +12,7 @@
  set(LUAJIT_DEST ${CMAKE_CURRENT_BINARY_DIR})
  
--if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
--  set(CFLAGS "${CFLAGS} -isysroot ${CMAKE_OSX_SYSROOT}")
--endif()
--
+ if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+-  set(CFLAGS "${CFLAGS} -isysroot ${CMAKE_OSX_SYSROOT} -fno-stack-check")
+-  if (CMAKE_HOST_SYSTEM_VERSION VERSION_GREATER_EQUAL 20
+-      AND CMAKE_HOST_SYSTEM_VERSION VERSION_LESS 21)
+-    set(DEPLOYMENT_TARGET "MACOSX_DEPLOYMENT_TARGET=11.0")
+-  else()
+-    set(DEPLOYMENT_TARGET "MACOSX_DEPLOYMENT_TARGET=10.15")
+-  endif()
+-else()
+-  set(DEPLOYMENT_TARGET "")
++  set(CFLAGS "${CFLAGS} -fno-stack-check")
+ endif()
+ 
  # luajit (UNIX)
- # =============
- ExternalProject_Add(luajit
+@@ -30,7 +22,7 @@
+   EXCLUDE_FROM_ALL TRUE
+   SOURCE_DIR ${LUAJIT_SRC}
+   CONFIGURE_COMMAND ./configure
+-  BUILD_COMMAND $(MAKE) CROSS=${CROSS_PREFIX} CFLAGS=${CFLAGS} BUILD_MODE=static "XCFLAGS=-fPIC" ${DEPLOYMENT_TARGET}
++  BUILD_COMMAND $(MAKE) DEFAULT_CC=cc CROSS=${CROSS_PREFIX} CFLAGS=${CFLAGS} BUILD_MODE=static "XCFLAGS=-fPIC"
+   INSTALL_COMMAND cp src/libluajit.a "${LUAJIT_DEST}/lib/libluajit.a")
+ 
+ # luajit (Windows)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5161,9 +5161,7 @@ with pkgs;
     icu = icu63;
   };
 
-  fluent-bit = callPackage ../tools/misc/fluent-bit {
-    stdenv = gccStdenv;
-  };
+  fluent-bit = callPackage ../tools/misc/fluent-bit { };
 
   flux = callPackage ../development/compilers/flux { };
 


### PR DESCRIPTION
#### Motivation for this change

ZHF: #144627 (@NixOS/nixos-release-managers)

#### Things done

- Update `fix-luajit-darwin.patch` to apply to the current version.

- Add a patch to fix compilation of bundled cmetrics on darwin.
  
    <details>

    ```
     [ 15%] Building C object lib/cmetrics/src/CMakeFiles/cmetrics-static.dir/cmt_gauge.c.o
     [ 15%] Building C object lib/cmetrics/src/CMakeFiles/cmetrics-static.dir/cmt_counter.c.o
     [ 16%] Building C object lib/cmetrics/src/CMakeFiles/cmetrics-static.dir/cmt_untyped.c.o
     [ 16%] Building C object lib/cmetrics/src/CMakeFiles/cmetrics-static.dir/cmt_metric.c.o
     [ 16%] Building C object lib/cmetrics/src/CMakeFiles/cmetrics-static.dir/cmt_map.c.o
     [ 16%] Building C object lib/cmetrics/src/CMakeFiles/cmetrics-static.dir/cmt_log.c.o
     [ 16%] Building C object lib/cmetrics/src/CMakeFiles/cmetrics-static.dir/cmt_opts.c.o
     [ 16%] Building C object lib/cmetrics/src/CMakeFiles/cmetrics-static.dir/cmt_time.c.o
     /tmp/nix-build-fluent-bit-1.8.9.drv-0/source/lib/cmetrics/src/cmt_time.c: In function 'cmt_time_now':
     /tmp/nix-build-fluent-bit-1.8.9.drv-0/source/lib/cmetrics/src/cmt_time.c:40:5: error: unknown type name 'clock_serv_t'
        40 |     clock_serv_t cclock;
           |     ^~~~~~~~~~~~
     /tmp/nix-build-fluent-bit-1.8.9.drv-0/source/lib/cmetrics/src/cmt_time.c:41:5: error: unknown type name 'mach_timespec_t'
        41 |     mach_timespec_t mts;
           |     ^~~~~~~~~~~~~~~
     /tmp/nix-build-fluent-bit-1.8.9.drv-0/source/lib/cmetrics/src/cmt_time.c:42:5: warning: implicit declaration of function 'host_get_clock_service' [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wimplicit-function-declaration-Wimplicit-function-declaration8;;]
        42 |     host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
           |     ^~~~~~~~~~~~~~~~~~~~~~
     /tmp/nix-build-fluent-bit-1.8.9.drv-0/source/lib/cmetrics/src/cmt_time.c:42:28: warning: implicit declaration of function 'mach_host_self' [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wimplicit-function-declaration-Wimplicit-function-declaration8;;]
        42 |     host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
           |                            ^~~~~~~~~~~~~~
     /tmp/nix-build-fluent-bit-1.8.9.drv-0/source/lib/cmetrics/src/cmt_time.c:42:46: error: 'CALENDAR_CLOCK' undeclared (first use in this function)
        42 |     host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
           |                                              ^~~~~~~~~~~~~~
     /tmp/nix-build-fluent-bit-1.8.9.drv-0/source/lib/cmetrics/src/cmt_time.c:42:46: note: each undeclared identifier is reported only once for each function it appears in
     /tmp/nix-build-fluent-bit-1.8.9.drv-0/source/lib/cmetrics/src/cmt_time.c:43:5: warning: implicit declaration of function 'clock_get_time'; did you mean 'clock_gettime'? [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wimplicit-function-declaration-Wimplicit-function-declaration8;;]
        43 |     clock_get_time(cclock, &mts);
           |     ^~~~~~~~~~~~~~
           |     clock_gettime
     /tmp/nix-build-fluent-bit-1.8.9.drv-0/source/lib/cmetrics/src/cmt_time.c:44:7: error: invalid type argument of '->' (have 'struct timespec')
        44 |     tm->tv_sec = mts.tv_sec;
           |       ^~
     /tmp/nix-build-fluent-bit-1.8.9.drv-0/source/lib/cmetrics/src/cmt_time.c:44:21: error: request for member 'tv_sec' in something not a structure or union
        44 |     tm->tv_sec = mts.tv_sec;
           |                     ^
     /tmp/nix-build-fluent-bit-1.8.9.drv-0/source/lib/cmetrics/src/cmt_time.c:45:7: error: invalid type argument of '->' (have 'struct timespec')
        45 |     tm->tv_nsec = mts.tv_nsec;
           |       ^~
     /tmp/nix-build-fluent-bit-1.8.9.drv-0/source/lib/cmetrics/src/cmt_time.c:45:22: error: request for member 'tv_nsec' in something not a structure or union
        45 |     tm->tv_nsec = mts.tv_nsec;
           |                      ^
     /tmp/nix-build-fluent-bit-1.8.9.drv-0/source/lib/cmetrics/src/cmt_time.c:46:5: warning: implicit declaration of function 'mach_port_deallocate' [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wimplicit-function-declaration-Wimplicit-function-declaration8;;]
        46 |     mach_port_deallocate(mach_task_self(), cclock);
           |     ^~~~~~~~~~~~~~~~~~~~
     /tmp/nix-build-fluent-bit-1.8.9.drv-0/source/lib/cmetrics/src/cmt_time.c:46:26: warning: implicit declaration of function 'mach_task_self' [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wimplicit-function-declaration-Wimplicit-function-declaration8;;]
        46 |     mach_port_deallocate(mach_task_self(), cclock);
           |                          ^~~~~~~~~~~~~~
     make[2]: *** [lib/cmetrics/src/CMakeFiles/cmetrics-static.dir/build.make:174: lib/cmetrics/src/CMakeFiles/cmetrics-static.dir/cmt_time.c.o] Error 1
     make[1]: *** [CMakeFiles/Makefile2:2741: lib/cmetrics/src/CMakeFiles/cmetrics-static.dir/all] Error 2
    ```

    </details>

- Use default `stdenv` instead of `gccStdenv`. The only requirement for GCC was the bundled luajit having `DEFAULT_CC = gcc` hardcoded, but it has been fixed with the updated `fix-luajit-darwin.patch` by adding `DEFAULT_CC=cc` to the luajit build command.

---------

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
