### PR TITLE
dbus: fix static build

### DIFF
--- a/pkgs/development/libraries/dbus/default.nix
+++ b/pkgs/development/libraries/dbus/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , lib
+, fetchpatch
 , fetchurl
 , pkg-config
 , expat
@@ -15,6 +16,8 @@
 , docbook_xml_dtd_44
 , docbook-xsl-nons
 , xmlto
+, autoreconfHook
+, autoconf-archive
 }:
 
 stdenv.mkDerivation rec {
@@ -32,15 +35,23 @@ stdenv.mkDerivation rec {
     # Also applied upstream in https://gitlab.freedesktop.org/dbus/dbus/-/merge_requests/189,
     # expected in version 1.14
     ./docs-reproducible-ids.patch
+    # AC_PATH_XTRA doesn't seem to find X11 libs even though libX11 seems
+    # to provide valid pkg-config files. This replace AC_PATH_XTRA with
+    # PKG_CHECK_MODULES.
+    # MR merged cf https://gitlab.freedesktop.org/dbus/dbus/-/merge_requests/212/diffs?commit_id=23880a181e82ee7f
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/dbus/dbus/-/commit/6bfaea0707ba1a7788c4b6d30c18fb094f3a1dd4.patch";
+      sha256 = "1d8ay55n2ksw5faqx3hsdpfni3xl3gq9hnjl65073xcfnx67x8d2";
+    })
   ] ++ (lib.optional stdenv.isSunOS ./implement-getgrouplist.patch);
 
   postPatch = ''
-    substituteInPlace tools/Makefile.in \
-      --replace 'install-localstatelibDATA:' 'disabled:' \
+    substituteInPlace bus/Makefile.am \
+      --replace 'install-data-hook:' 'disabled:' \
+      --replace '$(mkinstalldirs) $(DESTDIR)$(localstatedir)/run/dbus' ':'
+    substituteInPlace tools/Makefile.am \
       --replace 'install-data-local:' 'disabled:' \
       --replace 'installcheck-local:' 'disabled:'
-    substituteInPlace bus/Makefile.in \
-      --replace '$(mkinstalldirs) $(DESTDIR)$(localstatedir)/run/dbus' ':'
   '' + /* cleanup of runtime references */ ''
     substituteInPlace ./dbus/dbus-sysdeps-unix.c \
       --replace 'DBUS_BINDIR "/dbus-launch"' "\"$lib/bin/dbus-launch\""
@@ -51,6 +62,8 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" "lib" "doc" "man" ];
 
   nativeBuildInputs = [
+    autoreconfHook
+    autoconf-archive
     pkg-config
     docbook_xml_dtd_44
     docbook-xsl-nons


### PR DESCRIPTION
###### Motivation for this change
Part of a bigger project to build Qt 5 statically https://github.com/NixOS/nixpkgs/pull/136107.

###### Things done
Fixed the build of pkgsStatic.dbus and pkgsStatic.util-linux.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
