### PR TITLE
udisks2 - 2.8.4 -> 2.9.4

### DIFF
--- a/pkgs/os-specific/linux/udisks/2-default.nix
+++ b/pkgs/os-specific/linux/udisks/2-default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, substituteAll, libtool, pkg-config, gettext, gnused
+{ lib, stdenv, fetchFromGitHub, substituteAll, libtool, pkg-config, gettext, gnused
 , gtk-doc, acl, systemd, glib, libatasmart, polkit, coreutils, bash, which
 , expat, libxslt, docbook_xsl, util-linux, mdadm, libgudev, libblockdev, parted
 , gobject-introspection, docbook_xml_dtd_412, docbook_xml_dtd_43, autoconf, automake
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "udisks";
-  version = "2.8.4";
+  version = "2.9.4";
 
   src = fetchFromGitHub {
     owner = "storaged-project";
     repo = "udisks";
     rev = "${pname}-${version}";
-    sha256 = "01wx2x8xyal595dhdih7rva2bz7gqzgwdp56gi0ikjdzayx17wcf";
+    sha256 = "sha256-MYQztzIyp5kh9t1bCIlj08/gaOmZfuu/ZOwo3F+rZiw=";
   };
 
   outputs = [ "out" "man" "dev" ] ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) "devdoc";
@@ -37,17 +37,11 @@ stdenv.mkDerivation rec {
         xfsprogs ntfs3g parted util-linux
       ];
     })
-
-    # Fix tests: https://github.com/storaged-project/udisks/issues/724
-    (fetchpatch {
-      url = "https://github.com/storaged-project/udisks/commit/60a0c1c967821d317046d9494e45b9a8e4e7a1c1.patch";
-      sha256 = "0rlgqsxn7rb074x6ivm0ya5lywc4llifj5br0zr31mwwckv7hsdm";
-    })
   ];
 
   nativeBuildInputs = [
     autoconf automake pkg-config libtool gettext which gobject-introspection
-    gtk-doc libxslt docbook_xml_dtd_412 docbook_xml_dtd_43 docbook_xsl
+    gtk-doc libxslt docbook_xml_dtd_412 docbook_xml_dtd_43 docbook_xsl util-linux
   ];
 
   postPatch = lib.optionalString stdenv.hostPlatform.isMusl ''

--- a/pkgs/os-specific/linux/udisks/fix-paths.patch
+++ b/pkgs/os-specific/linux/udisks/fix-paths.patch
@@ -1,16 +1,20 @@
+diff --git a/Makefile.am b/Makefile.am
+index 56922b79..697f8c6e 100644
 --- a/Makefile.am
 +++ b/Makefile.am
 @@ -1,6 +1,6 @@
  ## Process this file with automake to produce Makefile.in
  
--SHELL = /bin/bash
+-SHELL = @BASH@
 +SHELL = @bash@
  .SHELLFLAGS = -o pipefail -c
  
  PYTHON ?= python3
+diff --git a/data/80-udisks2.rules b/data/80-udisks2.rules
+index 39bfa28b..ee1ca90a 100644
 --- a/data/80-udisks2.rules
 +++ b/data/80-udisks2.rules
-@@ -17,9 +17,9 @@
+@@ -17,9 +17,9 @@ ENV{DM_UDEV_DISABLE_OTHER_RULES_FLAG}=="?*", GOTO="udisks_probe_end"
  #
  # TODO: file bug against mdadm(8) to have --export-prefix option that can be used with e.g. UDISKS_MD_MEMBER
  #
@@ -22,17 +26,37 @@
  
  LABEL="udisks_probe_end"
  
+diff --git a/modules/zram/data/udisks2-zram-setup@.service.in b/modules/zram/data/udisks2-zram-setup@.service.in
+index ac868e84..03fdd887 100644
+--- a/modules/zram/data/udisks2-zram-setup@.service.in
++++ b/modules/zram/data/udisks2-zram-setup@.service.in
+@@ -8,7 +8,7 @@ Requires=dev-%i.device
+ Type=oneshot
+ RemainAfterExit=no
+ EnvironmentFile=-@zramconfdir@/%i
+-ExecStart=-/bin/sh -c 'if [ -n "$ZRAM_NUM_STR" ]; then echo "$ZRAM_NUM_STR" > /sys/class/block/%i/max_comp_streams; fi'
+-ExecStart=-/bin/sh -c 'if [ -n "$ZRAM_DEV_SIZE" ]; then echo "$ZRAM_DEV_SIZE" > /sys/class/block/%i/disksize; fi'
+-ExecStart=-/bin/sh -c 'if [ "$SWAP" = "y" ]; then mkswap /dev/%i && swapon /dev/%i; fi'
+-# ExecStop=-/bin/sh -c 'echo 1 > /sys/class/block/%i/reset'
++ExecStart=-@sh@ -c 'if [ -n "$ZRAM_NUM_STR" ]; then echo "$ZRAM_NUM_STR" > /sys/class/block/%i/max_comp_streams; fi'
++ExecStart=-@sh@ -c 'if [ -n "$ZRAM_DEV_SIZE" ]; then echo "$ZRAM_DEV_SIZE" > /sys/class/block/%i/disksize; fi'
++ExecStart=-@sh@ -c 'if [ "$SWAP" = "y" ]; then @mkswap@ /dev/%i && @swapon@ /dev/%i; fi'
++# ExecStop=-@sh@ -c 'echo 1 > /sys/class/block/%i/reset'
+diff --git a/modules/zram/udiskslinuxmanagerzram.c b/modules/zram/udiskslinuxmanagerzram.c
+index f647f653..df81e910 100644
 --- a/modules/zram/udiskslinuxmanagerzram.c
 +++ b/modules/zram/udiskslinuxmanagerzram.c
-@@ -250,7 +250,7 @@
+@@ -243,7 +243,7 @@ create_conf_files (guint64   num_devices,
  
        g_snprintf (tmp, 255, "zram%" G_GUINT64_FORMAT, i);
        filename = g_build_filename (PACKAGE_ZRAMCONF_DIR, tmp, NULL);
--      contents = g_strdup_printf ("#!/bin/bash\n\n"
-+      contents = g_strdup_printf ("#!@bash@\n\n"
+-      contents = g_strdup_printf ("#!/bin/bash\n"
++      contents = g_strdup_printf ("#!@bash@\n"
+                                   "# UDisks2 managed ZRAM configuration\n\n"
                                    "ZRAM_NUM_STR=%" G_GUINT64_FORMAT "\n"
                                    "ZRAM_DEV_SIZE=%" G_GUINT64_FORMAT "\n"
-                                   "SWAP=n\n",
+diff --git a/src/tests/install-udisks/runtest.sh b/src/tests/install-udisks/runtest.sh
+index e7df4ed2..ab4356d9 100644
 --- a/src/tests/install-udisks/runtest.sh
 +++ b/src/tests/install-udisks/runtest.sh
 @@ -1,4 +1,4 @@
@@ -41,18 +65,11 @@
  # vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
  # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  #
+diff --git a/src/tests/integration-test b/src/tests/integration-test
+index 4499a6a9..8b711f95 100755
 --- a/src/tests/integration-test
 +++ b/src/tests/integration-test
-@@ -414,7 +414,7 @@
-                 f.write('KERNEL=="sr*", ENV{DISK_EJECT_REQUEST}!="?*", '
-                         'ATTRS{model}=="scsi_debug*", '
-                         'ENV{ID_CDROM_MEDIA}=="?*", '
--                        'IMPORT{program}="/sbin/blkid -o udev -p -u noraid $tempnode"\n')
-+                        'IMPORT{program}="@blkid@ -o udev -p -u noraid $tempnode"\n')
-             # reload udev
-             subprocess.call('sync; pkill --signal HUP udevd || '
-                             'pkill --signal HUP systemd-udevd',
-@@ -1079,7 +1079,7 @@
+@@ -1142,7 +1142,7 @@ class FS(UDisksTestCase):
          self.assertFalse(os.access(f, os.X_OK))
  
          f = os.path.join(mount_point, 'simple.exe')
@@ -61,7 +78,7 @@
          self.assertTrue(os.access(f, os.R_OK))
          self.assertTrue(os.access(f, os.W_OK))
          self.assertTrue(os.access(f, os.X_OK))
-@@ -1092,7 +1092,7 @@
+@@ -1155,7 +1155,7 @@ class FS(UDisksTestCase):
          self.assertFalse(os.access(f, os.X_OK))
  
          f = os.path.join(mount_point, 'subdir', 'subdir.exe')
@@ -70,6 +87,8 @@
          self.assertTrue(os.access(f, os.R_OK))
          self.assertTrue(os.access(f, os.W_OK))
          self.assertTrue(os.access(f, os.X_OK))
+diff --git a/src/tests/storadectl/runtest.sh b/src/tests/storadectl/runtest.sh
+index f03885f9..baca6a93 100644
 --- a/src/tests/storadectl/runtest.sh
 +++ b/src/tests/storadectl/runtest.sh
 @@ -1,4 +1,4 @@
@@ -78,9 +97,11 @@
  # vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
  # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  #
+diff --git a/src/tests/test.c b/src/tests/test.c
+index 3ddbdf2c..a87f960a 100644
 --- a/src/tests/test.c
 +++ b/src/tests/test.c
-@@ -71,7 +71,7 @@
+@@ -71,7 +71,7 @@ test_spawned_job_successful (void)
  {
    UDisksSpawnedJob *job;
  
@@ -89,7 +110,7 @@
    udisks_spawned_job_start (job);
    _g_assert_signal_received (job, "completed", G_CALLBACK (on_completed_expect_success), NULL);
    g_object_unref (job);
-@@ -84,10 +84,10 @@
+@@ -84,10 +84,10 @@ test_spawned_job_failure (void)
  {
    UDisksSpawnedJob *job;
  
@@ -102,7 +123,7 @@
    g_object_unref (job);
  }
  
-@@ -119,7 +119,7 @@
+@@ -119,7 +119,7 @@ test_spawned_job_cancelled_at_start (void)
  
    cancellable = g_cancellable_new ();
    g_cancellable_cancel (cancellable);
@@ -111,7 +132,7 @@
    udisks_spawned_job_start (job);
    _g_assert_signal_received (job, "completed", G_CALLBACK (on_completed_expect_failure),
                               (gpointer) "Operation was cancelled (g-io-error-quark, 19)");
-@@ -145,7 +145,7 @@
+@@ -144,7 +144,7 @@ test_spawned_job_cancelled_midway (void)
    GCancellable *cancellable;
  
    cancellable = g_cancellable_new ();
@@ -119,8 +140,8 @@
 +  job = udisks_spawned_job_new ("@sleep@ 0.5", NULL, getuid (), geteuid (), NULL, cancellable);
    udisks_spawned_job_start (job);
    g_timeout_add (10, on_timeout, cancellable); /* 10 msec */
-   g_main_loop_run (loop);
-@@ -199,7 +199,7 @@
+   _g_assert_signal_received (job, "completed", G_CALLBACK (on_completed_expect_failure),
+@@ -197,7 +197,7 @@ test_spawned_job_premature_termination (void)
  {
    UDisksSpawnedJob *job;
  
@@ -129,3 +150,6 @@
    udisks_spawned_job_start (job);
    g_object_unref (job);
  }
+-- 
+2.33.1
+

--- a/pkgs/os-specific/linux/udisks/force-path.patch
+++ b/pkgs/os-specific/linux/udisks/force-path.patch
@@ -1,8 +1,9 @@
-diff -ruN udisks-2.1.0.orig/src/main.c udisks-2.1.0/src/main.c
---- udisks-2.1.0.orig/src/main.c	2013-04-02 10:43:41.629332135 +0000
-+++ udisks-2.1.0/src/main.c	2013-04-02 11:04:55.635342823 +0000
-@@ -140,8 +140,7 @@
-         }
+diff --git a/src/main.c b/src/main.c
+index b4dbf9e0..3171fa34 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -144,8 +144,7 @@ main (int    argc,
+       g_setenv("G_MESSAGES_DEBUG", "udisks", FALSE);
      }
  
 -  if (g_getenv ("PATH") == NULL)
@@ -11,3 +12,6 @@ diff -ruN udisks-2.1.0.orig/src/main.c udisks-2.1.0/src/main.c
  
    udisks_notice ("udisks daemon version %s starting", PACKAGE_VERSION);
  
+-- 
+2.33.1
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to a version that supports the ntfs3 kernel module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
