### PR TITLE
python3Packages.cwcwidth: fix tests on darwin

### DIFF
--- a/pkgs/development/python-modules/cwcwidth/default.nix
+++ b/pkgs/development/python-modules/cwcwidth/default.nix
@@ -13,12 +13,17 @@ buildPythonPackage rec {
   nativeBuildInputs = [ cython ];
 
   checkInputs = [ pytestCheckHook ];
-  # Hack needed to make pytest + cython work
-  # https://github.com/NixOS/nixpkgs/pull/82410#issuecomment-827186298
   preCheck = ''
+    # Hack needed to make pytest + cython work
+    # https://github.com/NixOS/nixpkgs/pull/82410#issuecomment-827186298
     export HOME=$(mktemp -d)
     cp -r $TMP/$sourceRoot/tests $HOME
     pushd $HOME
+
+    # locale settings used by upstream, has the effect of skipping
+    # otherwise-failing tests on darwin
+    export LC_ALL='C.UTF-8'
+    export LANG='C.UTF-8'
   '';
   postCheck = "popd";
 


### PR DESCRIPTION
###### Motivation for this change
ZHF #144627 @NixOS/nixos-release-managers

Use the same locale settings used by upstream's CI: https://github.com/sebastinas/cwcwidth/blob/2bc4360474b524148ffde3c8b837cbb0a4f172f5/.github/workflows/build.yaml#L33

This has the effect of skipping some otherwise-failing tests on darwin. Seems slightly counterproductive but who am I to judge?


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
