### PR TITLE
bmake: make tests work with libSystem

### DIFF
--- a/pkgs/development/tools/build-managers/bmake/default.nix
+++ b/pkgs/development/tools/build-managers/bmake/default.nix
@@ -12,16 +12,26 @@ stdenv.mkDerivation rec {
     sha256 = "0gpzv75ibzqz1j1h0hdjgx1v7hkl3i5cb5yf6q9sfcgx0bvb55xa";
   };
 
-  # Make tests work with musl
+  # Make tests work with musl:
   # * Disable deptgt-delete_on_error test (alpine does this too)
   # * Disable shell-ksh test (ksh doesn't compile with musl)
   # * Fix test failing due to different strerror(3) output for musl and glibc
-  postPatch = lib.optionalString (stdenv.hostPlatform.libc == "musl") ''
-    sed -i unit-tests/Makefile \
-      -e '/deptgt-delete_on_error/d' \
-      -e '/shell-ksh/d'
-    substituteInPlace unit-tests/opt-chdir.exp --replace "File name" "Filename"
-  '';
+  # and libSystem:
+  # * Disable shell-ksh (ksh doesn't compile with libSystem either (?))
+  # * Disable opt-chdir altogether (a bit much for Darwin syscalls to manage)
+  postPatch = {
+    "musl" = ''
+      sed -i unit-tests/Makefile \
+        -e '/deptgt-delete_on_error/d' \
+        -e '/shell-ksh/d'
+      substituteInPlace unit-tests/opt-chdir.exp --replace "File name" "Filename"
+    '';
+    "libSystem" = ''
+      sed -i unit-tests/Makefile \
+      -e '/shell-ksh/d' \
+      -e '/opt-chdir/d'
+    '';
+  }.${stdenv.hostPlatform.libc} or "";
 
   nativeBuildInputs = [ getopt ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Similar to the story with musl, though in the case of libSystem, `opt-chdir` probably fails because of Darwin itself (the big `././././././././././` spam is evidently too much for whatever syscall). Strikes me as a bit odd given it's NetBSD's bmake, but hey, what can you do.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
