### PR TITLE
spice: fixes for meson upgrade

### DIFF
--- a/pkgs/development/libraries/spice/default.nix
+++ b/pkgs/development/libraries/spice/default.nix
@@ -74,7 +74,6 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dgstreamer=1.0"
-    "-Dcelt051=disabled"
   ];
 
   postInstall = ''

--- a/pkgs/development/libraries/spice/default.nix
+++ b/pkgs/development/libraries/spice/default.nix
@@ -24,6 +24,16 @@
 , orc
 }:
 
+let
+  # This file was mistakenly not included with the 0.15.0 release tarball.
+  # Should be fixed with the next release.
+  # https://gitlab.freedesktop.org/spice/spice/-/issues/56
+  doxygen_sh = fetchurl {
+    url = "https://gitlab.freedesktop.org/spice/spice/-/raw/v0.15.0/doxygen.sh";
+    sha256 = "0g4bx91qclihp1jfhdhyj7wp4hf4289794xxbw32kk58lnd7bzkg";
+  };
+in
+
 stdenv.mkDerivation rec {
   pname = "spice";
   version = "0.15.0";
@@ -34,9 +44,9 @@ stdenv.mkDerivation rec {
   };
 
   postPatch = ''
+    install ${doxygen_sh} doxygen.sh
     patchShebangs build-aux
   '';
-
 
   nativeBuildInputs = [
     glib


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

We'll need these to keep spice working after https://github.com/NixOS/nixpkgs/pull/144779.  But it doesn't hurt to get them in separately, in advance, so there's less to do in that PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
