### PR TITLE
python3Packages.rflink: add patch to support async_timeout> 4

### DIFF
--- a/pkgs/development/python-modules/rflink/default.nix
+++ b/pkgs/development/python-modules/rflink/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , async-timeout
 , docopt
 , pyserial
@@ -12,6 +13,7 @@
 buildPythonPackage rec {
   pname = "rflink";
   version = "0.0.58";
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "aequitas";
@@ -19,11 +21,6 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "1zab55lsw419gg0jfrl69ap6128vbi3wdmg5z7qin65ijpjdhasc";
   };
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "version=version_from_git()" "version='${version}'"
-  '';
 
   propagatedBuildInputs = [
     async-timeout
@@ -37,7 +34,23 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "rflink.protocol" ];
+  patches = [
+    # Remove loop, https://github.com/aequitas/python-rflink/pull/61
+    (fetchpatch {
+      name = "remove-loop.patch";
+      url = "https://github.com/aequitas/python-rflink/commit/777e19b5bde3398df5b8f142896c34a01ae18d52.patch";
+      sha256 = "sJmihxY3fNSfZVFhkvQ/+9gysQup/1jklKDMyDDLOs8=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "version=version_from_git()" "version='${version}'"
+  '';
+
+  pythonImportsCheck = [
+    "rflink.protocol"
+  ];
 
   meta = with lib; {
     description = "Library and CLI tools for interacting with RFlink 433MHz transceiver";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/159182614)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
