### PR TITLE
nixops: fix dependencies

### DIFF
--- a/pkgs/development/python-modules/construct/2.10.54.nix
+++ b/pkgs/development/python-modules/construct/2.10.54.nix
@@ -14,9 +14,20 @@ buildPythonPackage rec {
     sha256 = "1mqspsn6bf3ibvih1zna2glkg8iw7vy5zg9gzg0d1m8zcndk2c48";
   };
 
-  checkInputs = [ pytestCheckHook pytest-benchmark enum34 numpy arrow ruamel-yaml ];
+  checkInputs = [ pytestCheckHook pytest-benchmark enum34 numpy ];
 
-  disabledTests = lib.optionals stdenv.isDarwin [ "test_multiprocessing" ];
+  # these have dependencies that are broken on Python 2
+  disabledTestPaths = [
+    "tests/gallery/test_gallery.py"
+    "tests/test_benchmarks.py"
+    "tests/test_compiler.py"
+  ];
+
+  disabledTests = [
+    "test_timestamp"
+  ] ++ lib.optionals stdenv.isDarwin [
+    "test_multiprocessing"
+  ];
 
   pytestFlagsArray = [ "--benchmark-disable" ];
 

--- a/pkgs/development/python-modules/html5lib/default.nix
+++ b/pkgs/development/python-modules/html5lib/default.nix
@@ -1,12 +1,11 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, flake8
-, pytest_4
-, pytest-expect
-, mock
 , six
 , webencodings
+, mock
+, pytest-expect
+, pytestCheckHook_5
 }:
 
 buildPythonPackage rec {
@@ -18,17 +17,16 @@ buildPythonPackage rec {
     sha256 = "b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f";
   };
 
-  checkInputs = [ flake8 pytest_4 pytest-expect mock ];
   propagatedBuildInputs = [
-    six webencodings
+    six
+    webencodings
   ];
 
-  checkPhase = ''
-    # remove test causing error
-    # https://github.com/html5lib/html5lib-python/issues/411
-    rm html5lib/tests/test_stream.py
-    py.test
-  '';
+  checkInputs = [
+    mock
+    pytest-expect
+    pytestCheckHook_5
+  ];
 
   meta = {
     homepage = "https://github.com/html5lib/html5lib-python";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -137,6 +137,11 @@ in {
   # it should not override the version of pytest that is used for say
   # Python 2. This is an ugly hack that is needed now because the hook
   # propagates the package.
+  pytestCheckHook_5 = if isPy3k then
+    self.pytestCheckHook.override { pytest = self.pytest_5; }
+  else
+    self.pytestCheckHook;
+
   pytestCheckHook_6_1 = if isPy3k then
     self.pytestCheckHook.override { pytest = self.pytest_6_1; }
   else


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
fixes https://github.com/NixOS/nixpkgs/issues/147034
#144627 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
