### PR TITLE
dolphin-emu-beta: add update script, 5.0-15260 -> 5.0-15445

### DIFF
--- a/pkgs/misc/emulators/dolphin-emu/master.nix
+++ b/pkgs/misc/emulators/dolphin-emu/master.nix
@@ -2,7 +2,7 @@
 , wrapQtAppsHook, qtbase, bluez, ffmpeg, libao, libGLU, libGL, pcre, gettext
 , libXrandr, libusb1, lzo, libpthreadstubs, libXext, libXxf86vm, libXinerama
 , libSM, libXdmcp, readline, openal, udev, libevdev, portaudio, curl, alsa-lib
-, miniupnpc, enet, mbedtls, soundtouch, sfml
+, miniupnpc, enet, mbedtls, soundtouch, sfml, writeScript
 , vulkan-loader ? null, libpulseaudio ? null
 
 # - Inputs used for Darwin
@@ -62,6 +62,17 @@ stdenv.mkDerivation rec {
 
   postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
     install -D $src/Data/51-usb-device.rules $out/etc/udev/rules.d/51-usb-device.rules
+  '';
+
+
+  passthru.updateScript = writeScript "dolphin-update-script" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl jq common-updater-scripts
+    set -eou pipefail
+    json="$(curl -s https://dolphin-emu.org/update/latest/beta)"
+    version="$(jq -r '.shortrev' <<< "$json")"
+    rev="$(jq -r '.hash' <<< "$json")"
+    update-source-version dolphin-emu-beta "$version" --rev="$rev"
   '';
 
   meta = with lib; {

--- a/pkgs/misc/emulators/dolphin-emu/master.nix
+++ b/pkgs/misc/emulators/dolphin-emu/master.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "dolphin-emu";
-  version = "5.0-15260";
+  version = "5.0-15445";
 
   src = fetchFromGitHub {
     owner = "dolphin-emu";
     repo = "dolphin";
-    rev = "207c931a04c8e2629a735bc2b3f36b5c89365ca7";
-    sha256 = "15r9syk7f62h16klcznw7css6sng8nqkkz4d1qr8d988rdfaiypx";
+    rev = "db02b50d2ecdfbbc21e19aadc57253c353069f77";
+    sha256 = "l2vbTZOcjfyZjKOI3n5ig2f7cDYR22GcqKS479LMtP8=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change
Some nice features have been added, especially Riivolution support: https://dolphin-emu.org/blog/2021/11/13/dolphin-progress-report-september-and-october-2021/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
