### PR TITLE
python3Packages.servefile: init at 0.5.3

### DIFF
--- a/pkgs/development/python-modules/servefile/default.nix
+++ b/pkgs/development/python-modules/servefile/default.nix
@@ -1,0 +1,43 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, pyopenssl
+, pytestCheckHook
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "servefile";
+  version = "0.5.3";
+
+  src = fetchFromGitHub {
+    owner = "sebageek";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-/ZEMZIH/ImuZ2gh5bwB0FlaWnG/ELxfBGEJ2SuNSEb8=";
+  };
+
+  propagatedBuildInputs = [ pyopenssl ];
+
+  checkInputs = [ pytestCheckHook requests ];
+  # Test attempts to connect to a port on localhost which fails in nix build
+  # environment.
+  disabledTests = [
+    "test_abort_download"
+    "test_big_download"
+    "test_https_big_download"
+    "test_https"
+    "test_redirect_and_download"
+    "test_specify_port"
+    "test_upload_size_limit"
+    "test_upload"
+  ];
+  pythonImportsCheck = [ "servefile" ];
+
+  meta = with lib; {
+    description = "Serve files from shell via a small HTTP server";
+    homepage = "https://github.com/sebageek/servefile";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ samuela ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9180,6 +9180,8 @@ in {
 
   serpy = callPackage ../development/python-modules/serpy { };
 
+  servefile = callPackage ../development/python-modules/servefile { };
+
   serverlessrepo = callPackage ../development/python-modules/serverlessrepo { };
 
   service-identity = callPackage ../development/python-modules/service_identity { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Introduce the servefile python package and general utility (https://github.com/sebageek/servefile, https://pypi.org/project/servefile/). It is already package for Ubuntu/Debian (http://manpages.ubuntu.com/manpages/bionic/man1/servefile.1.html).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
