### PR TITLE
pngoptimizer: init at 2.7

### DIFF
--- a/pkgs/tools/graphics/pngoptimizer/default.nix
+++ b/pkgs/tools/graphics/pngoptimizer/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, fetchFromGitHub, gtk3, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "pngoptimizer";
+  version = "2.7";
+
+  src = fetchFromGitHub {
+    owner = "hadrien-psydk";
+    repo = "pngoptimizer";
+    rev = "v${version}";
+    sha256 = "1hbgf91vzx46grslfdx86smdvm6gs6lq9hpa3bax9xfbsknxi0i7";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ gtk3 ];
+
+  makeFlags = [ "CONFIG=release" "DESTDIR=$(out)" ];
+
+  postInstall = ''
+    mv $out/usr/bin $out/bin
+    mv $out/usr/share $out/share
+    rmdir $out/usr
+  '';
+
+  meta = with lib; {
+    homepage = "https://psydk.org/pngoptimizer";
+    description = "PNG optimizer and converter";
+    # https://github.com/hadrien-psydk/pngoptimizer#license-information
+    license = with licenses; [ gpl2Only lgpl21Only zlib ];
+    maintainers = with maintainers; [ smitop ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8659,6 +8659,8 @@ with pkgs;
 
   pngnq = callPackage ../tools/graphics/pngnq { };
 
+  pngoptimizer = callPackage ../tools/graphics/pngoptimizer { };
+
   pngtoico = callPackage ../tools/graphics/pngtoico {
     libpng = libpng12;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This packages PngOptimizer, a PNG optimization and conversion program with a terminal (`pngoptimizercl`) and UI  (`pngoptimizer`) interface.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
