### PR TITLE
opendrop: init at 0.13.0

### DIFF
--- a/pkgs/development/python-modules/fleep/0001-Fixing-paths-on-tests.patch
+++ b/pkgs/development/python-modules/fleep/0001-Fixing-paths-on-tests.patch
@@ -1,0 +1,48 @@
+From 716fcfa3203bc881b543916bdb9a17460951cd26 Mon Sep 17 00:00:00 2001
+From: "P. R. d. O" <d.ol.rod@protonmail.com>
+Date: Fri, 26 Nov 2021 07:13:32 -0600
+Subject: [PATCH] Fixing paths on tests
+
+---
+ tests/maintest.py  | 7 ++++++-
+ tests/speedtest.py | 7 ++++++-
+ 2 files changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/tests/maintest.py b/tests/maintest.py
+index 0e24ca4..3484437 100644
+--- a/tests/maintest.py
++++ b/tests/maintest.py
+@@ -1,6 +1,11 @@
+ import fleep
++import os
+ 
+-with open("testfile", "rb") as file:
++current_dir = os.path.realpath(os.path.join(os.getcwd(),
++                                            os.path.dirname(__file__)))
++
++with open(os.path.join(current_dir, "./testfile"),
++          "rb") as file:
+     info = fleep.get(file.read(128))
+ 
+ assert info.type == ["raster-image"]
+diff --git a/tests/speedtest.py b/tests/speedtest.py
+index 89338ab..829d563 100644
+--- a/tests/speedtest.py
++++ b/tests/speedtest.py
+@@ -1,7 +1,12 @@
+ import time
+ import fleep
++import os
+ 
+-with open("testfile", "rb") as file:
++current_dir = os.path.realpath(os.path.join(os.getcwd(),
++                                            os.path.dirname(__file__)))
++
++with open(os.path.join(current_dir, "./testfile"),
++          "rb") as file:
+     stream = file.read(128)
+ 
+ times = []
+-- 
+2.33.1
+

--- a/pkgs/development/python-modules/fleep/default.nix
+++ b/pkgs/development/python-modules/fleep/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "fleep";
+  version = "1.0.1";
+
+  # Pypi version does not have tests
+  src = fetchFromGitHub {
+    owner = "floyernick";
+    repo = "fleep-py";
+    rev = "994bc2c274482d80ab13d89d8f7343eb316d3e44";
+    sha256 = "sha256-TaU7njx98nxkhZawGMFqWj4g+yCtIX9aPWQHoamzfMY=";
+  };
+
+  patches = [
+    ./0001-Fixing-paths-on-tests.patch
+  ];
+
+  checkPhase = ''
+    ${python.interpreter} tests/maintest.py
+    ${python.interpreter} tests/speedtest.py
+  '';
+
+  pythonImportsCheck = [ "fleep" ];
+
+  meta = with lib; {
+    description = "File format determination library";
+    homepage = "https://github.com/floyernick/fleep-py";
+    license = licenses.mit;
+    maintainers = with maintainers; [ wolfangaukang ];
+  };
+}

--- a/pkgs/tools/networking/opendrop/default.nix
+++ b/pkgs/tools/networking/opendrop/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonApplication
+, fetchPypi
+, fleep
+, libarchive-c
+, pillow
+, requests-toolbelt
+, setuptools
+, zeroconf }:
+
+buildPythonApplication rec {
+  pname = "opendrop";
+  version = "0.13.0";
+
+  src = fetchPypi {
+    inherit version pname;
+    sha256 = "sha256-FE1oGpL6C9iBhI8Zj71Pm9qkObJvSeU2gaBZwK1bTQc=";
+  };
+
+  propagatedBuildInputs = [
+    fleep
+    libarchive-c
+    pillow
+    requests-toolbelt
+    setuptools
+    zeroconf
+  ];
+
+  # There are tests, but getting the following error:
+  # nix_run_setup: error: argument action: invalid choice: 'test' (choose from 'receive', 'find', 'send')
+  # Opendrop works as intended though
+  doCheck = false;
+
+  meta = with lib; {
+    description = "An open Apple AirDrop implementation written in Python";
+    homepage = "https://owlink.org/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ wolfangaukang ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/tools/networking/owl/default.nix
+++ b/pkgs/tools/networking/owl/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, fetchFromGitHub, cmake, libev, libnl, libpcap }:
+
+stdenv.mkDerivation rec {
+  pname = "owl";
+  version = "unstable-2022-01-30";
+
+  src = fetchFromGitHub {
+    owner = "seemoo-lab";
+    repo = "owl";
+    rev = "8e4e840b212ae5a09a8a99484be3ab18bad22fa7";
+    sha256 = "sha256-kFk+JFLGWGBu5FPH3qp/Bxa6t04f1kpeHz3H8GNF3fg=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libev libnl libpcap ];
+
+  meta = with lib; {
+    description = "An open Apple Wireless Direct Link (AWDL) implementation written in C";
+    homepage = "https://owlink.org/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ wolfangaukang ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -544,6 +544,8 @@ with pkgs;
 
   graph-easy = callPackage ../tools/graphics/graph-easy { };
 
+  opendrop = python3Packages.callPackage ../tools/networking/opendrop { };
+
   owl = callPackage ../tools/networking/owl { };
 
   packer = callPackage ../development/tools/packer { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -544,6 +544,8 @@ with pkgs;
 
   graph-easy = callPackage ../tools/graphics/graph-easy { };
 
+  owl = callPackage ../tools/networking/owl { };
+
   packer = callPackage ../development/tools/packer { };
 
   packr = callPackage ../development/libraries/packr { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3029,6 +3029,8 @@ in {
 
   flax = callPackage ../development/python-modules/flax { };
 
+  fleep = callPackage ../development/python-modules/fleep { };
+
   flexmock = callPackage ../development/python-modules/flexmock { };
 
   flickrapi = callPackage ../development/python-modules/flickrapi { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#146777

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
