### PR TITLE
gst_all_1.gst-plugins-bad: fix gcc-11 build by applying fix unconditi…

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -105,7 +105,6 @@ stdenv.mkDerivation rec {
   patches = [
     # Use pkgconfig to inject the includedirs
     ./fix_pkgconfig_includedir.patch
-  ] ++ lib.optionals stdenv.isDarwin [
     # Fix “error: cannot initialize a parameter of type 'unsigned long *' with an rvalue of type 'typename std::remove_reference<decltype(*(&opencv_dilate_erode_type))>::type *' (aka 'volatile unsigned long *')” on Darwin.
     (fetchpatch {
       url = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/commit/640a65bf966df065d41a511e2d76d1f26a2e770c.patch";


### PR DESCRIPTION
…onally

Without the change build on `gcc-11` fails as:

    $ nix build --impure --expr 'with import ./. {}; gst_all_1.gst-plugins-bad.override { stdenv = gcc11Stdenv; }' -L
    ...
    include/glib-2.0/glib/gatomic.h:113:19: error: argument 2 of '__atomic_load' must not be a pointer to a 'volatile' type
      113 |     __atomic_load (gapg_temp_atomic, &gapg_temp_newval, __ATOMIC_SEQ_CST); \
          |     ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
