### PR TITLE
openjdk[8, 11, 16]: add zulu javaFx on darwin

### DIFF
--- a/pkgs/development/compilers/openjdk/darwin/11.nix
+++ b/pkgs/development/compilers/openjdk/darwin/11.nix
@@ -23,14 +23,13 @@ let
       zuluVersion = "11.48.21";
       jdkVersion = "11.0.11";
       sha256 =
-      if enableJavaFX then "ef0de2705c6c2d586812f7f3736b70e22b069545b38034816016f9f264ad43f9"
-      else "066whglrxx81c95grv2kxdbvyh32728ixhml2v44ildh549n4lhc";
+        if enableJavaFX then "ef0de2705c6c2d586812f7f3736b70e22b069545b38034816016f9f264ad43f9"
+        else "066whglrxx81c95grv2kxdbvyh32728ixhml2v44ildh549n4lhc";
     };
   }."${stdenv.hostPlatform.system}";
 
   jce-policies = fetchurl {
-    # Ugh, unversioned URLs... I hope this doesn't change often enough to cause pain before we move to a Darwin source build of OpenJDK!
-    url = "http://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip";
+    url = "https://web.archive.org/web/20211126120343/http://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip";
     sha256 = "0nk7m0lgcbsvldq2wbfni2pzq8h818523z912i7v8hdcij5s48c0";
   };
 

--- a/pkgs/development/compilers/openjdk/darwin/11.nix
+++ b/pkgs/development/compilers/openjdk/darwin/11.nix
@@ -1,4 +1,10 @@
-{ lib, stdenv, fetchurl, unzip, setJavaClassPath }:
+{ lib
+, stdenv
+, fetchurl
+, unzip
+, setJavaClassPath
+, enableJavaFX ? false
+}:
 let
   # Details from https://www.azul.com/downloads/?version=java-11-lts&os=macos&package=jdk
   # Note that the latest build may differ by platform
@@ -7,29 +13,35 @@ let
       arch = "x64";
       zuluVersion = "11.48.21";
       jdkVersion = "11.0.11";
-      sha256 = "0v0n7h7i04pvna41wpdq2k9qiy70sbbqzqzvazfdvgm3gb22asw6";
+      sha256 =
+        if enableJavaFX then "18bd9cd66d6abc6f8c627bc70278dc8fd4860e138e1dc9e170eddb89727ccc7b"
+        else "0v0n7h7i04pvna41wpdq2k9qiy70sbbqzqzvazfdvgm3gb22asw6";
     };
 
     aarch64-darwin = {
       arch = "aarch64";
       zuluVersion = "11.48.21";
       jdkVersion = "11.0.11";
-      sha256 = "066whglrxx81c95grv2kxdbvyh32728ixhml2v44ildh549n4lhc";
+      sha256 =
+      if enableJavaFX then "ef0de2705c6c2d586812f7f3736b70e22b069545b38034816016f9f264ad43f9"
+      else "066whglrxx81c95grv2kxdbvyh32728ixhml2v44ildh549n4lhc";
     };
   }."${stdenv.hostPlatform.system}";
 
   jce-policies = fetchurl {
     # Ugh, unversioned URLs... I hope this doesn't change often enough to cause pain before we move to a Darwin source build of OpenJDK!
-    url    = "http://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip";
+    url = "http://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip";
     sha256 = "0nk7m0lgcbsvldq2wbfni2pzq8h818523z912i7v8hdcij5s48c0";
   };
 
+  javaPackage = if enableJavaFX then "ca-fx-jdk" else "ca-jdk";
+
   jdk = stdenv.mkDerivation rec {
-    pname = "zulu${dist.zuluVersion}-ca-jdk";
+    pname = "zulu${dist.zuluVersion}-${javaPackage}";
     version = dist.jdkVersion;
 
     src = fetchurl {
-      url = "https://cdn.azul.com/zulu/bin/zulu${dist.zuluVersion}-ca-jdk${dist.jdkVersion}-macosx_${dist.arch}.tar.gz";
+      url = "https://cdn.azul.com/zulu/bin/zulu${dist.zuluVersion}-${javaPackage}${dist.jdkVersion}-macosx_${dist.arch}.tar.gz";
       inherit (dist) sha256;
       curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/";
     };
@@ -77,4 +89,5 @@ let
 
     meta = import ./meta.nix lib;
   };
-in jdk
+in
+jdk

--- a/pkgs/development/compilers/openjdk/darwin/16.nix
+++ b/pkgs/development/compilers/openjdk/darwin/16.nix
@@ -29,8 +29,7 @@ let
   }."${stdenv.hostPlatform.system}";
 
   jce-policies = fetchurl {
-    # Ugh, unversioned URLs... I hope this doesn't change often enough to cause pain before we move to a Darwin source build of OpenJDK!
-    url = "http://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip";
+    url = "https://web.archive.org/web/20211126120343/http://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip";
     sha256 = "0nk7m0lgcbsvldq2wbfni2pzq8h818523z912i7v8hdcij5s48c0";
   };
 

--- a/pkgs/development/compilers/openjdk/darwin/16.nix
+++ b/pkgs/development/compilers/openjdk/darwin/16.nix
@@ -1,4 +1,10 @@
-{ lib, stdenv, fetchurl, unzip, setJavaClassPath }:
+{ lib
+, stdenv
+, fetchurl
+, unzip
+, setJavaClassPath
+, enableJavaFX ? false
+}:
 let
   # Details from https://www.azul.com/downloads/?version=java-16-sts&os=macos&package=jdk
   # Note that the latest build may differ by platform
@@ -7,29 +13,35 @@ let
       arch = "x64";
       zuluVersion = "16.30.15";
       jdkVersion = "16.0.1";
-      sha256 = "1jihn125dmxr9y5h9jq89zywm3z6rbwv5q7msfzsf2wzrr13jh0z";
+      sha256 =
+        if enableJavaFX then "cbb3b96d80a0675893f21dc51ba3f532049c501bd7dc4c8d1ee930e63032c745"
+        else "1jihn125dmxr9y5h9jq89zywm3z6rbwv5q7msfzsf2wzrr13jh0z";
     };
 
     aarch64-darwin = {
       arch = "aarch64";
       zuluVersion = "16.30.19";
       jdkVersion = "16.0.1";
-      sha256 = "1i0bcjx3acb5dhslf6cabdcnd6mrz9728vxw9hb4al5y3f5fll4w";
+      sha256 =
+        if enableJavaFX then "a49b23abfd83784d2ac935fc24e25ab7cb09b8ffc8e47c32ed446e05b8a21396"
+        else "1i0bcjx3acb5dhslf6cabdcnd6mrz9728vxw9hb4al5y3f5fll4w";
     };
   }."${stdenv.hostPlatform.system}";
 
   jce-policies = fetchurl {
     # Ugh, unversioned URLs... I hope this doesn't change often enough to cause pain before we move to a Darwin source build of OpenJDK!
-    url    = "http://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip";
+    url = "http://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip";
     sha256 = "0nk7m0lgcbsvldq2wbfni2pzq8h818523z912i7v8hdcij5s48c0";
   };
 
+  javaPackage = if enableJavaFX then "ca-fx-jdk" else "ca-jdk";
+
   jdk = stdenv.mkDerivation rec {
-    pname = "zulu${dist.zuluVersion}-ca-jdk";
+    pname = "zulu${dist.zuluVersion}-${javaPackage}";
     version = dist.jdkVersion;
 
     src = fetchurl {
-      url = "https://cdn.azul.com/zulu/bin/zulu${dist.zuluVersion}-ca-jdk${dist.jdkVersion}-macosx_${dist.arch}.tar.gz";
+      url = "https://cdn.azul.com/zulu/bin/zulu${dist.zuluVersion}-${javaPackage}${dist.jdkVersion}-macosx_${dist.arch}.tar.gz";
       inherit (dist) sha256;
       curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/";
     };
@@ -77,4 +89,5 @@ let
 
     meta = import ./meta.nix lib;
   };
-in jdk
+in
+jdk

--- a/pkgs/development/compilers/openjdk/darwin/8.nix
+++ b/pkgs/development/compilers/openjdk/darwin/8.nix
@@ -29,8 +29,7 @@ let
   }."${stdenv.hostPlatform.system}";
 
   jce-policies = fetchurl {
-    # Ugh, unversioned URLs... I hope this doesn't change often enough to cause pain before we move to a Darwin source build of OpenJDK!
-    url = "http://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip";
+    url = "https://web.archive.org/web/20211126120343/http://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip";
     sha256 = "0nk7m0lgcbsvldq2wbfni2pzq8h818523z912i7v8hdcij5s48c0";
   };
 

--- a/pkgs/development/compilers/openjdk/darwin/8.nix
+++ b/pkgs/development/compilers/openjdk/darwin/8.nix
@@ -1,4 +1,10 @@
-{ lib, stdenv, fetchurl, unzip, setJavaClassPath }:
+{ lib
+, stdenv
+, fetchurl
+, unzip
+, setJavaClassPath
+, enableJavaFX ? false
+}:
 let
   # Details from https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk
   # Note that the latest build may differ by platform
@@ -7,32 +13,38 @@ let
       arch = "x64";
       zuluVersion = "8.54.0.21";
       jdkVersion = "8.0.292";
-      sha256 = "1pgl0bir4r5v349gkxk54k6v62w241q7vw4gjxhv2g6pfq6hv7in";
+      sha256 =
+        if enableJavaFX then "e671f8990229b1ca2a76faabb21ba2f1a9e1f7211392e0f657225559be9b05c8"
+        else "1pgl0bir4r5v349gkxk54k6v62w241q7vw4gjxhv2g6pfq6hv7in";
     };
 
     aarch64-darwin = {
       arch = "aarch64";
       zuluVersion = "8.54.0.21";
       jdkVersion = "8.0.292";
-      sha256 = "05w89wfjlfbpqfjnv6wisxmaf13qb28b2223f9264jyx30qszw1c";
+      sha256 =
+        if enableJavaFX then "1b05b2e40f707a151b063ebba821270fa930ebfc05712bc1f5a8a112395731a6"
+        else "05w89wfjlfbpqfjnv6wisxmaf13qb28b2223f9264jyx30qszw1c";
     };
   }."${stdenv.hostPlatform.system}";
 
   jce-policies = fetchurl {
     # Ugh, unversioned URLs... I hope this doesn't change often enough to cause pain before we move to a Darwin source build of OpenJDK!
-    url    = "http://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip";
+    url = "http://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip";
     sha256 = "0nk7m0lgcbsvldq2wbfni2pzq8h818523z912i7v8hdcij5s48c0";
   };
+
+  javaPackage = if enableJavaFX then "ca-fx-jdk" else "ca-jdk";
 
   jdk = stdenv.mkDerivation rec {
     # @hlolli: Later version than 1.8.0_202 throws error when building jvmci.
     # dyld: lazy symbol binding failed: Symbol not found: _JVM_BeforeHalt
     # Referenced from: ../libjava.dylib Expected in: .../libjvm.dylib
-    pname = "zulu${dist.zuluVersion}-ca-jdk";
+    pname = "zulu${dist.zuluVersion}-${javaPackage}";
     version = dist.jdkVersion;
 
     src = fetchurl {
-      url = "https://cdn.azul.com/zulu/bin/zulu${dist.zuluVersion}-ca-jdk${dist.jdkVersion}-macosx_${dist.arch}.tar.gz";
+      url = "https://cdn.azul.com/zulu/bin/zulu${dist.zuluVersion}-${javaPackage}${dist.jdkVersion}-macosx_${dist.arch}.tar.gz";
       inherit (dist) sha256;
       curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/";
     };
@@ -75,4 +87,5 @@ let
 
     meta = import ./meta.nix lib;
   };
-in jdk
+in
+jdk


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I needed a jdk with javaFX.

However, I only realized now that there exists also [zulu](https://github.com/NixOS/nixpkgs/blob/20a166d2603d76cba39ecbb8cb5907b34e59e457/pkgs/development/compilers/zulu/default.nix), which does kind of the same thing for linux and darwin x86_64 but not aarch64-darwin :sweat_smile:.

What is the general roadmap here? I am already confused but propose some options to get a discussion going:

1. add javaFX (this) and aarch64-darwin to [zulu](https://github.com/NixOS/nixpkgs/blob/20a166d2603d76cba39ecbb8cb5907b34e59e457/pkgs/development/compilers/zulu/default.nix) and remove [openjdk/darwin](https://github.com/NixOS/nixpkgs/blob/20a166d2603d76cba39ecbb8cb5907b34e59e457/pkgs/development/compilers/openjdk/darwin/default.nix)
2. keep them both like now
3. wait until someone packages a source build of openjdk on darwin (what is the difficulty there? impure Xcode dependency?)

Option 3 seems like a lot of work, so rather a long-term goal. Besides, it may be beneficial to have both openjdk source builds and pre-built zulu builds in nixpkgs. So what is the difference between [openjdk/darwin](https://github.com/NixOS/nixpkgs/blob/20a166d2603d76cba39ecbb8cb5907b34e59e457/pkgs/development/compilers/openjdk/darwin/default.nix) and [zulu](https://github.com/NixOS/nixpkgs/blob/20a166d2603d76cba39ecbb8cb5907b34e59e457/pkgs/development/compilers/zulu/default.nix)?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
