### PR TITLE
tetrio-desktop: init at 8.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12313,6 +12313,16 @@
     githubId = 3889405;
     name = "vyp";
   };
+  wackbyte = {
+    name = "wackbyte";
+    email = "wackbyte@pm.me";
+    github = "wackbyte";
+    githubId = 29505620;
+    keys = [{
+      longkeyid = "rsa4096/0x937F2AE5CCEFBF59";
+      fingerprint = "E595 7FE4 FEF6 714B 1AD3  1483 937F 2AE5 CCEF BF59";
+    }];
+  };
   wakira = {
     name = "Sheng Wang";
     email = "sheng@a64.work";

--- a/pkgs/games/tetrio-desktop/default.nix
+++ b/pkgs/games/tetrio-desktop/default.nix
@@ -1,0 +1,85 @@
+{ stdenv
+, lib
+, fetchurl
+, autoPatchelfHook
+, alsa-lib
+, cups
+, libX11
+, libXScrnSaver
+, libXtst
+, mesa
+, nss
+, systemd
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tetrio-desktop";
+  version = "8.0.0";
+
+  src = fetchurl {
+    url = "https://web.archive.org/web/20211130172544/https://tetr.io/about/desktop/builds/TETR.IO%20Setup.deb";
+    name = "tetrio-desktop.deb";
+    sha256 = "1nlblfhrph4cw8rpic9icrs78mzrxyskl7ggyy2i8bk9i07i21xf";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    alsa-lib
+    cups
+    libX11
+    libXScrnSaver
+    libXtst
+    mesa
+    nss
+  ];
+
+  dontWrapGApps = true;
+
+  libPath = lib.makeLibraryPath [
+    alsa-lib
+    cups
+    libX11
+    libXScrnSaver
+    libXtst
+    mesa
+    nss
+    systemd
+  ];
+
+  unpackPhase = ''
+    mkdir -p $TMP/tetrio-desktop $out/bin
+    cp $src $TMP/tetrio-desktop.deb
+    ar vx $TMP/tetrio-desktop.deb
+    tar --no-overwrite-dir -xvf data.tar.xz -C $TMP/tetrio-desktop/
+  '';
+
+  installPhase = ''
+    cp -R $TMP/tetrio-desktop/{usr/share,opt} $out/
+
+    wrapProgram $out/opt/TETR.IO/tetrio-desktop \
+      --prefix LD_LIBRARY_PATH : ${libPath}:$out/opt/TETR.IO
+
+    ln -s $out/opt/TETR.IO/tetrio-desktop $out/bin/
+
+    substituteInPlace $out/share/applications/tetrio-desktop.desktop \
+      --replace "Exec=\"/opt/TETR.IO/tetrio-desktop\"" "Exec=\"$out/opt/TETR.IO/tetrio-desktop\""
+  '';
+
+  meta = with lib; {
+    homepage = "https://tetr.io";
+    downloadPage = "https://tetr.io/about/desktop/";
+    description = "TETR.IO desktop client";
+    longDescription = ''
+      TETR.IO is a modern yet familiar online stacker.
+      Play against friends and foes all over the world, or claim a spot on the leaderboards - the stacker future is yours!
+    '';
+    platforms = [ "x86_64-linux" ];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ wackbyte ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28491,6 +28491,8 @@ with pkgs;
 
   tetraproc = callPackage ../applications/audio/tetraproc { };
 
+  tetrio-desktop = callPackage ../games/tetrio-desktop { };
+
   tev = callPackage ../applications/graphics/tev { };
 
   themechanger = callPackage ../applications/misc/themechanger { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
