### PR TITLE
[21.05] onedrive: 2.4.11 -> 2.4.13

### DIFF
--- a/pkgs/applications/networking/sync/onedrive/default.nix
+++ b/pkgs/applications/networking/sync/onedrive/default.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "onedrive";
-  version = "2.4.12";
+  version = "2.4.13";
 
   src = fetchFromGitHub {
     owner = "abraunegg";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-rG9W90+wGLnhnfhqJjUIFGP6ZcmaxGkrdhPxQVRyxoc=";
+    sha256 = "sha256-v1GSHwcP9EQaADIEKO14yotJBEEatbKugVJOCsTLr2w=";
   };
 
   nativeBuildInputs = [ autoreconfHook ldc installShellFiles pkg-config ];

--- a/pkgs/applications/networking/sync/onedrive/default.nix
+++ b/pkgs/applications/networking/sync/onedrive/default.nix
@@ -1,22 +1,34 @@
-{ stdenv, lib, fetchFromGitHub, autoreconfHook, ldc, installShellFiles, pkg-config
-, curl, sqlite, libnotify
-, withSystemd ? stdenv.isLinux, systemd ? null }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, autoreconfHook
+, ldc
+, installShellFiles
+, pkg-config
+, curl
+, sqlite
+, libnotify
+, withSystemd ? stdenv.isLinux
+, systemd
+}:
 
 stdenv.mkDerivation rec {
   pname = "onedrive";
-  version = "2.4.11";
+  version = "2.4.12";
 
   src = fetchFromGitHub {
     owner = "abraunegg";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-ioOrkhVeHHqIjoEXcYo8ATJW+2+nZOehf3XbAJUEXpY=";
+    sha256 = "sha256-rG9W90+wGLnhnfhqJjUIFGP6ZcmaxGkrdhPxQVRyxoc=";
   };
 
   nativeBuildInputs = [ autoreconfHook ldc installShellFiles pkg-config ];
 
   buildInputs = [
-    curl sqlite libnotify
+    curl
+    sqlite
+    libnotify
   ] ++ lib.optional withSystemd systemd;
 
   configureFlags = [
@@ -36,8 +48,8 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A complete tool to interact with OneDrive on Linux";
     homepage = "https://github.com/abraunegg/onedrive";
-    license = licenses.gpl3;
-    maintainers = with maintainers; [ srgom ianmjones ];
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ srgom peterhoeg ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR backports  #126809 and  #134218 to 21.05 stable. The upstream commits apply cleanly via cherry-pick.

These backports are done, because 2.4.11 has a bug uploading modified files (https://github.com/abraunegg/onedrive/pull/1394) that is fixed in newer versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
