### PR TITLE
qt4: pull upstream fix for gcc-11

### DIFF
--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -97,6 +97,16 @@ stdenv.mkDerivation rec {
           + "0d4a3dd61ccb156dee556c214dbe91c04d44a717/debian/patches/gcc9-qforeach.patch";
         sha256 = "0dzn6qxrgxb75rvck9kmy5gspawdn970wsjw56026dhkih8cp3pg";
       })
+
+      # Pull upstream fix for gcc-11 support.
+      (fetchpatch {
+        name = "gcc11-ptr-cmp.patch";
+        url = "https://github.com/qt/qttools/commit/7138c963f9d1258bc1b49cb4d63c3e2b7d0ccfda.patch";
+        sha256 = "1a9g05r267c94qpw3ssb6k4lci200vla3vm5hri1nna6xwdsmrhc";
+        # "src/" -> "tools/"
+        stripLen = 2;
+        extraPrefix = "tools/";
+      })
     ]
     ++ lib.optional gtkStyle (substituteAll ({
         src = ./dlopen-gtkstyle.diff;


### PR DESCRIPTION
Without the change the build on `gcc-11` fails as:

    $ nix build --impure --expr 'with import ./. {}; qt4.override { stdenv = gcc11Stdenv; }' -L
    ...
    messagemodel.cpp: In function 'int calcMergeScore(const DataModel*, const DataModel*)':
    messagemodel.cpp:186:61: error: ordered comparison of pointer with integer zero ('MessageItem*' and 'int')
      186 |                 if (c->findMessage(m->text(), m->comment()) >= 0)
          |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
