### PR TITLE
python3Packages.httplib2: 0.20.1 -> 0.20.3

### DIFF
--- a/pkgs/development/python-modules/httplib2/default.nix
+++ b/pkgs/development/python-modules/httplib2/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , buildPythonPackage
+, cryptography
 , fetchFromGitHub
 , isPy27
 , mock
@@ -15,27 +16,22 @@
 
 buildPythonPackage rec {
   pname = "httplib2";
-  version = "0.20.1";
+  version = "0.20.3";
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-1zqs3YRVtm5DwewETLtRg5XhMJPJsMi0QLfeGirOURs=";
+    sha256 = "sha256-Q5KkhVqyHDoIeKjvvYoHRbZPY7LUXGDwgp4CSuyvQ1g=";
   };
 
-  postPatch = ''
-    sed -i "/--cov/d" setup.cfg
-  '';
-
-  propagatedBuildInputs = [ pyparsing ];
-
-  pythonImportsCheck = [ "httplib2" ];
-
-  # Don't run tests for Python 2.7
-  doCheck = !isPy27;
+  propagatedBuildInputs = [
+    pyparsing
+  ];
 
   checkInputs = [
+    cryptography
     mock
     pytest-forked
     pytest-randomly
@@ -45,16 +41,29 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  # Don't run tests for Python 2.7
+  doCheck = !isPy27;
+
+  postPatch = ''
+    sed -i "/--cov/d" setup.cfg
+  '';
+
   disabledTests = lib.optionals (stdenv.isDarwin) [
     # fails with HTTP 408 Request Timeout, instead of expected 200 OK
     "test_timeout_subsequent"
   ];
 
-  pytestFlagsArray = [ "--ignore python2" ];
+  pytestFlagsArray = [
+    "--ignore python2"
+  ];
+
+  pythonImportsCheck = [
+    "httplib2"
+  ];
 
   meta = with lib; {
     description = "A comprehensive HTTP client library";
-    homepage = "https://httplib2.readthedocs.io";
+    homepage = "https://github.com/httplib2/httplib2";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.20.3

Change log: https://github.com/httplib2/httplib2/blob/master/CHANGELOG

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
