### PR TITLE
nixos/podman: Fix AppArmor support

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -587,6 +587,12 @@
     githubId = 15623522;
     name = "Amar Paul";
   };
+  amarshall = {
+    email = "andrew@johnandrewmarshall.com";
+    github = "amarshall";
+    githubId = 153175;
+    name = "Andrew Marshall";
+  };
   ambroisie = {
     email = "bruno.nixpkgs@belanyi.fr";
     github = "ambroisie";

--- a/nixos/modules/virtualisation/podman/default.nix
+++ b/nixos/modules/virtualisation/podman/default.nix
@@ -127,6 +127,7 @@ in
   config = lib.mkIf cfg.enable (lib.mkMerge [
     {
       environment.systemPackages = [ cfg.package ]
+        ++ lib.optional config.security.apparmor.enable pkgs.apparmor-parser
         ++ lib.optional cfg.dockerCompat dockerCompat;
 
       environment.etc."cni/net.d/87-podman-bridge.conflist".source = net-conflist;
@@ -140,6 +141,10 @@ in
           };
         };
       };
+
+      security.apparmor.includes."tunables/global" = ''
+        include "${pkgs.apparmor-profiles}/etc/apparmor.d/tunables/global"
+      '';
 
       systemd.packages = [ cfg.package ];
 

--- a/nixos/modules/virtualisation/podman/default.nix
+++ b/nixos/modules/virtualisation/podman/default.nix
@@ -94,7 +94,8 @@ in
 
     extraPackages = mkOption {
       type = with types; listOf package;
-      default = [ ];
+      default = [ ]
+        ++ lib.optional config.security.apparmor.enable pkgs.apparmor-parser;
       example = lib.literalExpression ''
         [
           pkgs.gvisor
@@ -127,7 +128,6 @@ in
   config = lib.mkIf cfg.enable (lib.mkMerge [
     {
       environment.systemPackages = [ cfg.package ]
-        ++ lib.optional config.security.apparmor.enable pkgs.apparmor-parser
         ++ lib.optional cfg.dockerCompat dockerCompat;
 
       environment.etc."cni/net.d/87-podman-bridge.conflist".source = net-conflist;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -370,6 +370,7 @@ in
   plotinus = handleTest ./plotinus.nix {};
   podgrab = handleTest ./podgrab.nix {};
   podman = handleTestOn ["x86_64-linux"] ./podman/default.nix {};
+  podman-apparmor = handleTestOn ["x86_64-linux"] ./podman/apparmor.nix {};
   podman-dnsname = handleTestOn ["x86_64-linux"] ./podman/dnsname.nix {};
   podman-tls-ghostunnel = handleTestOn ["x86_64-linux"] ./podman/tls-ghostunnel.nix {};
   pomerium = handleTestOn ["x86_64-linux"] ./pomerium.nix {};

--- a/nixos/tests/podman/apparmor.nix
+++ b/nixos/tests/podman/apparmor.nix
@@ -1,0 +1,63 @@
+# This test runs podman and checks AppArmor default confinement
+
+import ../make-test-python.nix (
+  { pkgs, lib, ... }: {
+    name = "podman-apparmor";
+    meta = with lib; {
+      maintainers = teams.podman.members + (with maintainers; [amarshall]);
+    };
+
+    nodes = {
+      podman =
+        { pkgs, ... }: {
+          virtualisation.podman.enable = true;
+          security.apparmor.enable = true;
+
+          users.users.alice = {
+            isNormalUser = true;
+            home = "/home/alice";
+            description = "Alice Foobar";
+            extraGroups = [ "podman" ];
+          };
+        };
+    };
+
+    testScript = ''
+      import shlex
+
+
+      def su_cmd(cmd, user = "alice"):
+          cmd = shlex.quote(cmd)
+          return f"su {user} -l -c {cmd}"
+
+
+      with subtest("Run container as root"):
+          podman.succeed("tar cv --files-from /dev/null | podman import - scratchimg")
+          podman.succeed(
+              "podman run -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg /bin/sleep 10"
+          )
+          podman.succeed("podman ps | grep sleeping")
+          podman.succeed("podman inspect sleeping -f '{{.AppArmorProfile}}' | grep -v unconfined | grep -E '^.+$'")
+          podman.succeed("podman stop sleeping")
+          podman.succeed("podman rm sleeping")
+
+
+      # create systemd session for rootless
+      podman.succeed("loginctl enable-linger alice")
+
+
+      with subtest("Run container rootless"):
+          podman.succeed(su_cmd("tar cv --files-from /dev/null | podman import - scratchimg"))
+          podman.succeed(
+              su_cmd(
+                  "podman run -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg /bin/sleep 10"
+              )
+          )
+          # AppArmor not supported rootless, but container should run
+          podman.succeed(su_cmd("podman inspect sleeping -f '{{.AppArmorProfile}}' | grep -E '^$'"))
+          podman.succeed(su_cmd("podman ps | grep sleeping"))
+          podman.succeed(su_cmd("podman stop sleeping"))
+          podman.succeed(su_cmd("podman rm sleeping"))
+    '';
+  }
+)

--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -79,6 +79,7 @@ buildGoModule rec {
     inherit (nixosTests) podman;
     # related modules
     inherit (nixosTests)
+      podman-apparmor
       podman-tls-ghostunnel
       podman-dnsname
       ;


### PR DESCRIPTION
###### Motivation for this change

Podman generates and loads its AppArmor profile at runtime, for this is
needs `apparmor_parser` to be in $PATH.

Podman detects at runtime if /etc/apparmor.d/tunables/global is present
and, if so, `include`s it in the runtime-generated profile. If it’s not
found then it does not, but then the profile fails to load successfully
because `…/abstractions/base` *is* found and that implicitly depends on
`…/tunables/global`.

Prevent future breakage with a dedicated test for Podman AppArmor
confinement with the default profile.

If this solution is acceptable I may also work on a similar fix for Docker as it seems to be broken as well (see #22953) and a lot of the underlying AppArmor integration code is shared between the two, I think.

###### Things done

Testing was done on latest nixos-unstable (715f63411952c86c8f57ab9e3e3cb866a015b5f2).

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
