### PR TITLE
[staging-next] qtwebengine: 5.15.6 → 5.15.7

### DIFF
--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -58,14 +58,7 @@ let
     qtdeclarative = [ ./qtdeclarative.patch ];
     qtscript = [ ./qtscript.patch ];
     qtserialport = [ ./qtserialport.patch ];
-    qtwebengine = [
-      # Fix invisible fonts with glibc 2.33: https://github.com/NixOS/nixpkgs/issues/131074
-      (fetchpatch {
-        url = "https://src.fedoraproject.org/rpms/qt5-qtwebengine/raw/d122c011631137b79455850c363676c655cf9e09/f/qtwebengine-everywhere-src-5.15.5-%231904652.patch";
-        name = "qtwebengine-everywhere-src-5.15.5-_1904652.patch";
-        sha256 = "01q7hagq0ysii1jnrh5adm97vdm9cis592xr6im7accyw6hgcn7b";
-      })
-    ] ++ lib.optionals stdenv.isDarwin [
+    qtwebengine = lib.optionals stdenv.isDarwin [
       ./qtwebengine-darwin-no-platform-check.patch
       ./qtwebengine-mac-dont-set-dsymutil-path.patch
     ];

--- a/pkgs/development/libraries/qt-5/5.15/srcs.nix
+++ b/pkgs/development/libraries/qt-5/5.15/srcs.nix
@@ -38,7 +38,7 @@ lib.mapAttrs mk (lib.importJSON ./srcs-generated.json)
 
   qtwebengine =
     let
-      branchName = "5.15.6";
+      branchName = "5.15.7";
       rev = "v${branchName}-lts";
     in
     {
@@ -46,7 +46,7 @@ lib.mapAttrs mk (lib.importJSON ./srcs-generated.json)
 
       src = fetchgit {
         url = "https://github.com/qt/qtwebengine.git";
-        sha256 = "17bw9yf04zmr9ck5jkrd435c8b03zpf937vn2nwgsr8p78wkg3kr";
+        sha256 = "fssBN/CDgXAuiNj14MPeIDI15ZDRBGuF7wxSXns9exU=";
         inherit rev branchName;
         fetchSubmodules = true;
         leaveDotGit = true;


### PR DESCRIPTION
###### Motivation for this change

Fix breakage on staging-next ( #146259 ): https://hydra.nixos.org/job/nixpkgs/staging-next/qt5.qtwebengine.x86_64-linux

```
  | # | Finished at | Package/release name | System
  | 158741897 | 11h ago | qtwebengine-5.15.6-v5.15.6 | x86_64-linux
  | 158467643 | 4d ago | qtwebengine-5.15.6-v5.15.6 | x86_64-linux
  | 157985194 | 2021-11-13 | qtwebengine-5.15.6-v5.15.6 | x86_64-linux
```

```
../../3rdparty/chromium/components/paint_preview/common/subset_font.cc: In function 'sk_sp<SkData> paint_preview::SubsetFont(SkTypeface*, const paint_preview::GlyphUsage&)':
../../3rdparty/chromium/components/paint_preview/common/subset_font.cc:74:3: error: 'hb_subset_input_set_retain_gids' was not declared in this scope; did you mean 'hb_subset_input_set_flags'?
   74 |   hb_subset_input_set_retain_gids(input.get(), true);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |   hb_subset_input_set_flags
../../3rdparty/chromium/components/paint_preview/common/subset_font.cc:76:35: error: 'hb_subset' was not declared in this scope; did you mean 'hb_set_set'?
   76 |   HbScoped<hb_face_t> subset_face(hb_subset(face.get(), input.get()));
      |                                   ^~~~~~~~~
      |                                   hb_set_set
[10983/24851] CXX obj/media/capture/mojom/image_capture/image_capture.mojom.odroid.omojom.o-utils.oshared.oK
```

From: https://hydra.nixos.org/build/158673597/nixlog/1

###### Things done

Currently doing a build and pending testing with dependent applications.

EDIT: Tested Zeal and Digikam that dependen on qtwebengine, no issues with font rendering.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
