### PR TITLE
nixos/doc: improve example of renaming network interfaces

### DIFF
--- a/nixos/doc/manual/configuration/renaming-interfaces.section.md
+++ b/nixos/doc/manual/configuration/renaming-interfaces.section.md
@@ -26,7 +26,7 @@ we assign the name `wan` to the interface with MAC address
 
 ```nix
 systemd.network.links."10-wan" = {
-  matchConfig.MACAddress = "52:54:00:12:01:01";
+  matchConfig.PermanentMACAddress = "52:54:00:12:01:01";
   linkConfig.Name = "wan";
 };
 ```

--- a/nixos/doc/manual/from_md/configuration/renaming-interfaces.section.xml
+++ b/nixos/doc/manual/from_md/configuration/renaming-interfaces.section.xml
@@ -32,7 +32,7 @@
     </para>
     <programlisting language="bash">
 systemd.network.links.&quot;10-wan&quot; = {
-  matchConfig.MACAddress = &quot;52:54:00:12:01:01&quot;;
+  matchConfig.PermanentMACAddress = &quot;52:54:00:12:01:01&quot;;
   linkConfig.Name = &quot;wan&quot;;
 };
 </programlisting>


### PR DESCRIPTION
###### Motivation for this change

The current example of identifying a network interface by `MACAddress` can lead to surprising results as that key is unstable; e.g. NetworkManager commonly changes the MAC address of wireless interfaces. In practice [`PermanentMACAddress`](https://www.freedesktop.org/software/systemd/man/systemd.link.html#PermanentMACAddress=) is likely to be preferable.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
