### PR TITLE
mpvScripts.video-cutter: init at unstable-2021-02-03

### DIFF
--- a/pkgs/applications/video/mpv/scripts/cutter.nix
+++ b/pkgs/applications/video/mpv/scripts/cutter.nix
@@ -1,0 +1,47 @@
+{ lib, stdenvNoCC, fetchFromGitHub, makeWrapper }:
+
+stdenvNoCC.mkDerivation {
+  pname = "video-cutter";
+  version = "unstable-2021-02-03";
+
+  src = fetchFromGitHub {
+    owner = "rushmj";
+    repo = "mpv-video-cutter";
+    rev = "718d6ce9356e63fdd47208ec44f575a212b9068a";
+    sha256 = "sha256-ramID1DPl0UqEzevpqdYKb9aaW3CAy3Dy9CPb/oJ4eY=";
+  };
+
+  dontBuild = true;
+  dontCheck = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postPatch = ''
+    substituteInPlace cutter.lua \
+      --replace '~/.config/mpv/scripts/c_concat.sh' '${placeholder "out"}/share/mpv/scripts/c_concat.sh'
+
+    # needs to be ran separately so that we can replace everything, and not every single mention explicitly
+    # original script places them in the scripts folder, just spawning unnecessary errors
+    # i know that hardcoding .config and especially the .mpv directory isn't best practice, but I didn't want to deviate too much from upstream
+    substituteInPlace cutter.lua \
+      --replace '~/.config/mpv/scripts' "''${XDG_CONFIG_HOME:-~/.config}/mpv/cutter"
+  '';
+
+  installPhase = ''
+    install -Dm755 c_concat.sh $out/share/mpv/scripts/c_concat.sh
+    install cutter.lua $out/share/mpv/scripts/cutter.lua
+
+    wrapProgram $out/share/mpv/scripts/c_concat.sh \
+      --run "mkdir -p ~/.config/mpv/cutter/"
+  '';
+
+  passthru.scriptName = "cutter.lua";
+
+  meta = with lib; {
+    description = "Cut videos and concat them automatically";
+    homepage = "https://github.com/rushmj/mpv-video-cutter";
+    # repo doesn't have a license
+    license = licenses.unfree;
+    maintainers = with maintainers; [ legendofmiracles ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26922,6 +26922,7 @@ with pkgs;
     sponsorblock = callPackage ../applications/video/mpv/scripts/sponsorblock.nix {};
     thumbnail = callPackage ../applications/video/mpv/scripts/thumbnail.nix { };
     youtube-quality = callPackage ../applications/video/mpv/scripts/youtube-quality.nix { };
+    cutter = callPackage ../applications/video/mpv/scripts/cutter.nix { };
   };
 
   mrpeach = callPackage ../applications/audio/pd-plugins/mrpeach { };


### PR DESCRIPTION
###### Motivation for this change
On first run one has to press `o` twice to export, I suspect an upstream bug
Tested with `nix-build -E "with import ./. { }; mpv-with-scripts.override { scripts = [ mpvScripts.cutter ]; }"`
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
