### PR TITLE
shaderc: include darwin libtool

### DIFF
--- a/pkgs/development/compilers/shaderc/default.nix
+++ b/pkgs/development/compilers/shaderc/default.nix
@@ -42,7 +42,7 @@ in stdenv.mkDerivation rec {
     ln -s ${spirv-headers} third_party/spirv-tools/external/spirv-headers
   '';
 
-  nativeBuildInputs = [ cmake darwin.cctools python3 ];
+  nativeBuildInputs = [ cmake python3 ] ++ lib.optionals stdenv.isDarwin [ darwin.cctools ];
 
   postInstall = ''
     moveToOutput "lib/*.a" $static
@@ -53,6 +53,7 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     inherit (src.meta) homepage;
     description = "A collection of tools, libraries and tests for shader compilation";
+    platforms = platforms.all;
     license = [ licenses.asl20 ];
   };
 }

--- a/pkgs/development/compilers/shaderc/default.nix
+++ b/pkgs/development/compilers/shaderc/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, python3 }:
+{ lib, stdenv, fetchFromGitHub, cmake, darwin, python3 }:
 # Like many google projects, shaderc doesn't gracefully support separately compiled dependencies, so we can't easily use
 # the versions of glslang and spirv-tools used by vulkan-loader. Exact revisions are taken from
 # https://github.com/google/shaderc/blob/known-good/known_good.json
@@ -42,7 +42,7 @@ in stdenv.mkDerivation rec {
     ln -s ${spirv-headers} third_party/spirv-tools/external/spirv-headers
   '';
 
-  nativeBuildInputs = [ cmake python3 ];
+  nativeBuildInputs = [ cmake darwin.cctools python3 ];
 
   postInstall = ''
     moveToOutput "lib/*.a" $static


### PR DESCRIPTION
###### Motivation for this change

Presently on `aarch64-darwin` (and possibly amd64?) the `shaderc` package fails to build using

```bash
nix build nixpkgs#shaderc --print-build-logs
```

This is due to the lack of `libtool` (an OS X system utility, not the GNU `libtool` found sometimes!)

```
shaderc> [ 96%] Building CXX object glslc/CMakeFiles/glslc.dir/src/file_compiler.cc.o
shaderc> [ 96%] Generating libshaderc_combined.a
shaderc> /nix/store/ppzr8yab3s3883skd0da5i4ylzpksk9l-bash-5.1-p8/bin/bash: line 1: libtool: command not found
shaderc> make[2]: *** [libshaderc/CMakeFiles/shaderc_combined_genfile.dir/build.make:83: libshaderc/libshaderc_combined.a] Error 127
shaderc> make[1]: *** [CMakeFiles/Makefile2:2205: libshaderc/CMakeFiles/shaderc_combined_genfile.dir/all] Error 2
shaderc> make[1]: *** Waiting for unfinished jobs....
shaderc> [ 96%] Built target shaderc_shared
shaderc> [ 96%] Building CXX object glslc/CMakeFiles/glslc.dir/src/dependency_info.cc.o
shaderc> [ 96%] Building CXX object glslc/CMakeFiles/glslc.dir/src/shader_stage.cc.o
shaderc> [ 97%] Building CXX object glslc/CMakeFiles/glslc.dir/src/resource_parse.cc.o
shaderc> [ 97%] Linking CXX static library libglslc.a
shaderc> [ 97%] Built target glslc
shaderc> make: *** [Makefile:146: all] Error 2
error: builder for '/nix/store/fsr9vvg9r0jj58qik7jz5hvf2cpkv9ja-shaderc-2021.0.drv' failed with exit code 2
```

This PR resolves this by including `darwin.cctools` in the `nativeBuildInputs` to ensure the correct `libtool` is available on Darwin hosts.

```bash
nix build github:hoverbear/nixpkgs/shaderc-darwin-libtool#shaderc --print-build-logs
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
