### PR TITLE
sbcl_2_1_10: init at 2.1.10

### DIFF
--- a/pkgs/development/compilers/sbcl/2.1.10.nix
+++ b/pkgs/development/compilers/sbcl/2.1.10.nix
@@ -1,0 +1,4 @@
+import ./common.nix {
+  version = "2.1.10";
+  sha256 = "0f5ihj486m7ghh3nc0jlnqa656sbqcmhdv32syz2rjx5b47ky67b";
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12989,6 +12989,7 @@ with pkgs;
   sbcl_2_1_1 = callPackage ../development/compilers/sbcl/2.1.1.nix {};
   sbcl_2_1_2 = callPackage ../development/compilers/sbcl/2.1.2.nix {};
   sbcl_2_1_9 = callPackage ../development/compilers/sbcl/2.1.9.nix {};
+  sbcl_2_1_10 = callPackage ../development/compilers/sbcl/2.1.10.nix {};
   sbcl = sbcl_2_1_9;
 
   roswell = callPackage ../development/tools/roswell { };


### PR DESCRIPTION
http://www.sbcl.org/all-news.html#2.1.10

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

<details>
<summary>Upgrading the default version of SBCL doesn't seem to be possible yet, as the following derivations would fail:</summary>

```
error: build of '/nix/store/0dgplkvi6k9rl0pyfg088gns7yaw51l4-lisp-generic-cl_dot_arithmetic-generic-cl-20211020-git.drv', '/nix/store/0lf9454v384igagzp2id5x85kj8pip5y-lisp-generic-cl_dot_object-generic-cl-20211020-git.drv', '/nix/store/1qy05qia9cjcjzpcl0z5x8cglg2mp5c8-lisp-generic-cl_dot_iterator-generic-cl-20211020-git.drv', '/nix/store/5p041zzqha4rhnz2r99mijxaig15i2fx-lisp-generic-cl-20211020-git.drv', '/nix/store/9yahshv51gi3brfzyxyvi9iijh5z9w63-lisp-generic-cl_dot_lazy-seq-generic-cl-20211020-git.drv', '/nix/store/dccj38qch39vj7hhqvfx0j0a0kki58rj-lisp-generic-cl_dot_set-generic-cl-20211020-git.drv', '/nix/store/dqdh4mhadx5q2wgb8vhgx2x7wyps6pwx-lisp-generic-cl_dot_internal-generic-cl-20211020-git.drv', '/nix/store/faizvjxbf03df3nncgfgqiwaaf03mbg6-lisp-generic-cl_dot_map-generic-cl-20211020-git.drv', '/nix/store/gzxn1djnc0jaqrdvmvnbykv1fhyr90a8-lisp-generic-cl_dot_sequence-generic-cl-20211020-git.drv', '/nix/store/jg09mb4m5fj72mg93dnklbvm8rfl5nzc-lisp-generic-cl_dot_collector-generic-cl-20211020-git.drv', '/nix/store/jhy5ajna16hfxx78hjm5wll6ig9ml4rk-lisp-generic-cl_dot_math-generic-cl-20211020-git.drv', '/nix/store/nc1mrssqfswa9b4w8zr3hx2li87v6lq3-lisp-generic-cl_dot_container-generic-cl-20211020-git.drv', '/nix/store/q5kym5c8a3p0nh3sdfqlkkwh2csd58l3-lisp-static-dispatch-20211020-git.drv', '/nix/store/yha0v2hamqrarxp4ysxnzy16sf0n60ax-lisp-generic-cl_dot_comparison-generic-cl-20211020-git.drv', '/nix/store/zfnsxj1d0ixi05pjw11v0sny7xg9sml0-lisp-nyxt-2.0.0.drv' failed
```

</details>

I'd propose we wait for the next quicklist dist info version to be released.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
