### PR TITLE
php: Init at 8.1.1

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -14,8 +14,13 @@
   </itemizedlist>
   <section xml:id="sec-release-22.05-highlights">
     <title>Highlights</title>
-    <para>
-    </para>
+    <itemizedlist spacing="compact">
+      <listitem>
+        <para>
+          PHP 8.1 is now available
+        </para>
+      </listitem>
+    </itemizedlist>
   </section>
   <section xml:id="sec-release-22.05-new-services">
     <title>New Services</title>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -6,6 +6,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 ## Highlights {#sec-release-22.05-highlights}
 
+- PHP 8.1 is now available
+
 ## New Services {#sec-release-22.05-new-services}
 
 ## Backward Incompatibilities {#sec-release-22.05-incompatibilities}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -358,6 +358,7 @@ in
   php = handleTest ./php {};
   php74 = handleTest ./php { php = pkgs.php74; };
   php80 = handleTest ./php { php = pkgs.php80; };
+  php81 = handleTest ./php { php = pkgs.php81; };
   pinnwand = handleTest ./pinnwand.nix {};
   plasma5 = handleTest ./plasma5.nix {};
   plasma5-systemd-start = handleTest ./plasma5-systemd-start.nix {};

--- a/pkgs/development/interpreters/php/8.1.nix
+++ b/pkgs/development/interpreters/php/8.1.nix
@@ -1,0 +1,51 @@
+{ callPackage, lib, stdenv, ... }@_args:
+
+let
+  base = callPackage ./generic.nix (_args // {
+    version = "8.1.1";
+    sha256 = "sha256-j4vJytbNEk7cER99sKEJdF4vY4dwoQGzwiopU/eptA4=";
+  });
+
+in
+base.withExtensions ({ all, ... }: with all; ([
+  bcmath
+  calendar
+  curl
+  ctype
+  dom
+  exif
+  fileinfo
+  filter
+  ftp
+  gd
+  gettext
+  gmp
+  iconv
+  intl
+  ldap
+  mbstring
+  mysqli
+  mysqlnd
+  opcache
+  openssl
+  pcntl
+  pdo
+  pdo_mysql
+  pdo_odbc
+  pdo_pgsql
+  pdo_sqlite
+  pgsql
+  posix
+  readline
+  session
+  simplexml
+  sockets
+  soap
+  sodium
+  sqlite3
+  tokenizer
+  xmlreader
+  xmlwriter
+  zip
+  zlib
+] ++ lib.optionals (!stdenv.isDarwin) [ imap ]))

--- a/pkgs/development/interpreters/php/fix-tokenizer-php81.patch
+++ b/pkgs/development/interpreters/php/fix-tokenizer-php81.patch
@@ -1,0 +1,12 @@
+diff --git a/ext/tokenizer/Makefile.frag b/ext/tokenizer/Makefile.frag
+index 745cbfce91..07bace6022 100644
+--- a/ext/tokenizer/Makefile.frag
++++ b/ext/tokenizer/Makefile.frag
+@@ -1,5 +1,5 @@
+-$(top_srcdir)/ext/tokenizer/tokenizer_data.c: $(top_srcdir)/Zend/zend_language_parser.y
++$(top_srcdir)/tokenizer_data.c: $(top_srcdir)/../../Zend/zend_language_parser.y
+ 	@if test ! -z "$(PHP)"; then \
+ 		$(PHP) $(srcdir)/tokenizer_data_gen.php; \
+ 	fi;
+-$(builddir)/tokenizer.lo: $(top_srcdir)/Zend/zend_language_parser.c $(top_srcdir)/Zend/zend_language_scanner.c
++$(builddir)/tokenizer.lo: $(top_srcdir)/../../Zend/zend_language_parser.c $(top_srcdir)/../../Zend/zend_language_scanner.c

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13493,6 +13493,13 @@ with pkgs;
   phpExtensions = php.extensions;
   phpPackages = php.packages;
 
+  # Import PHP81 interpreter, extensions and packages
+  php81 = callPackage ../development/interpreters/php/8.1.nix {
+    stdenv = if stdenv.cc.isClang then llvmPackages.stdenv else stdenv;
+  };
+  php81Extensions = recurseIntoAttrs php81.extensions;
+  php81Packages = recurseIntoAttrs php81.packages;
+
   # Import PHP80 interpreter, extensions and packages
   php80 = callPackage ../development/interpreters/php/8.0.nix {
     stdenv = if stdenv.cc.isClang then llvmPackages.stdenv else stdenv;

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -565,6 +565,7 @@ lib.makeScope pkgs.newScope (self: with self; {
           buildInputs = [ libxml2 ];
           internalDeps = [ php.extensions.dom ];
           NIX_CFLAGS_COMPILE = [ "-I../.." "-DHAVE_DOM" ];
+          doCheck = false;
           configureFlags = [ "--enable-xmlreader" ]
             # Required to build on darwin.
             ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ];

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -543,7 +543,11 @@ lib.makeScope pkgs.newScope (self: with self; {
         { name = "sysvsem"; }
         { name = "sysvshm"; }
         { name = "tidy"; configureFlags = [ "--with-tidy=${html-tidy}" ]; doCheck = false; }
-        { name = "tokenizer"; }
+        {
+          name = "tokenizer";
+          patches = lib.optional (lib.versionAtLeast php.version "8.1")
+            ../development/interpreters/php/fix-tokenizer-php81.patch;
+        }
         {
           name = "wddx";
           buildInputs = [ libxml2 ];


### PR DESCRIPTION
###### Motivation for this change

New PHP 8.1.1 version.

Unable to build it yet locally, the issue seems to come from the `tokenizer` extension.

Reproduce quickly the issue by checking out this branch and do: `nix-build -A php81.extensions.tokenizer`

<details>

```
$ nix log /nix/store/bp8y52njbdq3yg89k3ba8phismpbm26a-php-tokenizer-8.1.0.drv                                                                                                                                    
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking sources
unpacking source archive /nix/store/9nxgdf4zsg05x9h4vax782cy6q2rp4rq-php-8.1.0.tar.bz2
source root is php-8.1.0/ext/tokenizer
setting SOURCE_DATE_EPOCH to timestamp 1637693771 of file php-8.1.0/ext/tokenizer/tokenizer_data_gen.php
@nix { "action": "setPhase", "phase": "patchPhase" }
patching sources
/build/php-8.1.0 /build/php-8.1.0/ext/tokenizer
/build/php-8.1.0/ext/tokenizer
@nix { "action": "setPhase", "phase": "configurePhase" }
configuring
Configuring for:
PHP Api Version:         20210902
Zend Module Api No:      20210902
Zend Extension Api No:   420210902
configure.ac:18: warning: $as_echo is obsolete; use AS_ECHO(["message"]) instead
build/php.m4:2111: PHP_CONFIG_NICE is expanded from...
configure.ac:18: the top level
configure.ac:161: warning: The macro `AC_LANG_C' is obsolete.
configure.ac:161: You should run autoupdate.
./lib/autoconf/c.m4:72: AC_LANG_C is expanded from...
build/libtool.m4:2739: _LT_AC_LANG_C_CONFIG is expanded from...
build/libtool.m4:2738: AC_LIBTOOL_LANG_C_CONFIG is expanded from...
build/libtool.m4:70: AC_LIBTOOL_SETUP is expanded from...
build/libtool.m4:52: _AC_PROG_LIBTOOL is expanded from...
build/libtool.m4:39: AC_PROG_LIBTOOL is expanded from...
configure.ac:161: the top level
configure.ac:161: warning: The macro `AC_LANG_C' is obsolete.
configure.ac:161: You should run autoupdate.
./lib/autoconf/c.m4:72: AC_LANG_C is expanded from...
lib/m4sugar/m4sh.m4:692: _AS_IF_ELSE is expanded from...
lib/m4sugar/m4sh.m4:699: AS_IF is expanded from...
./lib/autoconf/general.m4:2249: AC_CACHE_VAL is expanded from...
./lib/autoconf/general.m4:2270: AC_CACHE_CHECK is expanded from...
build/libtool.m4:561: _LT_AC_LOCK is expanded from...
build/libtool.m4:1185: AC_LIBTOOL_SYS_HARD_LINK_LOCKS is expanded from...
build/libtool.m4:2739: _LT_AC_LANG_C_CONFIG is expanded from...
build/libtool.m4:2738: AC_LIBTOOL_LANG_C_CONFIG is expanded from...
build/libtool.m4:70: AC_LIBTOOL_SETUP is expanded from...
build/libtool.m4:52: _AC_PROG_LIBTOOL is expanded from...
build/libtool.m4:39: AC_PROG_LIBTOOL is expanded from...
configure.ac:161: the top level
configure.ac:161: warning: The macro `AC_TRY_LINK' is obsolete.
configure.ac:161: You should run autoupdate.
./lib/autoconf/general.m4:2920: AC_TRY_LINK is expanded from...
lib/m4sugar/m4sh.m4:692: _AS_IF_ELSE is expanded from...
lib/m4sugar/m4sh.m4:699: AS_IF is expanded from...
./lib/autoconf/general.m4:2249: AC_CACHE_VAL is expanded from...
./lib/autoconf/general.m4:2270: AC_CACHE_CHECK is expanded from...
build/libtool.m4:561: _LT_AC_LOCK is expanded from...
build/libtool.m4:1185: AC_LIBTOOL_SYS_HARD_LINK_LOCKS is expanded from...
build/libtool.m4:2739: _LT_AC_LANG_C_CONFIG is expanded from...
build/libtool.m4:2738: AC_LIBTOOL_LANG_C_CONFIG is expanded from...
build/libtool.m4:70: AC_LIBTOOL_SETUP is expanded from...
build/libtool.m4:52: _AC_PROG_LIBTOOL is expanded from...
build/libtool.m4:39: AC_PROG_LIBTOOL is expanded from...
configure.ac:161: the top level
configure.ac:161: warning: back quotes and double quotes must not be escaped in: $as_me:${as_lineno-$LINENO}: WARNING: \`$CC' does not support \`-c -o', so \`make -j' may be unsafe
build/libtool.m4:1185: AC_LIBTOOL_SYS_HARD_LINK_LOCKS is expanded from...
build/libtool.m4:2739: _LT_AC_LANG_C_CONFIG is expanded from...
build/libtool.m4:2738: AC_LIBTOOL_LANG_C_CONFIG is expanded from...
build/libtool.m4:70: AC_LIBTOOL_SETUP is expanded from...
build/libtool.m4:52: _AC_PROG_LIBTOOL is expanded from...
build/libtool.m4:39: AC_PROG_LIBTOOL is expanded from...
configure.ac:161: the top level
configure.ac:161: warning: back quotes and double quotes must not be escaped in: $as_me: WARNING: \`$CC' does not support \`-c -o', so \`make -j' may be unsafe
build/libtool.m4:1185: AC_LIBTOOL_SYS_HARD_LINK_LOCKS is expanded from...
build/libtool.m4:2739: _LT_AC_LANG_C_CONFIG is expanded from...
build/libtool.m4:2738: AC_LIBTOOL_LANG_C_CONFIG is expanded from...
build/libtool.m4:70: AC_LIBTOOL_SETUP is expanded from...
build/libtool.m4:52: _AC_PROG_LIBTOOL is expanded from...
build/libtool.m4:39: AC_PROG_LIBTOOL is expanded from...
configure.ac:161: the top level
configure.ac:161: warning: back quotes and double quotes must not be escaped in: $as_me:${as_lineno-$LINENO}: WARNING: output file \`$ofile' does not exist
build/libtool.m4:1929: _LT_AC_TAGCONFIG is expanded from...
build/libtool.m4:70: AC_LIBTOOL_SETUP is expanded from...
build/libtool.m4:52: _AC_PROG_LIBTOOL is expanded from...
build/libtool.m4:39: AC_PROG_LIBTOOL is expanded from...
configure.ac:161: the top level
configure.ac:161: warning: back quotes and double quotes must not be escaped in: $as_me: WARNING: output file \`$ofile' does not exist
build/libtool.m4:1929: _LT_AC_TAGCONFIG is expanded from...
build/libtool.m4:70: AC_LIBTOOL_SETUP is expanded from...
build/libtool.m4:52: _AC_PROG_LIBTOOL is expanded from...
build/libtool.m4:39: AC_PROG_LIBTOOL is expanded from...
configure.ac:161: the top level
configure.ac:161: warning: back quotes and double quotes must not be escaped in: $as_me:${as_lineno-$LINENO}: WARNING: output file \`$ofile' does not look like a libtool script
build/libtool.m4:1929: _LT_AC_TAGCONFIG is expanded from...
build/libtool.m4:70: AC_LIBTOOL_SETUP is expanded from...
build/libtool.m4:52: _AC_PROG_LIBTOOL is expanded from...
build/libtool.m4:39: AC_PROG_LIBTOOL is expanded from...
configure.ac:161: the top level
configure.ac:161: warning: back quotes and double quotes must not be escaped in: $as_me: WARNING: output file \`$ofile' does not look like a libtool script
build/libtool.m4:1929: _LT_AC_TAGCONFIG is expanded from...
build/libtool.m4:70: AC_LIBTOOL_SETUP is expanded from...
build/libtool.m4:52: _AC_PROG_LIBTOOL is expanded from...
build/libtool.m4:39: AC_PROG_LIBTOOL is expanded from...
configure.ac:161: the top level
configure.ac:161: warning: back quotes and double quotes must not be escaped in: $as_me:${as_lineno-$LINENO}: WARNING: using \`LTCC=$LTCC', extracted from \`$ofile'
build/libtool.m4:1929: _LT_AC_TAGCONFIG is expanded from...
build/libtool.m4:70: AC_LIBTOOL_SETUP is expanded from...
build/libtool.m4:52: _AC_PROG_LIBTOOL is expanded from...
build/libtool.m4:39: AC_PROG_LIBTOOL is expanded from...
configure.ac:161: the top level
configure.ac:161: warning: back quotes and double quotes must not be escaped in: $as_me: WARNING: using \`LTCC=$LTCC', extracted from \`$ofile'
build/libtool.m4:1929: _LT_AC_TAGCONFIG is expanded from...
build/libtool.m4:70: AC_LIBTOOL_SETUP is expanded from...
build/libtool.m4:52: _AC_PROG_LIBTOOL is expanded from...
build/libtool.m4:39: AC_PROG_LIBTOOL is expanded from...
configure.ac:161: the top level
configure.ac:161: warning: back quotes and double quotes must not be escaped in: tag name \"$tagname\" already exists
build/libtool.m4:1929: _LT_AC_TAGCONFIG is expanded from...
build/libtool.m4:70: AC_LIBTOOL_SETUP is expanded from...
build/libtool.m4:52: _AC_PROG_LIBTOOL is expanded from...
build/libtool.m4:39: AC_PROG_LIBTOOL is expanded from...
configure.ac:161: the top level
configure.ac:161: warning: The macro `AC_LANG_CPLUSPLUS' is obsolete.
configure.ac:161: You should run autoupdate.
./lib/autoconf/c.m4:262: AC_LANG_CPLUSPLUS is expanded from...
build/libtool.m4:2821: _LT_AC_LANG_CXX_CONFIG is expanded from...
build/libtool.m4:2820: AC_LIBTOOL_LANG_CXX_CONFIG is expanded from...
build/libtool.m4:1929: _LT_AC_TAGCONFIG is expanded from...
build/libtool.m4:70: AC_LIBTOOL_SETUP is expanded from...
build/libtool.m4:52: _AC_PROG_LIBTOOL is expanded from...
build/libtool.m4:39: AC_PROG_LIBTOOL is expanded from...
configure.ac:161: the top level
configure.ac:161: warning: back quotes and double quotes must not be escaped in: $as_me:${as_lineno-$LINENO}: WARNING: \`$CC' does not support \`-c -o', so \`make -j' may be unsafe
build/libtool.m4:1185: AC_LIBTOOL_SYS_HARD_LINK_LOCKS is expanded from...
build/libtool.m4:2821: _LT_AC_LANG_CXX_CONFIG is expanded from...
build/libtool.m4:2820: AC_LIBTOOL_LANG_CXX_CONFIG is expanded from...
build/libtool.m4:1929: _LT_AC_TAGCONFIG is expanded from...
build/libtool.m4:70: AC_LIBTOOL_SETUP is expanded from...
build/libtool.m4:52: _AC_PROG_LIBTOOL is expanded from...
build/libtool.m4:39: AC_PROG_LIBTOOL is expanded from...
configure.ac:161: the top level
configure.ac:161: warning: back quotes and double quotes must not be escaped in: $as_me: WARNING: \`$CC' does not support \`-c -o', so \`make -j' may be unsafe
build/libtool.m4:1185: AC_LIBTOOL_SYS_HARD_LINK_LOCKS is expanded from...
build/libtool.m4:2821: _LT_AC_LANG_CXX_CONFIG is expanded from...
build/libtool.m4:2820: AC_LIBTOOL_LANG_CXX_CONFIG is expanded from...
build/libtool.m4:1929: _LT_AC_TAGCONFIG is expanded from...
build/libtool.m4:70: AC_LIBTOOL_SETUP is expanded from...
build/libtool.m4:52: _AC_PROG_LIBTOOL is expanded from...
build/libtool.m4:39: AC_PROG_LIBTOOL is expanded from...
configure.ac:161: the top level
fixing libtool script ./build/ltmain.sh
configure flags: --disable-static --prefix=/nix/store/ys006mcrak7djal7b67d865kbw4wh3a6-php-tokenizer-8.1.0 --bindir=/nix/store/ys006mcrak7djal7b67d865kbw4wh3a6-php-tokenizer-8.1.0/bin --sbindir=/nix/store/ys006mcrak7djal7b67d865kbw4wh3>
checking for grep that handles long lines and -e... /nix/store/lhambyc1v2c7qzzr5sq7p449xs1j6pg8-gnugrep-3.7/bin/grep
checking for egrep... /nix/store/lhambyc1v2c7qzzr5sq7p449xs1j6pg8-gnugrep-3.7/bin/grep -E
checking for a sed that does not truncate output... /nix/store/9mp06ni69a44dmrjhn28mn15brdry52w-gnused-4.8/bin/sed
checking pkg-config is at least version 0.9.0... yes
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether the compiler supports GNU C... yes
checking whether gcc accepts -g... yes
checking for gcc option to enable C11 features... none needed
checking how to run the C preprocessor... gcc -E
checking for icc... no
checking for suncc... no
checking for system library directory... lib
checking if compiler supports -R... no
checking if compiler supports -Wl,-rpath,... yes
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
checking target system type... x86_64-pc-linux-gnu
checking for PHP prefix... /nix/store/srka020risamwgw14n7vbxamd7b86pwm-php-8.1.0
checking for PHP includes... -I/nix/store/0qpm6z741pblkxzn3gk05i7kj7nfs6y2-php-8.1.0-dev/include/php -I/nix/store/0qpm6z741pblkxzn3gk05i7kj7nfs6y2-php-8.1.0-dev/include/php/main -I/nix/store/0qpm6z741pblkxzn3gk05i7kj7nfs6y2-php-8.1.0-d>
checking for PHP extension directory... /nix/store/srka020risamwgw14n7vbxamd7b86pwm-php-8.1.0/lib/php/extensions
checking for PHP installed headers prefix... /nix/store/0qpm6z741pblkxzn3gk05i7kj7nfs6y2-php-8.1.0-dev/include/php
checking if debug is enabled... no
checking if zts is enabled... yes
checking for gawk... gawk
checking whether to enable tokenizer support... yes, shared
checking for a sed that does not truncate output... /nix/store/9mp06ni69a44dmrjhn28mn15brdry52w-gnused-4.8/bin/sed
checking for ld used by gcc... ld
checking if the linker (ld) is GNU ld... yes
checking for ld option to reload object files... -r
checking for BSD-compatible nm... nm
checking whether ln -s works... yes
checking how to recognize dependent libraries... (cached) pass_all
./configure: line 5380: /usr/bin/file: No such file or directory
checking for stdio.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for strings.h... yes
checking for sys/stat.h... yes
checking for sys/types.h... yes
checking for unistd.h... yes
checking for dlfcn.h... yes
checking the maximum length of command line arguments... 1572864
checking command to parse nm output from gcc object... ok
checking for objdir... .libs
checking for ar... ar
checking for ranlib... ranlib
checking for strip... strip
checking if gcc supports -fno-rtti -fno-exceptions... no
checking for gcc option to produce PIC... -fPIC
checking if gcc PIC flag -fPIC works... yes
checking if gcc static flag -static works... no
checking if gcc supports -c -o file.o... yes
checking whether the gcc linker (ld) supports shared libraries... yes
checking whether -lc should be explicitly linked in... no
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... yes
checking whether to build static libraries... no

creating libtool
appending configuration tag "CXX" to libtool
checking whether the g++ linker (ld) supports shared libraries... yes
checking for g++ option to produce PIC... 
checking if g++ static flag  works... yes
checking if g++ supports -c -o file.o... yes
checking whether the g++ linker (ld) supports shared libraries... yes
checking dynamic linker characteristics... GNU/Linux ld.so
(cached) (cached) checking how to hardcode library paths into programs... unsupported
configure: patching config.h.in
configure: creating ./config.status
config.status: creating config.h
@nix { "action": "setPhase", "phase": "buildPhase" }
building
build flags: -j4 -l4 SHELL=/nix/store/l0wlqpbsvh1pgvhcdhw7qkka3d31si7k-bash-5.1-p8/bin/bash
make: *** No rule to make target '/build/php-8.1.0/ext/tokenizer/Zend/zend_language_parser.y', needed by '/build/php-8.1.0/ext/tokenizer/Zend/zend_language_parser.c'.  Stop.      
```
</details>

I'm looking for help!

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
