### PR TITLE
pulseaudio-dlna: unstable-2017-11-01 -> unstable-2021-11-09

### DIFF
--- a/pkgs/applications/audio/pulseaudio-dlna/0001-setup.py-remove-dbus-python-from-list.patch
+++ b/pkgs/applications/audio/pulseaudio-dlna/0001-setup.py-remove-dbus-python-from-list.patch
@@ -1,0 +1,25 @@
+From a4bf7df795146c843696daee8c02826ba0034298 Mon Sep 17 00:00:00 2001
+From: Florian Klink <flokli@flokli.de>
+Date: Sun, 21 Nov 2021 12:04:48 +0100
+Subject: [PATCH] setup.py: remove dbus-python from list
+
+I wasn't able to convince setuptools to find this.
+---
+ setup.py | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 61d6831..013fff3 100644
+--- a/setup.py
++++ b/setup.py
+@@ -42,7 +42,6 @@ setuptools.setup(
+     install_requires=[
+     'docopt',
+     'chardet',
+-    'dbus-python',
+     'docopt',
+     'requests',
+     'setproctitle',
+-- 
+2.33.1
+

--- a/pkgs/applications/audio/pulseaudio-dlna/default.nix
+++ b/pkgs/applications/audio/pulseaudio-dlna/default.nix
@@ -13,6 +13,7 @@
 , sox
 , vorbisSupport ? true
 , vorbis-tools
+, pulseaudio
 }:
 
 python3Packages.buildPythonApplication {
@@ -53,6 +54,11 @@ python3Packages.buildPythonApplication {
   ++ lib.optional flacSupport flac
   ++ lib.optional soxSupport sox
   ++ lib.optional vorbisSupport vorbis-tools;
+
+  # pulseaudio-dlna shells out to pactl to configure sinks and sources.
+  # As pactl might not be in $PATH, add --suffix it (so pactl configured by the
+  # user get priority)
+  makeWrapperArgs = [ "--suffix PATH : ${lib.makeBinPath [ pulseaudio ]}" ];
 
   # upstream has no tests
   checkPhase = ''

--- a/pkgs/applications/audio/pulseaudio-dlna/default.nix
+++ b/pkgs/applications/audio/pulseaudio-dlna/default.nix
@@ -1,10 +1,18 @@
-{ fetchFromGitHub, lib, pythonPackages
-, mp3Support ? true, lame ? null
-, opusSupport ? true, opusTools ? null
-, faacSupport ? false, faac ? null
-, flacSupport ? true, flac ? null
-, soxSupport ? true, sox ? null
-, vorbisSupport ? true, vorbis-tools ? null
+{ fetchFromGitHub
+, lib
+, python3Packages
+, mp3Support ? true
+, lame ? null
+, opusSupport ? true
+, opusTools ? null
+, faacSupport ? false
+, faac ? null
+, flacSupport ? true
+, flac ? null
+, soxSupport ? true
+, sox ? null
+, vorbisSupport ? true
+, vorbis-tools ? null
 }:
 
 assert mp3Support -> lame != null;
@@ -14,30 +22,44 @@ assert flacSupport -> flac != null;
 assert soxSupport -> sox != null;
 assert vorbisSupport -> vorbis-tools != null;
 
-let
-  zeroconf = pythonPackages.callPackage ./zeroconf.nix { };
-in
-pythonPackages.buildPythonApplication {
+python3Packages.buildPythonApplication {
   pname = "pulseaudio-dlna";
-  version = "unstable-2017-11-01";
+  version = "unstable-2021-11-09";
 
   src = fetchFromGitHub {
-    owner = "masmu";
+    owner = "Cygn";
     repo = "pulseaudio-dlna";
-    rev = "4472928dd23f274193f14289f59daec411023ab0";
-    sha256 = "1dfn7036vrq49kxv4an7rayypnm5dlawsf02pfsldw877hzdamqk";
+    rev = "637a2e7bba2277137c5f12fb58e63100dab7cbe6";
+    sha256 = "sha256-Oda+zQQJE2D3fiNWTzxYvI8cZVHG5JAoV2Wf5Z6IU3M=";
   };
 
-  propagatedBuildInputs = with pythonPackages; [
-    dbus-python docopt requests setproctitle protobuf psutil futures
-    chardet notify2 netifaces pyroute2 pygobject2 lxml setuptools ]
-    ++ [ zeroconf ]
-    ++ lib.optional mp3Support lame
-    ++ lib.optional opusSupport opusTools
-    ++ lib.optional faacSupport faac
-    ++ lib.optional flacSupport flac
-    ++ lib.optional soxSupport sox
-    ++ lib.optional vorbisSupport vorbis-tools;
+  patches = [
+    ./0001-setup.py-remove-dbus-python-from-list.patch
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    dbus-python
+    docopt
+    requests
+    setproctitle
+    protobuf
+    psutil
+    chardet
+    netifaces
+    notify2
+    pyroute2
+    pygobject3
+    PyChromecast
+    lxml
+    setuptools
+    zeroconf
+  ]
+  ++ lib.optional mp3Support lame
+  ++ lib.optional opusSupport opusTools
+  ++ lib.optional faacSupport faac
+  ++ lib.optional flacSupport flac
+  ++ lib.optional soxSupport sox
+  ++ lib.optional vorbisSupport vorbis-tools;
 
   # upstream has no tests
   checkPhase = ''
@@ -46,7 +68,7 @@ pythonPackages.buildPythonApplication {
 
   meta = with lib; {
     description = "A lightweight streaming server which brings DLNA / UPNP and Chromecast support to PulseAudio and Linux";
-    homepage = "https://github.com/masmu/pulseaudio-dlna";
+    homepage = "https://github.com/Cygn/pulseaudio-dlna";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ mog ];
     platforms = platforms.linux;

--- a/pkgs/applications/audio/pulseaudio-dlna/default.nix
+++ b/pkgs/applications/audio/pulseaudio-dlna/default.nix
@@ -2,25 +2,18 @@
 , lib
 , python3Packages
 , mp3Support ? true
-, lame ? null
+, lame
 , opusSupport ? true
-, opusTools ? null
+, opusTools
 , faacSupport ? false
-, faac ? null
+, faac
 , flacSupport ? true
-, flac ? null
+, flac
 , soxSupport ? true
-, sox ? null
+, sox
 , vorbisSupport ? true
-, vorbis-tools ? null
+, vorbis-tools
 }:
-
-assert mp3Support -> lame != null;
-assert opusSupport -> opusTools != null;
-assert faacSupport -> faac != null;
-assert flacSupport -> flac != null;
-assert soxSupport -> sox != null;
-assert vorbisSupport -> vorbis-tools != null;
 
 python3Packages.buildPythonApplication {
   pname = "pulseaudio-dlna";


### PR DESCRIPTION
This moves pulseaudio-dlna to a more recent fork, which works with
Python 3.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
