### PR TITLE
arc_unpacker: Move to catch2 to support aarch64-darwin

### DIFF
--- a/pkgs/tools/archivers/arc_unpacker/default.nix
+++ b/pkgs/tools/archivers/arc_unpacker/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, cmake, makeWrapper, boost, libpng, libiconv
-, libjpeg, zlib, openssl, libwebp, catch }:
+, libjpeg, zlib, openssl, libwebp, catch2 }:
 
 stdenv.mkDerivation rec {
   pname = "arc_unpacker";
@@ -15,12 +15,12 @@ stdenv.mkDerivation rec {
     sha256 = "1xxrc9nww0rla3yh10z6glv05ax4rynwwbd0cdvkp7gyqzrv97xp";
   };
 
-  nativeBuildInputs = [ cmake makeWrapper catch ];
+  nativeBuildInputs = [ cmake makeWrapper catch2 ];
   buildInputs = [ boost libpng libjpeg zlib openssl libwebp ]
     ++ lib.optionals stdenv.isDarwin [ libiconv ];
 
   postPatch = ''
-    cp ${catch}/include/catch/catch.hpp tests/test_support/catch.h
+    cp ${catch2}/include/catch2/catch.hpp tests/test_support/catch.h
   '';
 
   checkPhase = ''
@@ -45,8 +45,8 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  # A few tests fail on aarch64
-  doCheck = !stdenv.isAarch64;
+  # A few tests fail on aarch64-linux
+  doCheck = !(stdenv.isLinux && stdenv.isAarch64);
 
   meta = with lib; {
     description = "A tool to extract files from visual novel archives";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
catch is ancient and has no support for aarch64-darwin. The following
snippet is an example of what is supported on darwin platforms in catch
(i.e., prior to v2).
```
#ifdef CATCH_PLATFORM_MAC
#if defined(__ppc64__) || defined(__ppc__)
    #define CATCH_TRAP() \
	__asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n" \
	: : : "memory","r0","r3","r4" ) /* NOLINT */
#else
    #define CATCH_TRAP() __asm__("int $3\n" : : /* NOLINT */ )
#endif
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
