### PR TITLE
arj: fix build on darwin

### DIFF
--- a/pkgs/tools/archivers/arj/default.nix
+++ b/pkgs/tools/archivers/arj/default.nix
@@ -128,6 +128,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook ];
 
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    substituteInPlace environ.c \
+        --replace "  #include <sys/statfs.h>" "  #include <sys/mount.h>"
+  '';
+
   preAutoreconf = ''
     cd gnu
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1281,7 +1281,9 @@ with pkgs;
 
   argyllcms = callPackage ../tools/graphics/argyllcms {};
 
-  arj = callPackage ../tools/archivers/arj { };
+  arj = callPackage ../tools/archivers/arj {
+    stdenv = gccStdenv;
+  };
 
   arp-scan = callPackage ../tools/misc/arp-scan { };
 


### PR DESCRIPTION

#### Motivation for this change

arj doesn't build on darwin: https://hydra.nixos.org/build/158242184

ZHF: #144627 (@NixOS/nixos-release-managers)

#### Things done

Fix wrong header for `statfs` function.

Use `gccStdenv` to build with GCC on all systems. GCC is hardcoded in `configure.in`, but after setting `CC_FOR_BUILD` to `cc` to use Clang, the build fails anyway when running a post-compilation command, which I have no idea how to fix:

    clang -DLOCALE=LANG_en -DLOCALE_DESC="\"en\"" -DPKGLIBDIR="\"<out>/lib/arj\"" -D_UNIX  -g -O2   -o darwin20.6.0/en/rs/arj/arj <objects_files>
    : darwin20.6.0/en/rs/arj/arj
    ./darwin20.6.0/en/rs/tools/join ./darwin20.6.0/en/rs/arj/arj ./darwin20.6.0/en/rs/arjsfxjr/arjsfxjr
    JOIN v 1.30  [26/04/2003]  Not a part of any binary package!

    Copying .. done!
    ./darwin20.6.0/en/rs/tools/join ./darwin20.6.0/en/rs/arj/arj ./darwin20.6.0/en/rs/arjsfx/arjsfx
    JOIN v 1.30  [26/04/2003]  Not a part of any binary package!

    Copying ... done!
    ./darwin20.6.0/en/rs/tools/join ./darwin20.6.0/en/rs/arj/arj ./darwin20.6.0/en/rs/arjsfxv/arjsfxv
    JOIN v 1.30  [26/04/2003]  Not a part of any binary package!

    Copying ..... done!
    ./darwin20.6.0/en/rs/tools/join ./darwin20.6.0/en/rs/arj/arj ./darwin20.6.0/en/rs/sfxstub/sfxstub
    JOIN v 1.30  [26/04/2003]  Not a part of any binary package!

    Copying . done!
    rm -f ./darwin20.6.0/en/rs/help.arj
    TZ=UTC0 ./darwin20.6.0/en/rs/arj/arj a ./darwin20.6.0/en/rs/help.arj -+ -t1f -2d -e -jm -jh65535 -jt -hdo200506231314 ./resource/en/arj?.txt
    ARJ32 v 3.10, Copyright (c) 1998-2004, ARJ Software Russia.

    Creating archive  : ./darwin20.6.0/en/rs/help.arj
    Adding    ./resource/en/arjl.txt       37.2%
    Adding    ./resource/en/arjs.txt       47.3%
    Testing arjl.txt                    OK
    Testing arjs.txt                    OK
         2 file(s)
    ./darwin20.6.0/en/rs/tools/join ./darwin20.6.0/en/rs/arj/arj ./darwin20.6.0/en/rs/help.arj
    JOIN v 1.30  [26/04/2003]  Not a part of any binary package!

    Copying . done!
    ./darwin20.6.0/en/rs/tools/postproc darwin20.6.0/en/rs/arj/arj
    POSTPROC v 1.30  [17/01/2003]  Not a part of any binary package!

    Patch not found
    make[1]: *** [GNUmakefile:398: darwin20.6.0/en/rs/arj/arj] Error 3

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
