### PR TITLE
pytho3Packages.m3u8: use upstream patch

### DIFF
--- a/pkgs/development/python-modules/m3u8/default.nix
+++ b/pkgs/development/python-modules/m3u8/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub, requests, iso8601, bottle, pytestCheckHook }:
+{ lib, buildPythonPackage, fetchFromGitHub, fetchpatch, requests, iso8601, bottle, pytestCheckHook }:
 
 buildPythonPackage rec {
   pname = "m3u8";
@@ -11,6 +11,14 @@ buildPythonPackage rec {
     sha256 = "sha256-EfHhmV2otEgEy2OVohS+DF7dk97GFdWZ4cFCERZBmlA=";
   };
 
+  patches = [
+    # Fix hardcoded /tmp dir (fix build on Hydra)
+    (fetchpatch {
+      url = "https://github.com/globocom/m3u8/commit/cf7ae5fda4681efcea796cd7c51c02f152c36009.patch";
+      sha256 = "sha256-SEETpIJQddid8D//6DVrSGs/BqDeMOzufE0bBrm+/xY=";
+    })
+  ];
+
   propagatedBuildInputs = [ requests iso8601 ];
 
   checkInputs = [ bottle pytestCheckHook ];
@@ -20,11 +28,6 @@ buildPythonPackage rec {
     "tests/test_model.py"
     "tests/test_variant_m3u8.py"
   ];
-
-  preCheck = ''
-    # Fix test on Hydra
-    substituteInPlace tests/test_model.py --replace "/tmp/d.m3u8" "$TMPDIR/d.m3u8"
-  '';
 
   meta = with lib; {
     homepage = "https://github.com/globocom/m3u8";


### PR DESCRIPTION
###### Motivation for this change

Follow up to #146667, now with upstream patch (from globocom/m3u8#267)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
