### PR TITLE
probe-run: 0.3.0 -> 0.3.1

### DIFF
--- a/pkgs/development/tools/rust/probe-run/default.nix
+++ b/pkgs/development/tools/rust/probe-run/default.nix
@@ -1,18 +1,16 @@
-{ lib, stdenv, rustPlatform, fetchFromGitHub, pkg-config, libusb1
+{ lib, stdenv, rustPlatform, fetchCrate, pkg-config, libusb1
 , libiconv, AppKit, IOKit }:
 
 rustPlatform.buildRustPackage rec {
   pname = "probe-run";
-  version = "0.3.0";
+  version = "0.3.1";
 
-  src = fetchFromGitHub {
-    owner = "knurling-rs";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "0qlpvy62wqc8k9sww6pbiqv0yrjwpnai1vgrijw5285qpvrdsdw2";
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "1nfbpdx378p988q75hka9r8zp3xb9zy3dnagcxmha6dca5dhgsdm";
   };
 
-  cargoSha256 = "10ybgzvv2iy5bjmmw48gmgvsx6rfqclsysyfbhd820dg2lshgi44";
+  cargoSha256 = "05p3vmar00215x4mwsvs5knf4wrwmpq52rmbbi6b4qaqs3gqaghy";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libusb1 ]


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update probe-run, a tool for running embedded rust binaries.

Changelog: https://github.com/knurling-rs/probe-run/blob/v0.3.1/CHANGELOG.md

I also changed from `fetchFromGitHub` to `fetchCrate` because `Cargo.lock` is out of sync with `Cargo.toml` for the `0.3.1` release on github, and the build fails.  The `Cargo.lock` file is up to date for the crates.io release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Tested with a STM32WL5x microcontroller.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
