### PR TITLE
maintainers/scripts: Lint check-maintainer-github-handles.sh

### DIFF
--- a/maintainers/scripts/check-maintainer-github-handles.sh
+++ b/maintainers/scripts/check-maintainer-github-handles.sh
@@ -62,4 +62,5 @@ nix-instantiate -A lib.maintainers --eval --strict --json \
     | jq -r '.[]|.github|select(.)' \
     | parallel -j5 checkUser
 
+# To check some arbitrary users:
 # parallel -j100 checkUser ::: "eelco" "profpatsch" "Profpatsch" "a"

--- a/maintainers/scripts/check-maintainer-github-handles.sh
+++ b/maintainers/scripts/check-maintainer-github-handles.sh
@@ -4,7 +4,8 @@
 # Example how to work with the `lib.maintainers` attrset.
 # Can be used to check whether all user handles are still valid.
 
-set -e
+set -o errexit -o noclobber -o nounset -o pipefail
+shopt -s failglob inherit_errexit
 
 # nixpkgs='<nixpkgs>'
 # if [ -n "$1" ]; then

--- a/maintainers/scripts/check-maintainer-github-handles.sh
+++ b/maintainers/scripts/check-maintainer-github-handles.sh
@@ -32,7 +32,7 @@ function checkCommits {
              checkCommits "$user"
              ret=$?
              ;;
-        *)   printf "BAD STATUS: $(tail -n1 $tmp) for %s\n" "$user"; ret=1
+        *)   printf "BAD STATUS: $(tail -n1 "$tmp") for %s\n" "$user"; ret=1
              ret=1
              ;;
     esac

--- a/maintainers/scripts/check-maintainer-github-handles.sh
+++ b/maintainers/scripts/check-maintainer-github-handles.sh
@@ -10,14 +10,15 @@ set -e
 # if [ -n "$1" ]; then
 
 function checkCommits {
-    local user="$1"
-    local tmp=$(mktemp)
+    local ret status tmp user
+    user="$1"
+    tmp=$(mktemp)
     curl --silent -w "%{http_code}" \
          "https://github.com/NixOS/nixpkgs/commits?author=$user" \
          > "$tmp"
     # the last line of tmp contains the http status
-    local status=$(tail -n1 "$tmp")
-    local ret=
+    status=$(tail -n1 "$tmp")
+    ret=
     case $status in
         200) if <"$tmp" grep -i "no commits found" > /dev/null; then
                  ret=1

--- a/maintainers/scripts/check-maintainer-github-handles.sh
+++ b/maintainers/scripts/check-maintainer-github-handles.sh
@@ -7,9 +7,6 @@
 set -o errexit -o noclobber -o nounset -o pipefail
 shopt -s failglob inherit_errexit
 
-# nixpkgs='<nixpkgs>'
-# if [ -n "$1" ]; then
-
 function checkCommits {
     local ret status tmp user
     user="$1"


### PR DESCRIPTION
###### Motivation for this change

ShellCheck compliance and detecting errors earlier, see #133088, #21166.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@Artturin 