### PR TITLE
google-cloud-sdk: 365.0.0 -> 365.0.1

### DIFF
--- a/pkgs/tools/admin/google-cloud-sdk/data.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/data.nix
@@ -1,32 +1,32 @@
 # DO NOT EDIT! This file is generated automatically by update.sh
 { }:
 {
-  version = "365.0.0";
+  version = "365.0.1";
   googleCloudSdkPkgs = {
     x86_64-linux =
       {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-365.0.0-linux-x86_64.tar.gz";
-        sha256 = "1h1z2ddhgrc74gnfaicvginl2yy7zjx8dlvkx017vsd3vijavl41";
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-365.0.1-linux-x86_64.tar.gz";
+        sha256 = "1c0gwc446y2r8hq8gyx9nwrma5y61nkfy5mc30jqr1kslvdkq00p";
       };
     x86_64-darwin =
       {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-365.0.0-darwin-x86_64.tar.gz";
-        sha256 = "0428pc85jlwsydn5nl7vya3rsbiww8z2jvc68wy1sdk7a1md01cy";
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-365.0.1-darwin-x86_64.tar.gz";
+        sha256 = "00nrwklm2cxyzrsqa9hidljqcd5w2gbyxwhyfsjzrdmr9qks7s2a";
       };
     aarch64-linux =
       {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-365.0.0-linux-arm.tar.gz";
-        sha256 = "0ji29kd6cfyl59vlms77bnlqf95yh86g9c08wkx1f1kdavi78l0d";
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-365.0.1-linux-arm.tar.gz";
+        sha256 = "0sr8cp3pjz6i7yf2zb178r160hc2krk6qn37plhsqj16bqw8vs7v";
       };
     aarch64-darwin =
       {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-365.0.0-darwin-arm.tar.gz";
-        sha256 = "1rg996y4r24aif5vv6cnl3g7g6fknz8zv6m87ayl8x7yljrqcy27";
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-365.0.1-darwin-arm.tar.gz";
+        sha256 = "0pkdvhlab1rsja6jz68pnkw3w4rbiv3wh3si3w0lj1kkjzjr2rb3";
       };
     i686-linux =
       {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-365.0.0-linux-x86.tar.gz";
-        sha256 = "0jvcridqlk2r5m6b22ldxi9g4mxfy120428ynw9rgpwx0chjmpi6";
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-365.0.1-linux-x86.tar.gz";
+        sha256 = "1kqn15akwlqxybrhy4drkfsz5nj3grvmyifv8ffmv4wjc53m9www";
       };
   };
 }

--- a/pkgs/tools/admin/google-cloud-sdk/update.sh
+++ b/pkgs/tools/admin/google-cloud-sdk/update.sh
@@ -5,7 +5,7 @@ BASE_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-clou
 
 # Version of Google Cloud SDK from
 # https://cloud.google.com/sdk/docs/release-notes
-VERSION="365.0.0"
+VERSION="365.0.1"
 
 function genMainSrc() {
     local url="${BASE_URL}-${VERSION}-${1}-${2}.tar.gz"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Upstream release: [Changelog 365.0.1](https://cloud.google.com/sdk/docs/release-notes#36501_2021-11-22)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
