### PR TITLE
cernlib: fix for gfortran10

### DIFF
--- a/pkgs/development/libraries/physics/cernlib/default.nix
+++ b/pkgs/development/libraries/physics/cernlib/default.nix
@@ -35,18 +35,30 @@ stdenv.mkDerivation rec {
     export PATH=$PATH:$CERN_ROOT/bin
   '';
 
+  FFLAGS = lib.optionals (lib.versionAtLeast gfortran.version "10.0.0") [
+    # Fix https://github.com/vmc-project/geant3/issues/17
+    "-fallow-invalid-boz"
+
+    # Fix for gfortran 10
+    "-fallow-argument-mismatch"
+  ];
+
+  makeFlags = [
+    "FORTRANOPTIONS=$(FFLAGS)"
+  ];
+
   buildPhase = ''
     cd $CERN_ROOT
     mkdir -p build bin lib
 
     cd $CERN_ROOT/build
     $CVSCOSRC/config/imake_boot
-    make -j $NIX_BUILD_CORES bin/kuipc
-    make -j $NIX_BUILD_CORES scripts/Makefile
+    make -j $NIX_BUILD_CORES $makeFlags bin/kuipc
+    make -j $NIX_BUILD_CORES $makeFlags scripts/Makefile
     pushd scripts
-    make -j $NIX_BUILD_CORES install.bin
+    make -j $NIX_BUILD_CORES $makeFlags install.bin
     popd
-    make -j $NIX_BUILD_CORES
+    make -j $NIX_BUILD_CORES $makeFlags
   '';
 
   installPhase = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes: #146859

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
