### PR TITLE
dnsperf: 2.5.2 -> 2.8.0

### DIFF
--- a/pkgs/tools/networking/dnsperf/default.nix
+++ b/pkgs/tools/networking/dnsperf/default.nix
@@ -1,51 +1,44 @@
-{ lib, stdenv, fetchurl, fetchFromGitHub, autoreconfHook, pkg-config
-, openssl, ldns, libck
+{ lib
+, stdenv
+, autoreconfHook
+, fetchFromGitHub
+, ldns
+, libck
+, nghttp2
+, openssl
+, pkg-config
 }:
 
 stdenv.mkDerivation rec {
   pname = "dnsperf";
-  version = "2.5.2";
+  version = "2.8.0";
 
-  # The same as the initial commit of the new GitHub repo (only readme changed).
   src = fetchFromGitHub {
     owner = "DNS-OARC";
     repo = "dnsperf";
     rev = "v${version}";
-    sha256 = "0dzi28z7hnyxbibwdsalvd93czf4d5pgmvrbn6hlh52znsn40gbb";
+    sha256 = "sha256-jemce+ix18IPAusEHh5QWcSQn/QRUOc3HTSk9jGt+SA=";
   };
 
-  outputs = [ "out" "man" "doc" ];
-
-  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
 
   buildInputs = [
-    openssl
     ldns # optional for DDNS (but cheap anyway)
     libck
+    nghttp2
+    openssl
   ];
 
   doCheck = true;
 
-  # For now, keep including the old PDFs as well.
-  # https://github.com/DNS-OARC/dnsperf/issues/27
-  postInstall = let
-    src-doc = fetchurl {
-      url = "ftp://ftp.nominum.com/pub/nominum/dnsperf/2.1.0.0/"
-          + "dnsperf-src-2.1.0.0-1.tar.gz";
-      sha256 = "03kfc65s5a9csa5i7xjsv0psq144k8d9yw7xlny61bg1h2kg1db4";
-    };
-  in ''
-    tar xf '${src-doc}'
-    cp ./dnsperf-src-*/doc/*.pdf "$doc/share/doc/dnsperf/"
-  '';
-
   meta = with lib; {
-    outputsToInstall = outputs; # The man pages and docs are likely useful to most.
-
     description = "Tools for DNS benchmaring";
-    homepage = "https://github.com/DNS-OARC/dnsperf";
+    homepage = "https://www.dns-oarc.net/tools/dnsperf";
     license = licenses.isc;
     platforms = platforms.unix;
-    maintainers = [ maintainers.vcunat ];
+    maintainers = with maintainers; [ vcunat ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.8.0

Change log: 
- https://github.com/DNS-OARC/dnsperf/releases/tag/v2.8.0
- https://github.com/DNS-OARC/dnsperf/releases/tag/v2.7.1
- https://github.com/DNS-OARC/dnsperf/releases/tag/v2.7.0
- https://github.com/DNS-OARC/dnsperf/releases/tag/v2.6.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
