### PR TITLE
QMK: cosmetical modifications

### DIFF
--- a/pkgs/development/python-modules/qmk-dotty-dict/default.nix
+++ b/pkgs/development/python-modules/qmk-dotty-dict/default.nix
@@ -14,8 +14,13 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "Dictionary wrapper for quick access to deeply nested keys";
     homepage = "https://github.com/pawelzny/dotty_dict";
+    description = "Dictionary wrapper for quick access to deeply nested keys";
+    longDescription = ''
+      This is a version of dotty-dict by QMK (https://qmk.fm) since the original
+      dotty-dict published to pypi has non-ASCII characters that breaks with
+      some non-UTF8 locale settings.
+    '';
     license = licenses.mit;
     maintainers = with maintainers; [ babariviere ];
   };

--- a/pkgs/tools/misc/qmk/default.nix
+++ b/pkgs/tools/misc/qmk/default.nix
@@ -1,16 +1,12 @@
-{ lib, python3, fetchpatch, writeText }:
+{ lib
+, python3
+}:
 
-let
-  inherit (python3.pkgs) buildPythonApplication fetchPypi;
-  setuppy = writeText "setup.py" ''
-    from setuptools import setup
-    setup()
-  '';
-in buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "qmk";
   version = "1.0.0";
 
-  src = fetchPypi {
+  src = python3.pkgs.fetchPypi {
     inherit pname version;
     sha256 = "sha256-2mLuxzxFSMw3sLm+OTcgLcOjAdwvJmNhDsynUaYQ+co=";
   };
@@ -36,8 +32,12 @@ in buildPythonApplication rec {
     pyusb
   ];
 
+  # buildPythonApplication requires setup.py; the setup.py file crafted below
+  # acts as a wrapper to setup.cfg
   postConfigure = ''
-    cp ${setuppy} setup.py
+    touch setup.py
+    echo "from setuptools import setup" >> setup.py
+    echo "setup()" >> setup.py
   '';
 
   # no tests implemented


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
