### PR TITLE
llvmPackages_13.libcxx: fix darwin build

### DIFF
--- a/pkgs/development/compilers/llvm/13/default.nix
+++ b/pkgs/development/compilers/llvm/13/default.nix
@@ -254,7 +254,7 @@ let
       cxx-headers = callPackage ./libcxx {
         inherit llvm_meta;
         stdenv = stdenv_;
-        isCxxHeaders = true;
+        headersOnly = true;
       };
     in callPackage ./libcxxabi {
       stdenv = stdenv_;

--- a/pkgs/development/compilers/llvm/13/default.nix
+++ b/pkgs/development/compilers/llvm/13/default.nix
@@ -247,11 +247,18 @@ let
                else stdenv;
     };
 
-    libcxxabi = callPackage ./libcxxabi {
-      inherit llvm_meta;
-      stdenv = if stdenv.hostPlatform.useLLVM or false
+    libcxxabi = let
+      stdenv_ = if stdenv.hostPlatform.useLLVM or false
                then overrideCC stdenv buildLlvmTools.clangNoLibcxx
                else stdenv;
+      cxx-headers = callPackage ./libcxx {
+        inherit llvm_meta;
+        stdenv = stdenv_;
+        isCxxHeaders = true;
+      };
+    in callPackage ./libcxxabi {
+      stdenv = stdenv_;
+      inherit llvm_meta cxx-headers;
     };
 
     libunwind = callPackage ./libunwind {

--- a/pkgs/development/compilers/llvm/13/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/13/libcxx/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake python3 ]
     ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
-  buildInputs = lib.optional (!isCxxHeaders) [ libcxxabi ];
+  buildInputs = lib.optionals (!isCxxHeaders) [ libcxxabi ];
 
   cmakeFlags = [ "-DLIBCXX_CXX_ABI=libcxxabi" ]
     ++ lib.optional (stdenv.hostPlatform.isMusl || stdenv.hostPlatform.isWasi) "-DLIBCXX_HAS_MUSL_LIBC=1"

--- a/pkgs/development/compilers/llvm/13/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/13/libcxx/default.nix
@@ -1,15 +1,23 @@
 { lib, stdenv, llvm_meta, src, cmake, python3, fixDarwinDylibNames, version
+, libcxxabi
 , enableShared ? !stdenv.hostPlatform.isStatic
+
+# If isCxxHeaders is true, the resulting package would only include the headers.
+# Use this to break the circular dependency between libcxx and libcxxabi.
+#
+# Some context:
+# https://reviews.llvm.org/rG1687f2bbe2e2aaa092f942d4a97d41fad43eedfb
+, isCxxHeaders ? false
 }:
 
 stdenv.mkDerivation rec {
-  pname = "libcxx";
+  pname = if isCxxHeaders then "cxx-headers" else "libcxx";
   inherit version;
 
   inherit src;
-  sourceRoot = "source/${pname}";
+  sourceRoot = "source/libcxx";
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" ] ++ lib.optional (!isCxxHeaders) "dev";
 
   patches = [
     ./gnu-install-dirs.patch
@@ -24,14 +32,28 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake python3 ]
     ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
-  cmakeFlags = [
-  ] ++ lib.optional (stdenv.hostPlatform.isMusl || stdenv.hostPlatform.isWasi) "-DLIBCXX_HAS_MUSL_LIBC=1"
+  buildInputs = lib.optional (!isCxxHeaders) [ libcxxabi ];
+
+  cmakeFlags = [ "-DLIBCXX_CXX_ABI=libcxxabi" ]
+    ++ lib.optional (stdenv.hostPlatform.isMusl || stdenv.hostPlatform.isWasi) "-DLIBCXX_HAS_MUSL_LIBC=1"
     ++ lib.optional (stdenv.hostPlatform.useLLVM or false) "-DLIBCXX_USE_COMPILER_RT=ON"
-    ++ lib.optional stdenv.hostPlatform.isWasm [
+    ++ lib.optionals stdenv.hostPlatform.isWasm [
       "-DLIBCXX_ENABLE_THREADS=OFF"
       "-DLIBCXX_ENABLE_FILESYSTEM=OFF"
       "-DLIBCXX_ENABLE_EXCEPTIONS=OFF"
     ] ++ lib.optional (!enableShared) "-DLIBCXX_ENABLE_SHARED=OFF";
+
+  buildFlags = lib.optional isCxxHeaders "generate-cxx-headers";
+  installTargets = lib.optional isCxxHeaders "install-cxx-headers";
+
+  # At this point, cxxabi headers would be installed in the dev output, which
+  # prevents moveToOutput from doing its job later in the build process.
+  postInstall = lib.optionalString (!isCxxHeaders) ''
+    mv "$dev/include/c++/v1/"* "$out/include/c++/v1/"
+    pushd "$dev"
+    rmdir -p include/c++/v1
+    popd
+  '';
 
   passthru = {
     isLLVM = true;
@@ -44,9 +66,6 @@ stdenv.mkDerivation rec {
       libc++ is an implementation of the C++ standard library, targeting C++11,
       C++14 and above.
     '';
-
-    # https://github.com/NixOS/nixpkgs/pull/133217#issuecomment-895742807
-    broken = stdenv.isDarwin;
 
     # "All of the code in libc++ is dual licensed under the MIT license and the
     # UIUC License (a BSD-like license)":

--- a/pkgs/development/compilers/llvm/13/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/13/libcxxabi/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, llvm_meta, cmake, python3, src, libunwind, libcxx, version
+{ lib, stdenv, llvm_meta, cmake, python3, src, cxx-headers, libunwind, version
 , enableShared ? !stdenv.hostPlatform.isStatic
 , standalone ? stdenv.hostPlatform.useLLVM or false
 , withLibunwind ? !stdenv.isDarwin && !stdenv.isFreeBSD && !stdenv.hostPlatform.isWasm
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   buildInputs = lib.optional withLibunwind libunwind;
 
   cmakeFlags = [
-    "-DLIBCXXABI_LIBCXX_INCLUDES=${libcxx.dev}/include/c++/v1"
+    "-DLIBCXXABI_LIBCXX_INCLUDES=${cxx-headers}/include/c++/v1"
   ] ++ lib.optionals standalone [
     "-DLLVM_ENABLE_LIBCXX=ON"
   ] ++ lib.optionals (standalone && withLibunwind) [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12578,6 +12578,8 @@ with pkgs;
     targetLlvmLibraries = targetPackages.llvmPackages_13.libraries;
   } // lib.optionalAttrs (stdenv.hostPlatform.isi686 && buildPackages.stdenv.cc.isGNU) {
     stdenv = gcc7Stdenv;
+  } // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    stdenv = llvmPackages_11.stdenv;
   }));
 
   llvmPackages_latest = llvmPackages_13;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12578,8 +12578,6 @@ with pkgs;
     targetLlvmLibraries = targetPackages.llvmPackages_13.libraries;
   } // lib.optionalAttrs (stdenv.hostPlatform.isi686 && buildPackages.stdenv.cc.isGNU) {
     stdenv = gcc7Stdenv;
-  } // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
-    stdenv = llvmPackages_11.stdenv;
   }));
 
   llvmPackages_latest = llvmPackages_13;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This succeeds #146517. It fixes the Darwin build of libcxx by applying the following fixes:

* Use a newer version of Clang to avoid compilation errors
* Break the circular dependency between libcxx and libcxxabi. libcxxabi needs libcxx headers to build, but libcxx has a runtime dependency on libcxxabi. To fix this, this PR creates a header-only variant of the libcxx derivation for building libcxxabi.

The Linux build seems to have avoided the circular dependency problem by dropping the libcxx dependency on libcxxabi. This approach appears not to be possible on Darwin.

`llvmPackages_git` probably needs the same fix too, but I haven't looked into it closely yet.

ZHF: #144627

###### Things done

Like in #146517, I've tested on the master branch and rebased against staging to avoid the overwhelming amount of local builds.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
