### PR TITLE
qpwgraph: init at 0.0.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5960,6 +5960,12 @@
     githubId = 3831860;
     name = "Arnold Krille";
   };
+  kanashimia = {
+    email = "chad@redpilled.dev";
+    github = "kanashimia";
+    githubId = 56224949;
+    name = "Mia Kanashi";
+  };
   karantan = {
     name = "Gasper Vozel";
     email = "karantan@gmail.com";

--- a/pkgs/applications/audio/qpwgraph/default.nix
+++ b/pkgs/applications/audio/qpwgraph/default.nix
@@ -1,0 +1,34 @@
+{ lib, mkDerivation, fetchFromGitLab
+, cmake, pkg-config
+, alsa-lib, pipewire
+}:
+
+mkDerivation rec {
+  pname = "qpwgraph";
+  version = "0.0.9";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "rncbc";
+    repo = "qpwgraph";
+    rev = "v${version}";
+    sha256 = "WC2SB6gisRSZxG9WZtMVBzwkEJtPEGZRmezElLAG0ns=";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [ alsa-lib pipewire ];
+
+  meta = with lib; {
+    description = "Qt graph manager for PipeWire, similar to QjackCtl.";
+    longDescription = ''
+      qpwgraph is a graph manager dedicated for PipeWire,
+      using the Qt C++ framework, based and pretty much like
+      the same of QjackCtl.
+    '';
+    homepage = "https://gitlab.freedesktop.org/rncbc/qpwgraph";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ kanashimia ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27825,6 +27825,8 @@ with pkgs;
 
   qnotero = libsForQt5.callPackage ../applications/office/qnotero { };
 
+  qpwgraph = libsForQt5.callPackage ../applications/audio/qpwgraph { };
+
   qrcode = callPackage ../tools/graphics/qrcode {};
 
   qsampler = libsForQt5.callPackage ../applications/audio/qsampler { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Added a tool similar to qjackctl, but that is native for pipewire.
It seems to work better than helvum even tho version number is that low :')  
It can also be compiled with Qt6, but nixpkgs doesn't have Qt6 at this point.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
