### PR TITLE
 invoice2data: 0.2.93 -> 0.3.6 

### DIFF
--- a/pkgs/tools/text/invoice2data/default.nix
+++ b/pkgs/tools/text/invoice2data/default.nix
@@ -1,20 +1,53 @@
-{ lib, python3Packages, xpdf, imagemagick, tesseract }:
+{ lib
+, fetchFromGitHub
+, imagemagick
+, python3
+, tesseract
+, xpdf
+}:
 
-python3Packages.buildPythonPackage rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "invoice2data";
-  version = "0.2.93";
+  version = "0.3.6";
+  format = "setuptools";
 
-  src = python3Packages.fetchPypi {
-    inherit pname version;
-    sha256 = "1phz0a8jxg074k0im7shrrdfvdps7bn1fa4zwcf8q3sa2iig26l4";
+  src = fetchFromGitHub {
+    owner = "invoice-x";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-t1jgLyKtQsLINlnkCdSbVfTM6B/EiD1yGtx9UHjyZVE=";
   };
 
-  makeWrapperArgs = ["--prefix" "PATH" ":" (lib.makeBinPath [ imagemagick xpdf tesseract ]) ];
+  nativeBuildInputs = with python3.pkgs; [
+    setuptools-git
+  ];
 
-  propagatedBuildInputs = with python3Packages; [ unidecode dateparser pyyaml pillow chardet pdfminer ];
+  propagatedBuildInputs = with python3.pkgs; [
+    chardet
+    dateparser
+    pdfminer
+    pillow
+    pyyaml
+    unidecode
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "pytest-runner" ""
+  '';
+
+  makeWrapperArgs = ["--prefix" "PATH" ":" (lib.makeBinPath [
+    imagemagick
+    tesseract
+    xpdf
+  ])];
 
   # Tests fails even when ran manually on my ubuntu machine !!
   doCheck = false;
+
+  pythonImportsCheck = [
+    "invoice2data"
+  ];
 
   meta = with lib; {
     description = "Data extractor for PDF invoices";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.3.6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
