### PR TITLE
python3Packages.monai: init at 0.8.0

### DIFF
--- a/pkgs/development/python-modules/monai/default.nix
+++ b/pkgs/development/python-modules/monai/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, ninja
+, ignite
+, numpy
+, pybind11
+, pytorch
+, which
+}:
+
+buildPythonPackage rec {
+  pname = "monai";
+  version = "0.8.0";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "Project-MONAI";
+    repo = pname;
+    rev = version;
+    sha256 = "08ji79ygrc90alak4q0nycm8wybkygyq22splagp6m256dmc1jhk";
+  };
+
+  # Ninja is not detected by setuptools here for some reason
+  patchPhase = ''
+    substituteInPlace "setup.cfg" --replace "ninja" ""
+  '';
+
+  preBuild = ''
+    export MAX_JOBS=$NIX_BUILD_CORES
+  '';
+
+  # note CUDA extensions will not be built if CUDA is not present
+  BUILD_MONAI = 1;
+
+  nativeBuildInputs = [ ninja which ];
+  buildInputs = [ pybind11 ];
+  propagatedBuildInputs = [ ignite numpy pytorch ];
+
+  doCheck = false;  # takes too long, numerous dependencies
+  pythonImportsCheck = [
+    "monai"
+    "monai.apps"
+    "monai.data"
+    "monai.engines"
+    "monai.handlers"
+    "monai.inferers"
+    "monai.losses"
+    "monai.metrics"
+    "monai.optimizers"
+    "monai.networks"
+    "monai.transforms"
+    "monai.utils"
+    "monai.visualize"
+  ];
+
+  meta = with lib; {
+    description = "Pytorch framework for deep learning in medical imaging";
+    homepage = "https://monai.io";
+    license = licenses.asl20;
+    maintainers = [ maintainers.bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4899,6 +4899,8 @@ in {
 
   mohawk = callPackage ../development/python-modules/mohawk { };
 
+  monai = callPackage ../development/python-modules/monai { };
+
   mongodict = callPackage ../development/python-modules/mongodict { };
 
   mongoengine = callPackage ../development/python-modules/mongoengine { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add a package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [NA] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [NA] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
