### PR TITLE
stdenv/generic: Fix generic builder lints

### DIFF
--- a/pkgs/stdenv/generic/builder.sh
+++ b/pkgs/stdenv/generic/builder.sh
@@ -1,3 +1,5 @@
+set -o errexit -o nounset
+
 export PATH=
 for i in $initialPath; do
     if [ "$i" = / ]; then i=; fi

--- a/pkgs/stdenv/generic/builder.sh
+++ b/pkgs/stdenv/generic/builder.sh
@@ -6,7 +6,7 @@ for i in $initialPath; do
     PATH=$PATH${PATH:+:}$i/bin
 done
 
-mkdir $out
+mkdir "$out"
 
 {
     echo "export SHELL=$shell"
@@ -19,7 +19,7 @@ mkdir $out
 
 # Allow the user to install stdenv using nix-env and get the packages
 # in stdenv.
-mkdir $out/nix-support
-if [ "$propagatedUserEnvPkgs" ]; then
-    printf '%s ' $propagatedUserEnvPkgs > $out/nix-support/propagated-user-env-packages
+mkdir "${out}/nix-support"
+if [ "${propagatedUserEnvPkgs-}" ]; then
+    printf '%s ' "$propagatedUserEnvPkgs" > "${out}/nix-support/propagated-user-env-packages"
 fi

--- a/pkgs/stdenv/generic/builder.sh
+++ b/pkgs/stdenv/generic/builder.sh
@@ -20,6 +20,6 @@ mkdir "$out"
 # Allow the user to install stdenv using nix-env and get the packages
 # in stdenv.
 mkdir "${out}/nix-support"
-if [ "${propagatedUserEnvPkgs-}" ]; then
+if [ -n "${propagatedUserEnvPkgs-}" ]; then
     printf '%s ' "$propagatedUserEnvPkgs" > "${out}/nix-support/propagated-user-env-packages"
 fi


### PR DESCRIPTION
###### Motivation for this change

Existing issues requesting ShellCheck compliance: #133088, #21166.

What is your opinion on also adding some more `shellcheck --enable=all --severity=style --shell=bash pkgs/stdenv/generic/builder.sh` suggestions? Both of them are really useful for clarity, IMO:

- [Prefer putting braces around variable references even when not strictly required](https://www.shellcheck.net/wiki/SC2250)
- [Prefer `[[ ]]` over `[ ]` for tests](https://www.shellcheck.net/wiki/SC2292)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
