### PR TITLE
python3Packages.glances-api: 0.2.1 -> 0.3.2

### DIFF
--- a/pkgs/development/python-modules/glances-api/default.nix
+++ b/pkgs/development/python-modules/glances-api/default.nix
@@ -1,29 +1,50 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, aiohttp
-, async-timeout
+, httpx
+, poetry-core
+, pytest-asyncio
+, pytest-httpx
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "glances-api";
-  version = "0.2.1";
+  version = "0.3.2";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "home-assistant-ecosystem";
     repo = "python-glances-api";
     rev = version;
-    sha256 = "sha256-mbkZZg2fmus4kOXFxHE/UV/nxemFAsoEZu8IUa7SPsg=";
+    sha256 = "sha256-zVK63SI8ZeVrY2iEEkgp8pq6RDheKeApb9/RWgZCKGI=";
   };
 
-  propagatedBuildInputs = [
-    aiohttp
-    async-timeout
+  nativeBuildInputs = [
+    poetry-core
   ];
 
-  # no tests are present
-  doCheck = false;
-  pythonImportsCheck = [ "glances_api" ];
+  propagatedBuildInputs = [
+    httpx
+  ];
+
+  checkInputs = [
+    pytest-asyncio
+    pytest-httpx
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'httpx = ">=0.20,<1"' 'httpx = ">=0.19,<1"'
+  '';
+
+  pythonImportsCheck = [
+    "glances_api"
+  ];
 
   meta = with lib; {
     description = "Python API for interacting with Glances";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.3.2

Change log:
- https://github.com/home-assistant-ecosystem/python-glances-api/releases/tag/0.3.2
- https://github.com/home-assistant-ecosystem/python-glances-api/releases/tag/0.3.1
- https://github.com/home-assistant-ecosystem/python-glances-api/releases/tag/0.3.0

Fix build (https://hydra.nixos.org/build/159181983)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
