### PR TITLE
numix-cursor-theme: 1.1 -> 1.2

### DIFF
--- a/pkgs/data/icons/numix-cursor-theme/default.nix
+++ b/pkgs/data/icons/numix-cursor-theme/default.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, inkscape, xcursorgen }:
+{ lib, stdenv, fetchFromGitHub, inkscape, xcursorgen }:
 
 stdenv.mkDerivation rec {
-  version = "1.1";
+  version = "1.2";
   package-name = "numix-cursor-theme";
   name = "${package-name}-${version}";
 
@@ -9,19 +9,10 @@ stdenv.mkDerivation rec {
     owner = "numixproject";
     repo = package-name;
     rev = "v${version}";
-    sha256 = "0p8h48wsy3z5dz9vdnp01fpn6q8ky0h74l5qgixlip557bsa1spi";
+    sha256 = "1q3w5i0h3ly6i7s9pqjdrb14kp89i78s0havri7lhiqyxizjvcvh";
   };
 
   nativeBuildInputs = [ inkscape xcursorgen ];
-
-  patches = [
-    # Remove when https://github.com/numixproject/numix-cursor-theme/pull/7 is merged
-    (fetchpatch {
-      url = "https://github.com/stephaneyfx/numix-cursor-theme/commit/3b647bf768cebb8f127b88e3786f6a9640460197.patch";
-      sha256 = "174kmhlvv76wwvndkys78aqc32051sqg3wzc0xg6b7by4agrbg76";
-      name = "support-inkscape-1-in-numix-cursor-theme.patch";
-    })
-  ];
 
   buildPhase = ''
     patchShebangs .

--- a/pkgs/data/icons/numix-cursor-theme/default.nix
+++ b/pkgs/data/icons/numix-cursor-theme/default.nix
@@ -1,13 +1,12 @@
 { lib, stdenv, fetchFromGitHub, inkscape, xcursorgen }:
 
 stdenv.mkDerivation rec {
+  pname = "numix-cursor-theme";
   version = "1.2";
-  package-name = "numix-cursor-theme";
-  name = "${package-name}-${version}";
 
   src = fetchFromGitHub {
     owner = "numixproject";
-    repo = package-name;
+    repo = pname;
     rev = "v${version}";
     sha256 = "1q3w5i0h3ly6i7s9pqjdrb14kp89i78s0havri7lhiqyxizjvcvh";
   };


### PR DESCRIPTION
The patch was merged in https://github.com/numixproject/numix-cursor-theme/pull/7

###### Motivation for this change
Updating version to follow upstream and remove patch.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
