### PR TITLE
systemd: pid1 crash fix

### DIFF
--- a/pkgs/os-specific/linux/systemd/0022-unit_is_bound_by_inactive-fix-return-pointer-check.patch
+++ b/pkgs/os-specific/linux/systemd/0022-unit_is_bound_by_inactive-fix-return-pointer-check.patch
@@ -1,0 +1,33 @@
+From b0b4622a8917cf86bcbee881b8b68aeea166ecbb Mon Sep 17 00:00:00 2001
+From: Dominique Martinet <asmadeus@codewreck.org>
+Date: Wed, 24 Nov 2021 22:27:22 +0900
+Subject: [PATCH] unit_is_bound_by_inactive: fix return pointer check
+
+*ret_culprit should be set if ret_culprit has been passed a non-null value,
+checking the previous *ret_culprit value does not make sense.
+
+This would cause the culprit to not properly be assigned, leading to
+pid1 crash when a unit could not be stopped.
+
+Fixes: #21476
+(cherry picked from commit 3da361064bf550d1818c7cd800a514326058e5f2)
+---
+ src/core/unit.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/core/unit.c b/src/core/unit.c
+index 69ed43578e34..b0a8e7bc3d1d 100644
+--- a/src/core/unit.c
++++ b/src/core/unit.c
+@@ -2125,7 +2125,7 @@ bool unit_is_bound_by_inactive(Unit *u, Unit **ret_culprit) {
+                         continue;
+ 
+                 if (UNIT_IS_INACTIVE_OR_FAILED(unit_active_state(other))) {
+-                        if (*ret_culprit)
++                        if (ret_culprit)
+                                 *ret_culprit = other;
+ 
+                         return true;
+-- 
+2.31.1
+

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -172,6 +172,10 @@ stdenv.mkDerivation {
     # systemd-stable
     ./0020-sd-boot-Unify-error-handling.patch
     ./0021-sd-boot-Rework-console-input-handling.patch
+
+    # Fix pid1 segfault encountered on nixos-rebuild switch
+    # https://github.com/systemd/systemd/issues/21476
+    ./0022-unit_is_bound_by_inactive-fix-return-pointer-check.patch
   ] ++ lib.optional stdenv.hostPlatform.isMusl (let
     oe-core = fetchzip {
       url = "https://git.openembedded.org/openembedded-core/snapshot/openembedded-core-14c6e5a4b72d0e4665279158a0740dd1dc21f72f.tar.bz2";


### PR DESCRIPTION
###### Motivation for this change

Fixes #147103 (pid1 crash)

While backporting the patch I noticed we weren't up to date, so also updated along the way.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
