### PR TITLE
httpdirfs: init at 1.2.2

### DIFF
--- a/pkgs/tools/filesystems/httpdirfs/default.nix
+++ b/pkgs/tools/filesystems/httpdirfs/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     description = "A FUSE filesystem for HTTP directory listings";
     homepage = "https://github.com/fangfufu/httpdirfs";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ sbruder ];
+    maintainers = with maintainers; [ sbruder schnusch ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/filesystems/httpdirfs/default.nix
+++ b/pkgs/tools/filesystems/httpdirfs/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "httpdirfs";
-  version = "1.2.2";
+  version = "1.2.3";
 
   src = fetchFromGitHub {
     owner = "fangfufu";
     repo = pname;
     rev = version;
-    sha256 = "sha256-IR+keGTEr1bPW6NIa7msH8DhwXrO6k1oGKdhe9Zl/pI=";
+    sha256 = "sha256-rdeBlAV3t/si9x488tirUGLZRYAxh13zdRIQe0OPd+A=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/tools/filesystems/httpdirfs/default.nix
+++ b/pkgs/tools/filesystems/httpdirfs/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, curl, expat, fuse, gumbo, libuuid }:
+
+stdenv.mkDerivation rec {
+  pname = "httpdirfs";
+  version = "1.2.2";
+
+  src = fetchFromGitHub {
+    owner = "fangfufu";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-IR+keGTEr1bPW6NIa7msH8DhwXrO6k1oGKdhe9Zl/pI=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ curl expat fuse gumbo libuuid ];
+
+  makeFlags = [ "prefix=${placeholder "out"}" ];
+
+  meta = with lib; {
+    description = "A FUSE filesystem for HTTP directory listings";
+    homepage = "https://github.com/fangfufu/httpdirfs";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ sbruder ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6317,6 +6317,8 @@ with pkgs;
 
   http-getter = callPackage ../applications/networking/flent/http-getter.nix { };
 
+  httpdirfs = callPackage ../tools/filesystems/httpdirfs { };
+
   httpdump = callPackage ../tools/security/httpdump { };
 
   httpie = callPackage ../tools/networking/httpie { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add [HTTPDirFS](https://github.com/fangfufu/httpdirfs).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
