### PR TITLE
python3Packages.levenshtein: init at 0.16.0

### DIFF
--- a/pkgs/development/python-modules/levenshtein/default.nix
+++ b/pkgs/development/python-modules/levenshtein/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, rapidfuzz
+}:
+
+buildPythonPackage rec {
+  pname = "levenshtein";
+  version = "0.16.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "maxbachmann";
+    repo = "Levenshtein";
+    rev = "v${version}";
+    sha256 = "agshUVkkqogj4FbonFd/rrGisMOomS62NND66YKZvjg=";
+  };
+
+  propagatedBuildInputs = [
+    rapidfuzz
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "Levenshtein"
+  ];
+
+  meta = with lib; {
+    description = "Functions for fast computation of Levenshtein distance and string similarity";
+    homepage = "https://github.com/maxbachmann/Levenshtein";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/python-levenshtein/default.nix
+++ b/pkgs/development/python-modules/python-levenshtein/default.nix
@@ -4,8 +4,9 @@
 }:
 
 buildPythonPackage rec {
-  pname = "python-Levenshtein";
+  pname = "python-levenshtein";
   version = "0.12.2";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
@@ -15,11 +16,14 @@ buildPythonPackage rec {
   # No tests included in archive
   doCheck = false;
 
+  pythonImportsCheck = [
+    "Levenshtein"
+  ];
+
   meta = with lib; {
     description = "Functions for fast computation of Levenshtein distance and string similarity";
-    homepage    = "https://github.com/ztane/python-Levenshtein";
-    license     = licenses.gpl2;
+    homepage = "https://github.com/ztane/python-Levenshtein";
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ aske ];
   };
-
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4276,6 +4276,8 @@ in {
 
   leveldb = callPackage ../development/python-modules/leveldb { };
 
+  levenshtein = callPackage ../development/python-modules/levenshtein { };
+
   lexid = callPackage ../development/python-modules/lexid { };
 
   lhapdf = toPythonModule (pkgs.lhapdf.override {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Functions for fast computation of Levenshtein distance and string similarity

https://github.com/maxbachmann/Levenshtein

`levenshtein` is a maintained fork of `python-Levenshtein`. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
