### PR TITLE
pkgsStatic.libselinux: fix build

### DIFF
--- a/pkgs/os-specific/linux/libselinux/default.nix
+++ b/pkgs/os-specific/linux/libselinux/default.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchurl, pcre, pkg-config, libsepol
-, enablePython ? true, swig ? null, python3 ? null
+{ lib, stdenv, fetchurl, fetchpatch, buildPackages, pcre, pkg-config, libsepol
+, enablePython ? !stdenv.hostPlatform.isStatic, swig ? null, python3 ? null
 , fts
 }:
 
@@ -19,7 +19,28 @@ stdenv.mkDerivation rec {
     sha256 = "0mvh793g7fg6wb6zqhkdyrv80x6k84ypqwi8ii89c91xcckyxzdc";
   };
 
-  nativeBuildInputs = [ pkg-config ] ++ optionals enablePython [ swig python3 ];
+  patches = [
+    # Make it possible to disable shared builds (for pkgsStatic).
+    #
+    # We can't use fetchpatch because it processes includes/excludes
+    # /after/ stripping the prefix, which wouldn't work here because
+    # there would be no way to distinguish between
+    # e.g. libselinux/src/Makefile and libsepol/src/Makefile.
+    #
+    # This is a static email, so we shouldn't have to worry about
+    # normalizing the patch.
+    (fetchurl {
+      url = "https://lore.kernel.org/selinux/20211113141616.361640-1-hi@alyssa.is/raw";
+      sha256 = "16a2s2ji9049892i15yyqgp4r20hi1hij4c1s4s8law9jsx65b3n";
+      postFetch = ''
+        mv "$out" $TMPDIR/patch
+        ${buildPackages.patchutils_0_3_3}/bin/filterdiff \
+            -i 'a/libselinux/*' --strip 1 <$TMPDIR/patch >"$out"
+      '';
+    })
+  ];
+
+  nativeBuildInputs = [ pkg-config python3 ] ++ optionals enablePython [ swig ];
   buildInputs = [ libsepol pcre fts ] ++ optionals enablePython [ python3 ];
 
   # drop fortify here since package uses it by default, leading to compile error:
@@ -40,6 +61,8 @@ stdenv.mkDerivation rec {
 
     "LIBSEPOLA=${lib.getLib libsepol}/lib/libsepol.a"
     "ARCH=${stdenv.hostPlatform.linuxArch}"
+  ] ++ optionals stdenv.hostPlatform.isStatic [
+    "DISABLE_SHARED=y"
   ] ++ optionals enablePython [
     "PYTHON=${python3.pythonForBuild.interpreter}"
     "PYTHONLIBDIR=$(py)/${python3.sitePackages}"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

@SCOTT-HAMILTON I figured it's time to start posting some of the static work I've been doing in the last few months, to avoid any more duplication of effort.  There are a few areas where our work has overlapped, but it looks like our end goals are very different (I've basically given up for GUI stuff), so hopefully there shouldn't be too many of these things where we've both come up with ways of doing the same thing.  This is similar to your approach in #136107, except that it uses a patch that is suitable for upstream (and will hopefully be accepted soon), and the patch works for non-static builds too (it just provides a knob that allows shared libraries to be disabled).  I think this is better because it means we're not building from slightly different sources when doing static builds (which hopefully means the patch won't stop applying next time selinux is updated if whoever does it doesn't test static builds), and if my patch is accepted upstream, we won't need to keep this patch around forever.  I'd really appreciate your review.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
