### PR TITLE
protonvpn-gui-legacy: init at 2.1.1

### DIFF
--- a/pkgs/applications/networking/protonvpn-gui-legacy/default.nix
+++ b/pkgs/applications/networking/protonvpn-gui-legacy/default.nix
@@ -1,0 +1,97 @@
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, copyDesktopItems
+, makeDesktopItem
+, wrapGAppsHook
+, gobject-introspection
+, imagemagick
+, libappindicator-gtk3
+, libnotify
+, procps
+, protonvpn-cli
+, openvpn
+# Python libraries
+, configparser
+, pycairo
+, pygobject3
+, requests }:
+
+buildPythonApplication rec {
+  pname = "protonvpn-gui-legacy";
+  version = "2.1.1";
+
+  src = fetchFromGitHub {
+    owner = "calexandru2018";
+    repo = "linux-gui-legacy";
+    rev = "v${version}";
+    sha256 = "avo5/2eq53HSHCnnjtxrsmpURtHvxmLZn2BxActImGY=";
+  };
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "ProtonVPN";
+      desktopName = "ProtonVPN GUI";
+      type = "Application";
+      exec = "protonvpn-gui";
+      icon = "protonvpn";
+      categories = "Network;";
+      terminal = "false";
+    })
+    (makeDesktopItem {
+      name = "ProtonVPN Tray";
+      desktopName = "ProtonVPN Tray";
+      type = "Application";
+      exec = "protonvpn-tray";
+      icon = "protonvpn";
+      categories = "Network;";
+      terminal = "false";
+    })
+  ];
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    gobject-introspection
+    imagemagick
+    wrapGAppsHook
+  ];
+
+  propagatedBuildInputs = [
+    configparser
+    # Although built as an Python application, it is also a package,
+    # hence it is needed here
+    protonvpn-cli
+    pycairo
+    pygobject3
+    requests
+  ];
+
+  buildInputs = [
+    gobject-introspection
+    libnotify
+    libappindicator-gtk3
+    procps
+    openvpn
+  ];
+
+  postInstall = ''
+    # create icons
+    for size in 16 32 48 64 72 96 128 192 512 1024; do
+      mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+      convert -resize "$size"x"$size" \
+        linux_gui/resources/img/logo/protonvpn_logo.png \
+        $out/share/icons/hicolor/"$size"x"$size"/apps/protonvpn.png
+    done
+  '';
+
+  # No tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "GTK3 GUI client with systray, for ProtonVPN (legacy)";
+    homepage = "https://github.com/calexandru2018/linux-gui-legacy";
+    maintainers = with maintainers; [ offline wolfangaukang ];
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27729,6 +27729,8 @@ with pkgs;
 
   protonvpn-gui = callPackage ../applications/networking/protonvpn-gui { };
 
+  protonvpn-gui-legacy = python3Packages.callPackage ../applications/networking/protonvpn-gui-legacy { };
+
   ps2client = callPackage ../applications/networking/ps2client { };
 
   psi = libsForQt5.callPackage ../applications/networking/instant-messengers/psi { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Recovering the old client overwritten by #142637 and renaming it as legacy. Although this old application, besides discontinued and with bugs as it does not show the full list of servers (unless you use a free account, which only shows 3 servers) and some features aren't even enabled, can be available on Nixpkgs.

Also improved the packaging method.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
