### PR TITLE
python3Packages.pythonegardia: add patch for search path

### DIFF
--- a/pkgs/development/python-modules/pythonegardia/default.nix
+++ b/pkgs/development/python-modules/pythonegardia/default.nix
@@ -1,25 +1,44 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
+, fetchpatch
 , requests
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "pythonegardia";
   version = "1.0.51";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "b99217e34c59bfae059db400acef99d3d32237d13da6fdce9e0d4decc9a07e61";
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "jeroenterheerdt";
+    repo = "python-egardia";
+    rev = "v${version}";
+    sha256 = "7HindS++jcV3GRn/SKoTMpVOchOnLojy/TY0HZjtyD8=";
   };
 
   propagatedBuildInputs = [
     requests
   ];
 
+  patches = [
+    # Adjust search path, https://github.com/jeroenterheerdt/python-egardia/pull/33
+    (fetchpatch {
+      name = "search-path.patch";
+      url = "https://github.com/jeroenterheerdt/python-egardia/commit/6b7bf5b7b2211e3557e0f438586b9d03b9bae440.patch";
+      sha256 = "wUSfmF0SrKCITQJJsHgkGgPZFouaB/zbVqupK6fARHY=";
+    })
+  ];
+
   # Project has no tests, only two test file for manual interaction
   doCheck = false;
-  pythonImportsCheck = [ "pythonegardia" ];
+
+  pythonImportsCheck = [
+    "pythonegardia"
+  ];
 
   meta = with lib; {
     description = "Python interface with Egardia/Woonveilig alarms";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/159224435)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
