### PR TITLE
burp: pull upstream fix for ncurses-6.3

### DIFF
--- a/pkgs/tools/backup/burp/default.nix
+++ b/pkgs/tools/backup/burp/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config
+{ lib, stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, pkg-config
 , acl, librsync, ncurses, openssl, zlib, uthash }:
 
 stdenv.mkDerivation rec {
@@ -11,6 +11,15 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "1zhq240kz881vs2s620qp0kifmgr582caalm85ls789w9rmdkhjl";
   };
+
+  patches = [
+    # Pull upstream fix for ncurses-6.3 support
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/grke/burp/commit/1d6c931af7c11f164cf7ad3479781e8f03413496.patch";
+      sha256 = "14sfbfahlankz3xg6v10i8fnmpnmqpp73q9xm0l0hnjh25igv6bl";
+    })
+  ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ librsync ncurses openssl zlib uthash ]


### PR DESCRIPTION
Without the fix build on ncurses-6.3 fails as:

    src/client/monitor/status_client_ncurses.c:350:9:
      error: format not a string literal and no format arguments [-Werror=format-security]
      350 |         mvprintw(0, col-l-1, date);
          |         ^~~~~~~~
