### PR TITLE
Add pulsar-client-cpp

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4215,6 +4215,12 @@
     githubId = 37017396;
     name = "gbtb";
   };
+  gdifolco = {
+    email = "gautier.difolco@gmail.com";
+    github = "blackheaven";
+    githubId = 1362807;
+    name = "Gautier Di Folco";
+  };
   gebner = {
     email = "gebner@gebner.org";
     github = "gebner";

--- a/pkgs/development/libraries/pulsar-client-cpp/default.nix
+++ b/pkgs/development/libraries/pulsar-client-cpp/default.nix
@@ -1,0 +1,71 @@
+{ stdenv
+, lib
+, pkgs
+, fetchurl
+, boost17x
+, clang
+, cmake
+, curl
+, gcc
+, jsoncpp
+, log4cxx
+, openssl
+, pkgconfig
+, protobuf
+, python3
+, snappy
+, zlib
+, zstd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pulsar-client-cpp";
+  version = "2.8.1";
+
+  src = fetchurl {
+    sha512 = "23i95k6gs5lh6gw6v6hybv6z8rfzc3mfgj2agb6iicad9ia2sf46wr3rqzi9bdhp0c990vcvn72bkz13i0hnh1hj5gnwqin339a2g0x";
+    url = "https://archive.apache.org/dist/pulsar/pulsar-${version}/apache-pulsar-${version}-src.tar.gz";
+  };
+
+  sourceRoot = "apache-pulsar-${version}-src/pulsar-client-cpp";
+
+  # python3 used in cmake script to calculate some values
+  nativeBuildInputs = [ cmake python3 pkgconfig ]
+    ++ lib.optionals stdenv.isDarwin [ clang ]
+    ++ lib.optionals stdenv.isLinux [ gcc ];
+
+  buildInputs = [ boost17x jsoncpp log4cxx openssl protobuf snappy zstd curl zlib ];
+
+  # since we cant expand $out in cmakeFlags
+  preConfigure = ''cmakeFlags="$cmakeFlags -DCMAKE_INSTALL_LIBDIR=${placeholder "out"}/lib"'';
+
+  cmakeFlags = [
+    "-DBUILD_TESTS=OFF"
+    "-DBUILD_PYTHON_WRAPPER=OFF"
+  ];
+
+  patches = [ ./reader_configuration_includes.diff ];
+  enableParallelBuilding = true;
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    echo ${lib.escapeShellArg ''
+      #include <pulsar/Client.h>
+      int main (int argc, char **argv) {
+        pulsar::Client client("pulsar://localhost:6650");
+        return 0;
+      }
+    ''} > test.cc
+  ${if stdenv.isDarwin
+    then "$CC++ test.cc -L $out/lib -I $out/include -lpulsar -o test"
+    else "g++ test.cc -L $out/lib -I $out/include -lpulsar -o test" }
+  '';
+
+  meta = with lib; {
+    homepage = "https://pulsar.apache.org/docs/en/client-libraries-cpp";
+    description = "Apache Pulsar C++ library";
+    platforms = [ "x86_64-darwin" "x86_64-linux" "aarch64-darwin" ];
+    license = licenses.asl20;
+    maintainers = with maintainers; [ gdifolco ];
+  };
+}

--- a/pkgs/development/libraries/pulsar-client-cpp/reader_configuration_includes.diff
+++ b/pkgs/development/libraries/pulsar-client-cpp/reader_configuration_includes.diff
@@ -1,0 +1,13 @@
+diff --git a/include/pulsar/c/reader_configuration.h b/include/pulsar/c/reader_configuration.h
+index 9d07476f82a..cc8436cdc46 100644
+--- a/include/pulsar/c/reader_configuration.h
++++ b/include/pulsar/c/reader_configuration.h
+@@ -20,6 +20,8 @@
+ #pragma once
+ 
+ #include <pulsar/defines.h>
++#include <pulsar/c/message.h>
++#include <pulsar/c/reader.h>
+ 
+ #ifdef __cplusplus
+ extern "C" {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19214,6 +19214,8 @@ with pkgs;
 
   pugixml = callPackage ../development/libraries/pugixml { };
 
+  pulsar-client-cpp = callPackage ../development/libraries/pulsar-client-cpp { };
+
   pylode = callPackage ../misc/pylode {};
 
   python-qt = callPackage ../development/libraries/python-qt {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I'm not actually the original author ([see](https://github.com/CorbanR/nixpkgs/issues/2#issuecomment-974553064))