### PR TITLE
obelisk: 0.5.2 → 0.6.0

### DIFF
--- a/pkgs/development/tools/ocaml/obelisk/default.nix
+++ b/pkgs/development/tools/ocaml/obelisk/default.nix
@@ -1,12 +1,14 @@
-{ lib, fetchurl, ocamlPackages }:
+{ lib, fetchFromGitHub, ocamlPackages }:
 
 ocamlPackages.buildDunePackage rec {
   pname = "obelisk";
-  version = "0.5.2";
+  version = "0.6.0";
   useDune2 = true;
-  src = fetchurl {
-    url = "https://github.com/Lelio-Brun/Obelisk/releases/download/v${version}/obelisk-v${version}.tbz";
-    sha256 = "0s86gkypyrkrp83xnay258ijri3yjwj3marsjnjf8mz58z0zd9g6";
+  src = fetchFromGitHub {
+    owner = "Lelio-Brun";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1jjaqa2b7msl9qd3x7j34vdh1s9alq8hbvzk8a5srb4yyfyim15b";
   };
 
   buildInputs = with ocamlPackages; [ menhir re ];


### PR DESCRIPTION
###### Motivation for this change

Improvements: https://github.com/Lelio-Brun/Obelisk/releases/tag/v0.6.0

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
