### PR TITLE
jing-trang: 20151127 -> 20181222

### DIFF
--- a/pkgs/tools/text/xml/jing-trang/default.nix
+++ b/pkgs/tools/text/xml/jing-trang/default.nix
@@ -1,19 +1,24 @@
 { lib, stdenv, fetchFromGitHub, jre_headless, jdk, ant, saxon }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "jing-trang";
-  version = "20151127";
+  version = "20181222";
 
   src = fetchFromGitHub {
     owner = "relaxng";
     repo = "jing-trang";
-    rev = "47a0cbdaec2d48824b78a1c19879ac7875509598"; # needed to compile with jdk8
-    sha256 = "1hhn52z9mv1x9nyvyqnmzg5yrs2lzm9xac7i15izppv02wp32qha";
+    rev = "V${version}";
+    sha256 = "sha256-Krupa3MGk5UaaQsaNpPMZuIUzHJytDiksz9ysCPkFS4=";
+    fetchSubmodules = true;
   };
 
   buildInputs = [ jdk ant saxon ];
 
   CLASSPATH = "lib/saxon.jar";
+
+  patches = [
+    ./no-git-during-build.patch
+  ];
 
   preBuild = "ant";
 
@@ -31,6 +36,9 @@ stdenv.mkDerivation {
 
     chmod +x "$out"/bin/*
   '';
+
+  doCheck = true;
+  checkPhase = "ant test";
 
   meta = with lib; {
     description = "A RELAX NG validator in Java";

--- a/pkgs/tools/text/xml/jing-trang/no-git-during-build.patch
+++ b/pkgs/tools/text/xml/jing-trang/no-git-during-build.patch
@@ -1,0 +1,47 @@
+From db0ed6267f1a85f0785c81b8ee396f74795c77c0 Mon Sep 17 00:00:00 2001
+From: Thomas Gerbet <thomas@gerbet.me>
+Date: Sat, 27 Nov 2021 10:24:07 +0100
+Subject: [PATCH] Do not rely on Git during the build
+
+---
+ build.xml | 6 ------
+ build.xsl | 6 ------
+ 2 files changed, 12 deletions(-)
+
+diff --git a/build.xml b/build.xml
+index e8ebaed8..2d26c72f 100644
+--- a/build.xml
++++ b/build.xml
+@@ -431,12 +431,6 @@
+ <target name="clean" 
+ 	description="Remove almost all files created during the build process">
+   <delete dir="${build.dir}"/>
+-  <exec executable="git">
+-    <arg value="clean"/>
+-    <arg value="-d"/>
+-    <arg value="--force"/>
+-    <arg value="${doc.dir}"/>
+-  </exec>
+ </target>
+ 
+ <target name="realclean" depends="clean"
+diff --git a/build.xsl b/build.xsl
+index fb9f3fef..fa384a27 100644
+--- a/build.xsl
++++ b/build.xsl
+@@ -23,12 +23,6 @@
+     <target name="dummy"/>
+     <target name="init">
+       <mkdir dir="{$build}"/>
+-      <exec executable="git">
+-        <arg value="submodule"/>
+-        <arg value="update"/>
+-        <arg value="--init"/>
+-        <arg value="--recursive"/>
+-      </exec>
+       <copy todir="{$doc}">
+         <fileset dir="relaxng.org/jclark" includes="**"/>
+       </copy>
+-- 
+2.34.1
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>jing</li>
    <li>xmloscopy</li>
  </ul>
</details>