### PR TITLE
Revert "wireshark: add wrapGAppsHook fixing open/save GUI"

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, pkg-config, pcre, perl, flex, bison, gettext, libpcap, libnl, c-ares
 , gnutls, libgcrypt, libgpg-error, geoip, openssl, lua5, python3, libcap, glib
 , libssh, nghttp2, zlib, cmake, makeWrapper
-, withQt ? true, qt5 ? null, wrapGAppsHook ? null
+, withQt ? true, qt5 ? null
 , ApplicationServices, SystemConfiguration, gmp
 }:
 
@@ -33,9 +33,7 @@ in stdenv.mkDerivation {
   # Avoid referencing -dev paths because of debug assertions.
   NIX_CFLAGS_COMPILE = [ "-DQT_NO_DEBUG" ];
 
-  nativeBuildInputs = [
-    bison cmake flex makeWrapper pkg-config
-  ] ++ optionals withQt [ qt5.wrapQtAppsHook wrapGAppsHook ];
+  nativeBuildInputs = [ bison cmake flex makeWrapper pkg-config ] ++ optional withQt qt5.wrapQtAppsHook;
 
   buildInputs = [
     gettext pcre perl libpcap lua5 libssh nghttp2 openssl libgcrypt


### PR DESCRIPTION
Reverts NixOS/nixpkgs#147592. This change was fixing something that was already fixed in master, but due to [a mistake](https://github.com/NixOS/nixpkgs/pull/147592#issuecomment-981054565) was still merged.

cc @Ma27 

(Also, it seems breaking the commit format for revert PRs [is](https://github.com/nixos/nixpkgs/commit/1cfecb636b1) [pretty](https://github.com/nixos/nixpkgs/commit/be2bc44d0e1) [common](https://github.com/nixos/nixpkgs/commit/2284d771dba))