### PR TITLE
ardour: Enable video support by default

### DIFF
--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -52,7 +52,7 @@
 , vamp-plugin-sdk
 , wafHook
 , xjadeo
-, videoSupport ? false
+, videoSupport ? true
 }:
 stdenv.mkDerivation rec {
   pname = "ardour";


### PR DESCRIPTION
Enables video support in ardour by default.

### Motivation for this change

I do a lot of sound design using ardour and in turn have it enabled in
my configuration. However, seeing as hydra only builds the default
configuration, the build I need is never cached, and I always end up
needing to build ardour from scratch which takes over an hour on my
small laptop.

The `videoSupport` flag itself just ensures that xjadeo
and harvid (both required for video support to work in ardour) are
accessible via the PATH. I've been using it successfully it ever since
I added it back in March so I think it's safe to enable by default. The
only reason I didn't originally was because it was one of my first
contributions to nixpkgs and I wanted to cause as little disruption as
possible :sweat_smile: In retrospect, I should have just enabled it
by default back then as it's a standard feature of the application
and most folks wanting to do any sound design or soundtracking
with ardour will expect it to just work by default anyway.

### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @magnetophon @cillianderoiste (fellow ardour maintainers)