### PR TITLE
clockify: init at 2.0.3

### DIFF
--- a/pkgs/applications/office/clockify/default.nix
+++ b/pkgs/applications/office/clockify/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, lib, fetchurl, dpkg, makeWrapper, electron }:
+
+stdenv.mkDerivation rec {
+  pname = "clockify";
+  version = "2.0.3";
+
+  src = fetchurl {
+    url = "https://web.archive.org/web/20211118160803/https://clockify-resources.s3.eu-central-1.amazonaws.com/downloads/Clockify_Setup.deb";
+    sha256 = "sha256-eVZ3OqM1eoWfST7Qu9o8VmLm8ntD+ETf/0aes6RY4Y8=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+  ];
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  unpackPhase = ''
+    dpkg-deb -x ${src} ./
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mv usr $out
+    mv opt $out
+
+    substituteInPlace $out/share/applications/clockify.desktop \
+      --replace "/opt/Clockify" $out/bin
+
+    makeWrapper ${electron}/bin/electron $out/bin/clockify \
+      --add-flags $out/opt/Clockify/resources/app.asar
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Free time tracker and timesheet app that lets you track work hours across projects";
+    homepage = "https://clockify.me";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ wolfangaukang ];
+    platforms = [ "x86_64-linux" ];
+
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2555,6 +2555,10 @@ with pkgs;
 
   clipster = callPackage ../tools/misc/clipster { };
 
+  clockify = callPackage ../applications/office/clockify {
+    electron = electron_11;
+  };
+
   contrast = callPackage ../applications/accessibility/contrast { };
 
   cplex = callPackage ../applications/science/math/cplex (config.cplex or {});


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#146395 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
