### PR TITLE
libreoffice: replace `openjdk` runtime-input with minimal JRE

### DIFF
--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -2,7 +2,7 @@
 , IOCompress, zlib, libjpeg, expat, freetype, libwpd
 , libxml2, db, curl, fontconfig, libsndfile, neon
 , bison, flex, zip, unzip, gtk3, libmspack, getopt, file, cairo, which
-, icu, boost, jdk, ant, cups, xorg, fontforge
+, icu, boost, jdk, ant, cups, xorg, fontforge, jre_minimal
 , openssl, gperf, cppunit, poppler, util-linux
 , librsvg, libGLU, libGL, bsh, CoinMP, libwps, libabw, libmysqlclient
 , autoconf, automake, openldap, bash, hunspell, librdf_redland, nss, nspr
@@ -24,6 +24,10 @@
 assert builtins.elem variant [ "fresh" "still" ];
 
 let
+  jre' = jre_minimal.override {
+    modules = [ "java.base" "java.desktop" ];
+  };
+
   importVariant = f: import (./. + "/src-${variant}/${f}");
 
   primary-src = importVariant "primary.nix" { inherit fetchurl; };
@@ -318,7 +322,6 @@ in (mkDrv rec {
     "--enable-dbus"
     "--enable-release-build"
     "--enable-epm"
-    "--with-jdk-home=${jdk.home}"
     "--with-ant-home=${ant}/lib/ant"
     "--with-system-cairo"
     "--with-system-libs"
@@ -379,7 +382,7 @@ in (mkDrv rec {
   '';
 
   nativeBuildInputs = [
-    gdb fontforge autoconf automake bison pkg-config libtool
+    gdb fontforge autoconf automake bison pkg-config libtool jdk
   ] ++ lib.optional (!kdeIntegration) wrapGAppsHook
     ++ lib.optional kdeIntegration wrapQtAppsHook;
 
@@ -387,7 +390,7 @@ in (mkDrv rec {
     [ ant ArchiveZip boost box2d cairo clucene_core
       IOCompress cppunit cups curl db dbus-glib expat file flex fontconfig
       freetype getopt gperf gtk3
-      hunspell icu jdk lcms libcdr libexttextcat unixODBC libjpeg
+      hunspell icu jre' lcms libcdr libexttextcat unixODBC libjpeg
       libmspack librdf_redland librsvg libsndfile libvisio libwpd libwpg libX11
       libXaw libXext libXi libXinerama libxml2 libxslt libXtst
       libXdmcp libpthreadstubs libGLU libGL mythes
@@ -407,7 +410,8 @@ in (mkDrv rec {
     ++ lib.optional kdeIntegration [ qtbase qtx11extras kcoreaddons kio ];
 
   passthru = {
-    inherit srcs jdk;
+    inherit srcs;
+    jdk = jre';
   };
 
   requiredSystemFeatures = [ "big-parallel" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Previously, `pkgs.libreoffice` had a total closure-size of 2.4GB where
`pkgs.openjdk` was a significant part:

    $ nix path-info ./result -Sh
    /nix/store/7xyfklmiz2azcnrfa8n9cz12dyyqc85r-libreoffice-7.1.7.2	   2.4G
    $ nix path-info ./result -shr | grep openjdk
    /nix/store/qcn7ihaak9g8ayyj4995ila2z0pkm37i-openjdk-17.0.1+12             	 643.6M

However we need exactly two components:

* a `javac` from `pkgs.openjdk`
* a minimal runtime (i.e. a JRE) for `libofficebean.so` where
  `libjawt.so` is also available.

I moved `jdk` to the `nativeBuildInputs` to ensure that `javac` is still
available in the build-environment and created a minimal JRE that seems
sufficient.

Now, the total closure-size is reduced by ~29.1% (basically the 600M
from `pkgs.openjdk`):

    $ nix path-info ./result -Sh
    /nix/store/zv34xijv64k7sz7rv50g3v6y59qg7p8k-libreoffice-7.1.7.2	   1.7G


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
