### PR TITLE
nixos/bluetooth: fix bluetooth warnings

### DIFF
--- a/nixos/modules/services/hardware/bluetooth.nix
+++ b/nixos/modules/services/hardware/bluetooth.nix
@@ -11,12 +11,8 @@ let
 
   cfgFmt = pkgs.formats.ini { };
 
-  # bluez will complain if some of the sections are not found, so just make them
-  # empty (but present in the file) for now
   defaults = {
     General.ControllerMode = "dual";
-    Controller = { };
-    GATT = { };
     Policy.AutoEnable = cfg.powerOnBoot;
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes #144457
I've tested and bluetoothd is capable to start with an empty config with no issues
```sh
ymatsiuk at nixps in nixpkgs on  ymatsiuk/bluetooth ❯ echo "" > /etc/bluetooth/main.conf
ymatsiuk at nixps in nixpkgs on  ymatsiuk/bluetooth ❯ systemctl status bluetooth.service
● bluetooth.service - Bluetooth service
     Loaded: loaded (/etc/systemd/system/bluetooth.service; enabled; vendor preset: enabled)
    Drop-In: /nix/store/ylcbhf9big5b8j99b3gigwik1b1xby2g-system-units/bluetooth.service.d
             └─overrides.conf
     Active: active (running) since Tue 2021-11-23 10:57:38 CET; 9s ago
       Docs: man:bluetoothd(8)
   Main PID: 222049 (bluetoothd)
     Status: "Running"
         IP: 0B in, 0B out
         IO: 0B read, 0B written
      Tasks: 1 (limit: 18823)
     Memory: 820.0K
        CPU: 19ms
     CGroup: /system.slice/bluetooth.service
             └─222049 /nix/store/q49b0sy8x24lfdflqqdfjd2nplfk0dvr-bluez-5.62/libexec/bluetooth/bluetoothd -f /etc/bluetooth/main.conf

nov 23 10:57:38 nixps systemd[1]: Starting Bluetooth service...
nov 23 10:57:38 nixps bluetoothd[222049]: Bluetooth daemon 5.62
nov 23 10:57:38 nixps systemd[1]: Started Bluetooth service.
nov 23 10:57:38 nixps bluetoothd[222049]: Starting SDP server
nov 23 10:57:38 nixps bluetoothd[222049]: Bluetooth management interface 1.21 initialized
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
