### PR TITLE
noice: fix build against ncurses-6.3

### DIFF
--- a/pkgs/applications/misc/noice/default.nix
+++ b/pkgs/applications/misc/noice/default.nix
@@ -12,6 +12,12 @@ stdenv.mkDerivation rec {
     sha256 = "0975j4m93s9a21pazwdzn4gqhkngwq7q6ghp0q8a75r6c4fb7aar";
   };
 
+  postPatch = ''
+    # Add support for ncurses-6.3. Can be dropped with 0.9 release.
+    # Fixed upstream at: https://git.2f30.org/noice/commit/53c35e6b340b7c135038e00057a198f03cb7d7cf.html
+    substituteInPlace noice.c --replace 'printw(str);' 'printw("%s", str);'
+  '';
+
   configFile = optionalString (conf!=null) (builtins.toFile "config.def.h" conf);
   preBuild = optionalString (conf!=null) "cp ${configFile} config.def.h";
 


### PR DESCRIPTION
Without the change the build on upcoming `ncurses-6.3` fails as:

    noice.c:377:9: error: format not a string literal and no format arguments [-Werror=format-security]
      377 |         printw(str);
          |         ^~~~~~
