### PR TITLE
libviper: fix build against ncurses-6.3

### DIFF
--- a/pkgs/development/libraries/libviper/default.nix
+++ b/pkgs/development/libraries/libviper/default.nix
@@ -7,8 +7,18 @@ stdenv.mkDerivation rec {
     sha256 = "1jvm7wdgw6ixyhl0pcfr9lnr9g6sg6whyrs9ihjiz0agvqrgvxwc";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i -e s@/usr/local@$out@ -e /ldconfig/d -e '/cd vdk/d' Makefile
+
+    # Fix pending upstream inclusion for ncurses-6.3 support:
+    #   https://github.com/TragicWarrior/libviper/pull/16
+    # Not applied as it due to unrelated code changes in context.
+    substituteInPlace viper_msgbox.c --replace \
+      'mvwprintw(window,height-3,tmp,prompt);' \
+      'mvwprintw(window,height-3,tmp,"%s",prompt);'
+    substituteInPlace w_decorate.c --replace \
+      'mvwprintw(window,0,x,title);' \
+      'mvwprintw(window,0,x,"%s",title);'
   '';
 
   preInstall = ''


### PR DESCRIPTION
Without the change the build on upcoming `ncurses-6.3` fails as:

    w_decorate.c:45:17: error: format not a string literal and no format arguments [-Werror=format-security]
       45 |                 mvwprintw(window,0,x,title);
          |                 ^~~~~~~~~