### PR TITLE
clasp-common-lisp: disable cmake hook to restore waf build system

### DIFF
--- a/pkgs/development/compilers/clasp/default.nix
+++ b/pkgs/development/compilers/clasp/default.nix
@@ -86,6 +86,12 @@ stdenv.mkDerivation rec {
   NIX_CXXSTDLIB_COMPILE = " -frtti ";
 
   postPatch = ''
+    # fix "TabError: inconsistent use of tabs and spaces in indentation"
+    # Sources are space-indented with occasional tabs present.
+    sed -i -e 's@^\t@        @g' \
+        wscript \
+        tools-for-build/wscript_utils.py
+
     echo "
       PREFIX = '$out'
     " | sed -e 's/^ *//' > wscript.config
@@ -116,6 +122,9 @@ stdenv.mkDerivation rec {
   installTargets = "install_cboehm";
 
   CLASP_SRC_DONTTOUCH = "true";
+
+  # The build system is waf. Avoid using cmake hook.
+  dontUseCmakeConfigure = true;
 
   meta = {
     description = "A Common Lisp implementation based on LLVM with C++ integration";


### PR DESCRIPTION
This change does not fix clasp build, but at least it makes the error
less confusing.

Before the change:

    cmake flags: ...
    CMake Error: The source directory "/build/source" does not appear to contain CMakeLists.txt.
    Specify --help for usage, or press the help button on the CMake GUI.

After the change:

    unhandled condition in --disable-debugger mode, quitting
    ; compilation unit aborted
    ;   caught 1 fatal ERROR condition
    Waf: Leaving directory `/build/source/build/boehm'
    Build failed
