### PR TITLE
python3Packages.azure-eventhub: 5.6.0 -> 5.6.1, python3Packages.azure-servicebus: 7.3.3 -> 7.4.0

### DIFF
--- a/pkgs/development/python-modules/azure-eventhub/default.nix
+++ b/pkgs/development/python-modules/azure-eventhub/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "azure-eventhub";
-  version = "5.6.0";
+  version = "5.6.1";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "aa6d9e3e9b8b1a5ad211a828de867b85910720722577a4d51cd5aa6889d1d9e9";
+    sha256 = "sha256-ssjTesjPFITaB5Uy061podqL14ojeCIVm3LWsF3kY40=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-servicebus/default.nix
+++ b/pkgs/development/python-modules/azure-servicebus/default.nix
@@ -1,29 +1,32 @@
 { lib
-, buildPythonPackage
-, fetchPypi
-, uamqp
 , azure-common
 , azure-core
-, msrestazure
+, buildPythonPackage
+, fetchPypi
 , futures ? null
+, isodate
 , isPy3k
+, msrestazure
+, uamqp
 }:
 
 buildPythonPackage rec {
   pname = "azure-servicebus";
-  version = "7.3.3";
+  version = "7.4.0";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "1c2133909a086bd4329135d6affcc05628e3a7da27afca584a0de8c21fc4e1ac";
+    sha256 = "sha256-nlt4wNHI613tK7JB85fBW2LE/FOa8+2aLeT6wzP1PQ4=";
   };
 
   propagatedBuildInputs = [
-    uamqp
     azure-common
     azure-core
+    isodate
     msrestazure
+    uamqp
   ] ++ lib.optionals (!isPy3k) [
     futures
   ];
@@ -32,7 +35,9 @@ buildPythonPackage rec {
   doCheck = false;
 
   # python2 will fail due to pep 420
-  pythonImportsCheck = lib.optionals isPy3k [ "azure.servicebus" ];
+  pythonImportsCheck = lib.optionals isPy3k [
+    "azure.servicebus"
+  ];
 
   meta = with lib; {
     description = "Microsoft Azure Service Bus Client Library";

--- a/pkgs/development/python-modules/uamqp/default.nix
+++ b/pkgs/development/python-modules/uamqp/default.nix
@@ -1,27 +1,45 @@
-{ stdenv
-, lib
+{ lib
+, stdenv
 , buildPythonPackage
-, fetchPypi
-, fetchpatch
-, isPy3k
 , certifi
-, cmake
-, enum34
-, openssl
-, six
 , CFNetwork
+, cmake
 , CoreFoundation
+, enum34
+, fetchpatch
+, fetchPypi
+, isPy3k
+, openssl
 , Security
+, six
 }:
 
 buildPythonPackage rec {
   pname = "uamqp";
-  version = "1.4.1";
+  version = "1.4.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-JNGlpu2HvwTGV77WnAQFyvJImHesE2R+ZwMAlhlyk2U=";
+    sha256 = "sha256-L4IQWnxRRL3yopNT91Mk8KKdph9Vg2PHkGH+86uDu7c=";
   };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = lib.optionals stdenv.isDarwin [
+    CoreFoundation
+    CFNetwork
+    Security
+  ];
+
+  propagatedBuildInputs = [
+    certifi
+    openssl
+    six
+  ] ++ lib.optionals (!isPy3k) [
+    enum34
+  ];
 
   patches = [
     (fetchpatch {
@@ -32,26 +50,14 @@ buildPythonPackage rec {
     })
   ];
 
-  buildInputs = [
-    openssl
-    certifi
-    six
-  ] ++ lib.optionals (!isPy3k) [
-    enum34
-  ] ++ lib.optionals stdenv.isDarwin [
-    CoreFoundation
-    CFNetwork
-    Security
-  ];
-
   dontUseCmakeConfigure = true;
 
-  nativeBuildInputs = [
-    cmake
-  ];
-
-  # has no tests
+  # Project has no tests
   doCheck = false;
+
+  pythonImportsCheck = [
+    "uamqp"
+  ];
 
   meta = with lib; {
     description = "An AMQP 1.0 client library for Python";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 5.6.1 and 7.4.0

Change log:
- https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/eventhub/azure-eventhub/CHANGELOG.md#561-2021-10-06
- https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/servicebus/azure-servicebus/CHANGELOG.md#740-2021-11-09

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
