### PR TITLE
hck: 0.6.7 -> 0.7.0

### DIFF
--- a/pkgs/tools/text/hck/default.nix
+++ b/pkgs/tools/text/hck/default.nix
@@ -9,20 +9,29 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "hck";
-  version = "0.6.7";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "sstadick";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-m4YVz3kh4nOkdf6PbbyxjKacUVKdFQet76CMrFYMRHI=";
+    sha256 = "sha256-BP1B1FlN+9qpkqv4WfT7OSyPCb7K47uxJQKXAW1Kkck=";
   };
 
-  cargoSha256 = "sha256-4z1kHSev+5+0wpYFEGvvafB50Wz1wr6zObCjvHR9FPU=";
+  cargoSha256 = "sha256-Lp0VGt6z9mE8b9Fi6Fz3MjmHmbr9Az72D7BzOju9uOI=";
 
   nativeBuildInputs = [ cmake ];
 
   buildInputs = lib.optionals stdenv.isDarwin [ CoreFoundation Security ];
+
+  # link System as a dylib instead of a framework on macos
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    core_affinity=../$(stripHash $cargoDeps)/core_affinity
+    oldHash=$(sha256sum $core_affinity/src/lib.rs | cut -d " " -f 1)
+    substituteInPlace $core_affinity/src/lib.rs --replace framework dylib
+    substituteInPlace $core_affinity/.cargo-checksum.json \
+      --replace $oldHash $(sha256sum $core_affinity/src/lib.rs | cut -d " " -f 1)
+  '';
 
   meta = with lib; {
     description = "A close to drop in replacement for cut that can use a regex delimiter instead of a fixed string";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/sstadick/hck/compare/v0.6.7...v0.7.0
https://github.com/sstadick/hck/blob/master/CHANGELOG.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
