### PR TITLE
nixosTests.keymap.qwertz: reduce platforms in `tested`

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -92,7 +92,7 @@ in rec {
         (onFullSupported "nixos.tests.keymap.dvorak")
         (onFullSupported "nixos.tests.keymap.dvorak-programmer")
         (onFullSupported "nixos.tests.keymap.neo")
-        (onFullSupported "nixos.tests.keymap.qwertz")
+        (onSystems ["x86_64-linux"] "nixos.tests.keymap.qwertz")
         (onFullSupported "nixos.tests.latestKernel.login")
         (onFullSupported "nixos.tests.lightdm")
         (onFullSupported "nixos.tests.login")


### PR DESCRIPTION
In particular, aarch64-linux variant doesn't work on Hydra,
so at least avoid this blocking the 21.11 channel.

Fixes https://github.com/NixOS/nixpkgs/issues/147294
(though the backport will be more important than this PR itself)