### PR TITLE
pkgs/pantheon: small cleanup

### DIFF
--- a/pkgs/desktops/pantheon/apps/elementary-code/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-code/default.nix
@@ -21,7 +21,6 @@
 , libsoup
 , vte
 , webkitgtk
-, zeitgeist
 , ctags
 , libgit2-glib
 , wrapGAppsHook
@@ -74,7 +73,6 @@ stdenv.mkDerivation rec {
     libsoup
     vte
     webkitgtk
-    zeitgeist
   ];
 
   # install script fails with UnicodeDecodeError because of printing a fancy elipsis character

--- a/pkgs/desktops/pantheon/apps/switchboard/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard/default.nix
@@ -13,7 +13,6 @@
 , libhandy
 , granite
 , gettext
-, clutter-gtk
 , elementary-icon-theme
 , wrapGAppsHook
 }:
@@ -46,7 +45,6 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    clutter-gtk
     elementary-icon-theme
     granite
     gtk3


### PR DESCRIPTION
###### Motivation for this change

Doing #130380 without reading all changes is dangerous...

- https://github.com/elementary/switchboard/pull/163
- https://github.com/elementary/code/pull/994

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
