### PR TITLE
dtools: Fix aarch64-darwin build

### DIFF
--- a/pkgs/development/tools/dtools/default.nix
+++ b/pkgs/development/tools/dtools/default.nix
@@ -1,33 +1,23 @@
-{stdenv, lib, fetchFromGitHub, ldc, curl}:
+{stdenv, lib, fetchFromGitHub, fetchpatch, ldc, curl}:
 
 stdenv.mkDerivation rec {
   pname = "dtools";
   version = "2.095.1";
 
-  srcs = [
-    (fetchFromGitHub {
-      owner = "dlang";
-      repo = "dmd";
-      rev = "v${version}";
-      sha256 = "sha256:0faca1y42a1h16aml4lb7z118mh9k9fjx3xlw3ki5f1h3ln91xhk";
-      name = "dmd";
-    })
-    (fetchFromGitHub {
-      owner = "dlang";
-      repo = "tools";
-      rev = "v${version}";
-      sha256 = "sha256:0rdfk3mh3fjrb0h8pr8skwlq6ac9hdl1fkrkdl7n1fa2806b740b";
-      name = "dtools";
+  src = fetchFromGitHub {
+    owner = "dlang";
+    repo = "tools";
+    rev = "v${version}";
+    sha256 = "sha256:0rdfk3mh3fjrb0h8pr8skwlq6ac9hdl1fkrkdl7n1fa2806b740b";
+    name = "dtools";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/dlang/tools/pull/441.patch"; # Fix LDC arm64 build
+      sha256 = "sha256-x6EclTYN1Y5FG57KLhbBK0BZicSYcZoWO7MTVcP4T18=";
     })
   ];
-
-  sourceRoot = ".";
-
-  postUnpack = ''
-      mv dmd dtools
-      cd dtools
-
-  '';
 
   nativeBuildInputs = [ ldc ];
   buildInputs = [ curl ];

--- a/pkgs/development/tools/dtools/default.nix
+++ b/pkgs/development/tools/dtools/default.nix
@@ -14,7 +14,8 @@ stdenv.mkDerivation rec {
 
   patches = [
     (fetchpatch {
-      url = "https://github.com/dlang/tools/pull/441.patch"; # Fix LDC arm64 build
+      # part of https://github.com/dlang/tools/pull/441
+      url = "https://github.com/dlang/tools/commit/6c6a042d1b08e3ec1790bd07a7f69424625ee866.patch"; # Fix LDC arm64 build
       sha256 = "sha256-x6EclTYN1Y5FG57KLhbBK0BZicSYcZoWO7MTVcP4T18=";
     })
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`dtools` fails to build on `aarch64-darwin` because of missing `arm64`/`aarch64` arch in the makefile.

###### Things done
* Pull in patch from upstream PR https://github.com/dlang/tools/pull/441
* Added `arm64`/`aarch64` handling in the makefile
* Decouple the tools repo from the `dmd` repo, since we're always building this with `ldc` in Nix anyway.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
