### PR TITLE
pympress: 1.6.3 -> 1.7.0

### DIFF
--- a/pkgs/applications/office/pympress/default.nix
+++ b/pkgs/applications/office/pympress/default.nix
@@ -1,6 +1,5 @@
 { lib
 , stdenv
-, fetchpatch
 , python3Packages
 , wrapGAppsHook
 , gtk3
@@ -13,21 +12,12 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "pympress";
-  version = "1.6.3";
+  version = "1.7.0";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "sha256-f+OjE0x/3yfJYHCLB+on7TT7MJ2vNu87SHRi67qFDCM=";
+    sha256 = "sha256-AxH0PyAWYEEIqQAx9gG2eYyXMijLZGZqXkRhld32ieE=";
   };
-
-  patches = [
-    # Should not be needed once v1.6.4 is released
-    (fetchpatch {
-      name = "fix-setuptools-version-parsing.patch";
-      url = "https://github.com/Cimbali/pympress/commit/474514d71396ac065e210fd846e07ed1139602d0.diff";
-      sha256 = "sha256-eiw54sjMrXrNrhtkAXxiSTatzoA0NDA03L+HpTDax58=";
-    })
-  ];
 
   nativeBuildInputs = [
     wrapGAppsHook


### PR DESCRIPTION
#### Motivation for this change

https://github.com/Cimbali/pympress/releases/tag/v1.7.0

#### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin (with overlay for broken `watchdog`)
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
