### PR TITLE
sweet: 2.0 -> 3.0

### DIFF
--- a/pkgs/data/themes/sweet/default.nix
+++ b/pkgs/data/themes/sweet/default.nix
@@ -1,31 +1,33 @@
-{ lib, stdenv, fetchurl, gtk-engine-murrine }:
+{ lib, stdenv, fetchurl, unzip, gtk-engine-murrine }:
 
 stdenv.mkDerivation rec {
   pname = "sweet";
-  version = "2.0";
+  version = "3.0";
 
   srcs = [
     (fetchurl {
-      url = "https://github.com/EliverLara/Sweet/releases/download/${version}/Sweet-Ambar-Blue.tar.xz";
-      sha256 = "028pk07im7pab8a2vh3bvjm8jg37dpvn4c1mwn6vhb6wcr9v5c75";
+      url = "https://github.com/EliverLara/Sweet/releases/download/v${version}/Sweet-Ambar-Blue.zip";
+      sha256 = "sha256-6ZrjH5L7Yox7riR+2I7vVbFoG4k7xHGyOq1OnkllyiY";
     })
     (fetchurl {
-      url = "https://github.com/EliverLara/Sweet/releases/download/${version}/Sweet-Ambar.tar.xz";
-      sha256 = "0zmdmqndj65kr43g3z57blrmv0y856zlfprm6y45zbf4xz3ybkg6";
+      url = "https://github.com/EliverLara/Sweet/releases/download/v${version}/Sweet-Ambar.zip";
+      sha256 = "sha256-FAbf682YJCCt8NKSdFoaFLwxLDU1aCcTgNdlybZtPMo=";
     })
     (fetchurl {
-      url = "https://github.com/EliverLara/Sweet/releases/download/${version}/Sweet-Dark.tar.xz";
-      sha256 = "02sw664fkrfpsygspq8fn4zgk8rxs9rd29nnx6nyvkji68mb51s6";
+      url = "https://github.com/EliverLara/Sweet/releases/download/v${version}/Sweet-Dark.zip";
+      sha256 = "sha256-t6fczOnKwi4B9hSFhHQaQ533o7MFL+7HPtUJ/p2CIXM=";
     })
     (fetchurl {
-      url = "https://github.com/EliverLara/Sweet/releases/download/${version}/Sweet-mars.tar.xz";
-      sha256 = "14rl3il61jyqwiqlpgbh397q3rcs7jcf2pvr2763ar5a9czmy8h6";
+      url = "https://github.com/EliverLara/Sweet/releases/download/v${version}/Sweet-mars.zip";
+      sha256 = "sha256-QGkkpUqkxGPM1DXrvToB3taajk7vK3rqibQF2M4N9i0=";
     })
     (fetchurl {
-      url = "https://github.com/EliverLara/Sweet/releases/download/${version}/Sweet.tar.xz";
-      sha256 = "0rza3yxwj256ibqimymjhd6lpjzr7fkhggq0ijdg1wab3q91x66q";
+      url = "https://github.com/EliverLara/Sweet/releases/download/v${version}/Sweet.zip";
+      sha256 = "sha256-1qVC2n7ypN1BFuSzBpbY7QzJUzF1anYNAVcMkNpGTMM";
     })
   ];
+
+  nativeBuildInputs = [ unzip ];
 
   propagatedUserEnvPkgs = [ gtk-engine-murrine ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to version [3.0](https://github.com/EliverLara/Sweet/releases/tag/v3.0)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
