### PR TITLE
nx-libs: fix build on upcoming binutils-2.36

### DIFF
--- a/pkgs/tools/X11/nx-libs/default.nix
+++ b/pkgs/tools/X11/nx-libs/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, autoconf, automake, fetchFromGitHub, libgcc, libjpeg_turbo
+{ lib, stdenv, autoconf, automake, fetchFromGitHub, fetchpatch
+, libgcc, libjpeg_turbo
 , libpng, libtool, libxml2, pkg-config, which, xorg
 , libtirpc
 }:
@@ -11,6 +12,14 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-qVOdD85sBMxKYx1cSLAGKeODsKKAm9UPBmYzPBbBOzQ=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "binutils-2.36.patch";
+      url = "https://github.com/ArcticaProject/nx-libs/commit/605a266911b50ababbb3f8a8b224efb42743379c.patch";
+      sha256 = "sha256-kk5ms3i0PrHL74I4OlsqDrdDcCJ0us03cQcBy4zjAoQ=";
+    })
+  ];
 
   nativeBuildInputs = [ autoconf automake libtool pkg-config which
     xorg.gccmakedep xorg.imake ];


### PR DESCRIPTION
Without the change build fails on binutils-2.36 as:

    ar: libdeps specified more than once
    failed command: ar clq libdix.a atom.o colormap.o cursor.o
