### PR TITLE
Add "Lightweight Music Server" application + service

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -548,6 +548,7 @@
   ./services/misc/lidarr.nix
   ./services/misc/libreddit.nix
   ./services/misc/lifecycled.nix
+  ./services/misc/lms.nix
   ./services/misc/mame.nix
   ./services/misc/matrix-appservice-discord.nix
   ./services/misc/matrix-appservice-irc.nix

--- a/nixos/modules/services/misc/lms.nix
+++ b/nixos/modules/services/misc/lms.nix
@@ -1,0 +1,164 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.lms;
+  settingsFormat = pkgs.formats.toml {};
+in
+{
+  options.services.lms = {
+    enable = mkEnableOption "LMS (Lightweight Music Server). A self-hosted, music streaming server";
+
+    stateDir = mkOption {
+      type = types.path;
+      default = "/var/lib/lms";
+      description = ''
+        The directory where lms uses as a working directory to store its state.
+        If left as the default value this directory will automatically be
+        created before the lms server starts, otherwise the sysadmin is
+        responsible for ensuring the directory exists with appropriate ownership
+        and permissions.
+      '';
+    };
+
+    virtualHost = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Name of the nginx virtualhost to setup as reverse proxy. If null, do
+        not setup any virtualhost.
+      '';
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "lms";
+      description = ''
+        User account under which LMS runs. If left as the default value this
+        user will automatically be created on system activation, otherwise the
+        sysadmin is responsible for ensuring the user exists before the lms
+        service starts.
+      '';
+    };
+
+    settings = mkOption {
+      type = types.submodule {
+        freeformType = settingsFormat.type;
+        options = {
+          listen-addr = mkOption {
+           type = types.str;
+           default = "127.0.0.1";
+           description = ''
+             The address on which to bind LMS.
+           '';
+          };
+
+          listen-port = mkOption {
+           type = types.port;
+           default = 5082;
+           description = ''
+             The port on which LMS will listen to.
+           '';
+          };
+
+          api-subsonic = mkOption {
+            type = types.bool;
+            default = true;
+            description = ''
+              Enable the Subsonic API.
+            '';
+          };
+        };
+      };
+      default = {};
+      description = ''
+        Configuration for LMS, see
+        <link xlink:href="https://github.com/epoupon/lms/blob/master/conf/lms.conf"/>
+        for full list of supported values.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.lms.settings = {
+      working-dir = cfg.stateDir;
+      behind-reverse-proxy = cfg.virtualHost != null;
+      docroot = "${pkgs.lms}/share/lms/docroot/;/resources,/css,/images,/js,/favicon.ico";
+      approot = "${pkgs.lms}/share/lms/approot";
+      cover-max-file-size = mkDefault 10;
+      cover-max-cache-size = mkDefault 30;
+    };
+
+    systemd.services.lms = {
+      description = "Lightweight Music Server";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = mkMerge [
+        {
+          ExecStart =
+            let lmsConfig = settingsFormat.generate "lms.conf" cfg.settings;
+            in "${pkgs.lms}/bin/lms ${lmsConfig}";
+          Restart = "on-failure";
+          RestartSec = 5;
+          User = cfg.user;
+          Group = "lms";
+          WorkingDirectory = cfg.stateDir;
+          UMask = "0022";
+
+          NoNewPrivileges = true;
+          ProtectSystem = true;
+          ProtectHome = true;
+          PrivateTmp = true;
+          PrivateDevices = true;
+          ProtectClock = true;
+          ProtectKernelTunables = true;
+          ProtectKernelModules = true;
+          ProtectKernelLogs = true;
+          ProtectControlGroups = true;
+        }
+        (mkIf (cfg.stateDir == "/var/lib/lms") {
+          StateDirectory = "/var/lib/lms";
+        })
+      ];
+    };
+
+    # from: https://github.com/epoupon/lms#reverse-proxy-settings
+    services.nginx = mkIf (cfg.virtualHost != null) {
+      enable = true;
+      virtualHosts.${cfg.virtualHost} = {
+        locations."/" = {
+          proxyPass = "http://${cfg.settings.listen-addr}:${toString cfg.settings.listen-port}";
+          extraConfig = ''
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 120;
+          '';
+        };
+        extraConfig = ''
+          proxy_request_buffering off;
+          proxy_buffering off;
+          proxy_buffer_size 4k;
+          proxy_read_timeout 10m;
+          proxy_send_timeout 10m;
+          keepalive_timeout 10m;
+        '';
+      };
+    };
+
+    users.users = mkIf (cfg.user == "lms") {
+      "${cfg.user}" = {
+        isSystemUser = true;
+        description = "LMS service user";
+        name = cfg.user;
+        group = "lms";
+        home = cfg.stateDir;
+      };
+    };
+
+    users.groups.lms = {};
+  };
+}

--- a/pkgs/servers/misc/lms/default.nix
+++ b/pkgs/servers/misc/lms/default.nix
@@ -1,0 +1,96 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, writeText
+, cmake
+, pkg-config
+, gtest
+, boost
+, zlib
+, ffmpeg_4
+, graphicsmagick
+, libconfig
+, taglib
+, wt, useMinimalWt ? false
+}:
+
+let
+  ffmpeg = ffmpeg_4;
+
+  # Wt with the minimum set of optional dependencies required for LMS
+  wt-minimal = wt.override {
+    # Docs not needed
+    doxygen = null;
+    # Graphics libraries not needed
+    glew = null; libharu = null; pango = null; graphicsmagick = null;
+    # LMS uses only sqlite
+    firebird = null; libmysqlclient = null; postgresql = null;
+    # Qt not used
+    qt48Full = null;
+  };
+
+  wt-lms = if useMinimalWt then wt-minimal else wt;
+in
+
+stdenv.mkDerivation rec {
+  pname = "lms";
+  version = "3.27.0";
+
+  src = fetchFromGitHub {
+    owner = "epoupon";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0rkky9c1yiqlgs9amrcnqsxdcwc7s7qghc1s1m0mbannsr1rb8rn";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config gtest ];
+  buildInputs = [
+    boost.dev zlib.dev ffmpeg.dev graphicsmagick libconfig taglib wt-lms
+  ];
+
+  patches = [
+    (writeText "hardcode-dependency-paths.patch" ''
+      diff --git a/src/libs/av/impl/Transcoder.cpp b/src/libs/av/impl/Transcoder.cpp
+      index 7efa044..16a6e4c 100644
+      --- a/src/libs/av/impl/Transcoder.cpp
+      +++ b/src/libs/av/impl/Transcoder.cpp
+      @@ -38,7 +38,7 @@ static std::filesystem::path	ffmpegPath;
+       void
+       Transcoder::init()
+       {
+      -	ffmpegPath = Service<IConfig>::get()->getPath("ffmpeg-file", "/usr/bin/ffmpeg");
+      +	ffmpegPath = Service<IConfig>::get()->getPath("ffmpeg-file", "${ffmpeg.bin}/bin/ffmpeg");
+       	if (!std::filesystem::exists(ffmpegPath))
+       		throw Exception {"File '" + ffmpegPath.string() + "' does not exist!"};
+       }
+      diff --git a/src/lms/main.cpp b/src/lms/main.cpp
+      index 98c0cec..b60e26a 100644
+      --- a/src/lms/main.cpp
+      +++ b/src/lms/main.cpp
+      @@ -53,7 +53,7 @@ generateWtConfig(std::string execPath)
+       	const std::filesystem::path wtConfigPath {Service<IConfig>::get()->getPath("working-dir") / "wt_config.xml"};
+       	const std::filesystem::path wtLogFilePath {Service<IConfig>::get()->getPath("log-file", "/var/log/lms.log")};
+       	const std::filesystem::path wtAccessLogFilePath {Service<IConfig>::get()->getPath("access-log-file", "/var/log/lms.access.log")};
+      -	const std::filesystem::path wtResourcesPath {Service<IConfig>::get()->getPath("wt-resources", "/usr/share/Wt/resources")};
+      +	const std::filesystem::path wtResourcesPath {Service<IConfig>::get()->getPath("wt-resources", "${wt-lms}/share/Wt/resources")};
+       	const unsigned long configHttpServerThreadCount {Service<IConfig>::get()->getULong("http-server-thread-count", 0)};
+       
+       	args.push_back(execPath);
+    '')
+  ];
+
+  meta = with lib; {
+    description = "Lightweight / low memory music streaming server";
+    longDescription = ''
+      LMS is a self-hosted music streaming software: access your music
+      collection from anywhere using a web interface or the subsonic API!
+      Written in C++, it has a low memory footprint and even comes with a
+      recommendation engine.
+    '';
+    homepage = https://github.com/epoupon/lms;
+    downloadPage = "https://github.com/epoupon/lms";
+    maintainers = with maintainers; [ arthur ];
+    license = licenses.gpl3;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20948,6 +20948,8 @@ with pkgs;
 
   livepeer = callPackage ../servers/livepeer { };
 
+  lms = callPackage ../servers/misc/lms { };
+
   lwan = callPackage ../servers/http/lwan { };
 
   labelImg = callPackage ../applications/science/machine-learning/labelimg { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
Follow up of https://github.com/NixOS/nixpkgs/pull/147206

###### Motivation for this change

It's a nice efficient music streaming server, especially suitable for resource constrained devices / servers. See [https://github.com/epoupon/lms]().

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] armv7l-linux
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
