### PR TITLE
boost: assertions and cleanup

### DIFF
--- a/pkgs/development/libraries/boost/default.nix
+++ b/pkgs/development/libraries/boost/default.nix
@@ -35,11 +35,9 @@ in {
   boost160 = makeBoost ./1.60.nix;
   boost165 = makeBoost ./1.65.nix;
   boost166 = makeBoost ./1.66.nix;
-  boost167 = makeBoost ./1.67.nix;
   boost168 = makeBoost ./1.68.nix;
   boost169 = makeBoost ./1.69.nix;
   boost170 = makeBoost ./1.70.nix;
-  boost171 = makeBoost ./1.71.nix;
   boost172 = makeBoost ./1.72.nix;
   boost173 = makeBoost ./1.73.nix;
   boost174 = makeBoost ./1.74.nix;

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -21,6 +21,7 @@
 
 # Attributes inherit from specific versions
 , version, src
+, python3
 , ...
 }:
 
@@ -30,6 +31,9 @@ assert enableShared || enableStatic;
 # Python isn't supported when cross-compiling
 assert enablePython -> stdenv.hostPlatform == stdenv.buildPlatform;
 assert enableNumpy -> enablePython;
+# Boost < 1.67 cannot be built with python3
+# https://github.com/boostorg/python/commit/660487c43fde76f3e64f1cb2e644500da92fe582
+assert enablePython && (python == python3) -> (lib.versionAtLeast version "1.68.0");
 
 # Boost <1.69 can't be build with clang >8, because pth was removed
 assert with lib; ((toolset == "clang" && !(versionOlder stdenv.cc.version "8.0.0")) -> !(versionOlder version "1.69"));


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
* Add assertion to avoid a build failure in the future when using unsupported boost versions
* Remove references to unsupported boost versions

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
