### PR TITLE
grafana-image-renderer: 3.2.1 -> 3.3.0

### DIFF
--- a/pkgs/servers/monitoring/grafana-image-renderer/default.nix
+++ b/pkgs/servers/monitoring/grafana-image-renderer/default.nix
@@ -10,13 +10,13 @@
 
 mkYarnPackage rec {
   pname = "grafana-image-renderer";
-  version = "3.2.1";
+  version = "3.3.0";
 
   src = fetchFromGitHub {
     owner = "grafana";
     repo = "grafana-image-renderer";
     rev = "v${version}";
-    sha256 = "sha256-1xHRfEjtxiXXRt6Rpl4j8xxTQ6qXG4/ps885CLc35OQ=";
+    sha256 = "sha256-q4w40Do3e4vMluwAb1YwSGMVHO6QRZr8Fa5I+05uzLI=";
   };
 
   buildPhase = ''

--- a/pkgs/servers/monitoring/grafana-image-renderer/package.json
+++ b/pkgs/servers/monitoring/grafana-image-renderer/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "husky": "^4.3.8",
     "lint-staged": "^11.2.0",
-    "pkg": "^5.3.3",
+    "pkg": "^5.4.1",
     "prettier": "2.2.1",
     "tsc-watch": "^4.2.3",
     "typescript": "^4.3.2"

--- a/pkgs/servers/monitoring/grafana-image-renderer/yarn.lock
+++ b/pkgs/servers/monitoring/grafana-image-renderer/yarn.lock
@@ -10,9 +10,9 @@
     "@babel/highlight" "^7.10.4"
 
 "@babel/code-frame@^7.0.0":
-  version "7.15.8"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.15.8.tgz#45990c47adadb00c03677baa89221f7cc23d2503"
-  integrity sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.14.5.tgz#23b08d740e83f49c5e59945fbf1b43e80bbf4edb"
+  integrity sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==
   dependencies:
     "@babel/highlight" "^7.14.5"
 
@@ -258,14 +258,14 @@
   integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
 
 "@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0":
-  version "16.10.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.10.3.tgz#7a8f2838603ea314d1d22bb3171d899e15c57bd5"
-  integrity sha512-ho3Ruq+fFnBrZhUYI46n/bV2GjwzSkwuT4dTf0GkuNFmnb8nq4ny2z9JEVemFi6bdEJanHLlYfy9c6FN9B9McQ==
+  version "16.10.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.10.2.tgz#5764ca9aa94470adb4e1185fe2e9f19458992b2e"
+  integrity sha512-zCclL4/rx+W5SQTzFs9wyvvyCwoK9QtBpratqz2IYJ3O8Umrn0m3nsTv0wQBk9sRGpvUe9CwPDrQFB10f1FIjQ==
 
 "@types/node@^14.14.41":
-  version "14.17.21"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.21.tgz#6359d8cf73481e312a43886fa50afc70ce5592c6"
-  integrity sha512-zv8ukKci1mrILYiQOwGSV4FpkZhyxQtuFWGya2GujWg+zVAeRQ4qbaMmWp9vb9889CFA8JECH7lkwCL6Ygg8kA==
+  version "14.17.20"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.20.tgz#74cc80438fd0467dc4377ee5bbad89a886df3c10"
+  integrity sha512-gI5Sl30tmhXsqkNvopFydP7ASc4c2cLfGNQrVKN3X90ADFWFsPEsotm/8JHSUJQKTHbwowAHtcJPeyVhtKv0TQ==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -1145,9 +1145,9 @@ eslint-plugin-jsdoc@31.6.1:
     spdx-expression-parse "^3.0.1"
 
 eslint-plugin-jsdoc@^36.1.0:
-  version "36.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-36.1.1.tgz#124cd0e53a5d07f01ebde916a96dd1a6009625d6"
-  integrity sha512-nuLDvH1EJaKx0PCa9oeQIxH6pACIhZd1gkalTUxZbaxxwokjs7TplqY0Q8Ew3CoZaf5aowm0g/Z3JGHCatt+gQ==
+  version "36.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-36.1.0.tgz#8dfe5f27edfb6aa3812e6d86ccaea849ddc86b03"
+  integrity sha512-Qpied2AJCQcScxfzTObLKRiP5QgLXjMU/ITjBagEV5p2Q/HpumD1EQtazdRYdjDSwPmXhwOl2yquwOGQ4HOJNw==
   dependencies:
     "@es-joy/jsdoccomment" "0.10.8"
     comment-parser "1.2.4"
@@ -2184,9 +2184,9 @@ lines-and-columns@^1.1.6:
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
 lint-staged@^11.2.0:
-  version "11.2.1"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-11.2.1.tgz#e49104cb4eb01ef36742531385be2efe2b85ed94"
-  integrity sha512-p56vAvBwABYSThvncT1Vuq0u6A8ZS56oC+eURfoavqyhBPJv+RGAmIU2kEYQOO19LPQVHQJ56eoBq/ARPlBoVQ==
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-11.2.0.tgz#6b9774a74b3eb4bef5c59fb6475bff84d6853008"
+  integrity sha512-0KIcRuO4HQS2Su7qWtjrfTXgSklvyIb9Fk9qVWRZkGHa5S81Vj6WBbs+ogQBvHUwLJYq1eQ4R+H82GSak4OM7w==
   dependencies:
     cli-truncate "2.1.0"
     colorette "^1.4.0"
@@ -2744,10 +2744,10 @@ pkg-dir@^5.0.0:
   dependencies:
     find-up "^5.0.0"
 
-pkg-fetch@3.2.3:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/pkg-fetch/-/pkg-fetch-3.2.3.tgz#9825febf4eadd470c126d3f6bdc2cb6996861d36"
-  integrity sha512-bv9vYANgAZ2Lvxn5Dsq7E0rLqzcqYkV4gnwe2f7oHV9N4SVMfDOIjjFCRuuTltop5EmsOcu7XkQpB5A/pIgC1g==
+pkg-fetch@3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/pkg-fetch/-/pkg-fetch-3.2.4.tgz#5372734b12167d4bacd872be348217461b517390"
+  integrity sha512-ewUD26GP86/8+Fu93zrb30CpJjKOtT4maSgm4SwTX9Ujy1pfdUdv+1PubsY9tTJES0iBYItAtqbfkf7Wu5LV9w==
   dependencies:
     chalk "^4.1.0"
     fs-extra "^9.1.0"
@@ -2757,10 +2757,10 @@ pkg-fetch@3.2.3:
     semver "^7.3.5"
     yargs "^16.2.0"
 
-pkg@^5.3.3:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/pkg/-/pkg-5.3.3.tgz#5ad1dadfc4e55169f0e1046626e669e0428d4cd7"
-  integrity sha512-48qPxwyPvKfUuXxeK+kS3mBvfWWTX2khAdceDThbWCc8OUz3RFyO1Ft8SVkq2gQfPU2DtiPtWaf2SKH0Dlx59g==
+pkg@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/pkg/-/pkg-5.4.1.tgz#4d824e42c454f32131e471d7cd8d14bfdb3e1c4c"
+  integrity sha512-iJs3W6MCgeZ4MrH7iZtX6HTqsNzoh2U9rGILL3eOLbQFV43U8WPAzrqRK7cBQGuHx38UXxcGT6G/2yDl/GveRg==
   dependencies:
     "@babel/parser" "7.13.13"
     "@babel/types" "7.13.12"
@@ -2771,7 +2771,7 @@ pkg@^5.3.3:
     into-stream "^6.0.0"
     minimist "^1.2.5"
     multistream "^4.1.0"
-    pkg-fetch "3.2.3"
+    pkg-fetch "3.2.4"
     prebuild-install "6.0.1"
     progress "^2.0.3"
     resolve "^1.20.0"

--- a/pkgs/servers/monitoring/grafana-image-renderer/yarn.nix
+++ b/pkgs/servers/monitoring/grafana-image-renderer/yarn.nix
@@ -10,11 +10,11 @@
       };
     }
     {
-      name = "_babel_code_frame___code_frame_7.15.8.tgz";
+      name = "_babel_code_frame___code_frame_7.14.5.tgz";
       path = fetchurl {
-        name = "_babel_code_frame___code_frame_7.15.8.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.15.8.tgz";
-        sha1 = "45990c47adadb00c03677baa89221f7cc23d2503";
+        name = "_babel_code_frame___code_frame_7.14.5.tgz";
+        url  = "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.14.5.tgz";
+        sha1 = "23b08d740e83f49c5e59945fbf1b43e80bbf4edb";
       };
     }
     {
@@ -290,19 +290,19 @@
       };
     }
     {
-      name = "_types_node___node_16.10.3.tgz";
+      name = "_types_node___node_16.10.2.tgz";
       path = fetchurl {
-        name = "_types_node___node_16.10.3.tgz";
-        url  = "https://registry.yarnpkg.com/@types/node/-/node-16.10.3.tgz";
-        sha1 = "7a8f2838603ea314d1d22bb3171d899e15c57bd5";
+        name = "_types_node___node_16.10.2.tgz";
+        url  = "https://registry.yarnpkg.com/@types/node/-/node-16.10.2.tgz";
+        sha1 = "5764ca9aa94470adb4e1185fe2e9f19458992b2e";
       };
     }
     {
-      name = "_types_node___node_14.17.21.tgz";
+      name = "_types_node___node_14.17.20.tgz";
       path = fetchurl {
-        name = "_types_node___node_14.17.21.tgz";
-        url  = "https://registry.yarnpkg.com/@types/node/-/node-14.17.21.tgz";
-        sha1 = "6359d8cf73481e312a43886fa50afc70ce5592c6";
+        name = "_types_node___node_14.17.20.tgz";
+        url  = "https://registry.yarnpkg.com/@types/node/-/node-14.17.20.tgz";
+        sha1 = "74cc80438fd0467dc4377ee5bbad89a886df3c10";
       };
     }
     {
@@ -1298,11 +1298,11 @@
       };
     }
     {
-      name = "eslint_plugin_jsdoc___eslint_plugin_jsdoc_36.1.1.tgz";
+      name = "eslint_plugin_jsdoc___eslint_plugin_jsdoc_36.1.0.tgz";
       path = fetchurl {
-        name = "eslint_plugin_jsdoc___eslint_plugin_jsdoc_36.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-36.1.1.tgz";
-        sha1 = "124cd0e53a5d07f01ebde916a96dd1a6009625d6";
+        name = "eslint_plugin_jsdoc___eslint_plugin_jsdoc_36.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-36.1.0.tgz";
+        sha1 = "8dfe5f27edfb6aa3812e6d86ccaea849ddc86b03";
       };
     }
     {
@@ -2386,11 +2386,11 @@
       };
     }
     {
-      name = "lint_staged___lint_staged_11.2.1.tgz";
+      name = "lint_staged___lint_staged_11.2.0.tgz";
       path = fetchurl {
-        name = "lint_staged___lint_staged_11.2.1.tgz";
-        url  = "https://registry.yarnpkg.com/lint-staged/-/lint-staged-11.2.1.tgz";
-        sha1 = "e49104cb4eb01ef36742531385be2efe2b85ed94";
+        name = "lint_staged___lint_staged_11.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/lint-staged/-/lint-staged-11.2.0.tgz";
+        sha1 = "6b9774a74b3eb4bef5c59fb6475bff84d6853008";
       };
     }
     {
@@ -3066,19 +3066,19 @@
       };
     }
     {
-      name = "pkg_fetch___pkg_fetch_3.2.3.tgz";
+      name = "pkg_fetch___pkg_fetch_3.2.4.tgz";
       path = fetchurl {
-        name = "pkg_fetch___pkg_fetch_3.2.3.tgz";
-        url  = "https://registry.yarnpkg.com/pkg-fetch/-/pkg-fetch-3.2.3.tgz";
-        sha1 = "9825febf4eadd470c126d3f6bdc2cb6996861d36";
+        name = "pkg_fetch___pkg_fetch_3.2.4.tgz";
+        url  = "https://registry.yarnpkg.com/pkg-fetch/-/pkg-fetch-3.2.4.tgz";
+        sha1 = "5372734b12167d4bacd872be348217461b517390";
       };
     }
     {
-      name = "pkg___pkg_5.3.3.tgz";
+      name = "pkg___pkg_5.4.1.tgz";
       path = fetchurl {
-        name = "pkg___pkg_5.3.3.tgz";
-        url  = "https://registry.yarnpkg.com/pkg/-/pkg-5.3.3.tgz";
-        sha1 = "5ad1dadfc4e55169f0e1046626e669e0428d4cd7";
+        name = "pkg___pkg_5.4.1.tgz";
+        url  = "https://registry.yarnpkg.com/pkg/-/pkg-5.4.1.tgz";
+        sha1 = "4d824e42c454f32131e471d7cd8d14bfdb3e1c4c";
       };
     }
     {


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ChangeLog: https://github.com/grafana/grafana-image-renderer/releases/tag/v3.3.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
