### PR TITLE
llvmPackages_{8,9}.lldb: fix darwin build

### DIFF
--- a/pkgs/development/compilers/llvm/8/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/8/lldb/default.nix
@@ -23,6 +23,9 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./gnu-install-dirs.patch
+
+    # Fix darwin build
+    ./lldb-gdb-remote-no-libcompress.patch
   ];
 
   postPatch = ''
@@ -33,6 +36,9 @@ stdenv.mkDerivation rec {
       cmake/modules/LLDBStandalone.cmake
     sed -i 's,"$.LLVM_LIBRARY_DIR.",${libllvm.lib}/lib ${libclang.lib}/lib,' \
       cmake/modules/LLDBStandalone.cmake
+
+    substituteInPlace tools/CMakeLists.txt \
+      --replace "add_subdirectory(debugserver)" ""
   '';
 
   outputs = [ "out" "lib" "dev" ];
@@ -46,7 +52,11 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals stdenv.isDarwin [
     darwin.libobjc
     darwin.apple_sdk.libs.xpc
-    darwin.apple_sdk.frameworks.Foundation darwin.bootstrap_cmds darwin.apple_sdk.frameworks.Carbon darwin.apple_sdk.frameworks.Cocoa
+    darwin.apple_sdk.frameworks.Foundation
+    darwin.bootstrap_cmds
+    darwin.apple_sdk.frameworks.Carbon
+    darwin.apple_sdk.frameworks.Cocoa
+    darwin.apple_sdk.frameworks.DebugSymbols
   ];
 
   CXXFLAGS = "-fno-rtti";
@@ -55,6 +65,9 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DLLDB_INCLUDE_TESTS=${if doCheck then "YES" else "NO"}"
     "-DLLDB_CODESIGN_IDENTITY=" # codesigning makes nondeterministic
+  ] ++ lib.optionals stdenv.isDarwin [
+    # Building debugserver requires the proprietary libcompression
+    "-DLLDB_NO_DEBUGSERVER=ON"
   ] ++ lib.optionals doCheck [
     "-DLLDB_TEST_C_COMPILER=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc"
     "-DLLDB_TEST_CXX_COMPILER=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}c++"
@@ -80,7 +93,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = llvm_meta // {
-    broken = stdenv.isDarwin;
+    broken = stdenv.isDarwin && stdenv.isAarch64;
     homepage = "https://lldb.llvm.org/";
     description = "A next-generation high-performance debugger";
     longDescription = ''

--- a/pkgs/development/compilers/llvm/8/lldb/lldb-gdb-remote-no-libcompress.patch
+++ b/pkgs/development/compilers/llvm/8/lldb/lldb-gdb-remote-no-libcompress.patch
@@ -1,0 +1,30 @@
+diff -ru a/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp b/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
+--- a/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp	2019-01-09 19:46:09.000000000 -0500
++++ b/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp	2021-11-27 00:23:08.000000000 -0500
+@@ -42,11 +42,6 @@
+ #define DEBUGSERVER_BASENAME "lldb-server"
+ #endif
+ 
+-#if defined(__APPLE__)
+-#define HAVE_LIBCOMPRESSION
+-#include <compression.h>
+-#endif
+-
+ #if defined(HAVE_LIBZ)
+ #include <zlib.h>
+ #endif
+diff -ru a/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp b/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+--- a/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp	2018-12-18 18:02:50.000000000 -0500
++++ b/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp	2021-11-27 00:09:07.000000000 -0500
+@@ -37,11 +37,6 @@
+ 
+ #include "llvm/ADT/StringSwitch.h"
+ 
+-#if defined(__APPLE__)
+-#define HAVE_LIBCOMPRESSION
+-#include <compression.h>
+-#endif
+-
+ using namespace lldb;
+ using namespace lldb_private;
+ using namespace lldb_private::process_gdb_remote;

--- a/pkgs/development/compilers/llvm/9/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/9/lldb/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, llvm_meta
 , fetch
+, fetchpatch
 , cmake
 , zlib
 , ncurses
@@ -13,6 +14,7 @@
 , version
 , darwin
 , makeWrapper
+, perl
 , lit
 }:
 
@@ -25,12 +27,27 @@ stdenv.mkDerivation rec {
   patches = [
     ./procfs.patch
     ./gnu-install-dirs.patch
+
+    # Fix darwin build
+    (fetchpatch {
+      name = "lldb-use-system-debugserver-fix.patch";
+      url = "https://github.com/llvm-mirror/lldb/commit/be770754cc43da22eacdb70c6203f4582eeb011f.diff";
+      sha256 = "sha256-tKkk6sn//0Hu0nlzoKWs5fXMWc+O2JAWOEJ1ZnaLuVU=";
+      excludes = [ "packages/*" ];
+      postFetch = ''
+        substituteInPlace "$out" --replace add_lldb_tool_subdirectory add_subdirectory
+      '';
+    })
+    ./lldb-gdb-remote-no-libcompress.patch
   ];
 
   outputs = [ "out" "lib" "dev" ];
 
   nativeBuildInputs = [
     cmake python3 which swig lit makeWrapper
+  ] ++ lib.optionals stdenv.isDarwin [
+    # for scripts/generate-vers.pl
+    perl
   ];
 
   buildInputs = [
@@ -42,6 +59,7 @@ stdenv.mkDerivation rec {
     darwin.bootstrap_cmds
     darwin.apple_sdk.frameworks.Carbon
     darwin.apple_sdk.frameworks.Cocoa
+    darwin.apple_sdk.frameworks.DebugSymbols
   ];
 
   CXXFLAGS = "-fno-rtti";
@@ -52,6 +70,9 @@ stdenv.mkDerivation rec {
     "-DClang_DIR=${libclang.dev}/lib/cmake"
     "-DLLVM_EXTERNAL_LIT=${lit}/bin/lit"
     "-DLLDB_CODESIGN_IDENTITY=" # codesigning makes nondeterministic
+  ] ++ lib.optionals stdenv.isDarwin [
+    # Building debugserver requires the proprietary libcompression
+    "-DLLDB_USE_SYSTEM_DEBUGSERVER=ON"
   ] ++ lib.optionals doCheck [
     "-DLLDB_TEST_C_COMPILER=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc"
     "-DLLDB_TEST_CXX_COMPILER=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}c++"
@@ -80,7 +101,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = llvm_meta // {
-    broken = stdenv.isDarwin;
+    broken = stdenv.isDarwin && stdenv.isAarch64;
     homepage = "https://lldb.llvm.org/";
     description = "A next-generation high-performance debugger";
     longDescription = ''

--- a/pkgs/development/compilers/llvm/9/lldb/lldb-gdb-remote-no-libcompress.patch
+++ b/pkgs/development/compilers/llvm/9/lldb/lldb-gdb-remote-no-libcompress.patch
@@ -1,0 +1,17 @@
+diff -ru a/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp b/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+--- a/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp	2019-12-11 14:15:30.000000000 -0500
++++ b/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp	2021-11-26 23:44:28.000000000 -0500
+@@ -36,13 +36,6 @@
+ 
+ #include "llvm/ADT/StringSwitch.h"
+ 
+-#if defined(__APPLE__)
+-#ifndef HAVE_LIBCOMPRESSION
+-#define HAVE_LIBCOMPRESSION
+-#endif
+-#include <compression.h>
+-#endif
+-
+ using namespace lldb;
+ using namespace lldb_private;
+ using namespace lldb_private::process_gdb_remote;

--- a/pkgs/os-specific/darwin/apple-sdk-11.0/private-frameworks.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/private-frameworks.nix
@@ -18,4 +18,7 @@
 
   # Also expose CoreSymbolication; used by `root` package.
   CoreSymbolication = {};
+
+  # Also expose DebugSymbols; used by `llvmPackages_8.lldb` package.
+  DebugSymbols = {};
 }

--- a/pkgs/os-specific/darwin/apple-sdk/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/default.nix
@@ -326,7 +326,7 @@ in rec {
         "Versions/A/Frameworks/WebKitLegacy.framework/Versions/A/WebKitLegacy.tbd"
       ];
     });
-  } // lib.genAttrs [ "ContactsPersistence" "CoreSymbolication" "GameCenter" "SkyLight" "UIFoundation" ] (x: tbdOnlyFramework x {});
+  } // lib.genAttrs [ "ContactsPersistence" "CoreSymbolication" "DebugSymbols" "GameCenter" "SkyLight" "UIFoundation" ] (x: tbdOnlyFramework x {});
 
   bareFrameworks = lib.mapAttrs framework (import ./frameworks.nix {
     inherit frameworks libs;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
