### PR TITLE
grub2_xen: pull upstream fix for binutils-2.36

### DIFF
--- a/pkgs/tools/misc/grub/2.0x.nix
+++ b/pkgs/tools/misc/grub/2.0x.nix
@@ -65,6 +65,13 @@ stdenv.mkDerivation rec {
       url = "https://marc.info/?l=grub-devel&m=146193404929072&q=mbox";
       sha256 = "00wa1q5adiass6i0x7p98vynj9vsz1w0gn1g4dgz89v35mpyw2bi";
     })
+
+    # Pull upstream patch to fix linkage against binutils-2.36.
+    (fetchpatch {
+      name = "binutils-2.36";
+      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=b98275138bf4fc250a1c362dfd2c8b1cf2421701";
+      sha256 = "001m058bsl2pcb0ii84jfm5ias8zgzabrfy6k2cc9w6w1y51ii82";
+    })
   ];
 
   postPatch = if kbdcompSupport then ''


### PR DESCRIPTION
Without the change linkage on binutils-2.36 fails as:

    ld: section .note.gnu.property VMA [0000000000400158,0000000000400187]
      overlaps section .bss VMA [000000000000f000,000000000041e1b7]
