### PR TITLE
marp: update to 1.4.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6382,6 +6382,13 @@
     githubId = 449813;
     name = "Roman Kuznetsov";
   };
+  kvark = {
+    name = "Dzmitry Malyshau";
+    email = "kvark@fastmail.com";
+    matrix = "@kvark:matrix.org";
+    github = "kvark";
+    githubId = 107301;
+  };
   kwohlfahrt = {
     email = "kai.wohlfahrt@gmail.com";
     github = "kwohlfahrt";

--- a/pkgs/applications/office/marp/default.nix
+++ b/pkgs/applications/office/marp/default.nix
@@ -1,37 +1,34 @@
-{ lib, stdenv, fetchurl, atomEnv, libXScrnSaver, gtk2 }:
+{ lib, stdenv, fetchurl  }:
 
 stdenv.mkDerivation rec {
   pname = "marp";
-  version = "0.0.14";
+  version = "1.4.2";
 
   src = fetchurl {
-    url = "https://github.com/yhatt/marp/releases/download/v${version}/${version}-Marp-linux-x64.tar.gz";
-    sha256 = "0nklzxwdx5llzfwz1hl2jpp2kwz78w4y63h5l00fh6fv6zisw6j4";
+    url = "https://github.com/marp-team/marp-cli/releases/download/v${version}/marp-cli-v${version}-linux.tar.gz";
+    sha256 = "sha256-URdpmuveb9xEyeHLABeyObZjT6XaXv9tPgrxH9XdBZk=";
   };
 
   unpackPhase = ''
-    mkdir {locales,resources}
-    tar --delay-directory-restore -xf $src
-    chmod u+x {locales,resources}
+    tar -xf $src
   '';
 
   installPhase = ''
-    mkdir -p $out/lib/marp $out/bin
-    cp -r ./* $out/lib/marp
-    ln -s $out/lib/marp/Marp $out/bin
+    mkdir -p $out/bin/
+    cp -r ./marp $out/bin/
   '';
 
   postFixup = ''
     patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath "${atomEnv.libPath}:${lib.makeLibraryPath [ libXScrnSaver gtk2 ]}:$out/lib/marp" \
-      $out/bin/Marp
+      --set-rpath "${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}" \
+      $out/bin/marp
   '';
 
   meta = with lib; {
-    description = "Markdown presentation writer, powered by Electron";
-    homepage = "https://yhatt.github.io/marp/";
+    description = "CLI interface for Marp and Marpit based converters";
+    homepage = "https://marp.app/";
     license = licenses.mit;
-    maintainers = [ maintainers.puffnfresh ];
+    maintainers = with maintainers; [ puffnfresh kvark ];
     platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Marp is a very useful tool for writing presentations in Markdown.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
