### PR TITLE
concatTextFile: init

### DIFF
--- a/doc/builders/trivial-builders.chapter.md
+++ b/doc/builders/trivial-builders.chapter.md
@@ -47,10 +47,87 @@ These functions write `text` to the Nix store. This is useful for creating scrip
 
 Many more commands wrap `writeTextFile` including `writeText`, `writeTextDir`, `writeScript`, and `writeScriptBin`. These are convenience functions over `writeTextFile`.
 
+Here are a few examples:
+```nix
+# Writes my-file to /nix/store/<store path>
+writeTextFile {
+  name = "my-file";
+  text = ''
+    Contents of File
+  '';
+}
+# See also the `writeText` helper function below.
+
+# Writes executable my-file to /nix/store/<store path>/bin/my-file
+writeTextFile {
+  name = "my-file";
+  text = ''
+    Contents of File
+  '';
+  executable = true;
+  destination = "/bin/my-file";
+}
+# Writes contents of file to /nix/store/<store path>
+writeText "my-file"
+  ''
+  Contents of File
+  '';
+# Writes contents of file to /nix/store/<store path>/share/my-file
+writeTextDir "share/my-file"
+  ''
+  Contents of File
+  '';
+# Writes my-file to /nix/store/<store path> and makes executable
+writeScript "my-file"
+  ''
+  Contents of File
+  '';
+# Writes my-file to /nix/store/<store path>/bin/my-file and makes executable.
+writeScriptBin "my-file"
+  ''
+  Contents of File
+  '';
+# Writes my-file to /nix/store/<store path> and makes executable.
+writeShellScript "my-file"
+  ''
+  Contents of File
+  '';
+# Writes my-file to /nix/store/<store path>/bin/my-file and makes executable.
+writeShellScriptBin "my-file"
+  ''
+  Contents of File
+  '';
+
+```
+
 ## `concatTextFile`, `concatText`, `concatScript` {#trivial-builder-concatText}
 
 These functions concatenate `files` to the Nix store in a single file. This is useful for configuration files structured in lines of text. `concatTextFile` takes an attribute set and expects two arguments, `name` and `files`. `name` corresponds to the name used in the Nix store path. `files` will be the files to be concatenated. You can also set `executable` to true to make this file have the executable bit set.
 `concatText` and`concatScript` are simple wrappers over `concatTextFile`.
+
+Here are a few examples:
+```nix
+
+# Writes my-file to /nix/store/<store path>
+concatTextFile {
+  name = "my-file";
+  files = [ drv1 "${drv2}/path/to/file" ];
+}
+# See also the `concatText` helper function below.
+
+# Writes executable my-file to /nix/store/<store path>/bin/my-file
+concatTextFile {
+  name = "my-file";
+  files = [ drv1 "${drv2}/path/to/file" ];
+  executable = true;
+  destination = "/bin/my-file";
+}
+# Writes contents of files to /nix/store/<store path>
+concatText "my-file" [ file1 file2 ]
+
+# Writes contents of files to /nix/store/<store path>
+concatScript "my-file" [ file1 file2 ]
+```
 
 ## `writeShellApplication` {#trivial-builder-writeShellApplication}
 
@@ -77,6 +154,26 @@ validation.
 ## `symlinkJoin` {#trivial-builder-symlinkJoin}
 
 This can be used to put many derivations into the same directory structure. It works by creating a new derivation and adding symlinks to each of the paths listed. It expects two arguments, `name`, and `paths`. `name` is the name used in the Nix store path for the created derivation. `paths` is a list of paths that will be symlinked. These paths can be to Nix store derivations or any other subdirectory contained within.
+Here is an example:
+```nix
+# adds symlinks of hello and stack to current build and prints "links added"
+symlinkJoin { name = "myexample"; paths = [ pkgs.hello pkgs.stack ]; postBuild = "echo links added"; }
+```
+This creates a derivation with a directory structure like the following:
+```
+/nix/store/sglsr5g079a5235hy29da3mq3hv8sjmm-myexample
+|-- bin
+|   |-- hello -> /nix/store/qy93dp4a3rqyn2mz63fbxjg228hffwyw-hello-2.10/bin/hello
+|   `-- stack -> /nix/store/6lzdpxshx78281vy056lbk553ijsdr44-stack-2.1.3.1/bin/stack
+`-- share
+    |-- bash-completion
+    |   `-- completions
+    |       `-- stack -> /nix/store/6lzdpxshx78281vy056lbk553ijsdr44-stack-2.1.3.1/share/bash-completion/completions/stack
+    |-- fish
+    |   `-- vendor_completions.d
+    |       `-- stack.fish -> /nix/store/6lzdpxshx78281vy056lbk553ijsdr44-stack-2.1.3.1/share/fish/vendor_completions.d/stack.fish
+...
+```
 
 ## `writeReferencesToFile` {#trivial-builder-writeReferencesToFile}
 

--- a/doc/builders/trivial-builders.chapter.md
+++ b/doc/builders/trivial-builders.chapter.md
@@ -47,6 +47,11 @@ These functions write `text` to the Nix store. This is useful for creating scrip
 
 Many more commands wrap `writeTextFile` including `writeText`, `writeTextDir`, `writeScript`, and `writeScriptBin`. These are convenience functions over `writeTextFile`.
 
+## `concatTextFile`, `concatText`, `concatScript` {#trivial-builder-concatText}
+
+These functions concatenate `files` to the Nix store in a single file. This is useful for configuration files structured in lines of text. `concatTextFile` takes an attribute set and expects two arguments, `name` and `files`. `name` corresponds to the name used in the Nix store path. `files` will be the files to be concatenated. You can also set `executable` to true to make this file have the executable bit set.
+`concatText` and`concatScript` are simple wrappers over `concatTextFile`.
+
 ## `writeShellApplication` {#trivial-builder-writeShellApplication}
 
 This can be used to easily produce a shell script that has some dependencies (`runtimeInputs`). It automatically sets the `PATH` of the script to contain all of the listed inputs, sets some sanity shellopts (`errexit`, `nounset`, `pipefail`), and checks the resulting script with [`shellcheck`](https://github.com/koalaman/shellcheck).

--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -190,9 +190,7 @@ in
         protocols.source  = pkgs.iana-etc + "/etc/protocols";
 
         # /etc/hosts: Hostname-to-IP mappings.
-        hosts.source = pkgs.runCommand "hosts" {} ''
-          cat ${escapeShellArgs cfg.hostFiles} > $out
-        '';
+        hosts.source = pkgs.concatText "hosts" cfg.hostFiles;
 
         # /etc/netgroup: Network-wide groups.
         netgroup.text = mkDefault "";

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -380,7 +380,7 @@ rec {
    * concatScript "my-file" [ file1 file2 ]
    *
   */
-  concatScript = name: files: concatTextFile { inherit name files; executable=true; };
+  concatScript = name: files: concatTextFile { inherit name files; executable = true; };
 
 
   /*

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -332,14 +332,12 @@ rec {
    *   name = "my-file";
    *   files = [ drv1 "${drv2}/path/to/file" ];
    * }
-   * # See also the `concatdText` helper function below.
+   * # See also the `concatText` helper function below.
    *
    * # Writes executable my-file to /nix/store/<store path>/bin/my-file
    * concatTextFile {
    *   name = "my-file";
-   *   files = ''
-   *     Contents of File
-   *   '';
+   *   files = [ drv1 "${drv2}/path/to/file" ];
    *   executable = true;
    *   destination = "/bin/my-file";
    * }
@@ -355,14 +353,12 @@ rec {
     runCommandLocal name
       { inherit files executable checkPhase meta destination; }
       ''
-        n=$out$destination
-        mkdir -p "$(dirname "$n")"
-        cat $files > "$n"
-        touch "$n"
+        file=$out$destination
+        mkdir -p "$(dirname "$file")"
+        cat $files > "$file"
 
+        (test -n "$executable" && chmod +x "$file") || true
         eval "$checkPhase"
-
-        (test -n "$executable" && chmod +x "$n") || true
       '';
 
 
@@ -381,7 +377,7 @@ rec {
    *
    * Example:
    * # Writes contents of files to /nix/store/<store path>
-   * concatdScript "my-file" [ file1 file2 ]
+   * concatScript "my-file" [ file1 file2 ]
    *
   */
   concatScript = name: files: concatTextFile { inherit name files; executable=true; };

--- a/pkgs/build-support/trivial-builders/test/concat-test.nix
+++ b/pkgs/build-support/trivial-builders/test/concat-test.nix
@@ -1,4 +1,4 @@
-{ callPackage, lib, pkgs, runCommand, concatText, writeText, hello }:
+{ callPackage, lib, pkgs, runCommand, concatText, writeText, hello, emptyFile }:
 let
   stri = writeText "pathToTest";
   txt1 = stri "abc";
@@ -7,5 +7,6 @@ let
 in
 runCommand "test-concatPaths" { } ''
   diff -U3 <(cat ${txt1} ${txt2}) ${res}
+  diff -U3 ${concatText "void" []} ${emptyFile}
   touch $out
 ''

--- a/pkgs/build-support/trivial-builders/test/concat-test.nix
+++ b/pkgs/build-support/trivial-builders/test/concat-test.nix
@@ -1,18 +1,11 @@
-{ callPackage, lib, pkgs, runCommand, writeText, writeStringReferencesToFile }:
+{ callPackage, lib, pkgs, runCommand, concatText, writeText, hello }:
 let
-  sample = import ./sample.nix { inherit pkgs; };
-  samplePaths = lib.unique (lib.attrValues sample);
-  str2drv = x: "${x}";
-  sampleText = concatText "cample-concat" (lib.unique (map str2drv samplePaths));
-  stringReferencesText =
-    writeStringReferencesToFile
-      ((lib.concatMapStringsSep "fillertext"
-        stri
-        (lib.attrValues sample)) + ''
-        STORE=${builtins.storeDir};\nsystemctl start bar-foo.service
-      '');
+  stri = writeText "pathToTest";
+  txt1 = stri "abc";
+  txt2 = stri hello;
+  res = concatText "textToTest" [ txt1 txt2 ];
 in
-runCommand "test-writeStringReferencesToFile" { } ''
-  diff -U3 <(sort ${stringReferencesText}) <(sort ${sampleText})
+runCommand "test-concatPaths" { } ''
+  diff -U3 <(cat ${txt1} ${txt2}) ${res}
   touch $out
 ''

--- a/pkgs/build-support/trivial-builders/test/concat-test.nix
+++ b/pkgs/build-support/trivial-builders/test/concat-test.nix
@@ -1,0 +1,18 @@
+{ callPackage, lib, pkgs, runCommand, writeText, writeStringReferencesToFile }:
+let
+  sample = import ./sample.nix { inherit pkgs; };
+  samplePaths = lib.unique (lib.attrValues sample);
+  str2drv = x: "${x}";
+  sampleText = concatText "cample-concat" (lib.unique (map str2drv samplePaths));
+  stringReferencesText =
+    writeStringReferencesToFile
+      ((lib.concatMapStringsSep "fillertext"
+        stri
+        (lib.attrValues sample)) + ''
+        STORE=${builtins.storeDir};\nsystemctl start bar-foo.service
+      '');
+in
+runCommand "test-writeStringReferencesToFile" { } ''
+  diff -U3 <(sort ${stringReferencesText}) <(sort ${sampleText})
+  touch $out
+''

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -57,6 +57,7 @@ with pkgs;
     writeStringReferencesToFile = callPackage ../build-support/trivial-builders/test/writeStringReferencesToFile.nix {};
     references = callPackage ../build-support/trivial-builders/test/references.nix {};
     overriding = callPackage ../build-support/trivial-builders/test-overriding.nix {};
+    concat = callPackage ../build-support/trivial-builders/test/concat-test.nix {};
   };
 
   writers = callPackage ../build-support/writers/test.nix {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/147589

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
