### PR TITLE
stdenv: remove bash array compatibility hack

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -31,7 +31,7 @@ runHook() {
     local hook
     # Hack around old bash being bad and thinking empty arrays are
     # undefined.
-    for hook in "_callImplicitHook 0 $hookName" ${!hooksSlice+"${!hooksSlice}"}; do
+    for hook in "_callImplicitHook 0 $hookName" ${!hooksSlice}; do
         _eval "$hook" "$@"
     done
 
@@ -48,7 +48,7 @@ runOneHook() {
 
     local hook ret=1
     # Hack around old bash like above
-    for hook in "_callImplicitHook 1 $hookName" ${!hooksSlice+"${!hooksSlice}"}; do
+    for hook in "_callImplicitHook 1 $hookName" ${!hooksSlice}; do
         if _eval "$hook" "$@"; then
             ret=0
             break
@@ -547,7 +547,7 @@ _activatePkgs() {
             (( hostOffset <= targetOffset )) || continue
             local pkgsRef="${pkgsVar}[$targetOffset - $hostOffset]"
             local pkgsSlice="${!pkgsRef}[@]"
-            for pkg in ${!pkgsSlice+"${!pkgsSlice}"}; do
+            for pkg in ${!pkgsSlice}; do
                 activatePackage "$pkg" "$hostOffset" "$targetOffset"
             done
         done
@@ -601,7 +601,7 @@ _addToEnv() {
             else
                 local pkgsRef="${pkgsVar}[$depTargetOffset - $depHostOffset]"
                 local pkgsSlice="${!pkgsRef}[@]"
-                for pkg in ${!pkgsSlice+"${!pkgsSlice}"}; do
+                for pkg in ${!pkgsSlice}; do
                     runHook "${!hookRef}" "$pkg"
                 done
             fi


### PR DESCRIPTION
###### Motivation for this change

Originally this syntax was introduced to keep compatibility with bash 3 I believe (darwin was running an older version of bash).
I've made a previous PR to remove some of those, but noticed more that could be removed. There is some of this syntax left outside setup.sh, but I don't have the bandwidth for that. I am doing this as part of my work on checking if an alternative shell can be used.

@andersk might see something that I missed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
