### PR TITLE
nixos-rebuild: log output to systemd journal

### DIFF
--- a/nixos/doc/manual/man-nixos-rebuild.xml
+++ b/nixos/doc/manual/man-nixos-rebuild.xml
@@ -180,6 +180,8 @@
    stop and (re)starts any system services if needed. Please note that
    user services need to be started manually as they aren't detected
    by the activation script at the moment.
+
+   output is logged to the systemd journal and can be viewed with <command>journalctl -t nixos-rebuild</command>.
   </para>
 
   <para>

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -545,8 +545,5 @@ fi
 
 
 if [[ "$action" = build-vm || "$action" = build-vm-with-bootloader ]]; then
-    cat 1>&3 2>&3 <<EOF
-
-Done.  The virtual machine can be started by running $(echo "${pathToConfig}/bin/"run-*-vm)
-EOF
+    msg "\nDone.  The virtual machine can be started by running $(echo \"${pathToConfig}/bin/\"run-*-vm)"
 fi

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -9,6 +9,13 @@ shopt -s inherit_errexit
 
 export PATH=@path@:$PATH
 
+# save all output to systemd journal
+# 'journalctl -t nixos-rebuild' to inspect
+# tee is used so we still get output to the terminal
+# check if systemd-cat exists and if systemctl exits with 0. if it does not
+# then systemd isn't running(chroot) and cannot use systemd-cat.
+command -v systemd-cat &>/dev/null && systemctl &>/dev/null && exec > >(tee >(systemd-cat -t nixos-rebuild)) 2>&1
+
 showSyntax() {
     exec man nixos-rebuild
     exit 1

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -9,12 +9,14 @@ shopt -s inherit_errexit
 
 export PATH=@path@:$PATH
 
-# save all output to systemd journal
+
+# open a new file descriptor called 3
+# save all >&3 to systemd journal
 # 'journalctl -t nixos-rebuild' to inspect
 # tee is used so we still get output to the terminal
 # check if systemd-cat exists and if systemctl exits with 0. if it does not
-# then systemd isn't running(chroot) and cannot use systemd-cat.
-command -v systemd-cat &>/dev/null && systemctl &>/dev/null && exec > >(tee >(systemd-cat -t nixos-rebuild)) 2>&1
+# then systemd isn't running(chroot) and we cannot use systemd-cat.
+command -v systemd-cat &>/dev/null && systemctl &>/dev/null && exec 3> >(tee >(systemd-cat -t nixos-rebuild)) || exec 3>&1
 
 showSyntax() {
     exec man nixos-rebuild
@@ -526,7 +528,7 @@ fi
 # If we're not just building, then make the new configuration the boot
 # default and/or activate it now.
 if [[ "$action" = switch || "$action" = boot || "$action" = test || "$action" = dry-activate ]]; then
-    if ! targetHostCmd "$pathToConfig/bin/switch-to-configuration" "$action"; then
+    if ! $(targetHostCmd "$pathToConfig/bin/switch-to-configuration" "$action" 1>&3 2>&3); then
         echo "warning: error(s) occurred while switching to the new configuration" >&2
         exit 1
     fi


### PR DESCRIPTION
can be viewed with journalctl -t nixos-rebuild

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This will help with debugging
maybe helps with issues such as https://github.com/NixOS/nixpkgs/issues/146727

###### Things done
tested with `nix build ".#nixos-rebuild" && sudo ./result/bin/nixos-rebuild switch`
and
```bash
#!/usr/bin/env bash

# save all output to systemd journal
# 'journalctl -t nixos-rebuild' to inspect
# tee is used so we still get output to the terminal
# check if systemd-cat exists and if systemctl exits with 0. if it does not
# then systemd isn't running(chroot) and we cannot use systemd-cat.
command -v systemd-cat &>/dev/null && systemctl &>/dev/null && exec > >(tee >(systemd-cat -t nixos-rebuild)) 2>&1

echo hello123
echo $RANDOM
echo goestostderr >&2
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
