### PR TITLE
symfony-cli: support more platforms

### DIFF
--- a/pkgs/development/tools/symfony-cli/default.nix
+++ b/pkgs/development/tools/symfony-cli/default.nix
@@ -1,13 +1,34 @@
 { stdenvNoCC, fetchurl, lib }:
 
-stdenvNoCC.mkDerivation rec {
-  pname = "symfony-cli";
-  version = "4.26.8";
+let
+  version = "4.26.9";
 
-  src = fetchurl {
-    url = "https://github.com/symfony/cli/releases/download/v${version}/symfony_linux_amd64.gz";
-    sha256 = "sha256-/9jsdl39TOkuNCB4G7orJH4qR4Spdt7VTsC1jelyLs0=";
+  srcs = {
+    x86_64-linux = fetchurl {
+      url = "https://github.com/symfony/cli/releases/download/v${version}/symfony_linux_amd64.gz";
+      sha256 = "0ivqqrpzbpyzp60bv25scarmvisj401rp7h2s3cxa7d17prja91v";
+    };
+
+    i686-linux = fetchurl {
+      url = "https://github.com/symfony/cli/releases/download/v${version}/symfony_linux_386.gz";
+      sha256 = "0ag5w70bkvj9wgp4yzzy824shj907sa5l20sqcgivi3r5gy0p277";
+    };
+
+    aarch64-linux = fetchurl {
+      url = "https://github.com/symfony/cli/releases/download/v${version}/symfony_linux_arm64.gz";
+      sha256 = "00325xz7xl3bprj5zbg5yhn36jf4n37zlyag10m8zcmq8asa6k51";
+    };
+
+    x86_64-darwin = fetchurl {
+        url = "https://github.com/symfony/cli/releases/download/v${version}/symfony_darwin_amd64.gz";
+        sha256 = "00325xz7xl3bprj5zbg5yhn36jf4n37zlyag10m8zcmq8asa6k51";
+      };
   };
+in stdenvNoCC.mkDerivation rec {
+  inherit version;
+  pname = "symfony-cli";
+
+  src = srcs.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
 
   dontBuild = true;
 
@@ -24,6 +45,6 @@ stdenvNoCC.mkDerivation rec {
     homepage = "https://symfony.com/download";
     license = licenses.unfree;
     maintainers = with maintainers; [ drupol ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "i686-linux" "x86_64-darwin" ];
   };
 }


### PR DESCRIPTION
This PR:

- [x] Bump the package version (minor version bump)
- [x] Support more platforms

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
