### PR TITLE
mod_itk: init at 2.4.7-04

### DIFF
--- a/pkgs/servers/http/apache-modules/mod_itk/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_itk/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenv
+, fetchurl
+, pkg-config
+, mod_ca
+, apr
+, aprutil
+, apacheHttpd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mod_itk";
+  version = "2.4.7-04";
+
+  src = fetchurl {
+    url = "http://mpm-itk.sesse.net/mpm-itk-${version}.tar.gz";
+    sha256 = "sha256:1kzgd1332pgpxf489kr0vdwsaik0y8wp3q282d4wa5jlk7l877v0";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ mod_ca apr aprutil apacheHttpd ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/modules
+    ${apacheHttpd.dev}/bin/apxs -S LIBEXECDIR=$out/modules -i mpm_itk.la
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "an MPM (Multi-Processing Module) for the Apache web server.";
+    maintainers = [ maintainers.zupo ];
+    homepage = "http://mpm-itk.sesse.net/";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20569,6 +20569,8 @@ with pkgs;
     mod_wsgi2 = callPackage ../servers/http/apache-modules/mod_wsgi { python = python2; ncurses = null; };
     mod_wsgi3 = callPackage ../servers/http/apache-modules/mod_wsgi { python = python3; };
 
+    mod_itk = callPackage ../servers/http/apache-modules/mod_itk { };
+
     php = pkgs.php.override { inherit apacheHttpd; };
 
     subversion = pkgs.subversion.override { httpServer = true; inherit apacheHttpd; };


### PR DESCRIPTION
###### Motivation for this change

I was asked to do this for @niteoweb and we figured we would contribute back the effort as well.

###### Things done
- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
  (I think.)
