### PR TITLE
liboping: pull pending upstream inclusion fix for ncurses-6.3

### DIFF
--- a/pkgs/development/libraries/liboping/default.nix
+++ b/pkgs/development/libraries/liboping/default.nix
@@ -9,6 +9,12 @@ stdenv.mkDerivation rec {
     sha256 = "1n2wkmvw6n80ybdwkjq8ka43z2x8mvxq49byv61b52iyz69slf7b";
   };
 
+  patches = [
+    # Add support for ncurses-6.3. A backport of patch pending upstream
+    # inclusion: https://github.com/octo/liboping/pull/61
+    ./ncurses-6.3.patch
+  ];
+
   NIX_CFLAGS_COMPILE = lib.optionalString
     stdenv.cc.isGNU "-Wno-error=format-truncation";
 

--- a/pkgs/development/libraries/liboping/ncurses-6.3.patch
+++ b/pkgs/development/libraries/liboping/ncurses-6.3.patch
@@ -1,0 +1,21 @@
+A backport of https://github.com/octo/liboping/pull/61
+--- a/src/oping.c
++++ b/src/oping.c
+@@ -1125,7 +1125,7 @@ static int update_graph_prettyping (ping_context_t *ctx, /* {{{ */
+ 			wattron (ctx->window, COLOR_PAIR(color));
+ 
+ 		if (has_utf8())
+-			mvwprintw (ctx->window, /* y = */ 3, /* x = */ x + 2, symbol);
++			mvwprintw (ctx->window, /* y = */ 3, /* x = */ x + 2, "%s", symbol);
+ 		else
+ 			mvwaddch (ctx->window, /* y = */ 3, /* x = */ x + 2, symbolc);
+ 
+@@ -1222,7 +1222,7 @@ static int update_graph_histogram (ping_context_t *ctx) /* {{{ */
+ 		if (counters[x] == 0)
+ 			mvwaddch (ctx->window, /* y = */ 3, /* x = */ x + 2, ' ');
+ 		else if (has_utf8 ())
+-			mvwprintw (ctx->window, /* y = */ 3, /* x = */ x + 2,
++			mvwprintw (ctx->window, /* y = */ 3, /* x = */ x + 2, "%s",
+ 					hist_symbols_utf8[index]);
+ 		else
+ 			mvwaddch (ctx->window, /* y = */ 3, /* x = */ x + 2,


### PR DESCRIPTION
Without the fix build on ncurses-6.3 fails as:

    oping.c:1128:25: error: format not a string literal and no format arguments [-Werror=format-security]
     1128 |                         mvwprintw (ctx->window, /* y = */ 3, /* x = */ x + 2, symbol);
          |                         ^~~~~~~~~
