### PR TITLE
nixos/i2pd: fix dataDir placement, add log & logFile options

### DIFF
--- a/nixos/modules/services/networking/i2pd.nix
+++ b/nixos/modules/services/networking/i2pd.nix
@@ -98,6 +98,7 @@ let
   i2pdConf = let
     opts = [
       notice
+      (strOpt "log" cfg.log)
       (strOpt "loglevel" cfg.logLevel)
       (boolOpt "logclftime" cfg.logCLFTime)
       (boolOpt "ipv4" cfg.enableIPv4)
@@ -105,10 +106,10 @@ let
       (boolOpt "notransit" cfg.notransit)
       (boolOpt "floodfill" cfg.floodfill)
       (intOpt "netid" cfg.netid)
-    ] ++ (optionalNullInt "bandwidth" cfg.bandwidth)
+    ] ++ (optionalNullString "logfile" cfg.logFile)
+      ++ (optionalNullInt "bandwidth" cfg.bandwidth)
       ++ (optionalNullInt "port" cfg.port)
       ++ (optionalNullString "family" cfg.family)
-      ++ (optionalNullString "datadir" cfg.dataDir)
       ++ (optionalNullInt "share" cfg.share)
       ++ (optionalNullBool "ssu" cfg.ssu)
       ++ (optionalNullBool "ntcp" cfg.ntcp)
@@ -223,7 +224,8 @@ let
     in pkgs.writeText "i2pd-tunnels.conf" opts;
 
   i2pdFlags = concatStringsSep " " (
-    optional (cfg.address != null) ("--host=" + cfg.address) ++ [
+    optional (cfg.address != null) ("--host=" + cfg.address) ++
+    optional (cfg.dataDir != null) ("--datadir=" + cfg.dataDir) ++ [
     "--service"
     ("--conf=" + i2pdConf)
     ("--tunconf=" + tunnelConf)
@@ -257,6 +259,23 @@ in
         defaultText = literalExpression "pkgs.i2pd";
         description = ''
           i2pd package to use.
+        '';
+      };
+
+      log = mkOption {
+        type = types.enum ["stdout" "file" "syslog"];
+        default = "stdout";
+        description = ''
+          Logs destination: stdout, file, syslog (stdout if not set or invalid)
+          (if daemon, stdout/unspecified are replaced by file in some cases)
+        '';
+      };
+
+      logFile = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        description = ''
+          Path to logfile (default - autodetect)
         '';
       };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
According to `i2pd` documentation, option `datadir` have effect only as command argument, not configuration
https://i2pd.readthedocs.io/en/latest/user-guide/configuration/#notes
Also, there are log output option available, but not accessible through `service.i2pd`


###### Things done
- `dataDir`option handling moved from `i2pd.conf` to command argument
- `log` output option added and set default as `stdout`
- possible `logFile` choosing option added

<!-- Please check what applies. Note that these are not hard requirements, but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
