### PR TITLE
cpplint: 1.5.1 -> 1.5.5

### DIFF
--- a/pkgs/development/tools/analysis/cpplint/0001-Remove-pytest-runner-version-pin.patch
+++ b/pkgs/development/tools/analysis/cpplint/0001-Remove-pytest-runner-version-pin.patch
@@ -1,0 +1,16 @@
+diff --git a/setup.py b/setup.py
+index aef5c4e..030ea14 100755
+--- a/setup.py
++++ b/setup.py
+@@ -73,7 +73,7 @@ setup(name='cpplint',
+       long_description=open('README.rst').read(),
+       license='BSD-3-Clause',
+       setup_requires=[
+-          "pytest-runner==5.2"
++          "pytest-runner"
+       ],
+       tests_require=test_required,
+       # extras_require allow pip install .[dev]
+-- 
+2.31.1
+

--- a/pkgs/development/tools/analysis/cpplint/default.nix
+++ b/pkgs/development/tools/analysis/cpplint/default.nix
@@ -2,15 +2,17 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "cpplint";
-  version = "1.5.1";
+  version = "1.5.5";
 
   # Fetch from github instead of pypi, since the test cases are not in the pypi archive
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "0k927mycj1k4l3fbxrk597bhcjl2nrpaas1imbjgk64cyq8dv7lh";
+    sha256 = "sha256-JXz2Ufo7JSceZVqYwCRkuAsOR08znZlIUk8GCLAyiI4=";
   };
+
+  patches = [ ./0001-Remove-pytest-runner-version-pin.patch ];
 
   postPatch = ''
     patchShebangs cpplint_unittest.py


### PR DESCRIPTION
###### Motivation for this change

Upstream pinned `pytest-runner` to version 5.2 to remain compatible for Python 2. Since the nixpkgs cpplint package builds only for Python 3, I have removed this version requirement so that it would build with the more recent version of `pytest-runner` present in nixpkgs.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
