### PR TITLE
cdrkit: fix -fno-common build

### DIFF
--- a/pkgs/tools/cd-dvd/cdrkit/cdrkit-1.1.11-fno-common.patch
+++ b/pkgs/tools/cd-dvd/cdrkit/cdrkit-1.1.11-fno-common.patch
@@ -1,0 +1,11 @@
+--- a/genisoimage/genisoimage.h
++++ b/genisoimage/genisoimage.h
+@@ -377,7 +377,7 @@ extern int	use_fileversion;
+ extern int	split_SL_component;
+ extern int	split_SL_field;
+ extern char	*trans_tbl;
+-char		*outfile;
++extern char	*outfile;
+ 
+ #define	JMAX		64	/* maximum Joliet file name length (spec) */
+ #define	JLONGMAX	103	/* out of spec Joliet file name length */

--- a/pkgs/tools/cd-dvd/cdrkit/default.nix
+++ b/pkgs/tools/cd-dvd/cdrkit/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ];
 
   # efi-boot-patch extracted from http://arm.koji.fedoraproject.org/koji/rpminfo?rpmID=174244
-  patches = [ ./include-path.patch ./cdrkit-1.1.9-efi-boot.patch ];
+  patches = [ ./include-path.patch ./cdrkit-1.1.9-efi-boot.patch ./cdrkit-1.1.11-fno-common.patch ];
 
   postInstall = ''
     # file name compatibility with the old cdrecord (growisofs wants this name)


### PR DESCRIPTION
Without the change build on toolchain with `-fno-common` default fails as:

    $ nix build --impure --expr 'with import ./. {}; cdrkit.override { stdenv = clang12Stdenv; }' -L
    ...
    cdrkit> ld: CMakeFiles/genisoimage.dir/apple.o:(.bss+0x2040):
      multiple definition of `outfile'; CMakeFiles/genisoimage.dir/genisoimage.o:(.bss+0x280): first defined here
