### PR TITLE
gnome update

### DIFF
--- a/pkgs/applications/editors/gnome-builder/default.nix
+++ b/pkgs/applications/editors/gnome-builder/default.nix
@@ -39,13 +39,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-builder";
-  version = "41.1";
+  version = "41.2";
 
   outputs = [ "out" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "XVXkqqKkdYpGJj0cf9AJyz20RV4O1/nkTDoWNIYfo4o=";
+    sha256 = "VjF7Vn94Yd2gNzKVsk6U7fSRnMlV+0XtYqyllGIY4BI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome/apps/cheese/default.nix
+++ b/pkgs/desktops/gnome/apps/cheese/default.nix
@@ -34,13 +34,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cheese";
-  version = "41.0";
+  version = "41.1";
 
   outputs = [ "out" "man" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/cheese/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "EG8d9n4c9Bwqp5yZveZ2rskA2wNstSX6EIObBhh9Ivk=";
+    sha256 = "UilgyihzD/ZkOQcLBEGMngpLtVVg11v+CLIY2ixn5Uc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome/core/evince/default.nix
+++ b/pkgs/desktops/gnome/core/evince/default.nix
@@ -46,13 +46,13 @@
 
 stdenv.mkDerivation rec {
   pname = "evince";
-  version = "41.2";
+  version = "41.3";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/evince/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "lautDW/urJVg2zq4C6fF6rsf3xyg47PJMzmvBUU6JNg=";
+    sha256 = "M0awH5vcjy1f/qkvEQoJDGSjYklCtbVDqtRZKp3jO7A=";
   };
 
   patches = lib.optionals withPantheon [

--- a/pkgs/desktops/gnome/core/gnome-screenshot/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-screenshot/default.nix
@@ -4,13 +4,13 @@
 
 let
   pname = "gnome-screenshot";
-  version = "40.0";
+  version = "41.0";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${name}.tar.xz";
-    sha256 = "1qm544ymwibk31s30k47vnn79xg30m18r7l4di0c57g375dak31n";
+    sha256 = "Stt97JJkKPdCY9V5ZnPPFC5HILbnaPVGio0JM/mMlZc=";
   };
 
   doCheck = true;

--- a/pkgs/desktops/gnome/misc/gnome-flashback/default.nix
+++ b/pkgs/desktops/gnome/misc/gnome-flashback/default.nix
@@ -30,7 +30,7 @@
 }:
 let
   pname = "gnome-flashback";
-  version = "3.40.0";
+  version = "3.42.0";
 
   # From data/sessions/Makefile.am
   requiredComponentsCommon = enableGnomePanel:
@@ -61,7 +61,7 @@ let
 
     src = fetchurl {
       url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${name}.tar.xz";
-      sha256 = "0fxv13m2q9z1q3i9jbggl35cb7jlckbdrfsr5sf030hr1w836gz0";
+      sha256 = "1CcdwHrHOyceS07cgfMfZPVzGqbUSOehXX2TOXbc3Us=";
     };
 
     # make .desktop Execs absolute

--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -216,6 +216,7 @@ stdenv.mkDerivation rec {
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "gtk";
+      versionPolicy = "odd-unstable";
       attrPath = "gtk4";
     };
   };

--- a/pkgs/tools/admin/gtk-vnc/default.nix
+++ b/pkgs/tools/admin/gtk-vnc/default.nix
@@ -15,6 +15,7 @@
 , vala
 , gettext
 , perl
+, python3
 , gnome
 , gdk-pixbuf
 , zlib
@@ -22,13 +23,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gtk-vnc";
-  version = "1.2.0";
+  version = "1.3.0";
 
   outputs = [ "out" "bin" "man" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0jmr6igyzcj2wmx5v5ywaazvdz3hx6a6rys26yb4l4s71l281bvs";
+    sha256 = "X6qlgjuMvowLC6HkVsTnDEsa5mhcn+gaQoLZjPAKIR0=";
   };
 
   nativeBuildInputs = [
@@ -39,6 +40,7 @@ stdenv.mkDerivation rec {
     vala
     gettext
     perl # for pod2man
+    python3
   ];
 
   buildInputs = [

--- a/pkgs/tools/networking/gupnp-tools/default.nix
+++ b/pkgs/tools/networking/gupnp-tools/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchurl
-, fetchpatch
 , meson
 , ninja
 , gupnp
@@ -18,25 +17,12 @@
 
 stdenv.mkDerivation rec {
   pname = "gupnp-tools";
-  version = "0.10.1";
+  version = "0.10.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "TqltFnRis6VI78T8TqCJ/lGNfSm+NJ0czomCuf+1O0o=";
+    sha256 = "beSe9LN1uKFk90t2YWixGE4NKBlrawek9TQfCN/YXWw=";
   };
-
-  patches = [
-    # Fix compilation with -Werror=format-security.
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gupnp-tools/commit/d738baae3bffaf6a8dfc12f5fe1ea13168fe2e48.patch";
-      sha256 = "wrORH4y9Yb0YGAsjzoeN2MM07y9o+91kx078RH0G76w=";
-    })
-    # Fix missing variable reference caused by the previous patch.
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gupnp-tools/commit/9b852d91175bc7607ad845459ba29d07a16fcbce.patch";
-      sha256 = "WjEBN/+snJSIg4SUP5iChdj2auIyzePI0TH3Ilks7fk=";
-    })
-  ];
 
   nativeBuildInputs = [
     meson


### PR DESCRIPTION
- gnome.cheese: 41.0 → 41.1
- evince: 41.2 → 41.3
- gnome.gnome-flashback: 3.40.0 → 3.42.0
- gnome.gnome-screenshot: 40.0 → 41.0
- gtk-vnc: 1.2.0 → 1.3.0
- gnome-builder: 41.1 → 41.2
- gupnp-tools: 0.10.1 → 0.10.2
- libhandy: 1.4.0 → 1.5.0
- gtk4.updateScript: correct policy

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
