### PR TITLE
famistudio: init at 3.3.0

### DIFF
--- a/pkgs/applications/audio/famistudio/default.nix
+++ b/pkgs/applications/audio/famistudio/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, stdenv
+, fetchzip
+, autoPatchelfHook
+, makeWrapper
+, alsa-lib
+, gtk-sharp-2_0
+, glib
+, gtk2
+, mono
+, openal
+}:
+
+stdenv.mkDerivation rec {
+  pname = "famistudio";
+  version = "3.3.0";
+
+  src = fetchzip {
+    url = "https://github.com/BleuBleu/FamiStudio/releases/download/${version}/FamiStudio${lib.strings.concatStrings (lib.splitVersion version)}-LinuxAMD64.zip";
+    stripRoot = false;
+    sha256 = "1r7y7z3s3b0zm7lvdgr9z70iall1swzlr3npx7g5azz6vza00vva";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
+
+  buildInputs = [ alsa-lib gtk-sharp-2_0 glib gtk2 mono openal ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib/famistudio}
+    mv * $out/lib/famistudio
+
+    makeWrapper ${mono}/bin/mono $out/bin/famistudio \
+      --add-flags $out/lib/famistudio/FamiStudio.exe \
+      --prefix MONO_GAC_PREFIX : ${gtk-sharp-2_0} \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ glib gtk2 gtk-sharp-2_0 ]}
+
+    # Fails to find openal32.dll on its own, needs abit of help
+    rm $out/lib/famistudio/libopenal32.so
+    cat <<EOF >$out/lib/famistudio/OpenTK.dll.config
+    <configuration>
+      <dllmap dll="openal32.dll" target="${openal}/lib/libopenal.so"/>
+    </configuration>
+    EOF
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://famistudio.org/";
+    description = "NES Music Editor";
+    longDescription = ''
+      FamiStudio is very simple music editor for the Nintendo Entertainment System
+      or Famicom. It is targeted at both chiptune artists and NES homebrewers.
+    '';
+    license = licenses.mit;
+    # Maybe possible to build from source but I'm not too familiar with C# packaging
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26163,6 +26163,8 @@ with pkgs;
 
   faircamp = callPackage ../applications/misc/faircamp { };
 
+  famistudio = callPackage ../applications/audio/famistudio { };
+
   fasttext = callPackage ../applications/science/machine-learning/fasttext { };
 
   fbmenugen = callPackage ../applications/misc/fbmenugen { };


### PR DESCRIPTION
###### Motivation for this change
https://famistudio.org/
https://github.com/BleuBleu/FamiStudio

I've given up on trying to build it from source, C# is the bane of my existence it seems.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
