### PR TITLE
stacs: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/pep440/default.nix
+++ b/pkgs/development/python-modules/pep440/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pep440";
+  version = "0.1.0";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "m1H/yqqDiFrj6tmD9jo8nDakCBZxkBPq/HtSOXMH4ZQ=";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "pep440"
+  ];
+
+  meta = with lib; {
+    description = "Python module to check whether versions number match PEP 440";
+    homepage = "https://github.com/Carreau/pep440";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/setupmeta/default.nix
+++ b/pkgs/development/python-modules/setupmeta/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, git
+, mock
+, pep440
+, pytestCheckHook
+, pythonOlder
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "setupmeta";
+  version = "3.3.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "codrsquad";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "21hABRiY8CTKkpFjePgBAtjs4/G5eFS3aPNMCBC41CY=";
+  };
+
+  checkInputs = [
+    git
+    mock
+    pep440
+    pytestCheckHook
+    setuptools-scm
+  ];
+
+  disabledTests = [
+    # Tests want to scan site-packages
+    "test_check_dependencies"
+    "test_scenario"
+    "test_git_versioning"
+  ];
+
+  pythonImportsCheck = [
+    "setupmeta"
+  ];
+
+  meta = with lib; {
+    description = "Python module to simplify setup.py files";
+    homepage = "https://github.com/codrsquad/setupmeta";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/tools/security/stacs/default.nix
+++ b/pkgs/tools/security/stacs/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "stacs";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "stacscan";
+    repo = pname;
+    rev = version;
+    sha256 = "00ZYdpJktqUXdzPcouHyZcOQyFm7jdFNVuDqsufOviE=";
+  };
+
+  nativeBuildInputs = with python3.pkgs; [
+    setupmeta
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    click
+    pydantic
+    typing-extensions
+    yara-python
+  ];
+
+  checkInputs = with python3.pkgs; [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "stacs"
+  ];
+
+  meta = with lib; {
+    description = "Static token and credential scanner";
+    homepage = "https://github.com/stacscan/stacs";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3543,6 +3543,8 @@ with pkgs;
 
   ssmsh = callPackage ../tools/admin/ssmsh { };
 
+  stacs = callPackage ../tools/security/stacs { };
+
   stagit = callPackage ../development/tools/stagit { };
 
   starboard = callPackage ../applications/networking/cluster/starboard { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8509,6 +8509,8 @@ in {
 
   setproctitle = callPackage ../development/python-modules/setproctitle { };
 
+  setupmeta = callPackage ../development/python-modules/setupmeta { };
+
   setuptools-declarative-requirements = callPackage ../development/python-modules/setuptools-declarative-requirements { };
 
   setuptools-git = callPackage ../development/python-modules/setuptools-git { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5608,6 +5608,8 @@ in {
 
   pep257 = callPackage ../development/python-modules/pep257 { };
 
+  pep440 = callPackage ../development/python-modules/pep440 { };
+
   pep517 = callPackage ../development/python-modules/pep517 { };
 
   pep8 = callPackage ../development/python-modules/pep8 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Static token and credential scanner

https://github.com/stacscan/stacs

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
