### PR TITLE
Add missing libretro cores

### DIFF
--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -512,6 +512,15 @@ in
     enableParallelBuilding = false;
   };
 
+  melonds = mkLibRetroCore {
+    core = "melonds";
+    version = "unstable-2021-11-22";
+    description = "Port of MelonDS to libretro";
+    license = lib.licenses.gpl3Only;
+    extraBuildInputs = [ libGL libGLU ];
+    makefile = "Makefile";
+  };
+
   mesen = mkLibRetroCore {
     core = "mesen";
     description = "Port of Mesen to libretro";

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -184,18 +184,6 @@ in
     description = "Port of Mednafen's Saturn core to libretro";
     license = lib.licenses.gpl2Only;
     makefile = "Makefile";
-    makeFlags = [ "HAVE_HW=0" ];
-    meta.platforms = [ "x86_64-linux" "aarch64-linux" ];
-  };
-
-  beetle-saturn-hw = mkLibRetroCore {
-    core = "mednafen-saturn-hw";
-    src = getCoreSrc "beetle-saturn";
-    description = "Port of Mednafen's Saturn core to libretro";
-    license = lib.licenses.gpl2Only;
-    extraBuildInputs = [ libGL libGLU ];
-    makefile = "Makefile";
-    makeFlags = [ "HAVE_OPENGL=1" "HAVE_HW=1" ];
     meta.platforms = [ "x86_64-linux" "aarch64-linux" ];
   };
 

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -230,6 +230,22 @@ in
     license = lib.licenses.gpl2Only;
   };
 
+  bsnes = mkLibRetroCore {
+    core = "bsnes";
+    version = "unstable-2021-11-22";
+    description = "Port of bsnes to libretro";
+    license = lib.licenses.gpl3Only;
+    makefile = "Makefile";
+    # https://github.com/libretro/bsnes-libretro/issues/10
+    patches = [
+      (fetchpatch {
+        name = "added-missing-GB_VERSION-define.patch";
+        url = "https://github.com/nE0sIghT/bsnes-libretro/commit/97fd8b486f9a9046277a580b238b6673a98f7f72.patch";
+        sha256 = "sha256-gCiy6sqc9sixT6Appr5ZCfHyBE2jYhPb0KvI63nfmEc=";
+      })
+    ];
+  };
+
   bsnes-mercury = mkLibRetroCore {
     core = "bsnes-mercury-accuracy";
     src = getCoreSrc "bsnes-mercury";

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -50,6 +50,7 @@ let
   mkLibRetroCore =
     { core
     , description
+      # Check https://github.com/libretro/libretro-super for license information
     , license
     , src ? null
     , broken ? false
@@ -114,14 +115,6 @@ in
     license = lib.licenses.gpl2Only;
     makefile = "Makefile";
     makeFlags = [ "GIT_VERSION=" ];
-  };
-
-  beetle-snes = mkLibRetroCore {
-    core = "mednafen-snes";
-    src = getCoreSrc "beetle-snes";
-    description = "Port of Mednafen's SNES core to libretro";
-    license = lib.licenses.gpl2Only;
-    makefile = "Makefile";
   };
 
   beetle-gba = mkLibRetroCore {
@@ -204,6 +197,14 @@ in
     meta.platforms = [ "x86_64-linux" "aarch64-linux" ];
   };
 
+  beetle-snes = mkLibRetroCore {
+    core = "mednafen-snes";
+    src = getCoreSrc "beetle-snes";
+    description = "Port of Mednafen's SNES core to libretro";
+    license = lib.licenses.gpl2Only;
+    makefile = "Makefile";
+  };
+
   beetle-supergrafx = mkLibRetroCore {
     core = "mednafen-supergrafx";
     src = getCoreSrc "beetle-supergrafx";
@@ -212,18 +213,18 @@ in
     makefile = "Makefile";
   };
 
-  beetle-wswan = mkLibRetroCore {
-    core = "mednafen-wswan";
-    src = getCoreSrc "beetle-wswan";
-    description = "Port of Mednafen's WonderSwan core to libretro";
-    license = lib.licenses.gpl2Only;
-    makefile = "Makefile";
-  };
-
   beetle-vb = mkLibRetroCore {
     core = "mednafen-vb";
     src = getCoreSrc "beetle-vb";
     description = "Port of Mednafen's VirtualBoy core to libretro";
+    license = lib.licenses.gpl2Only;
+    makefile = "Makefile";
+  };
+
+  beetle-wswan = mkLibRetroCore {
+    core = "mednafen-wswan";
+    src = getCoreSrc "beetle-wswan";
+    description = "Port of Mednafen's WonderSwan core to libretro";
     license = lib.licenses.gpl2Only;
     makefile = "Makefile";
   };
@@ -724,6 +725,20 @@ in
     makefile = "Makefile";
   };
 
+  swanstation = mkLibRetroCore {
+    core = "swanstation";
+    version = "unstable-2021-11-21";
+    description = "Port of SwanStation (a fork of DuckStation) to libretro";
+    license = lib.licenses.gpl3Only;
+    extraNativeBuildInputs = [ cmake ];
+    makefile = "Makefile";
+    cmakeFlags = [
+      "-DCMAKE_BUILD_TYPE=Release"
+      "-DBUILD_LIBRETRO_CORE=ON"
+    ];
+    postPatch = "mkdir -p src/duckstation-libretro";
+  };
+
   tgbdual = mkLibRetroCore {
     core = "tgbdual";
     description = "Port of TGBDual to libretro";
@@ -757,12 +772,6 @@ in
     postBuild = "cd lib";
   };
 
-  vba-next = mkLibRetroCore {
-    core = "vba-next";
-    description = "VBA-M libretro port with modifications for speed";
-    license = lib.licenses.gpl2Only;
-  };
-
   vba-m = mkLibRetroCore {
     core = "vbam";
     src = getCoreSrc "vba-m";
@@ -770,6 +779,12 @@ in
     license = lib.licenses.gpl2Only;
     makefile = "Makefile";
     preBuild = "cd src/libretro";
+  };
+
+  vba-next = mkLibRetroCore {
+    core = "vba-next";
+    description = "VBA-M libretro port with modifications for speed";
+    license = lib.licenses.gpl2Only;
   };
 
   vecx = mkLibRetroCore {

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -224,6 +224,12 @@ in
     makefile = "Makefile";
   };
 
+  blastem = mkLibRetroCore {
+    core = "blastem";
+    description = "Port of BlastEm to libretro";
+    license = lib.licenses.gpl3Only;
+  };
+
   bluemsx = mkLibRetroCore {
     core = "bluemsx";
     description = "Port of BlueMSX to libretro";

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -109,6 +109,8 @@ let
     );
 in
 {
+  inherit mkLibRetroCore;
+
   atari800 = mkLibRetroCore {
     core = "atari800";
     description = "Port of Atari800 to libretro";

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -50,7 +50,7 @@ let
   mkLibRetroCore =
     { core
     , description
-      # Check https://github.com/libretro/libretro-super for license information
+      # Check https://github.com/libretro/libretro-core-info for license information
     , license
     , src ? null
     , broken ? false

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -246,6 +246,29 @@ in
     ];
   };
 
+  bsnes-hd =
+    let
+      # linux = bsd
+      # https://github.com/DerKoun/bsnes-hd/blob/f0b6cf34e9780d53516977ed2de64137a8bcc3c5/bsnes/GNUmakefile#L37
+      platform = if stdenv.isDarwin then "macos" else "linux";
+    in
+    mkLibRetroCore {
+      core = "bsnes-hd-beta";
+      src = getCoreSrc "bsnes-hd";
+      version = "unstable-2021-11-22";
+      description = "Port of bsnes-hd to libretro";
+      license = lib.licenses.gpl3Only;
+      makefile = "GNUmakefile";
+      makeFlags = [
+        "-C"
+        "bsnes"
+        "target=libretro"
+        "platform=${platform}"
+      ];
+      extraBuildInputs = [ xorg.libX11 xorg.libXext ];
+      postBuild = "cd bsnes/out";
+    };
+
   bsnes-mercury = mkLibRetroCore {
     core = "bsnes-mercury-accuracy";
     src = getCoreSrc "bsnes-mercury";

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -54,7 +54,7 @@ let
     , license
     , src ? null
     , broken ? false
-    , version ? "unstable-2021-11-16"
+    , version ? "unstable-2021-11-22"
     , ...
     }@args:
     lib.makeOverridable stdenv.mkDerivation (
@@ -232,7 +232,6 @@ in
 
   bsnes = mkLibRetroCore {
     core = "bsnes";
-    version = "unstable-2021-11-22";
     description = "Port of bsnes to libretro";
     license = lib.licenses.gpl3Only;
     makefile = "Makefile";
@@ -255,7 +254,6 @@ in
     mkLibRetroCore {
       core = "bsnes-hd-beta";
       src = getCoreSrc "bsnes-hd";
-      version = "unstable-2021-11-22";
       description = "Port of bsnes-hd to libretro";
       license = lib.licenses.gpl3Only;
       makefile = "GNUmakefile";
@@ -558,7 +556,6 @@ in
 
   melonds = mkLibRetroCore {
     core = "melonds";
-    version = "unstable-2021-11-22";
     description = "Port of MelonDS to libretro";
     license = lib.licenses.gpl3Only;
     extraBuildInputs = [ libGL libGLU ];
@@ -567,7 +564,6 @@ in
 
   mesen = mkLibRetroCore {
     core = "mesen";
-    version = "unstable-2021-11-22";
     description = "Port of Mesen to libretro";
     license = lib.licenses.gpl3Only;
     makefile = "Makefile";
@@ -577,7 +573,6 @@ in
   mesen-s = mkLibRetroCore {
     core = "mesens";
     src = getCoreSrc "mesen-s";
-    version = "unstable-2021-11-22";
     description = "Port of Mesen-S to libretro";
     license = lib.licenses.gpl3Only;
     makefile = "Makefile";
@@ -804,7 +799,6 @@ in
 
   swanstation = mkLibRetroCore {
     core = "swanstation";
-    version = "unstable-2021-11-21";
     description = "Port of SwanStation (a fork of DuckStation) to libretro";
     license = lib.licenses.gpl3Only;
     extraNativeBuildInputs = [ cmake ];

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -83,13 +83,18 @@ let
           }.${stdenv.hostPlatform.parsed.cpu.name} or stdenv.hostPlatform.parsed.cpu.name}"
         ] ++ (args.makeFlags or [ ]);
 
+        coreDir = "${placeholder "out"}/lib/retroarch/cores";
+
         installPhase = ''
-          COREDIR="$out/lib/retroarch/cores"
+          runHook preInstall
+
           mkdir -p $out/bin
-          mkdir -p $COREDIR
-          mv ${d2u args.core}_libretro${stdenv.hostPlatform.extensions.sharedLibrary} $COREDIR
+          mkdir -p $coreDir
+          mv ${d2u args.core}_libretro${stdenv.hostPlatform.extensions.sharedLibrary} $coreDir
           makeWrapper ${retroarch}/bin/retroarch $out/bin/retroarch-${core} \
-            --add-flags "-L $COREDIR/${d2u core}_libretro${stdenv.hostPlatform.extensions.sharedLibrary} $@"
+            --add-flags "-L $coreDir/${d2u core}_libretro${stdenv.hostPlatform.extensions.sharedLibrary} $@"
+
+          runHook postInstall
         '';
 
         enableParallelBuilding = true;
@@ -528,6 +533,21 @@ in
     license = lib.licenses.gpl3Only;
     makefile = "Makefile";
     preBuild = "cd Libretro";
+  };
+
+  mesen-s = mkLibRetroCore {
+    core = "mesens";
+    src = getCoreSrc "mesen-s";
+    version = "unstable-2021-11-22";
+    description = "Port of Mesen-S to libretro";
+    license = lib.licenses.gpl3Only;
+    makefile = "Makefile";
+    preBuild = "cd Libretro";
+    postInstall = ''
+      # fix library name to match libretro-core-info
+      mv $coreDir/mesens_libretro${stdenv.hostPlatform.extensions.sharedLibrary} \
+        $coreDir/mesen-s_libretro${stdenv.hostPlatform.extensions.sharedLibrary}
+    '';
   };
 
   meteor = mkLibRetroCore {

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -246,6 +246,24 @@ in
     makeFlags = [ "PROFILE=accuracy" ];
   };
 
+  bsnes-mercury-balanced = mkLibRetroCore {
+    core = "bsnes-mercury-balanced";
+    src = getCoreSrc "bsnes-mercury";
+    description = "Fork of bsnes with HLE DSP emulation restored";
+    license = lib.licenses.gpl3Only;
+    makefile = "Makefile";
+    makeFlags = [ "PROFILE=balanced" ];
+  };
+
+  bsnes-mercury-performance = mkLibRetroCore {
+    core = "bsnes-mercury-performance";
+    src = getCoreSrc "bsnes-mercury";
+    description = "Fork of bsnes with HLE DSP emulation restored";
+    license = lib.licenses.gpl3Only;
+    makefile = "Makefile";
+    makeFlags = [ "PROFILE=performance" ];
+  };
+
   citra = mkLibRetroCore {
     core = "citra";
     # `nix-prefetch-github` doesn't support `deepClone`, necessary for citra

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -523,6 +523,7 @@ in
 
   mesen = mkLibRetroCore {
     core = "mesen";
+    version = "unstable-2021-11-22";
     description = "Port of Mesen to libretro";
     license = lib.licenses.gpl3Only;
     makefile = "Makefile";

--- a/pkgs/misc/emulators/retroarch/default.nix
+++ b/pkgs/misc/emulators/retroarch/default.nix
@@ -36,16 +36,18 @@
 with lib;
 
 let
+  mainVersion = "1.9.13";
+  revision = "2";
   libretroSuperSrc = fetchFromGitHub {
     owner = "libretro";
-    repo = "libretro-super";
-    sha256 = "sha256-4WB6/1DDec+smhMJKLCxWb4+LQlZN8v2ik69saKixkE=";
-    rev = "fa70d9843838df719623094965bd447e4db0d1b4";
+    repo = "libretro-core-info";
+    sha256 = "sha256-jM+iXNSCpJy4wOk1S72G1UjNGBzejyhs5LFFWCFjs2c=";
+    rev = "v${mainVersion}";
   };
 in
 stdenv.mkDerivation rec {
   pname = "retroarch-bare";
-  version = "1.9.13.2";
+  version = "${lib.concatStringsSep "." [ mainVersion revision ]}";
 
   src = fetchFromGitHub {
     owner = "libretro";
@@ -98,7 +100,7 @@ stdenv.mkDerivation rec {
   postInstall = optionalString withVulkan ''
     mkdir -p $out/share/libretro/info
     # TODO: ideally each core should have its own core information
-    cp -r ${libretroSuperSrc}/dist/info/* $out/share/libretro/info
+    cp -r ${libretroSuperSrc}/* $out/share/libretro/info
     wrapProgram $out/bin/retroarch --prefix LD_LIBRARY_PATH ':' ${vulkan-loader}/lib
   '';
 

--- a/pkgs/misc/emulators/retroarch/hashes.json
+++ b/pkgs/misc/emulators/retroarch/hashes.json
@@ -6,13 +6,6 @@
         "sha256": "LJpRegJVR2+sS1UmTTpVest0rMrNDBMXmj/jRFVglWI=",
         "fetchSubmodules": false
     },
-    "beetle-snes": {
-        "owner": "libretro",
-        "repo": "beetle-bsnes-libretro",
-        "rev": "bc867656d7438aaffc6818b3b92350587bc78a47",
-        "sha256": "TyUCRGK+uyXowDjXW9/4m+zL8Vh/3GGsX1eznrTCbAg=",
-        "fetchSubmodules": false
-    },
     "beetle-gba": {
         "owner": "libretro",
         "repo": "beetle-gba-libretro",
@@ -62,6 +55,13 @@
         "sha256": "lKlNNAHK1ynFXY++Ya0m1Ax5YTZkd44eQjzuOLXfWa8=",
         "fetchSubmodules": false
     },
+    "beetle-snes": {
+        "owner": "libretro",
+        "repo": "beetle-bsnes-libretro",
+        "rev": "bc867656d7438aaffc6818b3b92350587bc78a47",
+        "sha256": "TyUCRGK+uyXowDjXW9/4m+zL8Vh/3GGsX1eznrTCbAg=",
+        "fetchSubmodules": false
+    },
     "beetle-supergrafx": {
         "owner": "libretro",
         "repo": "beetle-supergrafx-libretro",
@@ -69,18 +69,18 @@
         "sha256": "kGyl5XJMFUALPAEZf4IynY6bmXWfqy0o65eO8zS0RTE=",
         "fetchSubmodules": false
     },
-    "beetle-wswan": {
-        "owner": "libretro",
-        "repo": "beetle-wswan-libretro",
-        "rev": "0c7faaf7f70b72ebb68e310530cd46a69e680d40",
-        "sha256": "UQyICcZe1DVotSFt0QVnGop+JG5NJwTBcGSZaFW0P0U=",
-        "fetchSubmodules": false
-    },
     "beetle-vb": {
         "owner": "libretro",
         "repo": "beetle-vb-libretro",
         "rev": "1bd0da71c8f6add253ad76e2b6e1357cd09fc304",
         "sha256": "KguKbRK0uXE+brpF8HdRwi8Gt76AMa4wkh1MFvNCbN4=",
+        "fetchSubmodules": false
+    },
+    "beetle-wswan": {
+        "owner": "libretro",
+        "repo": "beetle-wswan-libretro",
+        "rev": "0c7faaf7f70b72ebb68e310530cd46a69e680d40",
+        "sha256": "UQyICcZe1DVotSFt0QVnGop+JG5NJwTBcGSZaFW0P0U=",
         "fetchSubmodules": false
     },
     "bluemsx": {
@@ -454,6 +454,13 @@
         "sha256": "s7LQ47sAPTyk4COONk4qnebxCq78zGLIjh3Y2+1fIak=",
         "fetchSubmodules": false
     },
+    "swanstation": {
+        "owner": "libretro",
+        "repo": "swanstation",
+        "rev": "cc3946b2b3bd10282bc46078c245db09f6e68836",
+        "sha256": "UzdmjUS6+6z4K6VJtMPxOwGXsCtxoh08RWTNHlvy/h8=",
+        "fetchSubmodules": false
+    },
     "tgbdual": {
         "owner": "libretro",
         "repo": "tgbdual-libretro",
@@ -475,18 +482,18 @@
         "sha256": "SXJvWX6Q3BrdajNnT4HIf6H2z7dXXvnXTJXf/TYRw4I=",
         "fetchSubmodules": true
     },
-    "vba-next": {
-        "owner": "libretro",
-        "repo": "vba-next",
-        "rev": "b218f48bb27b5d3885fa4076ff325922b5acd817",
-        "sha256": "idqGMbMA9mZlIh0QAba3BxpPDi/bFJJkUbnxV3xMOCo=",
-        "fetchSubmodules": false
-    },
     "vba-m": {
         "owner": "libretro",
         "repo": "vbam-libretro",
         "rev": "254f6effebe882b7d3d29d9e417c6aeeabc08026",
         "sha256": "vJWjdqJ913NLGL4G15sRPqO/wp9xPsuhUMLUuAbDRKk=",
+        "fetchSubmodules": false
+    },
+    "vba-next": {
+        "owner": "libretro",
+        "repo": "vba-next",
+        "rev": "b218f48bb27b5d3885fa4076ff325922b5acd817",
+        "sha256": "idqGMbMA9mZlIh0QAba3BxpPDi/bFJJkUbnxV3xMOCo=",
         "fetchSubmodules": false
     },
     "vecx": {

--- a/pkgs/misc/emulators/retroarch/hashes.json
+++ b/pkgs/misc/emulators/retroarch/hashes.json
@@ -280,10 +280,10 @@
         "fetchSubmodules": false
     },
     "mesen": {
-        "owner": "SourMesen",
+        "owner": "libretro",
         "repo": "mesen",
-        "rev": "86326e832974d984846ae078e568c023a5f76f1f",
-        "sha256": "At5rhlJ6rAnXaQrmRA1NtCCi+Ff/ytlt5dwsaXZhxXg=",
+        "rev": "094d82bf724448426acbaad45e83bc38994e32f6",
+        "sha256": "9+AqZRv8lugNNa+ZZzIPJNO87J1aBUEiOggL8aYno1M=",
         "fetchSubmodules": false
     },
     "meteor": {

--- a/pkgs/misc/emulators/retroarch/hashes.json
+++ b/pkgs/misc/emulators/retroarch/hashes.json
@@ -286,6 +286,13 @@
         "sha256": "9+AqZRv8lugNNa+ZZzIPJNO87J1aBUEiOggL8aYno1M=",
         "fetchSubmodules": false
     },
+    "mesen-s": {
+        "owner": "libretro",
+        "repo": "mesen-s",
+        "rev": "42eb0e8ad346608dae86feb8a04833d16ad21541",
+        "sha256": "q6zeoNiZtFy8ZYls9/E+O7o9BYTcVcmYjbJA48qiraU=",
+        "fetchSubmodules": false
+    },
     "meteor": {
         "owner": "libretro",
         "repo": "meteor-libretro",

--- a/pkgs/misc/emulators/retroarch/hashes.json
+++ b/pkgs/misc/emulators/retroarch/hashes.json
@@ -90,6 +90,13 @@
         "sha256": "ix/AyYNer1R73ZJW1reXyj7geBr3ThrqXf5Ki5yrz9A=",
         "fetchSubmodules": false
     },
+    "bsnes": {
+        "owner": "libretro",
+        "repo": "bsnes-libretro",
+        "rev": "44d97b17d06a10ae17d97a91a48e5acd10ec6db4",
+        "sha256": "VNSeTRryrX2/V38GGXTRLuDEQqDUmX2DUOHAKLxJezU=",
+        "fetchSubmodules": false
+    },
     "bsnes-mercury": {
         "owner": "libretro",
         "repo": "bsnes-mercury",

--- a/pkgs/misc/emulators/retroarch/hashes.json
+++ b/pkgs/misc/emulators/retroarch/hashes.json
@@ -97,6 +97,13 @@
         "sha256": "VNSeTRryrX2/V38GGXTRLuDEQqDUmX2DUOHAKLxJezU=",
         "fetchSubmodules": false
     },
+    "bsnes-hd": {
+        "owner": "DerKoun",
+        "repo": "bsnes-hd",
+        "rev": "65f24e56c37f46bb752190024bd4058e64ad77d1",
+        "sha256": "1dk2i71NOLeTTOZjVll8wrkr5dIH5bGSGUeeHqWjZHE=",
+        "fetchSubmodules": false
+    },
     "bsnes-mercury": {
         "owner": "libretro",
         "repo": "bsnes-mercury",

--- a/pkgs/misc/emulators/retroarch/hashes.json
+++ b/pkgs/misc/emulators/retroarch/hashes.json
@@ -272,6 +272,13 @@
         "sha256": "GQ4Sdg/1nZRT4Z1Aqq1zPo96duqIGyt6sjghf9ap2Jg=",
         "fetchSubmodules": false
     },
+    "melonds": {
+        "owner": "libretro",
+        "repo": "melonds",
+        "rev": "1ad65728476d7b9594c4ff91a1ba60460a0a30e7",
+        "sha256": "EBV8F2MCmWuxWKMOXipTZKRGHqp8sb/ojK3JpGZe818=",
+        "fetchSubmodules": false
+    },
     "mesen": {
         "owner": "SourMesen",
         "repo": "mesen",

--- a/pkgs/misc/emulators/retroarch/hashes.json
+++ b/pkgs/misc/emulators/retroarch/hashes.json
@@ -83,6 +83,13 @@
         "sha256": "XHTzXlTt8op0bDLNn833Unt57zclXowlLhG3qvWwjXQ=",
         "fetchSubmodules": false
     },
+    "blastem": {
+        "owner": "libretro",
+        "repo": "blastem",
+        "rev": "0786858437ed71996f43b7af0fbe627eb88152fc",
+        "sha256": "uEP5hSgLAle1cLv/EM7D11TJMAggu7pqWxfrUt3rhEg=",
+        "fetchSubmodules": false
+    },
     "bluemsx": {
         "owner": "libretro",
         "repo": "bluemsx-libretro",

--- a/pkgs/misc/emulators/retroarch/hashes.json
+++ b/pkgs/misc/emulators/retroarch/hashes.json
@@ -23,36 +23,36 @@
     "beetle-ngp": {
         "owner": "libretro",
         "repo": "beetle-ngp-libretro",
-        "rev": "f969af2b52f20642aea7e800e3cfcce728f3aee9",
-        "sha256": "GIzLZ3iOJeHKdAowhM4S56iouaxX8v2XZgc/ZiCzCPk=",
+        "rev": "f7c393184e5228c3d3807ee74c951c4c549107d8",
+        "sha256": "7vki8VkwOzxwMZcUxekg1DFSskV7VNQ1SRaU3M1xHZ0=",
         "fetchSubmodules": false
     },
     "beetle-pce-fast": {
         "owner": "libretro",
         "repo": "beetle-pce-fast-libretro",
-        "rev": "81d4c9d07a76c89c32ad0e7450b69bde6403836f",
-        "sha256": "LhQbAEUMhoIF3VfwLbhtD7xxSddzdgwIHHnSabQPAvs=",
+        "rev": "a7608100d1cdd8eb65aea82fede7da61dcc3c5f1",
+        "sha256": "3v/TGz4y52IodXRmt/peZlabNS+quQVN9t5xucC2plg=",
         "fetchSubmodules": false
     },
     "beetle-pcfx": {
         "owner": "libretro",
         "repo": "beetle-pcfx-libretro",
-        "rev": "a1f1734509dd6acb11269f118d61f480ae8dbacf",
-        "sha256": "rvRDuYJLxb1TSwNXhp3ATJW0sQgWi8Cj4NR3hep/AJk=",
+        "rev": "19f2b7ce529e70655db04d3dd4faf32b4de14df2",
+        "sha256": "K3ZjOd8IGtwlwxExNAmHsOC0N0fz06w/3uua7sAm8Jc=",
         "fetchSubmodules": false
     },
     "beetle-psx": {
         "owner": "libretro",
         "repo": "beetle-psx-libretro",
-        "rev": "ccca81930a078c0efd77b00327d2ee212698f3b4",
-        "sha256": "Hy8Zrp0kTR+Mfbq0nVYerSarRCxZI+ykgDOscakDMiU=",
+        "rev": "bc1b6af8d7b8dd0b4133040fef82725520bbd560",
+        "sha256": "QgBB05o7941LsNKl2EIKy185xgcAf1vrAZgQiray/x0=",
         "fetchSubmodules": false
     },
     "beetle-saturn": {
         "owner": "libretro",
         "repo": "beetle-saturn-libretro",
-        "rev": "e1119e91a4e3f4b30971455aeb3c1a6f4cd05e59",
-        "sha256": "lKlNNAHK1ynFXY++Ya0m1Ax5YTZkd44eQjzuOLXfWa8=",
+        "rev": "f97fda5447d883220ce2f53a15f2cbe4790a8392",
+        "sha256": "r4kvrTIw1sOf5nEuPq2xF/QXw+0COQYWyERJ7HX1sFU=",
         "fetchSubmodules": false
     },
     "beetle-snes": {
@@ -65,22 +65,22 @@
     "beetle-supergrafx": {
         "owner": "libretro",
         "repo": "beetle-supergrafx-libretro",
-        "rev": "59062662d6e925ad512fcbb9c1a0db97d1592bc1",
-        "sha256": "kGyl5XJMFUALPAEZf4IynY6bmXWfqy0o65eO8zS0RTE=",
+        "rev": "083d102389a1ffaeddfa525a186adde0f35e42fc",
+        "sha256": "4hTOYPnOWdhb7CfWKZFO53NBFGa3lg0745ncBU6ejiQ=",
         "fetchSubmodules": false
     },
     "beetle-vb": {
         "owner": "libretro",
         "repo": "beetle-vb-libretro",
-        "rev": "1bd0da71c8f6add253ad76e2b6e1357cd09fc304",
-        "sha256": "KguKbRK0uXE+brpF8HdRwi8Gt76AMa4wkh1MFvNCbN4=",
+        "rev": "aa77198c6c60b935503b5ea2149b8ff7598344da",
+        "sha256": "ShsMYc2vjDoiN1yCCoSl91P5ecYJDj/V+VWUYuYVxas=",
         "fetchSubmodules": false
     },
     "beetle-wswan": {
         "owner": "libretro",
         "repo": "beetle-wswan-libretro",
-        "rev": "0c7faaf7f70b72ebb68e310530cd46a69e680d40",
-        "sha256": "UQyICcZe1DVotSFt0QVnGop+JG5NJwTBcGSZaFW0P0U=",
+        "rev": "3fcb582755a509ae33fc52cd0ca4b3edffc734ef",
+        "sha256": "XHTzXlTt8op0bDLNn833Unt57zclXowlLhG3qvWwjXQ=",
         "fetchSubmodules": false
     },
     "bluemsx": {
@@ -135,8 +135,8 @@
     "dolphin": {
         "owner": "libretro",
         "repo": "dolphin",
-        "rev": "82e617439b622af5d1189e9fec67e7f1376be099",
-        "sha256": "Q3a+0SYocX1hBGLs1K9r932NkiCDFINPhtHeyzUknJE=",
+        "rev": "d5193c4391addbd257b2aafe943a138ba89e20fb",
+        "sha256": "uRhYMO+fmAfwEr/KTKAhx//dKq44YdvhXxp7v+Gol0w=",
         "fetchSubmodules": false
     },
     "dosbox": {
@@ -163,29 +163,29 @@
     "fbneo": {
         "owner": "libretro",
         "repo": "fbneo",
-        "rev": "4d6387b7f3e3f1a9c25015789d751c6db1a9ae8c",
-        "sha256": "bIOmvhu9mOfOXoOTbwbjMHIZ3JkGz96yyFZALmqkOmk=",
+        "rev": "2447dd5385cb193801dc46be7b50a807d13162aa",
+        "sha256": "x70kPEC9LVm9ZyH5sviI8iW9dCkIi+lx2ns03OId2Oc=",
         "fetchSubmodules": false
     },
     "fceumm": {
         "owner": "libretro",
         "repo": "libretro-fceumm",
-        "rev": "a918869c18c9f30b84e04260b78b675b8a3c7be1",
-        "sha256": "nDYPrwIsvhWveDQDE0WEK7GO60iRE967p1XxXn+lNj4=",
+        "rev": "8864f6e246e4ba511b95a48713456b0dd3b3045b",
+        "sha256": "GrkD54ElseEYczPSb9WGTvI8SaNy/fWV4zve7sG9TTY=",
         "fetchSubmodules": false
     },
     "flycast": {
         "owner": "libretro",
         "repo": "flycast",
-        "rev": "ae670ea28fdbb9f08149cb598312a71a0970ca67",
-        "sha256": "jmSOfyak5mX04HgZOtCF9cz8HqAApxDXHJ6IqhqGILE=",
+        "rev": "254b66a017a087f0833777760b879abfe7f9d5cd",
+        "sha256": "pkgVjZCGlgq95Cv+xWLl3sjq+jIpgnfuVaXGDYtuGAY=",
         "fetchSubmodules": false
     },
     "fmsx": {
         "owner": "libretro",
         "repo": "fmsx-libretro",
-        "rev": "20c805409b8f6e1f9d61cb3dff0d5b28d82d1ee3",
-        "sha256": "uqqVF2+YpfWOKbe8aIreoImFb3/kL8ohslJkl+JivQI=",
+        "rev": "7b0c70c25fcc7f4bb876e729eacfcc01f494df60",
+        "sha256": "H3ttVMw3cUxXJ64olbTSO6K7YBpmdgKnaLEpTS9QQEg=",
         "fetchSubmodules": false
     },
     "freeintv": {
@@ -198,22 +198,22 @@
     "gambatte": {
         "owner": "libretro",
         "repo": "gambatte-libretro",
-        "rev": "4b822bcf561856689e101dd5505d365de5ffcffe",
-        "sha256": "FsIQLd/UO5xs/aTpggSn8WLPgi83gsxRlwKR+UzH+TY=",
+        "rev": "c842d49b1daab6e45f3a1802ee7516b100827599",
+        "sha256": "DUj4vEh3x7MaE8bHDwOoDY7K2yEkTGz8Cf3fx4sgCvY=",
         "fetchSubmodules": false
     },
     "genesis-plus-gx": {
         "owner": "libretro",
         "repo": "Genesis-Plus-GX",
-        "rev": "309a4aacfd582c312dcad61b7abfdffba4a0c66e",
-        "sha256": "jnbey1USldDZGXGXLLR5TgSJZgD+6ZFpwfIf6c8xvyM=",
+        "rev": "c1c605e862c4a277e880b510c68ebde630487948",
+        "sha256": "wDEwG+VMs0hXjL1pBn+wmvtaaN4nax+Dm6Ocy7HCLbQ=",
         "fetchSubmodules": false
     },
     "gpsp": {
         "owner": "libretro",
         "repo": "gpsp",
-        "rev": "a2aa78733d8daf1d550c9dc76c6ff94e8670b31c",
-        "sha256": "nKim7YkksUyZO97SvrW1TEYQlA+7Yi7xbLtyDPV4LWc=",
+        "rev": "bc0a3cf2c182b7f60c80464309a791377bef5af3",
+        "sha256": "27eOnAp6pzZAK5o1of5+2Fx/hHtUsjbBQlefdsCv0rk=",
         "fetchSubmodules": false
     },
     "gw": {
@@ -254,15 +254,15 @@
     "mame2003": {
         "owner": "libretro",
         "repo": "mame2003-libretro",
-        "rev": "d0ed1a565803cfada9f4088326eae616f6e5f8a3",
-        "sha256": "JGEy6Mp5qcZwaehzbj+qpdBfxHzqi6qIR7akxIj/WK8=",
+        "rev": "e6595b3fa677158a7d834391517ae68e3c5f8f41",
+        "sha256": "qxynDUQWtUKxJ7H7q9nGFhIjr1Pkrgtp8aJdTtG5/xU=",
         "fetchSubmodules": false
     },
     "mame2003-plus": {
         "owner": "libretro",
         "repo": "mame2003-plus-libretro",
-        "rev": "841e44dff953a346127f15be53cb34778e20ce1c",
-        "sha256": "aCXyeDcz0uSObe4S2bQWCxIAF5aA3kne5v0HT+oXHuw=",
+        "rev": "680f4679c7a15fcec007eff8ba9578567b821daa",
+        "sha256": "nxpmPE79C3hgeFLlwS4fHYteSmC4xuis1UySlqhqvzk=",
         "fetchSubmodules": false
     },
     "mame2010": {
@@ -359,8 +359,8 @@
     "opera": {
         "owner": "libretro",
         "repo": "opera-libretro",
-        "rev": "d8aa7cecf96298bd7ee51718086f7b1bc8c57e2a",
-        "sha256": "1t+zwCVmqiPFFNCNq9XzVfRGbEA1q8v4jzhOb+wV/nA=",
+        "rev": "aa868e656b518567a95b11b2f14c5db8001b11a0",
+        "sha256": "YUzfHtgKCzgxZwslFxwmAN0hg+MIGLAYBAI7RUCIW40=",
         "fetchSubmodules": false
     },
     "parallel-n64": {
@@ -380,22 +380,22 @@
     "picodrive": {
         "owner": "libretro",
         "repo": "picodrive",
-        "rev": "9cb99ce36f93871b05c5adc2790b2e33e63b50b6",
-        "sha256": "hhdEuri1hSNLAkno8Rwd0Yls11Yh6Q7/+t4T2LH+BaE=",
+        "rev": "3edf1a00f64e0f22331233bb1638170115b2ac2e",
+        "sha256": "4IWYOJ2wTDkdO4FxsAWCV724VNViHIb42nYc+j4pekU=",
         "fetchSubmodules": true
     },
     "play": {
         "owner": "jpd002",
         "repo": "Play-",
-        "rev": "b8e16159734c2068db0f2f12b11bc16ef55058ce",
-        "sha256": "qjp1rEjmDAAB2wXITA3lAS+ERJuZinoneJToYiYRi/w=",
+        "rev": "6b9cc418004c01a195c78387752cc99245ba54d5",
+        "sha256": "sha256-7nU5fQ8pQLmKy9Swmshkv2oj+HV0oTcqQ93LfNSq1us=",
         "fetchSubmodules": true
     },
     "ppsspp": {
         "owner": "hrydgard",
         "repo": "ppsspp",
-        "rev": "b6e7fe1aaf2bbb8f4faa1378bf14f434aea33cc1",
-        "sha256": "Kif6oF8Bjhgc02xKDivCG9RBxj5wxNFEwxl9nX3AZug=",
+        "rev": "712b87ae57d4e69ad5ba98d331912dead31b9c01",
+        "sha256": "sygZYAOkFrrfpaF6nfKMBecJTNeXk48oqlCRncPb340=",
         "fetchSubmodules": true
     },
     "prboom": {
@@ -422,8 +422,8 @@
     "sameboy": {
         "owner": "libretro",
         "repo": "sameboy",
-        "rev": "68f67b3db7747ba7aac84c5c253bc71d5a906525",
-        "sha256": "/4JQ1Tem3UgOUIcsLV0aLU+1R55hMTaT+wWElwj00Q4=",
+        "rev": "fb3c7dd7d89df1f696e4cde33a868e141c927790",
+        "sha256": "KFVNl43AJ11thHFFSJ6BO7wxfxhVdDVF+BAm1+GIzIs=",
         "fetchSubmodules": false
     },
     "scummvm": {
@@ -443,8 +443,8 @@
     "snes9x": {
         "owner": "snes9xgit",
         "repo": "snes9x",
-        "rev": "edc32fc0bd6aea6d5645a03f0f94b72f3cbfa43e",
-        "sha256": "Zeojdoykmk+lpG1z5EdZToGWYDQvSSQqaEr7F68iyk0=",
+        "rev": "cf1a5901fccafdaead225b0a5e55ff74fdcf9678",
+        "sha256": "p6qTCZnZSV5vgpZglI/HMi/wOfu0hG2TuvOQhQHeo2s=",
         "fetchSubmodules": false
     },
     "snes9x2002": {
@@ -471,8 +471,8 @@
     "stella": {
         "owner": "stella-emu",
         "repo": "stella",
-        "rev": "e1035b74fce26932078d00e8625688927efce34c",
-        "sha256": "+ZvSCnnoKGyToSFqUQOArolFdgUcBBFNjFw8aoVDkYI=",
+        "rev": "f619b4e5cb01eefe0c01dedc01b452b3f74aab26",
+        "sha256": "Oe++mDo1InvlvbRLlxcSjNQpioj4+ytt6ihTcvrD8g4=",
         "fetchSubmodules": false
     },
     "stella2014": {

--- a/pkgs/misc/emulators/retroarch/update.py
+++ b/pkgs/misc/emulators/retroarch/update.py
@@ -23,6 +23,7 @@ CORES = {
     "beetle-vb": {"repo": "beetle-vb-libretro"},
     "beetle-wswan": {"repo": "beetle-wswan-libretro"},
     "bluemsx": {"repo": "bluemsx-libretro"},
+    "bsnes": {"repo": "bsnes-libretro"},
     "bsnes-mercury": {"repo": "bsnes-mercury"},
     "citra": {"repo": "citra", "fetch_submodules": True},
     "desmume": {"repo": "desmume"},

--- a/pkgs/misc/emulators/retroarch/update.py
+++ b/pkgs/misc/emulators/retroarch/update.py
@@ -75,6 +75,7 @@ CORES = {
     "snes9x2010": {"repo": "snes9x2010"},
     "stella": {"repo": "stella", "owner": "stella-emu"},
     "stella2014": {"repo": "stella2014-libretro"},
+    "swanstation": {"repo": "swanstation"},
     "tgbdual": {"repo": "tgbdual-libretro"},
     "thepowdertoy": {"repo": "ThePowderToy"},
     "tic80": {"repo": "tic-80", "fetch_submodules": True},

--- a/pkgs/misc/emulators/retroarch/update.py
+++ b/pkgs/misc/emulators/retroarch/update.py
@@ -24,6 +24,7 @@ CORES = {
     "beetle-wswan": {"repo": "beetle-wswan-libretro"},
     "bluemsx": {"repo": "bluemsx-libretro"},
     "bsnes": {"repo": "bsnes-libretro"},
+    "bsnes-hd": {"repo": "bsnes-hd", "owner": "DerKoun"},
     "bsnes-mercury": {"repo": "bsnes-mercury"},
     "citra": {"repo": "citra", "fetch_submodules": True},
     "desmume": {"repo": "desmume"},

--- a/pkgs/misc/emulators/retroarch/update.py
+++ b/pkgs/misc/emulators/retroarch/update.py
@@ -11,7 +11,6 @@ SCRIPT_PATH = Path(__file__).absolute().parent
 HASHES_PATH = SCRIPT_PATH / "hashes.json"
 CORES = {
     "atari800": {"repo": "libretro-atari800"},
-    "beetle-snes": {"repo": "beetle-bsnes-libretro"},
     "beetle-gba": {"repo": "beetle-gba-libretro"},
     "beetle-lynx": {"repo": "beetle-lynx-libretro"},
     "beetle-ngp": {"repo": "beetle-ngp-libretro"},
@@ -19,9 +18,10 @@ CORES = {
     "beetle-pcfx": {"repo": "beetle-pcfx-libretro"},
     "beetle-psx": {"repo": "beetle-psx-libretro"},
     "beetle-saturn": {"repo": "beetle-saturn-libretro"},
+    "beetle-snes": {"repo": "beetle-bsnes-libretro"},
     "beetle-supergrafx": {"repo": "beetle-supergrafx-libretro"},
-    "beetle-wswan": {"repo": "beetle-wswan-libretro"},
     "beetle-vb": {"repo": "beetle-vb-libretro"},
+    "beetle-wswan": {"repo": "beetle-wswan-libretro"},
     "bluemsx": {"repo": "bluemsx-libretro"},
     "bsnes-mercury": {"repo": "bsnes-mercury"},
     "citra": {"repo": "citra", "fetch_submodules": True},
@@ -78,8 +78,8 @@ CORES = {
     "tgbdual": {"repo": "tgbdual-libretro"},
     "thepowdertoy": {"repo": "ThePowderToy"},
     "tic80": {"repo": "tic-80", "fetch_submodules": True},
-    "vba-next": {"repo": "vba-next"},
     "vba-m": {"repo": "vbam-libretro"},
+    "vba-next": {"repo": "vba-next"},
     "vecx": {"repo": "libretro-vecx"},
     "virtualjaguar": {"repo": "virtualjaguar-libretro"},
     "yabause": {"repo": "yabause"},
@@ -112,21 +112,33 @@ def get_repo_hash(fetcher="fetchFromGitHub", **kwargs):
         raise ValueError(f"Unsupported fetcher: {fetcher}")
 
 
-def get_repo_hashes():
-    repo_hashes = {}
+def get_repo_hashes(cores_to_update=[]):
+    with open(HASHES_PATH) as f:
+        repo_hashes = json.loads(f.read())
 
     for core, repo in CORES.items():
-        info(f"Getting repo hash for '{core}'...")
-        repo_hashes[core] = get_repo_hash(**repo)
+        if core in cores_to_update:
+            info(f"Getting repo hash for '{core}'...")
+            repo_hashes[core] = get_repo_hash(**repo)
+        else:
+            info(f"Skipping '{core}'...")
 
     return repo_hashes
 
 
 def main():
-    repo_hashes = get_repo_hashes()
+    # If you don't want to update all cores, pass the name of the cores you
+    # want to update on the command line. E.g.:
+    # $ ./update.py citra snes9x
+    if len(sys.argv) > 1:
+        cores_to_update = sys.argv[1:]
+    else:
+        cores_to_update = CORES.keys()
+
+    repo_hashes = get_repo_hashes(cores_to_update)
     info(f"Generating '{HASHES_PATH}'...")
     with open(HASHES_PATH, "w") as f:
-        f.write(json.dumps(repo_hashes, indent=4))
+        f.write(json.dumps(dict(sorted(repo_hashes.items())), indent=4))
         f.write("\n")
     info("Finished!")
 

--- a/pkgs/misc/emulators/retroarch/update.py
+++ b/pkgs/misc/emulators/retroarch/update.py
@@ -22,6 +22,7 @@ CORES = {
     "beetle-supergrafx": {"repo": "beetle-supergrafx-libretro"},
     "beetle-vb": {"repo": "beetle-vb-libretro"},
     "beetle-wswan": {"repo": "beetle-wswan-libretro"},
+    "blastem": {"repo": "blastem"},
     "bluemsx": {"repo": "bluemsx-libretro"},
     "bsnes": {"repo": "bsnes-libretro"},
     "bsnes-hd": {"repo": "bsnes-hd", "owner": "DerKoun"},

--- a/pkgs/misc/emulators/retroarch/update.py
+++ b/pkgs/misc/emulators/retroarch/update.py
@@ -51,6 +51,7 @@ CORES = {
     "mame2016": {"repo": "mame2016-libretro"},
     "melonds": {"repo": "melonds"},
     "mesen": {"repo": "mesen"},
+    "mesen-s": {"repo": "mesen-s"},
     "meteor": {"repo": "meteor-libretro"},
     "mgba": {"repo": "mgba"},
     "mupen64plus": {"repo": "mupen64plus-libretro-nx"},

--- a/pkgs/misc/emulators/retroarch/update.py
+++ b/pkgs/misc/emulators/retroarch/update.py
@@ -49,6 +49,7 @@ CORES = {
     "mame2010": {"repo": "mame2010-libretro"},
     "mame2015": {"repo": "mame2015-libretro"},
     "mame2016": {"repo": "mame2016-libretro"},
+    "melonds": {"repo": "melonds"},
     "mesen": {"repo": "mesen", "owner": "SourMesen"},
     "meteor": {"repo": "meteor-libretro"},
     "mgba": {"repo": "mgba"},

--- a/pkgs/misc/emulators/retroarch/update.py
+++ b/pkgs/misc/emulators/retroarch/update.py
@@ -50,7 +50,7 @@ CORES = {
     "mame2015": {"repo": "mame2015-libretro"},
     "mame2016": {"repo": "mame2016-libretro"},
     "melonds": {"repo": "melonds"},
-    "mesen": {"repo": "mesen", "owner": "SourMesen"},
+    "mesen": {"repo": "mesen"},
     "meteor": {"repo": "meteor-libretro"},
     "mgba": {"repo": "mgba"},
     "mupen64plus": {"repo": "mupen64plus-libretro-nx"},


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

We are missing some RetroArch cores, so this PR will add some of them.

The idea is not to package everything from upstream though (some of them are even impossible since they're missing the necessary files, e.g.: DuckStation). However I want to package at least some of the more interesting ones.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
