### PR TITLE
invidious/lsquic: fix build

### DIFF
--- a/pkgs/servers/invidious/lsquic.nix
+++ b/pkgs/servers/invidious/lsquic.nix
@@ -26,9 +26,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ boringssl' libevent zlib ];
 
   cmakeFlags = [
-    "-DBORINGSSL_DIR=${boringssl'}"
-    "-DBORINGSSL_LIB_crypto=${boringssl'}/lib/libcrypto.a"
-    "-DBORINGSSL_LIB_ssl=${boringssl'}/lib/libssl.a"
+    "-DBORINGSSL_DIR=${lib.getDev boringssl'}"
+    "-DBORINGSSL_LIB_crypto=${lib.getLib boringssl'}/lib/libcrypto.a"
+    "-DBORINGSSL_LIB_ssl=${lib.getLib boringssl'}/lib/libssl.a"
     "-DZLIB_LIB=${zlib}/lib/libz.so"
   ];
 
@@ -39,8 +39,8 @@ stdenv.mkDerivation rec {
 
     mkdir combinedlib
     cd combinedlib
-    ar -x ${boringssl'}/lib/libssl.a
-    ar -x ${boringssl'}/lib/libcrypto.a
+    ar -x ${lib.getLib boringssl'}/lib/libssl.a
+    ar -x ${lib.getLib boringssl'}/lib/libcrypto.a
     ar -x ../src/liblsquic/liblsquic.a
     ar rc liblsquic.a *.o
     ranlib liblsquic.a


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

boringssl deps break after #143477

ZHF: #144627

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
