### PR TITLE
twinkle: 1.10.2 -> unstable-2021-02-06

### DIFF
--- a/pkgs/applications/networking/instant-messengers/twinkle/default.nix
+++ b/pkgs/applications/networking/instant-messengers/twinkle/default.nix
@@ -15,20 +15,19 @@
 , alsa-lib
 , speex
 , ilbc
-, fetchurl
 , mkDerivation
 , bcg729
 }:
 
 mkDerivation rec {
   pname = "twinkle";
-  version = "1.10.2";
+  version = "unstable-2021-02-06";
 
   src = fetchFromGitHub {
-    repo = pname;
     owner = "LubosD";
-    rev = "v${version}";
-    sha256 = "0s0gi03xwvzp02ah4q6j33r9jx9nbayr6dxlg2ck9pwbay1nq1hx";
+    repo = "twinkle";
+    rev = "2301b66a3f54b266675415d261985488d86e9e4c";
+    sha256 = "xSwcaj1Hm62iL7C/AxqjVR07VEae8gDgYdr2EWmCoOM=";
   };
 
   buildInputs = [
@@ -44,19 +43,6 @@ mkDerivation rec {
     alsa-lib
     speex
     ilbc
-  ];
-
-  patches = [
-    # patch for bcg729 1.0.2+
-    (fetchurl { # https://github.com/LubosD/twinkle/pull/152
-      url = "https://github.com/LubosD/twinkle/compare/05082ae12051821b1d969e6672d9e4e5afe1bc07...7a6c533cda387652b5b4cb2a867be1a18585890c.patch";
-      sha256 = "39fc6cef3e88cfca8db44612b2d082fb618027b0f99509138d3c0d2777a494c2";
-    })
-    # patch manual link to not link to old url, which now points to NSFW page
-    (fetchurl { # https://github.com/LubosD/twinkle/commit/05082ae12051821b1d969e6672d9e4e5afe1bc07
-      url = "https://github.com/LubosD/twinkle/commit/05082ae12051821b1d969e6672d9e4e5afe1bc07.diff";
-      sha256 = "1iamragr9wp2vczsnp6n261fpr1ai2nc2abp0228jlar9zafksw0";
-    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Includes many useful fixes,
asked upstream about new release

https://github.com/LubosD/twinkle/issues/239

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
