### PR TITLE
 python3Packages.detect-secrets: fix several disabled tests and build on darwin

### DIFF
--- a/pkgs/development/python-modules/detect-secrets/default.nix
+++ b/pkgs/development/python-modules/detect-secrets/default.nix
@@ -4,6 +4,7 @@
 , gibberish-detector
 , isPy27
 , mock
+, pkgs
 , pyahocorasick
 , pytestCheckHook
 , pyyaml
@@ -21,7 +22,8 @@ buildPythonPackage rec {
     owner = "Yelp";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-dj0lqm9s8OKhM4OmNrmGVRc32/ZV0I9+5WcW2hvLwu0=";
+    sha256 = "sha256-dG2YaWXAMINxBGKNMlVfGTR9QHdnepiZmN+G88X4Wak=";
+    leaveDotGit = true;
   };
 
   propagatedBuildInputs = [
@@ -36,6 +38,7 @@ buildPythonPackage rec {
     pytestCheckHook
     responses
     unidiff
+    pkgs.gitMinimal
   ];
 
   preCheck = ''
@@ -44,24 +47,15 @@ buildPythonPackage rec {
 
   disabledTests = [
     # Tests are failing for various reasons. Needs to be adjusted with the next update
-    "test_baseline_filters_out_known_secrets"
     "test_basic"
-    "test_does_not_modify_slim_baseline"
     "test_handles_each_path_separately"
     "test_handles_multiple_directories"
     "test_load_and_output"
     "test_make_decisions"
-    "test_modifies_baseline"
-    "test_no_files_in_git_repo"
-    "test_outputs_baseline_if_none_supplied"
+    "test_restores_line_numbers"
     "test_saves_to_baseline"
     "test_scan_all_files"
-    "test_should_scan_all_files_in_directory_if_flag_is_provided"
-    "test_should_scan_specific_non_tracked_file"
-    "test_should_scan_tracked_files_in_directory"
     "test_start_halfway"
-    "test_works_from_different_directory"
-    "TestModifiesBaselineFromVersionChange"
   ];
 
   pythonImportsCheck = [ "detect_secrets" ];


### PR DESCRIPTION
#### Motivation for this change

detect-secrets is failing on darwin: https://hydra.nixos.org/build/159051891

ZHF: #144627 (@NixOS/nixos-release-managers)

#### Things done

- Clone the repo and leave the `.git` directory, and add Git to `checkInputs` to fix several failing tests (some tests use Git commands and expect to be inside a Git repository).
- Exclude a test failing on darwin (I didn't put a condition to exclude it only on darwin because it is just a single test of many and it would add noise to the derivation)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
