### PR TITLE
bviplus: pull pending upstream inclusion fix for ncurses-6.3

### DIFF
--- a/pkgs/applications/editors/bviplus/default.nix
+++ b/pkgs/applications/editors/bviplus/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, ncurses }:
+{ lib, stdenv, fetchurl, fetchpatch, ncurses }:
 
 stdenv.mkDerivation rec {
   pname = "bviplus";
@@ -8,6 +8,18 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/project/bviplus/bviplus/${version}/bviplus-${version}.tgz";
     sha256 = "08q2fdyiirabbsp5qpn3v8jxp4gd85l776w6gqvrbjwqa29a8arg";
   };
+
+  patches = [
+    # Fix pending upstream inclusion for ncurses-6.3 support:
+    #  https://sourceforge.net/p/bviplus/bugs/7/
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://sourceforge.net/p/bviplus/bugs/7/attachment/bviplus-ncurses-6.2.patch";
+      sha256 = "1g3s2fdly3qliy67f3dlb12a03a21zkjbya6gap4mqxhyyjbp46x";
+      # svn patch, rely on prefix added by fetchpatch:
+      extraPrefix = "";
+    })
+  ];
 
   buildInputs = [
     ncurses


### PR DESCRIPTION
Without the fix build on ncurses-6.3 fails as:

    creadline.c:71:3: error: format not a string literal and no format arguments [-Werror=format-security]
       71 |   mvwprintw(w, y, x, prompt);
          |   ^~~~~~~~~
