### PR TITLE
haskell.compiler: use wrapper scripts over propagating

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.7-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.7-binary.nix
@@ -3,6 +3,8 @@
 , ncurses5
 , ncurses6, gmp, libiconv, numactl
 , llvmPackages
+, coreutils
+, targetPackages
 
   # minimal = true; will remove files that aren't strictly necessary for
   # regular builds and GHC bootstrapping.
@@ -155,8 +157,17 @@ let
   libEnvVar = lib.optionalString stdenv.hostPlatform.isDarwin "DY"
     + "LD_LIBRARY_PATH";
 
-  runtimeDeps = lib.optionals useLLVM [
+  runtimeDeps = [
+    targetPackages.stdenv.cc
+    targetPackages.stdenv.cc.bintools
+    coreutils # for cat
+  ]
+  ++ lib.optionals useLLVM [
     (lib.getBin llvmPackages.llvm)
+  ]
+  # On darwin, we need unwrapped bintools as well (for otool)
+  ++ lib.optionals (stdenv.targetPlatform.linker == "cctools") [
+    targetPackages.stdenv.cc.bintools.bintools
   ];
 
 in
@@ -370,7 +381,6 @@ stdenv.mkDerivation rec {
 
   doInstallCheck = true;
   installCheckPhase = ''
-    unset ${libEnvVar}
     # Sanity check, can ghc create executables?
     cd $TMP
     mkdir test-ghc; cd test-ghc
@@ -379,7 +389,7 @@ stdenv.mkDerivation rec {
       module Main where
       main = putStrLn \$([|"yes"|])
     EOF
-    $out/bin/ghc --make main.hs || exit 1
+    env -i $out/bin/ghc --make main.hs || exit 1
     echo compilation ok
     [ $(./main) == "yes" ]
   '';

--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -134,7 +134,7 @@ let
 
   runtimeDeps = [
     targetPackages.stdenv.cc.bintools
-    coreutils
+    coreutils # for cat
   ]
   # On darwin, we need unwrapped bintools as well (for otool)
   ++ lib.optionals (stdenv.targetPlatform.linker == "cctools") [
@@ -321,11 +321,11 @@ stdenv.mkDerivation (rec {
     # Install the bash completion file.
     install -D -m 444 utils/completion/ghc.bash $out/share/bash-completion/completions/${targetPrefix}ghc
 
-    # Patch scripts to include "readelf" and "cat" in $PATH.
+    # Patch scripts to include runtime dependencies in $PATH.
     for i in "$out/bin/"*; do
       test ! -h $i || continue
       egrep --quiet '^#!' <(head -n 1 $i) || continue
-      sed -i -e '2i export PATH="$PATH:${lib.makeBinPath runtimeDeps}"' $i
+      sed -i -e '2i export PATH="${lib.makeBinPath runtimeDeps}:$PATH"' $i
     done
   '';
 

--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -326,9 +326,9 @@ stdenv.mkDerivation (rec {
 
     # Patch scripts to include runtime dependencies in $PATH.
     for i in "$out/bin/"*; do
-      test ! -h $i || continue
-      egrep --quiet '^#!' <(head -n 1 $i) || continue
-      sed -i -e '2i export PATH="${lib.makeBinPath runtimeDeps}:$PATH"' $i
+      test ! -h "$i" || continue
+      isScript "$i" || continue
+      sed -i -e '2i export PATH="${lib.makeBinPath runtimeDeps}:$PATH"' "$i"
     done
   '';
 

--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -132,9 +132,15 @@ let
   useLdGold = targetPlatform.linker == "gold" ||
     (targetPlatform.linker == "bfd" && (targetPackages.stdenv.cc.bintools.bintools.hasGold or false) && !targetPlatform.isMusl);
 
+  # Tools GHC will need to call at runtime. Some of these were handled using
+  # propagatedBuildInputs before, however this allowed for GHC environment and
+  # a derivations build environment to interfere, especially when GHC is built.
   runtimeDeps = [
+    targetPackages.stdenv.cc
     targetPackages.stdenv.cc.bintools
     coreutils # for cat
+  ] ++ lib.optionals useLLVM [
+    (lib.getBin llvmPackages.llvm)
   ]
   # On darwin, we need unwrapped bintools as well (for otool)
   ++ lib.optionals (stdenv.targetPlatform.linker == "cctools") [
@@ -289,9 +295,6 @@ stdenv.mkDerivation (rec {
   depsBuildTarget = toolsForTarget;
 
   buildInputs = [ perl bash ] ++ (libDeps hostPlatform);
-
-  propagatedBuildInputs = [ targetPackages.stdenv.cc ]
-    ++ lib.optional useLLVM llvmPackages.llvm;
 
   depsTargetTarget = map lib.getDev (libDeps targetPlatform);
   depsTargetTargetPropagated = map (lib.getOutput "out") (libDeps targetPlatform);

--- a/pkgs/development/compilers/ghc/8.8.4.nix
+++ b/pkgs/development/compilers/ghc/8.8.4.nix
@@ -142,7 +142,7 @@ let
 
   runtimeDeps = [
     targetPackages.stdenv.cc.bintools
-    coreutils
+    coreutils # for cat
   ]
   # On darwin, we need unwrapped bintools as well (for otool)
   ++ lib.optionals (stdenv.targetPlatform.linker == "cctools") [
@@ -320,11 +320,11 @@ stdenv.mkDerivation (rec {
     # Install the bash completion file.
     install -D -m 444 utils/completion/ghc.bash $out/share/bash-completion/completions/${targetPrefix}ghc
 
-    # Patch scripts to include "readelf" and "cat" in $PATH.
+    # Patch scripts to include runtime dependencies in $PATH.
     for i in "$out/bin/"*; do
       test ! -h $i || continue
       egrep --quiet '^#!' <(head -n 1 $i) || continue
-      sed -i -e '2i export PATH="$PATH:${lib.makeBinPath runtimeDeps}"' $i
+      sed -i -e '2i export PATH="${lib.makeBinPath runtimeDeps}:$PATH"' $i
     done
   '';
 

--- a/pkgs/development/compilers/ghc/8.8.4.nix
+++ b/pkgs/development/compilers/ghc/8.8.4.nix
@@ -140,9 +140,15 @@ let
   useLdGold = targetPlatform.linker == "gold" ||
     (targetPlatform.linker == "bfd" && (targetPackages.stdenv.cc.bintools.bintools.hasGold or false) && !targetPlatform.isMusl);
 
+  # Tools GHC will need to call at runtime. Some of these were handled using
+  # propagatedBuildInputs before, however this allowed for GHC environment and
+  # a derivations build environment to interfere, especially when GHC is built.
   runtimeDeps = [
+    targetPackages.stdenv.cc
     targetPackages.stdenv.cc.bintools
     coreutils # for cat
+  ] ++ lib.optionals useLLVM [
+    (lib.getBin llvmPackages.llvm)
   ]
   # On darwin, we need unwrapped bintools as well (for otool)
   ++ lib.optionals (stdenv.targetPlatform.linker == "cctools") [
@@ -292,9 +298,6 @@ stdenv.mkDerivation (rec {
   depsBuildTarget = toolsForTarget;
 
   buildInputs = [ perl bash ] ++ (libDeps hostPlatform);
-
-  propagatedBuildInputs = [ targetPackages.stdenv.cc ]
-    ++ lib.optional useLLVM llvmPackages.llvm;
 
   depsTargetTarget = map lib.getDev (libDeps targetPlatform);
   depsTargetTargetPropagated = map (lib.getOutput "out") (libDeps targetPlatform);

--- a/pkgs/development/compilers/ghc/8.8.4.nix
+++ b/pkgs/development/compilers/ghc/8.8.4.nix
@@ -325,9 +325,9 @@ stdenv.mkDerivation (rec {
 
     # Patch scripts to include runtime dependencies in $PATH.
     for i in "$out/bin/"*; do
-      test ! -h $i || continue
-      egrep --quiet '^#!' <(head -n 1 $i) || continue
-      sed -i -e '2i export PATH="${lib.makeBinPath runtimeDeps}:$PATH"' $i
+      test ! -h "$i" || continue
+      isScript "$i" || continue
+      sed -i -e '2i export PATH="${lib.makeBinPath runtimeDeps}:$PATH"' "$i"
     done
   '';
 

--- a/pkgs/development/compilers/ghc/9.0.1.nix
+++ b/pkgs/development/compilers/ghc/9.0.1.nix
@@ -129,7 +129,7 @@ let
 
   runtimeDeps = [
     targetPackages.stdenv.cc.bintools
-    coreutils
+    coreutils # for cat
   ]
   # On darwin, we need unwrapped bintools as well (for otool)
   ++ lib.optionals (stdenv.targetPlatform.linker == "cctools") [
@@ -286,11 +286,11 @@ stdenv.mkDerivation (rec {
     # Install the bash completion file.
     install -D -m 444 utils/completion/ghc.bash $out/share/bash-completion/completions/${targetPrefix}ghc
 
-    # Patch scripts to include "readelf" and "cat" in $PATH.
+    # Patch scripts to include runtime dependencies in $PATH.
     for i in "$out/bin/"*; do
       test ! -h $i || continue
       egrep --quiet '^#!' <(head -n 1 $i) || continue
-      sed -i -e '2i export PATH="$PATH:${lib.makeBinPath runtimeDeps}"' $i
+      sed -i -e '2i export PATH="${lib.makeBinPath runtimeDeps}:$PATH"' $i
     done
   '';
 

--- a/pkgs/development/compilers/ghc/9.0.1.nix
+++ b/pkgs/development/compilers/ghc/9.0.1.nix
@@ -291,9 +291,9 @@ stdenv.mkDerivation (rec {
 
     # Patch scripts to include runtime dependencies in $PATH.
     for i in "$out/bin/"*; do
-      test ! -h $i || continue
-      egrep --quiet '^#!' <(head -n 1 $i) || continue
-      sed -i -e '2i export PATH="${lib.makeBinPath runtimeDeps}:$PATH"' $i
+      test ! -h "$i" || continue
+      isScript "$i" || continue
+      sed -i -e '2i export PATH="${lib.makeBinPath runtimeDeps}:$PATH"' "$i"
     done
   '';
 

--- a/pkgs/development/compilers/ghc/9.2.1.nix
+++ b/pkgs/development/compilers/ghc/9.2.1.nix
@@ -128,7 +128,7 @@ let
 
   runtimeDeps = [
     targetPackages.stdenv.cc.bintools
-    coreutils
+    coreutils # for cat
   ]
   # On darwin, we need unwrapped bintools as well (for otool)
   ++ lib.optionals (stdenv.targetPlatform.linker == "cctools") [
@@ -289,11 +289,11 @@ stdenv.mkDerivation (rec {
     # Install the bash completion file.
     install -D -m 444 utils/completion/ghc.bash $out/share/bash-completion/completions/${targetPrefix}ghc
 
-    # Patch scripts to include "readelf" and "cat" in $PATH.
+    # Patch scripts to include runtime dependencies in $PATH.
     for i in "$out/bin/"*; do
       test ! -h $i || continue
       egrep --quiet '^#!' <(head -n 1 $i) || continue
-      sed -i -e '2i export PATH="$PATH:${lib.makeBinPath runtimeDeps}"' $i
+      sed -i -e '2i export PATH="${lib.makeBinPath runtimeDeps}:$PATH"' $i
     done
   '';
 

--- a/pkgs/development/compilers/ghc/9.2.1.nix
+++ b/pkgs/development/compilers/ghc/9.2.1.nix
@@ -12,7 +12,8 @@
 , # GHC can be built with system libffi or a bundled one.
   libffi ? null
 
-, useLLVM ? !stdenv.targetPlatform.isx86
+, useLLVM ? !(stdenv.targetPlatform.isx86
+              || (stdenv.targetPlatform.isAarch64 && stdenv.targetPlatform.isDarwin))
 , # LLVM is conceptually a run-time-only depedendency, but for
   # non-x86, we need LLVM to bootstrap later stages, so it becomes a
   # build-time dependency too.

--- a/pkgs/development/compilers/ghc/9.2.1.nix
+++ b/pkgs/development/compilers/ghc/9.2.1.nix
@@ -126,9 +126,15 @@ let
   # see #84670 and #49071 for more background.
   useLdGold = targetPlatform.linker == "gold" || (targetPlatform.linker == "bfd" && !targetPlatform.isMusl);
 
+  # Tools GHC will need to call at runtime. Some of these were handled using
+  # propagatedBuildInputs before, however this allowed for GHC environment and
+  # a derivations build environment to interfere, especially when GHC is built.
   runtimeDeps = [
+    targetPackages.stdenv.cc
     targetPackages.stdenv.cc.bintools
     coreutils # for cat
+  ] ++ lib.optionals useLLVM [
+    (lib.getBin llvmPackages.llvm)
   ]
   # On darwin, we need unwrapped bintools as well (for otool)
   ++ lib.optionals (stdenv.targetPlatform.linker == "cctools") [
@@ -257,9 +263,6 @@ stdenv.mkDerivation (rec {
   depsBuildTarget = toolsForTarget;
 
   buildInputs = [ perl bash ] ++ (libDeps hostPlatform);
-
-  propagatedBuildInputs = [ targetPackages.stdenv.cc ]
-    ++ lib.optional useLLVM llvmPackages.llvm;
 
   depsTargetTarget = map lib.getDev (libDeps targetPlatform);
   depsTargetTargetPropagated = map (lib.getOutput "out") (libDeps targetPlatform);

--- a/pkgs/development/compilers/ghc/9.2.1.nix
+++ b/pkgs/development/compilers/ghc/9.2.1.nix
@@ -294,9 +294,9 @@ stdenv.mkDerivation (rec {
 
     # Patch scripts to include runtime dependencies in $PATH.
     for i in "$out/bin/"*; do
-      test ! -h $i || continue
-      egrep --quiet '^#!' <(head -n 1 $i) || continue
-      sed -i -e '2i export PATH="${lib.makeBinPath runtimeDeps}:$PATH"' $i
+      test ! -h "$i" || continue
+      isScript "$i" || continue
+      sed -i -e '2i export PATH="${lib.makeBinPath runtimeDeps}:$PATH"' "$i"
     done
   '';
 

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -17,7 +17,8 @@
                 !stdenv.targetPlatform.isWindows
 , elfutils # for DWARF support
 
-, useLLVM ? !stdenv.targetPlatform.isx86 || stdenv.targetPlatform.isiOS
+, useLLVM ? !(stdenv.targetPlatform.isx86
+              || (stdenv.targetPlatform.isAarch64 && stdenv.targetPlatform.isDarwin))
 , # LLVM is conceptually a run-time-only depedendency, but for
   # non-x86, we need LLVM to bootstrap later stages, so it becomes a
   # build-time dependency too.

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -142,7 +142,7 @@ let
 
   runtimeDeps = [
     targetPackages.stdenv.cc.bintools
-    coreutils
+    coreutils # for cat
   ]
   # On darwin, we need unwrapped bintools as well (for otool)
   ++ lib.optionals (stdenv.targetPlatform.linker == "cctools") [
@@ -309,11 +309,11 @@ stdenv.mkDerivation (rec {
     # Install the bash completion file.
     install -D -m 444 utils/completion/ghc.bash $out/share/bash-completion/completions/${targetPrefix}ghc
 
-    # Patch scripts to include "readelf" and "cat" in $PATH.
+    # Patch scripts to include runtime dependencies in $PATH.
     for i in "$out/bin/"*; do
       test ! -h $i || continue
       egrep --quiet '^#!' <(head -n 1 $i) || continue
-      sed -i -e '2i export PATH="$PATH:${lib.makeBinPath runtimeDeps}"' $i
+      sed -i -e '2i export PATH="${lib.makeBinPath runtimeDeps}:$PATH"' $i
     done
   '';
 

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -140,9 +140,15 @@ let
   useLdGold = targetPlatform.linker == "gold" ||
     (targetPlatform.linker == "bfd" && (targetPackages.stdenv.cc.bintools.bintools.hasGold or false) && !targetPlatform.isMusl);
 
+  # Tools GHC will need to call at runtime. Some of these were handled using
+  # propagatedBuildInputs before, however this allowed for GHC environment and
+  # a derivations build environment to interfere, especially when GHC is built.
   runtimeDeps = [
+    targetPackages.stdenv.cc
     targetPackages.stdenv.cc.bintools
     coreutils # for cat
+  ] ++ lib.optionals useLLVM [
+    (lib.getBin llvmPackages.llvm)
   ]
   # On darwin, we need unwrapped bintools as well (for otool)
   ++ lib.optionals (stdenv.targetPlatform.linker == "cctools") [
@@ -277,9 +283,6 @@ stdenv.mkDerivation (rec {
   depsBuildTarget = toolsForTarget;
 
   buildInputs = [ perl bash ] ++ (libDeps hostPlatform);
-
-  propagatedBuildInputs = [ targetPackages.stdenv.cc ]
-    ++ lib.optional useLLVM llvmPackages.llvm;
 
   depsTargetTarget = map lib.getDev (libDeps targetPlatform);
   depsTargetTargetPropagated = map (lib.getOutput "out") (libDeps targetPlatform);

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -314,9 +314,9 @@ stdenv.mkDerivation (rec {
 
     # Patch scripts to include runtime dependencies in $PATH.
     for i in "$out/bin/"*; do
-      test ! -h $i || continue
-      egrep --quiet '^#!' <(head -n 1 $i) || continue
-      sed -i -e '2i export PATH="${lib.makeBinPath runtimeDeps}:$PATH"' $i
+      test ! -h "$i" || continue
+      isScript "$i" || continue
+      sed -i -e '2i export PATH="${lib.makeBinPath runtimeDeps}:$PATH"' "$i"
     done
   '';
 

--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -1,14 +1,8 @@
 { lib, stdenv, ghc, llvmPackages, packages, symlinkJoin, makeWrapper
-# Include LLVM by default if GHC doesn't have native code generation support
-# See https://gitlab.haskell.org/ghc/ghc/-/wikis/platforms
-, useLLVM ? !(lib.any lib.id ([
-    stdenv.targetPlatform.isx86
-    stdenv.targetPlatform.isPowerPC
-    stdenv.targetPlatform.isSparc
-  ] ++ lib.optionals (lib.versionAtLeast ghc.version "9.2") [
-    (stdenv.targetPlatform.isAarch64 && stdenv.targetPlatform.isDarwin)
-    # TODO(@sternenseemann): Is armv7a supported for iOS?
-  ]))
+# GHC will have LLVM available if necessary for the respective target,
+# so useLLVM only needs to be changed if -fllvm is to be used for a
+# platform that has NCG support
+, useLLVM ? false
 , postBuild ? ""
 , ghcLibdir ? null # only used by ghcjs, when resolving plugins
 }:


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Currently the C compiler and LLVM binaries used by GHC are `propagatedBuildInputs`. This has several downsides:

* If used outside of `stdenv` or `nixpkgs`, propagation is not respected and these binaries will not be in `PATH` — and GHC won't work.
* The precedence rules of propagation may cause (especially) the wrong LLVM version to leak into a build environment:
  * while bootstrapping GHC, the build->target LLVM version takes precedence over the LLVM version propagated by
    the binary GHC, causing a lot of warnings about unsupported LLVM versions to show up.
  * The LLVM version used by GHC leaks into Haskell derivations with higher precedence than one passed directly. This causes e. g. `llvm-hs` 9.0.1 to fail on `aarch64-linux` when compiling with a GHC which uses the LLVM backend and a more recent LLVM version.

TODO:

- [x] sanity checking (ideally especially on `aarch64-linux`)
- [x] applying the changes to the other GHCs
- [x] Adjust `ghcWithPackages` wrapper for the fact that LLVM only needs to be injected after explicit request now

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
