### PR TITLE
libvgm & co: init

### DIFF
--- a/pkgs/applications/audio/mmlgui/default.nix
+++ b/pkgs/applications/audio/mmlgui/default.nix
@@ -1,0 +1,87 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, unstableGitUpdater
+, pkg-config
+, glfw
+, libvgm
+, libX11
+, libXau
+, libXdmcp
+, Carbon
+, Cocoa
+, cppunit
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mmlgui";
+  version = "unstable-2022-05-24";
+
+  src = fetchFromGitHub {
+    owner = "superctr";
+    repo = "mmlgui";
+    rev = "fe2b298c1eddae4cc38096f6c1ba1ccaed562cf1";
+    fetchSubmodules = true;
+    sha256 = "Q34zzZthdThMbduXcc/qMome89mAMrn1Vinr073u4zo=";
+  };
+
+  postPatch = ''
+    # Actually wants pkgconf but that seems abit broken:
+    # https://github.com/NixOS/nixpkgs/pull/147503#issuecomment-1055943897
+    # Removing a pkgconf-specific option makes it work with pkg-config
+    substituteInPlace libvgm.mak \
+      --replace '--with-path=/usr/local/lib/pkgconfig' ""
+    substituteInPlace Makefile \
+      --replace 'all: $(MMLGUI_BIN) test' 'all: $(MMLGUI_BIN)'
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    glfw
+    libvgm
+  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
+    libX11
+    libXau
+    libXdmcp
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    Carbon
+    Cocoa
+  ];
+
+  checkInputs = [
+    cppunit
+  ];
+
+  makeFlags = [
+    "RELEASE=1"
+  ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 {,$out/}bin/mmlgui
+    mkdir -p $out/share/ctrmml
+    mv ctrmml/sample $out/share/ctrmml/
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = unstableGitUpdater {
+    url = "https://github.com/superctr/mmlgui.git";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/superctr/mmlgui";
+    description = "MML (Music Macro Language) editor and compiler GUI, powered by the ctrmml framework";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/audio/vgmplay-libvgm/default.nix
+++ b/pkgs/applications/audio/vgmplay-libvgm/default.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, unstableGitUpdater
+, cmake
+, pkg-config
+, zlib
+, libvgm
+, inih
+}:
+
+stdenv.mkDerivation rec {
+  pname = "vgmplay-libvgm";
+  version = "unstable-2022-03-17";
+
+  src = fetchFromGitHub {
+    owner = "ValleyBell";
+    repo = "vgmplay-libvgm";
+    rev = "a2c21cb134b58043a013ac2efc060144cdecf13d";
+    sha256 = "0g251laqjvvzblyflkg8xac424dbxm1v35ckfazsfchmcqiaqfw4";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [ zlib libvgm inih ];
+
+  postInstall = ''
+    install -Dm644 ../VGMPlay.ini $out/share/vgmplay/VGMPlay.ini
+  '';
+
+  passthru.updateScript = unstableGitUpdater {
+    url = "https://github.com/ValleyBell/vgmplay-libvgm.git";
+  };
+
+  meta = with lib; {
+    mainProgram = "vgmplay";
+    homepage = "https://github.com/ValleyBell/vgmplay-libvgm";
+    description = "New VGMPlay, based on libvgm";
+    license = licenses.unfree; # no licensing text anywhere yet
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/libvgm/default.nix
+++ b/pkgs/development/libraries/libvgm/default.nix
@@ -1,0 +1,122 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, unstableGitUpdater
+, cmake
+, libiconv
+, zlib
+, enableShared ? true
+
+, enableAudio ? true
+, withWaveWrite ? true
+, withWinMM ? stdenv.hostPlatform.isWindows
+, withDirectSound ? stdenv.hostPlatform.isWindows
+, withXAudio2 ? stdenv.hostPlatform.isWindows
+, withWASAPI ? stdenv.hostPlatform.isWindows
+, withOSS ? stdenv.hostPlatform.isFreeBSD
+, withSADA ? stdenv.hostPlatform.isSunOS
+, withALSA ? stdenv.hostPlatform.isLinux
+, alsa-lib
+, withPulseAudio ? stdenv.hostPlatform.isLinux
+, libpulseaudio
+, withCoreAudio ? stdenv.hostPlatform.isDarwin
+, CoreAudio
+, AudioToolbox
+, withLibao ? true
+, libao
+
+, enableEmulation ? true
+, withAllEmulators ? true
+, emulators ? [ ]
+
+, enableLibplayer ? true
+
+, enableTools ? false
+}:
+
+assert enableTools -> enableAudio && enableEmulation && enableLibplayer;
+
+let
+  inherit (lib) optional optionals;
+  onOff = val: if val then "ON" else "OFF";
+in
+stdenv.mkDerivation rec {
+  pname = "libvgm";
+  version = "unstable-2022-05-27";
+
+  src = fetchFromGitHub {
+    owner = "ValleyBell";
+    repo = "libvgm";
+    rev = "ec6ddae3e3488b6dc9e993cb0f76d3015d2f6fff";
+    sha256 = "AwIx4LuVSuCf7xgtximcB6N+rzC7g1ajeBdaBz6RSyk=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ] ++ optional enableTools "bin";
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  propagatedBuildInputs = [
+    libiconv
+    zlib
+  ] ++ optionals withALSA [
+    alsa-lib
+  ] ++ optionals withPulseAudio [
+    libpulseaudio
+  ] ++ optionals withCoreAudio [
+    CoreAudio
+    AudioToolbox
+  ] ++ optionals withLibao [
+    libao
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_LIBAUDIO=${onOff enableAudio}"
+    "-DBUILD_LIBEMU=${onOff enableEmulation}"
+    "-DBUILD_LIBPLAYER=${onOff enableLibplayer}"
+    "-DBUILD_TESTS=${onOff enableTools}"
+    "-DBUILD_PLAYER=${onOff enableTools}"
+    "-DBUILD_VGM2WAV=${onOff enableTools}"
+    "-DLIBRARY_TYPE=${if enableShared then "SHARED" else "STATIC"}"
+    "-DUSE_SANITIZERS=ON"
+  ] ++ optionals enableAudio [
+    "-DAUDIODRV_WAVEWRITE=${onOff withWaveWrite}"
+    "-DAUDIODRV_WINMM=${onOff withWinMM}"
+    "-DAUDIODRV_DSOUND=${onOff withDirectSound}"
+    "-DAUDIODRV_XAUDIO2=${onOff withXAudio2}"
+    "-DAUDIODRV_WASAPI=${onOff withWASAPI}"
+    "-DAUDIODRV_OSS=${onOff withOSS}"
+    "-DAUDIODRV_SADA=${onOff withSADA}"
+    "-DAUDIODRV_ALSA=${onOff withALSA}"
+    "-DAUDIODRV_PULSE=${onOff withPulseAudio}"
+    "-DAUDIODRV_APPLE=${onOff withCoreAudio}"
+    "-DAUDIODRV_LIBAO=${onOff withLibao}"
+  ] ++ optionals enableEmulation ([
+    "-DSNDEMU__ALL=${onOff withAllEmulators}"
+  ] ++ optionals (!withAllEmulators)
+    (lib.lists.forEach emulators (x: "-DSNDEMU_${x}=ON"))
+  ) ++ optionals enableTools [
+    "-DUTIL_CHARCNV_ICONV=ON"
+    "-DUTIL_CHARCNV_WINAPI=${onOff stdenv.hostPlatform.isWindows}"
+  ];
+
+  passthru.updateScript = unstableGitUpdater {
+    url = "https://github.com/ValleyBell/libvgm.git";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/ValleyBell/libvgm";
+    description = "More modular rewrite of most components from VGMPlay";
+    license =
+      if (enableEmulation && (withAllEmulators || (lib.lists.any (core: core == "WSWAN_ALL") emulators))) then
+        licenses.unfree # https://github.com/ValleyBell/libvgm/issues/43
+      else
+        licenses.gpl2Only;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/audio/fmtoy/default.nix
+++ b/pkgs/tools/audio/fmtoy/default.nix
@@ -1,0 +1,72 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, unstableGitUpdater
+, dos2unix
+, pkg-config
+, zlib
+, alsa-lib
+, libjack2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fmtoy";
+  version = "unstable-2021-12-24";
+
+  src = fetchFromGitHub {
+    owner = "vampirefrog";
+    repo = "fmtoy";
+    rev = "0de6703b3373eb5bf19fd3deaae889286f330c21";
+    sha256 = "0sr6klkmjd2hd2kyb9y0x986d6lsy8bziizfc6cmhkqcq92fh45c";
+  };
+
+  postPatch = ''
+    dos2unix Makefile
+    # Don't hardcode compilers
+    sed -i -e '/CC=/d' -e '/CXX=/d' Makefile
+  '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # Remove Linux-only program & its dependencies
+    sed -i -e '/PROGS/ s/fmtoy_jack//' Makefile
+    substituteInPlace Makefile \
+      --replace '$(shell pkg-config alsa jack --cflags)' ""
+  '';
+
+  nativeBuildInputs = [
+    dos2unix
+  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
+    pkg-config
+  ];
+
+  buildInputs = [
+    zlib
+  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
+    alsa-lib
+    libjack2
+  ];
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    for prog in $(grep 'PROGS=' Makefile | cut -d= -f2-); do
+      install -Dm755 $prog $out/bin/$prog
+    done
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = unstableGitUpdater {
+    url = "https://github.com/vampirefrog/fmtoy.git";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/vampirefrog/fmtoy";
+    description = "Tools for FM voices for Yamaha YM chips (OPL, OPM and OPN series)";
+    # Unknown license situation
+    # https://github.com/vampirefrog/fmtoy/issues/1
+    license = licenses.unfree;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/audio/vgmtools/default.nix
+++ b/pkgs/tools/audio/vgmtools/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, unstableGitUpdater
+, cmake
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "vgmtools";
+  version = "unstable-2022-05-23";
+
+  src = fetchFromGitHub {
+    owner = "vgmrips";
+    repo = "vgmtools";
+    rev = "e0df1511ddf7b1207b448487616ff18a9049c278";
+    sha256 = "2nM3E/XeZ1OeOj3fPqvuJgQcPOtBerduGpVfpGLVhHQ=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    zlib
+  ];
+
+  # Some targets are not enabled by default
+  makeFlags = [
+    "all" "opt_oki" "optdac" "optvgm32"
+  ];
+
+  passthru.updateScript = unstableGitUpdater {
+    url = "https://github.com/vgmrips/vgmtools.git";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/vgmrips/vgmtools";
+    description = "A collection of tools for the VGM file format";
+    license = licenses.gpl2; # Not clarified whether Only or Plus
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26567,6 +26567,8 @@ with pkgs;
 
   firefox_decrypt = python3Packages.callPackage ../tools/security/firefox_decrypt { };
 
+  fmtoy = callPackage ../tools/audio/fmtoy { };
+
   flac = callPackage ../applications/audio/flac { };
 
   redoflacs = callPackage ../applications/audio/redoflacs { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28153,6 +28153,17 @@ with pkgs;
     };
   };
 
+  mmlgui = callPackage ../applications/audio/mmlgui {
+    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+    libvgm = libvgm.override {
+      withAllEmulators = false;
+      emulators = [
+        "_PRESET_SMD"
+      ];
+      enableLibplayer = false;
+    };
+  };
+
   mmsd = callPackage ../tools/networking/mmsd { };
 
   mmtc = callPackage ../applications/audio/mmtc { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28825,6 +28825,8 @@ with pkgs;
 
   owamp = callPackage ../applications/networking/owamp { };
 
+  vgmplay-libvgm = callPackage ../applications/audio/vgmplay-libvgm { };
+
   vieb = callPackage ../applications/networking/browsers/vieb { };
 
   vivaldi = callPackage ../applications/networking/browsers/vivaldi {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28838,6 +28838,8 @@ with pkgs;
 
   vgmplay-libvgm = callPackage ../applications/audio/vgmplay-libvgm { };
 
+  vgmtools = callPackage ../tools/audio/vgmtools { };
+
   vieb = callPackage ../applications/networking/browsers/vieb { };
 
   vivaldi = callPackage ../applications/networking/browsers/vivaldi {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19348,6 +19348,10 @@ with pkgs;
 
   libversion = callPackage ../development/libraries/libversion { };
 
+  libvgm = callPackage ../development/libraries/libvgm {
+    inherit (darwin.apple_sdk.frameworks) CoreAudio AudioToolbox;
+  };
+
   libvirt = callPackage ../development/libraries/libvirt {
     inherit (darwin.apple_sdk.frameworks) Carbon AppKit;
   };


### PR DESCRIPTION
###### Motivation for this change
Packaging:

- [libvgm](https://github.com/ValleyBell/libvgm), a library for emulating a plethora of sound chips & systems
- [libvgm-based vgmplay](https://github.com/ValleyBell/vgmplay-libvgm), a player for VGM files
  (there exists a more well known, regular vgmplay but it's considered legacy and an absolute licensing mess)
- [mmlgui](https://github.com/superctr/mmlgui), a graphical MML editor that uses libvgm for Sega Mega Drive sound emulation & general audio playback
- [vgmtools](https://github.com/vgmrips/vgmtools), a set of tools for working with VGM files (some converters, trimming, compressing, looping, tagging etc)
- [fmtoy](https://github.com/vampirefrog/fmtoy), some tools for working with FM patches, including a popular tool for extracting patches from VGM files

To test vgmplay:
1. Download a VGM/VGZ file
  i.e. from https://vgmrips.net/packs/
  example: https://vgmrips.net/packs/vgm/Computers/Sharp/Asuka_120%25_Burning_Fest._%28Sharp_X68000%29/11%20Megumi%20Stage.vgz)
2. `vgmplay /path/to/file`, have working playback
  ![Bildschirmfoto_2021-11-26_14-52-23](https://user-images.githubusercontent.com/23431373/143591473-e39c6a3c-0b24-47e0-84b9-dd91718b9b09.png)

To test mmlgui: I include the examples from the underlying MML compiler in the output. The program doesn't understand command-line arguments or symlinks in its file manager so you'll have to press the L next to the current directory marker and paste the full result path into it to find them.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
