### PR TITLE
lispPackages: add cl-shellwords

### DIFF
--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-shellwords.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-shellwords.nix
@@ -1,0 +1,29 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "cl-shellwords";
+  version = "20150923-git";
+
+  description = "Common Lisp port of Ruby's shellwords.rb, for escaping and
+splitting strings to be passed to a shell.";
+
+  deps = [ args."cl-ppcre" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/cl-shellwords/2015-09-23/cl-shellwords-20150923-git.tgz";
+    sha256 = "1rb0ajpl2lai6bj4x0p3wf0cnf51nnyidhca4lpqp1w1wf1vkcqk";
+  };
+
+  packageName = "cl-shellwords";
+
+  asdFilesToKeep = ["cl-shellwords.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM cl-shellwords DESCRIPTION
+    Common Lisp port of Ruby's shellwords.rb, for escaping and
+splitting strings to be passed to a shell.
+    SHA256 1rb0ajpl2lai6bj4x0p3wf0cnf51nnyidhca4lpqp1w1wf1vkcqk URL
+    http://beta.quicklisp.org/archive/cl-shellwords/2015-09-23/cl-shellwords-20150923-git.tgz
+    MD5 c2c62c6a2ce4ed2590d60707ead2e084 NAME cl-shellwords FILENAME
+    cl-shellwords DEPS ((NAME cl-ppcre FILENAME cl-ppcre)) DEPENDENCIES
+    (cl-ppcre) VERSION 20150923-git SIBLINGS (cl-shellwords-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
@@ -71,6 +71,7 @@ cl-prevalence
 cl-protobufs
 cl-qprint
 cl-reexport
+cl-shellwords
 cl-slice
 cl-smt-lib
 cl-smtp

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -4024,6 +4024,15 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "cl-shellwords" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."cl-shellwords" or (x: {}))
+       (import ./quicklisp-to-nix-output/cl-shellwords.nix {
+         inherit fetchurl;
+           "cl-ppcre" = quicklisp-to-nix-packages."cl-ppcre";
+       }));
+
+
   "cl-reexport" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."cl-reexport" or (x: {}))


### PR DESCRIPTION
###### Motivation for this change

I just edited the txt file and ran the update script.

@7c6f434c Can you review this please?

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
  - [x] NixOS
  - [ ] macOS
  - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).