### PR TITLE
Fix bash completion for stable nix-* commands with Nix 2.4

### DIFF
--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -546,7 +546,7 @@ in
       [ nix
         pkgs.nix-info
       ]
-      ++ optional (config.programs.bash.enableCompletion && !versionAtLeast nixVersion "2.4pre") pkgs.nix-bash-completions;
+      ++ optional (config.programs.bash.enableCompletion) pkgs.nix-bash-completions;
 
     environment.etc."nix/nix.conf".source = nixConf;
 

--- a/pkgs/shells/bash/nix-bash-completions/default.nix
+++ b/pkgs/shells/bash/nix-bash-completions/default.nix
@@ -32,5 +32,7 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     platforms = platforms.all;
     maintainers = with maintainers; [ hedning ];
+    # Set a lower priority such that the newly provided completion from Nix 2.4 are preferred.
+    priority = 10;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Make `nix-*` commands complete again.

This obsoletes #144154, by fixing the root cause.

This also makes `nixos-*` commands complete again.

```
.../channels/nixpkgs $ ls -l /run/current-system/sw/share/bash-completion/completions/nix*
lrwxrwxrwx 1 root root  89 Dec 31  1969 /run/current-system/sw/share/bash-completion/completions/nix -> /nix/store/83nxpdacirjv274lihiyp18yaa3lyfsf-nix-2.4/share/bash-completion/completions/nix
lrwxrwxrwx 1 root root 114 Dec 31  1969 /run/current-system/sw/share/bash-completion/completions/nix-build -> /nix/store/ric38nrglpclj030pks9gg9r13cak4i2-nix-bash-completions-0.6.8/share/bash-completion/completions/nix-build
lrwxrwxrwx 1 root root 116 Dec 31  1969 /run/current-system/sw/share/bash-completion/completions/nix-channel -> /nix/store/ric38nrglpclj030pks9gg9r13cak4i2-nix-bash-completions-0.6.8/share/bash-completion/completions/nix-channel
lrwxrwxrwx 1 root root 124 Dec 31  1969 /run/current-system/sw/share/bash-completion/completions/nix-collect-garbage -> /nix/store/ric38nrglpclj030pks9gg9r13cak4i2-nix-bash-completions-0.6.8/share/bash-completion/completions/nix-collect-garbage
lrwxrwxrwx 1 root root 121 Dec 31  1969 /run/current-system/sw/share/bash-completion/completions/nix-copy-closure -> /nix/store/ric38nrglpclj030pks9gg9r13cak4i2-nix-bash-completions-0.6.8/share/bash-completion/completions/nix-copy-closure
lrwxrwxrwx 1 root root 112 Dec 31  1969 /run/current-system/sw/share/bash-completion/completions/nix-env -> /nix/store/ric38nrglpclj030pks9gg9r13cak4i2-nix-bash-completions-0.6.8/share/bash-completion/completions/nix-env
lrwxrwxrwx 1 root root 113 Dec 31  1969 /run/current-system/sw/share/bash-completion/completions/nix-hash -> /nix/store/ric38nrglpclj030pks9gg9r13cak4i2-nix-bash-completions-0.6.8/share/bash-completion/completions/nix-hash
lrwxrwxrwx 1 root root 124 Dec 31  1969 /run/current-system/sw/share/bash-completion/completions/nix-install-package -> /nix/store/ric38nrglpclj030pks9gg9r13cak4i2-nix-bash-completions-0.6.8/share/bash-completion/completions/nix-install-package
lrwxrwxrwx 1 root root 120 Dec 31  1969 /run/current-system/sw/share/bash-completion/completions/nix-instantiate -> /nix/store/ric38nrglpclj030pks9gg9r13cak4i2-nix-bash-completions-0.6.8/share/bash-completion/completions/nix-instantiate
lrwxrwxrwx 1 root root 120 Dec 31  1969 /run/current-system/sw/share/bash-completion/completions/nixos-build-vms -> /nix/store/ric38nrglpclj030pks9gg9r13cak4i2-nix-bash-completions-0.6.8/share/bash-completion/completions/nixos-build-vms
lrwxrwxrwx 1 root root 109 Dec 31  1969 /run/current-system/sw/share/bash-completion/completions/nixos-container -> /nix/store/ivybghav0vq0m44hmnmnd8nhb9fl3xj8-nixos-container/share/bash-completion/completions/nixos-container
lrwxrwxrwx 1 root root 126 Dec 31  1969 /run/current-system/sw/share/bash-completion/completions/nixos-generate-config -> /nix/store/ric38nrglpclj030pks9gg9r13cak4i2-nix-bash-completions-0.6.8/share/bash-completion/completions/nixos-generate-config
lrwxrwxrwx 1 root root 118 Dec 31  1969 /run/current-system/sw/share/bash-completion/completions/nixos-install -> /nix/store/ric38nrglpclj030pks9gg9r13cak4i2-nix-bash-completions-0.6.8/share/bash-completion/completions/nixos-install
lrwxrwxrwx 1 root root 117 Dec 31  1969 /run/current-system/sw/share/bash-completion/completions/nixos-option -> /nix/store/ric38nrglpclj030pks9gg9r13cak4i2-nix-bash-completions-0.6.8/share/bash-completion/completions/nixos-option
lrwxrwxrwx 1 root root 118 Dec 31  1969 /run/current-system/sw/share/bash-completion/completions/nixos-rebuild -> /nix/store/ric38nrglpclj030pks9gg9r13cak4i2-nix-bash-completions-0.6.8/share/bash-completion/completions/nixos-rebuild
lrwxrwxrwx 1 root root 118 Dec 31  1969 /run/current-system/sw/share/bash-completion/completions/nixos-version -> /nix/store/ric38nrglpclj030pks9gg9r13cak4i2-nix-bash-completions-0.6.8/share/bash-completion/completions/nixos-version
lrwxrwxrwx 1 root root 121 Dec 31  1969 /run/current-system/sw/share/bash-completion/completions/nix-prefetch-url -> /nix/store/ric38nrglpclj030pks9gg9r13cak4i2-nix-bash-completions-0.6.8/share/bash-completion/completions/nix-prefetch-url
lrwxrwxrwx 1 root root 113 Dec 31  1969 /run/current-system/sw/share/bash-completion/completions/nix-push -> /nix/store/ric38nrglpclj030pks9gg9r13cak4i2-nix-bash-completions-0.6.8/share/bash-completion/completions/nix-push
lrwxrwxrwx 1 root root 114 Dec 31  1969 /run/current-system/sw/share/bash-completion/completions/nix-shell -> /nix/store/ric38nrglpclj030pks9gg9r13cak4i2-nix-bash-completions-0.6.8/share/bash-completion/completions/nix-shell
lrwxrwxrwx 1 root root 114 Dec 31  1969 /run/current-system/sw/share/bash-completion/completions/nix-store -> /nix/store/ric38nrglpclj030pks9gg9r13cak4i2-nix-bash-completions-0.6.8/share/bash-completion/completions/nix-store
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
