### PR TITLE
factor98: add longDescription

### DIFF
--- a/pkgs/development/compilers/factor-lang/factor98.nix
+++ b/pkgs/development/compilers/factor-lang/factor98.nix
@@ -1,53 +1,53 @@
-{ stdenv
-, lib
-, git
-, curl
-, makeWrapper
-, runtimeShell
-, fetchurl
-, unzip
-, runCommand
-, writeScriptBin
-, interpreter
-, glib
-, pango
+{ lib
+, stdenv
 , cairo
-, gtk2-x11
+, curl
+, fetchurl
+, freealut
 , gdk-pixbuf
+, git
+, glib
 , gnome2
-, pcre
+, graphviz
+, gtk2-x11
+, interpreter
 , libGL
 , libGLU
-, freealut
-, openssl
-, udis86
-, openal
 , libogg
-, libvorbis
-, graphviz
 , librsvg
-, zlib
-, tzdata
+, libvorbis
+, makeWrapper
 , ncurses
+, openal
+, openssl
+, pango
+, pcre
+, runCommand
+, runtimeShell
+, tzdata
+, udis86
+, unzip
+, writeScriptBin
+, zlib
 }:
 let
   runtimeLibs = [
-    glib
-    pango
     cairo
-    gtk2-x11
+    freealut
     gdk-pixbuf
+    glib
     gnome2.gtkglext
-    pcre
+    graphviz
+    gtk2-x11
     libGL
     libGLU
-    freealut
-    openssl
-    udis86
-    openal
     libogg
     libvorbis
-    graphviz
+    openal
+    openssl
+    pango
+    pcre
+    udis86
     zlib
   ];
 
@@ -154,9 +154,9 @@ stdenv.mkDerivation {
     runHook postBuild
   '';
 
-  # For now, the check phase runs, but should always return 0.  This way the
-  # logs contain the test failures until all unit tests are fixed.  Then, it
-  # should return 1 if any test failures have occured.
+  # For now, the check phase runs, but should always return 0. This way the logs
+  # contain the test failures until all unit tests are fixed. Then, it should
+  # return 1 if any test failures have occured.
   doCheck = false;
   checkPhase = ''
     runHook preCheck
@@ -197,8 +197,21 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     homepage = "https://factorcode.org/";
-    license = licenses.bsd2;
     description = "A concatenative, stack-based programming language";
+    longDescription = ''
+      The Factor programming language is a concatenative, stack-based
+      programming language with high-level features including dynamic types,
+      extensible syntax, macros, and garbage collection. On a practical side,
+      Factor has a full-featured library, supports many different platforms, and
+      has been extensively documented.
+
+      The implementation is fully compiled for performance, while still
+      supporting interactive development. Factor applications are portable
+      between all common platforms. Factor can deploy stand-alone applications
+      on all platforms. Full source code for the Factor project is available
+      under a BSD license.
+    '';
+    license = licenses.bsd2;
     maintainers = with maintainers; [ vrthra spacefrogg ];
     platforms = lib.intersectLists platforms.x86_64 platforms.linux;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
