### PR TITLE
Pantheon updates 2021-11-23

### DIFF
--- a/pkgs/desktops/pantheon/apps/appcenter/default.nix
+++ b/pkgs/desktops/pantheon/apps/appcenter/default.nix
@@ -31,13 +31,13 @@
 
 stdenv.mkDerivation rec {
   pname = "appcenter";
-  version = "3.8.2";
+  version = "3.9.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-NHKP1vzb8qu+EkUWDvLWLl4U4pW9ZxbE7YFI6Vwesfg=";
+    sha256 = "sha256-+r19n42FPoBArZNDF4ZAdUBZqsSxpLwpeBoyaRJBCrg=";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/elementary-camera/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-camera/default.nix
@@ -25,7 +25,7 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-camera";
-  version = "6.0.1";
+  version = "6.0.2";
 
   repoName = "camera";
 
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-OdBinryF6XTcvtY4A1wdDVazjf/VritEGF97ts6d4RY=";
+    sha256 = "sha256-uVeV+LKA/W7WVUAvVWaSNRzeh1MUrhRjvS0HuhZZJ04=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/pantheon/apps/elementary-dock/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-dock/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
 , vala
 , atk
@@ -28,7 +29,7 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-dock";
-  version = "unstable-2021-07-16";
+  version = "unstable-2021-11-08";
 
   outputs = [ "out" "dev" ];
 
@@ -37,8 +38,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "elementary";
     repo = repoName;
-    rev = "05fd6fccdf1a769f6737a0d7e57e092825348660";
-    sha256 = "0lqqq5cx0kk8y7qyjx7z2k3v1kw2xxzns968ianarcji19wzcns4";
+    rev = "51e8d3ddfbed0dfce3158d80f997ab183e92567b";
+    sha256 = "sha256-w6HGxEAXNod/uMEEfSz9nRNTRrCbcEqJCP9EFkVbX1U=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
 , nix-update-script
 , pantheon
@@ -8,32 +9,35 @@
 , pkg-config
 , vala
 , libgee
+, gnome-settings-daemon
 , granite
+, gsettings-desktop-schemas
 , gtk3
 , libhandy
 , libxml2
 , libgnomekbd
 , libxklavier
 , ibus
+, onboard
 , switchboard
 }:
 
 stdenv.mkDerivation rec {
   pname = "switchboard-plug-keyboard";
-  version = "2.5.1";
+  version = "2.6.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "1p1l7dx5v1zzz89hhhkm6n3ls7ig4cf2prh1099f1c054qiy9b0y";
+    sha256 = "sha256-Bl0T+8upTdBnLs03UIimcAg0LO40KwuMZRNSM+y/3Hc=";
   };
 
   patches = [
     ./0001-Remove-Install-Unlisted-Engines-function.patch
     (substituteAll {
       src = ./fix-paths.patch;
-      ibus = ibus;
+      inherit ibus onboard;
     })
   ];
 
@@ -52,7 +56,9 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    gnome-settings-daemon # media-keys
     granite
+    gsettings-desktop-schemas
     gtk3
     ibus
     libgee

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/fix-paths.patch
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/fix-paths.patch
@@ -1,8 +1,8 @@
 diff --git a/src/Views/InputMethod.vala b/src/Views/InputMethod.vala
-index 6d79fdc..de4276e 100644
+index 7f73c1e1..1f0d6400 100644
 --- a/src/Views/InputMethod.vala
 +++ b/src/Views/InputMethod.vala
-@@ -325,7 +325,7 @@ public class Pantheon.Keyboard.InputMethodPage.Page : Gtk.Grid {
+@@ -328,7 +328,7 @@ public class Pantheon.Keyboard.InputMethodPage.Page : Gtk.Grid {
      private void spawn_ibus_daemon () {
          bool is_spawn_succeeded = false;
          try {
@@ -11,3 +11,16 @@ index 6d79fdc..de4276e 100644
          } catch (GLib.SpawnError e) {
              warning (e.message);
              set_visible_view (e.message);
+diff --git a/src/Views/Layout.vala b/src/Views/Layout.vala
+index 75d2d805..b86252a4 100644
+--- a/src/Views/Layout.vala
++++ b/src/Views/Layout.vala
+@@ -219,7 +219,7 @@ namespace Pantheon.Keyboard {
+ 
+             onscreen_keyboard_settings.clicked.connect (() => {
+                 try {
+-                    var appinfo = AppInfo.create_from_commandline ("onboard-settings", null, AppInfoCreateFlags.NONE);
++                    var appinfo = AppInfo.create_from_commandline ("@onboard@/bin/onboard-settings", null, AppInfoCreateFlags.NONE);
+                     appinfo.launch (null, null);
+                 } catch (Error e) {
+                     warning ("Unable to launch onboard-settings: %s", e.message);

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/pantheon-shell/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/pantheon-shell/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
-, fetchpatch
 , nix-update-script
 , pantheon
 , meson
@@ -25,28 +25,13 @@
 
 stdenv.mkDerivation rec {
   pname = "switchboard-plug-pantheon-shell";
-  version = "6.0.0";
+  version = "6.1.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "0349150kxdv14ald79pzn7lasiqipyc37fgchygbc8hsy62d9a32";
-  };
-
-  patches = [
-    # Upstream code not respecting our localedir
-    # https://github.com/elementary/switchboard-plug-pantheon-shell/pull/286
-    (fetchpatch {
-      url = "https://github.com/elementary/switchboard-plug-pantheon-shell/commit/0c3207ffaeaa82ca3c743bc9ec772185fbd7e8cf.patch";
-      sha256 = "11ymzqx6has4zf8y0xy7pfhymcl128hzzjcgp46inshjf99v5kiv";
-    })
-  ];
-
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
+    sha256 = "sha256-rwneQ1bqpWDyTHULMtGqhPdpSDa4ObnVortmL0E+gHA=";
   };
 
   nativeBuildInputs = [
@@ -72,6 +57,12 @@ stdenv.mkDerivation rec {
     switchboard
     wingpanel
   ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Switchboard Desktop Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/security-privacy/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/security-privacy/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
-, fetchpatch
 , nix-update-script
 , pantheon
 , meson
@@ -8,8 +8,10 @@
 , ninja
 , pkg-config
 , vala
+, elementary-settings-daemon
 , libgee
 , granite
+, gsettings-desktop-schemas
 , gala
 , gtk3
 , glib
@@ -20,28 +22,13 @@
 
 stdenv.mkDerivation rec {
   pname = "switchboard-plug-security-privacy";
-  version = "2.2.5";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "1ydr1xpbyxjcnd36c9j7a64srbz6gpbshwhcqj6591kmiqhmvknk";
-  };
-
-  patches = [
-    # Upstream code not respecting our localedir
-    # https://github.com/elementary/switchboard-plug-security-privacy/pull/130
-    (fetchpatch {
-      url = "https://github.com/elementary/switchboard-plug-security-privacy/commit/18fe438baba651670d7f0534856c3b2433e3d75d.patch";
-      sha256 = "19qwm725k6h41kgg4a98i4rxx45s4bb1wxx0fzkh75gz9syfi58w";
-    })
-  ];
-
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
+    sha256 = "sha256-pkpS7BR/eXA0rWV1C5AR+FdF5OkDnV8YDBAt1ZkaVPo=";
   };
 
   nativeBuildInputs = [
@@ -53,9 +40,11 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    elementary-settings-daemon # settings schema
     gala
     glib
     granite
+    gsettings-desktop-schemas
     gtk3
     libgee
     polkit
@@ -67,6 +56,12 @@ stdenv.mkDerivation rec {
     chmod +x meson/post_install.py
     patchShebangs meson/post_install.py
   '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Switchboard Security & Privacy Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/sound/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/sound/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
-, fetchpatch
 , nix-update-script
 , pantheon
 , meson
@@ -17,28 +17,13 @@
 
 stdenv.mkDerivation rec {
   pname = "switchboard-plug-sound";
-  version = "2.2.7";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "0yjqws7ryfid9lcafgzzbfnjjwccsankscwdwqfw486qid85whzc";
-  };
-
-  patches = [
-    # Upstream code not respecting our localedir
-    # https://github.com/elementary/switchboard-plug-sound/pull/203
-    (fetchpatch {
-      url = "https://github.com/elementary/switchboard-plug-sound/commit/1f3b9f001ace4c457ab194158dff04ba5e25d278.patch";
-      sha256 = "1lmf2bbif2wkfv500nxbqxp8jdmnjg8yk8xhx3g2g55d15rc5hk4";
-    })
-  ];
-
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
+    sha256 = "sha256-yHuboDpIcioZPNgpmnrM6J2eUCJpoNDdvgu27YuN65I=";
   };
 
   nativeBuildInputs = [
@@ -56,6 +41,12 @@ stdenv.mkDerivation rec {
     pulseaudio
     switchboard
   ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Switchboard Sound Plug";

--- a/pkgs/desktops/pantheon/artwork/elementary-gtk-theme/default.nix
+++ b/pkgs/desktops/pantheon/artwork/elementary-gtk-theme/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
 , nix-update-script
 , pantheon
@@ -10,7 +11,7 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-gtk-theme";
-  version = "6.1.0";
+  version = "6.1.1";
 
   repoName = "stylesheet";
 
@@ -18,13 +19,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-YvBjMbC3aQtYc/jPZmGdL4VfBH/VuxQ70PD0BWg9DTg=";
-  };
-
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
+    sha256 = "sha256-gciBn5MQ5Cu+dROL5kCt2GCbNA7W4HOWXyjMBd4OP+8=";
   };
 
   nativeBuildInputs = [
@@ -33,6 +28,12 @@ stdenv.mkDerivation rec {
     ninja
     sassc
   ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "GTK theme designed to be smooth, attractive, fast, and usable";

--- a/pkgs/desktops/pantheon/artwork/elementary-icon-theme/default.nix
+++ b/pkgs/desktops/pantheon/artwork/elementary-icon-theme/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
 , nix-update-script
 , pantheon
@@ -13,7 +14,7 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-icon-theme";
-  version = "6.0.0";
+  version = "6.1.0";
 
   repoName = "icons";
 
@@ -21,13 +22,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "0k94zi8fzi0nf5q471fmrlz8jjkv8m6vav1spzv7ynkg2hik8d9b";
-  };
-
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
+    sha256 = "sha256-WR4HV0nJKj0WeSFHXLK64O0LhX8myAJE4w0aztyhPn4=";
   };
 
   nativeBuildInputs = [
@@ -56,6 +51,12 @@ stdenv.mkDerivation rec {
   '';
 
   postFixup = "gtk-update-icon-cache $out/share/icons/elementary";
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Named, vector icons for elementary OS";

--- a/pkgs/desktops/pantheon/desktop/elementary-onboarding/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-onboarding/default.nix
@@ -1,5 +1,7 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , substituteAll
 , pantheon
@@ -14,6 +16,7 @@
 , libgee
 , elementary-icon-theme
 , elementary-gtk-theme
+, elementary-settings-daemon
 , gettext
 , libhandy
 , wrapGAppsHook
@@ -22,7 +25,7 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-onboarding";
-  version = "6.0.0";
+  version = "6.1.0";
 
   repoName = "onboarding";
 
@@ -30,13 +33,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "1mpw0j8ymb41py9v9qlk4nwy1lnwj7k388c7gqdv34ynck0ymfi4";
-  };
-
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
+    sha256 = "sha256-9voy9eje3VlV4IMM664EyjKWTfSVogX5JoRCqhsUXTE=";
   };
 
   nativeBuildInputs = [
@@ -52,6 +49,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     elementary-gtk-theme
     elementary-icon-theme
+    elementary-settings-daemon # settings schema
     glib
     granite
     gtk3
@@ -64,12 +62,24 @@ stdenv.mkDerivation rec {
       src = ./fix-paths.patch;
       appcenter = appcenter;
     })
+    # Provides the directory where the locales are actually installed
+    # https://github.com/elementary/onboarding/pull/147
+    (fetchpatch {
+      url = "https://github.com/elementary/onboarding/commit/af19c3dbefd1c0e0ec18eddacc1f21cb991f5513.patch";
+      sha256 = "sha256-fSFfjSd33W7rXXEUHY8b3rv9B9c31XfCjxjRxBBrqjs=";
+    })
   ];
 
   postPatch = ''
     chmod +x meson/post_install.py
     patchShebangs meson/post_install.py
   '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Onboarding app for new users designed for elementary OS";

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/network/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/network/default.nix
@@ -18,19 +18,13 @@
 
 stdenv.mkDerivation rec {
   pname = "wingpanel-indicator-network";
-  version = "2.3.1";
+  version = "2.3.2";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-xr1ZihWK8fU8M/rXRKk5dOjoQNe3aJO8ouKC/iVZ7Sk=";
-  };
-
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
+    sha256 = "sha256-4Fg8/Gm9mUqaL3wEc8h+/pMvOfD75ILjo7LhLz6LQmo=";
   };
 
   nativeBuildInputs = [
@@ -48,6 +42,12 @@ stdenv.mkDerivation rec {
     libnma
     wingpanel
   ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Network Indicator for Wingpanel";

--- a/pkgs/desktops/pantheon/granite/default.nix
+++ b/pkgs/desktops/pantheon/granite/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
 , nix-update-script
 , python3
@@ -18,7 +19,7 @@
 
 stdenv.mkDerivation rec {
   pname = "granite";
-  version = "6.1.2";
+  version = "6.2.0";
 
   outputs = [ "out" "dev" ];
 
@@ -26,13 +27,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-d48KQH8uwkSZWQEFSq1BD+TVUi9PWVVtMjKYmleRW58=";
-  };
-
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
+    sha256 = "sha256-WM0Wo9giVP5pkMFaPCHsMfnAP6xD71zg6QLCYV6lmkY=";
   };
 
   nativeBuildInputs = [
@@ -57,6 +52,12 @@ stdenv.mkDerivation rec {
     chmod +x meson/post_install.py
     patchShebangs meson/post_install.py
   '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "An extension to GTK used by elementary OS";


### PR DESCRIPTION
###### Motivation for this change

Part of Pantheon 6.0.4 updates (previous one at #146574).

- If you live on stable channel, please check our [planned backport workflow for 6.0.4 and 6.1](https://github.com/NixOS/nixpkgs/pull/146574).
- For upcoming Pantheon 7, check [OS 7 project board](https://github.com/orgs/elementary/projects/94) and [Danielle's tweet](https://twitter.com/DanielFore/status/1462885304419774468) for more details.

###### Things to do

- [x] See if `switchboard-plug-security-privacy` needs `gsettings-desktop-schemas` and/or `elementary-settings-daemon` as buildInput. [[1]](https://github.com/elementary/switchboard-plug-security-privacy/blob/1cc9a222aa16aba9e682b13a31cb666717dc7590/src/Views/HouseKeepingPanel.vala#L94) [[2]](https://github.com/elementary/switchboard-plug-security-privacy/blob/1cc9a222aa16aba9e682b13a31cb666717dc7590/src/Views/HouseKeepingPanel.vala#L99), same for `onboarding`
- [x] Correctly setup the locales for `onboarding`

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
