### PR TITLE
squirrel-sql: Add jtds as a driver.

### DIFF
--- a/pkgs/servers/sql/mssql/jdbc/jtds.nix
+++ b/pkgs/servers/sql/mssql/jdbc/jtds.nix
@@ -1,0 +1,27 @@
+{lib, stdenv, fetchurl, unzip}:
+
+stdenv.mkDerivation rec {
+  pname = "jtds";
+  version = "1.3.1";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/jtds/${version}/${pname}-${version}-dist.zip";
+    sha256 = "sha256-eV0P8QdjfuHXzYssH8yHhynuH0Clg7MAece2Up3S9M0";
+  };
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    mkdir -p $out/share/java
+    cp jtds-*.jar $out/share/java/jtds-jdbc.jar
+  '';
+
+  nativeBuildInputs = [ unzip ];
+
+  meta = with lib; {
+    description = "Pure Java (type 4) JDBC 3.0 driver for Microsoft SQL Server";
+    homepage = "http://jtds.sourceforge.net/";
+    license = licenses.lgpl21;
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/servers/sql/mssql/jdbc/jtds.nix
+++ b/pkgs/servers/sql/mssql/jdbc/jtds.nix
@@ -22,6 +22,6 @@ stdenv.mkDerivation rec {
     description = "Pure Java (type 4) JDBC 3.0 driver for Microsoft SQL Server";
     homepage = "http://jtds.sourceforge.net/";
     license = licenses.lgpl21;
-    platforms = lib.platforms.unix;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13057,7 +13057,7 @@ with pkgs;
   squeak = callPackage ../development/compilers/squeak { };
 
   squirrel-sql = callPackage ../development/tools/database/squirrel-sql {
-    drivers = [ mssql_jdbc mysql_jdbc postgresql_jdbc ];
+    drivers = [ jtds_jdbc mssql_jdbc mysql_jdbc postgresql_jdbc ];
   };
 
   stalin = callPackage ../development/compilers/stalin { };
@@ -21248,6 +21248,7 @@ with pkgs;
   mysql_jdbc = callPackage ../servers/sql/mysql/jdbc { };
 
   mssql_jdbc = callPackage ../servers/sql/mssql/jdbc { };
+  jtds_jdbc = callPackage ../servers/sql/mssql/jdbc/jtds.nix { };
 
   azuredatastudio = callPackage ../applications/misc/azuredatastudio { };
 


### PR DESCRIPTION
###### Motivation for this change

Add jTDS driver for squirrel-sql for connecting to MSSQL databases.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
