### PR TITLE
lib/modules: Add moduleType parameter

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -62,6 +62,8 @@ rec {
       ‘type’: A module system type representing the module set as a submodule,
             to be extended by configuration from the containing module set.
 
+            This is also available as the module argument ‘moduleType’.
+
       ‘extendModules’: A function similar to ‘evalModules’ but building on top
             of the module set. Its arguments, ‘modules’ and ‘specialArgs’ are
             added to the existing values.
@@ -148,6 +150,7 @@ rec {
         config = {
           _module.args = {
             inherit extendModules;
+            moduleType = type;
           } // args;
         };
       };

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -74,6 +74,8 @@ rec {
             override existing configuration fundamentally requires a new
             fixpoint to be constructed.
 
+            This is also available as a module argument.
+
       ‘_module’: A portion of the configuration tree which is elided from
             ‘config’. It contains some values that are mostly internal to the
             module system implementation.

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -281,6 +281,11 @@ checkConfigError 'A definition for option .fun.\[function body\]. is not of type
 checkConfigOutput "b a" config.result ./functionTo/list-order.nix
 checkConfigOutput "a c" config.result ./functionTo/merging-attrs.nix
 
+# moduleType
+checkConfigOutput "a b" config.resultFoo ./declare-variants.nix ./define-variant.nix
+checkConfigOutput "a y z" config.resultFooBar ./declare-variants.nix ./define-variant.nix
+checkConfigOutput "a b c" config.resultFooFoo ./declare-variants.nix ./define-variant.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules/declare-variants.nix
+++ b/lib/tests/modules/declare-variants.nix
@@ -1,0 +1,9 @@
+{ lib, moduleType, ... }:
+let inherit (lib) mkOption types;
+in
+{
+  options.variants = mkOption {
+    type = types.lazyAttrsOf moduleType;
+    default = {};
+  };
+}

--- a/lib/tests/modules/define-variant.nix
+++ b/lib/tests/modules/define-variant.nix
@@ -1,0 +1,22 @@
+{ config, lib, ... }:
+let inherit (lib) types mkOption attrNames;
+in
+{
+  options = {
+    attrs = mkOption { type = types.attrsOf lib.types.int; };
+    result = mkOption { };
+    resultFoo = mkOption { };
+    resultFooBar = mkOption { };
+    resultFooFoo = mkOption { };
+  };
+  config = {
+    attrs.a = 1;
+    variants.foo.attrs.b = 1;
+    variants.bar.attrs.y = 1;
+    variants.foo.variants.bar.attrs.z = 1;
+    variants.foo.variants.foo.attrs.c = 3;
+    resultFoo = lib.concatMapStringsSep " " toString (attrNames config.variants.foo.attrs);
+    resultFooBar = lib.concatMapStringsSep " " toString (attrNames config.variants.foo.variants.bar.attrs);
+    resultFooFoo = lib.concatMapStringsSep " " toString (attrNames config.variants.foo.variants.foo.attrs);
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Follow-up to #143207. Allows the current configuration to be replicated and modified. Summarizing the test:

```nix
{ moduleType, ... }:
{
  options.variants = mkOption {
    type = types.lazyAttrsOf moduleType;
  };
}
```

```nix
  config = {
    list = [ 1 ];
    variants.foo.list = [ 2 ];
  }
```

```nix
assert config.variants.foo.list == [ 1 2 ]
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
