### PR TITLE
p11-kit: fix static build

### DIFF
--- a/pkgs/build-support/setup-hooks/meson-shlibs-to-static.sh
+++ b/pkgs/build-support/setup-hooks/meson-shlibs-to-static.sh
@@ -1,0 +1,21 @@
+preConfigurePhases+=" mesonShlibsToStaticPhase"
+
+mesonShlibsToStaticPhase() {
+    runHook preMesonShlibsToStatic
+	replaceMesonFunction() {
+		foundFiles=$(find . -name "meson.build" -exec grep -El "	* *$1 *\(" {} \;)
+		for mesonFile in $foundFiles
+		do
+			echo "$mesonFile";
+			cp "$mesonFile" "$mesonFile.tmp_file_mesonShlibsToStaticPhase"
+			sed -i -E "s=(	* *)$1( *)\(=\1$2(\2=g" "$mesonFile";
+			echo -n "[meson-shlibs-to-static] applied patch : "
+			diff -u "$mesonFile.tmp_file_mesonShlibsToStaticPhase" "$mesonFile" || echo ""
+			rm -f "$mesonFile.tmp_file_mesonShlibsToStaticPhase"
+		done
+	}
+	replaceMesonFunction "shared_library" "static_library"
+	replaceMesonFunction "shared_module" "static_library"
+
+    runHook postMesonShlibsToStatic
+}

--- a/pkgs/development/libraries/p11-kit/default.nix
+++ b/pkgs/development/libraries/p11-kit/default.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, which
-, gettext, libffi, libiconv, libtasn1
+{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, which
+, gettext, libffi, libiconv, libtasn1, bash-completion
 }:
 
 stdenv.mkDerivation rec {
@@ -21,17 +21,15 @@ stdenv.mkDerivation rec {
   # at the same time, libtasn1 in buildInputs provides the libasn1 library
   # to link against for the target platform.
   # hence, libtasn1 is required in both native and build inputs.
-  nativeBuildInputs = [ autoreconfHook pkg-config which libtasn1 ];
+  nativeBuildInputs = [ meson ninja pkg-config which libtasn1 ];
   buildInputs = [ gettext libffi libiconv libtasn1 ];
+  propagatedBuildInputs = [ bash-completion ];
 
-  autoreconfPhase = ''
-    NOCONFIGURE=1 ./autogen.sh
-  '';
-
-  configureFlags = [
-    "--sysconfdir=/etc"
-    "--localstatedir=/var"
-    "--with-trust-paths=/etc/ssl/trust-source:/etc/ssl/certs/ca-certificates.crt"
+  mesonFlags = [
+    "-Dsystem_config=/etc"
+    "-Dtrust_paths=/etc/ssl/certs/ca-certificates.crt"
+    "-Dsystemd=disabled"
+    "-Dbashcompdir=${placeholder "out"}/share/bash-completion/completions"
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -132,6 +132,13 @@ with pkgs;
       ../build-support/setup-hooks/autoreconf.sh
   ) { };
 
+  mesonShlibsToStaticHook = callPackage (
+      { makeSetupHook }:
+      makeSetupHook
+        { deps = []; }
+        ../build-support/setup-hooks/meson-shlibs-to-static.sh
+  ) { };
+
   autoreconfHook264 = autoreconfHook.override {
     autoconf = autoconf264;
     automake = automake111x;


### PR DESCRIPTION
###### Motivation for this change
Part of a bigger project to build Qt 5 statically #136107.

###### Things done
Fixed build of pkgsStatic.p11-kit,
created mesonShlibsToStaticHook: a preconfigure setup hook that replaces all shared_library calls to static_library calls in meson.build files.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
