### PR TITLE
dhallPackages.dhall-grafana: Small simplification

### DIFF
--- a/pkgs/development/dhall-modules/dhall-grafana.nix
+++ b/pkgs/development/dhall-modules/dhall-grafana.nix
@@ -1,4 +1,4 @@
-{ dhallPackages, buildDhallGitHubPackage }:
+{ buildDhallGitHubPackage, Prelude }:
 
 buildDhallGitHubPackage {
   name = "grafana";
@@ -7,5 +7,5 @@ buildDhallGitHubPackage {
   # 2021-11-12
   rev = "d5630dc55deacf5100a99802a4df1d9680b263b3";
   sha256 = "01320hpqgr5r4grsydmdl9yznmly1ssnlc9gcwa8rj1ah0a8xlgz";
-  dependencies = [ dhallPackages.Prelude ];
+  dependencies = [ Prelude ];
 }


### PR DESCRIPTION
###### Motivation for this change

`dhallPackages.callPackage` can provide the `Prelude` package directly,
and this change uses that to simplify the build for `dhall-grafana`

###### Things done


- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
