### PR TITLE
php81: init at 8.1.0

### DIFF
--- a/pkgs/development/interpreters/php/8.1.nix
+++ b/pkgs/development/interpreters/php/8.1.nix
@@ -1,0 +1,51 @@
+{ callPackage, lib, stdenv, ... }@_args:
+
+let
+  base = callPackage ./generic.nix (_args // {
+    version = "8.1.0";
+    sha256 = "sha256-ByXtK66hJUlqiYRV1QGndGAhiyoM+tdz+pMi9JG4K2E=";
+  });
+
+in
+base.withExtensions ({ all, ... }: with all; ([
+  bcmath
+  calendar
+  curl
+  ctype
+  dom
+  exif
+  fileinfo
+  filter
+  ftp
+  gd
+  gettext
+  gmp
+  iconv
+  intl
+  ldap
+  mbstring
+  mysqli
+  mysqlnd
+  opcache
+  openssl
+  pcntl
+  pdo
+  pdo_mysql
+  pdo_odbc
+  pdo_pgsql
+  pdo_sqlite
+  pgsql
+  posix
+  readline
+  session
+  simplexml
+  sockets
+  soap
+  sodium
+  sqlite3
+  tokenizer
+  xmlreader
+  xmlwriter
+  zip
+  zlib
+] ++ lib.optionals (!stdenv.isDarwin) [ imap ]))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13486,6 +13486,13 @@ with pkgs;
   phpPackages = php.packages;
 
   # Import PHP80 interpreter, extensions and packages
+  php81 = callPackage ../development/interpreters/php/8.1.nix {
+    stdenv = if stdenv.cc.isClang then llvmPackages.stdenv else stdenv;
+  };
+  php81Extensions = recurseIntoAttrs php81.extensions;
+  php81Packages = recurseIntoAttrs php81.packages;
+
+  # Import PHP80 interpreter, extensions and packages
   php80 = callPackage ../development/interpreters/php/8.0.nix {
     stdenv = if stdenv.cc.isClang then llvmPackages.stdenv else stdenv;
   };


### PR DESCRIPTION

###### Motivation for this change

PHP 8.1 release

###### Things done

xmlreader and tokenizer cannot be built currently. If someone has an idea would be nice. Looking later again into it

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
