### PR TITLE
python39Packages.guessit: 3.3.1 -> 3.4.3

### DIFF
--- a/pkgs/development/python-modules/guessit/default.nix
+++ b/pkgs/development/python-modules/guessit/default.nix
@@ -1,31 +1,42 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, pytest-runner
 , python-dateutil
 , babelfish
 , rebulk
+, pythonOlder
+, importlib-resources
+, pytestCheckHook
+, pytest-mock
+, pytest-benchmark
+, pyyaml
 }:
 
 buildPythonPackage rec {
   pname = "guessit";
-  version = "3.3.1";
+  version = "3.4.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "8305e0086129614a8820a508303f98f56c584811489499bcc54a7ea6f1b0391e";
+    sha256 = "731e96e6a1f3b065d05accc8c19f35d4485d880b77ab8dc4b262cc353df294f7";
   };
 
-  # Tests require more packages.
-  doCheck = false;
-  buildInputs = [ pytest-runner ];
   propagatedBuildInputs = [
-    python-dateutil babelfish rebulk
-  ];
+    rebulk
+    babelfish
+    python-dateutil
+  ] ++ lib.optionals (pythonOlder "3.9") [ importlib-resources ];
+
+  checkInputs = [ pytestCheckHook pytest-mock pytest-benchmark pyyaml ];
+
+  pytestFlagsArray = [ "--benchmark-disable" ];
+
+  pythonImportsCheck = [ "guessit" ];
 
   meta = {
-    homepage = "https://pypi.python.org/pypi/guessit";
-    license = lib.licenses.lgpl3;
-    description = "A library for guessing information from video files";
+    homepage = "https://doc.guessit.io/";
+    description = "A Python library that extracts as much information as possible from a video filename";
+    changelog = "https://github.com/guessit-io/guessit/raw/v${version}/CHANGELOG.md";
+    license = lib.licenses.lgpl3Only;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/guessit-io/guessit/raw/v3.4.3/CHANGELOG.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
