### PR TITLE
neard: 0.16 → 0.18

### DIFF
--- a/pkgs/servers/neard/default.nix
+++ b/pkgs/servers/neard/default.nix
@@ -1,26 +1,63 @@
-{ lib, stdenv, fetchurl, autoreconfHook, pkg-config, systemd, glib, dbus, libnl, python2Packages }:
+{ stdenv
+, lib
+, fetchurl
+, autoreconfHook
+, autoconf-archive
+, pkg-config
+, systemd
+, glib
+, dbus
+, libnl
+, python2Packages
+}:
 
 stdenv.mkDerivation rec {
   pname = "neard";
-  version = "0.16";
+  version = "0.18";
+
+  outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "https://git.kernel.org/pub/scm/network/nfc/neard.git/snapshot/neard-${version}.tar.gz";
-    sha256 = "0bpdmyxvd3z54p95apz4bjb5jp8hbc04sicjapcryjwa8mh6pbil";
+    sha256 = "wBPjEVMV4uEdFrXw8cjOmvvNuiaACq2RJF/ZtKXck4s=";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkg-config python2Packages.wrapPython ];
-  buildInputs = [ systemd glib dbus libnl ] ++ (with python2Packages; [ python ]);
-  pythonPath = with python2Packages; [ pygobject2 dbus-python pygtk ];
+  nativeBuildInputs = [
+    autoreconfHook
+    autoconf-archive
+    pkg-config
+    python2Packages.wrapPython
+  ];
+
+  buildInputs = [
+    systemd
+    glib
+    dbus
+    libnl
+  ] ++ (with python2Packages; [
+    python
+  ]);
+
+  pythonPath = with python2Packages; [
+    pygobject2
+    dbus-python
+    pygtk
+  ];
 
   strictDeps = true;
 
-  configureFlags = [ "--disable-debug" "--enable-tools" "--enable-ese" "--with-systemdsystemunitdir=$out/lib/systemd/system" ];
+  enableParallelBuilding = true;
+
+  configureFlags = [
+    "--disable-debug"
+    "--enable-tools"
+    "--enable-ese"
+    "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
+  ];
 
   postInstall = ''
     install -m 0755 tools/snep-send $out/bin/
 
-    install -D -m644 src/neard.service $out/lib/systemd/system/neard.service
     install -D -m644 src/main.conf $out/etc/neard/main.conf
 
     # INFO: the config option "--enable-test" would copy the apps to $out/lib/neard/test/ instead
@@ -31,9 +68,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Near Field Communication manager";
-    homepage    = "https://01.org/linux-nfc";
-    license     = licenses.gpl2;
-    maintainers = with maintainers; [ tstrobel ];
-    platforms   = platforms.unix;
+    homepage = "https://01.org/linux-nfc";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ jtojnar tstrobel ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
https://git.kernel.org/pub/scm/network/nfc/neard.git/log/?h=v0.18

https://lists.01.org/hyperkitty/list/linux-nfc@lists.01.org/thread/NKL6257FUDB64OCAVZNBTDCLGWY3NQWS/

- Requires autoconf-archive
- The systemd service is now installed automatically.

On the packging side also

- cleaned up formatting
- split out dev output
- enabled parallel building
- corrected license
- added myself as maintainer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
