### PR TITLE
usbimager: init at 1.0.8

### DIFF
--- a/pkgs/tools/misc/usbimager/default.nix
+++ b/pkgs/tools/misc/usbimager/default.nix
@@ -1,0 +1,47 @@
+{ lib, stdenv, fetchFromGitLab, pkg-config
+, withLibui ? true, gtk3
+, withUdisks ? stdenv.isLinux, udisks, glib
+, libX11 }:
+
+stdenv.mkDerivation rec {
+  pname = "usbimager";
+  version = "1.0.8";
+
+  src = fetchFromGitLab {
+    owner = "bztsrc";
+    repo = pname;
+    rev = version;
+    sha256 = "1j0g1anmdwc3pap3m4kfzqjfkn7q0vpmqniii2kcz7svs5h3ybga";
+  };
+
+  sourceRoot = "source/src/";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = lib.optionals withUdisks [ udisks glib ]
+    ++ lib.optional (!withLibui) libX11
+    ++ lib.optional withLibui gtk3;
+    # libui is bundled with the source of usbimager as a compiled static libary
+
+  postPatch = ''
+    sed -i \
+      -e 's|install -m 2755 -g disk|install |g' \
+      -e 's|-I/usr/include/gio-unix-2.0|-I${glib.dev}/include/gio-unix-2.0|g' \
+      -e 's|install -m 2755 -g $(GRP)|install |g' Makefile
+  '';
+
+  dontConfigure = true;
+
+  makeFlags =  [ "PREFIX=$(out)" ]
+    ++ lib.optional withLibui "USE_LIBUI=yes"
+    ++ lib.optional withUdisks "USE_UDISKS2=yes";
+
+  meta = with lib; {
+    description = "A very minimal GUI app that can write compressed disk images to USB drives";
+    homepage = "https://gitlab.com/bztsrc/usbimager";
+    license = licenses.mit;
+    maintainers = with maintainers; [ vdot0x23 ];
+    # windows and darwin could work, but untested
+    # feel free add them if you have a machine to test
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4081,6 +4081,8 @@ with pkgs;
 
   usbview = callPackage ../tools/misc/usbview { };
 
+  usbimager = callPackage ../tools/misc/usbimager { };
+
   uwuify = callPackage ../tools/misc/uwuify { };
 
   anthy = callPackage ../tools/inputmethods/anthy { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add https://gitlab.com/bztsrc/usbimager 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

There will be permissions issues unless compiled with udisks (and the relevant daemons are running) but afaik that is to be solved by a NixOS module alá wireshark. 