### PR TITLE
release-cross.nix: add jobs for missing lib.systems.examples

### DIFF
--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -134,8 +134,9 @@ in
   /* Test some cross builds on 64 bit mingw-w64 */
   crossMingwW64 = mapTestOnCross lib.systems.examples.mingwW64 windowsCommon;
 
-  /* Linux on the fuloong */
+  /* Linux on mipsel */
   fuloongminipc = mapTestOnCross lib.systems.examples.fuloongminipc linuxCommon;
+  ben-nanonote = mapTestOnCross lib.systems.examples.ben-nanonote linuxCommon;
 
   /* Javacript */
   ghcjs = mapTestOnCross lib.systems.examples.ghcjs {
@@ -146,9 +147,32 @@ in
   rpi = mapTestOnCross lib.systems.examples.raspberryPi rpiCommon;
   rpi-musl = mapTestOnCross lib.systems.examples.muslpi rpiCommon;
 
+  /* Linux on the Remarkable */
+  remarkable1 = mapTestOnCross lib.systems.examples.remarkable1 linuxCommon;
+  remarkable2 = mapTestOnCross lib.systems.examples.remarkable2 linuxCommon;
+
+  /* Linux on armv7l-hf */
+  armv7l-hf = mapTestOnCross lib.systems.examples.armv7l-hf-multiplatform linuxCommon;
+  scaleway-c1 = mapTestOnCross lib.systems.examples.scaleway-c1 linuxCommon;
+
+  pogoplug4 = mapTestOnCross lib.systems.examples.pogoplug4 linuxCommon;
+
+  /* Linux on aarch64 */
+  aarch64 = mapTestOnCross lib.systems.examples.aarch64-multiplatform linuxCommon;
   aarch64-musl = mapTestOnCross lib.systems.examples.aarch64-multiplatform-musl linuxCommon;
 
+  /* Linux on RISCV */
+  riscv64 = mapTestOnCross lib.systems.examples.riscv64 linuxCommon;
+  riscv32 = mapTestOnCross lib.systems.examples.riscv32 linuxCommon;
+
+  m68k = mapTestOnCross lib.systems.examples.m68k linuxCommon;
+  s390x = mapTestOnCross lib.systems.examples.s390x linuxCommon;
+
+  /* (Cross-compiled) Linux on x86 */
   x86_64-musl = mapTestOnCross lib.systems.examples.musl64 linuxCommon;
+  x86_64-gnu = mapTestOnCross lib.systems.examples.gnu64 linuxCommon;
+  i686-musl = mapTestOnCross lib.systems.examples.musl32 linuxCommon;
+  i686-gnu = mapTestOnCross lib.systems.examples.gnu32 linuxCommon;
 
   ppc64le = mapTestOnCross lib.systems.examples.powernv linuxCommon;
   ppc64le-musl = mapTestOnCross lib.systems.examples.musl-power linuxCommon;
@@ -159,12 +183,20 @@ in
   wasi32 = mapTestOnCross lib.systems.examples.wasi32 wasiCommon;
 
   msp430 = mapTestOnCross lib.systems.examples.msp430 embedded;
+  mmix = mapTestOnCross lib.systems.examples.mmix embedded;
+  vc4 = mapTestOnCross lib.systems.examples.vc4 embedded;
+  or1k = mapTestOnCross lib.systems.examples.or1k embedded;
   avr = mapTestOnCross lib.systems.examples.avr embedded;
   arm-embedded = mapTestOnCross lib.systems.examples.arm-embedded embedded;
-  powerpc-embedded = mapTestOnCross lib.systems.examples.ppc-embedded embedded;
+  armhf-embedded = mapTestOnCross lib.systems.examples.armhf-embedded embedded;
   aarch64-embedded = mapTestOnCross lib.systems.examples.aarch64-embedded embedded;
+  aarch64be-embedded = mapTestOnCross lib.systems.examples.aarch64be-embedded embedded;
+  powerpc-embedded = mapTestOnCross lib.systems.examples.ppc-embedded embedded;
+  powerpcle-embedded = mapTestOnCross lib.systems.examples.ppcle-embedded embedded;
   i686-embedded = mapTestOnCross lib.systems.examples.i686-embedded embedded;
   x86_64-embedded = mapTestOnCross lib.systems.examples.x86_64-embedded embedded;
+  riscv64-embedded = mapTestOnCross lib.systems.examples.riscv64 embedded;
+  riscv32-embedded = mapTestOnCross lib.systems.examples.riscv32 embedded;
 
   # TODO: fix cross compilation of nix{,Unstable} to netbsd and switch to common
   x86_64-netbsd = mapTestOnCross lib.systems.examples.x86_64-netbsd embedded;


### PR DESCRIPTION
Adding something to lib.systems.examples means that it'll be exposed via
pkgsCross to users quite prominently. As a result we should try to
provide binary cache for at least the toolchains on a best effort
basis.

This commit syncs release-cross.nix with (new?) cross targets added to
lib.systems.examples in the meantime. We for example didn't have a
prebuilt toolchain for riscv64.

Not sure if the choice of `linuxCommon` is correct everywhere.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
