### PR TITLE
sharedown: 2.0.0 → 3.0.1

### DIFF
--- a/pkgs/tools/misc/sharedown/default.nix
+++ b/pkgs/tools/misc/sharedown/default.nix
@@ -13,13 +13,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "Sharedown";
-  version = "2.0.0";
+  version = "3.0.1";
 
   src = fetchFromGitHub {
     owner = "kylon";
     repo = pname;
     rev = version;
-    sha256 = "sha256-Z6OsZvVzk//qEkl4ciNz4cQRqC2GFg0qYgmliAyz6fo=";
+    sha256 = "sha256-0moxrRxydH/g3J5cQmaFSDhTZh9OnUi8ncPVw7q1JC0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/misc/sharedown/update.sh
+++ b/pkgs/tools/misc/sharedown/update.sh
@@ -3,11 +3,11 @@
 
 set -euo pipefail
 
+nix-update sharedown
+
 dirname="$(realpath "$(dirname "$0")")"
 sourceDir="$(nix-build -A sharedown.src --no-out-link)"
 tempDir="$(mktemp -d)"
-
-nix-update sharedown
 
 cp -r "$sourceDir"/* "$tempDir"
 cd "$tempDir"

--- a/pkgs/tools/misc/sharedown/yarn.lock
+++ b/pkgs/tools/misc/sharedown/yarn.lock
@@ -16,9 +16,9 @@
     ajv-keywords "^3.4.1"
 
 "@electron/get@^1.13.0":
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/@electron/get/-/get-1.13.0.tgz#95c6bcaff4f9a505ea46792424f451efea89228c"
-  integrity sha512-+SjZhRuRo+STTO1Fdhzqnv9D2ZhjxXP6egsJ9kiO8dtP68cDx7dFCwWi64dlMQV7sWcfW1OYCW4wviEBzmRsfQ==
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/@electron/get/-/get-1.13.1.tgz#42a0aa62fd1189638bd966e23effaebb16108368"
+  integrity sha512-U5vkXDZ9DwXtkPqlB45tfYnnYBN8PePp1z/XDCupnSpdrxT8/ThCv9WCwPLf9oqiSGZTkH6dx2jDUPuoXpjkcA==
   dependencies:
     debug "^4.1.1"
     env-paths "^2.2.0"
@@ -28,7 +28,7 @@
     semver "^6.2.0"
     sumchecker "^3.0.1"
   optionalDependencies:
-    global-agent "^2.0.2"
+    global-agent "^3.0.0"
     global-tunnel-ng "^2.7.1"
 
 "@electron/universal@1.0.5":
@@ -71,12 +71,12 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@tedconf/fessonia@*":
+"@tedconf/fessonia@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@tedconf/fessonia/-/fessonia-2.2.1.tgz#24499e69c3aeda4926670675b9fdfeb9ab15f19d"
   integrity sha512-eX+O8P/xIkuCDeDI3IOIoyzuTJLVqbGnoBhLiBoFU7MwntF02ygQcByMinhUtXv2zm0pOSy6zeKoQTKAVBK60A==
 
-"@types/debug@^4.1.5":
+"@types/debug@^4.1.6":
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
   integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
@@ -91,9 +91,9 @@
     "@types/node" "*"
 
 "@types/glob@^7.1.1":
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.4.tgz#ea59e21d2ee5c517914cb4bc8e4153b99e566672"
-  integrity sha512-w+LsMxKyYQm347Otw+IfBXOv9UWVjpHpCDdbBMt8Kz/xbvCYNjP+0qPh91Km3iKfSRLBB0P7fAMf0KHrPu+MyA==
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
+  integrity sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
   dependencies:
     "@types/minimatch" "*"
     "@types/node" "*"
@@ -109,14 +109,14 @@
   integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
 "@types/node@*":
-  version "16.9.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.6.tgz#040a64d7faf9e5d9e940357125f0963012e66f04"
-  integrity sha512-YHUZhBOMTM3mjFkXVcK+WwAcYmyhe1wL4lfqNtzI0b3qAy7yuSetnM7QJazgE5PFmgVTNGiLOgRFfJMqW7XpSQ==
+  version "16.11.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.10.tgz#2e3ad0a680d96367103d3e670d41c2fed3da61ae"
+  integrity sha512-3aRnHa1KlOEEhJ6+CvyHKK5vE9BcLGjtUpwvqYLRvYNQKMfabu3BwfJaA/SLW8dxe28LsNDjtHwePTuzn3gmOA==
 
 "@types/node@^14.6.2":
-  version "14.17.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.18.tgz#0198489a751005f71217744aa966cd1f29447c81"
-  integrity sha512-haYyibw4pbteEhkSg0xdDLAI3679L75EJ799ymVrPxOA922bPx3ML59SoDsQ//rHlvqpu+e36kcbR3XRQtFblA==
+  version "14.17.34"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.34.tgz#fe4b38b3f07617c0fa31ae923fca9249641038f0"
+  integrity sha512-USUftMYpmuMzeWobskoPfzDi+vkpe0dvcOBRNOscFrGxVp4jomnRxWuVohgqBow2xyIPC0S3gjxV/5079jhmDg==
 
 "@types/plist@^3.0.1":
   version "3.0.2"
@@ -136,10 +136,10 @@
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.1.tgz#3b9ce2489919d9e4fea439b76916abc34b2df129"
   integrity sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==
 
-"@types/yargs@^16.0.2":
-  version "16.0.4"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.4.tgz#26aad98dd2c2a38e421086ea9ad42b9e51642977"
-  integrity sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==
+"@types/yargs@^17.0.1":
+  version "17.0.7"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.7.tgz#44a484c634761da4391477515a98772b82b5060f"
+  integrity sha512-OvLKmpKdea1aWtqHv9bxVVcMoT6syAeK+198dfETIFkAevYRGwqh4H+KFxfjUETZuUuE5sQCAFwdOdoHUdo8eg==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -173,23 +173,18 @@ ajv@^6.10.0, ajv@^6.12.0:
     uri-js "^4.2.2"
 
 ansi-align@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.0.tgz#b536b371cf687caaef236c18d3e21fe3797467cb"
-  integrity sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.1.tgz#0cdf12e111ace773a86e9a1fad1225c43cb19a59"
+  integrity sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==
   dependencies:
-    string-width "^3.0.0"
+    string-width "^4.1.0"
 
 ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
-ansi-regex@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
-  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
-
-ansi-regex@^5.0.0:
+ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
@@ -208,15 +203,15 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
-app-builder-bin@3.5.13:
-  version "3.5.13"
-  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-3.5.13.tgz#6dd7f4de34a4e408806f99b8c7d6ef1601305b7e"
-  integrity sha512-ighVe9G+bT1ENGdp9ecO1P+94vv/f+FUwaI+XkNzeg9bYF8Oi3BQ+mJuxS00UgyHs8luuOzjzC+qnAtdb43Mpg==
+app-builder-bin@3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-3.7.1.tgz#cb0825c5e12efc85b196ac3ed9c89f076c61040e"
+  integrity sha512-ql93vEUq6WsstGXD+SBLSIQw6SNnhbDEM0swzgugytMxLp3rT24Ag/jcC80ZHxiPRTdew1niuR7P3/FCrDqIjw==
 
-app-builder-lib@22.11.7:
-  version "22.11.7"
-  resolved "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-22.11.7.tgz#c0ad1119ebfbf4189a8280ad693625f5e684dca6"
-  integrity sha512-pS9/cR4/TnNZVAHZECiSvvwTBzbwblj7KBBZkMKDG57nibq0I1XY8zAaYeHFdlYTyrRcz9JUXbAqJKezya7UFQ==
+app-builder-lib@22.14.5:
+  version "22.14.5"
+  resolved "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-22.14.5.tgz#a61a50b132b858e98fdc70b6b88994ae99b4f96d"
+  integrity sha512-k3VwKP4kpsnUaXoUkm1s4zaSHPHIMFnN4kPMU9yXaKmE1LfHHqBaEah5bXeTAX5V/BC41wFdg8CF5vOjvgy8Rg==
   dependencies:
     "7zip-bin" "~5.1.1"
     "@develar/schema-utils" "~2.6.5"
@@ -224,12 +219,14 @@ app-builder-lib@22.11.7:
     "@malept/flatpak-bundler" "^0.4.0"
     async-exit-hook "^2.0.1"
     bluebird-lst "^1.0.9"
-    builder-util "22.11.7"
-    builder-util-runtime "8.7.7"
+    builder-util "22.14.5"
+    builder-util-runtime "8.9.1"
     chromium-pickle-js "^0.2.0"
     debug "^4.3.2"
     ejs "^3.1.6"
-    electron-publish "22.11.7"
+    electron-osx-sign "^0.5.0"
+    electron-publish "22.14.5"
+    form-data "^4.0.0"
     fs-extra "^10.0.0"
     hosted-git-info "^4.0.2"
     is-ci "^3.0.0"
@@ -279,17 +276,22 @@ async@0.9.x:
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
   integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+
 at-least-node@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
-axios@*:
-  version "0.21.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
-  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+axios@^0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"
+  integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
   dependencies:
-    follow-redirects "^1.14.0"
+    follow-redirects "^1.14.4"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -317,7 +319,7 @@ bluebird-lst@^1.0.9:
   dependencies:
     bluebird "^3.5.5"
 
-bluebird@^3.5.5:
+bluebird@^3.5.0, bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -327,10 +329,10 @@ boolean@^3.0.1:
   resolved "https://registry.yarnpkg.com/boolean/-/boolean-3.1.4.tgz#f51a2fb5838a99e06f9b6ec1edb674de67026435"
   integrity sha512-3hx0kwU3uzG6ReQ3pnaFQPSktpBw6RHN3/ivDKEuU8g1XSfafowyvDnadjv1xp8IZqhtSukxlwv9bF6FhX8m0w==
 
-bootstrap@5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.1.1.tgz#9d6eed81e08feaccedf3adaca51fe4b73a2871df"
-  integrity sha512-/jUa4sSuDZWlDLQ1gwQQR8uoYSvLJzDd8m5o6bPKh3asLAMYVZKdRCjb1joUd5WXf0WwCNzd2EjwQQhupou0dA==
+bootstrap@5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.1.3.tgz#ba081b0c130f810fa70900acbc1c6d3c28fa8f34"
+  integrity sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==
 
 boxen@^5.0.0:
   version "5.1.2"
@@ -354,6 +356,19 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+buffer-alloc-unsafe@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
+  integrity sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==
+
+buffer-alloc@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec"
+  integrity sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==
+  dependencies:
+    buffer-alloc-unsafe "^1.1.0"
+    buffer-fill "^1.0.0"
+
 buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
@@ -363,6 +378,11 @@ buffer-equal@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-1.0.0.tgz#59616b498304d556abd466966b22eeda3eca5fbe"
   integrity sha1-WWFrSYME1Var1GaWayLu2j7KX74=
+
+buffer-fill@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
+  integrity sha1-+PeLdniYiO858gXNY39o5wISKyw=
 
 buffer-from@^1.0.0:
   version "1.1.2"
@@ -377,34 +397,27 @@ buffer@^5.1.0, buffer@^5.2.1, buffer@^5.5.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
-builder-util-runtime@8.7.6:
-  version "8.7.6"
-  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-8.7.6.tgz#4b43c96db2bd494ced7694bcd7674934655e8324"
-  integrity sha512-rj9AIY7CzLSuTOXpToiaQkruYh6UEQ+kYnd5UET22ch8MGClEtIZKXHG14qEiXEr2x4EOKDMxkcTa+9TYaE+ug==
+builder-util-runtime@8.9.1:
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-8.9.1.tgz#25f066b3fbc20b3e6236a9b956b1ebb0e33ff66a"
+  integrity sha512-c8a8J3wK6BIVLW7ls+7TRK9igspTbzWmUqxFbgK0m40Ggm6efUbxtWVCGIjc+dtchyr5qAMAUL6iEGRdS/6vwg==
   dependencies:
     debug "^4.3.2"
     sax "^1.2.4"
 
-builder-util-runtime@8.7.7:
-  version "8.7.7"
-  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-8.7.7.tgz#6c83cc3abe7a7a5c8b4ec8878f68adc828c07f0d"
-  integrity sha512-RUfoXzVrmFFI0K/Oft0CtP1LpTIOlBeLJatt5DePTI0KlxE156am4SGUpqtbbdqZNm++LkV9mX4olBDcXyGPow==
-  dependencies:
-    debug "^4.3.2"
-    sax "^1.2.4"
-
-builder-util@22.11.7:
-  version "22.11.7"
-  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-22.11.7.tgz#ae9707afa6a31feafa13c274ac83b4fe28ef1467"
-  integrity sha512-ihqUe5ey82LM9qqQe0/oIcaSm9w+B9UjcsWJZxJliTBsbU+sErOpDFpHW+sim0veiTF/EIcGUh9HoduWw+l9FA==
+builder-util@22.14.5:
+  version "22.14.5"
+  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-22.14.5.tgz#42a18608d2a566c0846e91266464776c8bfb0cc9"
+  integrity sha512-zqIHDFJwmA7jV7SC9aI+33MWwT2mWoijH+Ol9IntNAwuuRXoS+7XeJwnhLBXOhcDBzXT4kDzHnRk4JKeaygEYA==
   dependencies:
     "7zip-bin" "~5.1.1"
-    "@types/debug" "^4.1.5"
+    "@types/debug" "^4.1.6"
     "@types/fs-extra" "^9.0.11"
-    app-builder-bin "3.5.13"
+    app-builder-bin "3.7.1"
     bluebird-lst "^1.0.9"
-    builder-util-runtime "8.7.7"
+    builder-util-runtime "8.9.1"
     chalk "^4.1.1"
+    cross-spawn "^7.0.3"
     debug "^4.3.2"
     fs-extra "^10.0.0"
     is-ci "^3.0.0"
@@ -427,9 +440,9 @@ cacheable-request@^6.0.0:
     responselike "^1.0.2"
 
 camelcase@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
-  integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.1.tgz#250fd350cfd555d0d2160b1d51510eaf8326e86e"
+  integrity sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==
 
 chalk@^2.4.2:
   version "2.4.2"
@@ -468,10 +481,10 @@ ci-info@^2.0.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
-ci-info@^3.1.1:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.2.0.tgz#2876cb948a498797b5236f0095bc057d0dca38b6"
-  integrity sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==
+ci-info@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.0.tgz#b4ed1fb6818dea4803a55c623041f9165d2066b2"
+  integrity sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==
 
 cli-boxes@^2.2.1:
   version "2.2.1"
@@ -486,7 +499,7 @@ cli-truncate@^1.1.0:
     slice-ansi "^1.0.0"
     string-width "^2.0.0"
 
-clipboardy@^2.3.0:
+clipboardy@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/clipboardy/-/clipboardy-2.3.0.tgz#3c2903650c68e46a91b388985bc2774287dba290"
   integrity sha512-mKhiIL2DrQIsuXMgBgnfEHOZOryC7kY7YO//TN6c63wlEm3NG5tz+YgY5rVi29KCmq/QQjKYvM7a19+MDOTHOQ==
@@ -540,6 +553,13 @@ colors@1.0.3:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
@@ -551,6 +571,11 @@ commander@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
+
+compare-version@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/compare-version/-/compare-version-0.1.2.tgz#0162ec2d9351f5ddd59a9202cba935366a725080"
+  integrity sha1-AWLsLZNR9d3VmpICy6k1NmpyUIA=
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -587,11 +612,6 @@ configstore@^5.0.1:
     write-file-atomic "^3.0.0"
     xdg-basedir "^4.0.0"
 
-core-js@^3.6.5:
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.18.0.tgz#9af3f4a6df9ba3428a3fb1b171f1503b3f40cc49"
-  integrity sha512-WJeQqq6jOYgVgg4NrXKL0KLQhi0CT4ZOCvFL+3CQ5o7I6J8HkT5wd53EadMfqTDp1so/MT1J+w2ujhWcCJtN7w==
-
 core-util-is@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -620,7 +640,7 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.1:
+cross-spawn@^7.0.1, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -639,21 +659,14 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
+debug@4, debug@4.3.2, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
   dependencies:
     ms "2.1.2"
 
-debug@4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
-  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
-  dependencies:
-    ms "2.1.2"
-
-debug@^2.6.9:
+debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -684,6 +697,11 @@ define-properties@^1.1.3:
   dependencies:
     object-keys "^1.0.12"
 
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
 detect-node@^2.0.4:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
@@ -704,14 +722,14 @@ dir-compare@^2.4.0:
     commander "2.9.0"
     minimatch "3.0.4"
 
-dmg-builder@22.11.7:
-  version "22.11.7"
-  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-22.11.7.tgz#5956008c18d40ee72c0ea01ffea9590dbf51df89"
-  integrity sha512-+I+XfP2DODHB6PwFANgpH/WMzzCA5r5XoMvbFCIYjQjJpXlO0XnqQaamzFl2vh/Wz/Qt0d0lJMgRy8gKR3MGdQ==
+dmg-builder@22.14.5:
+  version "22.14.5"
+  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-22.14.5.tgz#137c0b55e639badcc0b119eb060e6fa4ed61d948"
+  integrity sha512-1GvFGQE332bvPamcMwZDqWqfWfJTyyDLOsHMcGi0zs+Jh7JOn6/zuBkHJIWHdsj2QJbhzLVyd2/ZqttOKv7I8w==
   dependencies:
-    app-builder-lib "22.11.7"
-    builder-util "22.11.7"
-    builder-util-runtime "8.7.6"
+    app-builder-lib "22.14.5"
+    builder-util "22.14.5"
+    builder-util-runtime "8.9.1"
     fs-extra "^10.0.0"
     iconv-lite "^0.6.2"
     js-yaml "^4.1.0"
@@ -762,17 +780,17 @@ ejs@^3.1.6:
   dependencies:
     jake "^10.6.1"
 
-electron-builder@^22.11.7:
-  version "22.11.7"
-  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-22.11.7.tgz#cd97a0d9f6e6d388112e66b4376de431cca4d596"
-  integrity sha512-yQExSLt7Hbz/P8lLkZDdE/OnJJ7NCX+uiQcV+XIH0TeEZcD87ZnSqBBzGUN5akySU4BXXlrVZKeUsXACWrm5Kw==
+electron-builder@^22.13.1:
+  version "22.14.5"
+  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-22.14.5.tgz#3a25547bd4fe3728d4704da80956a794c5c31496"
+  integrity sha512-N73hSbXFz6Mz5Z6h6C5ly6CB+dUN6k1LuCDJjI8VF47bMXv/QE0HE+Kkb0GPKqTqM7Hsk/yIYX+kHCfSkR5FGg==
   dependencies:
-    "@types/yargs" "^16.0.2"
-    app-builder-lib "22.11.7"
-    builder-util "22.11.7"
-    builder-util-runtime "8.7.7"
+    "@types/yargs" "^17.0.1"
+    app-builder-lib "22.14.5"
+    builder-util "22.14.5"
+    builder-util-runtime "8.9.1"
     chalk "^4.1.1"
-    dmg-builder "22.11.7"
+    dmg-builder "22.14.5"
     fs-extra "^10.0.0"
     is-ci "^3.0.0"
     lazy-val "^1.0.5"
@@ -780,32 +798,39 @@ electron-builder@^22.11.7:
     update-notifier "^5.1.0"
     yargs "^17.0.1"
 
-electron-publish@22.11.7:
-  version "22.11.7"
-  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-22.11.7.tgz#4126cbb08ccf082a2aa7fef89ee629b3a4b8ae9a"
-  integrity sha512-A4EhRRNBVz4SPzUlBrPO6BmuyDeI0pyprggPAV9rQ+SDVSnSB/WKPot9JwWMyArkGj3AUUTMNVT6hwZhMvhfqw==
+electron-osx-sign@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/electron-osx-sign/-/electron-osx-sign-0.5.0.tgz#fc258c5e896859904bbe3d01da06902c04b51c3a"
+  integrity sha512-icoRLHzFz/qxzDh/N4Pi2z4yVHurlsCAYQvsCSG7fCedJ4UJXBS6PoQyGH71IfcqKupcKeK7HX/NkyfG+v6vlQ==
+  dependencies:
+    bluebird "^3.5.0"
+    compare-version "^0.1.2"
+    debug "^2.6.8"
+    isbinaryfile "^3.0.2"
+    minimist "^1.2.0"
+    plist "^3.0.1"
+
+electron-publish@22.14.5:
+  version "22.14.5"
+  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-22.14.5.tgz#34bcdce671f0e651330db20040d6919c77c94bd6"
+  integrity sha512-h+NANRdaA0PqGF15GKvorseWPzh1PXa/zx4I37//PIokW8eKIov8ky23foUSb55ZFWUHGpxQJux7y2NCfBtQeg==
   dependencies:
     "@types/fs-extra" "^9.0.11"
-    builder-util "22.11.7"
-    builder-util-runtime "8.7.7"
+    builder-util "22.14.5"
+    builder-util-runtime "8.9.1"
     chalk "^4.1.1"
     fs-extra "^10.0.0"
     lazy-val "^1.0.5"
     mime "^2.5.2"
 
-electron@*:
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-15.0.0.tgz#b1b6244b1cffddf348c27c54b1310b3a3680246e"
-  integrity sha512-LlBjN5nCJoC7EDrgfDQwEGSGSAo/o08nSP5uJxN2m+ZtNA69SxpnWv4yPgo1K08X/iQPoGhoZu6C8LYYlk1Dtg==
+electron@^15.3.1:
+  version "15.3.2"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-15.3.2.tgz#4f0cbad781d14e0194f5dfef1709e09a70c8074a"
+  integrity sha512-sEpOX10gjAyvq33HDxJrq2HhYZT3qndZjUrHkzG16QTLjykP7lMvGnJ/bt6wn+T75f4wwv59FUbQx2hW3Xz5TQ==
   dependencies:
     "@electron/get" "^1.13.0"
     "@types/node" "^14.6.2"
     extract-zip "^1.0.3"
-
-emoji-regex@^7.0.1:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
-  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -889,9 +914,9 @@ extract-zip@^1.0.3:
     yauzl "^2.10.0"
 
 extsprintf@^1.2.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
-  integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
+  integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
 
 fast-deep-equal@^3.1.1:
   version "3.1.3"
@@ -925,15 +950,24 @@ find-up@^4.0.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-follow-redirects@^1.14.0:
-  version "1.14.4"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.4.tgz#838fdf48a8bbdd79e52ee51fb1c94e3ed98b9379"
-  integrity sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==
+follow-redirects@^1.14.4:
+  version "1.14.5"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.5.tgz#f09a5848981d3c772b5392309778523f8d85c381"
+  integrity sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==
 
-font-awesome@*:
+font-awesome@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/font-awesome/-/font-awesome-4.7.0.tgz#8fa8cf0411a1a31afd07b06d2902bb9fc815a133"
   integrity sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM=
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fs-constants@^1.0.0:
   version "1.0.0"
@@ -993,9 +1027,9 @@ get-stream@^5.1.0:
     pump "^3.0.0"
 
 glob@^7.1.3, glob@^7.1.6:
-  version "7.1.7"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
-  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
+  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -1004,13 +1038,12 @@ glob@^7.1.3, glob@^7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-global-agent@^2.0.2:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/global-agent/-/global-agent-2.2.0.tgz#566331b0646e6bf79429a16877685c4a1fbf76dc"
-  integrity sha512-+20KpaW6DDLqhG7JDiJpD1JvNvb8ts+TNl7BPOYcURqCrXqnN1Vf+XVOrkKJAFPqfX+oEhsdzOj1hLWkBTdNJg==
+global-agent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/global-agent/-/global-agent-3.0.0.tgz#ae7cd31bd3583b93c5a16437a1afe27cc33a1ab6"
+  integrity sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==
   dependencies:
     boolean "^3.0.1"
-    core-js "^3.6.5"
     es6-error "^4.1.1"
     matcher "^3.0.0"
     roarr "^2.15.3"
@@ -1169,11 +1202,11 @@ is-ci@^2.0.0:
     ci-info "^2.0.0"
 
 is-ci@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.0.tgz#c7e7be3c9d8eef7d0fa144390bd1e4b88dc4c994"
-  integrity sha512-kDXyttuLeslKAHYL/K28F2YkM3x5jvFPEw3yXbRptXydjD9rpLEz+C5K5iutY9ZiUu6AP41JdvRQwF4Iqs4ZCQ==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.1.tgz#db6ecbed1bd659c43dac0f45661e7674103d1867"
+  integrity sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==
   dependencies:
-    ci-info "^3.1.1"
+    ci-info "^3.2.0"
 
 is-docker@^2.0.0:
   version "2.2.1"
@@ -1240,6 +1273,13 @@ isarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
+isbinaryfile@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-3.0.3.tgz#5d6def3edebf6e8ca8cae9c30183a804b5f8be80"
+  integrity sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==
+  dependencies:
+    buffer-alloc "^1.2.0"
+
 isbinaryfile@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-4.0.8.tgz#5d34b94865bd4946633ecc78a026fc76c5b11fcf"
@@ -1250,7 +1290,7 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
-iso8601-duration@*:
+iso8601-duration@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/iso8601-duration/-/iso8601-duration-1.3.0.tgz#29d7b69e0574e4acdee50c5e5e09adab4137ba5a"
   integrity sha512-K4CiUBzo3YeWk76FuET/dQPH03WE04R94feo5TSKQCXpoXQt9E4yx2CnY737QZnSAI3PI4WlKo/zfqizGx52QQ==
@@ -1372,7 +1412,7 @@ matcher@^3.0.0:
   dependencies:
     escape-string-regexp "^4.0.0"
 
-md5@*:
+md5@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
   integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
@@ -1381,10 +1421,22 @@ md5@*:
     crypt "0.0.2"
     is-buffer "~1.1.6"
 
+mime-db@1.51.0:
+  version "1.51.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
+  integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
+
+mime-types@^2.1.12:
+  version "2.1.34"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
+  integrity sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
+  dependencies:
+    mime-db "1.51.0"
+
 mime@^2.5.2:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe"
-  integrity sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
+  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
 mimic-response@^1.0.0, mimic-response@^1.0.1:
   version "1.0.1"
@@ -1403,7 +1455,12 @@ minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-mkdirp@^0.5.1, mkdirp@^0.5.4:
+mkdirp-classic@^0.5.2:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
+  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
+
+mkdirp@^0.5.4:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -1430,10 +1487,12 @@ node-addon-api@^1.6.3:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
   integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
 
-node-fetch@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+node-fetch@2.6.5:
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.5.tgz#42735537d7f080a7e5f78b6c549b7146be1742fd"
+  integrity sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 normalize-url@^4.1.0:
   version "4.5.1"
@@ -1561,12 +1620,7 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-progress@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.1.tgz#c9242169342b1c29d275889c95734621b1952e31"
-  integrity sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==
-
-progress@^2.0.3:
+progress@2.0.3, progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -1601,23 +1655,23 @@ pupa@^2.1.1:
   dependencies:
     escape-goat "^2.0.0"
 
-puppeteer@10.2.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-10.2.0.tgz#7d8d7fda91e19a7cfd56986e0275448e6351849e"
-  integrity sha512-OR2CCHRashF+f30+LBOtAjK6sNtz2HEyTr5FqAvhf8lR/qB3uBRoIZOwQKgwoyZnMBsxX7ZdazlyBgGjpnkiMw==
+puppeteer@11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-11.0.0.tgz#0808719c38e15315ecc1b1c28911f1c9054d201f"
+  integrity sha512-6rPFqN1ABjn4shgOICGDBITTRV09EjXVqhDERBDKwCLz0UyBxeeBH6Ay0vQUJ84VACmlxwzOIzVEJXThcF3aNg==
   dependencies:
-    debug "4.3.1"
+    debug "4.3.2"
     devtools-protocol "0.0.901419"
     extract-zip "2.0.1"
     https-proxy-agent "5.0.0"
-    node-fetch "2.6.1"
+    node-fetch "2.6.5"
     pkg-dir "4.2.0"
-    progress "2.0.1"
+    progress "2.0.3"
     proxy-from-env "1.1.0"
     rimraf "3.0.2"
-    tar-fs "2.0.0"
-    unbzip2-stream "1.3.3"
-    ws "7.4.6"
+    tar-fs "2.1.1"
+    unbzip2-stream "1.4.3"
+    ws "8.2.3"
 
 rc@^1.2.8:
   version "1.2.8"
@@ -1795,9 +1849,9 @@ shebang-regex@^3.0.0:
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.4.tgz#366a4684d175b9cab2081e3681fda3747b6c51d7"
-  integrity sha512-rqYhcAnZ6d/vTPGghdrw7iumdcbXpsk1b8IG/rz+VWV51DM0p7XCtMoJ3qhPLIbp3tvyt3pKRbaaEMZYpHto8Q==
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.6.tgz#24e630c4b0f03fea446a2bd299e62b4a6ca8d0af"
+  integrity sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==
 
 slice-ansi@^1.0.0:
   version "1.0.0"
@@ -1812,9 +1866,9 @@ smart-buffer@^4.0.2:
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
 
 source-map-support@^0.5.19:
-  version "0.5.20"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.20.tgz#12166089f8f5e5e8c56926b377633392dd2cb6c9"
-  integrity sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -1842,23 +1896,14 @@ string-width@^2.0.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string-width@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
-  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
-  dependencies:
-    emoji-regex "^7.0.1"
-    is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^5.1.0"
-
 string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5"
-  integrity sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
   dependencies:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.0"
+    strip-ansi "^6.0.1"
 
 string_decoder@^1.1.1:
   version "1.3.0"
@@ -1881,19 +1926,12 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
-  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
-    ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
-  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
-  dependencies:
-    ansi-regex "^5.0.0"
+    ansi-regex "^5.0.1"
 
 strip-eof@^1.0.0:
   version "1.0.0"
@@ -1926,17 +1964,17 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-tar-fs@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.0.0.tgz#677700fc0c8b337a78bee3623fdc235f21d7afad"
-  integrity sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==
+tar-fs@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
+  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
   dependencies:
     chownr "^1.1.1"
-    mkdirp "^0.5.1"
+    mkdirp-classic "^0.5.2"
     pump "^3.0.0"
-    tar-stream "^2.0.0"
+    tar-stream "^2.1.4"
 
-tar-stream@^2.0.0:
+tar-stream@^2.1.4:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
   integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
@@ -1961,9 +1999,9 @@ through@^2.3.8:
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
 tmp-promise@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.2.tgz#6e933782abff8b00c3119d63589ca1fb9caaa62a"
-  integrity sha512-OyCLAKU1HzBjL6Ev3gxUeraJNlbNingmi8IrHHEsYH8LTmEuhvYfqvhn2F/je+mjf4N58UmZ96OMEy1JanSCpA==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.3.tgz#60a1a1cc98c988674fcbfd23b6e3367bdeac4ce7"
+  integrity sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==
   dependencies:
     tmp "^0.2.0"
 
@@ -1978,6 +2016,11 @@ to-readable-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/to-readable-stream/-/to-readable-stream-1.0.0.tgz#ce0aa0c2f3df6adf852efb404a783e77c0475771"
   integrity sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==
+
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
 truncate-utf8-bytes@^1.0.0:
   version "1.0.2"
@@ -2013,10 +2056,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-unbzip2-stream@1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz#d156d205e670d8d8c393e1c02ebd506422873f6a"
-  integrity sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==
+unbzip2-stream@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz#b0da04c4371311df771cdc215e87f2130991ace7"
+  integrity sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==
   dependencies:
     buffer "^5.2.1"
     through "^2.3.8"
@@ -2083,13 +2126,26 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
 verror@^1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
-  integrity sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.1.tgz#4bf09eeccf4563b109ed4b3d458380c972b0cdeb"
+  integrity sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==
   dependencies:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which@^1.2.9:
   version "1.3.1"
@@ -2136,10 +2192,10 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-ws@7.4.6:
-  version "7.4.6"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
-  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+ws@8.2.3:
+  version "8.2.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.2.3.tgz#63a56456db1b04367d0b721a0b80cae6d8becbba"
+  integrity sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==
 
 xdg-basedir@^4.0.0:
   version "4.0.0"
@@ -2172,9 +2228,9 @@ yargs-parser@^20.2.2:
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
 yargs@^17.0.1:
-  version "17.1.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.1.1.tgz#c2a8091564bdb196f7c0a67c1d12e5b85b8067ba"
-  integrity sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==
+  version "17.2.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.2.1.tgz#e2c95b9796a0e1f7f3bf4427863b42e0418191ea"
+  integrity sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==
   dependencies:
     cliui "^7.0.2"
     escalade "^3.1.1"

--- a/pkgs/tools/misc/sharedown/yarndeps.nix
+++ b/pkgs/tools/misc/sharedown/yarndeps.nix
@@ -18,11 +18,11 @@
       };
     }
     {
-      name = "_electron_get___get_1.13.0.tgz";
+      name = "_electron_get___get_1.13.1.tgz";
       path = fetchurl {
-        name = "_electron_get___get_1.13.0.tgz";
-        url  = "https://registry.yarnpkg.com/@electron/get/-/get-1.13.0.tgz";
-        sha1 = "95c6bcaff4f9a505ea46792424f451efea89228c";
+        name = "_electron_get___get_1.13.1.tgz";
+        url  = "https://registry.yarnpkg.com/@electron/get/-/get-1.13.1.tgz";
+        sha1 = "42a0aa62fd1189638bd966e23effaebb16108368";
       };
     }
     {
@@ -90,11 +90,11 @@
       };
     }
     {
-      name = "_types_glob___glob_7.1.4.tgz";
+      name = "_types_glob___glob_7.2.0.tgz";
       path = fetchurl {
-        name = "_types_glob___glob_7.1.4.tgz";
-        url  = "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.4.tgz";
-        sha1 = "ea59e21d2ee5c517914cb4bc8e4153b99e566672";
+        name = "_types_glob___glob_7.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz";
+        sha1 = "bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb";
       };
     }
     {
@@ -114,19 +114,19 @@
       };
     }
     {
-      name = "_types_node___node_16.9.6.tgz";
+      name = "_types_node___node_16.11.10.tgz";
       path = fetchurl {
-        name = "_types_node___node_16.9.6.tgz";
-        url  = "https://registry.yarnpkg.com/@types/node/-/node-16.9.6.tgz";
-        sha1 = "040a64d7faf9e5d9e940357125f0963012e66f04";
+        name = "_types_node___node_16.11.10.tgz";
+        url  = "https://registry.yarnpkg.com/@types/node/-/node-16.11.10.tgz";
+        sha1 = "2e3ad0a680d96367103d3e670d41c2fed3da61ae";
       };
     }
     {
-      name = "_types_node___node_14.17.18.tgz";
+      name = "_types_node___node_14.17.34.tgz";
       path = fetchurl {
-        name = "_types_node___node_14.17.18.tgz";
-        url  = "https://registry.yarnpkg.com/@types/node/-/node-14.17.18.tgz";
-        sha1 = "0198489a751005f71217744aa966cd1f29447c81";
+        name = "_types_node___node_14.17.34.tgz";
+        url  = "https://registry.yarnpkg.com/@types/node/-/node-14.17.34.tgz";
+        sha1 = "fe4b38b3f07617c0fa31ae923fca9249641038f0";
       };
     }
     {
@@ -154,11 +154,11 @@
       };
     }
     {
-      name = "_types_yargs___yargs_16.0.4.tgz";
+      name = "_types_yargs___yargs_17.0.7.tgz";
       path = fetchurl {
-        name = "_types_yargs___yargs_16.0.4.tgz";
-        url  = "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.4.tgz";
-        sha1 = "26aad98dd2c2a38e421086ea9ad42b9e51642977";
+        name = "_types_yargs___yargs_17.0.7.tgz";
+        url  = "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.7.tgz";
+        sha1 = "44a484c634761da4391477515a98772b82b5060f";
       };
     }
     {
@@ -194,11 +194,11 @@
       };
     }
     {
-      name = "ansi_align___ansi_align_3.0.0.tgz";
+      name = "ansi_align___ansi_align_3.0.1.tgz";
       path = fetchurl {
-        name = "ansi_align___ansi_align_3.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.0.tgz";
-        sha1 = "b536b371cf687caaef236c18d3e21fe3797467cb";
+        name = "ansi_align___ansi_align_3.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.1.tgz";
+        sha1 = "0cdf12e111ace773a86e9a1fad1225c43cb19a59";
       };
     }
     {
@@ -207,14 +207,6 @@
         name = "ansi_regex___ansi_regex_3.0.0.tgz";
         url  = "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz";
         sha1 = "ed0317c322064f79466c02966bddb605ab37d998";
-      };
-    }
-    {
-      name = "ansi_regex___ansi_regex_4.1.0.tgz";
-      path = fetchurl {
-        name = "ansi_regex___ansi_regex_4.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz";
-        sha1 = "8b9f8f08cf1acb843756a839ca8c7e3168c51997";
       };
     }
     {
@@ -242,19 +234,19 @@
       };
     }
     {
-      name = "app_builder_bin___app_builder_bin_3.5.13.tgz";
+      name = "app_builder_bin___app_builder_bin_3.7.1.tgz";
       path = fetchurl {
-        name = "app_builder_bin___app_builder_bin_3.5.13.tgz";
-        url  = "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-3.5.13.tgz";
-        sha1 = "6dd7f4de34a4e408806f99b8c7d6ef1601305b7e";
+        name = "app_builder_bin___app_builder_bin_3.7.1.tgz";
+        url  = "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-3.7.1.tgz";
+        sha1 = "cb0825c5e12efc85b196ac3ed9c89f076c61040e";
       };
     }
     {
-      name = "app_builder_lib___app_builder_lib_22.11.7.tgz";
+      name = "app_builder_lib___app_builder_lib_22.14.5.tgz";
       path = fetchurl {
-        name = "app_builder_lib___app_builder_lib_22.11.7.tgz";
-        url  = "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-22.11.7.tgz";
-        sha1 = "c0ad1119ebfbf4189a8280ad693625f5e684dca6";
+        name = "app_builder_lib___app_builder_lib_22.14.5.tgz";
+        url  = "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-22.14.5.tgz";
+        sha1 = "a61a50b132b858e98fdc70b6b88994ae99b4f96d";
       };
     }
     {
@@ -306,6 +298,14 @@
       };
     }
     {
+      name = "asynckit___asynckit_0.4.0.tgz";
+      path = fetchurl {
+        name = "asynckit___asynckit_0.4.0.tgz";
+        url  = "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz";
+        sha1 = "c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79";
+      };
+    }
+    {
       name = "at_least_node___at_least_node_1.0.0.tgz";
       path = fetchurl {
         name = "at_least_node___at_least_node_1.0.0.tgz";
@@ -314,11 +314,11 @@
       };
     }
     {
-      name = "axios___axios_0.21.4.tgz";
+      name = "axios___axios_0.24.0.tgz";
       path = fetchurl {
-        name = "axios___axios_0.21.4.tgz";
-        url  = "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz";
-        sha1 = "c67b90dc0568e5c1cf2b0b858c43ba28e2eda575";
+        name = "axios___axios_0.24.0.tgz";
+        url  = "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz";
+        sha1 = "804e6fa1e4b9c5288501dd9dff56a7a0940d20d6";
       };
     }
     {
@@ -370,11 +370,11 @@
       };
     }
     {
-      name = "bootstrap___bootstrap_5.1.1.tgz";
+      name = "bootstrap___bootstrap_5.1.3.tgz";
       path = fetchurl {
-        name = "bootstrap___bootstrap_5.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.1.1.tgz";
-        sha1 = "9d6eed81e08feaccedf3adaca51fe4b73a2871df";
+        name = "bootstrap___bootstrap_5.1.3.tgz";
+        url  = "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.1.3.tgz";
+        sha1 = "ba081b0c130f810fa70900acbc1c6d3c28fa8f34";
       };
     }
     {
@@ -394,6 +394,22 @@
       };
     }
     {
+      name = "buffer_alloc_unsafe___buffer_alloc_unsafe_1.1.0.tgz";
+      path = fetchurl {
+        name = "buffer_alloc_unsafe___buffer_alloc_unsafe_1.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz";
+        sha1 = "bd7dc26ae2972d0eda253be061dba992349c19f0";
+      };
+    }
+    {
+      name = "buffer_alloc___buffer_alloc_1.2.0.tgz";
+      path = fetchurl {
+        name = "buffer_alloc___buffer_alloc_1.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz";
+        sha1 = "890dd90d923a873e08e10e5fd51a57e5b7cce0ec";
+      };
+    }
+    {
       name = "buffer_crc32___buffer_crc32_0.2.13.tgz";
       path = fetchurl {
         name = "buffer_crc32___buffer_crc32_0.2.13.tgz";
@@ -407,6 +423,14 @@
         name = "buffer_equal___buffer_equal_1.0.0.tgz";
         url  = "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-1.0.0.tgz";
         sha1 = "59616b498304d556abd466966b22eeda3eca5fbe";
+      };
+    }
+    {
+      name = "buffer_fill___buffer_fill_1.0.0.tgz";
+      path = fetchurl {
+        name = "buffer_fill___buffer_fill_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz";
+        sha1 = "f8f78b76789888ef39f205cd637f68e702122b2c";
       };
     }
     {
@@ -426,27 +450,19 @@
       };
     }
     {
-      name = "builder_util_runtime___builder_util_runtime_8.7.6.tgz";
+      name = "builder_util_runtime___builder_util_runtime_8.9.1.tgz";
       path = fetchurl {
-        name = "builder_util_runtime___builder_util_runtime_8.7.6.tgz";
-        url  = "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-8.7.6.tgz";
-        sha1 = "4b43c96db2bd494ced7694bcd7674934655e8324";
+        name = "builder_util_runtime___builder_util_runtime_8.9.1.tgz";
+        url  = "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-8.9.1.tgz";
+        sha1 = "25f066b3fbc20b3e6236a9b956b1ebb0e33ff66a";
       };
     }
     {
-      name = "builder_util_runtime___builder_util_runtime_8.7.7.tgz";
+      name = "builder_util___builder_util_22.14.5.tgz";
       path = fetchurl {
-        name = "builder_util_runtime___builder_util_runtime_8.7.7.tgz";
-        url  = "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-8.7.7.tgz";
-        sha1 = "6c83cc3abe7a7a5c8b4ec8878f68adc828c07f0d";
-      };
-    }
-    {
-      name = "builder_util___builder_util_22.11.7.tgz";
-      path = fetchurl {
-        name = "builder_util___builder_util_22.11.7.tgz";
-        url  = "https://registry.yarnpkg.com/builder-util/-/builder-util-22.11.7.tgz";
-        sha1 = "ae9707afa6a31feafa13c274ac83b4fe28ef1467";
+        name = "builder_util___builder_util_22.14.5.tgz";
+        url  = "https://registry.yarnpkg.com/builder-util/-/builder-util-22.14.5.tgz";
+        sha1 = "42a18608d2a566c0846e91266464776c8bfb0cc9";
       };
     }
     {
@@ -458,11 +474,11 @@
       };
     }
     {
-      name = "camelcase___camelcase_6.2.0.tgz";
+      name = "camelcase___camelcase_6.2.1.tgz";
       path = fetchurl {
-        name = "camelcase___camelcase_6.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz";
-        sha1 = "924af881c9d525ac9d87f40d964e5cea982a1809";
+        name = "camelcase___camelcase_6.2.1.tgz";
+        url  = "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.1.tgz";
+        sha1 = "250fd350cfd555d0d2160b1d51510eaf8326e86e";
       };
     }
     {
@@ -514,11 +530,11 @@
       };
     }
     {
-      name = "ci_info___ci_info_3.2.0.tgz";
+      name = "ci_info___ci_info_3.3.0.tgz";
       path = fetchurl {
-        name = "ci_info___ci_info_3.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/ci-info/-/ci-info-3.2.0.tgz";
-        sha1 = "2876cb948a498797b5236f0095bc057d0dca38b6";
+        name = "ci_info___ci_info_3.3.0.tgz";
+        url  = "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.0.tgz";
+        sha1 = "b4ed1fb6818dea4803a55c623041f9165d2066b2";
       };
     }
     {
@@ -602,6 +618,14 @@
       };
     }
     {
+      name = "combined_stream___combined_stream_1.0.8.tgz";
+      path = fetchurl {
+        name = "combined_stream___combined_stream_1.0.8.tgz";
+        url  = "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz";
+        sha1 = "c3d45a8b34fd730631a110a8a2520682b31d5a7f";
+      };
+    }
+    {
       name = "commander___commander_2.9.0.tgz";
       path = fetchurl {
         name = "commander___commander_2.9.0.tgz";
@@ -615,6 +639,14 @@
         name = "commander___commander_5.1.0.tgz";
         url  = "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz";
         sha1 = "46abbd1652f8e059bddaef99bbdcb2ad9cf179ae";
+      };
+    }
+    {
+      name = "compare_version___compare_version_0.1.2.tgz";
+      path = fetchurl {
+        name = "compare_version___compare_version_0.1.2.tgz";
+        url  = "https://registry.yarnpkg.com/compare-version/-/compare-version-0.1.2.tgz";
+        sha1 = "0162ec2d9351f5ddd59a9202cba935366a725080";
       };
     }
     {
@@ -647,14 +679,6 @@
         name = "configstore___configstore_5.0.1.tgz";
         url  = "https://registry.yarnpkg.com/configstore/-/configstore-5.0.1.tgz";
         sha1 = "d365021b5df4b98cdd187d6a3b0e3f6a7cc5ed96";
-      };
-    }
-    {
-      name = "core_js___core_js_3.18.0.tgz";
-      path = fetchurl {
-        name = "core_js___core_js_3.18.0.tgz";
-        url  = "https://registry.yarnpkg.com/core-js/-/core-js-3.18.0.tgz";
-        sha1 = "9af3f4a6df9ba3428a3fb1b171f1503b3f40cc49";
       };
     }
     {
@@ -722,14 +746,6 @@
       };
     }
     {
-      name = "debug___debug_4.3.1.tgz";
-      path = fetchurl {
-        name = "debug___debug_4.3.1.tgz";
-        url  = "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz";
-        sha1 = "f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee";
-      };
-    }
-    {
       name = "debug___debug_2.6.9.tgz";
       path = fetchurl {
         name = "debug___debug_2.6.9.tgz";
@@ -770,6 +786,14 @@
       };
     }
     {
+      name = "delayed_stream___delayed_stream_1.0.0.tgz";
+      path = fetchurl {
+        name = "delayed_stream___delayed_stream_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz";
+        sha1 = "df3ae199acadfb7d440aaae0b29e2272b24ec619";
+      };
+    }
+    {
       name = "detect_node___detect_node_2.1.0.tgz";
       path = fetchurl {
         name = "detect_node___detect_node_2.1.0.tgz";
@@ -794,11 +818,11 @@
       };
     }
     {
-      name = "dmg_builder___dmg_builder_22.11.7.tgz";
+      name = "dmg_builder___dmg_builder_22.14.5.tgz";
       path = fetchurl {
-        name = "dmg_builder___dmg_builder_22.11.7.tgz";
-        url  = "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-22.11.7.tgz";
-        sha1 = "5956008c18d40ee72c0ea01ffea9590dbf51df89";
+        name = "dmg_builder___dmg_builder_22.14.5.tgz";
+        url  = "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-22.14.5.tgz";
+        sha1 = "137c0b55e639badcc0b119eb060e6fa4ed61d948";
       };
     }
     {
@@ -850,35 +874,35 @@
       };
     }
     {
-      name = "electron_builder___electron_builder_22.11.7.tgz";
+      name = "electron_builder___electron_builder_22.14.5.tgz";
       path = fetchurl {
-        name = "electron_builder___electron_builder_22.11.7.tgz";
-        url  = "https://registry.yarnpkg.com/electron-builder/-/electron-builder-22.11.7.tgz";
-        sha1 = "cd97a0d9f6e6d388112e66b4376de431cca4d596";
+        name = "electron_builder___electron_builder_22.14.5.tgz";
+        url  = "https://registry.yarnpkg.com/electron-builder/-/electron-builder-22.14.5.tgz";
+        sha1 = "3a25547bd4fe3728d4704da80956a794c5c31496";
       };
     }
     {
-      name = "electron_publish___electron_publish_22.11.7.tgz";
+      name = "electron_osx_sign___electron_osx_sign_0.5.0.tgz";
       path = fetchurl {
-        name = "electron_publish___electron_publish_22.11.7.tgz";
-        url  = "https://registry.yarnpkg.com/electron-publish/-/electron-publish-22.11.7.tgz";
-        sha1 = "4126cbb08ccf082a2aa7fef89ee629b3a4b8ae9a";
+        name = "electron_osx_sign___electron_osx_sign_0.5.0.tgz";
+        url  = "https://registry.yarnpkg.com/electron-osx-sign/-/electron-osx-sign-0.5.0.tgz";
+        sha1 = "fc258c5e896859904bbe3d01da06902c04b51c3a";
       };
     }
     {
-      name = "electron___electron_15.0.0.tgz";
+      name = "electron_publish___electron_publish_22.14.5.tgz";
       path = fetchurl {
-        name = "electron___electron_15.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/electron/-/electron-15.0.0.tgz";
-        sha1 = "b1b6244b1cffddf348c27c54b1310b3a3680246e";
+        name = "electron_publish___electron_publish_22.14.5.tgz";
+        url  = "https://registry.yarnpkg.com/electron-publish/-/electron-publish-22.14.5.tgz";
+        sha1 = "34bcdce671f0e651330db20040d6919c77c94bd6";
       };
     }
     {
-      name = "emoji_regex___emoji_regex_7.0.3.tgz";
+      name = "electron___electron_15.3.2.tgz";
       path = fetchurl {
-        name = "emoji_regex___emoji_regex_7.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz";
-        sha1 = "933a04052860c85e83c122479c4748a8e4c72156";
+        name = "electron___electron_15.3.2.tgz";
+        url  = "https://registry.yarnpkg.com/electron/-/electron-15.3.2.tgz";
+        sha1 = "4f0cbad781d14e0194f5dfef1709e09a70c8074a";
       };
     }
     {
@@ -978,11 +1002,11 @@
       };
     }
     {
-      name = "extsprintf___extsprintf_1.4.0.tgz";
+      name = "extsprintf___extsprintf_1.4.1.tgz";
       path = fetchurl {
-        name = "extsprintf___extsprintf_1.4.0.tgz";
-        url  = "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz";
-        sha1 = "e2689f8f356fad62cca65a3a91c5df5f9551692f";
+        name = "extsprintf___extsprintf_1.4.1.tgz";
+        url  = "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz";
+        sha1 = "8d172c064867f235c0c84a596806d279bf4bcc07";
       };
     }
     {
@@ -1026,11 +1050,11 @@
       };
     }
     {
-      name = "follow_redirects___follow_redirects_1.14.4.tgz";
+      name = "follow_redirects___follow_redirects_1.14.5.tgz";
       path = fetchurl {
-        name = "follow_redirects___follow_redirects_1.14.4.tgz";
-        url  = "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.4.tgz";
-        sha1 = "838fdf48a8bbdd79e52ee51fb1c94e3ed98b9379";
+        name = "follow_redirects___follow_redirects_1.14.5.tgz";
+        url  = "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.5.tgz";
+        sha1 = "f09a5848981d3c772b5392309778523f8d85c381";
       };
     }
     {
@@ -1039,6 +1063,14 @@
         name = "font_awesome___font_awesome_4.7.0.tgz";
         url  = "https://registry.yarnpkg.com/font-awesome/-/font-awesome-4.7.0.tgz";
         sha1 = "8fa8cf0411a1a31afd07b06d2902bb9fc815a133";
+      };
+    }
+    {
+      name = "form_data___form_data_4.0.0.tgz";
+      path = fetchurl {
+        name = "form_data___form_data_4.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz";
+        sha1 = "93919daeaf361ee529584b9b31664dc12c9fa452";
       };
     }
     {
@@ -1106,19 +1138,19 @@
       };
     }
     {
-      name = "glob___glob_7.1.7.tgz";
+      name = "glob___glob_7.2.0.tgz";
       path = fetchurl {
-        name = "glob___glob_7.1.7.tgz";
-        url  = "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz";
-        sha1 = "3b193e9233f01d42d0b3f78294bbeeb418f94a90";
+        name = "glob___glob_7.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz";
+        sha1 = "d15535af7732e02e948f4c41628bd910293f6023";
       };
     }
     {
-      name = "global_agent___global_agent_2.2.0.tgz";
+      name = "global_agent___global_agent_3.0.0.tgz";
       path = fetchurl {
-        name = "global_agent___global_agent_2.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/global-agent/-/global-agent-2.2.0.tgz";
-        sha1 = "566331b0646e6bf79429a16877685c4a1fbf76dc";
+        name = "global_agent___global_agent_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/global-agent/-/global-agent-3.0.0.tgz";
+        sha1 = "ae7cd31bd3583b93c5a16437a1afe27cc33a1ab6";
       };
     }
     {
@@ -1306,11 +1338,11 @@
       };
     }
     {
-      name = "is_ci___is_ci_3.0.0.tgz";
+      name = "is_ci___is_ci_3.0.1.tgz";
       path = fetchurl {
-        name = "is_ci___is_ci_3.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.0.tgz";
-        sha1 = "c7e7be3c9d8eef7d0fa144390bd1e4b88dc4c994";
+        name = "is_ci___is_ci_3.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.1.tgz";
+        sha1 = "db6ecbed1bd659c43dac0f45661e7674103d1867";
       };
     }
     {
@@ -1407,6 +1439,14 @@
         name = "isarray___isarray_1.0.0.tgz";
         url  = "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz";
         sha1 = "bb935d48582cba168c06834957a54a3e07124f11";
+      };
+    }
+    {
+      name = "isbinaryfile___isbinaryfile_3.0.3.tgz";
+      path = fetchurl {
+        name = "isbinaryfile___isbinaryfile_3.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-3.0.3.tgz";
+        sha1 = "5d6def3edebf6e8ca8cae9c30183a804b5f8be80";
       };
     }
     {
@@ -1586,11 +1626,27 @@
       };
     }
     {
-      name = "mime___mime_2.5.2.tgz";
+      name = "mime_db___mime_db_1.51.0.tgz";
       path = fetchurl {
-        name = "mime___mime_2.5.2.tgz";
-        url  = "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz";
-        sha1 = "6e3dc6cc2b9510643830e5f19d5cb753da5eeabe";
+        name = "mime_db___mime_db_1.51.0.tgz";
+        url  = "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz";
+        sha1 = "d9ff62451859b18342d960850dc3cfb77e63fb0c";
+      };
+    }
+    {
+      name = "mime_types___mime_types_2.1.34.tgz";
+      path = fetchurl {
+        name = "mime_types___mime_types_2.1.34.tgz";
+        url  = "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz";
+        sha1 = "5a712f9ec1503511a945803640fafe09d3793c24";
+      };
+    }
+    {
+      name = "mime___mime_2.6.0.tgz";
+      path = fetchurl {
+        name = "mime___mime_2.6.0.tgz";
+        url  = "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz";
+        sha1 = "a2a682a95cd4d0cb1d6257e28f83da7e35800367";
       };
     }
     {
@@ -1615,6 +1671,14 @@
         name = "minimist___minimist_1.2.5.tgz";
         url  = "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz";
         sha1 = "67d66014b66a6a8aaa0c083c5fd58df4e4e97602";
+      };
+    }
+    {
+      name = "mkdirp_classic___mkdirp_classic_0.5.3.tgz";
+      path = fetchurl {
+        name = "mkdirp_classic___mkdirp_classic_0.5.3.tgz";
+        url  = "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz";
+        sha1 = "fa10c9115cc6d8865be221ba47ee9bed78601113";
       };
     }
     {
@@ -1658,11 +1722,11 @@
       };
     }
     {
-      name = "node_fetch___node_fetch_2.6.1.tgz";
+      name = "node_fetch___node_fetch_2.6.5.tgz";
       path = fetchurl {
-        name = "node_fetch___node_fetch_2.6.1.tgz";
-        url  = "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz";
-        sha1 = "045bd323631f76ed2e2b55573394416b639a0052";
+        name = "node_fetch___node_fetch_2.6.5.tgz";
+        url  = "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.5.tgz";
+        sha1 = "42735537d7f080a7e5f78b6c549b7146be1742fd";
       };
     }
     {
@@ -1834,14 +1898,6 @@
       };
     }
     {
-      name = "progress___progress_2.0.1.tgz";
-      path = fetchurl {
-        name = "progress___progress_2.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/progress/-/progress-2.0.1.tgz";
-        sha1 = "c9242169342b1c29d275889c95734621b1952e31";
-      };
-    }
-    {
       name = "progress___progress_2.0.3.tgz";
       path = fetchurl {
         name = "progress___progress_2.0.3.tgz";
@@ -1890,11 +1946,11 @@
       };
     }
     {
-      name = "puppeteer___puppeteer_10.2.0.tgz";
+      name = "puppeteer___puppeteer_11.0.0.tgz";
       path = fetchurl {
-        name = "puppeteer___puppeteer_10.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/puppeteer/-/puppeteer-10.2.0.tgz";
-        sha1 = "7d8d7fda91e19a7cfd56986e0275448e6351849e";
+        name = "puppeteer___puppeteer_11.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/puppeteer/-/puppeteer-11.0.0.tgz";
+        sha1 = "0808719c38e15315ecc1b1c28911f1c9054d201f";
       };
     }
     {
@@ -2098,11 +2154,11 @@
       };
     }
     {
-      name = "signal_exit___signal_exit_3.0.4.tgz";
+      name = "signal_exit___signal_exit_3.0.6.tgz";
       path = fetchurl {
-        name = "signal_exit___signal_exit_3.0.4.tgz";
-        url  = "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.4.tgz";
-        sha1 = "366a4684d175b9cab2081e3681fda3747b6c51d7";
+        name = "signal_exit___signal_exit_3.0.6.tgz";
+        url  = "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.6.tgz";
+        sha1 = "24e630c4b0f03fea446a2bd299e62b4a6ca8d0af";
       };
     }
     {
@@ -2122,11 +2178,11 @@
       };
     }
     {
-      name = "source_map_support___source_map_support_0.5.20.tgz";
+      name = "source_map_support___source_map_support_0.5.21.tgz";
       path = fetchurl {
-        name = "source_map_support___source_map_support_0.5.20.tgz";
-        url  = "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.20.tgz";
-        sha1 = "12166089f8f5e5e8c56926b377633392dd2cb6c9";
+        name = "source_map_support___source_map_support_0.5.21.tgz";
+        url  = "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz";
+        sha1 = "04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f";
       };
     }
     {
@@ -2162,19 +2218,11 @@
       };
     }
     {
-      name = "string_width___string_width_3.1.0.tgz";
+      name = "string_width___string_width_4.2.3.tgz";
       path = fetchurl {
-        name = "string_width___string_width_3.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz";
-        sha1 = "22767be21b62af1081574306f69ac51b62203961";
-      };
-    }
-    {
-      name = "string_width___string_width_4.2.2.tgz";
-      path = fetchurl {
-        name = "string_width___string_width_4.2.2.tgz";
-        url  = "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz";
-        sha1 = "dafd4f9559a7585cfba529c6a0a4f73488ebd4c5";
+        name = "string_width___string_width_4.2.3.tgz";
+        url  = "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz";
+        sha1 = "269c7117d27b05ad2e536830a8ec895ef9c6d010";
       };
     }
     {
@@ -2202,19 +2250,11 @@
       };
     }
     {
-      name = "strip_ansi___strip_ansi_5.2.0.tgz";
+      name = "strip_ansi___strip_ansi_6.0.1.tgz";
       path = fetchurl {
-        name = "strip_ansi___strip_ansi_5.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz";
-        sha1 = "8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae";
-      };
-    }
-    {
-      name = "strip_ansi___strip_ansi_6.0.0.tgz";
-      path = fetchurl {
-        name = "strip_ansi___strip_ansi_6.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz";
-        sha1 = "0b1571dd7669ccd4f3e06e14ef1eed26225ae532";
+        name = "strip_ansi___strip_ansi_6.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz";
+        sha1 = "9e26c63d30f53443e9489495b2105d37b67a85d9";
       };
     }
     {
@@ -2258,11 +2298,11 @@
       };
     }
     {
-      name = "tar_fs___tar_fs_2.0.0.tgz";
+      name = "tar_fs___tar_fs_2.1.1.tgz";
       path = fetchurl {
-        name = "tar_fs___tar_fs_2.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.0.0.tgz";
-        sha1 = "677700fc0c8b337a78bee3623fdc235f21d7afad";
+        name = "tar_fs___tar_fs_2.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz";
+        sha1 = "489a15ab85f1f0befabb370b7de4f9eb5cbe8784";
       };
     }
     {
@@ -2290,11 +2330,11 @@
       };
     }
     {
-      name = "tmp_promise___tmp_promise_3.0.2.tgz";
+      name = "tmp_promise___tmp_promise_3.0.3.tgz";
       path = fetchurl {
-        name = "tmp_promise___tmp_promise_3.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.2.tgz";
-        sha1 = "6e933782abff8b00c3119d63589ca1fb9caaa62a";
+        name = "tmp_promise___tmp_promise_3.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.3.tgz";
+        sha1 = "60a1a1cc98c988674fcbfd23b6e3367bdeac4ce7";
       };
     }
     {
@@ -2311,6 +2351,14 @@
         name = "to_readable_stream___to_readable_stream_1.0.0.tgz";
         url  = "https://registry.yarnpkg.com/to-readable-stream/-/to-readable-stream-1.0.0.tgz";
         sha1 = "ce0aa0c2f3df6adf852efb404a783e77c0475771";
+      };
+    }
+    {
+      name = "tr46___tr46_0.0.3.tgz";
+      path = fetchurl {
+        name = "tr46___tr46_0.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz";
+        sha1 = "8184fd347dac9cdc185992f3a6622e14b9d9ab6a";
       };
     }
     {
@@ -2362,11 +2410,11 @@
       };
     }
     {
-      name = "unbzip2_stream___unbzip2_stream_1.3.3.tgz";
+      name = "unbzip2_stream___unbzip2_stream_1.4.3.tgz";
       path = fetchurl {
-        name = "unbzip2_stream___unbzip2_stream_1.3.3.tgz";
-        url  = "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz";
-        sha1 = "d156d205e670d8d8c393e1c02ebd506422873f6a";
+        name = "unbzip2_stream___unbzip2_stream_1.4.3.tgz";
+        url  = "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz";
+        sha1 = "b0da04c4371311df771cdc215e87f2130991ace7";
       };
     }
     {
@@ -2434,11 +2482,27 @@
       };
     }
     {
-      name = "verror___verror_1.10.0.tgz";
+      name = "verror___verror_1.10.1.tgz";
       path = fetchurl {
-        name = "verror___verror_1.10.0.tgz";
-        url  = "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz";
-        sha1 = "3a105ca17053af55d6e270c1f8288682e18da400";
+        name = "verror___verror_1.10.1.tgz";
+        url  = "https://registry.yarnpkg.com/verror/-/verror-1.10.1.tgz";
+        sha1 = "4bf09eeccf4563b109ed4b3d458380c972b0cdeb";
+      };
+    }
+    {
+      name = "webidl_conversions___webidl_conversions_3.0.1.tgz";
+      path = fetchurl {
+        name = "webidl_conversions___webidl_conversions_3.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz";
+        sha1 = "24534275e2a7bc6be7bc86611cc16ae0a5654871";
+      };
+    }
+    {
+      name = "whatwg_url___whatwg_url_5.0.0.tgz";
+      path = fetchurl {
+        name = "whatwg_url___whatwg_url_5.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz";
+        sha1 = "966454e8765462e37644d3626f6742ce8b70965d";
       };
     }
     {
@@ -2490,11 +2554,11 @@
       };
     }
     {
-      name = "ws___ws_7.4.6.tgz";
+      name = "ws___ws_8.2.3.tgz";
       path = fetchurl {
-        name = "ws___ws_7.4.6.tgz";
-        url  = "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz";
-        sha1 = "5654ca8ecdeee47c33a9a4bf6d28e2be2980377c";
+        name = "ws___ws_8.2.3.tgz";
+        url  = "https://registry.yarnpkg.com/ws/-/ws-8.2.3.tgz";
+        sha1 = "63a56456db1b04367d0b721a0b80cae6d8becbba";
       };
     }
     {
@@ -2546,11 +2610,11 @@
       };
     }
     {
-      name = "yargs___yargs_17.1.1.tgz";
+      name = "yargs___yargs_17.2.1.tgz";
       path = fetchurl {
-        name = "yargs___yargs_17.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/yargs/-/yargs-17.1.1.tgz";
-        sha1 = "c2a8091564bdb196f7c0a67c1d12e5b85b8067ba";
+        name = "yargs___yargs_17.2.1.tgz";
+        url  = "https://registry.yarnpkg.com/yargs/-/yargs-17.2.1.tgz";
+        sha1 = "e2c95b9796a0e1f7f3bf4427863b42e0418191ea";
       };
     }
     {


### PR DESCRIPTION
###### Motivation for this change

- https://github.com/kylon/Sharedown/releases/tag/3.0.0
  - new direct downloader – has a [serious bug](https://github.com/kylon/Sharedown/issues/18#issuecomment-979432699) causing `rm -rf $PWD` (RIP my nixpkgs tree)
- https://github.com/kylon/Sharedown/releases/tag/3.0.1
  - fixes the issue

Also fix the update script (the source needs to be updated before we can re-generate the lockfile.)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
