### PR TITLE
python.pkgs.protobuf: Fix cpp backend

### DIFF
--- a/pkgs/development/python-modules/protobuf/default.nix
+++ b/pkgs/development/python-modules/protobuf/default.nix
@@ -42,7 +42,9 @@ buildPythonPackage {
   setupPyGlobalFlags = lib.optional (lib.versionAtLeast protobuf.version "2.6.0")
     "--cpp_implementation";
 
-  pythonImportsCheck = lib.optionals (lib.versionAtLeast protobuf.version "2.6.0") [
+  pythonImportsCheck = [
+    "google.protobuf"
+  ] ++ lib.optionals (lib.versionAtLeast protobuf.version "2.6.0") [
     "google.protobuf.internal._api_implementation" # Verify that --cpp_implementation worked
   ];
 

--- a/pkgs/development/python-modules/protobuf/default.nix
+++ b/pkgs/development/python-modules/protobuf/default.nix
@@ -39,27 +39,12 @@ buildPythonPackage {
     cd python
   '';
 
-  preConfigure = lib.optionalString (lib.versionAtLeast protobuf.version "2.6.0") ''
-    export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=cpp
-    export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION_VERSION=2
-  '';
+  setupPyGlobalFlags = lib.optional (lib.versionAtLeast protobuf.version "2.6.0")
+    "--cpp_implementation";
 
-  preBuild = ''
-    # Workaround for https://github.com/google/protobuf/issues/2895
-    ${python.pythonForBuild.interpreter} setup.py build
-  '' + lib.optionalString (lib.versionAtLeast protobuf.version "2.6.0") ''
-    ${python.pythonForBuild.interpreter} setup.py build_ext --cpp_implementation
-  '';
-
-  installFlags = lib.optional (lib.versionAtLeast protobuf.version "2.6.0")
-    "--install-option='--cpp_implementation'";
-
-  # the _message.so isn't installed, so we'll do that manually.
-  # if someone can figure out a less hacky way to get the _message.so to
-  # install, please do replace this.
-  postInstall = lib.optionalString (lib.versionAtLeast protobuf.version "2.6.0") ''
-    cp -v $(find build -name "_message*") $out/${python.sitePackages}/google/protobuf/pyext
-  '';
+  pythonImportsCheck = lib.optionals (lib.versionAtLeast protobuf.version "2.6.0") [
+    "google.protobuf.internal._api_implementation" # Verify that --cpp_implementation worked
+  ];
 
   meta = with lib; {
     description = "Protocol Buffers are Google's data interchange format";

--- a/pkgs/development/python-modules/protobuf/default.nix
+++ b/pkgs/development/python-modules/protobuf/default.nix
@@ -52,6 +52,7 @@ buildPythonPackage {
     description = "Protocol Buffers are Google's data interchange format";
     homepage = "https://developers.google.com/protocol-buffers/";
     license = licenses.bsd3;
+    maintainers = with maintainers; [ knedlsepp ];
   };
 
   passthru.protobuf = protobuf;

--- a/pkgs/development/python-modules/protobuf/default.nix
+++ b/pkgs/development/python-modules/protobuf/default.nix
@@ -18,8 +18,6 @@ buildPythonPackage {
   inherit disabled;
   doCheck = doCheck && !isPy27; # setuptools>=41.4 no longer collects correctly on python2
 
-  outputs = [ "out" "dev" ];
-
   propagatedBuildInputs = [ six ] ++ lib.optionals isPy27 [ google-apputils ];
   propagatedNativeBuildInputs = [ buildPackages.protobuf ]; # For protoc.
   nativeBuildInputs = [ pyext ] ++ lib.optionals isPy27 [ google-apputils ];


### PR DESCRIPTION
###### Motivation for this change
This fixes the python-protobuf C++ backend which is way faster than the python backend.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
