### PR TITLE
krane: 2.3.2 → 2.3.4

### DIFF
--- a/pkgs/applications/networking/cluster/krane/Gemfile.lock
+++ b/pkgs/applications/networking/cluster/krane/Gemfile.lock
@@ -9,8 +9,10 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    cgi (0.3.1)
     colorize (0.8.1)
     concurrent-ruby (1.1.9)
+    date (3.2.2)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     ejson (1.3.0)
@@ -61,10 +63,12 @@ GEM
       multi_json
       to_regexp (~> 0.2.1)
     jwt (2.3.0)
-    krane (2.3.2)
+    krane (2.3.4)
       activesupport (>= 5.0)
+      cgi
       colorize (~> 0.8)
       concurrent-ruby (~> 1.1)
+      date
       ejson (~> 1.0)
       googleauth (~> 0.8)
       jsonpath (~> 0.9.6)

--- a/pkgs/applications/networking/cluster/krane/gemset.nix
+++ b/pkgs/applications/networking/cluster/krane/gemset.nix
@@ -21,6 +21,16 @@
     };
     version = "2.8.0";
   };
+  cgi = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1vy8g58ns18x3dl566wg5rp4hymlx9584ddf75isdyig0yxjl0sn";
+      type = "gem";
+    };
+    version = "0.3.1";
+  };
   colorize = {
     groups = ["default"];
     platforms = [];
@@ -40,6 +50,16 @@
       type = "gem";
     };
     version = "1.1.9";
+  };
+  date = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0j1ghv5lqpn8jdvvci2fqvl30j4x31hhgzzc0mj54cga1sgh97n7";
+      type = "gem";
+    };
+    version = "3.2.2";
   };
   domain_name = {
     dependencies = ["unf"];
@@ -271,15 +291,15 @@
     version = "2.3.0";
   };
   krane = {
-    dependencies = ["activesupport" "colorize" "concurrent-ruby" "ejson" "googleauth" "jsonpath" "kubeclient" "oj" "statsd-instrument" "thor"];
+    dependencies = ["activesupport" "cgi" "colorize" "concurrent-ruby" "date" "ejson" "googleauth" "jsonpath" "kubeclient" "oj" "statsd-instrument" "thor"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0x908645i92w012xglc07lb6k2irn1zpzwgn1n99h2x54qk1pz4v";
+      sha256 = "07pij3z7kz7n0nvf8xwcaackck8wyjwldjva7215k2dm8csdzaih";
       type = "gem";
     };
-    version = "2.3.2";
+    version = "2.3.4";
   };
   kubeclient = {
     dependencies = ["http" "recursive-open-struct" "rest-client"];


### PR DESCRIPTION
###### Motivation for this change
Update to the latest version: https://github.com/Shopify/krane/releases/tag/v2.3.4

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).