### PR TITLE
rtmidi: 4.0.0 -> 5.0.0

### DIFF
--- a/pkgs/applications/audio/milkytracker/default.nix
+++ b/pkgs/applications/audio/milkytracker/default.nix
@@ -12,6 +12,12 @@ stdenv.mkDerivation rec {
     sha256 = "025fj34gq2kmkpwcswcyx7wdxb89vm944dh685zi4bxx0hz16vvk";
   };
 
+  postPatch = ''
+    # https://github.com/milkytracker/MilkyTracker/issues/262
+    substituteInPlace CMakeLists.txt \
+      --replace 'CMAKE_CXX_STANDARD 98' 'CMAKE_CXX_STANDARD 11'
+  '';
+
   nativeBuildInputs = [ cmake pkg-config makeWrapper ];
 
   buildInputs = [ SDL2 alsa-lib libjack2 lhasa perl rtmidi zlib zziplib ];

--- a/pkgs/development/libraries/audio/rtmidi/default.nix
+++ b/pkgs/development/libraries/audio/rtmidi/default.nix
@@ -15,42 +15,30 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "4.0.0";
   pname = "rtmidi";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "thestk";
     repo = "rtmidi";
     rev = version;
-    sha256 = "1g31p6a96djlbk9jh5r4pjly3x76lhccva9hrw6xzdma8dsjzgyq";
+    sha256 = "1r1sqmdi499zfh6z6kjkab6d4a7kz3il5kkcdfz9saa6ry992211";
   };
 
   patches = [
-    # PR #230, fix CMake problems
+    # Remove when https://github.com/thestk/rtmidi/pull/278 merged
     (fetchpatch {
-      name = "RtMidi-Fix-JACK_HAS_PORT_RENAME-define.patch";
-      url = "https://github.com/thestk/rtmidi/pull/230/commits/768a30a61b60240b66cc2d43bc27a544ff9f1622.patch";
-      sha256 = "1sym4f7nb2qyyxfhi1l0xsm2hfh6gddn81y36qvfq4mcs33vvid0";
+      name = "0001-rtmidi-Use-posix-sched_yield-instead-of-pthread_yield.patch";
+      url = "https://github.com/thestk/rtmidi/pull/278/commits/cfe34c02112c256235b62b45895fc2c401fd874d.patch";
+      sha256 = "0yzq7zbdkl5r4i0r6vy2kq986cqdxz2cpzb7s977mvh09kdikrw1";
     })
+    # Remove when https://github.com/thestk/rtmidi/pull/277 merged
     (fetchpatch {
-      name = "RtMidi-Add-prefix-define-for-pkgconfig.patch";
-      url = "https://github.com/thestk/rtmidi/pull/230/commits/7a32e23e3f6cb43c0d2d58443ce205d438e76f44.patch";
-      sha256 = "06im8mb05wah6bnkadw2gpkhmilxb8p84pxqr50b205cchpq304w";
+      name = "0002-rtmidi-include-TargetConditionals.h-on-Apple-platforms.patch";
+      url = "https://github.com/thestk/rtmidi/pull/277/commits/9d863beb28f03ec53f3e4c22cc0d3c34a1e1789b.patch";
+      sha256 = "1hlrg23c1ycnwdvxpic8wvypiril04rlph0g820qn1naf92imfjg";
     })
-    (fetchpatch {
-      name = "RtMidi-Adjust-public-header-installs-to-match-autotools.patch";
-      url = "https://github.com/thestk/rtmidi/pull/230/commits/892fe5492f0e787484fa4a37027b08c265ce001f.patch";
-      sha256 = "0ca9m42xa3gmycimzvzvl67wa266xq9pfp1b4v555rh2fp52kbcj";
-    })
-
-    # https://github.com/thestk/rtmidi/pull/277
-    ./macos_include_targetconditionals.patch
   ];
-
-  postPatch = ''
-    substituteInPlace rtmidi.pc.in \
-      --replace 'Requires:' 'Requires.private:'
-  '';
 
   nativeBuildInputs = [ cmake pkg-config ];
 


### PR DESCRIPTION
###### Motivation for this change
After >2 years, finally a new release, and it obsoletes our patches too!
https://github.com/thestk/rtmidi/releases/tag/5.0.0

I have only tested building RtMidi itself, no reverse dependencies yet.

See #146836 for RtAudio version of this PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
