### PR TITLE
emacsMacport: fix aarch64-darwin

### DIFF
--- a/pkgs/applications/editors/emacs/codesign.patch
+++ b/pkgs/applications/editors/emacs/codesign.patch
@@ -1,0 +1,11 @@
+--- src/src/Makefile.in.orig	2021-11-27 15:38:14.424289798 +0100
++++ src/src/Makefile.in	2021-11-27 15:41:06.516685897 +0100
+@@ -804,6 +804,8 @@ $(lispsource)/loaddefs.el: $(VCSWITNESS)
+ ## files from loadup.el in source form.
+ 
+ bootstrap-emacs$(EXEEXT): temacs$(EXEEXT)
++	codesign -s - -f temacs
++	codesign -s - -f temacs$(EXEEXT)
+ 	$(MAKE) -C ../lisp update-subdirs
+ ifeq ($(DUMPING),unexec)
+ 	$(RUN_TEMACS) --batch $(BUILD_DETAILS) -l loadup --temacs=bootstrap

--- a/pkgs/applications/editors/emacs/macport.nix
+++ b/pkgs/applications/editors/emacs/macport.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchurl, ncurses, pkg-config, texinfo, libxml2, gnutls, gettext, autoconf, automake, jansson
-, AppKit, Carbon, Cocoa, IOKit, OSAKit, Quartz, QuartzCore, WebKit
+{ lib, stdenv, fetchurl, ncurses, pkg-config, texinfo, libxml2, gnutls, gettext, autoconf, automake, jansson, sigtool
+, AppKit, Carbon, Cocoa, IOKit, OSAKit, Quartz, QuartzCore, WebKit, UniformTypeIdentifiers
 , ImageCaptureCore, GSS, ImageIO # These may be optional
 }:
 
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ ncurses libxml2 gnutls texinfo gettext jansson
     AppKit Carbon Cocoa IOKit OSAKit Quartz QuartzCore WebKit
     ImageCaptureCore GSS ImageIO   # may be optional
-  ];
+  ] ++ lib.optionals stdenv.isAarch64 [ UniformTypeIdentifiers sigtool ];
 
   postUnpack = ''
     mv $sourceRoot $name
@@ -44,6 +44,8 @@ stdenv.mkDerivation rec {
     # extract retina image resources
     tar xfv $hiresSrc --strip 1 -C $sourceRoot
   '';
+
+  patches = lib.optional stdenv.isAarch64 ./codesign.patch;
 
   postPatch = ''
     patch -p1 < patch-mac
@@ -70,6 +72,7 @@ stdenv.mkDerivation rec {
     "--with-mac"
     "--with-modules"
     "--enable-mac-app=$$out/Applications"
+    #"--enable-mac-self-contained"
   ];
 
   CFLAGS = "-O3";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25051,7 +25051,9 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks)
       AppKit Carbon Cocoa IOKit OSAKit Quartz QuartzCore WebKit
       ImageCaptureCore GSS ImageIO;
-    stdenv = if stdenv.cc.isClang then llvmPackages_6.stdenv else stdenv;
+    UniformTypeIdentifiers = if stdenv.isAarch64 then darwin.apple_sdk.frameworks.UniformTypeIdentifiers else null;
+    sigtool = if stdenv.isAarch64 then darwin.sigtool else null;
+    stdenv = if stdenv.cc.isClang then llvmPackages_12.stdenv else stdenv;
   };
 
   emacsPackagesFor = emacs: import ./emacs-packages.nix {


### PR DESCRIPTION
###### Motivation for this change
Make emacsMacport compile under aarch64-darwin

###### Things done
emacsMacport does not currently open as gui. That's not yet fixed

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
