### PR TITLE
picoscope: 7.0.83 -> 7.0.86 + LANG=C

### DIFF
--- a/pkgs/applications/science/electronics/picoscope/default.nix
+++ b/pkgs/applications/science/electronics/picoscope/default.nix
@@ -104,7 +104,8 @@ in stdenv.mkDerivation rec {
     makeWrapper "$(command -v mono)" $out/bin/picoscope \
       --add-flags $out/lib/PicoScope.GTK.exe \
       --prefix MONO_PATH : "$MONO_PATH" \
-      --prefix LD_LIBRARY_PATH : "$MONO_PATH"
+      --prefix LD_LIBRARY_PATH : "$MONO_PATH" \
+      --set LANG C
     runHook postInstall
   '';
 

--- a/pkgs/applications/science/electronics/picoscope/sources.json
+++ b/pkgs/applications/science/electronics/picoscope/sources.json
@@ -6,64 +6,64 @@
       "version": "1.1.27-1r153"
     },
     "libpicoipp": {
-      "sha256": "87ae49cd5e8dda4a73a835b95ea13e4c3fc4d1c4c9d6495c9affdf6fa6b1b4aa",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libpicoipp/libpicoipp_1.3.0-4r121_amd64.deb",
-      "version": "1.3.0-4r121"
+      "sha256": "0e414ad547f506a39ff11a64772baec923e54f8ca98b81fc9b9cbd19ed573b22",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libpicoipp/libpicoipp_1.3.0-4r130_amd64.deb",
+      "version": "1.3.0-4r130"
     },
     "libps2000": {
-      "sha256": "792e506c08cebbd617e833e1547d3e5a13a186f93cea3f84608b7ed9451fb077",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps2000/libps2000_3.0.75-3r2957_amd64.deb",
-      "version": "3.0.75-3r2957"
+      "sha256": "d1e94148719a03b70f233cea9a686ed48be03224f2931c9cd282571819a780c7",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps2000/libps2000_3.0.76-3r2981_amd64.deb",
+      "version": "3.0.76-3r2981"
     },
     "libps2000a": {
-      "sha256": "f31b3a8e9c6af14a59e348e4b302f12f582cdb08a47a3c04d8a6a612b4630305",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps2000a/libps2000a_2.1.75-5r2957_amd64.deb",
-      "version": "2.1.75-5r2957"
+      "sha256": "c665b70c04203c98bb1b509830ec522f58906b2f393f35c1b4f9c27217ac3572",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps2000a/libps2000a_2.1.76-5r2981_amd64.deb",
+      "version": "2.1.76-5r2981"
     },
     "libps3000": {
-      "sha256": "27dce3c924bb0169768a4964ce567b4a18ce74079537ca1fcba61e9234691580",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps3000/libps3000_4.0.75-3r2957_amd64.deb",
-      "version": "4.0.75-3r2957"
+      "sha256": "dbb9f9afdc694c4451e652f22a4c4c67ef609407f45229d26330ce7cfbb02b1c",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps3000/libps3000_4.0.76-3r2981_amd64.deb",
+      "version": "4.0.76-3r2981"
     },
     "libps3000a": {
-      "sha256": "31cf00ce136526af6e8b211a44a56b221d137de6eaec4d6fd7f31593b4245d62",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps3000a/libps3000a_2.1.75-6r2957_amd64.deb",
-      "version": "2.1.75-6r2957"
+      "sha256": "5ab3daadc5d804b224215d138ca94abecc3c311bb91624638e2758ac2a490d25",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps3000a/libps3000a_2.1.76-6r2981_amd64.deb",
+      "version": "2.1.76-6r2981"
     },
     "libps4000": {
-      "sha256": "c976f09647f1fd2c980aafd1efe7f557bfc7c283fb9c135725c38dd59cc297e9",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps4000/libps4000_2.1.75-2r2957_amd64.deb",
-      "version": "2.1.75-2r2957"
+      "sha256": "13504936207f1a7410f726c93358bb21c0c0cd1bd8b473332308a345ff6692c7",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps4000/libps4000_2.1.76-2r2981_amd64.deb",
+      "version": "2.1.76-2r2981"
     },
     "libps4000a": {
-      "sha256": "727f24fa74759385902d41d52a26a4636b3e3f08a8743901d15cc49622207b97",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps4000a/libps4000a_2.1.75-2r2957_amd64.deb",
-      "version": "2.1.75-2r2957"
+      "sha256": "196ccce96e8cf29f5168cda83748857172ae43dc2b990adbacb3327511784492",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps4000a/libps4000a_2.1.76-2r2981_amd64.deb",
+      "version": "2.1.76-2r2981"
     },
     "libps5000": {
-      "sha256": "3237c1dfdb384079b7039d2b4a8e0b0126e804830b29d60e89ae018182667edb",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps5000/libps5000_2.1.75-3r2957_amd64.deb",
-      "version": "2.1.75-3r2957"
+      "sha256": "1793180d4067df12080ba7b01cbdf38397c2931a7f4915f13dbdb9295cc77cb3",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps5000/libps5000_2.1.76-3r2981_amd64.deb",
+      "version": "2.1.76-3r2981"
     },
     "libps5000a": {
-      "sha256": "27947f8461a16cf59d64cd23d7a78ddd27826e38dfe9fca3902e3b553591fb19",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps5000a/libps5000a_2.1.75-5r2957_amd64.deb",
-      "version": "2.1.75-5r2957"
+      "sha256": "b08a73f43bdcfa2bc02d01f398147da9b8cf2599477144b5a2b2af924d0bf0e9",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps5000a/libps5000a_2.1.76-5r2981_amd64.deb",
+      "version": "2.1.76-5r2981"
     },
     "libps6000": {
-      "sha256": "d65e923db969e306fb9f3f3892229a297d6187574d901dde44375270cc1e1404",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps6000/libps6000_2.1.75-6r2957_amd64.deb",
-      "version": "2.1.75-6r2957"
+      "sha256": "dda0fcb8b346f77a715053b52ad9e26b323991f8336001de7ff1bb6d04c716b4",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps6000/libps6000_2.1.76-6r2981_amd64.deb",
+      "version": "2.1.76-6r2981"
     },
     "libps6000a": {
-      "sha256": "eff8644ad44f9cc1cf9052e27786a1480a4ab599766c1c01e370fef40a76b224",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps6000a/libps6000a_1.0.75-0r2957_amd64.deb",
-      "version": "1.0.75-0r2957"
+      "sha256": "786e5772055500e2e445ddfd5402fed359a9afa54177bd731912d24522729004",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps6000a/libps6000a_1.0.76-0r2981_amd64.deb",
+      "version": "1.0.76-0r2981"
     },
     "picoscope": {
-      "sha256": "3d2a0e360c8143fc03c29b394c16bfc2387164e33099a46b6905af992cfab440",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/p/picoscope/picoscope_7.0.83-1r9320_amd64.deb",
-      "version": "7.0.83-1r9320"
+      "sha256": "12afae7992b9d60c93e5e39c7fe3f93955be3bdff554b52894064d5f320347f4",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/p/picoscope/picoscope_7.0.86-1r9656_amd64.deb",
+      "version": "7.0.86-1r9656"
     }
   }
 }


### PR DESCRIPTION
###### Motivation for this change

Picotech deletes their older packages and the ones referenced in the current derivation go to 404, so I bumped all packages using the python script and verified that it works with the hardware I have available.

Also since the update to picoscope 7.0 I was unable to launch the application with a non English LANG locale (see [comment on the update PR](https://github.com/NixOS/nixpkgs/pull/144833#issuecomment-971883090)), so I added `LANG=C` to the wrapper environment as proposed in the comment there. I'm not sure if this is the correct way to fix this or if this is not even just caused by a misconfiguration of my system.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
