### PR TITLE
inav-configurator: init at 3.0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11613,6 +11613,13 @@
     githubId = 1618946;
     name = "Tiago Castro";
   };
+  tilcreator = {
+    name = "Tilman Jackel";
+    email = "contact.nixos@tc-j.de";
+    matrix = "@tilcreator:matrix.org";
+    github = "TilCreator";
+    githubId = 18621411;
+  };
   tilpner = {
     email = "till@hoeppner.ws";
     github = "tilpner";

--- a/pkgs/applications/science/robotics/inav-configurator/default.nix
+++ b/pkgs/applications/science/robotics/inav-configurator/default.nix
@@ -1,0 +1,57 @@
+{ lib, stdenv, fetchurl, makeDesktopItem, copyDesktopItems, nwjs, wrapGAppsHook, gsettings-desktop-schemas, gtk3 }:
+
+stdenv.mkDerivation rec {
+  pname = "inav-configurator";
+  version = "3.0.2";
+
+  src = fetchurl {
+    url = "https://github.com/iNavFlight/inav-configurator/releases/download/${version}/INAV-Configurator_linux64_${version}.tar.gz";
+    sha256 = "0v6dcg634wpp9q4ya3mj00j3pg25g62aq209iq2dsvj0a03afbp2";
+  };
+
+  icon = fetchurl {
+    url = "https://raw.githubusercontent.com/iNavFlight/inav-configurator/bf3fc89e6df51ecb83a386cd000eebf16859879e/images/inav_icon_128.png";
+    sha256 = "1i844dzzc5s5cr4vfpi6k2kdn8jiqq2n6c0fjqvsp4wdidwjahzw";
+  };
+
+  nativeBuildInputs = [ copyDesktopItems wrapGAppsHook ];
+
+  buildInputs = [ gsettings-desktop-schemas gtk3 ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin \
+             $out/opt/${pname}
+
+    cp -r inav-configurator $out/opt/inav-configurator/
+    install -m 444 -D $icon $out/share/icons/hicolor/128x128/apps/${pname}.png
+
+    chmod +x $out/opt/inav-configurator/inav-configurator
+    makeWrapper ${nwjs}/bin/nw $out/bin/${pname} --add-flags $out/opt/inav-configurator/inav-configurator
+
+    runHook postInstall
+  '';
+
+  desktopItems = makeDesktopItem {
+    name = pname;
+    exec = pname;
+    icon = pname;
+    comment = "iNavFlight configuration tool";
+    desktopName = "iNav Configurator";
+    genericName = "Flight controller configuration tool";
+  };
+
+  meta = with lib; {
+    description = "The iNav flight control system configuration tool";
+    longDescription = ''
+      A crossplatform configuration tool for the iNav flight control system.
+      Various types of aircraft are supported by the tool and by iNav, e.g.
+      quadcopters, hexacopters, octocopters and fixed-wing aircraft.
+    '';
+    homepage = "https://github.com/iNavFlight/inav/wiki";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ tilcreator wucke13 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32025,6 +32025,8 @@ with pkgs;
 
   emuflight-configurator = callPackage ../applications/science/robotics/emuflight-configurator { };
 
+  inav-configurator = callPackage ../applications/science/robotics/inav-configurator { };
+
   mission-planner = callPackage ../applications/science/robotics/mission-planner { };
 
   ### MISC


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
There are 2 configurators for *flight (betaflight, inav, ...) flight controller firmwares already, but inav was missing.

###### Things done
Copy the betaflight-configurator package and modify it a bit.

@wucke13 As this is more or less a clone of your betaflight-configurator package, can I add you as a second maintainer?

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
