### PR TITLE
wlr-protocols: init at unstable-2021-11-01

### DIFF
--- a/pkgs/development/libraries/wlroots/protocols.nix
+++ b/pkgs/development/libraries/wlroots/protocols.nix
@@ -1,0 +1,47 @@
+{ lib, stdenv, fetchFromGitLab, wayland-scanner }:
+
+stdenv.mkDerivation rec {
+  pname = "wlr-protocols";
+  version = "unstable-2021-11-01";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "wlroots";
+    repo = "wlr-protocols";
+    rev = "d998ee6fc64ea7e066014023653d1271b7702c09";
+    sha256 = "1vw8b10d1pwsj6f4sr3imvwsy55d3435sp068sj4hdszkxc6axsr";
+  };
+
+  checkInputs = [ wayland-scanner ];
+
+  patchPhase = ''
+    substituteInPlace wlr-protocols.pc.in \
+      --replace '=''${pc_sysrootdir}' "=" \
+      --replace '=@prefix@' "=$out"
+
+    substituteInPlace Makefile \
+      --replace 'wlr-output-power-management-v1.xml' 'wlr-output-power-management-unstable-v1.xml'
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    make check
+  '';
+
+  installFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
+
+  meta = with lib; {
+    description = "Wayland roots protocol extensions";
+    longDescription = ''
+      wlr-protocols contains Wayland protocols that add functionality not
+      available in the Wayland core protocol, and specific to wlroots-based
+      compositors. Such protocols either add completely new functionality, or
+      extend the functionality of some other protocol either in Wayland core,
+      or some other protocol in wayland-protocols.
+    '';
+    homepage    = "https://gitlab.freedesktop.org/wlroots/wlr-protocols";
+    license     = licenses.mit; # See file headers
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ twitchyliquid64 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20115,6 +20115,8 @@ with pkgs;
 
   wiredtiger = callPackage ../development/libraries/wiredtiger { };
 
+  wlr-protocols = callPackage ../development/libraries/wlroots/protocols.nix { };
+
   wt = wt4;
   inherit (callPackages ../development/libraries/wt {})
     wt3


### PR DESCRIPTION
###### Motivation for this change

Pre-requisite library for `wl-mirror`, which can be used to mirror screens under wayland

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
