### PR TITLE
gnomeExtensions.pop-shell: init

### DIFF
--- a/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
+++ b/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
@@ -15,6 +15,7 @@
   "no-title-bar@jonaspoehler.de" = callPackage ./no-title-bar { };
   "paperwm@hedning:matrix.org" = callPackage ./paperwm { };
   "pidgin@muffinmad" = callPackage ./pidgin-im-integration { };
+  "pop-shell@system76.com" = callPackage ./pop-shell { };
   "sound-output-device-chooser@kgshank.net" = callPackage ./sound-output-device-chooser { };
   "system-monitor@paradoxxx.zero.gmail.com" = callPackage ./system-monitor { };
   "taskwhisperer-extension@infinicode.de" = callPackage ./taskwhisperer { };

--- a/pkgs/desktops/gnome/extensions/pop-shell/default.nix
+++ b/pkgs/desktops/gnome/extensions/pop-shell/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, lib, fetchFromGitHub, glib, nodePackages, gjs }:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-extension-pop-shell";
+  version = "unstable-2021-11-30";
+
+  src = fetchFromGitHub {
+    owner = "pop-os";
+    repo = "shell";
+    rev = "4b65ee865d01436ec75a239a0586a2fa6051b8c3";
+    sha256 = "DHmp3kzBgbyxRe0TjER/CAqyUmD9LeRqAFQ9apQDzfk=";
+  };
+
+  nativeBuildInputs = [ glib nodePackages.typescript gjs ];
+
+  buildInputs = [ gjs ];
+
+  patches = [
+    ./fix-gjs.patch
+  ];
+
+  makeFlags = [ "XDG_DATA_HOME=$(out)/share" ];
+
+  passthru = {
+    extensionUuid = "pop-shell@system76.com";
+    extensionPortalSlug = "pop-shell";
+  };
+
+  meta = with lib; {
+    description = "Keyboard-driven layer for GNOME Shell";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.genofire ];
+    homepage = "https://github.com/pop-os/shell";
+  };
+}

--- a/pkgs/desktops/gnome/extensions/pop-shell/fix-gjs.patch
+++ b/pkgs/desktops/gnome/extensions/pop-shell/fix-gjs.patch
@@ -1,0 +1,67 @@
+diff --git a/src/color_dialog/src/main.ts b/src/color_dialog/src/main.ts
+index 9522499..9911530 100644
+--- a/src/color_dialog/src/main.ts
++++ b/src/color_dialog/src/main.ts
+@@ -1,4 +1,4 @@
+-#!/usr/bin/gjs
++#!/usr/bin/env gjs
+ 
+ imports.gi.versions.Gtk = '3.0';
+ 
+@@ -84,4 +84,4 @@ function launch_color_dialog() {
+ 
+ Gtk.init(null);
+ 
+-launch_color_dialog()
+\ No newline at end of file
++launch_color_dialog()
+diff --git a/src/extension.ts b/src/extension.ts
+index 7417c46..00d5829 100644
+--- a/src/extension.ts
++++ b/src/extension.ts
+@@ -534,7 +534,7 @@ export class Ext extends Ecs.System<ExtEvent> {
+             return true
+         }
+ 
+-        const ipc = utils.async_process_ipc(["gjs", path])
++        const ipc = utils.async_process_ipc([path])
+ 
+         if (ipc) {
+             const generator = (stdout: any, res: any) => {
+diff --git a/src/floating_exceptions/src/main.ts b/src/floating_exceptions/src/main.ts
+index f298ec7..87a6bc4 100644
+--- a/src/floating_exceptions/src/main.ts
++++ b/src/floating_exceptions/src/main.ts
+@@ -1,4 +1,4 @@
+-#!/usr/bin/gjs
++#!/usr/bin/env gjs
+ 
+ imports.gi.versions.Gtk = '3.0'
+ 
+@@ -329,4 +329,4 @@ function main() {
+     Gtk.main()
+ }
+ 
+-main()
+\ No newline at end of file
++main()
+diff --git a/src/panel_settings.ts b/src/panel_settings.ts
+index 83ff56c..1bc1e98 100644
+--- a/src/panel_settings.ts
++++ b/src/panel_settings.ts
+@@ -338,7 +338,7 @@ function color_selector(ext: Ext, menu: any) {
+     color_selector_item.add_child(color_button);
+     color_button.connect('button-press-event', () => {
+         let path = Me.dir.get_path() + "/color_dialog/main.js";
+-        let resp = GLib.spawn_command_line_async(`gjs ${path}`);
++        let resp = GLib.spawn_command_line_async(path);
+         if (!resp) {
+ 
+             return null;
+@@ -353,4 +353,4 @@ function color_selector(ext: Ext, menu: any) {
+     });
+ 
+     return color_selector_item;
+-}
+\ No newline at end of file
++}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

solve #104160, #102150 and a part of #144411

 thanks @Enzime - sorry i could not wait and publish this part already in this PR.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
