### PR TITLE
musescore: Fix some qt issues

### DIFF
--- a/pkgs/applications/audio/musescore/default.nix
+++ b/pkgs/applications/audio/musescore/default.nix
@@ -29,9 +29,9 @@ mkDerivation rec {
   qtWrapperArgs = [
     # MuseScore JACK backend loads libjack at runtime.
     "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libjack2 ]}"
-    # Work around crash on update from 3.4.2 to 3.5.0
-    # https://bugreports.qt.io/browse/QTBUG-85967
-    "--set QML_DISABLE_DISK_CACHE 1"
+    # There are some issues with using the wayland backend, see:
+    # https://musescore.org/en/node/321936
+    "--set QT_QPA_PLATFORM xcb"
   ];
 
   nativeBuildInputs = [ cmake pkg-config ];
@@ -49,7 +49,7 @@ mkDerivation rec {
     description = "Music notation and composition software";
     homepage = "https://musescore.org/";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ vandenoever turion ];
+    maintainers = with maintainers; [ vandenoever turion doronbehar ];
     platforms = platforms.linux;
     repositories.git = "https://github.com/musescore/MuseScore";
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27023,7 +27023,7 @@ with pkgs;
     if stdenv.isDarwin then
       callPackage ../applications/audio/musescore/darwin.nix { }
     else
-      libsForQt514.callPackage ../applications/audio/musescore { };
+      libsForQt5.callPackage ../applications/audio/musescore { };
 
   mmh = callPackage ../applications/networking/mailreaders/mmh { };
   mutt = callPackage ../applications/networking/mailreaders/mutt { };


### PR DESCRIPTION
###### Motivation for this change

cc @orivej for the revert of c3cd2be2e2f504a0e054275b705bd09c39e3038a .


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).