### PR TITLE
qca-qt5: fix gcc-11 from upstream

### DIFF
--- a/pkgs/development/libraries/qca-qt5/default.nix
+++ b/pkgs/development/libraries/qca-qt5/default.nix
@@ -9,6 +9,14 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-wThREJq+/EYjNwmJ+uOnRb9rGss8KhOolYU5gj6XTks=";
   };
 
+  patches = [
+    # Pull upstream fix for gcc-11
+    (fetchurl {
+      url = "https://github.com/KDE/qca/commit/32275f1a74c161d2fed8c056b2dd9555687a22f2.patch";
+      sha256 = "sha256-SUH2eyzP2vH/ZjYcX8ybwiqhoTm/QjuEpTKjb2iH1No=";
+    })
+  ];
+
   buildInputs = [ openssl qtbase ];
   nativeBuildInputs = [ cmake pkg-config ];
 


### PR DESCRIPTION
Without the change build n `gcc-11` fails as:

    $ nix build --impure --expr 'with import ./. {}; qca-qt5.override { stdenv = gcc11Stdenv; }' -L
    ...
    ...gcc-11.2.0/include/c++/11.2.0/bits/stl_raw_storage_iter.h:69:22: error: expected template-name before '<' token
       69 |     : public iterator<output_iterator_tag, void, void, void, void>
          |                      ^
