### PR TITLE
glfw: 3.3.4 -> 3.3.5 and fix linkage with X11

### DIFF
--- a/pkgs/development/libraries/glfw/3.x.nix
+++ b/pkgs/development/libraries/glfw/3.x.nix
@@ -6,14 +6,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "3.3.4";
+  version = "3.3.5";
   pname = "glfw";
 
   src = fetchFromGitHub {
     owner = "glfw";
     repo = "GLFW";
     rev = version;
-    sha256 = "sha256-BP4wxjgm0x0E68tNz5eudkVUyBnXkQlP7LY3ppZunhw=";
+    sha256 = "sha256-1KkzYclOLGqiV1/8BsJ3e+pXMQ6a+sjLwZ7mjSuxxbA=";
   };
 
   patches = lib.optional waylandSupport ./wayland.patch;

--- a/pkgs/development/libraries/glfw/3.x.nix
+++ b/pkgs/development/libraries/glfw/3.x.nix
@@ -16,7 +16,9 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-1KkzYclOLGqiV1/8BsJ3e+pXMQ6a+sjLwZ7mjSuxxbA=";
   };
 
-  patches = lib.optional waylandSupport ./wayland.patch;
+  # Fix freezing on Wayland (https://github.com/glfw/glfw/pull/1711)
+  # and linkage issues on X11 (https://github.com/NixOS/nixpkgs/issues/142583)
+  patches = if waylandSupport then ./wayland.patch else ./x11.patch;
 
   propagatedBuildInputs = [ libGL ];
 

--- a/pkgs/development/libraries/glfw/x11.patch
+++ b/pkgs/development/libraries/glfw/x11.patch
@@ -1,0 +1,18 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index a0be580e..ba143851 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -219,6 +219,13 @@ if (GLFW_BUILD_X11)
+     if (NOT X11_Xshape_INCLUDE_PATH)
+         message(FATAL_ERROR "X Shape headers not found; install libxext development package")
+     endif()
++
++    target_link_libraries(glfw PRIVATE ${X11_Xrandr_LIB}
++                                       ${X11_Xinerama_LIB}
++                                       ${X11_Xkb_LIB}
++                                       ${X11_Xcursor_LIB}
++                                       ${X11_Xi_LIB}
++                                       ${X11_Xshape_LIB})
+ endif()
+ 
+ if (UNIX AND NOT APPLE)


### PR DESCRIPTION
###### Motivation for this change
Fix GH-142583 (thanks, @symphorien!), plus supersede and thus close GH-143709

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
