### PR TITLE
wayland: fix static build 

### DIFF
--- a/pkgs/development/libraries/wayland/default.nix
+++ b/pkgs/development/libraries/wayland/default.nix
@@ -51,6 +51,10 @@ stdenv.mkDerivation rec {
 
   postPatch = lib.optionalString withDocumentation ''
     patchShebangs doc/doxygen/gen-doxygen.py
+  '' + lib.optionalString stdenv.hostPlatform.isStatic ''
+    # delete line containing os-wrappers-test, disables
+    # the building of os-wrappers-test
+    sed -i '/os-wrappers-test/d' tests/meson.build
   '';
 
   outputs = [ "out" "bin" "dev" ] ++ lib.optionals withDocumentation [ "doc" "man" ];


### PR DESCRIPTION
###### Motivation for this change
Part of a bigger project to build Qt 5 statically https://github.com/NixOS/nixpkgs/pull/136107.

###### Things done

 - ~~Introduced `NIX_MESON_DEPENDENCY_STATIC` environment variable and the corresponding patch on meson which forces it to link dependencies statically, as if you were replacing all calls of `dependency(...)` with `dependency(..., static: true)` in each `meson.build` files. `NIX_MESON_DEPENDENCY_STATIC` is set by default to true when building with `pkgsStatic` (in reality, when using the `makeStaticLibraries` stdenv adapter)~~

-  ~~Introduced `dontForceMesonStaticLinking` which allows to disable `NIX_MESON_DEPENDENCY_STATIC` when needed. Based on [this proposal](https://github.com/NixOS/nixpkgs/pull/136107#discussion_r702321626) from @symphorien.~~

- Fixed build of `pkgsStatic.wayland`
Disabled os-wrapper test because of this:

<details>

```
FAILED: tests/os-wrappers-test
x86_64-unknown-linux-musl-gcc  -o tests/os-wrappers-test tests/os-wrappers-test.p/os-wrappers-test.c.o -Wl,--as-needed -Wl,--no-undefined -Wl,--start-group tests/libtest-runner.a src/libwayland-util.a src/libwayland-private.a src/libwayland-client.a src/libwayland-server.a -pthread -ldl /nix/store/k7ghx7dlcwgwb7wzw1ph6i1d4rji53r8-libffi-static-x86_64-unknown-linux-musl-3.4.2/lib/../lib64/libffi.a -lm -Wl,--end-group
/nix/store/grhgw78bcl0gj0rjmw6rb0g9gzv8hvmm-x86_64-unknown-linux-musl-binutils-2.35.2/bin/x86_64-unknown-linux-musl-ld: /nix/store/vwvd2hv3chx4f93vqh4gjh80lkhr6028-musl-static-x86_64-unknown-linux-musl-1.2.2/lib/libc.a(epoll.lo): in function `epoll_create1':
(.text.epoll_create1+0x0): multiple definition of `epoll_create1'; tests/os-wrappers-test.p/os-wrappers-test.c.o:/build/wayland-1.19.0/build/../tests/os-wrappers-test.c:120: first defined here
collect2: error: ld returned 1 exit status
[77/86] Compiling C object tests/newsignal-test.p/.._src_wayland-server.c.o
ninja: build stopped: subcommand failed.
builder for '/nix/store/00s9qvmfvmwwr75sg653b4xs490mpwk3-wayland-static-x86_64-unknown-linux-musl-1.19.0.drv' failed with exit code 1
```

</details>

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
