### PR TITLE
boofuzz: init at 0.4.0

### DIFF
--- a/pkgs/tools/security/boofuzz/default.nix
+++ b/pkgs/tools/security/boofuzz/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "boofuzz";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "jtpereyda";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "4WtTZ2S2rC2XXN0HbiEht9NW0JXcPnpp66AH67F88yk=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    attrs
+    click
+    colorama
+    flask
+    funcy
+    future
+    psutil
+    pyserial
+    pydot
+    six
+    tornado
+  ];
+
+  checkInputs = with python3.pkgs; [
+    mock
+    netifaces
+    pytest-bdd
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Tests require socket access
+    "test_raw_l2"
+    "test_raw_l3"
+  ];
+
+  pythonImportsCheck = [
+    "boofuzz"
+  ];
+
+  meta = with lib; {
+    description = "Network protocol fuzzing tool";
+    homepage = "https://github.com/jtpereyda/boofuzz";
+    license = with licenses; [ gpl2Plus ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3818,6 +3818,8 @@ with pkgs;
 
   bomutils = callPackage ../tools/archivers/bomutils { };
 
+  boofuzz= callPackage ../tools/security/boofuzz { };
+
   bsdbuild = callPackage ../development/tools/misc/bsdbuild { };
 
   bsdiff = callPackage ../tools/compression/bsdiff { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Network protocol fuzzing tool

https://github.com/jtpereyda/boofuzz

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
