### PR TITLE
buildBazelPackage: fix sandboxed builds on darwin

### DIFF
--- a/pkgs/build-support/build-bazel-package/default.nix
+++ b/pkgs/build-support/build-bazel-package/default.nix
@@ -90,6 +90,7 @@ in stdenv.mkDerivation (fBuildAttrs // {
       BAZEL_USE_CPP_ONLY_TOOLCHAIN=1 \
       USER=homeless-shelter \
       bazel \
+        --batch \
         --output_base="$bazelOut" \
         --output_user_root="$bazelUserRoot" \
         ${if fetchConfigured then "build --nobuild" else "fetch"} \
@@ -211,6 +212,7 @@ in stdenv.mkDerivation (fBuildAttrs // {
     BAZEL_USE_CPP_ONLY_TOOLCHAIN=1 \
     USER=homeless-shelter \
     bazel \
+      --batch \
       --output_base="$bazelOut" \
       --output_user_root="$bazelUserRoot" \
       build \

--- a/pkgs/development/tools/build-managers/bazel/bazel_3/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_3/default.nix
@@ -211,6 +211,10 @@ stdenv.mkDerivation rec {
       src = ../bazel_rc.patch;
       bazelSystemBazelRCPath = bazelRC;
     })
+
+    # disable suspend detection during a build inside Nix as this is
+    # not available inside the darwin sandbox
+    ../bazel_darwin_sandbox.patch
   ] ++ lib.optional enableNixHacks ../nix-hacks.patch;
 
 

--- a/pkgs/development/tools/build-managers/bazel/bazel_4/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_4/default.nix
@@ -246,6 +246,10 @@ stdenv.mkDerivation rec {
       src = ../bazel_rc.patch;
       bazelSystemBazelRCPath = bazelRC;
     })
+
+    # disable suspend detection during a build inside Nix as this is
+    # not available inside the darwin sandbox
+    ../bazel_darwin_sandbox.patch
   ] ++ lib.optional enableNixHacks ../nix-hacks.patch;
 
 

--- a/pkgs/development/tools/build-managers/bazel/bazel_5/bazel_darwin_sandbox.patch
+++ b/pkgs/development/tools/build-managers/bazel/bazel_5/bazel_darwin_sandbox.patch
@@ -1,0 +1,11 @@
+diff -ru a/src/main/native/unix_jni_darwin.cc b/src/main/native/unix_jni_darwin.cc
+--- a/src/main/native/unix_jni_darwin.cc	1980-01-01 00:00:00.000000000 -0500
++++ b/src/main/native/unix_jni_darwin.cc	2021-11-27 20:35:29.000000000 -0500
+@@ -270,6 +270,7 @@
+ }
+ 
+ void portable_start_suspend_monitoring() {
++  if (getenv("NIX_BUILD_TOP")) return;
+   static dispatch_once_t once_token;
+   static SuspendState suspend_state;
+   dispatch_once(&once_token, ^{

--- a/pkgs/development/tools/build-managers/bazel/bazel_5/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_5/default.nix
@@ -9,7 +9,7 @@
 # updater
 , python27, python3, writeScript
 # Apple dependencies
-, cctools, libcxx, CoreFoundation, CoreServices, Foundation
+, cctools, libcxx, sigtool, CoreFoundation, CoreServices, Foundation
 # Allow to independently override the jdks used to build and run respectively
 , buildJdk, runJdk
 , runtimeShell
@@ -211,7 +211,7 @@ stdenv.mkDerivation rec {
 
     # disable suspend detection during a build inside Nix as this is
     # not available inside the darwin sandbox
-    ../bazel_darwin_sandbox.patch
+    ./bazel_darwin_sandbox.patch
   ] ++ lib.optional enableNixHacks ../nix-hacks.patch;
 
 
@@ -382,7 +382,7 @@ stdenv.mkDerivation rec {
       # clang installed from Xcode has a compatibility wrapper that forwards
       # invocations of gcc to clang, but vanilla clang doesn't
       sed -i -e 's;_find_generic(repository_ctx, "gcc", "CC", overriden_tools);_find_generic(repository_ctx, "clang", "CC", overriden_tools);g' tools/cpp/unix_cc_configure.bzl
-
+      sed -i -e 's;env -i codesign --identifier $@ --force --sign;env -i CODESIGN_ALLOCATE=${cctools}/bin/${cctools.targetPrefix}codesign_allocate ${sigtool}/bin/codesign --identifier $@ --force -s;g' tools/osx/BUILD
       sed -i -e 's;"/usr/bin/libtool";_find_generic(repository_ctx, "libtool", "LIBTOOL", overriden_tools);g' tools/cpp/unix_cc_configure.bzl
       wrappers=( tools/cpp/osx_cc_wrapper.sh tools/cpp/osx_cc_wrapper.sh.tpl )
       for wrapper in "''${wrappers[@]}"; do

--- a/pkgs/development/tools/build-managers/bazel/bazel_5/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_5/default.nix
@@ -208,6 +208,10 @@ stdenv.mkDerivation rec {
       src = ../bazel_rc.patch;
       bazelSystemBazelRCPath = bazelRC;
     })
+
+    # disable suspend detection during a build inside Nix as this is
+    # not available inside the darwin sandbox
+    ../bazel_darwin_sandbox.patch
   ] ++ lib.optional enableNixHacks ../nix-hacks.patch;
 
 

--- a/pkgs/development/tools/build-managers/bazel/bazel_darwin_sandbox.patch
+++ b/pkgs/development/tools/build-managers/bazel/bazel_darwin_sandbox.patch
@@ -1,0 +1,11 @@
+diff -ru a/src/main/native/unix_jni_darwin.cc b/src/main/native/unix_jni_darwin.cc
+--- a/src/main/native/unix_jni_darwin.cc	1980-01-01 00:00:00.000000000 -0500
++++ b/src/main/native/unix_jni_darwin.cc	2021-11-27 20:35:29.000000000 -0500
+@@ -270,6 +270,7 @@
+ }
+ 
+ int portable_suspend_count() {
++  if (getenv("NIX_BUILD_TOP")) return 0;
+   static dispatch_once_t once_token;
+   static SuspendState suspend_state;
+   dispatch_once(&once_token, ^{

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15746,7 +15746,7 @@ with pkgs;
   };
 
   bazel_5 = callPackage ../development/tools/build-managers/bazel/bazel_5 {
-    inherit (darwin) cctools;
+    inherit (darwin) cctools sigtool;
     inherit (darwin.apple_sdk.frameworks) CoreFoundation CoreServices Foundation;
     buildJdk = jdk11_headless;
     runJdk = jdk11_headless;


### PR DESCRIPTION
 - [ ] Upstream [claims](https://docs.bazel.build/versions/4.2.1/user-manual.html) that the `--batch` is less performant than the server/client mode. Would be nice to check if that applies to our case.