### PR TITLE
nixos/nginx: fix http3 configuration

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -260,6 +260,7 @@ let
           listen ${addr}:${toString port} http3 "
           + optionalString vhost.default "default_server "
           + optionalString vhost.reuseport "reuseport "
+          + optionalString (extraParameters != []) (concatStringsSep " " extraParameters)
           + ";" else "")
           + "
 

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -259,6 +259,7 @@ let
           # UDP listener for **QUIC+HTTP/3
           listen ${addr}:${toString port} http3 "
           + optionalString vhost.default "default_server "
+          + optionalString vhost.reuseport "reuseport "
           + ";" else "")
           + "
 
@@ -266,6 +267,7 @@ let
           + optionalString (ssl && vhost.http2) "http2 "
           + optionalString ssl "ssl "
           + optionalString vhost.default "default_server "
+          + optionalString vhost.reuseport "reuseport "
           + optionalString (extraParameters != []) (concatStringsSep " " extraParameters)
           + ";";
 

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -20,7 +20,7 @@ with lib;
     serverAliases = mkOption {
       type = types.listOf types.str;
       default = [];
-      example = ["www.example.org" "example.org"];
+      example = [ "www.example.org" "example.org" ];
       description = ''
         Additional names of virtual hosts served by this virtual host configuration.
       '';
@@ -31,11 +31,11 @@ with lib;
         addr = mkOption { type = str;  description = "IP address.";  };
         port = mkOption { type = int;  description = "Port number."; default = 80; };
         ssl  = mkOption { type = bool; description = "Enable SSL.";  default = false; };
-        extraParameters = mkOption { type = listOf str; description = "Extra parameters of this listen directive."; default = []; example = [ "reuseport" "deferred" ]; };
+        extraParameters = mkOption { type = listOf str; description = "Extra parameters of this listen directive."; default = []; example = [ "backlog=1024" "deferred" ]; };
       }; });
       default = [];
       example = [
-        { addr = "195.154.1.1"; port = 443; ssl = true;}
+        { addr = "195.154.1.1"; port = 443; ssl = true; }
         { addr = "192.154.1.1"; port = 80; }
       ];
       description = ''
@@ -204,6 +204,15 @@ with lib;
         Note that HTTP 3 support is experimental and
         *not* yet recommended for production.
         Read more at https://quic.nginx.org/
+      '';
+    };
+
+    reuseport = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Create an individual listening socket .
+        It is required to specify only once on one of the hosts.
       '';
     };
 


### PR DESCRIPTION
###### Motivation for this change
Update nginx http3 configuration.
Fixed work nginx with enabled  http3 protocol on multiple hosts.
Option `reuseport` only needs to be specified once on one of the hosts.

Test configuration:
```
  services.nginx = {
    enable = true;
    enableReload = true;
    package = pkgs.nginxQuic;
    user = "nginx";
    group = "nginx";

    virtualHosts."default_server" = {
      default = true;
      addSSL = true;
      forceSSL = false;
      enableACME = false;
      http3 = true;
      sslCertificate    = "/var/certs/test1.crt";
      sslCertificateKey = "/var/certs/test1.key";
    };

    virtualHosts."test1.local" = {
      default = false;
      addSSL = true;
      forceSSL = false;
      enableACME = false;
      http3 = true;
      reuseport = true;
      sslCertificate    = "/var/certs/test1.crt";
      sslCertificateKey = "/var/certs/test1.key";
      root = "/var/www/test1";
    };

    virtualHosts."test2.local" = {
      default = false;
      addSSL = true;
      forceSSL = false;
      enableACME = false;
      http3 = false;
      sslCertificate    = "/var/certs/test1.crt";
      sslCertificateKey = "/var/certs/test1.key";
      root = "/var/www/test2";
    };
  };
```
Generated nginx configuration before update:
```
  server {
    listen 0.0.0.0:443 ssl http2 default_server ;# UDP listener for **QUIC+HTTP/3
    listen 0.0.0.0:443 http3 reuseport;
    # Advertise that HTTP/3 is available
    add_header Alt-Svc 'h3=":443"';
    # Sent when QUIC was used
    add_header QUIC-Status $quic;
    listen [::0]:443 ssl http2 default_server ;# UDP listener for **QUIC+HTTP/3
    listen [::0]:443 http3 reuseport;
    # Advertise that HTTP/3 is available
    add_header Alt-Svc 'h3=":443"';
    # Sent when QUIC was used
    add_header QUIC-Status $quic;
    listen 0.0.0.0:80 default_server ;
    listen [::0]:80 default_server ;
    server_name default_server ;
    ssl_certificate /var/certs/test1.crt;
    ssl_certificate_key /var/certs/test1.key;
  }
  server {
    listen 0.0.0.0:443 ssl http2 ;# UDP listener for **QUIC+HTTP/3
    listen 0.0.0.0:443 http3 reuseport;
    # Advertise that HTTP/3 is available
    add_header Alt-Svc 'h3=":443"';
    # Sent when QUIC was used
    add_header QUIC-Status $quic;
    listen [::0]:443 ssl http2 ;# UDP listener for **QUIC+HTTP/3
    listen [::0]:443 http3 reuseport;
    # Advertise that HTTP/3 is available
    add_header Alt-Svc 'h3=":443"';
    # Sent when QUIC was used
    add_header QUIC-Status $quic;
    listen 0.0.0.0:80 ;
    listen [::0]:80 ;
    server_name test1.local ;
    root /var/www/test1;
    ssl_certificate /var/certs/test1.crt;
    ssl_certificate_key /var/certs/test1.key;
  }
  server {
    listen 0.0.0.0:443 ssl http2 ;
    listen [::0]:443 ssl http2 ;
    listen 0.0.0.0:80 ;
    listen [::0]:80 ;
    server_name test2.local ;
    root /var/www/test2;
    ssl_certificate /var/certs/test1.crt;
    ssl_certificate_key /var/certs/test1.key;
  }
```

Generated nginx configuration after update:
```
  server {
    # UDP listener for **QUIC+HTTP/3
    listen 0.0.0.0:443 http3 default_server ;
    listen 0.0.0.0:443 http2 ssl default_server ;
    # UDP listener for **QUIC+HTTP/3
    listen [::0]:443 http3 default_server ;
    listen [::0]:443 http2 ssl default_server ;
    listen 0.0.0.0:80 default_server ;
    listen [::0]:80 default_server ;
    server_name default_server ;
    ssl_certificate /var/certs/test1.crt;
    ssl_certificate_key /var/certs/test1.key;
    # Advertise that HTTP/3 is available
    add_header Alt-Svc 'h3=":443"; ma=86400';
    # Sent when QUIC was used
    add_header QUIC-Status $quic;
  }
  server {
    # UDP listener for **QUIC+HTTP/3
    listen 0.0.0.0:443 http3 reuseport;
    listen 0.0.0.0:443 http2 ssl ;
    # UDP listener for **QUIC+HTTP/3
    listen [::0]:443 http3 reuseport;
    listen [::0]:443 http2 ssl ;
    listen 0.0.0.0:80 ;
    listen [::0]:80 ;
    server_name test1.local ;
    root /var/www/test1;
    ssl_certificate /var/certs/test1.crt;
    ssl_certificate_key /var/certs/test1.key;
    # Advertise that HTTP/3 is available
    add_header Alt-Svc 'h3=":443"; ma=86400';
    # Sent when QUIC was used
    add_header QUIC-Status $quic;
  }
  server {
    listen 0.0.0.0:443 http2 ssl ;
    listen [::0]:443 http2 ssl ;
    listen 0.0.0.0:80 ;
    listen [::0]:80 ;
    server_name test2.local ;
    root /var/www/test2;
    ssl_certificate /var/certs/test1.crt;
    ssl_certificate_key /var/certs/test1.key;
  }

```

cc @mkg20001 @ajs124 @Mic92
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
