### PR TITLE
libretro.pcsx2: init at unstable-2021-11-27

### DIFF
--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -14,6 +14,7 @@
 , hexdump
 , hidapi
 , icu
+, libaio
 , libGL
 , libGLU
 , libevdev
@@ -21,6 +22,7 @@
 , libpcap
 , libpng
 , libvorbis
+, libxml2
 , libzip
 , makeWrapper
 , nasm
@@ -36,6 +38,8 @@
 , udev
 , which
 , xorg
+, xxd
+, xz
 , zlib
 }:
 
@@ -667,6 +671,38 @@ in
       sed -i -e '1 i\CPUFLAGS += -DARM_FIX -DNO_ASM -DARM_ASM -DDONT_WANT_ARM_OPTIMIZATIONS -DARM64' Makefile \
       && sed -i -e 's,CPUFLAGS  :=,,g' Makefile
     '';
+  };
+
+  pcsx2 = mkLibRetroCore {
+    core = "pcsx2";
+    version = "unstable-2021-11-27";
+    description = "Port of PCSX2 to libretro";
+    license = lib.licenses.gpl3Plus;
+    extraNativeBuildInputs = [
+      cmake
+      gettext
+      pkg-config
+    ];
+    extraBuildInputs = [
+      libaio
+      libGL
+      libGLU
+      libpcap
+      libpng
+      libxml2
+      xz
+      xxd
+    ];
+    makefile = "Makefile";
+    cmakeFlags = [
+      "-DCMAKE_BUILD_TYPE=Release"
+      "-DLIBRETRO=ON"
+    ];
+    postPatch = ''
+      # remove ccache
+      substituteInPlace CMakeLists.txt --replace "ccache" ""
+    '';
+    postBuild = "cd /build/source/build/pcsx2";
   };
 
   pcsx_rearmed = mkLibRetroCore {

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -59,6 +59,7 @@ let
     , src ? null
     , broken ? false
     , version ? "unstable-2021-11-22"
+    , platforms ? retroarch.meta.platforms
     , ...
     }@args:
     lib.makeOverridable stdenv.mkDerivation (
@@ -109,10 +110,9 @@ let
         };
 
         meta = with lib; {
-          inherit broken description license;
+          inherit broken description license platforms;
           homepage = "https://www.libretro.com/";
           maintainers = with maintainers; [ edwtjo hrdinka MP2E thiagokokada ];
-          platforms = platforms.unix;
         };
       }) // builtins.removeAttrs args [ "core" "src" "description" "license" "makeFlags" ]
     );
@@ -193,7 +193,7 @@ in
     description = "Port of Mednafen's Saturn core to libretro";
     license = lib.licenses.gpl2Only;
     makefile = "Makefile";
-    meta.platforms = [ "x86_64-linux" "aarch64-linux" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
   };
 
   beetle-snes = mkLibRetroCore {
@@ -423,7 +423,7 @@ in
     extraBuildInputs = [ libGL libGLU ];
     makefile = "Makefile";
     makeFlags = lib.optional stdenv.hostPlatform.isAarch64 [ "platform=arm64" ];
-    meta.platforms = [ "aarch64-linux" "x86_64-linux" ];
+    platforms = [ "aarch64-linux" "x86_64-linux" ];
   };
 
   fmsx = mkLibRetroCore {
@@ -701,6 +701,7 @@ in
       substituteInPlace CMakeLists.txt --replace "ccache" ""
     '';
     postBuild = "cd /build/source/build/pcsx2";
+    platforms = lib.platforms.x86;
   };
 
   pcsx_rearmed = mkLibRetroCore {

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -367,7 +367,6 @@ in
     ] ++ (with xorg; [ libSM libX11 libXi libpthreadstubs libxcb xcbutil libXext libXrandr libXinerama libXxf86vm ]);
     makefile = "Makefile";
     cmakeFlags = [
-      "-DCMAKE_BUILD_TYPE=Release"
       "-DLIBRETRO=ON"
       "-DLIBRETRO_STATIC=1"
       "-DENABLE_QT=OFF"
@@ -695,7 +694,6 @@ in
     ];
     makefile = "Makefile";
     cmakeFlags = [
-      "-DCMAKE_BUILD_TYPE=Release"
       "-DLIBRETRO=ON"
     ];
     postPatch = ''
@@ -846,7 +844,6 @@ in
     extraNativeBuildInputs = [ cmake ];
     makefile = "Makefile";
     cmakeFlags = [
-      "-DCMAKE_BUILD_TYPE=Release"
       "-DBUILD_LIBRETRO_CORE=ON"
     ];
     postPatch = "mkdir -p src/duckstation-libretro";

--- a/pkgs/misc/emulators/retroarch/default.nix
+++ b/pkgs/misc/emulators/retroarch/default.nix
@@ -110,7 +110,7 @@ stdenv.mkDerivation rec {
     homepage = "https://libretro.com";
     description = "Multi-platform emulator frontend for libretro cores";
     license = licenses.gpl3Plus;
-    platforms = platforms.all;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ MP2E edwtjo matthewbauer kolbycrouch thiagokokada ];
     # FIXME: exits with error on macOS:
     # No Info.plist file in application bundle or no NSPrincipalClass in the Info.plist file, exiting

--- a/pkgs/misc/emulators/retroarch/hashes.json
+++ b/pkgs/misc/emulators/retroarch/hashes.json
@@ -377,6 +377,13 @@
         "sha256": "rms+T8JOp/TJ/T5a5uLj8lu1LLz/GAsJZ7UbK42C9yU=",
         "fetchSubmodules": false
     },
+    "pcsx2": {
+        "owner": "libretro",
+        "repo": "pcsx2",
+        "rev": "18e0685ed4f191796c8e923caf4f5e96a930057e",
+        "sha256": "V2eS741us2p+JC+ghmHjAtFeptB0UcBlwZuisZ8Co7M=",
+        "fetchSubmodules": false
+    },
     "pcsx_rearmed": {
         "owner": "libretro",
         "repo": "pcsx_rearmed",

--- a/pkgs/misc/emulators/retroarch/update.py
+++ b/pkgs/misc/emulators/retroarch/update.py
@@ -64,6 +64,7 @@ CORES = {
     "o2em": {"repo": "libretro-o2em"},
     "opera": {"repo": "opera-libretro"},
     "parallel-n64": {"repo": "parallel-n64"},
+    "pcsx2": {"repo": "pcsx2"},
     "pcsx_rearmed": {"repo": "pcsx_rearmed"},
     "picodrive": {"repo": "picodrive", "fetch_submodules": True},
     "play": {"repo": "Play-", "owner": "jpd002", "fetch_submodules": True},


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I was having difficult to package this core on #146958, however with the help of @jnetod I finally got it right.

Tested and working.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
