### PR TITLE
phpExtensions.gnupg: init at 1.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11296,6 +11296,16 @@
     githubId = 321799;
     name = "Paul Colomiets";
   };
+  taikx4 = {
+    email = "taikx4@taikx4szlaj2rsdupcwabg35inbny4jk322ngeb7qwbbhd5i55nf5yyd.onion";
+    github = "taikx4";
+    githubId = 94917129;
+    name = "taikx4";
+    keys = [{
+      longkeyid = "ed25519/0xCCD52C7B37BB837E";
+      fingerprint = "6B02 8103 C4E5 F68C D77C  9E54 CCD5 2C7B 37BB 837E";
+    }];
+  };
   takagiy = {
     email = "takagiy.4dev@gmail.com";
     github = "takagiy";

--- a/pkgs/development/php-packages/gnupg/default.nix
+++ b/pkgs/development/php-packages/gnupg/default.nix
@@ -1,0 +1,37 @@
+{ buildPecl, lib, gpgme, file, gnupg }:
+
+buildPecl {
+  pname = "gnupg";
+
+  version = "1.5.0";
+  sha256 = "0r0akrjjf9i460z11llybdr6sg2rlcz38nwfy0yqz443ljdggxfl";
+
+  buildInputs = [ gpgme ];
+  checkInputs = [ gnupg ];
+
+  postPhpize = ''
+    substituteInPlace configure \
+      --replace '/usr/bin/file' '${file}/bin/file' \
+      --replace 'SEARCH_PATH="/usr/local /usr /opt"' 'SEARCH_PATH="${gpgme.dev}"'
+  '';
+
+  postConfigure = with lib; ''
+    substituteInPlace Makefile \
+      --replace 'run-tests.php' 'run-tests.php -q --offline'
+    substituteInPlace tests/gnupg_res_init_file_name.phpt \
+      --replace '/usr/bin/gpg' '${gnupg}/bin/gpg' \
+      --replace 'string(12)' 'string(${toString (stringLength "${gnupg}/bin/gpg")})'
+    substituteInPlace tests/gnupg_oo_init_file_name.phpt \
+      --replace '/usr/bin/gpg' '${gnupg}/bin/gpg' \
+      --replace 'string(12)' 'string(${toString (stringLength "${gnupg}/bin/gpg")})'
+  '';
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "PHP wrapper for GpgME library that provides access to GnuPG";
+    license = licenses.bsd3;
+    homepage = "https://pecl.php.net/package/gnupg";
+    maintainers = with maintainers; [ taikx4 ] ++ teams.php.members;
+  };
+}

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -173,6 +173,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
     event = callPackage ../development/php-packages/event { };
 
+    gnupg = callPackage ../development/php-packages/gnupg { };
+
     igbinary = callPackage ../development/php-packages/igbinary { };
 
     imagick = callPackage ../development/php-packages/imagick { };


### PR DESCRIPTION
###### Motivation for this change
It's a requirement for the nextcloud [gpgmailer](https://apps.nextcloud.com/apps/gpgmailer) app.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
