### PR TITLE
camlp4: add new versions

### DIFF
--- a/pkgs/development/tools/ocaml/camlp4/default.nix
+++ b/pkgs/development/tools/ocaml/camlp4/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchzip, which, ocaml, ocamlbuild }:
 
-if lib.versionAtLeast ocaml.version "4.09"
+if lib.versionAtLeast ocaml.version "4.14"
 then throw "camlp4 is not available for OCaml ${ocaml.version}"
 else
 
@@ -26,6 +26,21 @@ let param = {
   "4.08" = {
      version = "4.08+1";
      sha256 = "0qplawvxwai25bi27niw2cgz2al01kcnkj8wxwhxslpi21z6pyx1"; };
+  "4.09" = {
+     version = "4.09+1";
+     sha256 = "1gr33x6xs1rs0bpyq4vzyfxd6vn47jfkg8imi81db2r0cbs0kxx1"; };
+  "4.10" = {
+     version = "4.10+1";
+     sha256 = "093bc1c28wid5li0jwglnd4p3csxw09fmbs9ffybq2z41a5mgay6"; };
+  "4.11" = {
+     version = "4.11+1";
+     sha256 = "0sn7f6im940qh0ixmx1k738xrwwdvy9g7r19bv5218jb6mh0g068"; };
+  "4.12" = {
+     version = "4.12+1";
+     sha256 = "1cfk5ppnd511vzsr9gc0grxbafmh0m3m897aij198rppzxps5kyz"; };
+  "4.13" = {
+     version = "4.13+1";
+     sha256 = "0fzxa1zdhk74mlxpin7p90flks6sp4gkc0mfclmj9zak15rii55n"; };
   }.${ocaml.meta.branch};
 in
 


### PR DESCRIPTION
###### Motivation for this change

This hasn't been updated in a while, and when using nixpkgs-provided ocaml, opam insists on having a system-provided camlp4 as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
