### PR TITLE
prometheus-smartctl-exporter: init at unstable-2020-11-14

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -61,6 +61,7 @@ let
     "rtl_433"
     "script"
     "snmp"
+    "smartctl"
     "smokeping"
     "sql"
     "surfboard"

--- a/nixos/modules/services/monitoring/prometheus/exporters/smartctl.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/smartctl.nix
@@ -1,0 +1,64 @@
+{ config, lib, pkgs, options }:
+
+with lib;
+
+let
+  cfg = config.services.prometheus.exporters.smartctl;
+  format = pkgs.formats.yaml {};
+  configFile = format.generate "smartctl-exporter.yml" {
+    smartctl_exporter = {
+      bind_to = "${cfg.listenAddress}:${toString cfg.port}";
+      url_path = "/metrics";
+      smartctl_location = "${pkgs.smartmontools}/bin/smartctl";
+      collect_not_more_than_period = cfg.maxInterval;
+      devices = cfg.devices;
+    };
+  };
+in {
+  port = 9633;
+
+  extraOpts = {
+    devices = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      example = literalExpression ''
+        [ "/dev/sda", "/dev/nvme0n1" ];
+      '';
+      description = ''
+        Paths to disks that will be monitored.
+      '';
+    };
+    maxInterval = mkOption {
+      type = types.str;
+      default = "60s";
+      example = "2m";
+      description = ''
+        Interval that limits how often a disk can be queried.
+      '';
+    };
+  };
+
+  serviceOpts = {
+    serviceConfig = {
+      AmbientCapabilities = [
+        "CAP_SYS_ADMIN"
+      ];
+      CapabilityBoundingSet = [
+        "CAP_SYS_ADMIN"
+      ];
+      DevicePolicy = "closed";
+      DeviceAllow = lib.mkForce cfg.devices;
+      ExecStart = ''
+        ${pkgs.prometheus-smartctl-exporter}/bin/smartctl_exporter -config ${configFile}
+      '';
+      PrivateDevices = lib.mkForce false;
+      ProtectProc = "invisible";
+      ProcSubset = "pid";
+      SupplementaryGroups = [ "disk" ];
+      SystemCallFilter = [
+        "@system-service"
+        "~@privileged @resources"
+      ];
+    };
+  };
+}

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -1015,6 +1015,25 @@ let
       '';
     };
 
+    smartctl = {
+      exporterConfig = {
+        enable = true;
+        devices = [
+          "/dev/vda"
+        ];
+      };
+      exporterTest = ''
+        wait_for_unit("prometheus-smartctl-exporter.service")
+        wait_for_open_port("9633")
+        wait_until_succeeds(
+          "curl -sSf 'localhost:9633/metrics'"
+        )
+        wait_until_succeeds(
+            'journalctl -eu prometheus-smartctl-exporter.service -o cat | grep "/dev/vda: Unable to detect device type"'
+        )
+      '';
+    };
+
     smokeping = {
       exporterConfig = {
         enable = true;

--- a/pkgs/servers/monitoring/prometheus/smartctl-exporter/0001-Return-the-cached-value-if-it-s-not-time-to-scan-aga.patch
+++ b/pkgs/servers/monitoring/prometheus/smartctl-exporter/0001-Return-the-cached-value-if-it-s-not-time-to-scan-aga.patch
@@ -1,0 +1,51 @@
+From e81b06df67b1d42ef915615fafa0b56ef956673b Mon Sep 17 00:00:00 2001
+From: Andreas Fuchs <asf@boinkor.net>
+Date: Thu, 11 Feb 2021 17:30:44 -0500
+Subject: [PATCH] Return the cached value if it's not time to scan again yet
+
+This should ensure that if we have a valid value cached (which ought
+to be every time after the first scan), we return it as metrics.
+
+This fixes the crashes that would happen if queries happened earlier
+than the re-scan interval allowed.
+
+Address review feedback: Shorten the time-to-scan logic
+
+We can express this in a single if statement, so it takes fewer lines
+to do the "should we check again" check.
+---
+ readjson.go | 11 ++---------
+ 1 file changed, 2 insertions(+), 9 deletions(-)
+
+diff --git a/readjson.go b/readjson.go
+index da35448..c9996fd 100644
+--- a/readjson.go
++++ b/readjson.go
+@@ -78,14 +78,7 @@ func readData(device string) (gjson.Result, error) {
+ 
+ 	if _, err := os.Stat(device); err == nil {
+ 		cacheValue, cacheOk := jsonCache[device]
+-		timeToScan := false
+-		if cacheOk {
+-			timeToScan = time.Now().After(cacheValue.LastCollect.Add(options.SMARTctl.CollectPeriodDuration))
+-		} else {
+-			timeToScan = true
+-		}
+-
+-		if timeToScan {
++		if !cacheOk || time.Now().After(cacheValue.LastCollect.Add(options.SMARTctl.CollectPeriodDuration)) {
+ 			json, ok := readSMARTctl(device)
+ 			if ok {
+ 				jsonCache[device] = JSONCache{JSON: json, LastCollect: time.Now()}
+@@ -93,7 +86,7 @@ func readData(device string) (gjson.Result, error) {
+ 			}
+ 			return gjson.Parse(DEFAULT_EMPTY_JSON), fmt.Errorf("smartctl returned bad data for device %s", device)
+ 		}
+-		return gjson.Parse(DEFAULT_EMPTY_JSON), fmt.Errorf("Too early collect called for device %s", device)
++		return cacheValue.JSON, nil
+ 	}
+ 	return gjson.Parse(DEFAULT_EMPTY_JSON), fmt.Errorf("Device %s unavialable", device)
+ }
+-- 
+2.33.1
+

--- a/pkgs/servers/monitoring/prometheus/smartctl-exporter/default.nix
+++ b/pkgs/servers/monitoring/prometheus/smartctl-exporter/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, fetchFromGitHub
+, fetchpatch
+, buildGoModule
+}:
+
+buildGoModule rec {
+  pname = "smartctl_exporter";
+  version = "unstable-2020-11-14";
+
+  src = fetchFromGitHub {
+    owner = "prometheus-community";
+    repo = pname;
+    rev = "e27581d56ad80340fb076d3ce22cef337ed76679";
+    sha256 = "sha256-iWaFDjVLBIAA9zGe0utbuvmEdA3R5lge0iCh3j2JfE8=";
+  };
+
+  patches = [
+    # Fixes out of range panic (https://github.com/prometheus-community/smartctl_exporter/issues/19)
+    (fetchpatch {
+      url = "https://github.com/prometheus-community/smartctl_exporter/commit/15575301a8e2fe5802a8c066c6fa9765d50b8cfa.patch";
+      sha256 = "sha256-HLUrGXNz3uKpuQBUgQBSw6EGbGl23hQnimTGl64M5bQ=";
+    })
+    # Fix validation on empty smartctl response (https://github.com/prometheus-community/smartctl_exporter/pull/31)
+    (fetchpatch {
+      url = "https://github.com/prometheus-community/smartctl_exporter/commit/744b4e5f6a46e029d31d5aa46642e85f429c2cfa.patch";
+      sha256 = "sha256-MgLtYR1SpM6XrZQQ3AgQRmNF3OnaBCqXMJRV9BOzKPc=";
+    })
+    # Fixes missing metrics if outside of query interval (https://github.com/prometheus-community/smartctl_exporter/pull/18)
+    ./0001-Return-the-cached-value-if-it-s-not-time-to-scan-aga.patch
+  ];
+
+  vendorSha256 = "1xhrzkfm2p20k7prgdfax4408g4qpa4wbxigmcmfz7kjg2zi88ld";
+
+  meta = with lib; {
+    description = "Export smartctl statistics for Prometheus";
+    homepage = "https://github.com/prometheus-community/smartctl_exporter";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21381,6 +21381,7 @@ with pkgs;
   prometheus-rabbitmq-exporter = callPackage ../servers/monitoring/prometheus/rabbitmq-exporter.nix { };
   prometheus-rtl_433-exporter = callPackage ../servers/monitoring/prometheus/rtl_433-exporter.nix { };
   prometheus-script-exporter = callPackage ../servers/monitoring/prometheus/script-exporter.nix { };
+  prometheus-smartctl-exporter = callPackage ../servers/monitoring/prometheus/smartctl-exporter { };
   prometheus-smokeping-prober = callPackage ../servers/monitoring/prometheus/smokeping-prober.nix { };
   prometheus-snmp-exporter = callPackage ../servers/monitoring/prometheus/snmp-exporter.nix { };
   prometheus-statsd-exporter = callPackage ../servers/monitoring/prometheus/statsd-exporter.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Monitoring harddisk healthyness over time with Prometheus.

- Negative NixOS test, since `/dev/vda` doesn't work for <s>the exporter</s> smartmontools.
  ```json
  {
    "json_format_version": [
      1,
      0
    ],
    "smartctl": {
      "version": [
        7,
        2
      ],
      "svn_revision": "5155",
      "platform_info": "x86_64-linux-5.10.79",
      "build_info": "(local build)",
      "argv": [
        "smartctl",
        "--json",
        "--xall",
        "/dev/vda"
      ],
      "messages": [
        {
          "string": "/dev/vda: Unable to detect device type",
          "severity": "error"
        }
      ],
      "exit_status": 1
    }
  }
  ```
- Not sure if this is the right exporter to package, it has a fair share of problems and seems a bit undermaintained  :disappointed: 
	- which can be fixed by applying a few patches from open pull requests, hope they get merged soon

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
