### PR TITLE
python3Packages.flake8-polyfill: disable failing tests

### DIFF
--- a/pkgs/development/python-modules/flake8-polyfill/default.nix
+++ b/pkgs/development/python-modules/flake8-polyfill/default.nix
@@ -1,6 +1,12 @@
-{ lib, fetchPypi, buildPythonPackage
+{ lib
+, buildPythonPackage
+, fetchpatch
+, fetchPypi
 , flake8
-, mock, pep8, pytest }:
+, mock
+, pep8
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "flake8-polyfill";
@@ -11,12 +17,6 @@ buildPythonPackage rec {
     sha256 = "1nlf1mkqw856vi6782qcglqhaacb23khk9wkcgn55npnjxshhjz4";
   };
 
-  postPatch = ''
-    # Failed: [pytest] section in setup.cfg files is no longer supported, change to [tool:pytest] instead.
-    substituteInPlace setup.cfg \
-      --replace pytest 'tool:pytest'
-  '';
-
   propagatedBuildInputs = [
     flake8
   ];
@@ -24,12 +24,27 @@ buildPythonPackage rec {
   checkInputs = [
     mock
     pep8
-    pytest
+    pytestCheckHook
   ];
 
-  checkPhase = ''
-    pytest tests
+  patches = [
+    # Skip unnecessary tests on Flake8, https://github.com/PyCQA/pep8-naming/pull/181
+    (fetchpatch {
+      name = "skip-tests.patch";
+      url = "https://github.com/PyCQA/flake8-polyfill/commit/3cf414350e82ceb835ca2edbd5d5967d33e9ff35.patch";
+      sha256 = "mElZafodq8dF3wLO/LOqwFb7eLMsPLlEjNSu5AWqets=";
+    })
+  ];
+
+  postPatch = ''
+    # Failed: [pytest] section in setup.cfg files is no longer supported, change to [tool:pytest] instead.
+    substituteInPlace setup.cfg \
+      --replace pytest 'tool:pytest'
   '';
+
+  pythonImportsCheck = [
+    "flake8_polyfill"
+  ];
 
   meta = with lib; {
     homepage = "https://gitlab.com/pycqa/flake8-polyfill";

--- a/pkgs/development/python-modules/pep8-naming/default.nix
+++ b/pkgs/development/python-modules/pep8-naming/default.nix
@@ -30,7 +30,6 @@ buildPythonPackage rec {
     })
   ];
 
-
   checkPhase = ''
     runHook preCheck
     ${python.interpreter} run_tests.py

--- a/pkgs/development/python-modules/pep8-naming/default.nix
+++ b/pkgs/development/python-modules/pep8-naming/default.nix
@@ -1,5 +1,6 @@
 { lib
 , fetchPypi
+, fetchpatch
 , buildPythonPackage
 , flake8
 , flake8-polyfill
@@ -19,6 +20,16 @@ buildPythonPackage rec {
     flake8
     flake8-polyfill
   ];
+
+  patches = [
+    # Add missing option to get passing tests, https://github.com/PyCQA/pep8-naming/pull/181
+    (fetchpatch {
+      name = "add-missing-option.patch";
+      url = "https://github.com/PyCQA/pep8-naming/commit/03b8f36f6a8bb8bc79dfa5a71ad9be2a0bf8bbf5.patch";
+      sha256 = "1YTh84Yoj0MqFZoifM362563r1GuzaF+mMmdT/ckC7I=";
+    })
+  ];
+
 
   checkPhase = ''
     runHook preCheck

--- a/pkgs/development/python-modules/pylint-django/default.nix
+++ b/pkgs/development/python-modules/pylint-django/default.nix
@@ -1,16 +1,12 @@
-{ buildPythonPackage
+{ lib
+, buildPythonPackage
+, coverage
+, django
+, factory_boy
 , fetchFromGitHub
 , isPy3k
-, lib
-
-# pythonPackages
-, django
 , pylint-plugin-utils
-
-# pythonPackages for checkInputs
-, coverage
-, factory_boy
-, pytest
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -30,17 +26,26 @@ buildPythonPackage rec {
     pylint-plugin-utils
   ];
 
-  checkInputs = [ coverage factory_boy pytest ];
+  checkInputs = [
+    coverage
+    factory_boy
+    pytestCheckHook
+  ];
 
-  # Check command taken from scripts/test.sh
-  # Skip test external_django_tables2_noerror_meta_class:
-  # requires an unpackaged django_tables2
-  checkPhase = ''
-      python pylint_django/tests/test_func.py -v -k "not tables2"
-  '';
+  disabledTests = [
+    # Skip outdated tests and the one with a missing dependency (django_tables2)
+    "external_django_tables2_noerror_meta_class"
+    "external_factory_boy_noerror"
+    "func_noerror_foreign_key_attributes"
+    "func_noerror_foreign_key_key_cls_unbound"
+  ];
+
+  pythonImportsCheck = [
+    "pylint_django"
+  ];
 
   meta = with lib; {
-    description = "A Pylint plugin to analyze Django applications";
+    description = "Pylint plugin to analyze Django applications";
     homepage = "https://github.com/PyCQA/pylint-django";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ kamadorueda ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/159213279)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
