### PR TITLE
darwin.installApplication + unpkg + unxar: init

### DIFF
--- a/pkgs/os-specific/darwin/installApplication/default.nix
+++ b/pkgs/os-specific/darwin/installApplication/default.nix
@@ -1,0 +1,43 @@
+{ cpio, fetchurl, fixDarwinDylibNames, lib, stdenvNoCC, undmg, unpkg, unzip }:
+{ description, homepage, license, maintainers, pname, sha256, url, version }:
+
+stdenvNoCC.mkDerivation rec {
+  inherit pname version;
+
+  nativeBuildInputs = [ cpio fixDarwinDylibNames undmg unpkg unzip ];
+
+  sourceRoot = ".";
+  src = fetchurl {
+    name = builtins.replaceStrings [ "%20" ] [ "-" ] (builtins.head (builtins.match ".*/([^/]+)" url));
+    inherit url sha256;
+  };
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  installPhase = ''
+      # .dmg files or compressed Applications
+      app=( ./*.app )
+      if [ ! -z "$app" ]; then
+        mkdir -p $out/Applications
+        mv -n "$app" $out/Applications/
+      fi
+
+      # .pkg files
+      if [ -d "./usr/local" ]; then
+        mv -n ./usr/local/* $out/
+      fi
+
+      if [ ! -L "./Applications" ] && [ -d "./Applications" ]; then
+        mkdir -p $out/Applications
+        mv -n ./Applications/*.app $out/Applications/
+      fi
+    '';
+
+  meta = with lib; {
+    description = description;
+    homepage = homepage;
+    license = licenses."${license}";
+    maintainers = forEach maintainers (x: maintainers."${maintainer}");
+    platforms = platforms.darwin;
+  };
+}

--- a/pkgs/tools/archivers/unpkg/default.nix
+++ b/pkgs/tools/archivers/unpkg/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenvNoCC, xar }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "unpkg";
+  version = "0.1.0";
+
+  nativeBuildInputs = [ xar ];
+  setupHook = ./setup-hook.sh;
+
+  src = ./.;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    ln -s $(command -v xar) $out/bin/xar
+  '';
+
+  meta = with lib; {
+    description = "Extract a pkg file";
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ spease ];
+  };
+}

--- a/pkgs/tools/archivers/unpkg/setup-hook.sh
+++ b/pkgs/tools/archivers/unpkg/setup-hook.sh
@@ -1,0 +1,11 @@
+unpackCmdHooks+=(_tryUnpackPkg)
+_tryUnpackPkg() {
+  if ! [[ "${curSrc}" =~ \.pkg$ ]]; then return 1; fi
+  xar --dump-header -f "${curSrc}" | grep -q "^magic:\s\+[0-9a-z]\+\s\+(OK)$"
+  [ $? -ne 0 ] && return 1
+  xar -tf "${curSrc}" | grep -q "/Payload$"
+  dir="$(mktemp -d)"
+  xar -xf "${curSrc}" -C "${dir}"
+  zcat ${dir}/*/Payload | cpio -idm --no-absolute-filenames
+  rm -rf --preserve-root "${dir}"
+}

--- a/pkgs/tools/archivers/unxar/default.nix
+++ b/pkgs/tools/archivers/unxar/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenvNoCC, xar }:
+
+stdenvNoCC.mkDerivation rec {
+  version = "0.1.0";
+  pname = "unxar";
+
+  buildInputs = [ xar ];
+  setupHook = ./setup-hook.sh;
+
+  src = ./.;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    ln -s $(command -v xar) $out/bin/xar
+  '';
+
+  meta = with lib; {
+    description = "Extract a xar file";
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ spease ];
+  };
+}

--- a/pkgs/tools/archivers/unxar/setup-hook.sh
+++ b/pkgs/tools/archivers/unxar/setup-hook.sh
@@ -1,0 +1,6 @@
+unpackCmdHooks+=(_tryUnpackXar)
+_tryUnpackXar() {
+  xar --dump-header -f "${curSrc}" | grep -q "^magic:\s\+[0-9a-z]\+\s\+(OK)$"
+  [ $? -ne 0 ] && return 1
+  xar -xf "$curSrc"
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10773,6 +10773,8 @@ with pkgs;
 
   undmg = callPackage ../tools/archivers/undmg { };
 
+  unxar = callPackage ../tools/archivers/unxar { };
+
   uptimed = callPackage ../tools/system/uptimed { };
 
   upwork = callPackage ../applications/misc/upwork { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10773,6 +10773,8 @@ with pkgs;
 
   undmg = callPackage ../tools/archivers/undmg { };
 
+  unpkg = callPackage ../tools/archivers/unpkg { };
+
   unxar = callPackage ../tools/archivers/unxar { };
 
   uptimed = callPackage ../tools/system/uptimed { };

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -199,4 +199,6 @@ impure-cmds // appleSourcePackages // chooseLibs // {
 
   discrete-scroll = callPackage ../os-specific/darwin/discrete-scroll { };
 
+  installApplication = callPackage ../os-specific/darwin/installApplication {};
+
 })


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Greatly improve ease-of-use for developing nix derivations on macOS, particularly with regards to desktop applications packaged in the typical conventions expected for non-store installation. This is intended to be an "easy path" that's as simple and minimal as possible - if someone wants to get fancy and deal with a nonstandard or more complex application, that is outside the scope of this.

This is intended to get used by as many packages as possible to rapidly increase the number of native macOS applications available under nix, perhaps even by nix newbies, so please be as critical as possible. Once merged, the interface and behavior should remain as static as possible, as later changes could require multiple packages to be refactored.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Example of usage
```
{ config, darwin }:

let
  systemLocale = config.i18n.defaultLocale or "en-US";
in
darwin.installApplication rec {
  pname = "Firefox";
  version = "94.0.2";

  url = "https://download-installer.cdn.mozilla.net/pub/firefox/releases/${version}/mac/${systemLocale}/Firefox%20${version}.dmg";
  sha256 = "Ud5k8HjzHgZOG3DxKVcbULXxHh6pHX6ymzkHkqOrGVk=";

  description = "The Firefox web browser";
  homepage = "https://www.mozilla.org/firefox";
  license = "mpl20";
  maintainers = [ "spease" ];
}
```

```
{ darwin }:

darwin.installApplication rec {
  pname = "divvy";
  version = "1.5.1";

  url = "https://mizage.com/downloads/Divvy_${version}.zip";
  sha256 = "0lwsz0ci3akd3r178h7gisjbdydcp3yv31qafqkhwksyildc88r8";

  description = "Click-and-drag popup grid window manager";
  homepage = "https://mizage.com/divvy";
  maintainers = [ "spease" ];
  license = "unfree";
}
```

```
{ darwin }:

darwin.installApplication rec {
  pname = "f.lux";
  version = "41.5";

  url = "https://justgetflux.com/mac/Flux${version}.zip";
  sha256 = "/7aSsJu7MOjnDsionAdu3oygBqvTuZB2DJIYrmZ7DPs=";

  description = "Reddens computer screen in the evening";
  homepage = "https://justgetflux.com/";
  maintainers = [ "spease" ];
  license = "free";
}
```

```
{ darwin, lib }:

darwin.installApplication rec {
  pname = "mountain-duck";
  version = "4.9.0.18884";

  url = "https://dist.mountainduck.io/Mountain%20Duck-${version}.zip";
  sha256 = "l4eFm5CxqVCeJZ4B2rLx57y4tlB5gI/E+nvfH4Ql92I=";

  description = "Lets you mount network storage as a disk";
  homepage = "https://mountainduck.io/";
  license = "unfree";
  maintainers = [ "spease" ];
}
```

```
{ darwin }:

darwin.installApplication rec {
  pname="signal-desktop";
  version="5.24.0";

  url="https://updates.signal.org/desktop/signal-desktop-mac-${version}.dmg";
  sha256="XEmK8Z4wuzfWd6YU8sNsTmKE+JzwF0EwhoKMCCoGKCM=";

  description="Private, simple, and secure messenger";
  homepage="https://www.signal.org/";
  license="free";
  maintainers="spease";
}
```