### PR TITLE
flex: use fetchurl instead of fetchpatch to avoid extra depends

### DIFF
--- a/pkgs/development/tools/parsing/flex/default.nix
+++ b/pkgs/development/tools/parsing/flex/default.nix
@@ -1,6 +1,10 @@
 { lib, stdenv, buildPackages, fetchurl, bison, m4
-, fetchpatch, autoreconfHook, help2man
+, autoreconfHook, help2man
 }:
+
+# Avoid 'fetchpatch' to allow 'flex' to be used as a possible 'gcc'
+# dependency during bootstrap. Useful when gcc is built from snapshot
+# or from a git tree (flex lexers are not pre-generated there).
 
 stdenv.mkDerivation rec {
   pname = "flex";
@@ -13,11 +17,10 @@ stdenv.mkDerivation rec {
 
   # Also upstream, will be part of 2.6.5
   # https://github.com/westes/flex/commit/24fd0551333e
-  patches = [(fetchpatch {
+  patches = [(fetchurl {
     name = "glibc-2.26.patch";
-    url = "https://raw.githubusercontent.com/lede-project/source/0fb14a2b1ab2f82c"
-        + "/tools/flex/patches/200-build-AC_USE_SYSTEM_EXTENSIONS-in-configure.ac.patch";
-    sha256 = "1aarhcmz7mfrgh15pkj6f7ikxa2m0mllw1i1vscsf1kw5d05lw6f";
+    url = "https://raw.githubusercontent.com/lede-project/source/0fb14a2b1ab2f82ce63f4437b062229d73d90516/tools/flex/patches/200-build-AC_USE_SYSTEM_EXTENSIONS-in-configure.ac.patch";
+    sha256 = "0mpp41zdg17gx30kcpj83jl8hssks3adbks0qzbhcz882b9c083r";
   })];
 
   postPatch = ''


### PR DESCRIPTION
Weekly `gcc` snapshots don't come with pre-generated `flex` lexers
and thus require `flex` dependency. Attempt to use them as is fails as:

    error: anonymous function at pkgs/build-support/fetchurl/boot.nix:5:1 called with unexpected argument 'meta'
       at pkgs/build-support/fetchpatch/default.nix:18:1:
           17| in
           18| fetchurl ({
             | ^
           19|   postFetch = ''
    (use '--show-trace' to show detailed location information)

This happens due to a circulare dependency between fetchpatch dependencies
and flex.

The change uses simpler `fetchurl` to ease use of `flex` in `gcc`.

This allows me to use existing `gcc` `.nix` files for weekly `gcc`
snapshots by only adding extra `flex` dependency.