### PR TITLE
vwm: fix build against ncurses-6.3

### DIFF
--- a/pkgs/applications/window-managers/vwm/default.nix
+++ b/pkgs/applications/window-managers/vwm/default.nix
@@ -19,11 +19,16 @@ stdenv.mkDerivation rec {
     sha256 = "1r5wiqyfqwnyx7dfihixlnavbvg8rni36i4gq169aisjcg7laxaf";
   };
 
-  prePatch = ''
+  postPatch = ''
     sed -i -e s@/usr/local@$out@ \
       -e s@/usr/lib@$out/lib@ \
       -e 's@tic vwmterm@tic -o '$out/lib/terminfo' vwmterm@' \
       -e /ldconfig/d Makefile modules/*/Makefile vwm.h
+
+    # Fix ncurses-6.3 support:
+    substituteInPlace vwm_bkgd.c --replace \
+      'mvwprintw(window,height-1,width-(strlen(version_str)),version_str);' \
+      'mvwprintw(window,height-1,width-(strlen(version_str)),"%s", version_str);'
   '';
 
   preInstall = ''


### PR DESCRIPTION
Without the change the build on upcoming `ncurses-6.3` fails as:

    vwm_bkgd.c:71:63: error: format not a string literal and no format arguments [-Werror=format-security]
       71 |         mvwprintw(window,height-1,width-(strlen(version_str)),version_str);
          |                                                               ^~~~~~~~~~~

