### PR TITLE
Codeowners: update teams and add entry for GNOME

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,13 @@
 #
 # For documentation on this file, see https://help.github.com/articles/about-codeowners/
 # Mentioned users will get code review requests.
+#
+# IMPORTANT NOTE: in order to actually get pinged, commit access is required.
+# This also holds true for GitHub teams. Since almost none of our teams have write
+# permissions, you need to list all members of the team with commit access individually.
+# We still add the team to the list next to its members, this helps keeping things
+# in sync. (Put non team members before the team to distinguish them.)
+# See https://github.com/NixOS/nixpkgs/issues/124085 for more details
 
 # This file
 /.github/CODEOWNERS @edolstra
@@ -210,11 +217,11 @@
 /pkgs/top-level/php-packages.nix         @jtojnar @NixOS/php @aanderse @etu @globin @ma27 @talyz
 
 # Podman, CRI-O modules and related
-/nixos/modules/virtualisation/containers.nix @NixOS/podman @zowoq
-/nixos/modules/virtualisation/cri-o.nix      @NixOS/podman @zowoq
-/nixos/modules/virtualisation/podman.nix     @NixOS/podman @zowoq
-/nixos/tests/cri-o.nix                       @NixOS/podman @zowoq
-/nixos/tests/podman.nix                      @NixOS/podman @zowoq
+/nixos/modules/virtualisation/containers.nix @NixOS/podman @zowoq @adisbladis
+/nixos/modules/virtualisation/cri-o.nix      @NixOS/podman @zowoq @adisbladis
+/nixos/modules/virtualisation/podman.nix     @NixOS/podman @zowoq @adisbladis
+/nixos/tests/cri-o.nix                       @NixOS/podman @zowoq @adisbladis
+/nixos/tests/podman.nix                      @NixOS/podman @zowoq @adisbladis
 
 # Docker tools
 /pkgs/build-support/docker                   @roberth @utdemir

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -237,6 +237,10 @@
 /pkgs/development/go-modules   @kalbasit @Mic92 @zowoq
 /pkgs/development/go-packages  @kalbasit @Mic92 @zowoq
 
+# GNOME
+/pkgs/desktops/gnome                              @NixOS/GNOME @jtojnar @hedning
+/pkgs/desktops/gnome/extensions       @piegamesde @NixOS/GNOME @jtojnar @hedning
+
 # Cinnamon
 /pkgs/desktops/cinnamon @mkg20001
 


### PR DESCRIPTION
###### Motivation for this change

Alas, we need to manually keep our teams in sync with this file. See #124085. Also added an entry for GNOME and the extensions.

- @saschagrunert, @adisbladis, @vdemeester: Heads up, you just got added to the file.
- @jtojnar, @hedning: I added the GNOME team to `/pkgs/desktops/gnome` and myself for `/pkgs/desktops/gnome/extensions`. 
- @NixOS/darwin-maintainers: You are the only team left whose entries are broken. This affects `/pkgs/stdenv/darwin` and `/pkgs/os-specific/darwin`. I did not want to add over 30 people to the list, so please deal with this in a separate PR.