### PR TITLE
 llvm_{5..11}: pull upstream build fix for for gcc-12 

### DIFF
--- a/pkgs/development/compilers/llvm/10/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/10/llvm/default.nix
@@ -73,6 +73,20 @@ in stdenv.mkDerivation (rec {
       sha256 = "0nh123kld0dgz2h941lng331dkj3wbm5lfxm375k1f569gv83hlk";
       stripLen = 1;
     })
+
+    # Fix invalid std::string(nullptr) for GCC 12
+    (fetchpatch {
+      name = "nvptx-gcc-12.patch";
+      url = "https://github.com/llvm/llvm-project/commit/99e64623ec9b31def9375753491cc6093c831809.patch";
+      sha256 = "0zjfjgavqzi2ypqwqnlvy6flyvdz8hi1anwv0ybwnm2zqixg7za3";
+      stripLen = 1;
+    })
+    (fetchpatch {
+      name = "dfaemitter-gcc-12.patch";
+      url = "https://github.com/llvm/llvm-project/commit/0841916e87a39e3c223c986e8da31e4a9a1432e3.patch";
+      sha256 = "1kckghvsngs51mqm82asy0s9vr19h8aqbw43a0w44mccqw6bzrwf";
+      stripLen = 1;
+    })
   ] ++ lib.optional enablePolly ./gnu-install-dirs-polly.patch;
 
   postPatch = optionalString stdenv.isDarwin ''

--- a/pkgs/development/compilers/llvm/11/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/11/llvm/default.nix
@@ -65,6 +65,26 @@ in stdenv.mkDerivation (rec {
       sha256 = "sha256:12s8vr6ibri8b48h2z38f3afhwam10arfiqfy4yg37bmc054p5hi";
       stripLen = 1;
     })
+    # gcc-11 compat upstream patch
+    (fetchpatch {
+      url = "https://github.com/llvm/llvm-project/commit/b498303066a63a203d24f739b2d2e0e56dca70d1.patch";
+      sha256 = "sha256:0nh123kld0dgz2h941lng331dkj3wbm5lfxm375k1f569gv83hlk";
+      stripLen = 1;
+    })
+
+    # Fix invalid std::string(nullptr) for GCC 12
+    (fetchpatch {
+      name = "nvptx-gcc-12.patch";
+      url = "https://github.com/llvm/llvm-project/commit/99e64623ec9b31def9375753491cc6093c831809.patch";
+      sha256 = "0zjfjgavqzi2ypqwqnlvy6flyvdz8hi1anwv0ybwnm2zqixg7za3";
+      stripLen = 1;
+    })
+    (fetchpatch {
+      name = "dfaemitter-gcc-12.patch";
+      url = "https://github.com/llvm/llvm-project/commit/0841916e87a39e3c223c986e8da31e4a9a1432e3.patch";
+      sha256 = "1kckghvsngs51mqm82asy0s9vr19h8aqbw43a0w44mccqw6bzrwf";
+      stripLen = 1;
+    })
   ] ++ lib.optional enablePolly ./gnu-install-dirs-polly.patch;
 
   postPatch = optionalString stdenv.isDarwin ''

--- a/pkgs/development/compilers/llvm/5/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/5/llvm/default.nix
@@ -66,6 +66,14 @@ stdenv.mkDerivation ({
     #  stripLen = 1;
     #})
     ./gnu-install-dirs.patch
+
+    # Fix invalid std::string(nullptr) for GCC 12
+    (fetchpatch {
+      name = "nvptx-gcc-12.patch";
+      url = "https://github.com/llvm/llvm-project/commit/99e64623ec9b31def9375753491cc6093c831809.patch";
+      sha256 = "0zjfjgavqzi2ypqwqnlvy6flyvdz8hi1anwv0ybwnm2zqixg7za3";
+      stripLen = 1;
+    })
   ] ++ lib.optional enablePolly ./gnu-install-dirs-polly.patch;
 
   postPatch = optionalString stdenv.isDarwin ''

--- a/pkgs/development/compilers/llvm/6/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/6/llvm/default.nix
@@ -64,6 +64,14 @@ stdenv.mkDerivation ({
       sha256 = "0fxgrxmfnjx17w3lcq19rk68b2xksh1bynz3ina784kma7hp4wdb";
     })
     ./gnu-install-dirs.patch
+
+    # Fix invalid std::string(nullptr) for GCC 12
+    (fetchpatch {
+      name = "nvptx-gcc-12.patch";
+      url = "https://github.com/llvm/llvm-project/commit/99e64623ec9b31def9375753491cc6093c831809.patch";
+      sha256 = "0zjfjgavqzi2ypqwqnlvy6flyvdz8hi1anwv0ybwnm2zqixg7za3";
+      stripLen = 1;
+    })
   ] ++ lib.optional enablePolly ./gnu-install-dirs-polly.patch;
 
   postPatch = optionalString stdenv.isDarwin ''

--- a/pkgs/development/compilers/llvm/7/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/7/llvm/default.nix
@@ -68,6 +68,14 @@ in stdenv.mkDerivation ({
       sha256 = "0k6k1p5yisgwx417a67s7sr9930rqh1n0zv5jvply8vjjy4b3kf8";
     })
     ./gnu-install-dirs.patch
+
+    # Fix invalid std::string(nullptr) for GCC 12
+    (fetchpatch {
+      name = "nvptx-gcc-12.patch";
+      url = "https://github.com/llvm/llvm-project/commit/99e64623ec9b31def9375753491cc6093c831809.patch";
+      sha256 = "0zjfjgavqzi2ypqwqnlvy6flyvdz8hi1anwv0ybwnm2zqixg7za3";
+      stripLen = 1;
+    })
   ] ++ lib.optional enablePolly ./gnu-install-dirs-polly.patch;
 
   postPatch = optionalString stdenv.isDarwin ''

--- a/pkgs/development/compilers/llvm/8/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/8/llvm/default.nix
@@ -71,6 +71,14 @@ in stdenv.mkDerivation ({
       sha256 = "0nh123kld0dgz2h941lng331dkj3wbm5lfxm375k1f569gv83hlk";
       stripLen = 1;
     })
+
+    # Fix invalid std::string(nullptr) for GCC 12
+    (fetchpatch {
+      name = "nvptx-gcc-12.patch";
+      url = "https://github.com/llvm/llvm-project/commit/99e64623ec9b31def9375753491cc6093c831809.patch";
+      sha256 = "0zjfjgavqzi2ypqwqnlvy6flyvdz8hi1anwv0ybwnm2zqixg7za3";
+      stripLen = 1;
+    })
   ] ++ lib.optional enablePolly ./gnu-install-dirs-polly.patch;
 
   postPatch = optionalString stdenv.isDarwin ''

--- a/pkgs/development/compilers/llvm/9/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/9/llvm/default.nix
@@ -69,6 +69,14 @@ in stdenv.mkDerivation (rec {
       sha256 = "0nh123kld0dgz2h941lng331dkj3wbm5lfxm375k1f569gv83hlk";
       stripLen = 1;
     })
+
+    # Fix invalid std::string(nullptr) for GCC 12
+    (fetchpatch {
+      name = "nvptx-gcc-12.patch";
+      url = "https://github.com/llvm/llvm-project/commit/99e64623ec9b31def9375753491cc6093c831809.patch";
+      sha256 = "0zjfjgavqzi2ypqwqnlvy6flyvdz8hi1anwv0ybwnm2zqixg7za3";
+      stripLen = 1;
+    })
   ] ++ lib.optional enablePolly ./gnu-install-dirs-polly.patch;
 
   postPatch = optionalString stdenv.isDarwin ''


### PR DESCRIPTION
Without the fix build fails on gcc-12 as:

    /build/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp:
      In member function 'std::string llvm::NVPTXAsmPrinter::getPTXFundamentalTypeStr(...':
    /build/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp:1319:10:
      error: use of deleted function 'std::__cxx11::basic_string<...>; std::nullptr_t = std::nullptr_t]'
     1319 |   return nullptr;
          |          ^~~~~~~

The patch is present in upstream releases since llvm-12.