### PR TITLE
mbuffer: 20210328 -> 20211018

### DIFF
--- a/pkgs/tools/misc/mbuffer/default.nix
+++ b/pkgs/tools/misc/mbuffer/default.nix
@@ -1,32 +1,40 @@
-{ lib, stdenv, fetchurl,
-  openssl,
- } :
+{ lib
+, stdenv
+, fetchurl
+, openssl
+, which
+}:
 
 stdenv.mkDerivation rec {
-  version = "20210328";
   pname = "mbuffer";
+  version = "20211018";
 
   src = fetchurl {
     url = "http://www.maier-komor.de/software/mbuffer/mbuffer-${version}.tgz";
-    sha256 = "sha256-UbW42EiJkaVf4d/OkBMPnke8HOKGugO09ijAS3hP3F0=";
+    sha256 = "sha256-4kDB5OSsFMKL6MZg7EfUTOFrHo7JKqkHrRMAT/1dtuM=";
   };
 
-  buildInputs = [ openssl ];
+  buildInputs = [
+    openssl
+    which
+  ];
 
   # The mbuffer configure scripts fails to recognize the correct
   # objdump binary during cross-building for foreign platforms.
   # The correct objdump is exposed via the environment variable
   # $OBJDUMP, which should be used in such cases.
   preConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
-    substituteInPlace configure --replace "OBJDUMP=$ac_cv_path_OBJDUMP" 'OBJDUMP=''${OBJDUMP}'
+    substituteInPlace configure \
+      --replace "OBJDUMP=$ac_cv_path_OBJDUMP" 'OBJDUMP=''${OBJDUMP}'
   '';
+
   doCheck = true;
 
-  meta = {
-    homepage = "https://www.maier-komor.de/mbuffer.html";
+  meta = with lib; {
     description  = "A tool for buffering data streams with a large set of unique features";
-    license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ tokudan ];
-    platforms = lib.platforms.linux; # Maybe other non-darwin Unix
+    homepage = "https://www.maier-komor.de/mbuffer.html";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ tokudan ];
+    platforms = platforms.linux; # Maybe other non-darwin Unix
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 20211018

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
