### PR TITLE
ctl: fix build on darwin

### DIFF
--- a/pkgs/development/libraries/ctl/default.nix
+++ b/pkgs/development/libraries/ctl/default.nix
@@ -19,6 +19,16 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  postPatch = ''
+    # Fix include guard name
+    substituteInPlace lib/dpx/dpx_raw.hh \
+        --replace CRL_DPX_RAW_INTERNAL_INCLUDE CTL_DPX_RAW_INTERNAL_INCLUDE
+
+    # Fix undefined symbols (link with Imath)
+    substituteInPlace lib/IlmCtlMath/CMakeLists.txt \
+        --replace "( IlmCtlMath IlmCtl )" "( IlmCtlMath IlmCtl Imath)"
+  '';
+
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ libtiff ilmbase openexr ];
 


### PR DESCRIPTION
#### Motivation for this change

ctl doesn't build on darwin: https://hydra.nixos.org/build/158257871

ZHF: #144627 (@NixOS/nixos-release-managers)

#### Things done

Patch the `target_link_libraries` CMake command for the `IlmCtlMath` library to fix undefined symbols.

No need to make the patch darwin-only.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
