### PR TITLE
python3Packages.asyncio-nats-client: 0.11.4 -> 0.11.5

### DIFF
--- a/pkgs/development/python-modules/asyncio-nats-client/default.nix
+++ b/pkgs/development/python-modules/asyncio-nats-client/default.nix
@@ -10,14 +10,16 @@
 
 buildPythonPackage rec {
   pname = "asyncio-nats-client";
-  version = "0.11.4";
+  version = "0.11.5";
+  format = "setuptools";
+
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "nats-io";
     repo = "nats.py";
     rev = "v${version}";
-    sha256 = "1aj57xi2rj1xswq8air13xdsll1ybpi0nmz5f6jq01azm0zy9xyd";
+    sha256 = "sha256-UCDZpdcQxlFF5xt4iOKrjpRuzbqt4tjCmc1VrpWMkX8=";
   };
 
   propagatedBuildInputs = [
@@ -38,12 +40,12 @@ buildPythonPackage rec {
   disabledTests = [
     # RuntimeError: Event loop is closed
     "test_subscribe_no_echo"
-    "test_reconnect_to_new_server_with_auth"
-    "test_drain_connection"
-    "test_discover_servers_on_first_connect"
+    "test_kv_simple"
   ];
 
-  pythonImportsCheck = [ "nats.aio" ];
+  pythonImportsCheck = [
+    "nats.aio"
+  ];
 
   meta = with lib; {
     description = "Python client for NATS.io";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.11.5

Change log: https://github.com/nats-io/nats.py/releases/tag/v0.11.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
