### PR TITLE
perlPackages.DistZilla: shortenPerlShebang on Darwin

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -6887,6 +6887,10 @@ let
     };
     buildInputs = [ CPANMetaCheck TestDeep TestFailWarnings TestFatal TestFileShareDir ];
     propagatedBuildInputs = [ AppCmd CPANUploader ConfigMVPReaderINI DateTime FileCopyRecursive FileFindRule FileShareDirInstall Filepushd LogDispatchouli MooseXLazyRequire MooseXSetOnce MooseXTypesPerl PathTiny PerlPrereqScanner SoftwareLicense TermEncoding TermUI YAMLTiny ];
+    nativeBuildInputs = lib.optional stdenv.isDarwin shortenPerlShebang;
+    postInstall = lib.optionalString stdenv.isDarwin ''
+      shortenPerlShebang $out/bin/dzil
+    '';
     meta = {
       homepage = "http://dzil.org/";
       description = "Distribution builder; installer not included!";


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
DistZilla is broken on Darwin because of generated long shebang:
``` Shell
dzil
/nix/store/7b793mhvn7b90kc58jd6w6dpw7c302vn-perl5.34.0-Dist-Zilla-6.017/bin/dzil: line 2: use: command not found
/nix/store/7b793mhvn7b90kc58jd6w6dpw7c302vn-perl5.34.0-Dist-Zilla-6.017/bin/dzil: line 3: use: command not found
/nix/store/7b793mhvn7b90kc58jd6w6dpw7c302vn-perl5.34.0-Dist-Zilla-6.017/bin/dzil: line 4: package: command not found
/nix/store/7b793mhvn7b90kc58jd6w6dpw7c302vn-perl5.34.0-Dist-Zilla-6.017/bin/dzil: line 2: use: command not found
/nix/store/7b793mhvn7b90kc58jd6w6dpw7c302vn-perl5.34.0-Dist-Zilla-6.017/bin/dzil: line 3: use: command not found
/nix/store/7b793mhvn7b90kc58jd6w6dpw7c302vn-perl5.34.0-Dist-Zilla-6.017/bin/dzil: line 4: package: command not found
/nix/store/7b793mhvn7b90kc58jd6w6dpw7c302vn-perl5.34.0-Dist-Zilla-6.017/bin/dzil: line 2: use: command not found
/nix/store/7b793mhvn7b90kc58jd6w6dpw7c302vn-perl5.34.0-Dist-Zilla-6.017/bin/dzil: line 3: use: command not found
/nix/store/7b793mhvn7b90kc58jd6w6dpw7c302vn-perl5.34.0-Dist-Zilla-6.017/bin/dzil: line 4: package: command not found
/nix/store/7b793mhvn7b90kc58jd6w6dpw7c302vn-perl5.34.0-Dist-Zilla-6.017/bin/dzil: line 2: use: command not found
/nix/store/7b793mhvn7b90kc58jd6w6dpw7c302vn-perl5.34.0-Dist-Zilla-6.017/bin/dzil: line 3: use: command not found
/nix/store/7b793mhvn7b90kc58jd6w6dpw7c302vn-perl5.34.0-Dist-Zilla-6.017/bin/dzil: line 4: package: command not found
```

Fortunately, the problem is solved by leveraging the shortenPerlShebang function (#66446) 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).