### PR TITLE
python3Packages.pkginfo: 1.7.1 -> 1.8.1 

### DIFF
--- a/pkgs/development/python-modules/pkginfo/default.nix
+++ b/pkgs/development/python-modules/pkginfo/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -13,7 +14,13 @@ buildPythonPackage rec {
     sha256 = "sha256-ZRdf+iyAciBnOkHDcVc6yaHqGxn/1e75FiePQoMZk08=";
   };
 
-  doCheck = false; # I don't know why, but with doCheck = true it fails.
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "pkginfo"
+  ];
 
   meta = with lib; {
     description = "Query metadatdata from sdists, bdists or installed packages";

--- a/pkgs/development/python-modules/pkginfo/default.nix
+++ b/pkgs/development/python-modules/pkginfo/default.nix
@@ -1,21 +1,23 @@
-{ lib, buildPythonPackage, fetchPypi }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
 
 buildPythonPackage rec {
   pname = "pkginfo";
-  version = "1.7.1";
+  version = "1.8.1";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "e7432f81d08adec7297633191bbf0bd47faf13cd8724c3a13250e51d542635bd";
+    sha256 = "sha256-ZRdf+iyAciBnOkHDcVc6yaHqGxn/1e75FiePQoMZk08=";
   };
 
   doCheck = false; # I don't know why, but with doCheck = true it fails.
 
   meta = with lib; {
-    homepage = "https://pypi.python.org/pypi/pkginfo";
-    license = licenses.mit;
-    description = "Query metadatdata from sdists / bdists / installed packages";
-
+    description = "Query metadatdata from sdists, bdists or installed packages";
+    homepage = "https://pythonhosted.org/pkginfo/";
     longDescription = ''
       This package provides an API for querying the distutils metadata
       written in the PKG-INFO file inside a source distriubtion (an sdist)
@@ -24,5 +26,7 @@ buildPythonPackage rec {
       *.egg-info stored in a “development checkout” (e.g, created by running
       setup.py develop).
     '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/toggl-cli/default.nix
+++ b/pkgs/development/python-modules/toggl-cli/default.nix
@@ -1,12 +1,29 @@
-{ lib, buildPythonPackage, fetchPypi, pythonOlder, click
-, click-completion, factory_boy, faker, inquirer, notify-py, pbr, pendulum
-, ptable, pytestCheckHook, pytest-cov, pytest-mock, requests, twine
-, validate-email }:
+{ lib
+, buildPythonPackage
+, click
+, click-completion
+, factory_boy
+, faker
+, fetchPypi
+, inquirer
+, notify-py
+, pbr
+, pendulum
+, ptable
+, pytest-mock
+, pytestCheckHook
+, pythonOlder
+, requests
+, twine
+, validate-email
+}:
 
 buildPythonPackage rec {
   pname = "toggl-cli";
   version = "2.4.2";
-  disabled = pythonOlder "3.5";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     pname = "togglCli";
@@ -14,13 +31,38 @@ buildPythonPackage rec {
     sha256 = "1wgh231r16jyvaj1ch1pajvl9szflb4srs505pfdwdlqvz7rzww8";
   };
 
+  nativeBuildInputs = [
+    pbr
+    twine
+  ];
+
+  propagatedBuildInputs = [
+    click
+    click-completion
+    inquirer
+    notify-py
+    pbr
+    pendulum
+    ptable
+    requests
+    validate-email
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-mock
+    faker
+    factory_boy
+  ];
+
   postPatch = ''
     substituteInPlace requirements.txt \
-      --replace "notify-py==0.3.1" "notify-py>=0.3.1"
+      --replace "notify-py==0.3.1" "notify-py>=0.3.1" \
+      --replace "click==7.1.2" "click>=7.1.2" \
+      --replace "pbr==5.5.1" "pbr>=5.5.1"
+    substituteInPlace pytest.ini \
+      --replace ' --cov toggl -m "not premium"' ""
   '';
-
-  nativeBuildInputs = [ pbr twine ];
-  checkInputs = [ pbr pytestCheckHook pytest-cov pytest-mock faker factory_boy ];
 
   preCheck = ''
     export TOGGL_API_TOKEN=your_api_token
@@ -36,22 +78,14 @@ buildPythonPackage rec {
     "test_now"
   ];
 
-  propagatedBuildInputs = [
-    click
-    click-completion
-    inquirer
-    notify-py
-    pendulum
-    ptable
-    requests
-    pbr
-    validate-email
+  pythonImportsCheck = [
+    "toggl"
   ];
 
   meta = with lib; {
-    homepage = "https://toggl.uhlir.dev/";
     description = "Command line tool and set of Python wrapper classes for interacting with toggl's API";
+    homepage = "https://toggl.uhlir.dev/";
     license = licenses.mit;
-    maintainers = [ maintainers.mmahut ];
+    maintainers = with maintainers; [ mmahut ];
   };
 }

--- a/pkgs/development/python-modules/typecode/default.nix
+++ b/pkgs/development/python-modules/typecode/default.nix
@@ -15,6 +15,7 @@
 buildPythonPackage rec {
   pname = "typecode";
   version = "21.6.1";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
@@ -43,6 +44,8 @@ buildPythonPackage rec {
 
   disabledTests = [
     "TestFileTypesDataDriven"
+    # AssertionError: assert 'application/x-bytecode.python'...
+    "test_compiled_python_1"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.8.1

Change log: https://bazaar.launchpad.net/~tseaver/pkginfo/trunk/view/head:/CHANGES.txt

Enable tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
