### PR TITLE
indicator-sound-switcher: init at 2.3.6

### DIFF
--- a/pkgs/applications/audio/indicator-sound-switcher/default.nix
+++ b/pkgs/applications/audio/indicator-sound-switcher/default.nix
@@ -13,8 +13,6 @@
 , gdk-pixbuf
 }:
 
-let
-in
 python3Packages.buildPythonApplication rec {
   pname = "indicator-sound-switcher";
   version = "2.3.6";

--- a/pkgs/applications/audio/indicator-sound-switcher/default.nix
+++ b/pkgs/applications/audio/indicator-sound-switcher/default.nix
@@ -1,6 +1,6 @@
 { python3Packages
 , lib
-, fetchurl
+, fetchFromGitHub
 , perlPackages
 , gettext
 , gtk3
@@ -14,16 +14,15 @@
 }:
 
 let
-  name = "indicator-sound-switcher";
-  version = "2.3.6";
 in
-python3Packages.buildPythonApplication {
-#python3Packages.buildPythonPackage {
-  pname = name;
-  inherit version;
-  src = fetchurl {
-    url = "https://github.com/yktoo/${name}/archive/v${version}.tar.gz";
-    sha256 = "sha256:0xrywmppzrr4x6hhlsgrhbh516djzb04ms717vfbpycy7316arvr";
+python3Packages.buildPythonApplication rec {
+  pname = "indicator-sound-switcher";
+  version = "2.3.6";
+  src = fetchFromGitHub {
+    owner = "yktoo";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "APU8Y0xUhRd9RbMSG9TD0TBvFLu/VlLGauf56z8gZDw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/audio/indicator-sound-switcher/default.nix
+++ b/pkgs/applications/audio/indicator-sound-switcher/default.nix
@@ -16,6 +16,7 @@
 python3Packages.buildPythonApplication rec {
   pname = "indicator-sound-switcher";
   version = "2.3.6";
+
   src = fetchFromGitHub {
     owner = "yktoo";
     repo = pname;

--- a/pkgs/applications/audio/indicator-sound-switcher/default.nix
+++ b/pkgs/applications/audio/indicator-sound-switcher/default.nix
@@ -25,7 +25,6 @@ python3Packages.buildPythonApplication rec {
   };
 
   postPatch = ''
-    ls -lah lib
     substituteInPlace lib/indicator_sound_switcher/lib_pulseaudio.py \
       --replace "CDLL('libpulse.so.0')" "CDLL('${libpulseaudio}/lib/libpulse.so')"
   '';

--- a/pkgs/applications/audio/indicator-sound-switcher/default.nix
+++ b/pkgs/applications/audio/indicator-sound-switcher/default.nix
@@ -57,9 +57,7 @@ python3Packages.buildPythonApplication rec {
     description = "Sound input/output selector indicator for Linux";
     homepage = "https://yktoo.com/en/software/sound-switcher-indicator/";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [
-      alexnortung
-    ];
+    maintainers = with maintainers; [ alexnortung ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/audio/indicator-sound-switcher/default.nix
+++ b/pkgs/applications/audio/indicator-sound-switcher/default.nix
@@ -23,6 +23,12 @@ python3Packages.buildPythonApplication rec {
     sha256 = "APU8Y0xUhRd9RbMSG9TD0TBvFLu/VlLGauf56z8gZDw=";
   };
 
+  postPatch = ''
+    ls -lah lib
+    substituteInPlace lib/indicator_sound_switcher/lib_pulseaudio.py \
+      --replace "CDLL('libpulse.so.0')" "CDLL('${libpulseaudio}/lib/libpulse.so')"
+  '';
+
   nativeBuildInputs = [
     gettext
     intltool
@@ -44,10 +50,6 @@ python3Packages.buildPythonApplication rec {
     libayatana-appindicator-gtk3
     libpulseaudio
     keybinder3
-  ];
-
-  makeWrapperArgs = [
-    "--prefix LD_LIBRARY_PATH : ${libpulseaudio}/lib"
   ];
 
   meta = with lib; {

--- a/pkgs/applications/audio/indicator-sound-switcher/default.nix
+++ b/pkgs/applications/audio/indicator-sound-switcher/default.nix
@@ -1,0 +1,65 @@
+{ python3Packages
+, lib
+, fetchurl
+, perlPackages
+, gettext
+, gtk3
+, gobject-introspection
+, intltool, wrapGAppsHook, glib
+, librsvg
+, libayatana-appindicator-gtk3
+, libpulseaudio
+, keybinder3
+, gdk-pixbuf
+}:
+
+let
+  name = "indicator-sound-switcher";
+  version = "2.3.6";
+in
+python3Packages.buildPythonApplication {
+#python3Packages.buildPythonPackage {
+  pname = name;
+  inherit version;
+  src = fetchurl {
+    url = "https://github.com/yktoo/${name}/archive/v${version}.tar.gz";
+    sha256 = "sha256:0xrywmppzrr4x6hhlsgrhbh516djzb04ms717vfbpycy7316arvr";
+  };
+
+  nativeBuildInputs = [
+    gettext
+    intltool
+    wrapGAppsHook
+    glib
+    gdk-pixbuf
+  ];
+
+  buildInputs = [
+    librsvg
+  ];
+
+  propagatedBuildInputs = [
+    python3Packages.setuptools
+    python3Packages.pygobject3
+    gtk3
+    gobject-introspection
+    librsvg
+    libayatana-appindicator-gtk3
+    libpulseaudio
+    keybinder3
+  ];
+
+  makeWrapperArgs = [
+    "--prefix LD_LIBRARY_PATH : ${libpulseaudio}/lib"
+  ];
+
+  meta = with lib; {
+    description = "Sound input/output selector indicator for Linux";
+    homepage = "https://yktoo.com/en/software/sound-switcher-indicator/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [
+      alexnortung
+    ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17064,6 +17064,8 @@ with pkgs;
   indicator-application-gtk2 = callPackage ../development/libraries/indicator-application/gtk2.nix { };
   indicator-application-gtk3 = callPackage ../development/libraries/indicator-application/gtk3.nix { };
 
+  indicator-sound-switcher = callPackage ../applications/audio/indicator-sound-switcher { };
+
   indilib = callPackage ../development/libraries/science/astronomy/indilib { };
   indi-full = callPackage ../development/libraries/science/astronomy/indilib/indi-full.nix { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This package is added for a packaging request #136303

There are also some -wrapped files in the bin/ folder, but I don't know if they should be there.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
