### PR TITLE
samtools: pull upstream fix for ncurses-6.3

### DIFF
--- a/pkgs/applications/science/biology/samtools/default.nix
+++ b/pkgs/applications/science/biology/samtools/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, zlib, htslib, perl, ncurses ? null }:
+{ lib, stdenv, fetchurl, fetchpatch, zlib, htslib, perl, ncurses ? null }:
 
 stdenv.mkDerivation rec {
   pname = "samtools";
@@ -8,6 +8,15 @@ stdenv.mkDerivation rec {
     url = "https://github.com/samtools/samtools/releases/download/${version}/${pname}-${version}.tar.bz2";
     sha256 = "sha256-YWyi4FHMgAmh6cAc/Yx8r4twkW3f9m87dpFAeUZfjGA=";
   };
+
+  patches = [
+    # Pull upstream patch for ncurses-6.3 support
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/samtools/samtools/commit/396ef20eb0854d6b223c3223b60bb7efe42301f7.patch";
+      sha256 = "sha256-p0l9ymXK9nqL2w8EytbW+qeaI7dD86IQgIVxacBj838=";
+    })
+  ];
 
   nativeBuildInputs = [ perl ];
 


### PR DESCRIPTION
Without the fix build on ncurses-6.3 fails as:

    bam_tview_curses.c:88:5: error: format not a string literal and no format arguments [-Werror=format-security]
       88 |     mvprintw(y,x,str);
          |     ^~~~~~~~
