### PR TITLE
xob: 0.2 -> 0.3

### DIFF
--- a/pkgs/tools/X11/xob/default.nix
+++ b/pkgs/tools/X11/xob/default.nix
@@ -2,17 +2,17 @@
 
 stdenv.mkDerivation rec {
   pname = "xob";
-  version = "0.2";
+  version = "0.3";
 
   src = fetchFromGitHub {
     owner = "florentc";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0jbj61adwrpscfaadjman4hbyxhxv3ac8b4d88d623samx6kbvkk";
+    sha256 = "1x4aafiyd9k4y8cmvn7rgfif3g5s5hhlbj5nz71qsyqg21nn7hrw";
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ xorg.libX11 libconfig ];
+  buildInputs = [ xorg.libX11 xorg.libXrender libconfig ];
 
   makeFlags = [ "prefix=$(out)" ];
 
@@ -20,16 +20,16 @@ stdenv.mkDerivation rec {
     description = "A lightweight overlay bar for the X Window System";
     longDescription = ''
       A lightweight configurable overlay volume/backlight/progress/anything bar
-      for the X Window System. Each time a new value is read on the standard
-      input, it is displayed as a tv-like bar over other windows. It then
-      vanishes after a configurable amount of time. A value followed by a bang
-      '!' is displayed using an alternate color to account for special states
-      (e.g. muted audio). There is also support for overflows (when the value
-      exceeds the maximum).
+      for the X Window System (and Wayland compositors with XWayland). Each
+      time a new value is read on the standard input, it is displayed as a
+      tv-like bar over other windows. It then vanishes after a configurable
+      amount of time. A value followed by a bang '!' is displayed using an
+      alternate color to account for special states (e.g. muted audio). There
+      is also support for overflows (when the value exceeds the maximum).
     '';
     inherit (src.meta) homepage;
     license = licenses.gpl3Plus;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ florentc ];
   };
 }


### PR DESCRIPTION


###### Motivation for this change

The current package is outdated and does not have a maintainer anymore.
This updates the package to version 0.3 and adds myself as the new
package maintainer since I am already the maintainer of xob.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
