### PR TITLE
bitcoin-knots: 0.20.0.knots20200614 -> 22.0.knots20211108

### DIFF
--- a/pkgs/applications/blockchains/bitcoin-knots/default.nix
+++ b/pkgs/applications/blockchains/bitcoin-knots/default.nix
@@ -1,41 +1,83 @@
-{ lib, stdenv
-, fetchFromGitHub
-, pkg-config
+{ lib
+, stdenv
+, fetchurl
 , autoreconfHook
-, db5
-, openssl
-, boost
-, zlib
-, miniupnpc
-, libevent
-, protobuf
+, pkg-config
 , util-linux
+, hexdump
+, autoSignDarwinBinariesHook
+, wrapQtAppsHook ? null
+, boost
+, libevent
+, miniupnpc
+, zeromq
+, zlib
+, db48
+, sqlite
+, qrencode
+, qtbase ? null
+, qttools ? null
+, python3
+, nixosTests
+, withGui
+, withWallet ? true
 }:
 
+with lib;
 stdenv.mkDerivation rec {
-  pname = "bitcoind-knots";
-  version = "0.20.0";
-  versionDate = "20200614";
+  pname = if withGui then "bitcoin-knots" else "bitcoind-knots";
+  version = "22.0.knots20211108";
 
-  src = fetchFromGitHub {
-    owner = "bitcoinknots";
-    repo = "bitcoin";
-    rev = "v${version}.knots${versionDate}";
-    sha256 = "0c8k1154kcwz6q2803wx0zigvqaij1fi5akgfqlj3yl57jjw48jj";
+  src = fetchurl {
+    url = "https://bitcoinknots.org/files/22.x/${version}/guix/bitcoin-${version}.tar.gz";
+    sha256 = "04sqbx4sp3bzwbl8z53nz96n3s0590h327ih0mbgyvfvl3b8pj4i";
   };
 
-  nativeBuildInputs = [ pkg-config autoreconfHook ];
-  buildInputs = [ openssl db5 openssl util-linux
-                  protobuf boost zlib miniupnpc libevent ];
+  nativeBuildInputs =
+    [ autoreconfHook pkg-config ]
+    ++ optionals stdenv.isLinux [ util-linux ]
+    ++ optionals stdenv.isDarwin [ hexdump ]
+    ++ optionals (stdenv.isDarwin && stdenv.isAarch64) [ autoSignDarwinBinariesHook ]
+    ++ optionals withGui [ wrapQtAppsHook ];
 
-  configureFlags = [ "--with-incompatible-bdb"
-                     "--with-boost-libdir=${boost.out}/lib" ];
+  buildInputs = [ boost libevent miniupnpc zeromq zlib ]
+    ++ optionals withWallet [ db48 sqlite ]
+    ++ optionals withGui [ qrencode qtbase qttools ];
 
-  meta = with lib; {
-    description = "An enhanced Bitcoin node software";
+  configureFlags = [
+    "--with-boost-libdir=${boost.out}/lib"
+    "--disable-bench"
+  ] ++ optionals (!doCheck) [
+    "--disable-tests"
+    "--disable-gui-tests"
+  ] ++ optionals (!withWallet) [
+    "--disable-wallet"
+  ] ++ optionals withGui [
+    "--with-gui=qt5"
+    "--with-qt-bindir=${qtbase.dev}/bin:${qttools.dev}/bin"
+  ];
+
+  checkInputs = [ python3 ];
+
+  doCheck = true;
+
+  checkFlags =
+    [ "LC_ALL=en_US.UTF-8" ]
+    # QT_PLUGIN_PATH needs to be set when executing QT, which is needed when testing Bitcoin's GUI.
+    # See also https://github.com/NixOS/nixpkgs/issues/24256
+    ++ optional withGui "QT_PLUGIN_PATH=${qtbase}/${qtbase.qtPluginPrefix}";
+
+  enableParallelBuilding = true;
+
+  passthru.tests = {
+    smoke-test = nixosTests.bitcoind-knots;
+  };
+
+  meta = {
+    description = "A derivative of Bitcoin Core with a collection of improvements";
     homepage = "https://bitcoinknots.org/";
+    maintainers = with maintainers; [ prusnak mmahut ];
     license = licenses.mit;
-    maintainers = [ maintainers.mmahut ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/blockchains/bitcoin/default.nix
+++ b/pkgs/applications/blockchains/bitcoin/default.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   checkFlags =
-    [ "LC_ALL=C.UTF-8" ]
+    [ "LC_ALL=en_US.UTF-8" ]
     # QT_PLUGIN_PATH needs to be set when executing QT, which is needed when testing Bitcoin's GUI.
     # See also https://github.com/NixOS/nixpkgs/issues/24256
     ++ optional withGui "QT_PLUGIN_PATH=${qtbase}/${qtbase.qtPluginPrefix}";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29627,7 +29627,12 @@ with pkgs;
     inherit (darwin) autoSignDarwinBinariesHook;
   };
 
-  bitcoind-knots = callPackage ../applications/blockchains/bitcoin-knots { miniupnpc = miniupnpc_2; };
+  bitcoind-knots = callPackage ../applications/blockchains/bitcoin-knots {
+    boost = boost17x;
+    miniupnpc = miniupnpc_2;
+    withGui = false;
+    inherit (darwin) autoSignDarwinBinariesHook;
+  };
 
   cgminer = callPackage ../applications/blockchains/cgminer { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- version update
-  make `bitcoin-knots/default.nix` much more similar to `bitcoin/default.nix` to simplify maintenance

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
