### PR TITLE
De-lint lib/tests scripts

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # This script is used to test that the module system is working as expected.
 # By default it test the version of nixpkgs which is defined in the NIX_PATH.

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -14,14 +14,14 @@ fail=0
 evalConfig() {
     local attr=$1
     shift
-    local script="import ./default.nix { modules = [ $@ ];}"
+    local script="import ./default.nix { modules = [ $* ];}"
     nix-instantiate --timeout 1 -E "$script" -A "$attr" --eval-only --show-trace --read-write-mode
 }
 
 reportFailure() {
     local attr=$1
     shift
-    local script="import ./default.nix { modules = [ $@ ];}"
+    local script="import ./default.nix { modules = [ $* ];}"
     echo 2>&1 "$ nix-instantiate -E '$script' -A '$attr' --eval-only"
     evalConfig "$attr" "$@"
     fail=$((fail + 1))

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -13,14 +13,14 @@ fail=0
 
 evalConfig() {
     local attr=$1
-    shift;
+    shift
     local script="import ./default.nix { modules = [ $@ ];}"
     nix-instantiate --timeout 1 -E "$script" -A "$attr" --eval-only --show-trace --read-write-mode
 }
 
 reportFailure() {
     local attr=$1
-    shift;
+    shift
     local script="import ./default.nix { modules = [ $@ ];}"
     echo 2>&1 "$ nix-instantiate -E '$script' -A '$attr' --eval-only"
     evalConfig "$attr" "$@"
@@ -29,10 +29,10 @@ reportFailure() {
 
 checkConfigOutput() {
     local outputContains=$1
-    shift;
+    shift
     if evalConfig "$@" 2>/dev/null | grep --silent "$outputContains" ; then
         pass=$((pass + 1))
-        return 0;
+        return 0
     else
         echo 2>&1 "error: Expected result matching '$outputContains', while evaluating"
         reportFailure "$@"
@@ -43,7 +43,7 @@ checkConfigOutput() {
 checkConfigError() {
     local errorContains=$1
     local err=""
-    shift;
+    shift
     if err="$(evalConfig "$@" 2>&1 >/dev/null)"; then
         echo 2>&1 "error: Expected error code, got exit code 0, while evaluating"
         reportFailure "$@"
@@ -51,7 +51,7 @@ checkConfigError() {
     else
         if echo "$err" | grep -zP --silent "$errorContains" ; then
             pass=$((pass + 1))
-            return 0;
+            return 0
         else
             echo 2>&1 "error: Expected error matching '$errorContains', while evaluating"
             reportFailure "$@"

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -44,7 +44,7 @@ checkConfigError() {
     local errorContains=$1
     local err=""
     shift;
-    if err==$(evalConfig "$@" 2>&1 >/dev/null); then
+    if err="$(evalConfig "$@" 2>&1 >/dev/null)"; then
         echo 2>&1 "error: Expected error code, got exit code 0, while evaluating"
         reportFailure "$@"
         return 1

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -59,53 +59,53 @@ checkConfigError() {
 }
 
 # Check boolean option.
-checkConfigOutput "false" config.enable ./declare-enable.nix
+checkConfigOutput '^false$' config.enable ./declare-enable.nix
 checkConfigError 'The option .* does not exist. Definition values:\n\s*- In .*: true' config.enable ./define-enable.nix
 
 # Check integer types.
 # unsigned
-checkConfigOutput "42" config.value ./declare-int-unsigned-value.nix ./define-value-int-positive.nix
+checkConfigOutput '^42$' config.value ./declare-int-unsigned-value.nix ./define-value-int-positive.nix
 checkConfigError 'A definition for option .* is not of type.*unsigned integer.*. Definition values:\n\s*- In .*: -23' config.value ./declare-int-unsigned-value.nix ./define-value-int-negative.nix
 # positive
 checkConfigError 'A definition for option .* is not of type.*positive integer.*. Definition values:\n\s*- In .*: 0' config.value ./declare-int-positive-value.nix ./define-value-int-zero.nix
 # between
-checkConfigOutput "42" config.value ./declare-int-between-value.nix ./define-value-int-positive.nix
+checkConfigOutput '^42$' config.value ./declare-int-between-value.nix ./define-value-int-positive.nix
 checkConfigError 'A definition for option .* is not of type.*between.*-21 and 43.*inclusive.*. Definition values:\n\s*- In .*: -23' config.value ./declare-int-between-value.nix ./define-value-int-negative.nix
 
 # Check either types
 # types.either
-checkConfigOutput "42" config.value ./declare-either.nix ./define-value-int-positive.nix
-checkConfigOutput "\"24\"" config.value ./declare-either.nix ./define-value-string.nix
+checkConfigOutput '^42$' config.value ./declare-either.nix ./define-value-int-positive.nix
+checkConfigOutput '^"24"$' config.value ./declare-either.nix ./define-value-string.nix
 # types.oneOf
-checkConfigOutput "42" config.value ./declare-oneOf.nix ./define-value-int-positive.nix
-checkConfigOutput "[ ]" config.value ./declare-oneOf.nix ./define-value-list.nix
-checkConfigOutput "\"24\"" config.value ./declare-oneOf.nix ./define-value-string.nix
+checkConfigOutput '^42$' config.value ./declare-oneOf.nix ./define-value-int-positive.nix
+checkConfigOutput '^\[ \]$' config.value ./declare-oneOf.nix ./define-value-list.nix
+checkConfigOutput '^"24"$' config.value ./declare-oneOf.nix ./define-value-string.nix
 
 # Check mkForce without submodules.
 set -- config.enable ./declare-enable.nix ./define-enable.nix
-checkConfigOutput "true" "$@"
-checkConfigOutput "false" "$@" ./define-force-enable.nix
-checkConfigOutput "false" "$@" ./define-enable-force.nix
+checkConfigOutput '^true$' "$@"
+checkConfigOutput '^false$' "$@" ./define-force-enable.nix
+checkConfigOutput '^false$' "$@" ./define-enable-force.nix
 
 # Check mkForce with option and submodules.
 checkConfigError 'attribute .*foo.* .* not found' config.attrsOfSub.foo.enable ./declare-attrsOfSub-any-enable.nix
-checkConfigOutput 'false' config.attrsOfSub.foo.enable ./declare-attrsOfSub-any-enable.nix ./define-attrsOfSub-foo.nix
+checkConfigOutput '^false$' config.attrsOfSub.foo.enable ./declare-attrsOfSub-any-enable.nix ./define-attrsOfSub-foo.nix
 set -- config.attrsOfSub.foo.enable ./declare-attrsOfSub-any-enable.nix ./define-attrsOfSub-foo-enable.nix
-checkConfigOutput 'true' "$@"
-checkConfigOutput 'false' "$@" ./define-force-attrsOfSub-foo-enable.nix
-checkConfigOutput 'false' "$@" ./define-attrsOfSub-force-foo-enable.nix
-checkConfigOutput 'false' "$@" ./define-attrsOfSub-foo-force-enable.nix
-checkConfigOutput 'false' "$@" ./define-attrsOfSub-foo-enable-force.nix
+checkConfigOutput '^true$' "$@"
+checkConfigOutput '^false$' "$@" ./define-force-attrsOfSub-foo-enable.nix
+checkConfigOutput '^false$' "$@" ./define-attrsOfSub-force-foo-enable.nix
+checkConfigOutput '^false$' "$@" ./define-attrsOfSub-foo-force-enable.nix
+checkConfigOutput '^false$' "$@" ./define-attrsOfSub-foo-enable-force.nix
 
 # Check overriding effect of mkForce on submodule definitions.
 checkConfigError 'attribute .*bar.* .* not found' config.attrsOfSub.bar.enable ./declare-attrsOfSub-any-enable.nix ./define-attrsOfSub-foo.nix
-checkConfigOutput 'false' config.attrsOfSub.bar.enable ./declare-attrsOfSub-any-enable.nix ./define-attrsOfSub-foo.nix ./define-attrsOfSub-bar.nix
+checkConfigOutput '^false$' config.attrsOfSub.bar.enable ./declare-attrsOfSub-any-enable.nix ./define-attrsOfSub-foo.nix ./define-attrsOfSub-bar.nix
 set -- config.attrsOfSub.bar.enable ./declare-attrsOfSub-any-enable.nix ./define-attrsOfSub-foo.nix ./define-attrsOfSub-bar-enable.nix
-checkConfigOutput 'true' "$@"
+checkConfigOutput '^true$' "$@"
 checkConfigError 'attribute .*bar.* .* not found' "$@" ./define-force-attrsOfSub-foo-enable.nix
 checkConfigError 'attribute .*bar.* .* not found' "$@" ./define-attrsOfSub-force-foo-enable.nix
-checkConfigOutput 'true' "$@" ./define-attrsOfSub-foo-force-enable.nix
-checkConfigOutput 'true' "$@" ./define-attrsOfSub-foo-enable-force.nix
+checkConfigOutput '^true$' "$@" ./define-attrsOfSub-foo-force-enable.nix
+checkConfigOutput '^true$' "$@" ./define-attrsOfSub-foo-enable-force.nix
 
 # Check mkIf with submodules.
 checkConfigError 'attribute .*foo.* .* not found' config.attrsOfSub.foo.enable ./declare-enable.nix ./declare-attrsOfSub-any-enable.nix
@@ -113,16 +113,16 @@ set -- config.attrsOfSub.foo.enable ./declare-enable.nix ./declare-attrsOfSub-an
 checkConfigError 'attribute .*foo.* .* not found' "$@" ./define-if-attrsOfSub-foo-enable.nix
 checkConfigError 'attribute .*foo.* .* not found' "$@" ./define-attrsOfSub-if-foo-enable.nix
 checkConfigError 'attribute .*foo.* .* not found' "$@" ./define-attrsOfSub-foo-if-enable.nix
-checkConfigOutput 'false' "$@" ./define-attrsOfSub-foo-enable-if.nix
-checkConfigOutput 'true' "$@" ./define-enable.nix ./define-if-attrsOfSub-foo-enable.nix
-checkConfigOutput 'true' "$@" ./define-enable.nix ./define-attrsOfSub-if-foo-enable.nix
-checkConfigOutput 'true' "$@" ./define-enable.nix ./define-attrsOfSub-foo-if-enable.nix
-checkConfigOutput 'true' "$@" ./define-enable.nix ./define-attrsOfSub-foo-enable-if.nix
+checkConfigOutput '^false$' "$@" ./define-attrsOfSub-foo-enable-if.nix
+checkConfigOutput '^true$' "$@" ./define-enable.nix ./define-if-attrsOfSub-foo-enable.nix
+checkConfigOutput '^true$' "$@" ./define-enable.nix ./define-attrsOfSub-if-foo-enable.nix
+checkConfigOutput '^true$' "$@" ./define-enable.nix ./define-attrsOfSub-foo-if-enable.nix
+checkConfigOutput '^true$' "$@" ./define-enable.nix ./define-attrsOfSub-foo-enable-if.nix
 
 # Check disabledModules with config definitions and option declarations.
 set -- config.enable ./define-enable.nix ./declare-enable.nix
-checkConfigOutput "true" "$@"
-checkConfigOutput "false" "$@" ./disable-define-enable.nix
+checkConfigOutput '^true$' "$@"
+checkConfigOutput '^false$' "$@" ./disable-define-enable.nix
 checkConfigError "The option .*enable.* does not exist. Definition values:\n\s*- In .*: true" "$@" ./disable-declare-enable.nix
 checkConfigError "attribute .*enable.* in selection path .*config.enable.* not found" "$@" ./disable-define-enable.nix ./disable-declare-enable.nix
 checkConfigError "attribute .*enable.* in selection path .*config.enable.* not found" "$@" ./disable-enable-modules.nix
@@ -130,7 +130,7 @@ checkConfigError "attribute .*enable.* in selection path .*config.enable.* not f
 # Check _module.args.
 set -- config.enable ./declare-enable.nix ./define-enable-with-custom-arg.nix
 checkConfigError 'while evaluating the module argument .*custom.* in .*define-enable-with-custom-arg.nix.*:' "$@"
-checkConfigOutput "true" "$@" ./define-_module-args-custom.nix
+checkConfigOutput '^true$' "$@" ./define-_module-args-custom.nix
 
 # Check that using _module.args on imports cause infinite recursions, with
 # the proper error context.
@@ -141,77 +141,77 @@ checkConfigError 'infinite recursion encountered' "$@"
 # Check _module.check.
 set -- config.enable ./declare-enable.nix ./define-enable.nix ./define-attrsOfSub-foo.nix
 checkConfigError 'The option .* does not exist. Definition values:\n\s*- In .*' "$@"
-checkConfigOutput "true" "$@" ./define-module-check.nix
+checkConfigOutput '^true$' "$@" ./define-module-check.nix
 
 # Check coerced value.
-checkConfigOutput "\"42\"" config.value ./declare-coerced-value.nix
-checkConfigOutput "\"24\"" config.value ./declare-coerced-value.nix ./define-value-string.nix
+checkConfigOutput '^"42"$' config.value ./declare-coerced-value.nix
+checkConfigOutput '^"24"$' config.value ./declare-coerced-value.nix ./define-value-string.nix
 checkConfigError 'A definition for option .* is not.*string or signed integer convertible to it.*. Definition values:\n\s*- In .*: \[ \]' config.value ./declare-coerced-value.nix ./define-value-list.nix
 
 # Check coerced value with unsound coercion
-checkConfigOutput "12" config.value ./declare-coerced-value-unsound.nix
+checkConfigOutput '^12$' config.value ./declare-coerced-value-unsound.nix
 checkConfigError 'A definition for option .* is not of type .*. Definition values:\n\s*- In .*: "1000"' config.value ./declare-coerced-value-unsound.nix ./define-value-string-bigint.nix
 checkConfigError 'json.exception.parse_error' config.value ./declare-coerced-value-unsound.nix ./define-value-string-arbitrary.nix
 
 # Check mkAliasOptionModule.
-checkConfigOutput "true" config.enable ./alias-with-priority.nix
-checkConfigOutput "true" config.enableAlias ./alias-with-priority.nix
-checkConfigOutput "false" config.enable ./alias-with-priority-can-override.nix
-checkConfigOutput "false" config.enableAlias ./alias-with-priority-can-override.nix
+checkConfigOutput '^true$' config.enable ./alias-with-priority.nix
+checkConfigOutput '^true$' config.enableAlias ./alias-with-priority.nix
+checkConfigOutput '^false$' config.enable ./alias-with-priority-can-override.nix
+checkConfigOutput '^false$' config.enableAlias ./alias-with-priority-can-override.nix
 
 # submoduleWith
 
 ## specialArgs should work
-checkConfigOutput "foo" config.submodule.foo ./declare-submoduleWith-special.nix
+checkConfigOutput '^"foo"$' config.submodule.foo ./declare-submoduleWith-special.nix
 
 ## shorthandOnlyDefines config behaves as expected
-checkConfigOutput "true" config.submodule.config ./declare-submoduleWith-shorthand.nix ./define-submoduleWith-shorthand.nix
+checkConfigOutput '^true$' config.submodule.config ./declare-submoduleWith-shorthand.nix ./define-submoduleWith-shorthand.nix
 checkConfigError 'is not of type `boolean' config.submodule.config ./declare-submoduleWith-shorthand.nix ./define-submoduleWith-noshorthand.nix
 checkConfigError "You're trying to declare a value of type \`bool'\n\s*rather than an attribute-set for the option" config.submodule.config ./declare-submoduleWith-noshorthand.nix ./define-submoduleWith-shorthand.nix
-checkConfigOutput "true" config.submodule.config ./declare-submoduleWith-noshorthand.nix ./define-submoduleWith-noshorthand.nix
+checkConfigOutput '^true$' config.submodule.config ./declare-submoduleWith-noshorthand.nix ./define-submoduleWith-noshorthand.nix
 
 ## submoduleWith should merge all modules in one swoop
-checkConfigOutput "true" config.submodule.inner ./declare-submoduleWith-modules.nix
-checkConfigOutput "true" config.submodule.outer ./declare-submoduleWith-modules.nix
+checkConfigOutput '^true$' config.submodule.inner ./declare-submoduleWith-modules.nix
+checkConfigOutput '^true$' config.submodule.outer ./declare-submoduleWith-modules.nix
 # Should also be able to evaluate the type name (which evaluates freeformType,
 # which evaluates all the modules defined by the type)
-checkConfigOutput "submodule" options.submodule.type.description ./declare-submoduleWith-modules.nix
+checkConfigOutput '^"submodule"$' options.submodule.type.description ./declare-submoduleWith-modules.nix
 
 ## submodules can be declared using (evalModules {...}).type
-checkConfigOutput "true" config.submodule.inner ./declare-submodule-via-evalModules.nix
-checkConfigOutput "true" config.submodule.outer ./declare-submodule-via-evalModules.nix
+checkConfigOutput '^true$' config.submodule.inner ./declare-submodule-via-evalModules.nix
+checkConfigOutput '^true$' config.submodule.outer ./declare-submodule-via-evalModules.nix
 # Should also be able to evaluate the type name (which evaluates freeformType,
 # which evaluates all the modules defined by the type)
-checkConfigOutput "submodule" options.submodule.type.description ./declare-submodule-via-evalModules.nix
+checkConfigOutput '^"submodule"$' options.submodule.type.description ./declare-submodule-via-evalModules.nix
 
 ## Paths should be allowed as values and work as expected
-checkConfigOutput "true" config.submodule.enable ./declare-submoduleWith-path.nix
+checkConfigOutput '^true$' config.submodule.enable ./declare-submoduleWith-path.nix
 
 # Check that disabledModules works recursively and correctly
-checkConfigOutput "true" config.enable ./disable-recursive/main.nix
-checkConfigOutput "true" config.enable ./disable-recursive/{main.nix,disable-foo.nix}
-checkConfigOutput "true" config.enable ./disable-recursive/{main.nix,disable-bar.nix}
+checkConfigOutput '^true$' config.enable ./disable-recursive/main.nix
+checkConfigOutput '^true$' config.enable ./disable-recursive/{main.nix,disable-foo.nix}
+checkConfigOutput '^true$' config.enable ./disable-recursive/{main.nix,disable-bar.nix}
 checkConfigError 'The option .* does not exist. Definition values:\n\s*- In .*: true' config.enable ./disable-recursive/{main.nix,disable-foo.nix,disable-bar.nix}
 
 # Check that imports can depend on derivations
-checkConfigOutput "true" config.enable ./import-from-store.nix
+checkConfigOutput '^true$' config.enable ./import-from-store.nix
 
 # Check that configs can be conditional on option existence
-checkConfigOutput true config.enable ./define-option-dependently.nix ./declare-enable.nix ./declare-int-positive-value.nix
-checkConfigOutput 360 config.value ./define-option-dependently.nix ./declare-enable.nix ./declare-int-positive-value.nix
-checkConfigOutput 7 config.value ./define-option-dependently.nix ./declare-int-positive-value.nix
-checkConfigOutput true config.set.enable ./define-option-dependently-nested.nix ./declare-enable-nested.nix ./declare-int-positive-value-nested.nix
-checkConfigOutput 360 config.set.value ./define-option-dependently-nested.nix ./declare-enable-nested.nix ./declare-int-positive-value-nested.nix
-checkConfigOutput 7 config.set.value ./define-option-dependently-nested.nix ./declare-int-positive-value-nested.nix
+checkConfigOutput '^true$' config.enable ./define-option-dependently.nix ./declare-enable.nix ./declare-int-positive-value.nix
+checkConfigOutput '^360$' config.value ./define-option-dependently.nix ./declare-enable.nix ./declare-int-positive-value.nix
+checkConfigOutput '^7$' config.value ./define-option-dependently.nix ./declare-int-positive-value.nix
+checkConfigOutput '^true$' config.set.enable ./define-option-dependently-nested.nix ./declare-enable-nested.nix ./declare-int-positive-value-nested.nix
+checkConfigOutput '^360$' config.set.value ./define-option-dependently-nested.nix ./declare-enable-nested.nix ./declare-int-positive-value-nested.nix
+checkConfigOutput '^7$' config.set.value ./define-option-dependently-nested.nix ./declare-int-positive-value-nested.nix
 
 # Check attrsOf and lazyAttrsOf. Only lazyAttrsOf should be lazy, and only
 # attrsOf should work with conditional definitions
 # In addition, lazyAttrsOf should honor an options emptyValue
 checkConfigError "is not lazy" config.isLazy ./declare-attrsOf.nix ./attrsOf-lazy-check.nix
-checkConfigOutput "true" config.isLazy ./declare-lazyAttrsOf.nix ./attrsOf-lazy-check.nix
-checkConfigOutput "true" config.conditionalWorks ./declare-attrsOf.nix ./attrsOf-conditional-check.nix
-checkConfigOutput "false" config.conditionalWorks ./declare-lazyAttrsOf.nix ./attrsOf-conditional-check.nix
-checkConfigOutput "empty" config.value.foo ./declare-lazyAttrsOf.nix ./attrsOf-conditional-check.nix
+checkConfigOutput '^true$' config.isLazy ./declare-lazyAttrsOf.nix ./attrsOf-lazy-check.nix
+checkConfigOutput '^true$' config.conditionalWorks ./declare-attrsOf.nix ./attrsOf-conditional-check.nix
+checkConfigOutput '^false$' config.conditionalWorks ./declare-lazyAttrsOf.nix ./attrsOf-conditional-check.nix
+checkConfigOutput '^"empty"$' config.value.foo ./declare-lazyAttrsOf.nix ./attrsOf-conditional-check.nix
 
 
 # Even with multiple assignments, a type error should be thrown if any of them aren't valid
@@ -220,69 +220,69 @@ checkConfigError 'A definition for option .* is not of type .*' \
 
 ## Freeform modules
 # Assigning without a declared option should work
-checkConfigOutput 24 config.value ./freeform-attrsOf.nix ./define-value-string.nix
+checkConfigOutput '^"24"$' config.value ./freeform-attrsOf.nix ./define-value-string.nix
 # No freeform assigments shouldn't make it error
-checkConfigOutput '{ }' config ./freeform-attrsOf.nix
+checkConfigOutput '^{ }$' config ./freeform-attrsOf.nix
 # but only if the type matches
 checkConfigError 'A definition for option .* is not of type .*' config.value ./freeform-attrsOf.nix ./define-value-list.nix
 # and properties should be applied
-checkConfigOutput yes config.value ./freeform-attrsOf.nix ./define-value-string-properties.nix
+checkConfigOutput '^"yes"$' config.value ./freeform-attrsOf.nix ./define-value-string-properties.nix
 # Options should still be declarable, and be able to have a type that doesn't match the freeform type
-checkConfigOutput false config.enable ./freeform-attrsOf.nix ./define-value-string.nix ./declare-enable.nix
-checkConfigOutput 24 config.value ./freeform-attrsOf.nix ./define-value-string.nix ./declare-enable.nix
+checkConfigOutput '^false$' config.enable ./freeform-attrsOf.nix ./define-value-string.nix ./declare-enable.nix
+checkConfigOutput '^"24"$' config.value ./freeform-attrsOf.nix ./define-value-string.nix ./declare-enable.nix
 # and this should work too with nested values
-checkConfigOutput false config.nest.foo ./freeform-attrsOf.nix ./freeform-nested.nix
-checkConfigOutput bar config.nest.bar ./freeform-attrsOf.nix ./freeform-nested.nix
+checkConfigOutput '^false$' config.nest.foo ./freeform-attrsOf.nix ./freeform-nested.nix
+checkConfigOutput '^"bar"$' config.nest.bar ./freeform-attrsOf.nix ./freeform-nested.nix
 # Check whether a declared option can depend on an freeform-typed one
-checkConfigOutput null config.foo ./freeform-attrsOf.nix ./freeform-str-dep-unstr.nix
-checkConfigOutput 24 config.foo ./freeform-attrsOf.nix ./freeform-str-dep-unstr.nix ./define-value-string.nix
+checkConfigOutput '^null$' config.foo ./freeform-attrsOf.nix ./freeform-str-dep-unstr.nix
+checkConfigOutput '^"24"$' config.foo ./freeform-attrsOf.nix ./freeform-str-dep-unstr.nix ./define-value-string.nix
 # Check whether an freeform-typed value can depend on a declared option, this can only work with lazyAttrsOf
 checkConfigError 'infinite recursion encountered' config.foo ./freeform-attrsOf.nix ./freeform-unstr-dep-str.nix
 checkConfigError 'The option .* is used but not defined' config.foo ./freeform-lazyAttrsOf.nix ./freeform-unstr-dep-str.nix
-checkConfigOutput 24 config.foo ./freeform-lazyAttrsOf.nix ./freeform-unstr-dep-str.nix ./define-value-string.nix
+checkConfigOutput '^"24"$' config.foo ./freeform-lazyAttrsOf.nix ./freeform-unstr-dep-str.nix ./define-value-string.nix
 
 ## types.anything
 # Check that attribute sets are merged recursively
-checkConfigOutput null config.value.foo ./types-anything/nested-attrs.nix
-checkConfigOutput null config.value.l1.foo ./types-anything/nested-attrs.nix
-checkConfigOutput null config.value.l1.l2.foo ./types-anything/nested-attrs.nix
-checkConfigOutput null config.value.l1.l2.l3.foo ./types-anything/nested-attrs.nix
+checkConfigOutput '^null$' config.value.foo ./types-anything/nested-attrs.nix
+checkConfigOutput '^null$' config.value.l1.foo ./types-anything/nested-attrs.nix
+checkConfigOutput '^null$' config.value.l1.l2.foo ./types-anything/nested-attrs.nix
+checkConfigOutput '^null$' config.value.l1.l2.l3.foo ./types-anything/nested-attrs.nix
 # Attribute sets that are coercible to strings shouldn't be recursed into
-checkConfigOutput foo config.value.outPath ./types-anything/attrs-coercible.nix
+checkConfigOutput '^"foo"$' config.value.outPath ./types-anything/attrs-coercible.nix
 # Multiple lists aren't concatenated together
 checkConfigError 'The option .* has conflicting definitions' config.value ./types-anything/lists.nix
 # Check that all equalizable atoms can be used as long as all definitions are equal
-checkConfigOutput 0 config.value.int ./types-anything/equal-atoms.nix
-checkConfigOutput false config.value.bool ./types-anything/equal-atoms.nix
-checkConfigOutput '""' config.value.string ./types-anything/equal-atoms.nix
-checkConfigOutput / config.value.path ./types-anything/equal-atoms.nix
-checkConfigOutput null config.value.null ./types-anything/equal-atoms.nix
-checkConfigOutput 0.1 config.value.float ./types-anything/equal-atoms.nix
+checkConfigOutput '^0$' config.value.int ./types-anything/equal-atoms.nix
+checkConfigOutput '^false$' config.value.bool ./types-anything/equal-atoms.nix
+checkConfigOutput '^""$' config.value.string ./types-anything/equal-atoms.nix
+checkConfigOutput '^/$' config.value.path ./types-anything/equal-atoms.nix
+checkConfigOutput '^null$' config.value.null ./types-anything/equal-atoms.nix
+checkConfigOutput '^0.1$' config.value.float ./types-anything/equal-atoms.nix
 # Functions can't be merged together
 checkConfigError "The option .value.multiple-lambdas.<function body>. has conflicting option types" config.applied.multiple-lambdas ./types-anything/functions.nix
-checkConfigOutput '<LAMBDA>' config.value.single-lambda ./types-anything/functions.nix
-checkConfigOutput 'null' config.applied.merging-lambdas.x ./types-anything/functions.nix
-checkConfigOutput 'null' config.applied.merging-lambdas.y ./types-anything/functions.nix
+checkConfigOutput '^<LAMBDA>$' config.value.single-lambda ./types-anything/functions.nix
+checkConfigOutput '^null$' config.applied.merging-lambdas.x ./types-anything/functions.nix
+checkConfigOutput '^null$' config.applied.merging-lambdas.y ./types-anything/functions.nix
 # Check that all mk* modifiers are applied
 checkConfigError 'attribute .* not found' config.value.mkiffalse ./types-anything/mk-mods.nix
-checkConfigOutput '{ }' config.value.mkiftrue ./types-anything/mk-mods.nix
-checkConfigOutput 1 config.value.mkdefault ./types-anything/mk-mods.nix
-checkConfigOutput '{ }' config.value.mkmerge ./types-anything/mk-mods.nix
-checkConfigOutput true config.value.mkbefore ./types-anything/mk-mods.nix
-checkConfigOutput 1 config.value.nested.foo ./types-anything/mk-mods.nix
-checkConfigOutput baz config.value.nested.bar.baz ./types-anything/mk-mods.nix
+checkConfigOutput '^{ }$' config.value.mkiftrue ./types-anything/mk-mods.nix
+checkConfigOutput '^1$' config.value.mkdefault ./types-anything/mk-mods.nix
+checkConfigOutput '^{ }$' config.value.mkmerge ./types-anything/mk-mods.nix
+checkConfigOutput '^true$' config.value.mkbefore ./types-anything/mk-mods.nix
+checkConfigOutput '^1$' config.value.nested.foo ./types-anything/mk-mods.nix
+checkConfigOutput '^"baz"$' config.value.nested.bar.baz ./types-anything/mk-mods.nix
 
 ## types.functionTo
-checkConfigOutput "input is input" config.result ./functionTo/trivial.nix
-checkConfigOutput "a b" config.result ./functionTo/merging-list.nix
+checkConfigOutput '^"input is input"$' config.result ./functionTo/trivial.nix
+checkConfigOutput '^"a b"$' config.result ./functionTo/merging-list.nix
 checkConfigError 'A definition for option .fun.\[function body\]. is not of type .string.. Definition values:\n\s*- In .*wrong-type.nix' config.result ./functionTo/wrong-type.nix
-checkConfigOutput "b a" config.result ./functionTo/list-order.nix
-checkConfigOutput "a c" config.result ./functionTo/merging-attrs.nix
+checkConfigOutput '^"b a"$' config.result ./functionTo/list-order.nix
+checkConfigOutput '^"a c"$' config.result ./functionTo/merging-attrs.nix
 
 # moduleType
-checkConfigOutput "a b" config.resultFoo ./declare-variants.nix ./define-variant.nix
-checkConfigOutput "a y z" config.resultFooBar ./declare-variants.nix ./define-variant.nix
-checkConfigOutput "a b c" config.resultFooFoo ./declare-variants.nix ./define-variant.nix
+checkConfigOutput '^"a b"$' config.resultFoo ./declare-variants.nix ./define-variant.nix
+checkConfigOutput '^"a y z"$' config.resultFooBar ./declare-variants.nix ./define-variant.nix
+checkConfigOutput '^"a b c"$' config.resultFooFoo ./declare-variants.nix ./define-variant.nix
 
 cat <<EOF
 ====== module tests ======

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -290,7 +290,7 @@ $pass Pass
 $fail Fail
 EOF
 
-if test $fail -ne 0; then
+if [ "$fail" -ne 0 ]; then
     exit 1
 fi
 exit 0

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -32,11 +32,9 @@ checkConfigOutput() {
     shift
     if evalConfig "$@" 2>/dev/null | grep --silent "$outputContains" ; then
         pass=$((pass + 1))
-        return 0
     else
         echo 2>&1 "error: Expected result matching '$outputContains', while evaluating"
         reportFailure "$@"
-        return 1
     fi
 }
 
@@ -47,15 +45,12 @@ checkConfigError() {
     if err="$(evalConfig "$@" 2>&1 >/dev/null)"; then
         echo 2>&1 "error: Expected error code, got exit code 0, while evaluating"
         reportFailure "$@"
-        return 1
     else
         if echo "$err" | grep -zP --silent "$errorContains" ; then
             pass=$((pass + 1))
-            return 0
         else
             echo 2>&1 "error: Expected error matching '$errorContains', while evaluating"
             reportFailure "$@"
-            return 1
         fi
     fi
 }

--- a/lib/tests/sources.sh
+++ b/lib/tests/sources.sh
@@ -11,7 +11,7 @@ die() {
 if test -n "${TEST_LIB:-}"; then
   NIX_PATH=nixpkgs="$(dirname "$TEST_LIB")"
 else
-  NIX_PATH=nixpkgs="$(cd $(dirname ${BASH_SOURCE[0]})/../..; pwd)"
+  NIX_PATH=nixpkgs="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.."; pwd)"
 fi
 export NIX_PATH
 
@@ -20,7 +20,7 @@ clean_up() {
   rm -rf "$work"
 }
 trap clean_up EXIT
-cd $work
+cd "$work"
 
 touch {README.md,module.o,foo.bar}
 
@@ -30,7 +30,7 @@ touch {README.md,module.o,foo.bar}
 dir="$(nix eval --impure --raw --expr '(with import <nixpkgs/lib>; "${
   cleanSource ./.
 }")')"
-(cd $dir; find) | sort -f | diff -U10 - <(cat <<EOF
+(cd "$dir"; find) | sort -f | diff -U10 - <(cat <<EOF
 .
 ./foo.bar
 ./README.md
@@ -41,7 +41,7 @@ EOF
 dir="$(nix eval --impure --raw --expr '(with import <nixpkgs/lib>; "${
   cleanSourceWith { src = '"$work"'; filter = path: type: ! hasSuffix ".bar" path; }
 }")')"
-(cd $dir; find) | sort -f | diff -U10 - <(cat <<EOF
+(cd "$dir"; find) | sort -f | diff -U10 - <(cat <<EOF
 .
 ./module.o
 ./README.md
@@ -51,7 +51,7 @@ EOF
 dir="$(nix eval --impure --raw --expr '(with import <nixpkgs/lib>; "${
   cleanSourceWith { src = cleanSource '"$work"'; filter = path: type: ! hasSuffix ".bar" path; }
 }")')"
-(cd $dir; find) | sort -f | diff -U10 - <(cat <<EOF
+(cd "$dir"; find) | sort -f | diff -U10 - <(cat <<EOF
 .
 ./README.md
 EOF

--- a/lib/tests/sources.sh
+++ b/lib/tests/sources.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+shopt -s inherit_errexit
 
 # Use
 #     || die

--- a/lib/tests/sources.sh
+++ b/lib/tests/sources.sh
@@ -9,10 +9,11 @@ die() {
 }
 
 if test -n "${TEST_LIB:-}"; then
-  export NIX_PATH=nixpkgs="$(dirname "$TEST_LIB")"
+  NIX_PATH=nixpkgs="$(dirname "$TEST_LIB")"
 else
-  export NIX_PATH=nixpkgs="$(cd $(dirname ${BASH_SOURCE[0]})/../..; pwd)"
+  NIX_PATH=nixpkgs="$(cd $(dirname ${BASH_SOURCE[0]})/../..; pwd)"
 fi
+export NIX_PATH
 
 work="$(mktemp -d)"
 clean_up() {


### PR DESCRIPTION
###### Motivation for this change

More reliable shell scripts, see #133088, #21166.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
