### PR TITLE
megasync: 4.5.3.0 -> 4.6.1.0

### DIFF
--- a/pkgs/applications/misc/megasync/default.nix
+++ b/pkgs/applications/misc/megasync/default.nix
@@ -7,7 +7,8 @@
 , curl
 , doxygen
 , fetchFromGitHub
-#, ffmpeg
+, ffmpeg
+, freeimage
 , libmediainfo
 , libraw
 , libsodium
@@ -27,13 +28,13 @@
 }:
 mkDerivation rec {
   pname = "megasync";
-  version = "4.5.3.0";
+  version = "4.6.1.0";
 
   src = fetchFromGitHub {
     owner = "meganz";
     repo = "MEGAsync";
     rev = "v${version}_Linux";
-    sha256 = "1lwjmdbqyxx5wd8nx4mc830fna37jad4h93viwfh5x7sxn104js7";
+    sha256 = "0v2fvji9hs7valya0wx5qjx01c7yjld6nnp6m9gpxfkr30h5s5wb";
     fetchSubmodules = true;
   };
 
@@ -52,8 +53,8 @@ mkDerivation rec {
     c-ares
     cryptopp
     curl
-    # temporarily disable until patched for ffmpeg 4.4
-    #ffmpeg
+    ffmpeg
+    freeimage
     libmediainfo
     libraw
     libsodium
@@ -71,6 +72,7 @@ mkDerivation rec {
     ./noinstall-distro-version.patch
     # megasync target is not part of the install rule thanks to a commented block
     ./install-megasync.patch
+    ./ffmpeg_44.patch
   ];
 
   postPatch = ''
@@ -95,9 +97,8 @@ mkDerivation rec {
     "--with-cares"
     "--with-cryptopp"
     "--with-curl"
-    # temporarily disable until patched for ffmpeg 4.4
-    #"--with-ffmpeg"
-    "--without-freeimage" # unreferenced even when found
+    "--with-ffmpeg"
+    "--with-freeimage"
     "--without-readline"
     "--without-termcap"
     "--with-sodium"

--- a/pkgs/applications/misc/megasync/ffmpeg_44.patch
+++ b/pkgs/applications/misc/megasync/ffmpeg_44.patch
@@ -1,0 +1,14 @@
+Index: megasync-4.6.1.0/src/MEGASync/mega/src/gfx/freeimage.cpp
+===================================================================
+--- megasync-4.6.1.0.orig/src/MEGASync/mega/src/gfx/freeimage.cpp
++++ megasync-4.6.1.0/src/MEGASync/mega/src/gfx/freeimage.cpp
+@@ -253,7 +253,8 @@ bool GfxProcFreeImage::readbitmapFfmpeg(
+ 
+     // Force seeking to key frames
+     formatContext->seek2any = false;
+-    videoStream->skip_to_keyframe = true;
++    // no longer exposed in ffmpeg 4.4; the line above should be sufficient
++    //videoStream->skip_to_keyframe = true;
+     if (decoder->capabilities & CAP_TRUNCATED)
+     {
+         codecContext->flags |= CAP_TRUNCATED;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3288,7 +3288,9 @@ with pkgs;
 
   medusa = callPackage ../tools/security/medusa { };
 
-  megasync = libsForQt515.callPackage ../applications/misc/megasync { };
+  megasync = libsForQt5.callPackage ../applications/misc/megasync {
+    ffmpeg = ffmpeg-full;
+  };
 
   megacmd = callPackage ../applications/misc/megacmd { };
 


### PR DESCRIPTION
re-enabled ffmpeg 
with freeimage

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).