### PR TITLE
Fix NixOps 1.7 one last time

### DIFF
--- a/pkgs/development/python-modules/flake8/3.nix
+++ b/pkgs/development/python-modules/flake8/3.nix
@@ -1,0 +1,60 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, configparser
+, enum34
+, mccabe
+, pycodestyle
+, pyflakes
+, functools32
+, typing
+, importlib-metadata
+, mock
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "flake8";
+  version = "3.9.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "pyflakes >= 2.3.0, < 2.4.0" "pyflakes >= 2.3.0, < 2.5.0"
+  '';
+
+  propagatedBuildInputs = [
+    pyflakes
+    pycodestyle
+    mccabe
+  ] ++ lib.optionals (pythonOlder "3.2") [
+    configparser
+    functools32
+  ] ++ lib.optionals (pythonOlder "3.4") [
+    enum34
+  ] ++ lib.optionals (pythonOlder "3.5") [
+    typing
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    importlib-metadata
+  ];
+
+  # Tests fail on Python 3.7 due to importlib using a deprecated interface
+  doCheck = !(pythonOlder "3.8");
+
+  checkInputs = [
+    mock
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Flake8 is a wrapper around pyflakes, pycodestyle and mccabe.";
+    homepage = "https://github.com/pycqa/flake8";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/pycodestyle/2.7.nix
+++ b/pkgs/development/python-modules/pycodestyle/2.7.nix
@@ -1,0 +1,34 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "pycodestyle";
+  version = "2.7.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef";
+  };
+
+  dontUseSetuptoolsCheck = true;
+
+  # https://github.com/PyCQA/pycodestyle/blob/2.5.0/tox.ini#L14
+  checkPhase = ''
+    ${python.interpreter} pycodestyle.py --max-doc-length=72 --testsuite testsuite
+    ${python.interpreter} pycodestyle.py --statistics pycodestyle.py
+    ${python.interpreter} pycodestyle.py --max-doc-length=72 --doctest
+    ${python.interpreter} -m unittest discover testsuite -vv
+  '';
+
+  meta = with lib; {
+    description = "Python style guide checker (formerly called pep8)";
+    homepage = "https://pycodestyle.readthedocs.io";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      kamadorueda
+    ];
+  };
+}

--- a/pkgs/development/python-modules/ruamel-base/2.nix
+++ b/pkgs/development/python-modules/ruamel-base/2.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "ruamel-base";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    pname = "ruamel.base";
+    inherit version;
+    sha256 = "1wswxrn4givsm917mfl39rafgadimf1sldpbjdjws00g1wx36hf0";
+  };
+
+  # no tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Common routines for ruamel packages";
+    homepage = "https://sourceforge.net/projects/ruamel-base/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ SuperSandro2000 ];
+  };
+}

--- a/pkgs/development/python-modules/ruamel-yaml-clib/2.0.nix
+++ b/pkgs/development/python-modules/ruamel-yaml-clib/2.0.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildPythonPackage
+, fetchhg
+, ruamel-base
+, ruamel-ordereddict ? null
+}:
+
+buildPythonPackage rec {
+  pname = "ruamel-yaml-clib";
+  version = "0.2.0";
+
+  src = fetchhg {
+    url = "http://hg.code.sf.net/p/ruamel-yaml-clib/code";
+    rev = version;
+    sha256 = "0kq6zi96qlm72lzj90fc2rfk6nm5kqhk6qxdl8wl9s3a42b0v6wl";
+  };
+
+  # outputs match wheel
+  doCheck = false;
+
+  meta = with lib; {
+    description = "YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order";
+    homepage = "https://sourceforge.net/projects/ruamel-yaml-clib/";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -112,6 +112,8 @@ with self; with super; {
 
   filelock =  callPackage ../development/python-modules/filelock/3.2.nix { };
 
+  flake8 = callPackage ../development/python-modules/flake8/3.nix { };
+
   flask = callPackage ../development/python-modules/flask/1.nix { };
 
   flask_ldap_login = callPackage ../development/python-modules/flask-ldap-login { };

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -539,6 +539,8 @@ with self; with super; {
 
   robotframework-ride = callPackage ../development/python-modules/robotframework-ride { };
 
+  ruamel-base = callPackage ../development/python-modules/ruamel-base/2.nix { };
+
   ruamel-ordereddict = callPackage ../development/python-modules/ruamel-ordereddict { };
 
   ruamel-yaml = callPackage ../development/python-modules/ruamel-yaml/0.16.nix { };

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -436,6 +436,8 @@ with self; with super; {
 
   pycassa = callPackage ../development/python-modules/pycassa { };
 
+  pycodestyle = callPackage ../development/python-modules/pycodestyle/2.7.nix { };
+
   pycryptopp = callPackage ../development/python-modules/pycryptopp { };
 
   pycurl2 = callPackage ../development/python-modules/pycurl2 { };

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -545,6 +545,8 @@ with self; with super; {
 
   ruamel-yaml = callPackage ../development/python-modules/ruamel-yaml/0.16.nix { };
 
+  ruamel-yaml-clib = callPackage ../development/python-modules/ruamel-yaml-clib/2.0.nix { };
+
   runsnakerun = callPackage ../development/python-modules/runsnakerun { };
 
   rpm = disabled super.rpm;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
NixOps 1.7 needs to go. Fixing it up one last time for the release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
