### PR TITLE
vengi-tools: init at 0.0.14

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -486,6 +486,7 @@ in
   vault-postgresql = handleTest ./vault-postgresql.nix {};
   vaultwarden = handleTest ./vaultwarden.nix {};
   vector = handleTest ./vector.nix {};
+  vengi-tools = handleTest ./vengi-tools.nix {};
   victoriametrics = handleTest ./victoriametrics.nix {};
   vikunja = handleTest ./vikunja.nix {};
   virtualbox = handleTestOn ["x86_64-linux"] ./virtualbox.nix {};

--- a/nixos/tests/vengi-tools.nix
+++ b/nixos/tests/vengi-tools.nix
@@ -1,0 +1,29 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "vengi-tools";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ fgaz ];
+  };
+
+  machine = { config, pkgs, ... }: {
+    imports = [
+      ./common/x11.nix
+    ];
+
+    services.xserver.enable = true;
+    environment.systemPackages = [ pkgs.vengi-tools ];
+  };
+
+  enableOCR = true;
+
+  testScript =
+    ''
+      machine.wait_for_x()
+      machine.execute("vengi-voxedit >&2 &")
+      machine.wait_for_window("voxedit")
+      # OCR on voxedit's window is very expensive, so we avoid wasting a try
+      # by letting the window load fully first
+      machine.sleep(15)
+      machine.wait_for_text("Palette")
+      machine.screenshot("screen")
+    '';
+})

--- a/pkgs/applications/graphics/vengi-tools/default.nix
+++ b/pkgs/applications/graphics/vengi-tools/default.nix
@@ -23,6 +23,7 @@
 , OpenCL
 
 , callPackage
+, nixosTests
 }:
 
 # cmake 3.21 inserts invalid `ldd` and `-Wl,--no-as-needed` calls, apparently
@@ -97,6 +98,7 @@ in stdenv.mkDerivation rec {
 
   passthru.tests = {
     voxconvert-roundtrip = callPackage ./test-voxconvert-roundtrip.nix {};
+    run-voxedit = nixosTests.vengi-tools;
   };
 
   meta = with lib; {

--- a/pkgs/applications/graphics/vengi-tools/default.nix
+++ b/pkgs/applications/graphics/vengi-tools/default.nix
@@ -1,0 +1,117 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchurl
+
+, cmake
+, pkg-config
+, ninja
+, python3
+, makeWrapper
+
+, glm
+, lua5_4
+, SDL2
+, SDL2_mixer
+, enet
+, libuv
+, libuuid
+, wayland-protocols
+, Carbon
+# optionals
+, opencl-headers
+, OpenCL
+
+, callPackage
+}:
+
+# cmake 3.21 inserts invalid `ldd` and `-Wl,--no-as-needed` calls, apparently
+# related to
+# https://cmake.org/cmake/help/v3.21/prop_tgt/LINK_WHAT_YOU_USE.html
+let cmake3_22 = cmake.overrideAttrs (old: {
+  version = "3.22.0";
+  src = fetchurl {
+    url = "https://cmake.org/files/v3.22/cmake-3.22.0.tar.gz";
+    sha256 = "sha256-mYx7o0d40t/bPfimlUaeJLEeK/oh++QbNho/ReHJNF4=";
+  };
+});
+
+in stdenv.mkDerivation rec {
+  pname = "vengi-tools";
+  version = "0.0.14";
+
+  src = fetchFromGitHub {
+    owner = "mgerhardy";
+    repo = "engine";
+    rev = "v${version}";
+    sha256 = "sha256-v82hKskTSwM0NDgLVHpHZNRQW6tWug4pPIt91MrUwUo=";
+  };
+
+  nativeBuildInputs = [
+    cmake3_22
+    pkg-config
+    ninja
+    python3
+    makeWrapper
+  ];
+
+  buildInputs = [
+    glm
+    lua5_4
+    SDL2
+    SDL2_mixer
+    enet
+    libuv
+    libuuid
+    # Only needed for the game
+    #postgresql
+    #libpqxx
+    #mosquitto
+  ] ++ lib.optional stdenv.isLinux wayland-protocols
+    ++ lib.optionals stdenv.isDarwin [ Carbon OpenCL ]
+    ++ lib.optional (!stdenv.isDarwin) opencl-headers;
+
+  cmakeFlags = [
+    # Disable tests due to a problem in linking gtest:
+    # ld: /build/vengi-tests-core.LDHlV1.ltrans0.ltrans.o: in function `main':
+    # <artificial>:(.text.startup+0x3f): undefined reference to `testing::InitGoogleMock(int*, char**)'
+    "-DUNITTESTS=OFF"
+    "-DVISUALTESTS=OFF"
+    # We're only interested in the generic tools
+    "-DGAMES=OFF"
+    "-DMAPVIEW=OFF"
+    "-DAIDEBUG=OFF"
+  ];
+
+  # Set the data directory for each executable. We cannot set it at build time
+  # with the PKGDATADIR cmake variable because each executable needs a specific
+  # one.
+  # This is not needed on darwin, since on that platform data files are saved
+  # in *.app/Contents/Resources/ too, and are picked up automatically.
+  postInstall = lib.optionalString (!stdenv.isDarwin) ''
+    for prog in $out/bin/*; do
+      wrapProgram "$prog" \
+        --set CORE_PATH $out/share/$(basename "$prog")/
+    done
+  '';
+
+  passthru.tests = {
+    voxconvert-roundtrip = callPackage ./test-voxconvert-roundtrip.nix {};
+  };
+
+  meta = with lib; {
+    description = "Tools from the vengi voxel engine, including a thumbnailer, a converter, and the VoxEdit voxel editor";
+    longDescription = ''
+      Tools from the vengi C++ voxel game engine. It includes a voxel editor
+      with character animation support and loading/saving into a lot of voxel
+      volume formats. There are other tools like e.g. a thumbnailer for your
+      filemanager and a command line tool to convert between several voxel
+      formats.
+    '';
+    homepage = "https://mgerhardy.github.io/engine/";
+    downloadPage = "https://github.com/mgerhardy/engine/releases";
+    license = [ licenses.mit licenses.cc-by-sa-30 ];
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/graphics/vengi-tools/test-voxconvert-roundtrip.nix
+++ b/pkgs/applications/graphics/vengi-tools/test-voxconvert-roundtrip.nix
@@ -1,0 +1,15 @@
+{ stdenv
+, vengi-tools
+}:
+
+stdenv.mkDerivation {
+  name = "vengi-tools-test-voxconvert-roundtrip";
+  meta.timeout = 10;
+  buildCommand = ''
+    ${vengi-tools}/bin/vengi-voxconvert ${vengi-tools}/share/vengi-voxedit/chr_knight.qb chr_knight.vox
+    ${vengi-tools}/bin/vengi-voxconvert chr_knight.vox chr_knight.qb
+    ${vengi-tools}/bin/vengi-voxconvert chr_knight.qb chr_knight1.vox
+    diff chr_knight.vox chr_knight1.vox
+    touch $out
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28750,6 +28750,10 @@ with pkgs;
 
   vdpauinfo = callPackage ../tools/X11/vdpauinfo { };
 
+  vengi-tools = callPackage ../applications/graphics/vengi-tools {
+    inherit (darwin.apple_sdk.frameworks) Carbon OpenCL;
+  };
+
   verbiste = callPackage ../applications/misc/verbiste {
     inherit (gnome2) libgnomeui;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
