### PR TITLE
nordic: install the kde related themes

### DIFF
--- a/pkgs/data/themes/nordic/default.nix
+++ b/pkgs/data/themes/nordic/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "nordic";
-  version = "unstable-2021-11-19";
+  version = "2.1.0";
 
   srcs = [
     (fetchFromGitHub {

--- a/pkgs/data/themes/nordic/default.nix
+++ b/pkgs/data/themes/nordic/default.nix
@@ -76,6 +76,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
+
     mkdir -p $out/share/themes
     cp -a Nordic* $out/share/themes
     rm -r $out/share/themes/*/.gitignore
@@ -88,13 +89,23 @@ stdenv.mkDerivation rec {
     rm -r $out/share/themes/*/gnome-shell/{extensions,*.scss}
     rm -r $out/share/themes/*/gtk-2.0/{assets.svg,assets.txt,links.fish,render-assets.sh}
     rm -r $out/share/themes/*/gtk-3.0/{apps,widgets,*.scss}
-    rm -r $out/share/themes/*/kde
     rm -r $out/share/themes/*/xfwm4/{assets,render_assets.fish}
+
+    # move kde related contents to appropriate directories
+    mkdir -p $out/share/{aurorae/themes,color-schemes,Kvantum,plasma,sddm/themes/Nordic}
+    mv -v $out/share/themes/Nordic/kde/aurorae/* $out/share/aurorae/themes/
+    mv -v $out/share/themes/Nordic/kde/colorschemes/* $out/share/color-schemes/
+    mv -v $out/share/themes/Nordic/kde/konsole $out/share/
+    mv -v $out/share/themes/Nordic/kde/kvantum/* $out/share/Kvantum/
+    mv -v $out/share/themes/Nordic/kde/plasma/look-and-feel $out/share/plasma/
+    mv -v $out/share/themes/Nordic/kde/sddm/* $out/share/sddm/themes/Nordic/
+    rm -rf $out/share/themes/Nordic/kde
+
     runHook postInstall
   '';
 
   meta = with lib; {
-    description = "Gtk themes using the Nord color pallete";
+    description = "Gtk and KDE themes using the Nord color pallete";
     homepage = "https://github.com/EliverLara/Nordic";
     license = licenses.gpl3Only;
     platforms = platforms.all;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Install kde related themes.
- This git revision was released as stable [v2.1.0](https://github.com/EliverLara/Nordic/releases/tag/v2.1.0)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
