### PR TITLE
dhcpcd: 8.1.4 -> 9.4.1, module updates, enable privsep

### DIFF
--- a/nixos/modules/services/networking/dhcpcd.nix
+++ b/nixos/modules/services/networking/dhcpcd.nix
@@ -214,11 +214,11 @@ in
           };
       };
 
-    users.users._dhcpcd = {
+    users.users.dhcpcd = {
       isSystemUser = true;
-      group = "_dhcpcd";
+      group = "dhcpcd";
     };
-    users.groups._dhcpcd = {};
+    users.groups.dhcpcd = {};
 
     environment.systemPackages = [ dhcpcd ];
 

--- a/nixos/modules/services/networking/dhcpcd.nix
+++ b/nixos/modules/services/networking/dhcpcd.nix
@@ -214,6 +214,12 @@ in
           };
       };
 
+    users.users._dhcpcd = {
+      isSystemUser = true;
+      group = "_dhcpcd";
+    };
+    users.groups._dhcpcd = {};
+
     environment.systemPackages = [ dhcpcd ];
 
     environment.etc."dhcpcd.exit-hook".source = exitHook;

--- a/nixos/modules/services/networking/dhcpcd.nix
+++ b/nixos/modules/services/networking/dhcpcd.nix
@@ -207,7 +207,7 @@ in
 
         serviceConfig =
           { Type = "forking";
-            PIDFile = "/run/dhcpcd.pid";
+            PIDFile = "/run/dhcpcd/pid";
             ExecStart = "@${dhcpcd}/sbin/dhcpcd dhcpcd --quiet ${optionalString cfg.persistent "--persistent"} --config ${dhcpcdConf}";
             ExecReload = "${dhcpcd}/sbin/dhcpcd --rebind";
             Restart = "always";

--- a/nixos/modules/services/networking/dhcpcd.nix
+++ b/nixos/modules/services/networking/dhcpcd.nix
@@ -208,6 +208,7 @@ in
         serviceConfig =
           { Type = "forking";
             PIDFile = "/run/dhcpcd/pid";
+            RuntimeDirectory = "dhcpcd";
             ExecStart = "@${dhcpcd}/sbin/dhcpcd dhcpcd --quiet ${optionalString cfg.persistent "--persistent"} --config ${dhcpcdConf}";
             ExecReload = "${dhcpcd}/sbin/dhcpcd --rebind";
             Restart = "always";

--- a/pkgs/tools/networking/dhcpcd/default.nix
+++ b/pkgs/tools/networking/dhcpcd/default.nix
@@ -37,8 +37,8 @@ stdenv.mkDerivation rec {
   ++ lib.optionals enablePrivSep [
     "--enable-privsep"
     # dhcpcd disables privsep if it can't find the default user,
-    # so we explicitly specify the default.
-    "--privsepuser=_dhcpcd"
+    # so we explicitly specify a user.
+    "--privsepuser=dhcpcd"
   ];
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];

--- a/pkgs/tools/networking/dhcpcd/default.nix
+++ b/pkgs/tools/networking/dhcpcd/default.nix
@@ -1,15 +1,20 @@
-{ lib, stdenv, fetchurl, fetchpatch, pkg-config, udev, runtimeShellPackage,
-runtimeShell }:
+{ lib
+, stdenv
+, fetchurl
+, pkg-config
+, udev
+, runtimeShellPackage
+, runtimeShell
+, nixosTests
+}:
 
 stdenv.mkDerivation rec {
-  # when updating this to >=7, check, see previous reverts:
-  # nix-build -A nixos.tests.networking.scripted.macvlan.x86_64-linux nixos/release-combined.nix
   pname = "dhcpcd";
-  version = "8.1.4";
+  version = "9.4.1";
 
   src = fetchurl {
     url = "mirror://roy/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "0gf1qif25wy5lffzw39pi4sshmpxz1f4a1m9sglj7am1gaix3817";
+    sha256 = "sha256-gZNXY07+0epc9E7AGyTT0/iFL+yLQkmSXcxWZ8VON2w=";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -21,14 +26,6 @@ stdenv.mkDerivation rec {
   prePatch = ''
     substituteInPlace hooks/dhcpcd-run-hooks.in --replace /bin/sh ${runtimeShell}
   '';
-
-  patches = [
-    (fetchpatch {
-      name = "?id=114870290a8d3d696bc4049c32eef3eed03d6070";
-      url = "https://roy.marples.name/git/dhcpcd/commitdiff_plain/114870290a8d3d696bc4049c32eef3eed03d6070";
-      sha256 = "0kzpwjh2gzvl5lvlnw6lis610p67nassk3apns68ga2pyxlky8qb";
-    })
-  ];
 
   preConfigure = "patchShebangs ./configure";
 
@@ -45,6 +42,8 @@ stdenv.mkDerivation rec {
 
   # Check that the udev plugin got built.
   postInstall = lib.optionalString (udev != null) "[ -e ${placeholder "out"}/lib/dhcpcd/dev/udev.so ]";
+
+  passthru.tests = { inherit (nixosTests.networking.scripted) macvlan dhcpSimple dhcpOneIf; };
 
   meta = with lib; {
     description = "A client for the Dynamic Host Configuration Protocol (DHCP)";

--- a/pkgs/tools/networking/dhcpcd/default.nix
+++ b/pkgs/tools/networking/dhcpcd/default.nix
@@ -6,6 +6,7 @@
 , runtimeShellPackage
 , runtimeShell
 , nixosTests
+, enablePrivSep ? true
 }:
 
 stdenv.mkDerivation rec {
@@ -32,6 +33,12 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--sysconfdir=/etc"
     "--localstatedir=/var"
+  ]
+  ++ lib.optionals enablePrivSep [
+    "--enable-privsep"
+    # dhcpcd disables privsep if it can't find the default user,
+    # so we explicitly specify the default.
+    "--privsepuser=_dhcpcd"
   ];
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];


### PR DESCRIPTION
###### Motivation for this change

@erictapen can't continue with #116220. also having privsep in dhcpcd would be nice, since it's been enabled for quite a while on other distros with no apparent ill effects.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
