### PR TITLE
xxh: init at 0.8.8

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -504,6 +504,7 @@ in
   xrdp = handleTest ./xrdp.nix {};
   xss-lock = handleTest ./xss-lock.nix {};
   xterm = handleTest ./xterm.nix {};
+  xxh = handleTest ./xxh.nix {};
   yabar = handleTest ./yabar.nix {};
   yggdrasil = handleTest ./yggdrasil.nix {};
   zfs = handleTest ./zfs.nix {};

--- a/nixos/tests/xxh.nix
+++ b/nixos/tests/xxh.nix
@@ -1,0 +1,67 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }:
+
+  let
+    inherit (import ./ssh-keys.nix pkgs) snakeOilPrivateKey snakeOilPublicKey;
+    xxh-shell-zsh = pkgs.stdenv.mkDerivation {
+      pname = "xxh-shell-zsh";
+      version = "";
+      src = pkgs.fetchFromGitHub {
+        owner = "xxh";
+        repo = "xxh-shell-zsh";
+        # gets rarely updated, we can then just replace the hash
+        rev = "91e1f84f8d6e0852c3235d4813f341230cac439f";
+        sha256 = "sha256-Y1FrIRxTd0yooK+ZzKcCd6bLSy5E2fRXYAzrIsm7rIc=";
+      };
+
+      postPatch = ''
+        substituteInPlace build.sh \
+          --replace "echo Install wget or curl" "cp ${zsh-portable-binary} zsh-5.8-linux-x86_64.tar.gz" \
+          --replace "command -v curl" "command -v this-should-not-trigger"
+      '';
+
+      installPhase = ''
+        mkdir -p $out
+        mv * $out/
+      '';
+    };
+
+    zsh-portable-binary = pkgs.fetchurl {
+      # kept in sync with https://github.com/xxh/xxh-shell-zsh/tree/master/build.sh#L27
+      url = "https://github.com/romkatv/zsh-bin/releases/download/v3.0.1/zsh-5.8-linux-x86_64.tar.gz";
+      sha256 = "sha256-i8flMd2Isc0uLoeYQNDnOGb/kK3oTFVqQgIx7aOAIIo=";
+    };
+  in
+  {
+    name = "xxh";
+    meta = with lib.maintainers; {
+      maintainers = [ lom ];
+    };
+
+    nodes = {
+      server = { ... }: {
+        services.openssh.enable = true;
+        users.users.root.openssh.authorizedKeys.keys = [ snakeOilPublicKey ];
+      };
+
+      client = { ... }: {
+        programs.zsh.enable = true;
+        users.users.root.shell = pkgs.zsh;
+        environment.systemPackages = with pkgs; [ xxh git ];
+      };
+    };
+
+    testScript = ''
+      start_all()
+
+      client.succeed("mkdir -m 700 /root/.ssh")
+
+      client.succeed(
+         "cat ${snakeOilPrivateKey} > /root/.ssh/id_ecdsa"
+      )
+      client.succeed("chmod 600 /root/.ssh/id_ecdsa")
+
+      server.wait_for_unit("sshd")
+
+      client.succeed("xxh server -i /root/.ssh/id_ecdsa +hc \'echo $0\' +i +s zsh +I xxh-shell-zsh+path+${xxh-shell-zsh} | grep -Fq '/root/.xxh/.xxh/shells/xxh-shell-zsh/build/zsh-bin/bin/zsh'")
+    '';
+  })

--- a/pkgs/tools/networking/xxh/default.nix
+++ b/pkgs/tools/networking/xxh/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildPythonApplication, pexpect, pyyaml, openssh }:
+{ lib, fetchFromGitHub, buildPythonApplication, pexpect, pyyaml, openssh, nixosTests }:
 
 buildPythonApplication rec{
   pname = "xxh";
@@ -12,6 +12,10 @@ buildPythonApplication rec{
   };
 
   propagatedBuildInputs = [ pexpect pyyaml openssh ];
+
+  passthru.tests = {
+    inherit (nixosTests) xxh;
+  };
 
   meta = with lib; {
     description = "Bring your favorite shell wherever you go through ssh";

--- a/pkgs/tools/networking/xxh/default.nix
+++ b/pkgs/tools/networking/xxh/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonApplication rec{
   pname = "xxh";
-  version = "0.8.7";
+  version = "0.8.8";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    hash = "sha256-AKfiFBaV8DC/Z7Bc+ZpwcJor/mzYomUaQKKobKXICn4=";
+    hash = "sha256-TzC8GTDmnYN56Rp5DyZxh+yGrkgWr6Xt86a/jyB3j5k=";
   };
 
   propagatedBuildInputs = [ pexpect pyyaml openssh ];

--- a/pkgs/tools/networking/xxh/default.nix
+++ b/pkgs/tools/networking/xxh/default.nix
@@ -14,10 +14,9 @@ buildPythonApplication rec{
   propagatedBuildInputs = [ pexpect pyyaml openssh ];
 
   meta = with lib; {
-    description = "Bring your favorite shell wherever you go through the ssh";
+    description = "Bring your favorite shell wherever you go through ssh";
     homepage = "https://github.com/xxh/xxh";
     license = licenses.bsd2;
     maintainers = [ maintainers.pasqui23 ];
   };
-
 }

--- a/pkgs/tools/networking/xxh/default.nix
+++ b/pkgs/tools/networking/xxh/default.nix
@@ -1,14 +1,18 @@
 { lib, fetchFromGitHub, buildPythonApplication, pexpect, pyyaml, openssh }:
+
 buildPythonApplication rec{
   pname = "xxh";
   version = "0.8.7";
+
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
     hash = "sha256-AKfiFBaV8DC/Z7Bc+ZpwcJor/mzYomUaQKKobKXICn4=";
   };
+
   propagatedBuildInputs = [ pexpect pyyaml openssh ];
+
   meta = with lib; {
     description = "Bring your favorite shell wherever you go through the ssh";
     homepage = "https://github.com/xxh/xxh";

--- a/pkgs/tools/networking/xxh/default.nix
+++ b/pkgs/tools/networking/xxh/default.nix
@@ -1,0 +1,20 @@
+{ lib, fetchFromGitHub, buildPythonApplication, pexpect, pyyaml, openssh }:
+buildPythonApplication rec{
+  pname = "xxh";
+  version = "0.8.7";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    hash = "sha256-AKfiFBaV8DC/Z7Bc+ZpwcJor/mzYomUaQKKobKXICn4=";
+  };
+  propagatedBuildInputs = [ pexpect pyyaml openssh ];
+  meta = with lib; {
+    description = "Bring your favorite shell wherever you go through the ssh";
+    homepage = "https://github.com/xxh/xxh";
+    license = licenses.bsd2;
+    maintainers = [ maintainers.pasqui23 ];
+    platforms = platforms.all;
+  };
+
+}

--- a/pkgs/tools/networking/xxh/default.nix
+++ b/pkgs/tools/networking/xxh/default.nix
@@ -14,7 +14,6 @@ buildPythonApplication rec{
     homepage = "https://github.com/xxh/xxh";
     license = licenses.bsd2;
     maintainers = [ maintainers.pasqui23 ];
-    platforms = platforms.all;
   };
 
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29219,6 +29219,8 @@ with pkgs;
     gtk = gtk2;
   };
 
+  xxh = with python3Packages; toPythonApplication xxh;
+
   kodiPackages = recurseIntoAttrs (kodi.packages);
 
   kodi = callPackage ../applications/video/kodi {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10165,6 +10165,8 @@ in {
     inherit (pkgs.xorg) xorgserver;
   };
 
+  xxh = callPackage ../tools/networking/xxh { };
+
   xxhash = callPackage ../development/python-modules/xxhash { };
 
   yahooweather = callPackage ../development/python-modules/yahooweather { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
