### PR TITLE
httpunit: remove builder.sh

### DIFF
--- a/pkgs/development/libraries/java/httpunit/builder.sh
+++ b/pkgs/development/libraries/java/httpunit/builder.sh
@@ -1,5 +1,0 @@
-source $stdenv/setup
-
-$unzip/bin/unzip $src
-mkdir $out
-mv $name/* $out/

--- a/pkgs/development/libraries/java/httpunit/default.nix
+++ b/pkgs/development/libraries/java/httpunit/default.nix
@@ -1,15 +1,17 @@
-{lib, stdenv, fetchurl, unzip} :
+{ lib, stdenv, fetchurl }:
 
-stdenv.mkDerivation {
-  name = "httpunit-1.7";
-  builder = ./builder.sh;
+stdenv.mkDerivation rec {
+  pname = "httpunit";
+  version = "1.7";
 
   src = fetchurl {
-    url = "mirror://sourceforge/httpunit/httpunit-1.7.zip";
+    url = "mirror://sourceforge/httpunit/httpunit-${version}.zip";
     sha256 = "09gnayqgizd8cjqayvdpkxrc69ipyxawc96aznfrgdhdiwv8l5zf";
   };
 
-  inherit unzip;
+  buildCommand = ''
+    cp ./* $out
+  '';
 
   meta = with lib; {
     homepage = "http://httpunit.sourceforge.net";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
"builder.sh" should be deprecated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
