### PR TITLE
python3Packages.jupyterhub-systemdspawner: install check-kernel.bash

### DIFF
--- a/pkgs/development/python-modules/jupyterhub-systemdspawner/default.nix
+++ b/pkgs/development/python-modules/jupyterhub-systemdspawner/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , jupyterhub
 , tornado
 , bash
@@ -10,15 +10,22 @@ buildPythonPackage rec {
   pname = "jupyterhub-systemdspawner";
   version = "0.15.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "b6e2d981657aa5d3794abb89b1650d056524158a3d0f0f706007cae9b6dbeb2b";
+  src = fetchFromGitHub {
+    owner = "jupyterhub";
+    repo = "systemdspawner";
+    # Corresponds to 0.15.0
+    # Upstream didn't tag the latest release:
+    # https://github.com/jupyterhub/systemdspawner/issues/89
+    rev = "7d7cf42db76d9cfa5a4bc42fff14943877ac570b";
+    sha256 = "sha256-EUCA+CKCeYr+cLVrqTqe3Q32JkbqeALL6tfOnlVHk8Q=";
   };
 
   propagatedBuildInputs = [
     jupyterhub
     tornado
   ];
+
+  buildInputs = [ bash ];
 
   postPatch = ''
     substituteInPlace systemdspawner/systemd.py \
@@ -31,10 +38,16 @@ buildPythonPackage rec {
   # no tests
   doCheck = false;
 
+  postInstall = ''
+    mkdir -p $out/bin
+    cp check-kernel.bash $out/bin/
+    patchShebangs $out/bin
+  '';
+
   meta = with lib; {
     description = "JupyterHub Spawner using systemd for resource isolation";
     homepage = "https://github.com/jupyterhub/systemdspawner";
     license = licenses.bsd3;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc erictapen ];
   };
 }


### PR DESCRIPTION
This file allows for easy checking wether the kernel is configured correctly for running the spawner.

For that I had to use the sources from GitHub.

Also added myself as maintainer.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
