### PR TITLE
Add pythonPackages.csv-diff and dependencies

### DIFF
--- a/pkgs/development/python-modules/csv-diff/default.nix
+++ b/pkgs/development/python-modules/csv-diff/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, pytest-runner
+, dictdiffer
+, click
+}:
+
+buildPythonPackage rec {
+  pname = "csv-diff";
+  version = "1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1skbaxgn72qlpl8pmmmihpzlb28rvks78wwi9yydhzf6j9wi357z";
+  };
+
+  propagatedBuildInputs = [
+    dictdiffer
+    click
+  ];
+
+  checkInputs = [
+    pytest
+    pytest-runner
+  ];
+
+  meta = with lib; {
+    description = "Tool for viewing the difference between two CSV, TSV or JSON files";
+    homepage = "https://github.com/simonw/csv-diff";
+    license = licenses.asl20;
+    maintainer = with maintainers; [ turion ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-pycodestyle/default.nix
+++ b/pkgs/development/python-modules/pytest-pycodestyle/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pycodestyle
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-pycodestyle";
+  version = "2.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-bA4qBznDUNTc/+ZouV9j85D86LTme0+yNiCN1tDPZTA=";
+  };
+
+  buildInputs = [
+    pytest
+  ];
+
+  propagatedBuildInputs = [
+    pycodestyle
+  ];
+
+  meta = with lib; {
+    description = "pytest plugin to run pycodestyle";
+    homepage = "https://github.com/henry0312/pytest-pycodestyle";
+    license = licenses.mit;
+    maintainer = with maintainers; [ turion ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-pydocstyle/default.nix
+++ b/pkgs/development/python-modules/pytest-pydocstyle/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pydocstyle
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-pydocstyle";
+  version = "2.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-Hy2Tc0nP60llxTCgwPJEK0jAMplVjbQ1tlVJcZUQ0ys=";
+  };
+
+  buildInputs = [
+    pytest
+  ];
+
+  propagatedBuildInputs = [
+    pydocstyle
+  ];
+
+  meta = with lib; {
+    description = "pytest plugin to run pydocstyle";
+    homepage = "https://github.com/henry0312/pytest-pydocstyle";
+    license = licenses.mit;
+    maintainer = with maintainers; [ turion ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-pydocstyle/default.nix
+++ b/pkgs/development/python-modules/pytest-pydocstyle/default.nix
@@ -26,6 +26,6 @@ buildPythonPackage rec {
     description = "pytest plugin to run pydocstyle";
     homepage = "https://github.com/henry0312/pytest-pydocstyle";
     license = licenses.mit;
-    maintainer = with maintainers; [ turion ];
+    maintainers = with maintainers; [ turion ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8145,6 +8145,8 @@ in {
 
   pytest-pydocstyle = callPackage ../development/python-modules/pytest-pydocstyle { };
 
+  pytest-pycodestyle = callPackage ../development/python-modules/pytest-pycodestyle { };
+
   pytest-pylint = callPackage ../development/python-modules/pytest-pylint { };
 
   pytest-qt = callPackage ../development/python-modules/pytest-qt { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1973,6 +1973,8 @@ in {
 
   csvw = callPackage ../development/python-modules/csvw { };
 
+  csv-diff = callPackage ../development/python-modules/csv-diff { };
+
   cucumber-tag-expressions = callPackage ../development/python-modules/cucumber-tag-expressions { };
 
   cufflinks = callPackage ../development/python-modules/cufflinks { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8143,6 +8143,8 @@ in {
 
   pytest-ordering = callPackage ../development/python-modules/pytest-ordering { };
 
+  pytest-pydocstyle = callPackage ../development/python-modules/pytest-pydocstyle { };
+
   pytest-pylint = callPackage ../development/python-modules/pytest-pylint { };
 
   pytest-qt = callPackage ../development/python-modules/pytest-qt { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds https://pypi.org/project/csv-diff/ and a few missing dependencies

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
