### PR TITLE
sasquatch: pass -fcommon to fix build on -fno-common toolchains

### DIFF
--- a/pkgs/tools/filesystems/sasquatch/default.nix
+++ b/pkgs/tools/filesystems/sasquatch/default.nix
@@ -45,7 +45,10 @@ stdenv.mkDerivation rec {
   postPatch = ''
     # Drop blanket -Werror to avoid build failure on fresh toolchains
     # like gcc-11.
-    substituteInPlace squashfs-tools/Makefile --replace ' -Werror' ' '
+    # Add -fcommon as a woarkaround for compiler that default to -fno-common
+    # like upstream gcc-10 or clang-11. Will be fixed upstream at:
+    #   https://github.com/devttys0/sasquatch/pull/44
+    substituteInPlace squashfs-tools/Makefile --replace ' -Werror' ' -fcommon'
     cd squashfs-tools
   '';
 


### PR DESCRIPTION
Without the change build on clang-12 or upstream gcc-12 fails as:

    $ nix build --impure --expr 'with import ./. {}; sasquatch.override { stdenv = clang12Stdenv; }' -L
    ...
    c++   ./LZMA/lzmalt/*.o ... -o sasquatch
    ld: squashfs-tools/./error.h:34: multiple definition of `verbose'; unsquashfs.o:error.h:34: first defined here

Until upstream fixes it by fixing `verbose` variable declaration at:
  https://github.com/devttys0/sasquatch/pull/44
and fork rebases let's set `-fcommon` explicitly.
