### PR TITLE
cinnamon: package and add default xapps, upgrade to latest

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/cinnamon.nix
+++ b/nixos/modules/services/x11/desktop-managers/cinnamon.nix
@@ -202,6 +202,13 @@ in
         blueberry
         warpinator
 
+        # cinnamon xapps
+        xviewer
+        xreader
+        xed
+        xplayer
+        pix
+
         # external apps shipped with linux-mint
         hexchat
         gnome-calculator

--- a/pkgs/desktops/cinnamon/bulky/default.nix
+++ b/pkgs/desktops/cinnamon/bulky/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "bulky";
-  version = "1.7";
+  version = "1.9";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "bulky";
     rev = version;
-    sha256 = "sha256-+3OoeuGuyiHWlUrxm5A7CmNR+ijxdlmecmvqk+i+h08=";
+    hash = "sha256-OCBFhlnEXZROp47KDiy7Y6l4GDVCCP+i1IFYQa7esyg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/bulky/default.nix
+++ b/pkgs/desktops/cinnamon/bulky/default.nix
@@ -55,6 +55,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/linuxmint/bulky";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.mkg20001 ];
+    maintainers = teams.cinnamon.members;
   };
 }

--- a/pkgs/desktops/cinnamon/cinnamon-common/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-common/default.nix
@@ -50,13 +50,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-common";
-  version = "4.8.6";
+  version = "5.2.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "cinnamon";
     rev = version;
-    hash = "sha256-4DMXQYH1/RjLhgrn55I7Vkk6+gGsR+OVmiwxVHUIyro=";
+    hash = "sha256-B2Du2zis0xWeeyh3kSyz1doWImk9Fuk4qQ8HNZZdqdw=";
   };
 
   patches = [
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     # TODO: review if we really need this all
-    (python3.withPackages (pp: with pp; [ dbus-python setproctitle pygobject3 pycairo xapp pillow pytz tinycss2 python-pam pexpect distro ]))
+    (python3.withPackages (pp: with pp; [ dbus-python setproctitle pygobject3 pycairo xapp pillow pytz tinycss2 python-pam pexpect distro requests ]))
     atk
     cacert
     cinnamon-control-center

--- a/pkgs/desktops/cinnamon/cinnamon-common/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-common/default.nix
@@ -62,6 +62,11 @@ stdenv.mkDerivation rec {
   patches = [
     ./use-sane-install-dir.patch
     ./libdir.patch
+
+    (fetchpatch {
+      url = "https://github.com/linuxmint/cinnamon/commit/77ed66050f7df889fcb7a10b702c7b8bcdeaa130.patch";
+      sha256 = "sha256-OegLxz6Xr/nxVwVOAd2oOY62ohZ3r6uYn1+YED5EBHQ=";
+    })
   ];
 
   buildInputs = [

--- a/pkgs/desktops/cinnamon/cinnamon-control-center/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-control-center/default.nix
@@ -29,17 +29,18 @@
 , meson
 , ninja
 , cinnamon-translations
+, python3
 }:
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-control-center";
-  version = "4.8.2";
+  version = "5.2.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-vALThDY0uN9bV7b1fga3MK7b2/l5uL33+B2x6oSLPRE=";
+    hash = "sha256-j7+2uLcHr7bO7i8OGqkw3ifawZULNyihhJ+h2D5gx/k=";
   };
 
   buildInputs = [
@@ -74,6 +75,8 @@ stdenv.mkDerivation rec {
     sed 's|TZ_DIR "/usr/share/zoneinfo/"|TZ_DIR "${tzdata}/share/zoneinfo/"|g' -i ./panels/datetime/test-timezone.c
     sed 's|TZ_DATA_FILE "/usr/share/zoneinfo/zone.tab"|TZ_DATA_FILE "${tzdata}/share/zoneinfo/zone.tab"|g' -i ./panels/datetime/tz.h
     sed 's|"/usr/share/i18n/locales/"|"${glibc}/share/i18n/locales/"|g' -i panels/datetime/test-endianess.c
+
+    patchShebangs meson_install_schemas.py
   '';
 
   # it needs to have access to that file, otherwise we can't run tests after build
@@ -103,6 +106,7 @@ stdenv.mkDerivation rec {
     ninja
     wrapGAppsHook
     gettext
+    python3
   ];
 
   meta = with lib; {

--- a/pkgs/desktops/cinnamon/cinnamon-desktop/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-desktop/default.nix
@@ -17,13 +17,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-desktop";
-  version = "4.8.1";
+  version = "5.2.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-FLruY1lxzB3iJ/So3jSjrbv9e8VoN/0+U2YDXju/u3E=";
+    hash = "sha256-gOlSmcHjBjnLdDpgC5mZ4M3eUBTG3BuET6Kr/Xby14A=";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/desktops/cinnamon/cinnamon-menus/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-menus/default.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-menus";
-  version = "4.8.2";
+  version = "5.2.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-9VSrqCjC8U3js1gqjl5QFctWYECATxN+AdfMdHLxYUY=";
+    hash = "sha256-ioluv/GdWCNGP2jQqsyEbHncCFm8iu69yR8QVKQTJk8=";
   };
 
   buildInputs = [

--- a/pkgs/desktops/cinnamon/cinnamon-screensaver/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-screensaver/default.nix
@@ -27,13 +27,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-screensaver";
-  version = "4.8.1";
+  version = "5.2.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-gvSGxSYKnRqJhj2unRYRHp6qGw/O9SxKPzhw5xjCSSQ=";
+    hash = "sha256-weQ5sw5SY89JFIxamCeLiSLy8xCXGg0Yxj/5Ca5r+6o=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/cinnamon-session/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-session/default.nix
@@ -21,20 +21,19 @@
 , xapps
 , xmlto
 , xorg
-, cmake
 , libexecinfo
 , pango
 }:
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-session";
-  version = "4.8.0";
+  version = "5.2.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-lrwR8VSdPzHoc9MeBEQPbVfWNhPZDJ2wYizKSVpobmk=";
+    hash = "sha256-E5ascwLnpa5NSBAPo9dXRhoraUntzDPHVV32uDU4U8k=";
   };
 
   patches = [
@@ -85,7 +84,6 @@ stdenv.mkDerivation rec {
     # TODO: https://github.com/NixOS/nixpkgs/issues/36468
     "-Dc_args=-I${glib.dev}/include/gio-unix-2.0"
     "-Dgconf=false"
-    "-DENABLE_IPV6=true"
     # use locales from cinnamon-translations
     "--localedir=${cinnamon-translations}/share/locale"
   ];

--- a/pkgs/desktops/cinnamon/cinnamon-settings-daemon/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-settings-daemon/default.nix
@@ -13,7 +13,8 @@
 , wrapGAppsHook
 , pkg-config
 , pulseaudio
-, lib, stdenv
+, lib
+, stdenv
 , systemd
 , upower
 , dconf
@@ -35,7 +36,7 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-settings-daemon";
-  version = "4.8.5";
+  version = "5.2.0";
 
   /* csd-power-manager.c:50:10: fatal error: csd-power-proxy.h: No such file or directory
    #include "csd-power-proxy.h"
@@ -50,7 +51,7 @@ stdenv.mkDerivation rec {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-PAWVTjGFs8yKXgNQ2ucDnEDS+n7bp2n3lhGl9gHXfdQ=";
+    hash = "sha256-6omif4UxMrXWxL+R9lQ8ogxotW+3E9Kp99toH3PJtaU=";
   };
 
   patches = [

--- a/pkgs/desktops/cinnamon/cinnamon-settings-daemon/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-settings-daemon/default.nix
@@ -121,6 +121,6 @@ stdenv.mkDerivation rec {
     description = "The settings daemon for the Cinnamon desktop";
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = [ maintainers.mkg20001 ];
+    maintainers = teams.cinnamon.members;
   };
 }

--- a/pkgs/desktops/cinnamon/cinnamon-translations/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-translations/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-translations";
-  version = "5.0.0";
+  version = "5.2.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-qBLg0z0ZoS7clclKsIxMG6378Q1iv1NnhS9cz3f4cEc=";
+    hash = "sha256-t3PydmS2+LU++2NcosgMr9KTXW0Qy1Re9+YcS3KMDi8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/cjs/default.nix
+++ b/pkgs/desktops/cinnamon/cjs/default.nix
@@ -25,23 +25,24 @@
 , makeWrapper
 , which
 , libxml2
+, gtk4
 }:
 
 stdenv.mkDerivation rec {
   pname = "cjs";
-  version = "4.8.2";
+  version = "5.2.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "cjs";
     rev = version;
-    hash = "sha256-6+zlWL0DmyP+RFp1ECA4XGbgYUlsMqqyTd6z46w99Ug=";
+    hash = "sha256-06sTk513qVMdznSHJzzB3XIPTcfjgxTB2o+ALqwPpHM=";
   };
 
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [
-    meson # ADDING cmake breaks the build, ignore meson warning
+    meson
     ninja
     pkg-config
     makeWrapper
@@ -50,6 +51,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    gtk4
     gobject-introspection
     cairo
     readline

--- a/pkgs/desktops/cinnamon/default.nix
+++ b/pkgs/desktops/cinnamon/default.nix
@@ -30,6 +30,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   mint-x-icons = callPackage ./mint-x-icons { };
   mint-y-icons = callPackage ./mint-y-icons { };
   muffin = callPackage ./muffin { };
+  pix = callPackage ./pix { };
   xapps = callPackage ./xapps { };
   warpinator = callPackage ./warpinator { };
   xreader = callPackage ./xreader { };

--- a/pkgs/desktops/cinnamon/default.nix
+++ b/pkgs/desktops/cinnamon/default.nix
@@ -32,5 +32,6 @@ lib.makeScope pkgs.newScope (self: with self; {
   muffin = callPackage ./muffin { };
   xapps = callPackage ./xapps { };
   warpinator = callPackage ./warpinator { };
+  xreader = callPackage ./xreader { };
   xviewer = callPackage ./xviewer { };
 })

--- a/pkgs/desktops/cinnamon/mint-artwork/default.nix
+++ b/pkgs/desktops/cinnamon/mint-artwork/default.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mint-artwork";
-  version = "1.4.3";
+  version = "1.5.4";
 
   src = fetchurl {
     url = "http://packages.linuxmint.com/pool/main/m/mint-artwork/mint-artwork_${version}.tar.xz";
-    sha256 = "126asxpg722qfg2wkwcr7bhsplchq3jn6bkdwf1scpc5za8dd62j";
+    hash = "sha256-ZRJK1fzIF36BdUlVhLwdFdfgQvN2ashzjgpCxoOIbK8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/mint-artwork/default.nix
+++ b/pkgs/desktops/cinnamon/mint-artwork/default.nix
@@ -1,4 +1,5 @@
 { stdenv
+, lib
 , fetchurl
 , glib
 , nixos-artwork
@@ -36,4 +37,12 @@ stdenv.mkDerivation rec {
     mv etc $out/etc
     mv usr/share $out/share
   '';
+
+  meta = with lib; {
+    homepage = "https://github.com/linuxmint/mint-artwork";
+    description = "Artwork for the cinnamon desktop";
+    license = licenses.gpl3; # from debian/copyright
+    platforms = platforms.linux;
+    maintainers = teams.cinnamon.members;
+  };
 }

--- a/pkgs/desktops/cinnamon/mint-themes/default.nix
+++ b/pkgs/desktops/cinnamon/mint-themes/default.nix
@@ -7,14 +7,14 @@
 
 stdenv.mkDerivation rec {
   pname = "mint-themes";
-  version = "1.8.6";
+  version = "1.8.8";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
-    # commit is named 1.8.6, tags=404
-    rev = "fa0b9530f6e68c390aecd622b229072fcd08f05f";
-    sha256 = "0pgv5hglsscip5s7nv0mn301vkn0j6wp4rv34vr941yai1jfk2wb";
+    # they don't exactly do tags, it's just a named commit
+    rev = "a833fba6917043bf410dee4364c9a36af1ce4c83";
+    hash = "sha256-8abjjD0XoApvqB8SNlWsqIEp7ozgiERGS0kWglw2DWA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/mint-x-icons/default.nix
+++ b/pkgs/desktops/cinnamon/mint-x-icons/default.nix
@@ -10,14 +10,14 @@
 
 stdenv.mkDerivation rec {
   pname = "mint-x-icons";
-  version = "1.5.5";
+  version = "1.6.3";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
-    # commit is named 1.5.5, tags=404
-    rev = "ecfbeb62bba41e85a61099df467c4700ac63c1e0";
-    sha256 = "1yxm7h7giag5hmymgxsg16vc0rhxb2vn3piaksc463mic4vwfa3i";
+    # they don't exactly do tags, it's just a named commit
+    rev = "286eb4acdfc3e3c77572dfd0cd70ffd4208d3a35";
+    hash = "sha256-mZkCEBC1O2mW8rM1kpOWdC5CwIeafyBS95cMY6x1yco=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/desktops/cinnamon/mint-y-icons/default.nix
+++ b/pkgs/desktops/cinnamon/mint-y-icons/default.nix
@@ -8,14 +8,14 @@
 
 stdenv.mkDerivation rec {
   pname = "mint-y-icons";
-  version = "1.4.3";
+  version = "1.5.8";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
-    # commit is named 1.4.3, tags=404
-    rev = "c997af402d425889f2e4277966eebe473f7451f7";
-    sha256 = "0yfas949xm85a28vgjqm9ym3bhhynrq256w9vfs8aiqq9nbm18mf";
+    # they don't exactly do tags, it's just a named commit
+    rev = "9489bd161e9503d071227dd36057386a34cfc0a3";
+    hash = "sha256-53yTCWNSJjCpVvrxLfsiaCPNDEZWxJgGVAmVNMNql2M=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/desktops/cinnamon/muffin/default.nix
+++ b/pkgs/desktops/cinnamon/muffin/default.nix
@@ -35,13 +35,13 @@
 
 stdenv.mkDerivation rec {
   pname = "muffin";
-  version = "4.8.1";
+  version = "5.2.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-zRW+hnoaKKTe4zIJpY1D0Ahc8k5zRbvYBF5Y4vZ6Rbs=";
+    hash = "sha256-WAp0HbfRtwsPjJX1kPBqUStqLaudQPZ8E+h4jmggmw8=";
   };
 
   buildInputs = [

--- a/pkgs/desktops/cinnamon/nemo/default.nix
+++ b/pkgs/desktops/cinnamon/nemo/default.nix
@@ -22,7 +22,7 @@
 
 stdenv.mkDerivation rec {
   pname = "nemo";
-  version = "5.0.3";
+  version = "5.2.0";
 
   # TODO: add plugins support (see https://github.com/NixOS/nixpkgs/issues/78327)
 
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    sha256 = "sha256-Ah1Rp/o4LPdYm+wj2W5ljjMkCI3PgoAHrlM8yEQP77o=";
+    hash = "sha256-ehcqRlI1d/KWNas36dz+hb7KU1H8wtQHTpg2fz1XdXU=";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/desktops/cinnamon/pix/default.nix
+++ b/pkgs/desktops/cinnamon/pix/default.nix
@@ -1,0 +1,75 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, autoreconfHook
+, cinnamon-desktop
+, file
+, gdk-pixbuf
+, glib
+, gobject-introspection
+, gtk-doc
+, gtk3
+, intltool
+, itstool
+, libtool
+, libxml2
+, pkg-config
+, shared-mime-info
+, wrapGAppsHook
+, xapps
+, yelp-tools
+, libsecret
+, webkitgtk
+, libwebp
+, librsvg
+, json-glib
+, gnome
+, clutter
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pix";
+  version = "2.6.5";
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = pname;
+    rev = version;
+    sha256 = "qBF5lc7ZNwuTr6x4c4pJA6a7oXqOYsYA1lpTmQkylT0=";
+  };
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+    autoreconfHook
+    cinnamon-desktop
+    gdk-pixbuf
+    gnome.gnome-common
+    gobject-introspection
+    gtk-doc
+    intltool
+    itstool
+    libtool
+    pkg-config
+    yelp-tools
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    xapps
+    libsecret
+    webkitgtk
+    libwebp
+    librsvg
+    json-glib
+    clutter
+  ];
+
+  meta = with lib; {
+    description = "A generic image viewer from Linux Mint";
+    homepage = "https://github.com/linuxmint/pix";
+    license = licenses.gpl2Only;
+    platforms = platforms.linux;
+    maintainers = teams.cinnamon.members;
+  };
+}

--- a/pkgs/desktops/cinnamon/warpinator/default.nix
+++ b/pkgs/desktops/cinnamon/warpinator/default.nix
@@ -73,6 +73,6 @@ python3.pkgs.buildPythonApplication rec  {
     description = "Share files across the LAN";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.mkg20001 ];
+    maintainers = teams.cinnamon.members;
   };
 }

--- a/pkgs/desktops/cinnamon/warpinator/default.nix
+++ b/pkgs/desktops/cinnamon/warpinator/default.nix
@@ -14,7 +14,7 @@
 
 python3.pkgs.buildPythonApplication rec  {
   pname = "warpinator";
-  version = "1.0.8";
+  version = "1.2.5";
 
   format = "other";
 
@@ -22,7 +22,7 @@ python3.pkgs.buildPythonApplication rec  {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    sha256 = "0n1b50j2w76qnhfj5yg5q2j7fgxr9gbmzpazmbml4q41h8ybcmxm";
+    hash = "sha256-pTLM4CrkBLEZS9IdM9IBSGH0WPOj1rlAgvWLOUy6MxY=";
   };
 
   nativeBuildInputs = [
@@ -52,6 +52,10 @@ python3.pkgs.buildPythonApplication rec  {
     cryptography
     pynacl
     netifaces
+  ];
+
+  mesonFlags = [
+    "-Dbundle-zeroconf=false"
   ];
 
   postPatch = ''

--- a/pkgs/desktops/cinnamon/xapps/default.nix
+++ b/pkgs/desktops/cinnamon/xapps/default.nix
@@ -21,7 +21,7 @@
 
 stdenv.mkDerivation rec {
   pname = "xapps";
-  version = "2.2.3";
+  version = "2.2.5";
 
   outputs = [ "out" "dev" ];
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    sha256 = "sha256-hrSyoHA3XQXQb9N3YJ+NNfBjJNOuUhXhKEimh/n73MM=";
+    hash = "sha256-Ev+gTl9jY1HLbXKnCsVVSsY8ZrHyzsIkp+JTaXOTm6I=";
   };
 
   # TODO: https://github.com/NixOS/nixpkgs/issues/36468

--- a/pkgs/desktops/cinnamon/xreader/default.nix
+++ b/pkgs/desktops/cinnamon/xreader/default.nix
@@ -1,0 +1,76 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, glib
+, gobject-introspection
+, intltool
+, shared-mime-info
+, gtk3
+, wrapGAppsHook
+, libxml2
+, xapps
+, meson
+, pkg-config
+, cairo
+, libsecret
+, poppler
+, libspectre
+, libgxps
+, webkitgtk
+, nodePackages
+, ninja
+, gsettings-desktop-schemas
+, djvulibre
+, backends ? [ "pdf" "ps" /* "dvi" "t1lib" */ "djvu" "tiff" "pixbuf" "comics" "xps" "epub" ]
+}:
+
+stdenv.mkDerivation rec {
+  pname = "xreader";
+  version = "3.0.2";
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = pname;
+    rev = version;
+    sha256 = "vyZhKsuASbkc6IBtfbhTIHOQ0XYNFaCVua+jS4B5LWk=";
+  };
+
+  nativeBuildInputs = [
+    shared-mime-info
+    wrapGAppsHook
+    meson
+    ninja
+    pkg-config
+    gobject-introspection
+    intltool
+  ];
+
+  mesonFlags = [
+    "-Dmathjax-directory=${nodePackages.mathjax}"
+    "-Dc_args=-I${glib.dev}/include/gio-unix-2.0"
+  ] ++ (map (x: "-D${x}=true") backends);
+
+  buildInputs = [
+    glib
+    gtk3
+    xapps
+    cairo
+    libxml2
+    libsecret
+    poppler
+    libspectre
+    libgxps
+    webkitgtk
+    nodePackages.mathjax
+    djvulibre
+  ];
+
+  meta = with lib; {
+    description = "A document viewer capable of displaying multiple and single page
+document formats like PDF and Postscript";
+    homepage = "https://github.com/linuxmint/xreader";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = teams.cinnamon.members;
+  };
+}

--- a/pkgs/desktops/cinnamon/xviewer/default.nix
+++ b/pkgs/desktops/cinnamon/xviewer/default.nix
@@ -65,6 +65,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/linuxmint/xviewer";
     license = licenses.gpl2Only;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ tu-maurice ];
+    maintainers = with maintainers; [ tu-maurice ] ++ teams.cinnamon.members;
   };
 }

--- a/pkgs/development/python-modules/xapp/default.nix
+++ b/pkgs/development/python-modules/xapp/default.nix
@@ -11,13 +11,13 @@
 
 buildPythonPackage rec {
   pname = "xapp";
-  version = "2.0.2";
+  version = "2.2.1";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "python-xapp";
     rev = version;
-    sha256 = "1zgh4k96i939w4scikajmlriayk1zg3md16f8fckjvqbphpxrysl";
+    hash = "sha256-UC+0nbf+SRQsF5R0LcrPpmNbaoRM14DC82JccSpsKsY=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/109578

Also upgrades everything to 5.2.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
