### PR TITLE
argocd-autopilot: init at 0.2.30

### DIFF
--- a/pkgs/applications/networking/cluster/argocd-autopilot/default.nix
+++ b/pkgs/applications/networking/cluster/argocd-autopilot/default.nix
@@ -1,0 +1,55 @@
+{ lib, stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "argocd-autopilot";
+  version = "0.3.0";
+  commit = "c8d17bef976649e4dc2428c14c39e30a0f846552";
+
+  src = fetchFromGitHub {
+    owner = "argoproj-labs";
+    repo = "argocd-autopilot";
+    rev = "v${version}";
+    sha256 = "sha256-tggE1T+oD/dJS9tD9xOExjhy+T1GDd0vwTerD3P2KvA=";
+  };
+
+  vendorSha256 = "sha256-v8UMSObE6w+ULzueEK0UFeebLqoamy/788SQLBmJZ8U=";
+
+  proxyVendor = true;
+
+  ldflags =
+    let package_url = "github.com/argoproj-labs/argocd-autopilot/pkg/store"; in
+    [
+      "-s"
+      "-w"
+      "-X ${package_url}.binaryName=${pname}"
+      "-X ${package_url}.version=${src.rev}"
+      "-X ${package_url}.buildDate=unknown"
+      "-X ${package_url}.gitCommit=${commit}"
+      "-X ${package_url}.installationManifestURL=github.com/argoproj-labs/argocd-autopilot/manifests/base?ref=${src.rev}"
+      "-X ${package_url}.installationManifestsNamespacedURL=github.com/argoproj-labs/argocd-autopilot/manifests/insecure?ref=${src.rev}"
+    ];
+
+  subPackages = [ "cmd" ];
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/argocd-autopilot version | grep ${src.rev} > /dev/null
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    install -Dm755 "$GOPATH/bin/cmd" -T $out/bin/argocd-autopilot
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "ArgoCD Autopilot";
+    downloadPage = "https://github.com/argoproj-labs/argocd-autopilot";
+    homepage = "https://argocd-autopilot.readthedocs.io/en/stable/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ sagikazarmark bryanasdev000 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24557,6 +24557,8 @@ with pkgs;
 
   argocd = callPackage ../applications/networking/cluster/argocd { };
 
+  argocd-autopilot = callPackage ../applications/networking/cluster/argocd-autopilot { };
+
   argo-rollouts = callPackage ../applications/networking/cluster/argo-rollouts { };
 
   ario = callPackage ../applications/audio/ario { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

A new component in the ArgoCD ecosystem to run ArgoCD itself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
