### PR TITLE
[staging-next] python3Packages.luftdaten: 0.6.5 -> 0.7.0

### DIFF
--- a/pkgs/development/python-modules/luftdaten/default.nix
+++ b/pkgs/development/python-modules/luftdaten/default.nix
@@ -1,17 +1,24 @@
-{ lib, buildPythonPackage, isPy3k, fetchPypi, aiohttp, async-timeout }:
+{ lib, buildPythonPackage, isPy3k, fetchPypi, httpx }:
 
 buildPythonPackage rec {
   pname = "luftdaten";
-  version = "0.6.5";
+  version = "0.7.0";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-5SFb+psULyg9UKVY3oJPNLF3TGS/W+Bxoj79iTzReL4=";
+    sha256 = "sha256-D1eMZ8lvqgW0u9DvzSR2wkoMu1aXUchbckhfTTAwH1I=";
   };
 
-  propagatedBuildInputs = [ aiohttp async-timeout ];
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "httpx>=0.20.0,<0.21.0" "httpx"
+  '';
+
+  propagatedBuildInputs = [
+    httpx
+  ];
 
   # No tests implemented
   doCheck = false;

--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -50,13 +50,7 @@ in buildPythonPackage rec {
     sha256 = "423216d8afc5923b15df86037c6053bf030d15cc9e3224206ef868c2d63dd6dc";
   };
 
-  patches = [
-    # fix https://github.com/numpy/numpy/issues/19624
-    (fetchpatch {
-      url = "https://github.com/numpy/numpy/commit/ae279066d6bd253e8675428fac8946938b8d48d9.diff";
-      sha256 = "sha256-q8SoF/pMzLI4zYCx2YAZzR31cARlZXerNnBSevBO5pE=";
-    })
-  ] ++ lib.optionals python.hasDistutilsCxxPatch [
+  patches = lib.optionals python.hasDistutilsCxxPatch [
     # We patch cpython/distutils to fix https://bugs.python.org/issue1222585
     # Patching of numpy.distutils is needed to prevent it from undoing the
     # patch to distutils.


### PR DESCRIPTION
###### Motivation for this change

built on #147094, as otherwise numpy is broken. can rebase after merge



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
