### PR TITLE
xh: 0.13.0 -> 0.14.0

### DIFF
--- a/pkgs/tools/networking/xh/default.nix
+++ b/pkgs/tools/networking/xh/default.nix
@@ -1,22 +1,33 @@
-{ stdenv, lib, openssl, pkg-config, rustPlatform, fetchFromGitHub, Security
-, libiconv, installShellFiles }:
+{ stdenv
+, lib
+, pkg-config
+, rustPlatform
+, fetchFromGitHub
+, installShellFiles
+, withNativeTls ? true
+, Security
+, libiconv
+, openssl }:
 
 rustPlatform.buildRustPackage rec {
   pname = "xh";
-  version = "0.13.0";
+  version = "0.14.0";
 
   src = fetchFromGitHub {
     owner = "ducaale";
     repo = "xh";
     rev = "v${version}";
-    sha256 = "sha256-fTd4VSUUj9Im+kCEuFgDsA7eofM1xQfrRzigr1vyJ3I=";
+    sha256 = "sha256-G6uAHpptX+hvh0ND+mqgR3AG0GT/qily6Y8Pt5yVbxg=";
   };
 
-  cargoSha256 = "sha256-yZdGw/6iVg8PaUyjTrxj6h/2yhBtqEqvMhdRHhMwDZc=";
+  cargoSha256 = "sha256-W2l1kiD2yY6FFA29WYPlWCjxKzuSgCdPN8M8bE4QGMU=";
+
+  buildFeatures = lib.optional withNativeTls "native-tls";
 
   nativeBuildInputs = [ installShellFiles pkg-config ];
 
-  buildInputs = if stdenv.isDarwin then [ Security libiconv ] else [ openssl ];
+  buildInputs = lib.optionals withNativeTls
+    (if stdenv.isDarwin then [ Security libiconv ] else [ openssl ]);
 
   # Get openssl-sys to use pkg-config
   OPENSSL_NO_VENDOR = 1;


### PR DESCRIPTION
###### Motivation for this change
<https://github.com/ducaale/xh/releases/tag/v0.14.0>

Added `withNativeTls` arg to enable building xh with native TLS support, which makes `xh --native-tls` usable. With or without native TLS support, xh uses rustls by default. More details in ducaale/xh#136. 

I built it both with and without native TLS on x86_64-linux, and the binary seems to work.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
