### PR TITLE
bikeshed: init at 3.3.2 & its dependencies

### DIFF
--- a/pkgs/applications/misc/bikeshed/default.nix
+++ b/pkgs/applications/misc/bikeshed/default.nix
@@ -1,0 +1,77 @@
+{ lib
+, buildPythonApplication
+, fetchPypi
+# build inputs
+, aiofiles
+, aiohttp
+, attrs
+, certifi
+, cssselect
+, html5lib
+, isodate
+, json-home-client
+, lxml
+, pillow
+, pygments
+, requests
+, result
+, setuptools
+, tenacity
+, widlparser
+}:
+
+buildPythonApplication rec {
+  pname = "bikeshed";
+  version = "3.4.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-vJW4yNbKCZraJ5vx8FheNsBl+zObGoLFgAVqoU0p9QQ=";
+  };
+
+  # Relax requirements from "==" to ">="
+  # https://github.com/tabatkins/bikeshed/issues/2178
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "==" ">="
+  '';
+
+  propagatedBuildInputs = [
+    aiofiles
+    aiohttp
+    attrs
+    certifi
+    cssselect
+    html5lib
+    isodate
+    json-home-client
+    lxml
+    pillow
+    pygments
+    requests
+    result
+    setuptools
+    tenacity
+    widlparser
+  ];
+
+  checkPhase = ''
+    $out/bin/bikeshed test
+  '';
+
+  pythonImportsCheck = [ "bikeshed" ];
+
+  meta = with lib; {
+    description = "Preprocessor for anyone writing specifications that converts source files into actual specs";
+    longDescription = ''
+      Bikeshed is a pre-processor for spec documents, turning a source document
+      (containing only the actual spec content, plus several shorthands for linking
+      to terms and other things) into a final spec document, with appropriate boilerplate,
+      bibliography, indexes, etc all filled in. It's used on specs for CSS
+      and many other W3C working groups, WHATWG, the C++ standards committee, and elsewhere!
+    '';
+    homepage = "https://tabatkins.github.io/bikeshed/";
+    license = licenses.cc0;
+    maintainers = [ maintainers.kvark ];
+  };
+}

--- a/pkgs/development/python-modules/json-home-client/default.nix
+++ b/pkgs/development/python-modules/json-home-client/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+# build inputs
+, typing-extensions
+, uri-template
+}:
+
+buildPythonPackage rec {
+  pname = "json-home-client";
+  version = "1.1.1";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "plinss";
+    repo = "json_home_client";
+    rev = "v${version}";
+    sha256 = "sha256-DhnvvY1nMe1sdRE+OgjBt4TsLmiqnD8If4rl700zW9E=";
+  };
+
+  postPatch = ''
+    sed -i -e 's/0.0.0/${version}/' setup.py
+  '';
+
+  propagatedBuildInputs = [
+    typing-extensions
+    uri-template
+  ];
+
+  pythonImportsCheck = [ "json_home_client" ];
+
+  meta = with lib; {
+    description = "Client class for calling http+json APIs in Python";
+    homepage = "https://github.com/plinss/json_home_client";
+    license = licenses.mit;
+    maintainers = [ maintainers.kvark ];
+  };
+}

--- a/pkgs/development/python-modules/result/default.nix
+++ b/pkgs/development/python-modules/result/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "result";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "rustedpy";
+    repo = "result";
+     rev = "v${version}";
+    sha256 = "sha256-bEf3OJg6ksDvzZE7ezA58Q2FObb5V7BG8vkKtX284Jg=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace '"--flake8",' "" \
+      --replace '"--tb=short",' "" \
+      --replace '"--cov=result",' "" \
+      --replace '"--cov=tests",' "" \
+      --replace '"--cov-report=term",' "" \
+      --replace '"--cov-report=xml",' ""
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    #TODO: figure out the failure "match o:" Invalid Syntax
+    "tests/test_pattern_matching.py"
+  ];
+
+  pythonImportsCheck = [ "result" ];
+
+  meta = with lib; {
+    description = "A simple Result type for Python 3 inspired by Rust, fully type annotated";
+    homepage = "https://github.com/rustedpy/result";
+    license = licenses.mit;
+    maintainers = [ maintainers.kvark ];
+  };
+}

--- a/pkgs/development/python-modules/uri-template/default.nix
+++ b/pkgs/development/python-modules/uri-template/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildPythonPackage, fetchFromGitHub, python }:
+
+buildPythonPackage rec {
+  pname = "uri-template";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "plinss";
+    repo = "uri_template";
+    rev = "v${version}";
+    sha256 = "sha256-IAq6GpEwimq45FU0QugLZLSOhwAmC1KbpZKD0zyxsUs=";
+  };
+
+  postPatch = ''
+    sed -i -e 's/0.0.0/${version}/' setup.py
+  '';
+
+  checkPhase = ''
+    ${python.interpreter} test.py
+  '';
+
+  pythonImportsCheck = [ "uri_template" ];
+
+  meta = with lib; {
+    description = "An implementation of RFC 6570 URI Templates";
+    homepage = "https://github.com/plinss/uri_template/";
+    license = licenses.mit;
+    maintainers = [ maintainers.kvark ];
+  };
+}

--- a/pkgs/development/python-modules/widlparser/default.nix
+++ b/pkgs/development/python-modules/widlparser/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+# build inputs
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "widlparser";
+  version = "1.0.12";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "plinss";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-T17fDWYd1naza/ao7kXWGcRIl2fzL1/Z9SaJiutZzqk=";
+  };
+
+  postPatch = ''
+    sed -i -e 's/0.0.0/${version}/' setup.py
+  '';
+
+  propagatedBuildInputs = [
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [ "widlparser" ];
+
+  meta = with lib; {
+    description = "Stand-alone WebIDL Parser in Python";
+    homepage = "https://github.com/plinss/widlparser";
+    license = licenses.mit;
+    maintainers = [ maintainers.kvark ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1071,6 +1071,8 @@ with pkgs;
 
   cf-vault = callPackage ../tools/admin/cf-vault { };
 
+  bikeshed = python3Packages.callPackage ../applications/misc/bikeshed { };
+
   cope = callPackage ../tools/misc/cope { };
 
   ejson2env = callPackage ../tools/admin/ejson2env { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8823,6 +8823,8 @@ in {
 
   restview = callPackage ../development/python-modules/restview { };
 
+  result = callPackage ../development/python-modules/result { };
+
   rethinkdb = callPackage ../development/python-modules/rethinkdb { };
 
   retry = callPackage ../development/python-modules/retry { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10459,6 +10459,8 @@ in {
 
   uritemplate = callPackage ../development/python-modules/uritemplate { };
 
+  uri-template = callPackage ../development/python-modules/uri-template { };
+
   uritools = callPackage ../development/python-modules/uritools { };
 
   url-normalize = callPackage ../development/python-modules/url-normalize { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10753,6 +10753,8 @@ in {
 
   widgetsnbextension = callPackage ../development/python-modules/widgetsnbextension { };
 
+  widlparser = callPackage ../development/python-modules/widlparser { };
+
   wiffi = callPackage ../development/python-modules/wiffi { };
 
   willow = callPackage ../development/python-modules/willow { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4335,6 +4335,8 @@ in {
 
   jsonmerge = callPackage ../development/python-modules/jsonmerge { };
 
+  json-home-client = callPackage ../development/python-modules/json-home-client { };
+
   json-merge-patch = callPackage ../development/python-modules/json-merge-patch { };
 
   json-schema-for-humans = callPackage ../development/python-modules/json-schema-for-humans { };


### PR DESCRIPTION
###### Motivation for this change

Bikeshed is needed to work on W3C specifications.
https://tabatkins.github.io/bikeshed/

I had to do some `sed`ding to work around https://github.com/plinss/widlparser/blob/807b3db92210026baefaf5c9696d107ef3de183a/setup.py#L10
Perhaps, there is an easier way known to Python package maintainers?

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
