### PR TITLE
pythonPackages.openai: init at 0.11.4

### DIFF
--- a/pkgs/development/python-modules/openai/default.nix
+++ b/pkgs/development/python-modules/openai/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+
+# Python dependencies
+, openpyxl
+, pandas
+, pandas-stubs
+, requests
+, tqdm
+
+# Check dependencies
+, pytest-mock
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "openai";
+  version = "0.11.4";
+
+  disabled = pythonOlder "3.7.1";
+
+  # Use GitHub source since PyPi source does not include tests
+  src = fetchFromGitHub {
+    owner = "openai";
+    repo = "openai-python";
+    rev = "v${version}";
+    sha256 = "O2O4+GkyMyAxJqMNgiyPKoSXeJk0HGAst02QV6c9mJs=";
+  };
+
+  propagatedBuildInputs = [
+    openpyxl
+    pandas
+    pandas-stubs
+    requests
+    tqdm
+  ];
+
+  pythonImportsCheck = [ "openai" ];
+  checkInputs = [ pytestCheckHook pytest-mock ];
+  pytestFlagsArray = [ "openai/tests" ];
+  OPENAI_API_KEY = "sk-foo";
+  disabledTestPaths = [
+    "openai/tests/test_endpoints.py" # requires a real API key
+    "openai/tests/test_file_cli.py"
+  ];
+
+  meta = with lib; {
+    description = "Python client library for the OpenAI API";
+    homepage = "https://github.com/openai/openai-python";
+    license = licenses.mit;
+    maintainers = [ maintainers.malo ];
+  };
+}

--- a/pkgs/development/python-modules/pandas-stubs/default.nix
+++ b/pkgs/development/python-modules/pandas-stubs/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, isPy27
+, fetchFromGitHub
+, typing-extensions
+, mypy
+}:
+
+buildPythonPackage rec {
+  pname = "pandas-stubs";
+  version = "1.2.0.39";
+
+  disabled = isPy27;
+
+  # Use GitHub source since PyPi source does not include tests
+  src = fetchFromGitHub {
+    owner = "VirtusLab";
+    repo = pname;
+    rev = "2bd932777d1050ea8f86c527266a4cd205aa15b1";
+    sha256 = "m2McU53NNvRwnWKN9GL8dW1eCGKbTi0471szRQwZu1Q=";
+  };
+
+  propagatedBuildInputs = [
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [ "pandas" ];
+  checkInputs = [ mypy ];
+  checkPhase = ''
+    mypy --config-file mypy.ini third_party/3/pandas tests/snippets
+  '';
+
+  meta = with lib; {
+    description = "Type annotations for Pandas";
+    homepage = "https://github.com/VirtusLab/pandas-stubs";
+    license = licenses.mit;
+    maintainers = [ maintainers.malo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14993,6 +14993,8 @@ with pkgs;
 
   omniorb = callPackage ../development/tools/omniorb { };
 
+  openai = with python3Packages; toPythonApplication openai;
+
   opengrok = callPackage ../development/tools/misc/opengrok { };
 
   openocd = callPackage ../development/embedded/openocd { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5694,6 +5694,8 @@ in {
 
   netmap = callPackage ../development/python-modules/netmap { };
 
+  openai = callPackage ../development/python-modules/openai { };
+
   openapi-core = callPackage ../development/python-modules/openapi-core { };
 
   pandas-stubs = callPackage ../development/python-modules/pandas-stubs { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5696,6 +5696,8 @@ in {
 
   openapi-core = callPackage ../development/python-modules/openapi-core { };
 
+  pandas-stubs = callPackage ../development/python-modules/pandas-stubs { };
+
   parameterizedtestcase = callPackage ../development/python-modules/parameterizedtestcase { };
 
   pdunehd = callPackage ../development/python-modules/pdunehd { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Want to have access to the `openai` Python package in `nixpkgs`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
