### PR TITLE
libredirect: implement port-remapping

### DIFF
--- a/pkgs/build-support/libredirect/default.nix
+++ b/pkgs/build-support/libredirect/default.nix
@@ -6,7 +6,8 @@ stdenv.mkDerivation rec {
 
   unpackPhase = ''
     cp ${./libredirect.c} libredirect.c
-    cp ${./test.c} test.c
+    cp ${./test-files.c} test-files.c
+    cp ${./test-sockets.c} test-sockets.c
   '';
 
   libName = "libredirect" + stdenv.targetPlatform.extensions.sharedLibrary;
@@ -22,7 +23,8 @@ stdenv.mkDerivation rec {
       libredirect.c
 
     if [ -n "$doInstallCheck" ]; then
-      $CC -Wall -std=c99 -O3 test.c -o test
+      $CC -Wall -std=c99 -O3 test-files.c -o test-files
+      $CC -Wall -std=c99 -O3 test-sockets.c -o test-sockets
     fi
 
     runHook postBuild
@@ -56,7 +58,12 @@ stdenv.mkDerivation rec {
   installCheckPhase = ''
     (
       source "$hook/nix-support/setup-hook"
-      NIX_REDIRECTS="/foo/bar/test=${coreutils}/bin/true" ./test
+      NIX_REDIRECTS="/foo/bar/test=${coreutils}/bin/true" ./test-files
+
+      ./test-sockets occupy-ports &
+      OCCUPY_PID="$!"
+      NIX_PORT_REMAP_SEED="$RANDOM" ./test-sockets
+      kill $OCCUPY_PID
     )
   '';
 

--- a/pkgs/build-support/libredirect/libredirect.c
+++ b/pkgs/build-support/libredirect/libredirect.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <dlfcn.h>
+#include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -11,8 +12,10 @@
 #include <string.h>
 #include <spawn.h>
 #include <dirent.h>
+#include <netinet/in.h>
 
 #define MAX_REDIRECTS 128
+#define RESERVED_PORT_MAX 1023
 
 #ifdef __APPLE__
   struct dyld_interpose {
@@ -33,23 +36,14 @@
 static int nrRedirects = 0;
 static char * from[MAX_REDIRECTS];
 static char * to[MAX_REDIRECTS];
+static int portRemapSeed = -1;
 
 static int isInitialized = 0;
 
-// FIXME: might run too late.
-static void init() __attribute__((constructor));
-
-static void init()
+static void init_redirects()
 {
-    if (isInitialized) return;
-
     char * spec = getenv("NIX_REDIRECTS");
     if (!spec) return;
-
-    // Ensure we only run this code once.
-    // We do not do `unsetenv("NIX_REDIRECTS")` to ensure that redirects
-    // also get initialized for subprocesses.
-    isInitialized = 1;
 
     char * spec2 = malloc(strlen(spec) + 1);
     strcpy(spec2, spec);
@@ -67,7 +61,40 @@ static void init()
         *end = 0;
         pos = end + 1;
     }
+}
 
+static void init_port_remapping()
+{
+    char * seed_str = getenv("NIX_PORT_REMAP_SEED");
+    if (!seed_str) return;
+    // also perform no remapping if var is set but empty
+    if (seed_str[0] == '\0') return;
+
+    const uint32_t FNV_offset_basis = 0x811c9dc5;
+    const uint32_t FNV_prime = 0x01000193;
+
+    uint32_t seed = FNV_offset_basis;
+    for (int i=0; seed_str[i] != '\0'; i++) {
+        seed ^= seed_str[i];
+        seed *= FNV_prime;
+    }
+
+    portRemapSeed = (seed ^ (seed>>16)) % (USHRT_MAX - RESERVED_PORT_MAX);
+}
+
+// FIXME: might run too late.
+static void init() __attribute__((constructor));
+
+static void init()
+{
+    if (isInitialized) return;
+    // Ensure we only run this code once.
+    // We do not do `unsetenv("NIX_REDIRECTS")` to ensure that redirects
+    // also get initialized for subprocesses.
+    isInitialized = 1;
+
+    init_redirects();
+    init_port_remapping();
 }
 
 static const char * rewrite(const char * path, char * buf)
@@ -352,3 +379,226 @@ WRAPPER(int, mkdirat)(int dirfd, const char *path, mode_t mode)
     return mkdirat_real(dirfd, rewrite(path, buf), mode);
 }
 WRAPPER_DEF(mkdirat)
+
+// without this trick we aren't able to subtract past zero properly
+static uint16_t positive_modulo(int32_t v, uint16_t m) {
+    int32_t mod = v % m;
+    if (mod < 0) {
+        mod += m;
+    }
+    return (uint16_t)mod;
+}
+
+static in_port_t port_internal_to_external(in_port_t internal) {
+    if (ntohs(internal) <= RESERVED_PORT_MAX) {
+        return internal;
+    }
+
+    return htons(
+        RESERVED_PORT_MAX + positive_modulo(
+            ((((int32_t)ntohs(internal)) - RESERVED_PORT_MAX) + portRemapSeed),
+            USHRT_MAX - RESERVED_PORT_MAX
+        )
+    );
+}
+
+static in_port_t port_external_to_internal(in_port_t external) {
+    if (ntohs(external) <= RESERVED_PORT_MAX) {
+        return external;
+    }
+
+    return htons(
+        RESERVED_PORT_MAX + positive_modulo(
+            ((((int32_t)ntohs(external)) - RESERVED_PORT_MAX) - portRemapSeed),
+            USHRT_MAX - RESERVED_PORT_MAX
+        )
+    );
+}
+
+
+WRAPPER(int, bind)(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
+{
+    int (*bind_real) (
+        int sockfd,
+        const struct sockaddr *addr,
+        socklen_t addrlen
+    ) = LOOKUP_REAL(bind);
+
+    struct sockaddr_in addr_in_new;
+
+    if (portRemapSeed >= 0 && addr != NULL && addr->sa_family == AF_INET) {
+        memcpy(&addr_in_new, addr, sizeof addr_in_new);
+        addr_in_new.sin_port = port_internal_to_external(addr_in_new.sin_port);
+        addr = (struct sockaddr *)&addr_in_new;
+    }
+
+    return bind_real(sockfd, addr, addrlen);
+}
+WRAPPER_DEF(bind)
+
+WRAPPER(int, connect)(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
+{
+    int (*connect_real) (
+        int sockfd,
+        const struct sockaddr *addr,
+        socklen_t addrlen
+    ) = LOOKUP_REAL(connect);
+
+    struct sockaddr_in addr_in_new;
+
+    if (portRemapSeed >= 0 && addr != NULL && addr->sa_family == AF_INET) {
+        memcpy(&addr_in_new, addr, sizeof addr_in_new);
+        addr_in_new.sin_port = port_internal_to_external(addr_in_new.sin_port);
+        addr = (struct sockaddr *)&addr_in_new;
+    }
+
+    return connect_real(sockfd, addr, addrlen);
+}
+WRAPPER_DEF(connect)
+
+WRAPPER(int, accept)(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
+{
+    int (*accept_real) (
+        int sockfd,
+        struct sockaddr *addr,
+        socklen_t *addrlen
+    ) = LOOKUP_REAL(accept);
+
+    int retval = accept_real(sockfd, addr, addrlen);
+
+    if (portRemapSeed >= 0 && addr != NULL && addr->sa_family == AF_INET) {
+        struct sockaddr_in *addr_in = (struct sockaddr_in *)addr;
+        addr_in->sin_port = port_external_to_internal(addr_in->sin_port);
+    }
+
+    return retval;
+}
+WRAPPER_DEF(accept)
+
+WRAPPER(ssize_t, recvfrom)(
+    int sockfd,
+    void *buf,
+    size_t len,
+    int flags,
+    struct sockaddr *src_addr,
+    socklen_t *addrlen
+) {
+    ssize_t (*recvfrom_real) (
+        int sockfd,
+        void *buf,
+        size_t len,
+        int flags,
+        struct sockaddr *src_addr,
+        socklen_t *addrlen
+    ) = LOOKUP_REAL(recvfrom);
+
+    ssize_t retval = recvfrom_real(sockfd, buf, len, flags, src_addr, addrlen);
+
+    if (portRemapSeed >= 0 && src_addr != NULL && src_addr->sa_family == AF_INET) {
+        struct sockaddr_in *src_addr_in = (struct sockaddr_in *)src_addr;
+        src_addr_in->sin_port = port_external_to_internal(src_addr_in->sin_port);
+    }
+
+    return retval;
+}
+WRAPPER_DEF(recvfrom)
+
+WRAPPER(ssize_t, recvmsg)(int sockfd, struct msghdr *msg, int flags)
+{
+    ssize_t (*recvmsg_real) (
+        int sockfd,
+        struct msghdr *msg,
+        int flags
+    ) = LOOKUP_REAL(recvmsg);
+
+    ssize_t retval = recvmsg_real(sockfd, msg, flags);
+
+    if (
+        portRemapSeed >= 0
+        && msg != NULL
+        && msg->msg_name != NULL
+        && ((struct sockaddr*)msg->msg_name)->sa_family == AF_INET
+    ) {
+        struct sockaddr_in *addr_in = (struct sockaddr_in *)msg->msg_name;
+        addr_in->sin_port = port_external_to_internal(addr_in->sin_port);
+    }
+
+    return retval;
+}
+WRAPPER_DEF(recvmsg)
+
+WRAPPER(ssize_t, sendto)(
+    int sockfd,
+    const void *buf,
+    size_t len,
+    int flags,
+    const struct sockaddr *dest_addr,
+    socklen_t addrlen
+) {
+    ssize_t (*sendto_real) (
+        int sockfd,
+        const void *buf,
+        size_t len,
+        int flags,
+        const struct sockaddr *dest_addr,
+        socklen_t addrlen
+    ) = LOOKUP_REAL(sendto);
+
+    struct sockaddr_in dest_addr_in_new;
+
+    if (portRemapSeed >= 0 && dest_addr != NULL && dest_addr->sa_family == AF_INET) {
+        memcpy(&dest_addr_in_new, dest_addr, sizeof dest_addr_in_new);
+        dest_addr_in_new.sin_port = port_internal_to_external(dest_addr_in_new.sin_port);
+        dest_addr = (struct sockaddr *)&dest_addr_in_new;
+    }
+
+    return sendto_real(sockfd, buf, len, flags, dest_addr, addrlen);
+}
+WRAPPER_DEF(sendto)
+
+WRAPPER(ssize_t, sendmsg)(int sockfd, const struct msghdr *msg, int flags)
+{
+    ssize_t (*sendmsg_real) (
+        int sockfd,
+        const struct msghdr *msg,
+        int flags
+    ) = LOOKUP_REAL(sendmsg);
+
+    struct msghdr msg_new;
+    struct sockaddr_in msg_name_new;
+
+    if (
+        portRemapSeed >= 0
+        && msg != NULL
+        && msg->msg_name != NULL
+        && ((struct sockaddr*)msg->msg_name)->sa_family == AF_INET
+    ) {
+        memcpy(&msg_new, msg, sizeof msg_new);
+        memcpy(&msg_name_new, msg->msg_name, sizeof msg_name_new);
+        msg_name_new.sin_port = port_internal_to_external(msg_name_new.sin_port);
+        msg_new.msg_name = &msg_name_new;
+        msg = &msg_new;
+    }
+
+    return sendmsg_real(sockfd, msg, flags);
+}
+WRAPPER_DEF(sendmsg)
+
+WRAPPER(int, getsockname)(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
+{
+    int (*getsockname_real) (
+        int sockfd,
+        struct sockaddr *addr,
+        socklen_t *addrlen
+    ) = LOOKUP_REAL(getsockname);
+
+    int retval = getsockname_real(sockfd, addr, addrlen);
+
+    if (portRemapSeed >= 0 && addr != NULL && addr->sa_family == AF_INET) {
+        struct sockaddr_in *addr_in = (struct sockaddr_in *)addr;
+        addr_in->sin_port = port_external_to_internal(addr_in->sin_port);
+    }
+
+    return retval;
+}
+WRAPPER_DEF(getsockname)

--- a/pkgs/build-support/libredirect/test-files.c
+++ b/pkgs/build-support/libredirect/test-files.c
@@ -10,7 +10,7 @@
 #include <sys/wait.h>
 
 #define TESTPATH "/foo/bar/test"
-#define SUBTEST "./test sub"
+#define SUBTEST "./test-files sub"
 
 extern char **environ;
 

--- a/pkgs/build-support/libredirect/test-sockets.c
+++ b/pkgs/build-support/libredirect/test-sockets.c
@@ -1,0 +1,396 @@
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#define SERVER_PORT 4321
+#define CLIENT_PORT 5432
+
+#define PAYLOAD0 "bananas"
+#define PAYLOAD1 "pineapples"
+
+
+// like system(), but non-blocking
+static pid_t system_nonblock(const char* command) {
+    pid_t pid = fork();
+    if (pid)
+        // parent process
+        return pid;
+
+    // child process
+    assert(execl("/bin/sh", "sh", "-c", command, (char *) NULL) != -1);
+    return 0; // not really
+}
+
+
+static void test_tcp(void) {
+    int listen_socket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    assert(listen_socket >= 0);
+
+    //
+    // test bind
+    //
+
+    struct sockaddr_in my_addr;
+    memset(&my_addr, 0, sizeof my_addr);
+    my_addr.sin_family = AF_INET;
+    my_addr.sin_port = htons(SERVER_PORT);
+    my_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    assert(bind(
+        listen_socket,
+        (struct sockaddr *)&my_addr,
+        sizeof my_addr
+    ) == 0);
+    assert(listen(listen_socket, 2) == 0);
+
+    //
+    // test getsockname
+    //
+
+    memset(&my_addr, 0, sizeof my_addr);
+    socklen_t my_addr_len = sizeof my_addr;
+    assert(getsockname(
+        listen_socket,
+        (struct sockaddr *)&my_addr,
+        &my_addr_len
+    ) == 0);
+
+    assert(my_addr_len == sizeof my_addr);
+    assert(my_addr.sin_family == AF_INET);
+    assert(my_addr.sin_port == htons(SERVER_PORT));
+    assert(my_addr.sin_addr.s_addr == htonl(INADDR_LOOPBACK));
+
+    pid_t child_pid = system_nonblock("./test-sockets tcp-client");
+
+    //
+    // test accept
+    //
+
+    struct sockaddr_in incoming_addr;
+    memset(&incoming_addr, 0, sizeof incoming_addr);
+    socklen_t incoming_addr_len = sizeof incoming_addr;
+    int conn_socket = accept(
+        listen_socket,
+        (struct sockaddr *)&incoming_addr,
+        &incoming_addr_len
+    );
+    assert(conn_socket >= 0);
+    assert(incoming_addr_len == sizeof incoming_addr);
+
+    assert(incoming_addr.sin_family == AF_INET);
+    assert(incoming_addr.sin_port == htons(CLIENT_PORT));
+    assert(incoming_addr.sin_addr.s_addr == htonl(INADDR_LOOPBACK));
+
+    //
+    // test recvfrom
+    //
+
+    char in_buffer[16];
+    memset(&in_buffer, 0xff, sizeof in_buffer);
+    memset(&incoming_addr, 0, sizeof incoming_addr);
+    incoming_addr_len = sizeof incoming_addr;
+    assert(recvfrom(
+        conn_socket,
+        &in_buffer,
+        sizeof in_buffer,
+        0,
+        (struct sockaddr *)&incoming_addr,
+        &incoming_addr_len
+    ) == sizeof PAYLOAD0);
+    assert(strncmp(PAYLOAD0, in_buffer, sizeof in_buffer) == 0);
+    assert(incoming_addr_len == 0);
+
+    int wstatus;
+    assert(waitpid(child_pid, &wstatus, 0) != -1);
+    assert(WIFEXITED(wstatus));
+    assert(WEXITSTATUS(wstatus) == 0);
+}
+
+
+static void test_tcp_client(void) {
+    int _socket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    assert(_socket >= 0);
+
+    //
+    // test bind
+    //
+
+    struct sockaddr_in my_addr;
+    memset(&my_addr, 0, sizeof my_addr);
+    my_addr.sin_family = AF_INET;
+    my_addr.sin_port = htons(CLIENT_PORT);
+    my_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    assert(bind(_socket, (struct sockaddr *)&my_addr, sizeof my_addr) == 0);
+
+    //
+    // test connect
+    //
+
+    struct sockaddr_in dest_addr;
+    memset(&dest_addr, 0, sizeof dest_addr);
+    dest_addr.sin_family = AF_INET;
+    dest_addr.sin_port = htons(SERVER_PORT);
+    dest_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    assert(connect(_socket, (struct sockaddr *)&dest_addr, sizeof dest_addr) == 0);
+
+    //
+    // test sendto
+    //
+
+    assert(sendto(
+        _socket,
+        PAYLOAD0,
+        sizeof PAYLOAD0,
+        0,
+        NULL,
+        0
+    ) == sizeof PAYLOAD0);
+
+    //
+    // test getsockname
+    //
+
+    memset(&my_addr, 0, sizeof my_addr);
+    socklen_t my_addr_len = sizeof my_addr;
+    assert(getsockname(
+        _socket,
+        (struct sockaddr *)&my_addr,
+        &my_addr_len
+    ) == 0);
+
+    assert(my_addr_len == sizeof my_addr);
+    assert(my_addr.sin_family == AF_INET);
+    assert(my_addr.sin_port == htons(CLIENT_PORT));
+    assert(my_addr.sin_addr.s_addr == htonl(INADDR_LOOPBACK));
+
+    exit(0);
+}
+
+
+static void test_udp(void) {
+    int _socket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    assert(_socket >= 0);
+
+    //
+    // test bind
+    //
+
+    struct sockaddr_in my_addr;
+    memset(&my_addr, 0, sizeof my_addr);
+    my_addr.sin_family = AF_INET;
+    my_addr.sin_port = htons(SERVER_PORT);
+    my_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    assert(bind(
+        _socket,
+        (struct sockaddr *)&my_addr,
+        sizeof my_addr
+    ) == 0);
+
+    //
+    // test getsockname
+    //
+
+    memset(&my_addr, 0, sizeof my_addr);
+    socklen_t my_addr_len = sizeof my_addr;
+    assert(getsockname(
+        _socket,
+        (struct sockaddr *)&my_addr,
+        &my_addr_len
+    ) == 0);
+
+    assert(my_addr_len == sizeof my_addr);
+    assert(my_addr.sin_family == AF_INET);
+    assert(my_addr.sin_port == htons(SERVER_PORT));
+    assert(my_addr.sin_addr.s_addr == htonl(INADDR_LOOPBACK));
+
+    pid_t child_pid = system_nonblock("./test-sockets udp-client");
+
+    //
+    // test recvfrom
+    //
+
+    struct sockaddr_in incoming_addr;
+    memset(&incoming_addr, 0, sizeof incoming_addr);
+    socklen_t incoming_addr_len = sizeof incoming_addr;
+    char in_buffer[16];
+    memset(&in_buffer, 0xff, sizeof in_buffer);
+    assert(recvfrom(
+        _socket,
+        &in_buffer,
+        sizeof in_buffer,
+        0,
+        (struct sockaddr *)&incoming_addr,
+        &incoming_addr_len
+    ) == sizeof PAYLOAD0);
+    assert(strncmp(PAYLOAD0, in_buffer, sizeof in_buffer) == 0);
+    assert(incoming_addr_len == sizeof incoming_addr);
+
+    assert(incoming_addr.sin_family == AF_INET);
+    assert(incoming_addr.sin_port == htons(CLIENT_PORT));
+    assert(incoming_addr.sin_addr.s_addr == htonl(INADDR_LOOPBACK));
+
+    //
+    // test recvmsg
+    //
+
+    memset(&incoming_addr, 0, sizeof incoming_addr);
+    memset(&in_buffer, 0xff, sizeof in_buffer);
+    struct iovec _iov;
+    memset(&_iov, 0, sizeof _iov);
+    _iov.iov_base = &in_buffer;
+    _iov.iov_len = sizeof in_buffer;
+    struct msghdr _msg;
+    memset(&_msg, 0, sizeof _msg);
+    _msg.msg_name = &incoming_addr;
+    _msg.msg_namelen = sizeof incoming_addr;
+    _msg.msg_iov = &_iov;
+    _msg.msg_iovlen = 1;
+
+    assert(recvmsg(
+        _socket,
+        &_msg,
+        0
+    ) == sizeof PAYLOAD1);
+    assert(strncmp(PAYLOAD1, in_buffer, sizeof in_buffer) == 0);
+    assert(_msg.msg_namelen == sizeof incoming_addr);
+
+    assert(incoming_addr.sin_family == AF_INET);
+    assert(incoming_addr.sin_port == htons(CLIENT_PORT));
+    assert(incoming_addr.sin_addr.s_addr == htonl(INADDR_LOOPBACK));
+
+    int wstatus;
+    assert(waitpid(child_pid, &wstatus, 0) != -1);
+    assert(WIFEXITED(wstatus));
+    assert(WEXITSTATUS(wstatus) == 0);
+}
+
+
+static void test_udp_client(void) {
+    int _socket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    assert(_socket >= 0);
+
+    //
+    // test bind
+    //
+
+    struct sockaddr_in my_addr;
+    memset(&my_addr, 0, sizeof my_addr);
+    my_addr.sin_family = AF_INET;
+    my_addr.sin_port = htons(CLIENT_PORT);
+    my_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    assert(bind(_socket, (struct sockaddr *)&my_addr, sizeof my_addr) == 0);
+
+    //
+    // test sendto
+    //
+
+    struct sockaddr_in dest_addr;
+    memset(&dest_addr, 0, sizeof dest_addr);
+    dest_addr.sin_family = AF_INET;
+    dest_addr.sin_port = htons(SERVER_PORT);
+    dest_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    assert(sendto(
+        _socket,
+        PAYLOAD0,
+        sizeof PAYLOAD0,
+        0,
+        (struct sockaddr *)&dest_addr,
+        sizeof dest_addr
+    ) == sizeof PAYLOAD0);
+
+    //
+    // test getsockname
+    //
+
+    memset(&my_addr, 0, sizeof my_addr);
+    socklen_t my_addr_len = sizeof my_addr;
+    assert(getsockname(
+        _socket,
+        (struct sockaddr *)&my_addr,
+        &my_addr_len
+    ) == 0);
+
+    assert(my_addr_len == sizeof my_addr);
+    assert(my_addr.sin_family == AF_INET);
+    assert(my_addr.sin_port == htons(CLIENT_PORT));
+    assert(my_addr.sin_addr.s_addr == htonl(INADDR_LOOPBACK));
+
+    //
+    // test sendmsg
+    //
+
+    struct iovec _iov;
+    memset(&_iov, 0, sizeof _iov);
+    _iov.iov_base = PAYLOAD1;
+    _iov.iov_len = sizeof PAYLOAD1;
+    struct msghdr _msg;
+    memset(&_msg, 0, sizeof _msg);
+    _msg.msg_name = &dest_addr;
+    _msg.msg_namelen = sizeof dest_addr;
+    _msg.msg_iov = &_iov;
+    _msg.msg_iovlen = 1;
+
+    assert(sendmsg(
+        _socket,
+        &_msg,
+        0
+    ) == sizeof PAYLOAD1);
+
+    exit(0);
+}
+
+
+static void occupy_ports(void) {
+    const int socket_types[] = {SOCK_STREAM, SOCK_STREAM, SOCK_DGRAM, SOCK_DGRAM};
+    const int socket_protocols[] = {IPPROTO_TCP, IPPROTO_TCP, IPPROTO_UDP, IPPROTO_UDP};
+    const int ports[] = {SERVER_PORT, CLIENT_PORT, SERVER_PORT, CLIENT_PORT};
+    int sockets[4];
+
+    struct sockaddr_in my_addr;
+    memset(&my_addr, 0, sizeof my_addr);
+    my_addr.sin_family = AF_INET;
+    my_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+    for (int i=0; i<4; i++) {
+        sockets[i] = socket(AF_INET, socket_types[i], socket_protocols[i]);
+        assert(sockets[i] >= 0);
+
+        my_addr.sin_port = htons(ports[i]);
+        assert(bind(
+            sockets[i],
+            (struct sockaddr *)&my_addr,
+            sizeof my_addr
+        ) == 0);
+        if (socket_types[i] == SOCK_STREAM)
+            assert(listen(sockets[i], 2) == 0);
+    }
+
+    sleep(9999999);
+}
+
+
+int main(int argc, char *argv[]) {
+    if (argc > 1) {
+        if (!strcmp(argv[1], "tcp-client")) {
+            test_tcp_client();
+        }
+        if (!strcmp(argv[1], "udp-client")) {
+            test_udp_client();
+        }
+        if (!strcmp(argv[1], "occupy-ports")) {
+            occupy_ports();
+        }
+        // execution shouldn't have reached here
+        return 7;
+    }
+
+    test_tcp();
+    test_udp();
+
+    return 0;
+}


### PR DESCRIPTION
###### Motivation for this change
This is my proposed approach to address the perennial darwin problem of network port collisions during the check phases of multiple packages built in parallel.

For anyone who hasn't experienced this problem - because darwin lacks network namespaces, tests which exercise network functionality share the same loopback interface, and two build processes attempting to claim the same port at the same time will interfere with each other, leading to unexplained test failures. You'd think this happens extremely rarely, but in fact it happens frequently with python packages as most changes will trigger a rebuild of both the `python38Packages` version and `python39Packages` version at the same time. This causes spurious failures both for reviewers running `nixpkgs-review` and also on hydra when both packages happen to get scheduled onto the same node at the same time.

An example hydra package that's failing right now due to this is `python3Packages.zeroconf` on darwin: https://hydra.nixos.org/build/158208739

This change gives `libredirect` the ability to intercept calls to the socket api and transparently remap the port to another. The remapping is controlled by the environment variable `NIX_PORT_REMAP_SEED`, the idea being that processes sharing the same "seed" value will be able to communicate with one another seamlessly while processes with a different seed value will be able to communicate over the same apparent port to _their_ cooperating processes without anything interfering with each other.

It's intended that builds will set the `NIX_PORT_REMAP_SEED` to e.g. `$RANDOM` in the `preCheck`, thus assigning a unique value for each build. I know that might make some people uncomfortable introducing a possible source of nondeterminism here, but please consider the nondeterminism of the _existing_ situation on darwin.

For the actual permutation of the ports, I was going to do some fancy pseudorandom nonsense, but for now I decided to keep it simple and effectively use the "seed" as an offset.

Ports below `RESERVED_PORT_MAX` are excluded from the scheme - they shouldn't be used by test suites anyway and we don't want to risk remapping an unreserved port to a reserved port and throw failures that way.

~This still needs tests, which I've started but I think I'm going to defer until 21.11 is out as ZHF (#144627) is more pressing right now.~ Done

(why configure using a "seed" and not a literal offset value? after all `$RANDOM` gives you a 15bit integer... well, parsing integers can fail and `libredirect` doesn't have a nice way of handling failures. running a simple FNV hash can't really fail. also it's better not to make any promises to the user over how we're going to do the remapping)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
