### PR TITLE
blahtexml: init at 0.9+unstable=20200516

### DIFF
--- a/pkgs/tools/typesetting/tex/blahtexml/default.nix
+++ b/pkgs/tools/typesetting/tex/blahtexml/default.nix
@@ -1,0 +1,48 @@
+{ fetchFromGitHub, lib, stdenv, libiconv, texlive, xercesc }:
+
+stdenv.mkDerivation {
+  pname = "blahtexml";
+  version = "0.9+date=2020-05-16";
+
+  src = fetchFromGitHub {
+    owner = "gvanas";
+    repo = "blahtexml";
+    rev = "92f2c5ff1f2b00a541b2222facc51ec72e5f6559";
+    hash = "sha256-ts+2gWsp7+rQu1US2/qEdbttB2Ps12efTSrcioZYsmE=";
+  };
+
+  outputs = [ "out" "doc" ];
+
+  nativeBuildInputs = [ texlive.combined.scheme-full ];
+  buildInputs = [ xercesc ] ++ lib.optionals stdenv.isDarwin [ libiconv ];
+
+  buildFlags =
+    [ "doc" ] ++
+    (if stdenv.isDarwin
+     then [ "blahtex-mac" "blahtexml-mac" ]
+     else [ "blahtex-linux" "blahtexml-linux" ]);
+
+  installPhase = ''
+    install -D -t "$out/bin" blahtex blahtexml
+    install -m644 -D -t "$doc/share/doc/blahtexml" Documentation/manual.pdf
+  '';
+
+  meta = with lib; {
+    homepage = "http://gva.noekeon.org/blahtexml/";
+    description = "A TeX to MathML converter";
+    longDescription = ''
+      Blahtex is a program written in C++, which converts an equation given in
+      a syntax close to TeX into MathML. It is designed by David Harvey and is
+      aimed at supporting equations in MediaWiki.
+
+      Blahtexml is a simple extension of blahtex, written by Gilles Van Assche.
+      In addition to the functionality of blahtex, blahtexml has XML processing
+      in mind and is able to process a whole XML document into another XML
+      document. Instead of converting only one formula at a time, blahtexml can
+      convert all the formulas of the given XML file into MathML.
+    '';
+    license = licenses.bsd3;
+    maintainers = [ maintainers.xworld21 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3830,6 +3830,8 @@ with pkgs;
 
   blastem = callPackage ../misc/emulators/blastem { };
 
+  blahtexml = callPackage ../tools/typesetting/tex/blahtexml { };
+
   blueberry = callPackage ../tools/bluetooth/blueberry { };
 
   blueman = callPackage ../tools/bluetooth/blueman { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add package [blahtexml](http://gva.noekeon.org/blahtexml/).

Not sure if it works on ARM64, though.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
