### PR TITLE
rtaudio: 5.1.0 -> 5.2.0

### DIFF
--- a/pkgs/development/libraries/audio/rtaudio/default.nix
+++ b/pkgs/development/libraries/audio/rtaudio/default.nix
@@ -2,7 +2,6 @@
 , lib
 , config
 , fetchFromGitHub
-, fetchpatch
 , cmake
 , pkg-config
 , alsaSupport ? stdenv.hostPlatform.isLinux
@@ -16,30 +15,15 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "5.1.0";
   pname = "rtaudio";
+  version = "5.2.0";
 
   src = fetchFromGitHub {
     owner = "thestk";
     repo = "rtaudio";
     rev = version;
-    sha256 = "1pglnjz907ajlhnlnig3p0sx7hdkpggr8ss7b3wzf1lykzgv9l52";
+    sha256 = "0xvahlfj3ysgsjsp53q81hayzw7f99n1g214gh7dwdr52kv2l987";
   };
-
-  patches = [
-    # Fixes missing headers & install location
-    # Drop with version > 5.1.0
-    (fetchpatch {
-      name = "RtAudio-Adjust-CMake-public-header-installs-to-match-autotools.patch";
-      url = "https://github.com/thestk/rtaudio/commit/4273cf7572b8f51b5996cf6b42e3699cc6b165da.patch";
-      sha256 = "1p0idll0xsfk3jwjg83jkxkaf20gk0wqa7l982ni389rn6i4n26p";
-    })
-  ];
-
-  postPatch = ''
-    substituteInPlace rtaudio.pc.in \
-      --replace 'Requires:' 'Requires.private:'
-  '';
 
   nativeBuildInputs = [ cmake pkg-config ];
 


### PR DESCRIPTION
###### Motivation for this change
After >2 years, finally a new release, and it obsoletes our patches too!
https://github.com/thestk/rtaudio/releases/tag/5.2.0

I have only tested building RtAudio itself, no reverse dependencies yet.

See #146864 for RtMidi version of this PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
