### PR TITLE
_2048-in-terminal: 2017-11-29 -> 2021-09-12

### DIFF
--- a/pkgs/games/2048-in-terminal/default.nix
+++ b/pkgs/games/2048-in-terminal/default.nix
@@ -1,28 +1,35 @@
-{ lib, stdenv, fetchFromGitHub, ncurses }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, ncurses, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "2048-in-terminal";
-  version = "2017-11-29";
+  version = "2021-09-12";
 
   src = fetchFromGitHub {
-    sha256 = "1cqv5z1i5zcrvj0w6pdfnnff8m6kjndqxwkwsw5ma9jz503bmyc6";
-    rev = "4e525066b0ef3442e92d2ba8dd373bdc205ece28";
+    sha256 = "1jgacyimn59kxqhrk8jp13qayc2mncxhx393spqcxbz0sj6lxq9p";
+    rev = "466abe827638598e40cb627d2b017fe8f76b3a14";
     repo = "2048-in-terminal";
     owner = "alewmoose";
   };
 
-  buildInputs = [ ncurses ];
+  # Fix pending upstream inclusion for ncurses-6.3 support:
+  #  https://github.com/alewmoose/2048-in-terminal/pull/6
+  patches = [
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/alewmoose/2048-in-terminal/commit/b1c78dc4b3cca3a193b1afea1ab85a75966823cf.patch";
+      sha256 = "05ibpgr83r7zxsak2l0gaf33858bp0sp0mjfdpmcmw745z3jw7q1";
+    })
+  ];
 
-  prePatch = ''
-    sed -i '1i#include <fcntl.h>\n' save.c
-  '';
+  buildInputs = [ ncurses ];
+  nativeBuildInputs = [ pkg-config ];
 
   enableParallelBuilding = true;
 
   preInstall = ''
     mkdir -p $out/bin
   '';
-  installFlags = [ "DESTDIR=$(out)/bin" ];
+  installFlags = [ "PREFIX=$(out)" ];
 
   meta = with lib; {
     inherit (src.meta) homepage;


### PR DESCRIPTION
While at it apply pending ncurses-6.3 fix. Otherwise build fails as:

    draw.c:232:9: error: format not a string literal and no format arguments [-Werror=format-security]
      232 |         mvwprintw(board_win, center, left+1, tile_str[val]);
          |         ^~~~~~~~~
