### PR TITLE
[Backport release 21.11] buildGraalvmNativeImage: init

### DIFF
--- a/pkgs/build-support/build-graalvm-native-image/default.nix
+++ b/pkgs/build-support/build-graalvm-native-image/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation (args // {
     "-H:CLibraryPath=${lib.getLib graalvm}/lib"
     "${lib.optionalString stdenv.isDarwin "-H:-CheckToolchain"}"
     "-H:Name=${executable}"
+    "--verbose"
     extraNativeImageBuildArgs
     graalvmXmx
   ]);
@@ -46,8 +47,6 @@ stdenv.mkDerivation (args // {
     runHook postInstall
   '';
 
-  meta = {
-    platforms = lib.attrByPath [ "meta" "platforms" ] graalvm.meta.platforms args;
-    mainProgram = lib.attrByPath [ "meta" "mainProgram" ] executable args;
-  };
+  meta.platforms = lib.attrByPath [ "meta" "platforms" ] graalvm.meta.platforms args;
+  meta.mainProgram = lib.attrByPath [ "meta" "mainProgram" ] executable args;
 })

--- a/pkgs/build-support/build-graalvm-native-image/default.nix
+++ b/pkgs/build-support/build-graalvm-native-image/default.nix
@@ -1,0 +1,53 @@
+{ lib, stdenv, graalvmCEPackages, glibcLocales }:
+
+{ name ? "${args.pname}-${args.version}"
+  # Final executable name
+, executable
+  # JAR used as input for GraalVM derivation, defaults to src
+, jar ? args.src
+, dontUnpack ? (jar == args.src)
+  # Extra arguments to be passed to the native-image
+, extraNativeImageBuildArgs ? [ ]
+  # XMX size of GraalVM during build
+, graalvmXmx ? "-J-Xmx6g"
+  # The GraalVM to use
+, graalvm ? graalvmCEPackages.graalvm11-ce
+, ...
+} @ args:
+
+stdenv.mkDerivation (args // {
+  inherit dontUnpack;
+
+  nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ graalvm glibcLocales ];
+
+  nativeImageBuildArgs = lib.flatten ([
+    "-jar"
+    jar
+    "-H:CLibraryPath=${lib.getLib graalvm}/lib"
+    "${lib.optionalString stdenv.isDarwin "-H:-CheckToolchain"}"
+    "-H:Name=${executable}"
+    extraNativeImageBuildArgs
+    graalvmXmx
+  ]);
+
+  buildPhase = args.buildPhase or ''
+    runHook preBuild
+
+    native-image ''${nativeImageBuildArgs[@]}
+
+    runHook postBuild
+  '';
+
+  installPhase = args.installPhase or ''
+    runHook preInstall
+
+    install -Dm755 ${executable} -t $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = {
+    platforms = lib.attrByPath [ "meta" "platforms" ] graalvm.meta.platforms args;
+    mainProgram = lib.attrByPath [ "meta" "mainProgram" ] executable args;
+  };
+})

--- a/pkgs/build-support/build-graalvm-native-image/default.nix
+++ b/pkgs/build-support/build-graalvm-native-image/default.nix
@@ -2,7 +2,7 @@
 
 { name ? "${args.pname}-${args.version}"
   # Final executable name
-, executable
+, executable ? args.pname
   # JAR used as input for GraalVM derivation, defaults to src
 , jar ? args.src
 , dontUnpack ? (jar == args.src)

--- a/pkgs/development/interpreters/clojure/babashka.nix
+++ b/pkgs/development/interpreters/clojure/babashka.nix
@@ -13,7 +13,6 @@ buildGraalvmNativeImage rec {
 
   extraNativeImageBuildArgs = [
     "-H:+ReportExceptionStackTraces"
-    "--verbose"
     "--no-fallback"
     "--native-image-info"
   ];

--- a/pkgs/development/tools/clj-kondo/default.nix
+++ b/pkgs/development/tools/clj-kondo/default.nix
@@ -9,8 +9,6 @@ buildGraalvmNativeImage rec {
     sha256 = "sha256-i0OeQPZfQPUeXC/Bs84I91IahBKK6W1mFix97s8/lVA=";
   };
 
-  executable = "clj-kondo";
-
   extraNativeImageBuildArgs = [
     "-H:+ReportExceptionStackTraces"
     "--verbose"

--- a/pkgs/development/tools/clj-kondo/default.nix
+++ b/pkgs/development/tools/clj-kondo/default.nix
@@ -11,7 +11,6 @@ buildGraalvmNativeImage rec {
 
   extraNativeImageBuildArgs = [
     "-H:+ReportExceptionStackTraces"
-    "--verbose"
     "--no-fallback"
   ];
 

--- a/pkgs/development/tools/clj-kondo/default.nix
+++ b/pkgs/development/tools/clj-kondo/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, lib, graalvm11-ce, fetchurl }:
+{ lib, buildGraalvmNativeImage, fetchurl }:
 
-stdenv.mkDerivation rec {
+buildGraalvmNativeImage rec {
   pname = "clj-kondo";
   version = "2021.10.19";
 
@@ -9,38 +9,18 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-i0OeQPZfQPUeXC/Bs84I91IahBKK6W1mFix97s8/lVA=";
   };
 
-  dontUnpack = true;
+  executable = "clj-kondo";
 
-  buildInputs = [ graalvm11-ce ];
-
-  buildPhase = ''
-    runHook preBuild
-
-    # https://github.com/clj-kondo/clj-kondo/blob/v2021.10.19/script/compile#L17-L21
-    args=("-jar" "$src"
-          "-H:CLibraryPath=${graalvm11-ce.lib}/lib"
-          # Required to build babashka on darwin. Do not remove.
-          "${lib.optionalString stdenv.isDarwin "-H:-CheckToolchain"}"
-          "-H:+ReportExceptionStackTraces"
-          "--verbose"
-          "--no-fallback"
-          "-J-Xmx3g")
-
-     native-image ''${args[@]}
-
-     runHook postBuild
-  '';
-
-  installPhase = ''
-    mkdir -p $out/bin
-    cp clj-kondo $out/bin/clj-kondo
-  '';
+  extraNativeImageBuildArgs = [
+    "-H:+ReportExceptionStackTraces"
+    "--verbose"
+    "--no-fallback"
+  ];
 
   meta = with lib; {
     description = "A linter for Clojure code that sparks joy";
     homepage = "https://github.com/clj-kondo/clj-kondo";
     license = licenses.epl10;
-    platforms = graalvm11-ce.meta.platforms;
     maintainers = with maintainers; [ jlesquembre bandresen thiagokokada ];
   };
 }

--- a/pkgs/development/tools/jet/default.nix
+++ b/pkgs/development/tools/jet/default.nix
@@ -22,7 +22,6 @@ buildGraalvmNativeImage rec {
     "-H:ReflectionConfigurationFiles=${reflectionJson}"
     "--initialize-at-build-time"
     "-H:Log=registerResource:"
-    "--verbose"
     "--no-fallback"
     "--no-server"
   ];

--- a/pkgs/development/tools/jet/default.nix
+++ b/pkgs/development/tools/jet/default.nix
@@ -14,8 +14,6 @@ buildGraalvmNativeImage rec {
     sha256 = "sha256-mOUiKEM5tYhtpBpm7KtslyPYFsJ+Wr+4ul6Zi4aS09Q=";
   };
 
-  executable = "jet";
-
   extraNativeImageBuildArgs = [
     "-H:+ReportExceptionStackTraces"
     "-J-Dclojure.spec.skip-macros=true"

--- a/pkgs/development/tools/jet/default.nix
+++ b/pkgs/development/tools/jet/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, lib, graalvm11-ce, fetchurl }:
+{ lib, buildGraalvmNativeImage, fetchurl }:
 
-stdenv.mkDerivation rec {
+buildGraalvmNativeImage rec {
   pname = "jet";
   version = "0.1.0";
 
@@ -14,46 +14,25 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-mOUiKEM5tYhtpBpm7KtslyPYFsJ+Wr+4ul6Zi4aS09Q=";
   };
 
-  dontUnpack = true;
+  executable = "jet";
 
-  buildInputs = [ graalvm11-ce ];
-
-  buildPhase = ''
-    runHook preBuild
-
-    # https://github.com/borkdude/jet/blob/v0.1.0/script/compile#L16-L29
-    args=("-jar" "$src"
-          "-H:CLibraryPath=${graalvm11-ce.lib}/lib"
-          # Required to build jet on darwin. Do not remove.
-          "${lib.optionalString stdenv.isDarwin "-H:-CheckToolchain"}"
-          "-H:Name=jet"
-          "-H:+ReportExceptionStackTraces"
-          "-J-Dclojure.spec.skip-macros=true"
-          "-J-Dclojure.compiler.direct-linking=true"
-          "-H:IncludeResources=JET_VERSION"
-          "-H:ReflectionConfigurationFiles=${reflectionJson}"
-          "--initialize-at-build-time"
-          "-H:Log=registerResource:"
-          "--verbose"
-          "--no-fallback"
-          "--no-server"
-          "-J-Xmx3g")
-
-     native-image ''${args[@]}
-
-     runHook postBuild
-  '';
-
-  installPhase = ''
-    mkdir -p $out/bin
-    cp jet $out/bin/jet
-  '';
+  extraNativeImageBuildArgs = [
+    "-H:+ReportExceptionStackTraces"
+    "-J-Dclojure.spec.skip-macros=true"
+    "-J-Dclojure.compiler.direct-linking=true"
+    "-H:IncludeResources=JET_VERSION"
+    "-H:ReflectionConfigurationFiles=${reflectionJson}"
+    "--initialize-at-build-time"
+    "-H:Log=registerResource:"
+    "--verbose"
+    "--no-fallback"
+    "--no-server"
+  ];
 
   meta = with lib; {
     description = "CLI to transform between JSON, EDN and Transit, powered with a minimal query language";
     homepage = "https://github.com/borkdude/jet";
     license = licenses.epl10;
-    platforms = graalvm11-ce.meta.platforms;
     maintainers = with maintainers; [ ericdallo ];
   };
 }

--- a/pkgs/development/tools/misc/clojure-lsp/default.nix
+++ b/pkgs/development/tools/misc/clojure-lsp/default.nix
@@ -16,8 +16,6 @@ buildGraalvmNativeImage rec {
     sha256 = "sha256-k0mzibcLAspklCPE6f2qsUm9bwSvcJRgWecMBq7mpF0=";
   };
 
-  executable = "clojure-lsp";
-
   # https://github.com/clojure-lsp/clojure-lsp/blob/2021.11.02-15.24.47/graalvm/native-unix-compile.sh#L18-L27
   DTLV_LIB_EXTRACT_DIR = "/tmp";
 
@@ -33,8 +31,8 @@ buildGraalvmNativeImage rec {
     runHook preCheck
 
     export HOME="$(mktemp -d)"
-    ./${executable} --version | fgrep -q '${version}'
-    ${babashka}/bin/bb integration-test ./${executable}
+    ./${pname} --version | fgrep -q '${version}'
+    ${babashka}/bin/bb integration-test ./${pname}
 
     runHook postCheck
   '';

--- a/pkgs/development/tools/misc/clojure-lsp/default.nix
+++ b/pkgs/development/tools/misc/clojure-lsp/default.nix
@@ -21,7 +21,6 @@ buildGraalvmNativeImage rec {
 
   extraNativeImageBuildArgs = [
     "-H:CLibraryPath=${DTLV_LIB_EXTRACT_DIR}"
-    "--verbose"
     "--no-fallback"
     "--native-image-info"
   ];

--- a/pkgs/development/tools/misc/clojure-lsp/default.nix
+++ b/pkgs/development/tools/misc/clojure-lsp/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, graalvm11-ce, babashka, fetchurl, fetchFromGitHub, clojure, writeScript }:
+{ lib, stdenv, buildGraalvmNativeImage, graalvm11-ce, babashka, fetchurl, fetchFromGitHub, clojure, writeScript }:
 
-stdenv.mkDerivation rec {
+buildGraalvmNativeImage rec {
   pname = "clojure-lsp";
   version = "2021.11.02-15.24.47";
 
@@ -16,39 +16,17 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-k0mzibcLAspklCPE6f2qsUm9bwSvcJRgWecMBq7mpF0=";
   };
 
-  GRAALVM_HOME = graalvm11-ce;
-  CLOJURE_LSP_JAR = jar;
-  CLOJURE_LSP_XMX = "-J-Xmx6g";
+  extraNativeImageBuildArgs = [
+    "-H:CLibraryPath=$DTLV_LIB_EXTRACT_DIR"
+    "--verbose"
+    "--no-fallback"
+    "--native-image-info"
+  ];
 
-  buildInputs = [ graalvm11-ce clojure ];
-
-  buildPhase = with lib; ''
-    runHook preBuild
-
+  preBuild = ''
     # https://github.com/clojure-lsp/clojure-lsp/blob/2021.11.02-15.24.47/graalvm/native-unix-compile.sh#L18-L27
     DTLV_LIB_EXTRACT_DIR=$(mktemp -d)
     export DTLV_LIB_EXTRACT_DIR=$DTLV_LIB_EXTRACT_DIR
-
-    args=("-jar" "$CLOJURE_LSP_JAR"
-          "-H:+ReportExceptionStackTraces"
-          "-H:CLibraryPath=${graalvm11-ce.lib}/lib"
-          "-H:CLibraryPath=$DTLV_LIB_EXTRACT_DIR"
-          "--verbose"
-          "--no-fallback"
-          "--native-image-info"
-          "$CLOJURE_LSP_XMX")
-
-    native-image ''${args[@]}
-
-    runHook postBuild
-  '';
-
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm755 ./clojure-lsp $out/bin/clojure-lsp
-
-    runHook postInstall
   '';
 
   doCheck = true;
@@ -88,7 +66,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/clojure-lsp/clojure-lsp";
     license = licenses.mit;
     maintainers = with maintainers; [ ericdallo babariviere ];
-    platforms = graalvm11-ce.meta.platforms;
     # Depends on datalevin that is x86_64 only
     # https://github.com/juji-io/datalevin/blob/bb7d9328f4739cddea5d272b5cd6d6dcb5345da6/native/src/java/datalevin/ni/Lib.java#L86-L102
     broken = !stdenv.isx86_64;

--- a/pkgs/development/tools/misc/clojure-lsp/default.nix
+++ b/pkgs/development/tools/misc/clojure-lsp/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, buildGraalvmNativeImage, graalvm11-ce, babashka, fetchurl, fetchFromGitHub, clojure, writeScript }:
+{ lib, stdenv, buildGraalvmNativeImage, babashka, fetchurl, fetchFromGitHub, clojure, writeScript }:
 
 buildGraalvmNativeImage rec {
   pname = "clojure-lsp";
@@ -16,26 +16,25 @@ buildGraalvmNativeImage rec {
     sha256 = "sha256-k0mzibcLAspklCPE6f2qsUm9bwSvcJRgWecMBq7mpF0=";
   };
 
+  executable = "clojure-lsp";
+
+  # https://github.com/clojure-lsp/clojure-lsp/blob/2021.11.02-15.24.47/graalvm/native-unix-compile.sh#L18-L27
+  DTLV_LIB_EXTRACT_DIR = "/tmp";
+
   extraNativeImageBuildArgs = [
-    "-H:CLibraryPath=$DTLV_LIB_EXTRACT_DIR"
+    "-H:CLibraryPath=${DTLV_LIB_EXTRACT_DIR}"
     "--verbose"
     "--no-fallback"
     "--native-image-info"
   ];
-
-  preBuild = ''
-    # https://github.com/clojure-lsp/clojure-lsp/blob/2021.11.02-15.24.47/graalvm/native-unix-compile.sh#L18-L27
-    DTLV_LIB_EXTRACT_DIR=$(mktemp -d)
-    export DTLV_LIB_EXTRACT_DIR=$DTLV_LIB_EXTRACT_DIR
-  '';
 
   doCheck = true;
   checkPhase = ''
     runHook preCheck
 
     export HOME="$(mktemp -d)"
-    ./clojure-lsp --version | fgrep -q '${version}'
-    ${babashka}/bin/bb integration-test ./clojure-lsp
+    ./${executable} --version | fgrep -q '${version}'
+    ${babashka}/bin/bb integration-test ./${executable}
 
     runHook postCheck
   '';

--- a/pkgs/development/tools/zprint/default.nix
+++ b/pkgs/development/tools/zprint/default.nix
@@ -1,40 +1,22 @@
-{ stdenv, lib, fetchurl, graalvm11-ce, glibcLocales }:
+{ lib, buildGraalvmNativeImage, fetchurl  }:
 
-stdenv.mkDerivation rec {
+buildGraalvmNativeImage rec {
   pname = "zprint";
   version = "1.1.2";
 
   src = fetchurl {
-    url =
-      "https://github.com/kkinnear/${pname}/releases/download/${version}/${pname}-filter-${version}";
+    url = "https://github.com/kkinnear/${pname}/releases/download/${version}/${pname}-filter-${version}";
     sha256 = "1wh8jyj7alfa6h0cycfwffki83wqb5d5x0p7kvgdkhl7jx7isrwj";
   };
 
-  dontUnpack = true;
-
-  LC_ALL = "en_US.UTF-8";
-  nativeBuildInputs = [ graalvm11-ce glibcLocales ];
-
-  buildPhase = ''
-    native-image \
-    --no-server \
-    -J-Xmx7G \
-    -J-Xms4G \
-    -jar ${src} \
-    -H:Name=${pname} \
-    -H:EnableURLProtocols=https,http \
-    -H:+ReportExceptionStackTraces \
-    -H:CLibraryPath=${graalvm11-ce.lib}/lib \
-    ${lib.optionalString stdenv.isDarwin ''-H:-CheckToolchain''} \
-    --report-unsupported-elements-at-runtime \
-    --initialize-at-build-time \
-    --no-fallback
-  '';
-
-  installPhase = ''
-    mkdir -p $out/bin
-    install ${pname} $out/bin
-  '';
+  extraNativeImageBuildArgs = [
+    "--no-server"
+    "-H:EnableURLProtocols=https,http"
+    "-H:+ReportExceptionStackTraces"
+    "--report-unsupported-elements-at-runtime"
+    "--initialize-at-build-time"
+    "--no-fallback"
+  ];
 
   meta = with lib; {
     description = "Clojure/EDN source code formatter and pretty printer";
@@ -45,7 +27,6 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/kkinnear/zprint";
     license = licenses.mit;
-    platforms = graalvm11-ce.meta.platforms;
     maintainers = with maintainers; [ stelcodes ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12322,6 +12322,7 @@ with pkgs;
     });
   graalvm11-ce = graalvmCEPackages.graalvm11-ce;
   graalvm17-ce = graalvmCEPackages.graalvm17-ce;
+  buildGraalvmNativeImage = callPackage ../build-support/build-graalvm-native-image { };
 
   inherit (callPackages ../development/compilers/graalvm/enterprise-edition.nix { })
     graalvm8-ee


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Backport of https://github.com/NixOS/nixpkgs/pull/147136 to release 21.11.

I initially was not sure if I should backport it, however this PR only affects leaf packages and without it this will make much more difficult to backport GraalVM packages from master to release-21.11.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
