### PR TITLE
nordic: unstable-2021-08-13 -> unstable-2021-11-19

### DIFF
--- a/pkgs/data/themes/nordic/default.nix
+++ b/pkgs/data/themes/nordic/default.nix
@@ -2,70 +2,70 @@
 
 stdenv.mkDerivation rec {
   pname = "nordic";
-  version = "unstable-2021-08-13";
+  version = "unstable-2021-11-19";
 
   srcs = [
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "937ca200e8148a61c73228030ec260abecc27fb2";
-      sha256 = "0h7z7jh5p0916i9lx4n94r6vbydafnikdi6d9p4djvpyhn5nizgy";
+      rev = "0112af91943b8819f7a1af9a508cda7fe3d74051";
+      sha256 = "sha256-ccOA5/jXTx20495NpTgVu7DvsjfTEULqL3IyJ+Pd/ug";
       name = "Nordic";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "e736846a130be7907e977b16d0b3a0ab19631015";
-      sha256 = "0dv7z31zw1r3iac5bvwapf9lm99y5l0xfzaw93hn8msh10w5crx8";
+      rev = "b30d2c844cc6ef5d020308f1c02791de45b607a7";
+      sha256 = "sha256-g5yCCFXzipZLmUat+1r6QWHB7DWQvMKhMexHPV/DJHM";
       name = "Nordic-standard-buttons";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "8ff12077f28e25f4e57f055a51e5e3b9b1bf53fd";
-      sha256 = "082k0na39qb97kbvc15g3mdfh8d8ricql84i4wdjy3rjfbfwq0pl";
+      rev = "6d38d6af363528f42619f663e3ecd4c08dfd2411";
+      sha256 = "sha256-jaRiSE6yfTltzZ2vr8w4d+YtSz7REOcL7vOOhQvIMlQ";
       name = "Nordic-darker";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "8c422e4bfdf5680ff323938f49f411680154d3d6";
-      sha256 = "1w540zlmsxpwa455wpxy1dpgv2fjr36xwjqbyc8x4y0ya0qfify0";
+      rev = "4142817c14c27b371d42796445bedc84dc94672c";
+      sha256 = "sha256-FAb1+EREcwYrfSxAl6LrPaJtkHMt67NV3bG87g1cFT4";
       name = "Nordic-darker-standard-buttons";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "ce31d794fe1c6b72d3cff2e9513e08ddce014118";
-      sha256 = "09d41wllr9hgxshgvpgngx9rlg8pvx5aqgkk5q8jra4jz2a92fhq";
+      rev = "2a91d6f3db70412b0a80ed33546fbe93075627d8";
+      sha256 = "sha256-Su+amS7moc2IDONNvqw3bjL6Q0WLJWzHu6WvfcVDcDY";
       name = "Nordic-bluish-accent";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "8ca4fe244c31775effacc77f0a25ae10c6bee60c";
-      sha256 = "1cby8wmaqdqpd9c40wiy7i9wmrazwfhb3h818hg0ni7yfcm2fr58";
+      rev = "3ebd334f97d638fdc888b16d69851e3ee31131f2";
+      sha256 = "sha256-h0IXtWcdDvAEVi/1cLZF4Vacdl6VAY+5uo0LGPNe0bg";
       name = "Nordic-bluish-accent-standard-buttons";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = "${pname}-polar";
-      rev = "a2d1c633ac2bfe261e8f612c8af14af0311c7f67";
-      sha256 = "05llvix671i6128vbr3jiik8mipaab7bn0v9i89ydwyfhw822n7v";
+      rev = "803926882f8178c72b433466a377aaa33c5b372a";
+      sha256 = "sha256-G7Vu03PoFOEU9uxb5JiHR4Tr8qk47fPo7Gg7Vt9Zzns";
       name = "Nordic-Polar";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = "${pname}-polar";
-      rev = "62a1702a17e7ea96e9b692832d68a0a7f26aabb6";
-      sha256 = "0r1qn1rj322b44h15hcfbx79hhmb1m4pkv2fpdsn3s2klcxwr1ql";
+      rev = "988cb8a16ece3901b8b0e7a5b86503400491cb1e";
+      sha256 = "sha256-Zx1mrzJm5o4wQwOR8ZU2OEcjD3/6UXwLrBYpMtCkQbg";
       name = "Nordic-Polar-standard-buttons";
     })
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to [unstable-2021-11-19](https://github.com/EliverLara/Nordic/commits/master)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
