### PR TITLE
supercollider: add plugin support; supercolliderPlugins.sc3-plugins: init at 3.11.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7184,6 +7184,13 @@
     githubId = 714;
     name = "Lily Ballard";
   };
+  lilyinstarlight = {
+    email = "lily@lily.flowers";
+    matrix = "@lily:lily.flowers";
+    github = "lilyinstarlight";
+    githubId = 298109;
+    name = "Lily Foster";
+  };
   limeytexan = {
     email = "limeytexan@gmail.com";
     github = "limeytexan";

--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -2,6 +2,8 @@
 , pkg-config, alsa-lib, libjack2, libsndfile, fftw
 , curl, gcc, libXt, qtbase, qttools, qtwebengine
 , readline, qtwebsockets, useSCEL ? false, emacs
+, supercollider-with-plugins, supercolliderPlugins
+, writeText, runCommand
 }:
 
 mkDerivation rec {
@@ -30,6 +32,26 @@ mkDerivation rec {
     "-DSC_WII=OFF"
     "-DSC_EL=${if useSCEL then "ON" else "OFF"}"
   ];
+
+  passthru.tests = {
+    # test to make sure sclang runs and included plugins are successfully found
+    sclang-sc3-plugins = let
+      supercollider-with-test-plugins = supercollider-with-plugins.override {
+        plugins = with supercolliderPlugins; [ sc3-plugins ];
+      };
+      testsc = writeText "test.sc" ''
+        var err = 0;
+        try {
+        MdaPiano.name.postln;
+        } {
+        err = 1;
+        };
+        err.exit;
+      '';
+    in runCommand "sclang-sc3-plugins-test" {} ''
+      timeout 60s env XDG_CONFIG_HOME="$(mktemp -d)" QT_QPA_PLATFORM=minimal ${supercollider-with-test-plugins}/bin/sclang ${testsc} >$out
+    '';
+  };
 
   meta = with lib; {
     description = "Programming language for real time audio synthesis";

--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -33,7 +33,7 @@ mkDerivation rec {
   meta = with lib; {
     description = "Programming language for real time audio synthesis";
     homepage = "https://supercollider.github.io";
-    maintainers = with maintainers; [ mrmebelman ];
+    maintainers = with maintainers; [ lilyinstarlight ];
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
   };

--- a/pkgs/development/interpreters/supercollider/plugins/sc3-plugins.nix
+++ b/pkgs/development/interpreters/supercollider/plugins/sc3-plugins.nix
@@ -1,0 +1,33 @@
+{ stdenv, lib, fetchurl, cmake, supercollider, fftw }:
+
+stdenv.mkDerivation rec {
+  pname = "sc3-plugins";
+  version = "3.11.1";
+
+  src = fetchurl {
+    url = "https://github.com/supercollider/sc3-plugins/releases/download/Version-${version}/sc3-plugins-${version}-Source.tar.bz2";
+    sha256 = "sha256-JjUmu7PJ+x3yRibr+Av2gTREng51fPo7Rk+B4y2JvkQ=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    supercollider
+    fftw
+  ];
+
+  cmakeFlags = [
+    "-DSC_PATH=${supercollider}/include/SuperCollider"
+    "-DSUPERNOVA=ON"
+  ];
+
+  stripDebugList = [ "lib" "share" ];
+
+  meta = with lib; {
+    description = "Community plugins for SuperCollider";
+    homepage = "https://supercollider.github.io/sc3-plugins/";
+    maintainers = with maintainers; [ lilyinstarlight ];
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/interpreters/supercollider/supercollider-3.12.0-env-dirs.patch
+++ b/pkgs/development/interpreters/supercollider/supercollider-3.12.0-env-dirs.patch
@@ -1,0 +1,65 @@
+diff --git a/common/SC_Filesystem_unix.cpp b/common/SC_Filesystem_unix.cpp
+index 52dc1fd2d..aae09ed9c 100644
+--- a/common/SC_Filesystem_unix.cpp
++++ b/common/SC_Filesystem_unix.cpp
+@@ -94,6 +94,10 @@ bool SC_Filesystem::isNonHostPlatformDirectoryName(const std::string& s) {
+ }
+ 
+ Path SC_Filesystem::defaultSystemAppSupportDirectory() {
++    const char* sc_data_dir = getenv("SC_DATA_DIR");
++    if (sc_data_dir)
++        return Path(sc_data_dir);
++
+ #    ifdef SC_DATA_DIR
+     return Path(SC_DATA_DIR);
+ #    else
+@@ -125,6 +129,10 @@ Path SC_Filesystem::defaultUserConfigDirectory() {
+ }
+ 
+ Path SC_Filesystem::defaultResourceDirectory() {
++    const char* sc_data_dir = getenv("SC_DATA_DIR");
++    if (sc_data_dir)
++        return Path(sc_data_dir);
++
+ #    ifdef SC_DATA_DIR
+     return Path(SC_DATA_DIR);
+ #    else
+diff --git a/server/scsynth/SC_Lib_Cintf.cpp b/server/scsynth/SC_Lib_Cintf.cpp
+index f6219307e..28e13eb98 100644
+--- a/server/scsynth/SC_Lib_Cintf.cpp
++++ b/server/scsynth/SC_Lib_Cintf.cpp
+@@ -178,9 +178,13 @@ void initialize_library(const char* uGensPluginPath) {
+     using DirName = SC_Filesystem::DirName;
+ 
+     if (loadUGensExtDirs) {
++        const char* sc_plugin_dir = getenv("SC_PLUGIN_DIR");
++        if (sc_plugin_dir) {
++            PlugIn_LoadDir(sc_plugin_dir, true);
++        }
+ #ifdef SC_PLUGIN_DIR
+         // load globally installed plugins
+-        if (bfs::is_directory(SC_PLUGIN_DIR)) {
++        else if (bfs::is_directory(SC_PLUGIN_DIR)) {
+             PlugIn_LoadDir(SC_PLUGIN_DIR, true);
+         }
+ #endif // SC_PLUGIN_DIR
+diff --git a/server/supernova/server/main.cpp b/server/supernova/server/main.cpp
+index b2b5adf4e..6cb8c411c 100644
+--- a/server/supernova/server/main.cpp
++++ b/server/supernova/server/main.cpp
+@@ -224,8 +224,14 @@ void set_plugin_paths(server_arguments const& args, nova::sc_ugen_factory* facto
+             }
+         }
+     } else {
++        const char* sc_plugin_dir = getenv("SC_PLUGIN_DIR");
++        if (sc_plugin_dir) {
++            factory->load_plugin_folder(sc_plugin_dir);
++        }
+ #ifdef SC_PLUGIN_DIR
+-        factory->load_plugin_folder(SC_PLUGIN_DIR);
++        else {
++            factory->load_plugin_folder(SC_PLUGIN_DIR);
++        }
+ #endif
+         factory->load_plugin_folder(SC_Filesystem::instance().getDirectory(DirName::Resource) / SC_PLUGIN_DIR_NAME);
+         factory->load_plugin_folder(SC_Filesystem::instance().getDirectory(DirName::SystemExtension));

--- a/pkgs/development/interpreters/supercollider/wrapper.nix
+++ b/pkgs/development/interpreters/supercollider/wrapper.nix
@@ -1,0 +1,18 @@
+{ symlinkJoin, makeWrapper, supercollider, plugins }:
+
+symlinkJoin {
+  name = "supercollider-with-plugins-${supercollider.version}";
+  paths = [ supercollider ] ++ plugins;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    for exe in $out/bin/*; do
+      wrapProgram $exe \
+        --set SC_PLUGIN_DIR "$out/lib/SuperCollider/plugins" \
+        --set SC_DATA_DIR   "$out/share/SuperCollider"
+    done
+  '';
+
+  inherit (supercollider) pname version meta;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14432,8 +14432,18 @@ with pkgs;
 
   supercollider_scel = supercollider.override { useSCEL = true; };
 
+  supercolliderPlugins = recurseIntoAttrs {
+    sc3-plugins = callPackage ../development/interpreters/supercollider/plugins/sc3-plugins.nix {
+      fftw = fftwSinglePrec;
+    };
+  };
+
   supercollider-with-plugins = callPackage ../development/interpreters/supercollider/wrapper.nix {
     plugins = [];
+  };
+
+  supercollider-with-sc3-plugins = supercollider-with-plugins.override {
+    plugins = with supercolliderPlugins; [ sc3-plugins ];
   };
 
   taktuk = callPackage ../applications/networking/cluster/taktuk { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14432,6 +14432,10 @@ with pkgs;
 
   supercollider_scel = supercollider.override { useSCEL = true; };
 
+  supercollider-with-plugins = callPackage ../development/interpreters/supercollider/wrapper.nix {
+    plugins = [];
+  };
+
   taktuk = callPackage ../applications/networking/cluster/taktuk { };
 
   tcl = tcl-8_6;


### PR DESCRIPTION
###### Motivation for this change

This PR adds support in the `supercollider` package for creating symlinked and self-contained plugin derivations like some other programs in nixpkgs support. I modeled this after a few such plugin package sets I found in nixpkgs, but let me know if it could be changed to better follow desired behavior or practices.

It does require patching SuperCollider to support setting the system data and plugin directories via environment variables rather than just using the values at compile-time so that plugins can be loaded from the symlinked directories similar to how they would on other operating systems which put stuff in `/usr/share/SuperCollider` and `/usr/lib/SuperCollider/plugins`.

I've added [sc3-plugins](https://github.com/supercollider/sc3-plugins) version 3.11.1 to this PR which supercedes #142626 (per https://github.com/NixOS/nixpkgs/pull/142626#issuecomment-974895312) and added a `supercollider_sc3-plugins` package alias (which can be renamed if needed) since combining just those two would be fairly common (e.g. newer versions of Sonic Pi require it -- I also plan to PR updates for Sonic Pi one once 4.0 comes out but this PR is a prereq for that).

I've also added two tests: one to make sure scsynth runs on NixOS (but it does not test behavior further than initialization) and one to make sure sclang runs and automatically loads specified plugins (by checking for the existence of `MdaPiano` from sc3-plugins).

One quick question: if I am okay to maintain the SuperCollider patch and already watch for SuperCollider updates, would you like me to add myself as a maintainer to the `supercollider` package as well?

cc: @mrmebelman as current maintainer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


###### nixpkgs-review

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>7 packages built:</summary>
  <ul>
    <li>foxdot (python39Packages.foxdot)</li>
    <li>python38Packages.foxdot</li>
    <li>sonic-pi</li>
    <li>supercollider</li>
    <li>supercolliderPlugins.sc3-plugins</li>
    <li>supercollider_sc3-plugins</li>
    <li>supercollider_scel</li>
  </ul>
</details>