### PR TITLE
libxklavier: support cross-compilation

### DIFF
--- a/pkgs/development/libraries/libxklavier/default.nix
+++ b/pkgs/development/libraries/libxklavier/default.nix
@@ -1,5 +1,7 @@
 { lib, stdenv, fetchgit, autoreconfHook, pkg-config, gtk-doc, xkeyboard_config, libxml2, xorg, docbook_xsl
-, glib, isocodes, gobject-introspection }:
+, glib, isocodes, gobject-introspection
+, withDoc ? (stdenv.buildPlatform == stdenv.hostPlatform)
+}:
 
 stdenv.mkDerivation rec {
   pname = "libxklavier";
@@ -13,14 +15,12 @@ stdenv.mkDerivation rec {
 
   patches = [ ./honor-XKB_CONFIG_ROOT.patch ];
 
-  outputs = [ "out" "dev" "devdoc" ];
+  outputs = [ "out" "dev" ] ++ lib.optionals withDoc [ "devdoc" ];
 
   # TODO: enable xmodmap support, needs xmodmap DB
   propagatedBuildInputs = with xorg; [ libX11 libXi xkeyboard_config libxml2 libICE glib libxkbfile isocodes ];
 
-  nativeBuildInputs = [ autoreconfHook pkg-config gtk-doc docbook_xsl ];
-
-  buildInputs = [ gobject-introspection ];
+  nativeBuildInputs = [ autoreconfHook pkg-config gtk-doc docbook_xsl gobject-introspection ];
 
   preAutoreconf = ''
     export NOCONFIGURE=1
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     "--with-xkb-base=${xkeyboard_config}/etc/X11/xkb"
     "--with-xkb-bin-base=${xorg.xkbcomp}/bin"
     "--disable-xmodmap-support"
-    "--enable-gtk-doc"
+    "${if withDoc then "--enable-gtk-doc" else "--disable-gtk-doc"}"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Support cross-compiling libxklavier.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux (ca-derivation hash does not change with this change)
  - [x] aarch64-linux (cross-compiled)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
