### PR TITLE
obs: 27.0.1 -> 27.1.3 [WIP]

### DIFF
--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -36,6 +36,7 @@
 , libcef
 , pipewireSupport ? stdenv.isLinux
 , pipewire
+, libdrm
 }:
 
 let
@@ -44,13 +45,13 @@ let
 in
 mkDerivation rec {
   pname = "obs-studio";
-  version = "27.0.1";
+  version = "27.1.3";
 
   src = fetchFromGitHub {
     owner = "obsproject";
     repo = "obs-studio";
     rev = version;
-    sha256 = "04fzsr9yizmxy0r7z2706crvnsnybpnv5kgfn77znknxxjacfhkn";
+    sha256 = "EmBzxJHai++cvdYBYuR6mQJapSTDvaiqhxGbNnJWsdk=";
     fetchSubmodules = true;
   };
 
@@ -59,7 +60,7 @@ mkDerivation rec {
     ./Enable-file-access-and-universal-access-for-file-URL.patch
 
     # Lets obs-browser build against CEF 91.1.0+
-    ./Change-product_version-to-user_agent_product.patch
+    # ./Change-product_version-to-user_agent_product.patch
   ];
 
   nativeBuildInputs = [
@@ -93,7 +94,7 @@ mkDerivation rec {
   ++ optionals scriptingSupport [ luajit python3 ]
   ++ optional alsaSupport alsa-lib
   ++ optional pulseaudioSupport libpulseaudio
-  ++ optional pipewireSupport pipewire;
+  ++ optionals pipewireSupport [ pipewire libdrm ];
 
   # Copied from the obs-linuxbrowser
   postUnpack = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This should fix in part https://github.com/NixOS/nixpkgs/issues/145174 for obs as the new version includes https://github.com/obsproject/obs-studio/pull/5294.
FOr firefox screen sharing this does nto resolve anything yet.

###### Things done

For now it fails with
```
@nix { "action": "setPhase", "phase": "qtPreHook" }
qtPreHook
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking sources
unpacking source archive /nix/store/02lv6pc5fm6dib1rfkfhqj1y18kkkkn4-source
source root is source
@nix { "action": "setPhase", "phase": "patchPhase" }
patching sources
applying patch /nix/store/f4kv9vm7iyvq8k725hhypqpsdnkzxhzn-Enable-file-access-and-universal-access-for-file-URL.patch
patching file plugins/obs-browser/obs-browser-source.cpp
Hunk #1 succeeded at 180 (offset 1 line).
@nix { "action": "setPhase", "phase": "configurePhase" }
configuring
fixing cmake files...
cmake flags: -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_SKIP_BUILD_RPATH=ON -DBUILD_TESTING=OFF -DCMAKE_INSTALL_LOCALEDIR=/nix/store/bx4lxznbw3823c2bmcmxba2478fmg07b-obs-studio-27.1.3/share/locale -DCMAKE_INSTALL_LIBEXECDIR=/nix/store/bx4lxznbw3823c2bmcmxba2478fmg07b-obs-studio-27.1.3/libexec -DCMAKE_INSTALL_LIBDIR=/nix/store/bx4lxznbw3823c2bmcmxba2478fmg07b-obs-studio-27.1.3/lib -DCMAKE_INSTALL_DOCDIR=/nix/store/bx4lxznbw3823c2bmcmxba2478fmg07b-obs-studio-27.1.3/share/doc/obs-studio -DCMAKE_INSTALL_INFODIR=/nix/store/bx4lxznbw3823c2bmcmxba2478fmg07b-obs-studio-27.1.3/share/info -DCMAKE_INSTALL_MANDIR=/nix/store/bx4lxznbw3823c2bmcmxba2478fmg07b-obs-studio-27.1.3/share/man -DCMAKE_INSTALL_OLDINCLUDEDIR=/nix/store/bx4lxznbw3823c2bmcmxba2478fmg07b-obs-studio-27.1.3/include -DCMAKE_INSTALL_INCLUDEDIR=/nix/store/bx4lxznbw3823c2bmcmxba2478fmg07b-obs-studio-27.1.3/include -DCMAKE_INSTALL_SBINDIR=/nix/store/bx4lxznbw3823c2bmcmxba2478fmg07b-obs-studio-27.1.3/sbin -DCMAKE_INSTALL_BINDIR=/nix/store/bx4lxznbw3823c2bmcmxba2478fmg07b-obs-studio-27.1.3/bin -DCMAKE_INSTALL_NAME_DIR=/nix/store/bx4lxznbw3823c2bmcmxba2478fmg07b-obs-studio-27.1.3/lib -DCMAKE_POLICY_DEFAULT_CMP0025=NEW -DCMAKE_OSX_SYSROOT= -DCMAKE_FIND_FRAMEWORK=LAST -DCMAKE_STRIP=/nix/store/da9l6ifizmh883j94gzx5n51h8lrrp00-gcc-wrapper-10.3.0/bin/strip -DCMAKE_RANLIB=/nix/store/js66s0xwjnzg0ggi2lq9bcvlk6x2za13-binutils-2.35.2/bin/ranlib -DCMAKE_AR=/nix/store/js66s0xwjnzg0ggi2lq9bcvlk6x2za13-binutils-2.35.2/bin/ar -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_INSTALL_PREFIX=/nix/store/bx4lxznbw3823c2bmcmxba2478fmg07b-obs-studio-27.1.3 -DCMAKE_CXX_FLAGS=-DDL_OPENGL=\"$(out)/lib/libobs-opengl.so\" -DOBS_VERSION_OVERRIDE=27.1.3 -Wno-dev -DBUILD_BROWSER=ON -DCEF_ROOT_DIR=../../cef 
-- The C compiler identification is GNU 10.3.0
-- The CXX compiler identification is GNU 10.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /nix/store/da9l6ifizmh883j94gzx5n51h8lrrp00-gcc-wrapper-10.3.0/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /nix/store/da9l6ifizmh883j94gzx5n51h8lrrp00-gcc-wrapper-10.3.0/bin/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- OBS_VERSION: 27.1.3
-- Found OpenGL: /nix/store/5icl3gj83q5ar5klx2lc61qyll669inw-libGL-1.3.4/lib/libOpenGL.so   
-- Found X11: /nix/store/4avf3mizws2s23sldkaf8k89a2kxz8gf-xorgproto-2021.5/include   
-- Looking for XOpenDisplay in /nix/store/9mg4w9gk1bl4xx90painmfx47vn9acpl-libX11-1.7.2/lib/libX11.so;/nix/store/8kq4p99xixlhp0dp8lm81564g3aqshvy-libXext-1.3.4/lib/libXext.so
-- Looking for XOpenDisplay in /nix/store/9mg4w9gk1bl4xx90painmfx47vn9acpl-libX11-1.7.2/lib/libX11.so;/nix/store/8kq4p99xixlhp0dp8lm81564g3aqshvy-libXext-1.3.4/lib/libXext.so - found
-- Looking for gethostbyname
-- Looking for gethostbyname - found
-- Looking for connect
-- Looking for connect - found
-- Looking for remove
-- Looking for remove - found
-- Looking for shmat
-- Looking for shmat - found
-- Found PkgConfig: pkg-config (found version "0.29.2") 
-- Checking for module 'egl'
--   Found egl, version 1.3.4
-- Found EGL: /nix/store/9ih6dz9mpy0vik73j4dqslmvyg6mixdq-libGL-1.3.4-dev/include  
-- Found FFmpeg: /nix/store/6pnb66bszixqbq44v2f03nvb26m75j2w-ffmpeg-4.4.1/lib/../lib/libavcodec.so (found version "58.134.100") found components: avcodec avdevice avutil avformat 
-- Found Libcurl: /nix/store/4kx13qnwgwyb1zq57x0gnvzvdaq91m5r-curl-7.79.1/lib/../lib/libcurl.so  
-- Scripting: Luajit supported
-- Scripting: Python 3 supported
-- Found SWIG: /nix/store/l8fl2686p8slgyqflr4ap1jjz1cfwmly-swig-3.0.12/bin/swig (found suitable version "3.0.12", minimum required is "2")  
-- Using system Jansson library
-- XCB[XCB]: Found component XCB
-- Found XCB: /nix/store/c2ghjp08azbccl3nj75rrm3s78vwkxvh-libxcb-1.14/lib/libxcb.so  found components: XCB 
-- Found X11_XCB: /nix/store/9mg4w9gk1bl4xx90painmfx47vn9acpl-libX11-1.7.2/lib/libX11-xcb.so  
-- Found Wayland: /nix/store/kw2y4gc6cmpf7riivgbw20zk4dj3sakr-wayland-1.19.0/lib/libwayland-client.so;/nix/store/kw2y4gc6cmpf7riivgbw20zk4dj3sakr-wayland-1.19.0/lib/libwayland-server.so;/nix/store/kw2y4gc6cmpf7riivgbw20zk4dj3sakr-wayland-1.19.0/lib/libwayland-egl.so;/nix/store/kw2y4gc6cmpf7riivgbw20zk4dj3sakr-wayland-1.19.0/lib/libwayland-cursor.so   
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Found FFmpeg: /nix/store/6pnb66bszixqbq44v2f03nvb26m75j2w-ffmpeg-4.4.1/lib/../lib/libavformat.so (found version "58.76.100") found components: avformat avutil swscale swresample avcodec 
-- XCB[XINPUT]: Found component XINPUT
-- Found XCB: /nix/store/c2ghjp08azbccl3nj75rrm3s78vwkxvh-libxcb-1.14/lib/libxcb-xinput.so  found components: XINPUT 
-- XCB[XCB]: Found component XCB
-- XCB[COMPOSITE]: Found component COMPOSITE
-- XCB[DAMAGE]: Found component DAMAGE
-- XCB[DRI2]: Found component DRI2
-- XCB[EWMH]: Found component EWMH
-- XCB[GLX]: Found component GLX
-- XCB[ICCCM]: Found component ICCCM
-- XCB[IMAGE]: Found component IMAGE
-- XCB[KEYSYMS]: Found component KEYSYMS
-- XCB[RANDR]: Found component RANDR
-- XCB[RENDER]: Found component RENDER
-- XCB[RENDERUTIL]: Found component RENDERUTIL
-- XCB[SHAPE]: Found component SHAPE
-- XCB[SHM]: Found component SHM
-- XCB[SYNC]: Found component SYNC
-- XCB[UTIL]: Found component UTIL
-- XCB[XFIXES]: Found component XFIXES
-- XCB[XTEST]: Found component XTEST
-- XCB[XV]: Found component XV
-- XCB[XINPUT]: Found component XINPUT
-- XCB[XINERAMA]: Found component XINERAMA
-- Found XCB: /nix/store/c2ghjp08azbccl3nj75rrm3s78vwkxvh-libxcb-1.14/lib/libxcb-xinput.so;/nix/store/c2ghjp08azbccl3nj75rrm3s78vwkxvh-libxcb-1.14/lib/libxcb.so;/nix/store/c2ghjp08azbccl3nj75rrm3s78vwkxvh-libxcb-1.14/lib/libxcb-composite.so;/nix/store/c2ghjp08azbccl3nj75rrm3s78vwkxvh-libxcb-1.14/lib/libxcb-damage.so;/nix/store/c2ghjp08azbccl3nj75rrm3s78vwkxvh-libxcb-1.14/lib/libxcb-dri2.so;/nix/store/qs95819s0mrb86j0m3ax2plx87vghiwh-xcb-util-wm-0.4.1/lib/libxcb-ewmh.so;/nix/store/c2ghjp08azbccl3nj75rrm3s78vwkxvh-libxcb-1.14/lib/libxcb-glx.so;/nix/store/qs95819s0mrb86j0m3ax2plx87vghiwh-xcb-util-wm-0.4.1/lib/libxcb-icccm.so;/nix/store/9cbwnx9py8hh8fnivz6s7g574glilbgc-xcb-util-image-0.4.0/lib/libxcb-image.so;/nix/store/5alr4wx76wg2y17mi01mm56xddj9bhif-xcb-util-keysyms-0.4.0/lib/libxcb-keysyms.so;/nix/store/c2ghjp08azbccl3nj75rrm3s78vwkxvh-libxcb-1.14/lib/libxcb-randr.so;/nix/store/c2ghjp08azbccl3nj75rrm3s78vwkxvh-libxcb-1.14/lib/libxcb-render.so;/nix/store/gpxnnj4xcf27v7p0cz9j9g9awrmg6pwj-xcb-util-renderutil-0.3.9/lib/libxcb-render-util.so;/nix/store/c2ghjp08azbccl3nj75rrm3s78vwkxvh-libxcb-1.14/lib/libxcb-shape.so;/nix/store/c2ghjp08azbccl3nj75rrm3s78vwkxvh-libxcb-1.14/lib/libxcb-shm.so;/nix/store/c2ghjp08azbccl3nj75rrm3s78vwkxvh-libxcb-1.14/lib/libxcb-sync.so;/nix/store/ym6nzlqs38p447lqjca0b8m798jzmywh-xcb-util-0.4.0/lib/libxcb-util.so;/nix/store/c2ghjp08azbccl3nj75rrm3s78vwkxvh-libxcb-1.14/lib/libxcb-xfixes.so;/nix/store/c2ghjp08azbccl3nj75rrm3s78vwkxvh-libxcb-1.14/lib/libxcb-xtest.so;/nix/store/c2ghjp08azbccl3nj75rrm3s78vwkxvh-libxcb-1.14/lib/libxcb-xv.so;/nix/store/c2ghjp08azbccl3nj75rrm3s78vwkxvh-libxcb-1.14/lib/libxcb-xinput.so;/nix/store/c2ghjp08azbccl3nj75rrm3s78vwkxvh-libxcb-1.14/lib/libxcb-xinerama.so   
-- Found PulseAudio - Audio Monitor enabled
-- Checking for modules 'gio-2.0;gio-unix-2.0'
--   Found gio-2.0, version 2.70.1
--   Found gio-unix-2.0, version 2.70.1
Package libpcre was not found in the pkg-config search path.
Perhaps you should add the directory containing `libpcre.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libpcre', required by 'glib-2.0', not found
Package libpcre was not found in the pkg-config search path.
Perhaps you should add the directory containing `libpcre.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libpcre', required by 'glib-2.0', not found
Package libpcre was not found in the pkg-config search path.
Perhaps you should add the directory containing `libpcre.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libpcre', required by 'glib-2.0', not found
Package libpcre was not found in the pkg-config search path.
Perhaps you should add the directory containing `libpcre.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libpcre', required by 'glib-2.0', not found
-- Using libavcodec for image loading in libobs
-- Found ZLIB: /nix/store/1l4r0r4ab3v3a3ppir4jwiah3icalk9d-zlib-1.2.11/lib/../lib/libz.so  
-- Found Wayland: /nix/store/kw2y4gc6cmpf7riivgbw20zk4dj3sakr-wayland-1.19.0/lib/libwayland-client.so;/nix/store/kw2y4gc6cmpf7riivgbw20zk4dj3sakr-wayland-1.19.0/lib/libwayland-server.so;/nix/store/kw2y4gc6cmpf7riivgbw20zk4dj3sakr-wayland-1.19.0/lib/libwayland-egl.so;/nix/store/kw2y4gc6cmpf7riivgbw20zk4dj3sakr-wayland-1.19.0/lib/libwayland-cursor.so  found components: Client 
-- XCB[XCB]: Found component XCB
-- XCB[RANDR]: Found component RANDR
-- XCB[SHM]: Found component SHM
-- XCB[XFIXES]: Found component XFIXES
-- XCB[XINERAMA]: Found component XINERAMA
-- Found XCB: /nix/store/c2ghjp08azbccl3nj75rrm3s78vwkxvh-libxcb-1.14/lib/libxcb.so;/nix/store/c2ghjp08azbccl3nj75rrm3s78vwkxvh-libxcb-1.14/lib/libxcb-randr.so;/nix/store/c2ghjp08azbccl3nj75rrm3s78vwkxvh-libxcb-1.14/lib/libxcb-shm.so;/nix/store/c2ghjp08azbccl3nj75rrm3s78vwkxvh-libxcb-1.14/lib/libxcb-xfixes.so;/nix/store/c2ghjp08azbccl3nj75rrm3s78vwkxvh-libxcb-1.14/lib/libxcb-xinerama.so  found components: XCB RANDR SHM XFIXES XINERAMA 
Package valgrind was not found in the pkg-config search path.
Perhaps you should add the directory containing `valgrind.pc'
to the PKG_CONFIG_PATH environment variable
Package 'valgrind', required by 'libdrm', not found
Package valgrind was not found in the pkg-config search path.
Perhaps you should add the directory containing `valgrind.pc'
to the PKG_CONFIG_PATH environment variable
Package 'valgrind', required by 'libdrm', not found
Package valgrind was not found in the pkg-config search path.
Perhaps you should add the directory containing `valgrind.pc'
to the PKG_CONFIG_PATH environment variable
Package 'valgrind', required by 'libdrm', not found
Package valgrind was not found in the pkg-config search path.
Perhaps you should add the directory containing `valgrind.pc'
to the PKG_CONFIG_PATH environment variable
Package 'valgrind', required by 'libdrm', not found
-- Found Libv4l2: /nix/store/qa090z443z131hiwbih120p5nnl5kchl-v4l-utils-1.20.0/lib/libv4l2.so  
-- Found UDev: /nix/store/q0881awy50g4srnnwasci37y2jk5sf99-systemd-249.5/lib/libudev.so  
-- Checking for module 'jack'
--   Found jack, version 1.9.19
-- Found jack: /nix/store/bgah4h1gznfq7971d05f0vkj2ncghlh7-libjack2-1.9.19/lib/libjack.so
-- Found ALSA: /nix/store/1h35ql1p654zrjnxzxkm7hfk08k58sp7-alsa-lib-1.2.5.1/lib/libasound.so (found version "1.2.5.1") 
-- Found LibVLC: /nix/store/fr7bskhmvbykhid7p7bkhq50d1gnqswj-libvlc-3.0.16/include/vlc  
-- Could NOT find Sndio (missing: Sndio_LIBRARY Sndio_INCLUDE_DIR) 
-- Sndio not found, disabling Sndio plugin
-- Looking for Chromium Embedded Framework in /build/cef
-- Using the bundled VST header.
-- Found Libx264: /nix/store/bicqwnsf06i7fiagi3jaza58wdgnqszz-x264-unstable-2021-06-13-lib/lib/../lib/libx264.so  
-- Found FFmpeg: /nix/store/6pnb66bszixqbq44v2f03nvb26m75j2w-ffmpeg-4.4.1/lib/../lib/libavcodec.so (found version "58.134.100") found components: avcodec avfilter avdevice avutil swscale avformat swresample 
-- Found FFmpeg: /nix/store/6pnb66bszixqbq44v2f03nvb26m75j2w-ffmpeg-4.4.1/lib/../lib/libavcodec.so (found version "58.134.100") found components: avcodec avutil avformat 
-- Found MbedTLS: /nix/store/ax93fcdfcf76vi83wbwdv3hm2101zihk-mbedtls-2.26.0/lib/../lib/libmbedtls.so;/nix/store/ax93fcdfcf76vi83wbwdv3hm2101zihk-mbedtls-2.26.0/lib/../lib/libmbedcrypto.so;/nix/store/ax93fcdfcf76vi83wbwdv3hm2101zihk-mbedtls-2.26.0/lib/../lib/libmbedx509.so  
-- Checking for module 'libftl'
--   No package 'libftl' found
-- Found ftl-sdk: ftl outputs enabled
-- Found Libspeexdsp: /nix/store/4hc262q65x4n87sy8r90hbq298hpvjnp-speexdsp-1.2.0/lib/../lib/libspeexdsp.so  
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    BUILD_TESTING


-- Build files have been written to: /build/source/build
cmake: enabled parallel building
@nix { "action": "setPhase", "phase": "buildPhase" }
building
build flags: -j16 -l16 SHELL=/nix/store/l0wlqpbsvh1pgvhcdhw7qkka3d31si7k-bash-5.1-p8/bin/bash
Scanning dependencies of target obslua_swig_compilation
Scanning dependencies of target obspython_swig_compilation
[  1%] Building C object deps/libcaption/CMakeFiles/caption.dir/src/srt.c.o
[  1%] Building C object deps/glad/CMakeFiles/glad.dir/src/glad_egl.c.o
[  1%] Building C object deps/glad/CMakeFiles/glad.dir/src/glad.c.o
[  1%] Automatic MOC for target obs-browser-page
[  1%] Building C object deps/media-playback/CMakeFiles/media-playback.dir/media-playback/media.c.o
[  1%] Building C object deps/media-playback/CMakeFiles/media-playback.dir/media-playback/decode.c.o
[  1%] Building C object deps/libcaption/CMakeFiles/caption.dir/src/utf8.c.o
[  1%] Building C object deps/glad/CMakeFiles/glad.dir/src/glad_glx.c.o
[  1%] Building C object deps/libcaption/CMakeFiles/caption.dir/src/scc.c.o
[  1%] Building C object deps/libcaption/CMakeFiles/caption.dir/src/mpeg.c.o
[  1%] Building C object deps/libcaption/CMakeFiles/caption.dir/src/cea708.c.o
[  1%] Building C object deps/libcaption/CMakeFiles/caption.dir/src/xds.c.o
[  2%] Building C object deps/libcaption/CMakeFiles/caption.dir/src/caption.c.o
[  2%] Building C object deps/libcaption/CMakeFiles/caption.dir/src/eia608_charmap.c.o
[  3%] Swig compile obslua.i for lua
[  3%] Swig compile obspython.i for python
[  3%] Building C object deps/libcaption/CMakeFiles/caption.dir/src/eia608_from_utf8.c.o
[  3%] Building C object deps/libcaption/CMakeFiles/caption.dir/src/eia608.c.o
/build/source/deps/media-playback/media-playback/decode.c: In function 'mp_decode_next':
/build/source/deps/media-playback/media-playback/decode.c:373:5: warning: 'av_init_packet' is deprecated [-Wdeprecated-declarations]
  373 |     av_init_packet(&d->orig_pkt);
      |     ^~~~~~~~~~~~~~
In file included from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/bsf.h:30,
                 from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/avcodec.h:44,
                 from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavformat/avformat.h:312,
                 from /build/source/deps/media-playback/media-playback/decode.h:31,
                 from /build/source/deps/media-playback/media-playback/decode.c:17:
/nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/packet.h:488:6: note: declared here
  488 | void av_init_packet(AVPacket *pkt);
      |      ^~~~~~~~~~~~~~
/build/source/deps/media-playback/media-playback/decode.c:374:5: warning: 'av_init_packet' is deprecated [-Wdeprecated-declarations]
  374 |     av_init_packet(&d->pkt);
      |     ^~~~~~~~~~~~~~
In file included from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/bsf.h:30,
                 from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/avcodec.h:44,
                 from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavformat/avformat.h:312,
                 from /build/source/deps/media-playback/media-playback/decode.h:31,
                 from /build/source/deps/media-playback/media-playback/decode.c:17:
/nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/packet.h:488:6: note: declared here
  488 | void av_init_packet(AVPacket *pkt);
      |      ^~~~~~~~~~~~~~
/build/source/deps/media-playback/media-playback/decode.c:390:5: warning: 'av_init_packet' is deprecated [-Wdeprecated-declarations]
  390 |     av_init_packet(&d->orig_pkt);
      |     ^~~~~~~~~~~~~~
In file included from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/bsf.h:30,
                 from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/avcodec.h:44,
                 from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavformat/avformat.h:312,
                 from /build/source/deps/media-playback/media-playback/decode.h:31,
                 from /build/source/deps/media-playback/media-playback/decode.c:17:
/nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/packet.h:488:6: note: declared here
  488 | void av_init_packet(AVPacket *pkt);
      |      ^~~~~~~~~~~~~~
/build/source/deps/media-playback/media-playback/decode.c:391:5: warning: 'av_init_packet' is deprecated [-Wdeprecated-declarations]
  391 |     av_init_packet(&d->pkt);
      |     ^~~~~~~~~~~~~~
In file included from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/bsf.h:30,
                 from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/avcodec.h:44,
                 from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavformat/avformat.h:312,
                 from /build/source/deps/media-playback/media-playback/decode.h:31,
                 from /build/source/deps/media-playback/media-playback/decode.c:17:
/nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/packet.h:488:6: note: declared here
  488 | void av_init_packet(AVPacket *pkt);
      |      ^~~~~~~~~~~~~~
/build/source/deps/media-playback/media-playback/media.c: In function 'mp_media_next_packet':
/build/source/deps/media-playback/media-playback/media.c:149:2: warning: 'av_init_packet' is deprecated [-Wdeprecated-declarations]
  149 |  av_init_packet(&pkt);
      |  ^~~~~~~~~~~~~~
In file included from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/bsf.h:30,
                 from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/avcodec.h:44,
                 from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavformat/avformat.h:312,
                 from /build/source/deps/media-playback/media-playback/decode.h:31,
                 from /build/source/deps/media-playback/media-playback/media.h:20,
                 from /build/source/deps/media-playback/media-playback/media.c:22:
/nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/packet.h:488:6: note: declared here
  488 | void av_init_packet(AVPacket *pkt);
      |      ^~~~~~~~~~~~~~
AutoMoc: /build/source/plugins/obs-browser/browser-app.hpp:0: Note: No relevant classes found. No output generated.
[  3%] Built target obs-browser-page_autogen
[  3%] Building CXX object plugins/obs-browser/CMakeFiles/obs-browser-page.dir/obs-browser-page/obs-browser-page-main.cpp.o
[  3%] Building CXX object plugins/obs-browser/CMakeFiles/obs-browser-page.dir/obs-browser-page_autogen/mocs_compilation.cpp.o
[  3%] Building CXX object plugins/obs-browser/CMakeFiles/obs-browser-page.dir/deps/json11/json11.cpp.o
[  3%] Building CXX object plugins/obs-browser/CMakeFiles/obs-browser-page.dir/browser-app.cpp.o
[  3%] Linking C static library libcaption.a
[  3%] Built target caption
[  3%] Building C object libobs/CMakeFiles/libobs.dir/callback/calldata.c.o
[  3%] Building C object libobs/CMakeFiles/libobs.dir/callback/signal.c.o
[  3%] Building C object libobs/CMakeFiles/libobs.dir/callback/decl.c.o
[  3%] Building C object libobs/CMakeFiles/libobs.dir/callback/proc.c.o
[  4%] Building C object libobs/CMakeFiles/libobs.dir/graphics/graphics-ffmpeg.c.o
[  4%] Building C object libobs/CMakeFiles/libobs.dir/graphics/quat.c.o
[  4%] Building C object libobs/CMakeFiles/libobs.dir/graphics/effect-parser.c.o
[  4%] Building C object libobs/CMakeFiles/libobs.dir/graphics/axisang.c.o
[  4%] Building C object libobs/CMakeFiles/libobs.dir/graphics/vec4.c.o
[  4%] Linking C static library libmedia-playback.a
[  4%] Built target media-playback
[  5%] Building C object libobs/CMakeFiles/libobs.dir/graphics/vec2.c.o
[  5%] Building C object libobs/CMakeFiles/libobs.dir/graphics/libnsgif/libnsgif.c.o
[  5%] Building C object libobs/CMakeFiles/libobs.dir/graphics/texture-render.c.o
[  5%] Building C object libobs/CMakeFiles/libobs.dir/graphics/image-file.c.o
[  6%] Building C object libobs/CMakeFiles/libobs.dir/graphics/bounds.c.o
[  6%] Building C object libobs/CMakeFiles/libobs.dir/graphics/matrix3.c.o
[  6%] Building C object libobs/CMakeFiles/libobs.dir/graphics/matrix4.c.o
[  6%] Building C object libobs/CMakeFiles/libobs.dir/graphics/vec3.c.o
[  6%] Building C object libobs/CMakeFiles/libobs.dir/graphics/graphics.c.o
[  7%] Building C object libobs/CMakeFiles/libobs.dir/graphics/shader-parser.c.o
[  7%] Building C object libobs/CMakeFiles/libobs.dir/graphics/plane.c.o
[  7%] Building C object libobs/CMakeFiles/libobs.dir/graphics/effect.c.o
[  7%] Building C object libobs/CMakeFiles/libobs.dir/graphics/math-extra.c.o
[  7%] Building C object libobs/CMakeFiles/libobs.dir/graphics/graphics-imports.c.o
[  8%] Building C object libobs/CMakeFiles/libobs.dir/media-io/video-io.c.o
[  8%] Building C object libobs/CMakeFiles/libobs.dir/media-io/video-fourcc.c.o
[  8%] Building C object libobs/CMakeFiles/libobs.dir/media-io/video-matrices.c.o
[  8%] Building C object libobs/CMakeFiles/libobs.dir/media-io/audio-io.c.o
[  9%] Building C object libobs/CMakeFiles/libobs.dir/media-io/video-frame.c.o
[  9%] Building C object libobs/CMakeFiles/libobs.dir/media-io/format-conversion.c.o
[  9%] Building C object libobs/CMakeFiles/libobs.dir/media-io/audio-resampler-ffmpeg.c.o
[  9%] Building C object libobs/CMakeFiles/libobs.dir/media-io/video-scaler-ffmpeg.c.o
[  9%] Building C object libobs/CMakeFiles/libobs.dir/media-io/media-remux.c.o
[ 10%] Building C object libobs/CMakeFiles/libobs.dir/util/array-serializer.c.o
[ 10%] Built target obslua_swig_compilation
[ 10%] Building C object libobs/CMakeFiles/libobs.dir/util/base.c.o
[ 10%] Building C object libobs/CMakeFiles/libobs.dir/util/file-serializer.c.o
[ 10%] Building C object libobs/CMakeFiles/libobs.dir/util/platform.c.o
[ 10%] Building C object libobs/CMakeFiles/libobs.dir/util/cf-lexer.c.o
[ 11%] Building C object libobs/CMakeFiles/libobs.dir/util/bmem.c.o
[ 11%] Building C object libobs/CMakeFiles/libobs.dir/util/config-file.c.o
[ 11%] Building C object libobs/CMakeFiles/libobs.dir/util/lexer.c.o
[ 11%] Building C object libobs/CMakeFiles/libobs.dir/util/dstr.c.o
[ 12%] Building C object libobs/CMakeFiles/libobs.dir/util/utf8.c.o
[ 12%] Building C object libobs/CMakeFiles/libobs.dir/util/crc32.c.o
[ 12%] Building C object libobs/CMakeFiles/libobs.dir/util/text-lookup.c.o
[ 12%] Building C object libobs/CMakeFiles/libobs.dir/util/cf-parser.c.o
[ 12%] Building C object libobs/CMakeFiles/libobs.dir/util/profiler.c.o
[ 13%] Linking C shared library libobsglad.so
[ 14%] Building C object libobs/CMakeFiles/libobs.dir/util/bitstream.c.o
[ 14%] Building C object libobs/CMakeFiles/libobs.dir/obs-nix.c.o
[ 14%] Building C object libobs/CMakeFiles/libobs.dir/obs-nix-platform.c.o
[ 14%] Building C object libobs/CMakeFiles/libobs.dir/obs-nix-x11.c.o
[ 14%] Building C object libobs/CMakeFiles/libobs.dir/util/threading-posix.c.o
[ 15%] Building C object libobs/CMakeFiles/libobs.dir/util/pipe-posix.c.o
[ 15%] Building C object libobs/CMakeFiles/libobs.dir/util/platform-nix.c.o
[ 15%] Built target glad
[ 15%] Building C object libobs/CMakeFiles/libobs.dir/obs-nix-wayland.c.o
[ 15%] Building C object libobs/CMakeFiles/libobs.dir/util/platform-nix-dbus.c.o
[ 16%] Building C object libobs/CMakeFiles/libobs.dir/util/platform-nix-portal.c.o
[ 16%] Building C object libobs/CMakeFiles/libobs.dir/obs-audio-controls.c.o
[ 16%] Building C object libobs/CMakeFiles/libobs.dir/obs-avc.c.o
[ 16%] Building C object libobs/CMakeFiles/libobs.dir/obs-encoder.c.o
[ 16%] Building C object libobs/CMakeFiles/libobs.dir/obs-service.c.o
[ 17%] Building C object libobs/CMakeFiles/libobs.dir/obs-source.c.o
[ 17%] Building C object libobs/CMakeFiles/libobs.dir/obs-source-deinterlace.c.o
[ 17%] Building C object libobs/CMakeFiles/libobs.dir/obs-source-transition.c.o
[ 17%] Building C object libobs/CMakeFiles/libobs.dir/obs-output.c.o
[ 18%] Building C object libobs/CMakeFiles/libobs.dir/obs-output-delay.c.o
[ 18%] Building C object libobs/CMakeFiles/libobs.dir/obs.c.o
[ 18%] Building C object libobs/CMakeFiles/libobs.dir/obs-properties.c.o
[ 18%] Building C object libobs/CMakeFiles/libobs.dir/obs-data.c.o
[ 18%] Building C object libobs/CMakeFiles/libobs.dir/obs-missing-files.c.o
[ 19%] Building C object libobs/CMakeFiles/libobs.dir/obs-hotkey.c.o
[ 19%] Building C object libobs/CMakeFiles/libobs.dir/obs-hotkey-name-map.c.o
[ 19%] Building C object libobs/CMakeFiles/libobs.dir/obs-module.c.o
[ 19%] Building C object libobs/CMakeFiles/libobs.dir/obs-display.c.o
[ 19%] Building C object libobs/CMakeFiles/libobs.dir/obs-view.c.o
[ 20%] Building C object libobs/CMakeFiles/libobs.dir/obs-scene.c.o
[ 20%] Building C object libobs/CMakeFiles/libobs.dir/obs-audio.c.o
[ 20%] Building C object libobs/CMakeFiles/libobs.dir/obs-video-gpu-encode.c.o
[ 20%] Building C object libobs/CMakeFiles/libobs.dir/obs-video.c.o
[ 20%] Building C object libobs/CMakeFiles/libobs.dir/audio-monitoring/pulse/pulseaudio-wrapper.c.o
[ 21%] Building C object libobs/CMakeFiles/libobs.dir/audio-monitoring/pulse/pulseaudio-enum-devices.c.o
[ 21%] Building C object libobs/CMakeFiles/libobs.dir/audio-monitoring/pulse/pulseaudio-output.c.o
[ 22%] Linking CXX executable obs-browser-page
[ 22%] Built target obspython_swig_compilation
[ 22%] Built target obs-browser-page
[ 22%] Linking C shared library libobs.so
[ 22%] Built target libobs
[ 27%] Building C object plugins/linux-pulseaudio/CMakeFiles/linux-pulseaudio.dir/linux-pulseaudio.c.o
[ 27%] Building C object plugins/linux-alsa/CMakeFiles/linux-alsa.dir/linux-alsa.c.o
[ 27%] Building C object plugins/linux-capture/CMakeFiles/linux-capture.dir/linux-capture.c.o
[ 27%] Building CXX object UI/obs-frontend-api/CMakeFiles/obs-frontend-api.dir/obs-frontend-api.cpp.o
[ 27%] Building C object plugins/linux-jack/CMakeFiles/linux-jack.dir/linux-jack.c.o
[ 27%] Building C object deps/file-updater/CMakeFiles/file-updater.dir/file-updater/file-updater.c.o
[ 27%] Building C object libobs-opengl/CMakeFiles/libobs-opengl.dir/gl-egl-common.c.o
[ 27%] Building C object plugins/linux-v4l2/CMakeFiles/linux-v4l2.dir/linux-v4l2.c.o
[ 27%] Automatic MOC for target obs-vst
[ 27%] Building C object plugins/vlc-video/CMakeFiles/vlc-video.dir/vlc-video-plugin.c.o
[ 27%] Building CXX object plugins/decklink/linux/CMakeFiles/linux-decklink.dir/__/plugin-main.cpp.o
[ 27%] Building C object plugins/obs-x264/CMakeFiles/obs-x264-util.dir/obs-x264-options.c.o
[ 27%] Building C object plugins/image-source/CMakeFiles/image-source.dir/image-source.c.o
[ 27%] Building C object plugins/obs-ffmpeg/ffmpeg-mux/CMakeFiles/obs-ffmpeg-mux.dir/ffmpeg-mux.c.o
[ 27%] Building C object plugins/obs-ffmpeg/CMakeFiles/obs-ffmpeg.dir/obs-ffmpeg.c.o
[ 27%] Building C object plugins/obs-libfdk/CMakeFiles/obs-libfdk.dir/obs-libfdk.c.o
[ 28%] Linking C static library libobs-x264-util.a
/build/source/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c: In function 'create_video_stream':
/build/source/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c:418:2: warning: 'codec' is deprecated [-Wdeprecated-declarations]
  418 |  ffm->video_stream->codec->time_base = context->time_base;
      |  ^~~
In file included from /build/source/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c:30:
/nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavformat/avformat.h:888:21: note: declared here
  888 |     AVCodecContext *codec;
      |                     ^~~~~
/build/source/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c: In function 'ffmpeg_mux_packet':
/build/source/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c:794:2: warning: 'av_init_packet' is deprecated [-Wdeprecated-declarations]
  794 |  av_init_packet(&packet);
      |  ^~~~~~~~~~~~~~
In file included from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/bsf.h:30,
                 from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/avcodec.h:44,
                 from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavformat/avformat.h:312,
                 from /build/source/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c:30:
/nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/packet.h:488:6: note: declared here
  488 | void av_init_packet(AVPacket *pkt);
      |      ^~~~~~~~~~~~~~
[ 28%] Built target obs-x264-util
[ 28%] Building C object plugins/linux-alsa/CMakeFiles/linux-alsa.dir/alsa-input.c.o
[ 28%] Building C object plugins/linux-pulseaudio/CMakeFiles/linux-pulseaudio.dir/pulse-wrapper.c.o
[ 28%] Building C object plugins/linux-jack/CMakeFiles/linux-jack.dir/jack-wrapper.c.o
[ 28%] Building C object plugins/linux-jack/CMakeFiles/linux-jack.dir/jack-input.c.o
[ 28%] Building C object plugins/linux-v4l2/CMakeFiles/linux-v4l2.dir/v4l2-controls.c.o
[ 28%] Building C object plugins/linux-capture/CMakeFiles/linux-capture.dir/xcursor.c.o
[ 29%] Building C object plugins/obs-ffmpeg/CMakeFiles/obs-ffmpeg.dir/obs-ffmpeg-audio-encoders.c.o
[ 29%] Building C object plugins/vlc-video/CMakeFiles/vlc-video.dir/vlc-video-source.c.o
[ 30%] Building C object libobs-opengl/CMakeFiles/libobs-opengl.dir/gl-nix.c.o
[ 30%] Building C object plugins/image-source/CMakeFiles/image-source.dir/color-source.c.o
[ 30%] Linking C shared module obs-libfdk.so
[ 30%] Linking C executable obs-ffmpeg-mux
[ 30%] Linking C static library libfile-updater.a
[ 30%] Built target obs-vst_autogen
[ 30%] Building C object plugins/linux-pulseaudio/CMakeFiles/linux-pulseaudio.dir/pulse-input.c.o
[ 30%] Built target file-updater
[ 30%] Building C object plugins/image-source/CMakeFiles/image-source.dir/obs-slideshow.c.o
[ 31%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/ftl-stream.c.o
[ 31%] Linking C shared module linux-jack.so
[ 31%] Building C object plugins/linux-capture/CMakeFiles/linux-capture.dir/xcursor-xcb.c.o
[ 31%] Built target obs-libfdk
[ 31%] Building C object plugins/linux-capture/CMakeFiles/linux-capture.dir/xhelpers.c.o
[ 32%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/rnnoise/src/celt_lpc.c.o
[ 32%] Building C object plugins/linux-v4l2/CMakeFiles/linux-v4l2.dir/v4l2-input.c.o
[ 32%] Building C object plugins/linux-v4l2/CMakeFiles/linux-v4l2.dir/v4l2-helpers.c.o
[ 32%] Linking C shared module linux-alsa.so
[ 32%] Building C object libobs-opengl/CMakeFiles/libobs-opengl.dir/gl-x11-egl.c.o
[ 32%] Building C object plugins/obs-ffmpeg/CMakeFiles/obs-ffmpeg.dir/obs-ffmpeg-nvenc.c.o
[ 32%] Built target linux-jack
[ 32%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/rnnoise/src/denoise.c.o
[ 32%] Built target obs-ffmpeg-mux
[ 32%] Linking C shared module linux-pulseaudio.so
[ 32%] Building C object plugins/obs-ffmpeg/CMakeFiles/obs-ffmpeg.dir/obs-ffmpeg-output.c.o
[ 32%] Building C object plugins/linux-capture/CMakeFiles/linux-capture.dir/xshm-input.c.o
[ 32%] Built target linux-alsa
[ 32%] Building C object libobs-opengl/CMakeFiles/libobs-opengl.dir/gl-x11-glx.c.o
[ 32%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/rnnoise/src/kiss_fft.c.o
[ 33%] Building CXX object plugins/linux-capture/CMakeFiles/linux-capture.dir/xcomposite-main.cpp.o
/build/source/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c: In function 'nvenc_init_codec':
/build/source/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c:93:62: warning: unused parameter 'psycho_aq' [-Wunused-parameter]
   93 | static bool nvenc_init_codec(struct nvenc_encoder *enc, bool psycho_aq)
      |                                                              ^
/build/source/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c: In function 'nvenc_encode':
/build/source/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c:440:2: warning: 'av_init_packet' is deprecated [-Wdeprecated-declarations]
  440 |  av_init_packet(&av_pkt);
      |  ^~~~~~~~~~~~~~
In file included from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/bsf.h:30,
                 from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/avcodec.h:44,
                 from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavformat/avformat.h:312,
                 from /build/source/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c:27:
/nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/packet.h:488:6: note: declared here
  488 | void av_init_packet(AVPacket *pkt);
      |      ^~~~~~~~~~~~~~
[ 34%] Linking C shared module vlc-video.so
[ 35%] Building C object plugins/obs-transitions/CMakeFiles/obs-transitions.dir/obs-transitions.c.o
[ 35%] Built target linux-pulseaudio
[ 35%] Building C object plugins/obs-transitions/CMakeFiles/obs-transitions.dir/transition-slide.c.o
[ 36%] Linking C shared module image-source.so
/build/source/plugins/obs-ffmpeg/obs-ffmpeg-output.c: In function 'receive_video':
/build/source/plugins/obs-ffmpeg/obs-ffmpeg-output.c:728:2: warning: 'av_init_packet' is deprecated [-Wdeprecated-declarations]
  728 |  av_init_packet(&packet);
      |  ^~~~~~~~~~~~~~
In file included from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/bsf.h:30,
                 from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/avcodec.h:44,
                 from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavformat/avformat.h:312,
                 from /build/source/plugins/obs-ffmpeg/obs-ffmpeg-output.h:5,
                 from /build/source/plugins/obs-ffmpeg/obs-ffmpeg-output.c:25:
/nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/packet.h:488:6: note: declared here
  488 | void av_init_packet(AVPacket *pkt);
      |      ^~~~~~~~~~~~~~
[ 36%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/ftl-sdk/libftl/hmac/hmac.c.o
[ 36%] Building C object libobs-opengl/CMakeFiles/libobs-opengl.dir/gl-wayland-egl.c.o
[ 36%] Building C object plugins/linux-v4l2/CMakeFiles/linux-v4l2.dir/v4l2-output.c.o
[ 37%] Building C object plugins/linux-v4l2/CMakeFiles/linux-v4l2.dir/v4l2-udev.c.o
[ 37%] Built target vlc-video
[ 37%] Building CXX object plugins/decklink/linux/CMakeFiles/linux-decklink.dir/__/decklink-devices.cpp.o
[ 37%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/rnnoise/src/pitch.c.o
[ 37%] Building C object plugins/rtmp-services/CMakeFiles/rtmp-services.dir/service-specific/twitch.c.o
[ 37%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/ftl-sdk/libftl/hmac/sha2.c.o
[ 37%] Building C object plugins/obs-transitions/CMakeFiles/obs-transitions.dir/transition-swipe.c.o
[ 38%] Building CXX object plugins/decklink/linux/CMakeFiles/linux-decklink.dir/__/decklink-source.cpp.o
[ 38%] Building C object libobs-opengl/CMakeFiles/libobs-opengl.dir/gl-helpers.c.o
[ 38%] Built target image-source
[ 38%] Building C object plugins/obs-ffmpeg/CMakeFiles/obs-ffmpeg.dir/obs-ffmpeg-mux.c.o
[ 38%] Building C object plugins/obs-transitions/CMakeFiles/obs-transitions.dir/transition-fade.c.o
[ 39%] Building C object plugins/obs-transitions/CMakeFiles/obs-transitions.dir/transition-cut.c.o
[ 39%] Linking C shared module linux-v4l2.so
[ 39%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/ftl-sdk/libftl/ftl-sdk.c.o
[ 40%] Building C object libobs-opengl/CMakeFiles/libobs-opengl.dir/gl-indexbuffer.c.o
[ 40%] Building CXX object plugins/linux-capture/CMakeFiles/linux-capture.dir/xcompcap-main.cpp.o
[ 40%] Linking CXX shared library libobs-frontend-api.so
[ 40%] Building C object plugins/obs-transitions/CMakeFiles/obs-transitions.dir/transition-fade-to-color.c.o
[ 40%] Building C object plugins/rtmp-services/CMakeFiles/rtmp-services.dir/service-specific/younow.c.o
[ 40%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/ftl-sdk/libftl/handshake.c.o
[ 41%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/ftl-sdk/libftl/ingest.c.o
[ 42%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/rnnoise/src/rnn.c.o
[ 42%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/rnnoise/src/rnn_data.c.o
/build/source/plugins/obs-outputs/ftl-sdk/libftl/handshake.c: In function '_ingest_connect':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/handshake.c:153:21: warning: implicit conversion from 'enum <anonymous>' to 'ftl_response_code_t' [-Wenum-conversion]
  153 |       response_code = FTL_INGEST_NO_RESPONSE;
      |                     ^
/build/source/plugins/obs-outputs/ftl-sdk/libftl/handshake.c:231:23: warning: implicit conversion from 'enum <anonymous>' to 'ftl_response_code_t' [-Wenum-conversion]
  231 |         response_code = FTL_MALLOC_FAILURE;
      |                       ^
/build/source/plugins/obs-outputs/ftl-sdk/libftl/handshake.c:236:23: warning: implicit conversion from 'enum <anonymous>' to 'ftl_response_code_t' [-Wenum-conversion]
  236 |         response_code = FTL_MALLOC_FAILURE;
      |                       ^
/build/source/plugins/obs-outputs/ftl-sdk/libftl/handshake.c:243:21: warning: implicit conversion from 'enum <anonymous>' to 'ftl_response_code_t' [-Wenum-conversion]
  243 |       response_code = FTL_MALLOC_FAILURE;
      |                     ^
/build/source/plugins/obs-outputs/ftl-sdk/libftl/handshake.c:250:21: warning: implicit conversion from 'enum <anonymous>' to 'ftl_response_code_t' [-Wenum-conversion]
  250 |       response_code = FTL_MALLOC_FAILURE;
      |                     ^
[ 42%] Built target linux-v4l2
[ 42%] Building C object plugins/obs-transitions/CMakeFiles/obs-transitions.dir/transition-luma-wipe.c.o
[ 42%] Building C object plugins/text-freetype2/CMakeFiles/text-freetype2.dir/find-font-unix.c.o
[ 42%] Building C object libobs-opengl/CMakeFiles/libobs-opengl.dir/gl-shader.c.o
/build/source/plugins/obs-outputs/ftl-sdk/libftl/ingest.c: In function '_ping_server':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/ingest.c:34:7: warning: unused variable 'ingest_port' [-Wunused-variable]
   34 |   int ingest_port = INGEST_PORT;
      |       ^~~~~~~~~~~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/ingest.c: In function '_ingest_get_rtt':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/ingest.c:82:41: warning: unused variable 'ftl' [-Wunused-variable]
   82 |     ftl_stream_configuration_private_t *ftl = thread_data->ftl;
      |                                         ^~~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/ingest.c: In function 'ftl_find_closest_available_ingest':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/ingest.c:179:9: warning: unused variable 'ms' [-Wunused-variable]
  179 |     int ms = (int)timeval_to_ms(&delta);
      |         ^~
[ 43%] Building C object plugins/rtmp-services/CMakeFiles/rtmp-services.dir/service-specific/nimotv.c.o
/build/source/plugins/obs-outputs/ftl-sdk/libftl/ingest.c: In function '_ingest_get_hosts':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/ingest.c:338:10: warning: returning 'int' from a function with return type 'OS_THREAD_ROUTINE' {aka 'void *'} makes pointer from integer without a cast [-Wint-conversion]
  338 |   return total_ingest_cnt;
      |          ^~~~~~~~~~~~~~~~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/ingest.c:243:7: warning: unused variable 'formatUri' [-Wunused-variable]
  243 |   int formatUri = snprintf(ingestBestUrl, sizeof(ingestBestUrl), INGEST_LIST_URI, ftl->channel_id);
      |       ^~~~~~~~~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/ingest.c:230:9: warning: unused variable 'query_result' [-Wunused-variable]
  230 |   char *query_result = NULL;
      |         ^~~~~~~~~~~~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/ingest.c: In function 'ingest_find_best':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/ingest.c:357:30: warning: ordered comparison of pointer with integer zero [-Wextra]
  357 |   if (_ingest_get_hosts(ftl) <= 0) {
      |                              ^~
[ 43%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/ftl-sdk/libftl/ftl_helpers.c.o
[ 43%] Building C object plugins/obs-transitions/CMakeFiles/obs-transitions.dir/transition-stinger.c.o
/build/source/plugins/obs-outputs/ftl-sdk/libftl/ingest.c: In function '_ingest_get_rtt':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/ingest.c:74:3: warning: 'sock' may be used uninitialized in this function [-Wmaybe-uninitialized]
   74 |   shutdown_socket(sock, SD_BOTH);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/ingest.c:19:10: note: 'sock' was declared here
   19 |   SOCKET sock;
      |          ^~~~
[ 43%] Building C object libobs-opengl/CMakeFiles/libobs-opengl.dir/gl-shaderparser.c.o
[ 43%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/ftl-sdk/libftl/media.c.o
[ 43%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/rnnoise/src/rnn_reader.c.o
[ 43%] Built target obs-frontend-api
[ 43%] Scripting plugin: Building Python SWIG interface header
[ 43%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/obs-filters.c.o
/build/source/plugins/obs-outputs/ftl-sdk/libftl/ftl_helpers.c: In function 'recv_all':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/ftl_helpers.c:71:9: warning: unused variable 'pos' [-Wunused-variable]
   71 |     int pos = 0;
      |         ^~~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/ftl_helpers.c: In function '_get_remote_ip':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/ftl_helpers.c:281:50: warning: unused parameter 'addrlen' [-Wunused-parameter]
  281 | int _get_remote_ip(struct sockaddr *addr, size_t addrlen, char *remote_ip, size_t ip_len) {
      |                                           ~~~~~~~^~~~~~~
[ 44%] Scripting: Building Lua SWIG interface header
[ 44%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/ftl-sdk/libftl/gettimeofday/gettimeofday.c.o
[ 44%] Building C object deps/obs-scripting/CMakeFiles/obs-scripting.dir/obs-scripting.c.o
[ 44%] Building C object plugins/rtmp-services/CMakeFiles/rtmp-services.dir/service-specific/showroom.c.o
[ 44%] Building C object plugins/obs-ffmpeg/CMakeFiles/obs-ffmpeg.dir/obs-ffmpeg-hls-mux.c.o
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c: In function 'media_init':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c:128:23: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
  128 |     for (idx = 0; idx < sizeof(media_comp) / sizeof(media_comp[0]); idx++) {
      |                       ^
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c: In function 'media_speed_test':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c:487:71: warning: comparison of integer expressions of different signedness: 'int64_t' {aka 'long int'} and 'long unsigned int' [-Wsign-compare]
  487 |       if ((bytes_sent = media_send_audio(ftl, 0, data, sizeof(data))) < sizeof(data)) {
      |                                                                       ^
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c:445:7: warning: unused variable 'rtp_hdr_len' [-Wunused-variable]
  445 |   int rtp_hdr_len = 0;
      |       ^~~~~~~~~~~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c:421:9: warning: unused variable 'packet_loss' [-Wunused-variable]
  421 |   float packet_loss = 0.f;
      |         ^~~~~~~~~~~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c:411:23: warning: unused variable 'media' [-Wunused-variable]
  411 |   ftl_media_config_t *media = &ftl->media;
      |                       ^~~~~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c: In function 'media_send_audio':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c:590:7: warning: unused variable 'retries' [-Wunused-variable]
  590 |   int retries = 0;
      |       ^~~~~~~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c:583:11: warning: unused variable 'nalu_type' [-Wunused-variable]
  583 |   uint8_t nalu_type = 0;
      |           ^~~~~~~~~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c: In function '_media_set_marker_bit':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c:1040:64: warning: unused parameter 'mc' [-Wunused-parameter]
 1040 | static int _media_set_marker_bit(ftl_media_component_common_t *mc, uint8_t *in) {
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c: In function 'recv_thread':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c:1119:56: warning: variable 'ssrcSender' set but not used [-Wunused-but-set-variable]
 1119 |     int version, padding, feedbackType, ptype, length, ssrcSender, ssrcMedia;
      |                                                        ^~~~~~~~~~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c:1119:18: warning: variable 'padding' set but not used [-Wunused-but-set-variable]
 1119 |     int version, padding, feedbackType, ptype, length, ssrcSender, ssrcMedia;
      |                  ^~~~~~~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c:1119:9: warning: variable 'version' set but not used [-Wunused-but-set-variable]
 1119 |     int version, padding, feedbackType, ptype, length, ssrcSender, ssrcMedia;
      |         ^~~~~~~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c: In function 'video_send_thread':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c:1200:23: warning: unused variable 'media' [-Wunused-variable]
 1200 |   ftl_media_config_t *media = &ftl->media;
      |                       ^~~~~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c: In function '_update_xmit_level':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c:1305:68: warning: unused parameter 'ftl' [-Wunused-parameter]
 1305 | static void _update_xmit_level(ftl_stream_configuration_private_t *ftl, int *transmit_level, struct timeval *start_tv, int bytes_per_ms) {
      |                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c: In function '_send_pkt_stats':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c:1337:107: warning: unused parameter 'interval_ms' [-Wunused-parameter]
 1337 | static int _send_pkt_stats(ftl_stream_configuration_private_t *ftl, ftl_media_component_common_t *mc, int interval_ms) {
      |                                                                                                       ~~~~^~~~~~~~~~~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c: In function '_send_video_stats':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c:1385:109: warning: unused parameter 'interval_ms' [-Wunused-parameter]
 1385 | static int _send_video_stats(ftl_stream_configuration_private_t *ftl, ftl_media_component_common_t *mc, int interval_ms) {
      |                                                                                                         ~~~~^~~~~~~~~~~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c: In function 'ping_thread':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c:1470:45: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
 1470 |             for (mediaCount = 0; mediaCount < sizeof(media_comp) / sizeof(media_comp[0]); mediaCount++) {
      |                                             ^
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c: In function 'ftl_adaptive_bitrate_thread':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/media.c:1628:44: warning: assignment to 'BOOL (*)(void *, uint64_t)' {aka '_Bool (*)(void *, long unsigned int)'} from incompatible pointer type 'int (*)(void *, uint64_t)' {aka 'int (*)(void *, long unsigned int)'} [-Wincompatible-pointer-types]
 1628 |     thread_params->change_bitrate_callback = change_bitrate_callback;
      |                                            ^
[ 44%] Building C object plugins/text-freetype2/CMakeFiles/text-freetype2.dir/obs-convenience.c.o
[ 44%] Building C object deps/obs-scripting/CMakeFiles/obs-scripting.dir/obs-scripting-logging.c.o
[ 44%] Building CXX object deps/obs-scripting/CMakeFiles/obs-scripting.dir/cstrcache.cpp.o
[ 44%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/ftl-sdk/libftl/logging.c.o
[ 44%] Building C object deps/obs-scripting/CMakeFiles/obs-scripting.dir/obs-scripting-python.c.o
[ 44%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/color-correction-filter.c.o
[ 45%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/async-delay-filter.c.o
/build/source/plugins/obs-outputs/ftl-sdk/libftl/logging.c: In function 'ftl_log_msg':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/logging.c:28:102: warning: unused parameter 'file' [-Wunused-parameter]
   28 | void ftl_log_msg(ftl_stream_configuration_private_t *ftl, ftl_log_severity_t log_level, const char * file, int lineno, const char * fmt, ...) {
      |                                                                                         ~~~~~~~~~~~~~^~~~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/logging.c:28:112: warning: unused parameter 'lineno' [-Wunused-parameter]
   28 | void ftl_log_msg(ftl_stream_configuration_private_t *ftl, ftl_log_severity_t log_level, const char * file, int lineno, const char * fmt, ...) {
      |                                                                                                            ~~~~^~~~~~
[ 46%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/ftl-sdk/libftl/posix/socket.c.o
[ 46%] Linking C shared module obs-transitions.so
[ 46%] Building C object plugins/text-freetype2/CMakeFiles/text-freetype2.dir/text-functionality.c.o
[ 46%] Building C object plugins/rtmp-services/CMakeFiles/rtmp-services.dir/service-specific/dacast.c.o
[ 46%] Building C object plugins/rtmp-services/CMakeFiles/rtmp-services.dir/rtmp-common.c.o
In file included from /build/source/deps/obs-scripting/obs-scripting-python.h:34,
                 from /build/source/deps/obs-scripting/obs-scripting-python.c:19:
/build/source/build/deps/obs-scripting/swig/swigpyrun.h:1795:23: warning: cast between incompatible function types from 'PyObject * (*)(PyObject *)' {aka 'struct _object * (*)(struct _object *)'} to 'PyObject * (*)(PyObject *, PyObject *)' {aka 'struct _object * (*)(struct _object *, struct _object *)'} [-Wcast-function-type]
 1795 |   {(char *)"disown",  (PyCFunction)SwigPyObject_disown,  METH_NOARGS,  (char *)"releases ownership of the pointer"},
      |                       ^
/build/source/build/deps/obs-scripting/swig/swigpyrun.h:1796:23: warning: cast between incompatible function types from 'PyObject * (*)(PyObject *)' {aka 'struct _object * (*)(struct _object *)'} to 'PyObject * (*)(PyObject *, PyObject *)' {aka 'struct _object * (*)(struct _object *, struct _object *)'} [-Wcast-function-type]
 1796 |   {(char *)"acquire", (PyCFunction)SwigPyObject_acquire, METH_NOARGS,  (char *)"acquires ownership of the pointer"},
      |                       ^
/build/source/build/deps/obs-scripting/swig/swigpyrun.h:1799:23: warning: cast between incompatible function types from 'PyObject * (*)(PyObject *)' {aka 'struct _object * (*)(struct _object *)'} to 'PyObject * (*)(PyObject *, PyObject *)' {aka 'struct _object * (*)(struct _object *, struct _object *)'} [-Wcast-function-type]
 1799 |   {(char *)"next",    (PyCFunction)SwigPyObject_next,    METH_NOARGS,  (char *)"returns the next 'this' object"},
      |                       ^
/build/source/build/deps/obs-scripting/swig/swigpyrun.h:1800:23: warning: cast between incompatible function types from 'PyObject * (*)(SwigPyObject *)' {aka 'struct _object * (*)(SwigPyObject *)'} to 'PyObject * (*)(PyObject *, PyObject *)' {aka 'struct _object * (*)(struct _object *, struct _object *)'} [-Wcast-function-type]
 1800 |   {(char *)"__repr__",(PyCFunction)SwigPyObject_repr,    METH_NOARGS,  (char *)"returns object representation"},
      |                       ^
[ 47%] Building C object deps/obs-scripting/CMakeFiles/obs-scripting.dir/obs-scripting-python-frontend.c.o
[ 48%] Building C object plugins/obs-ffmpeg/CMakeFiles/obs-ffmpeg.dir/obs-ffmpeg-source.c.o
/build/source/plugins/obs-outputs/ftl-sdk/libftl/posix/socket.c: In function 'get_socket_send_buf':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/posix/socket.c:82:73: warning: pointer targets in passing argument 5 of 'getsockopt' differ in signedness [-Wpointer-sign]
   82 |   return getsockopt(socket, SOL_SOCKET, SO_SNDBUF, (char*)buffer_space, &len);
      |                                                                         ^~~~
      |                                                                         |
      |                                                                         int *
In file included from /build/source/plugins/obs-outputs/ftl-sdk/libftl/ftl_private.h:42,
                 from /build/source/plugins/obs-outputs/ftl-sdk/libftl/posix/socket.c:26:
/nix/store/7rfaw11na5ajdgwr55ffzwfibbrdpk8z-glibc-2.33-56-dev/include/sys/socket.h:210:32: note: expected 'socklen_t * restrict' {aka 'unsigned int * restrict'} but argument is of type 'int *'
  210 |          socklen_t *__restrict __optlen) __THROW;
      |          ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
[ 48%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/ftl-sdk/libftl/posix/threads.c.o
[ 48%] Building C object libobs-opengl/CMakeFiles/libobs-opengl.dir/gl-stagesurf.c.o
/build/source/deps/obs-scripting/obs-scripting-python.c: In function 'obs_scripting_load_python':
/build/source/deps/obs-scripting/obs-scripting-python.c:1629:2: warning: 'PyEval_InitThreads' is deprecated [-Wdeprecated-declarations]
 1629 |  PyEval_InitThreads();
      |  ^~~~~~~~~~~~~~~~~~
In file included from /nix/store/5bh6rpya1ar6l49vrhx1rg58dsa42906-python3-3.9.6/include/python3.9/Python.h:154,
                 from /build/source/deps/obs-scripting/obs-scripting-python-import.h:39,
                 from /build/source/deps/obs-scripting/obs-scripting-python.h:31,
                 from /build/source/deps/obs-scripting/obs-scripting-python.c:19:
/nix/store/5bh6rpya1ar6l49vrhx1rg58dsa42906-python3-3.9.6/include/python3.9/ceval.h:130:37: note: declared here
  130 | Py_DEPRECATED(3.9) PyAPI_FUNC(void) PyEval_InitThreads(void);
      |                                     ^~~~~~~~~~~~~~~~~~
/build/source/deps/obs-scripting/obs-scripting-python.c:1630:2: warning: 'PyEval_ThreadsInitialized' is deprecated [-Wdeprecated-declarations]
 1630 |  if (!PyEval_ThreadsInitialized())
      |  ^~
In file included from /nix/store/5bh6rpya1ar6l49vrhx1rg58dsa42906-python3-3.9.6/include/python3.9/Python.h:154,
                 from /build/source/deps/obs-scripting/obs-scripting-python-import.h:39,
                 from /build/source/deps/obs-scripting/obs-scripting-python.h:31,
                 from /build/source/deps/obs-scripting/obs-scripting-python.c:19:
/nix/store/5bh6rpya1ar6l49vrhx1rg58dsa42906-python3-3.9.6/include/python3.9/ceval.h:129:36: note: declared here
  129 | Py_DEPRECATED(3.9) PyAPI_FUNC(int) PyEval_ThreadsInitialized(void);
      |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~
[ 48%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/obs-outputs.c.o
[ 48%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/null-output.c.o
[ 48%] Built target obs-transitions
[ 49%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/rtmp-stream.c.o
[ 49%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/rtmp-windows.c.o
[ 49%] Building CXX object plugins/decklink/linux/CMakeFiles/linux-decklink.dir/__/decklink-output.cpp.o
[ 49%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/gpu-delay.c.o
/build/source/plugins/obs-outputs/ftl-sdk/libftl/posix/threads.c: In function 'os_create_thread':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/posix/threads.c:29:67: warning: unused parameter 'attibs' [-Wunused-parameter]
   29 | int os_create_thread(OS_THREAD_HANDLE *handle, OS_THREAD_ATTRIBS *attibs, OS_THREAD_START_ROUTINE func, void *args) {
      |                                                ~~~~~~~~~~~~~~~~~~~^~~~~~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/posix/threads.c: In function 'os_destroy_thread':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/posix/threads.c:34:40: warning: unused parameter 'handle' [-Wunused-parameter]
   34 | int os_destroy_thread(OS_THREAD_HANDLE handle) {
      |                       ~~~~~~~~~~~~~~~~~^~~~~~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/posix/threads.c: In function 'os_delete_mutex':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/posix/threads.c:65:31: warning: unused parameter 'mutex' [-Wunused-parameter]
   65 | int os_delete_mutex(OS_MUTEX *mutex) {
      |                     ~~~~~~~~~~^~~~~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/posix/threads.c: In function 'os_semaphore_create':
/build/source/plugins/obs-outputs/ftl-sdk/libftl/posix/threads.c:71:7: warning: unused variable 'retval' [-Wunused-variable]
   71 |   int retval = 0;
      |       ^~~~~~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/posix/threads.c:69:56: warning: unused parameter 'name' [-Wunused-parameter]
   69 | int os_semaphore_create(OS_SEMAPHORE *sem, const char *name, int oflag, unsigned int value) {
      |                                            ~~~~~~~~~~~~^~~~
/build/source/plugins/obs-outputs/ftl-sdk/libftl/posix/threads.c:69:66: warning: unused parameter 'oflag' [-Wunused-parameter]
   69 | int os_semaphore_create(OS_SEMAPHORE *sem, const char *name, int oflag, unsigned int value) {
      |                                                              ~~~~^~~~~
[ 49%] Building CXX object plugins/linux-capture/CMakeFiles/linux-capture.dir/xcompcap-helper.cpp.o
[ 49%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/flv-output.c.o
In file included from /build/source/deps/obs-scripting/obs-scripting-python.h:34,
                 from /build/source/deps/obs-scripting/obs-scripting-python-frontend.c:21:
/build/source/build/deps/obs-scripting/swig/swigpyrun.h:1795:23: warning: cast between incompatible function types from 'PyObject * (*)(PyObject *)' {aka 'struct _object * (*)(struct _object *)'} to 'PyObject * (*)(PyObject *, PyObject *)' {aka 'struct _object * (*)(struct _object *, struct _object *)'} [-Wcast-function-type]
 1795 |   {(char *)"disown",  (PyCFunction)SwigPyObject_disown,  METH_NOARGS,  (char *)"releases ownership of the pointer"},
      |                       ^
/build/source/build/deps/obs-scripting/swig/swigpyrun.h:1796:23: warning: cast between incompatible function types from 'PyObject * (*)(PyObject *)' {aka 'struct _object * (*)(struct _object *)'} to 'PyObject * (*)(PyObject *, PyObject *)' {aka 'struct _object * (*)(struct _object *, struct _object *)'} [-Wcast-function-type]
 1796 |   {(char *)"acquire", (PyCFunction)SwigPyObject_acquire, METH_NOARGS,  (char *)"acquires ownership of the pointer"},
      |                       ^
/build/source/build/deps/obs-scripting/swig/swigpyrun.h:1799:23: warning: cast between incompatible function types from 'PyObject * (*)(PyObject *)' {aka 'struct _object * (*)(struct _object *)'} to 'PyObject * (*)(PyObject *, PyObject *)' {aka 'struct _object * (*)(struct _object *, struct _object *)'} [-Wcast-function-type]
 1799 |   {(char *)"next",    (PyCFunction)SwigPyObject_next,    METH_NOARGS,  (char *)"returns the next 'this' object"},
      |                       ^
/build/source/build/deps/obs-scripting/swig/swigpyrun.h:1800:23: warning: cast between incompatible function types from 'PyObject * (*)(SwigPyObject *)' {aka 'struct _object * (*)(SwigPyObject *)'} to 'PyObject * (*)(PyObject *, PyObject *)' {aka 'struct _object * (*)(struct _object *, struct _object *)'} [-Wcast-function-type]
 1800 |   {(char *)"__repr__",(PyCFunction)SwigPyObject_repr,    METH_NOARGS,  (char *)"returns object representation"},
      |                       ^
[ 49%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/flv-mux.c.o
[ 49%] Building C object libobs-opengl/CMakeFiles/libobs-opengl.dir/gl-subsystem.c.o
[ 49%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/net-if.c.o
[ 50%] Building C object plugins/text-freetype2/CMakeFiles/text-freetype2.dir/text-freetype2.c.o
[ 50%] Building C object deps/obs-scripting/CMakeFiles/obs-scripting.dir/obs-scripting-lua.c.o
[ 50%] Building C object plugins/obs-ffmpeg/CMakeFiles/obs-ffmpeg.dir/obs-ffmpeg-vaapi.c.o
[ 50%] Building C object plugins/rtmp-services/CMakeFiles/rtmp-services.dir/rtmp-custom.c.o
[ 50%] Building CXX object plugins/decklink/linux/CMakeFiles/linux-decklink.dir/__/DecklinkOutput.cpp.o
/build/source/plugins/obs-outputs/net-if.c: In function 'netif_str_to_addr':
/build/source/plugins/obs-outputs/net-if.c:122:5: warning: pointer type mismatch in conditional expression
  122 |     : &((struct sockaddr_in *)out)->sin_addr;
      |     ^
[ 50%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/crop-filter.c.o
[ 51%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/librtmp/amf.c.o
[ 51%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/librtmp/cencode.c.o
[ 51%] Building C object deps/obs-scripting/CMakeFiles/obs-scripting.dir/obs-scripting-lua-source.c.o
[ 51%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/librtmp/hashswf.c.o
/build/source/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c: In function 'vaapi_encode':
/build/source/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c:443:2: warning: 'av_init_packet' is deprecated [-Wdeprecated-declarations]
  443 |  av_init_packet(&av_pkt);
      |  ^~~~~~~~~~~~~~
In file included from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/bsf.h:30,
                 from /nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/avcodec.h:44,
                 from /build/source/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c:34:
/nix/store/f6qs0mvjrs7m45b7q32jc3ikkjpsvjvl-ffmpeg-4.4.1-dev/include/libavcodec/packet.h:488:6: note: declared here
  488 | void av_init_packet(AVPacket *pkt);
      |      ^~~~~~~~~~~~~~
[ 51%] Building C object plugins/linux-capture/CMakeFiles/linux-capture.dir/pipewire.c.o
[ 51%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/librtmp/log.c.o
[ 51%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/scale-filter.c.o
[ 51%] Linking C shared module text-freetype2.so
[ 52%] Building C object plugins/rtmp-services/CMakeFiles/rtmp-services.dir/rtmp-services-main.c.o
[ 52%] Linking C shared module obs-ffmpeg.so
[ 52%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/librtmp/md5.c.o
[ 53%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/librtmp/parseurl.c.o
[ 53%] Building C object deps/obs-scripting/CMakeFiles/obs-scripting.dir/obs-scripting-lua-frontend.c.o
[ 53%] Built target text-freetype2
[ 53%] Building C object plugins/obs-outputs/CMakeFiles/obs-outputs.dir/librtmp/rtmp.c.o
[ 53%] Automatic MOC for target obs-browser
[ 53%] Linking C shared module rtmp-services.so
[ 53%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/scroll-filter.c.o
[ 53%] Built target obs-ffmpeg
[ 54%] Building CXX object plugins/obs-vst/CMakeFiles/obs-vst.dir/obs-vst_autogen/mocs_compilation.cpp.o
[ 54%] Building C object plugins/obs-x264/CMakeFiles/obs-x264-test.dir/obs-x264-test.c.o
[ 54%] Building CXX object plugins/obs-vst/CMakeFiles/obs-vst.dir/obs-vst.cpp.o
[ 54%] Building CXX object plugins/obs-vst/CMakeFiles/obs-vst.dir/VSTPlugin.cpp.o
[ 54%] Building C object plugins/obs-x264/CMakeFiles/obs-x264.dir/obs-x264.c.o
AutoMoc: /build/source/plugins/obs-browser/browser-app.hpp:0: Note: No relevant classes found. No output generated.
[ 54%] Building CXX object plugins/obs-vst/CMakeFiles/obs-vst.dir/EditorWidget.cpp.o
[ 54%] Linking C executable obs-x264-test
[ 55%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/chroma-key-filter.c.o
[ 55%] Built target rtmp-services
[ 56%] Building C object libobs-opengl/CMakeFiles/libobs-opengl.dir/gl-texture2d.c.o
[ 56%] Linking CXX shared library libobs-scripting.so
[ 56%] Building CXX object plugins/decklink/linux/CMakeFiles/linux-decklink.dir/__/DecklinkInput.cpp.o
[ 56%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/color-key-filter.c.o
[ 56%] Built target obs-browser_autogen
[ 56%] Building CXX object plugins/decklink/linux/CMakeFiles/linux-decklink.dir/__/DecklinkBase.cpp.o
[ 56%] Built target obs-scripting
[ 57%] Building CXX object plugins/decklink/linux/CMakeFiles/linux-decklink.dir/__/decklink-device-instance.cpp.o
[ 57%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/color-grade-filter.c.o
[ 57%] Automatic MOC for target obs
[ 58%] Building C object plugins/obs-x264/CMakeFiles/obs-x264.dir/obs-x264-plugin-main.c.o
[ 58%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/sharpness-filter.c.o
[ 58%] Built target obs-x264-test
[ 58%] Automatic MOC for target decklink-ouput-ui
[ 59%] Building C object plugins/linux-capture/CMakeFiles/linux-capture.dir/pipewire-capture.c.o
[ 59%] Building C object libobs-opengl/CMakeFiles/libobs-opengl.dir/gl-texture3d.c.o
[ 59%] Building C object libobs-opengl/CMakeFiles/libobs-opengl.dir/gl-texturecube.c.o
[ 59%] Linking C shared module obs-x264.so
[ 60%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/gain-filter.c.o
[ 60%] Built target obs-x264
[ 60%] Building C object libobs-opengl/CMakeFiles/libobs-opengl.dir/gl-vertexbuffer.c.o
[ 60%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/noise-gate-filter.c.o
[ 61%] Building C object libobs-opengl/CMakeFiles/libobs-opengl.dir/gl-zstencil.c.o
[ 61%] Automatic MOC for target frontend-tools
[ 61%] Building C object plugins/linux-capture/CMakeFiles/linux-capture.dir/portal.c.o
[ 61%] Built target decklink-ouput-ui_autogen
[ 62%] Automatic MOC for target decklink-captions
[ 62%] Building C object deps/obs-scripting/obspython/CMakeFiles/_obspython.dir/CMakeFiles/_obspython.dir/obspythonPYTHON_wrap.c.o
[ 62%] Building CXX object plugins/decklink/linux/CMakeFiles/linux-decklink.dir/__/decklink-device-discovery.cpp.o
[ 62%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/mask-filter.c.o
[ 62%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/invert-audio-polarity.c.o
/build/source/build/deps/obs-scripting/obspython/CMakeFiles/_obspython.dir/obspythonPYTHON_wrap.c:1820:23: warning: cast between incompatible function types from 'PyObject * (*)(PyObject *)' {aka 'struct _object * (*)(struct _object *)'} to 'PyObject * (*)(PyObject *, PyObject *)' {aka 'struct _object * (*)(struct _object *, struct _object *)'} [-Wcast-function-type]
 1820 |   {(char *)"disown",  (PyCFunction)SwigPyObject_disown,  METH_NOARGS,  (char *)"releases ownership of the pointer"},
      |                       ^
/build/source/build/deps/obs-scripting/obspython/CMakeFiles/_obspython.dir/obspythonPYTHON_wrap.c:1821:23: warning: cast between incompatible function types from 'PyObject * (*)(PyObject *)' {aka 'struct _object * (*)(struct _object *)'} to 'PyObject * (*)(PyObject *, PyObject *)' {aka 'struct _object * (*)(struct _object *, struct _object *)'} [-Wcast-function-type]
 1821 |   {(char *)"acquire", (PyCFunction)SwigPyObject_acquire, METH_NOARGS,  (char *)"acquires ownership of the pointer"},
      |                       ^
/build/source/build/deps/obs-scripting/obspython/CMakeFiles/_obspython.dir/obspythonPYTHON_wrap.c:1824:23: warning: cast between incompatible function types from 'PyObject * (*)(PyObject *)' {aka 'struct _object * (*)(struct _object *)'} to 'PyObject * (*)(PyObject *, PyObject *)' {aka 'struct _object * (*)(struct _object *, struct _object *)'} [-Wcast-function-type]
 1824 |   {(char *)"next",    (PyCFunction)SwigPyObject_next,    METH_NOARGS,  (char *)"returns the next 'this' object"},
      |                       ^
/build/source/build/deps/obs-scripting/obspython/CMakeFiles/_obspython.dir/obspythonPYTHON_wrap.c:1825:23: warning: cast between incompatible function types from 'PyObject * (*)(SwigPyObject *)' {aka 'struct _object * (*)(SwigPyObject *)'} to 'PyObject * (*)(PyObject *, PyObject *)' {aka 'struct _object * (*)(struct _object *, struct _object *)'} [-Wcast-function-type]
 1825 |   {(char *)"__repr__",(PyCFunction)SwigPyObject_repr,    METH_NOARGS,  (char *)"returns object representation"},
      |                       ^
[ 62%] Linking C shared library libobs-opengl.so
/build/source/build/deps/obs-scripting/obspython/CMakeFiles/_obspython.dir/obspythonPYTHON_wrap.c: In function '_wrap_gs_debug_marker_begin_format__varargs__':
/build/source/build/deps/obs-scripting/obspython/CMakeFiles/_obspython.dir/obspythonPYTHON_wrap.c:12193:126: warning: unused parameter 'varargs' [-Wunused-parameter]
12193 | SWIGINTERN PyObject *_wrap_gs_debug_marker_begin_format__varargs__(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *varargs) {
      |                                                                                                                    ~~~~~~~~~~^~~~~~~
[ 62%] Building C object deps/obs-scripting/obslua/CMakeFiles/obslua.dir/CMakeFiles/obslua.dir/obsluaLUA_wrap.c.o
[ 62%] Building CXX object deps/obs-scripting/obslua/CMakeFiles/obslua.dir/__/cstrcache.cpp.o
[ 62%] Linking CXX shared module linux-capture.so
[ 62%] Linking C shared module obs-outputs.so
[ 62%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/compressor-filter.c.o
[ 62%] Built target decklink-captions_autogen
[ 62%] Building CXX object plugins/obs-browser/CMakeFiles/obs-browser.dir/obs-browser_autogen/mocs_compilation.cpp.o
[ 62%] Built target libobs-opengl
[ 62%] Generating ui_output.h
[ 62%] Built target frontend-tools_autogen
[ 63%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/limiter-filter.c.o
[ 63%] Building CXX object UI/frontend-plugins/decklink-output-ui/CMakeFiles/decklink-ouput-ui.dir/decklink-ouput-ui_autogen/mocs_compilation.cpp.o
[ 63%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/expander-filter.c.o
[ 63%] Built target obs-outputs
[ 63%] Building CXX object plugins/decklink/linux/CMakeFiles/linux-decklink.dir/__/decklink-device.cpp.o
[ 63%] Building CXX object plugins/obs-vst/CMakeFiles/obs-vst.dir/linux/VSTPlugin-linux.cpp.o
[ 63%] Built target linux-capture
[ 63%] Building CXX object plugins/obs-browser/CMakeFiles/obs-browser.dir/obs-browser-source.cpp.o
[ 63%] Building CXX object plugins/decklink/linux/CMakeFiles/linux-decklink.dir/__/decklink-device-mode.cpp.o
[ 63%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/luma-key-filter.c.o
[ 63%] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/noise-suppress-filter.c.o
[ 64%] Building C object plugins/decklink/linux/CMakeFiles/linux-decklink.dir/__/audio-repack.c.o
[ 65%] Building CXX object plugins/obs-vst/CMakeFiles/obs-vst.dir/linux/EditorWidget-linux.cpp.o
[ 65%] Building CXX object UI/frontend-plugins/decklink-output-ui/CMakeFiles/decklink-ouput-ui.dir/__/__/qt-wrappers.cpp.o
/build/source/build/deps/obs-scripting/obspython/CMakeFiles/_obspython.dir/obspythonPYTHON_wrap.c: In function 'PyInit__obspython':
/build/source/build/deps/obs-scripting/obspython/CMakeFiles/_obspython.dir/obspythonPYTHON_wrap.c:57294:3: warning: 'PyEval_InitThreads' is deprecated [-Wdeprecated-declarations]
57294 |   SWIG_PYTHON_INITIALIZE_THREADS;
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /nix/store/5bh6rpya1ar6l49vrhx1rg58dsa42906-python3-3.9.6/include/python3.9/Python.h:154,
                 from /build/source/build/deps/obs-scripting/obspython/CMakeFiles/_obspython.dir/obspythonPYTHON_wrap.c:150:
/nix/store/5bh6rpya1ar6l49vrhx1rg58dsa42906-python3-3.9.6/include/python3.9/ceval.h:130:37: note: declared here
  130 | Py_DEPRECATED(3.9) PyAPI_FUNC(void) PyEval_InitThreads(void);
      |                                     ^~~~~~~~~~~~~~~~~~
[ 65%] Building CXX object UI/frontend-plugins/decklink-output-ui/CMakeFiles/decklink-ouput-ui.dir/__/__/properties-view.cpp.o
[ 65%] Building CXX object deps/obs-scripting/obspython/CMakeFiles/_obspython.dir/__/cstrcache.cpp.o
[ 65%] Building CXX object plugins/decklink/linux/CMakeFiles/linux-decklink.dir/platform.cpp.o
[ 65%] Linking C shared module obs-filters.so
[ 65%] Building CXX object plugins/decklink/linux/CMakeFiles/linux-decklink.dir/__/util.cpp.o
[ 65%] Built target obs_autogen
[ 66%] Generating ui_captions.h
[ 66%] Building CXX object UI/frontend-plugins/decklink-captions/CMakeFiles/decklink-captions.dir/decklink-captions_autogen/mocs_compilation.cpp.o
[ 66%] Built target obs-filters
[ 66%] Generating ui_text-source-toolbar.h
[ 66%] Generating qrc_obs.cpp
[ 66%] Building CXX object plugins/obs-browser/CMakeFiles/obs-browser.dir/obs-browser-source-audio.cpp.o
[ 66%] Generating ui_AutoConfigStartPage.h
[ 67%] Generating ui_AutoConfigStreamPage.h
[ 67%] Generating ui_AutoConfigTestPage.h
[ 67%] Generating ui_AutoConfigVideoPage.h
[ 67%] Generating ui_ColorSelect.h
[ 67%] Building CXX object plugins/decklink/linux/CMakeFiles/linux-decklink.dir/__/OBSVideoFrame.cpp.o
[ 67%] Generating ui_OBSAbout.h
[ 67%] Generating ui_OBSBasic.h
[ 67%] Generating ui_OBSBasicFilters.h
[ 68%] Generating ui_OBSBasicInteraction.h
[ 68%] Building CXX object plugins/decklink/linux/CMakeFiles/linux-decklink.dir/decklink-sdk/DeckLinkAPIDispatch.cpp.o
[ 68%] Generating ui_OBSBasicSettings.h
[ 68%] Generating ui_OBSBasicSourceSelect.h
[ 69%] Generating ui_OBSBasicTransform.h
[ 69%] Generating ui_OBSExtraBrowsers.h
[ 69%] Generating ui_OBSImporter.h
[ 69%] Generating ui_OBSLogReply.h
[ 70%] Generating ui_OBSMissingFiles.h
[ 71%] Generating ui_OBSRemux.h
[ 71%] Building CXX object plugins/obs-browser/CMakeFiles/obs-browser.dir/obs-browser-plugin.cpp.o
[ 72%] Building CXX object UI/frontend-plugins/decklink-output-ui/CMakeFiles/decklink-ouput-ui.dir/__/__/vertical-scroll-area.cpp.o
[ 72%] Building CXX object UI/frontend-plugins/decklink-output-ui/CMakeFiles/decklink-ouput-ui.dir/__/__/double-slider.cpp.o
[ 72%] Generating ui_OBSUpdate.h
[ 73%] Generating ui_browser-source-toolbar.h
[ 74%] Generating ui_color-source-toolbar.h
[ 74%] Generating ui_device-select-toolbar.h
[ 74%] Generating ui_game-capture-toolbar.h
[ 74%] Generating ui_image-source-toolbar.h
[ 74%] Generating ui_media-controls.h
[ 74%] Building CXX object UI/CMakeFiles/obs.dir/obs_autogen/mocs_compilation.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 75%] Linking CXX shared module linux-decklink.so
[ 75%] Building CXX object UI/CMakeFiles/obs.dir/platform-x11.cpp.o
[ 75%] Building CXX object plugins/obs-browser/CMakeFiles/obs-browser.dir/browser-scheme.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 75%] Built target linux-decklink
[ 75%] Building CXX object plugins/obs-browser/CMakeFiles/obs-browser.dir/browser-client.cpp.o
[ 75%] Building CXX object plugins/obs-browser/CMakeFiles/obs-browser.dir/browser-app.cpp.o
[ 75%] Linking CXX shared module obs-vst.so
/build/source/plugins/obs-browser/obs-browser-plugin.cpp: In function 'void BrowserInit()':
/build/source/plugins/obs-browser/obs-browser-plugin.cpp:330:22: error: 'CefSettings' {aka 'class CefStructBase<CefSettingsTraits>'} has no member named 'product_version'
  330 |  CefString(&settings.product_version) = prod_ver.str();
      |                      ^~~~~~~~~~~~~~~
[ 75%] Building CXX object UI/frontend-plugins/decklink-output-ui/CMakeFiles/decklink-ouput-ui.dir/__/__/slider-ignorewheel.cpp.o
[ 75%] Built target obs-vst
[ 75%] Generating ui_scripts.h
[ 75%] Generating ui_auto-scene-switcher.h
[ 75%] Generating ui_output-timer.h
make[2]: *** [plugins/obs-browser/CMakeFiles/obs-browser.dir/build.make:118: plugins/obs-browser/CMakeFiles/obs-browser.dir/obs-browser-plugin.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
[ 75%] Building CXX object UI/frontend-plugins/decklink-output-ui/CMakeFiles/decklink-ouput-ui.dir/__/__/combobox-ignorewheel.cpp.o
[ 76%] Building CXX object UI/frontend-plugins/frontend-tools/CMakeFiles/frontend-tools.dir/frontend-tools_autogen/mocs_compilation.cpp.o
[ 76%] Building CXX object UI/frontend-plugins/frontend-tools/CMakeFiles/frontend-tools.dir/auto-scene-switcher.cpp.o
[ 76%] Building CXX object UI/frontend-plugins/decklink-output-ui/CMakeFiles/decklink-ouput-ui.dir/__/__/spinbox-ignorewheel.cpp.o
[ 76%] Building CXX object UI/frontend-plugins/decklink-captions/CMakeFiles/decklink-captions.dir/decklink-captions.cpp.o
[ 77%] Building CXX object UI/frontend-plugins/decklink-output-ui/CMakeFiles/decklink-ouput-ui.dir/DecklinkOutputUI.cpp.o
[ 78%] Building C object UI/CMakeFiles/obs.dir/obf.c.o
[ 78%] Building CXX object UI/CMakeFiles/obs.dir/window-dock-browser.cpp.o
[ 78%] Building CXX object UI/CMakeFiles/obs.dir/window-extra-browsers.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_bmemdup':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:48180:12: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
48180 |   result = (void *)bmemdup((void const *)arg1,arg2);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_brealloc':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:48103:12: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
48103 |   result = (void *)brealloc(arg1,arg2);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_gs_effect_set_val':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:5968:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
 5968 |   gs_effect_set_val(arg1,(void const *)arg2,arg3);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_calldata_set_ptr':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:2510:9: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
 2510 |   void *result;
      |         ^~~~~~
[ 78%] Building C object UI/CMakeFiles/obs.dir/__/deps/libff/libff/ff-util.c.o
/build/source/plugins/obs-browser/browser-client.cpp: In member function 'virtual bool BrowserClient::OnProcessMessageReceived(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>, CefProcessId, CefRefPtr<CefProcessMessage>)':
/build/source/plugins/obs-browser/browser-client.cpp:104:3: warning: this statement may fall through [-Wimplicit-fallthrough=]
  104 |   if (name == "startRecording") {
      |   ^~
/build/source/plugins/obs-browser/browser-client.cpp:121:2: note: here
  121 |  case ControlLevel::Advanced:
      |  ^~~~
/build/source/plugins/obs-browser/browser-client.cpp:122:3: warning: this statement may fall through [-Wimplicit-fallthrough=]
  122 |   if (name == "startReplayBuffer") {
      |   ^~
/build/source/plugins/obs-browser/browser-client.cpp:127:2: note: here
  127 |  case ControlLevel::Basic:
      |  ^~~~
/build/source/plugins/obs-browser/browser-client.cpp:128:3: warning: this statement may fall through [-Wimplicit-fallthrough=]
  128 |   if (name == "saveReplayBuffer") {
      |   ^~
/build/source/plugins/obs-browser/browser-client.cpp:131:2: note: here
  131 |  case ControlLevel::ReadOnly:
      |  ^~~~
/build/source/plugins/obs-browser/browser-client.cpp:160:3: warning: this statement may fall through [-Wimplicit-fallthrough=]
  160 |   }
      |   ^
/build/source/plugins/obs-browser/browser-client.cpp:161:2: note: here
  161 |  case ControlLevel::None:
      |  ^~~~
[ 78%] Building CXX object UI/frontend-plugins/decklink-output-ui/CMakeFiles/decklink-ouput-ui.dir/decklink-ui-main.cpp.o
[ 79%] Building CXX object UI/CMakeFiles/obs.dir/__/deps/json11/json11.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 79%] Building CXX object UI/CMakeFiles/obs.dir/obs-app.cpp.o
[ 79%] Building CXX object UI/CMakeFiles/obs.dir/window-dock.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 79%] Building CXX object UI/CMakeFiles/obs.dir/api-interface.cpp.o
make[1]: *** [CMakeFiles/Makefile2:1329: plugins/obs-browser/CMakeFiles/obs-browser.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 79%] Building CXX object UI/CMakeFiles/obs.dir/window-basic-main.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 79%] Linking CXX shared module decklink-captions.so
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_properties_create_param':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:24183:12: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
24183 |   result = (obs_properties_t *)obs_properties_create_param(arg1,arg2);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ 79%] Building C object UI/frontend-plugins/frontend-tools/CMakeFiles/frontend-tools.dir/frontend-tools.c.o
[ 80%] Building CXX object UI/CMakeFiles/obs.dir/window-basic-stats.cpp.o
[ 80%] Building CXX object UI/CMakeFiles/obs.dir/window-basic-filters.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 80%] Building CXX object UI/frontend-plugins/frontend-tools/CMakeFiles/frontend-tools.dir/output-timer.cpp.o
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_proc_handler_add':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:47605:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
47605 |   proc_handler_add(arg1,(char const *)arg2,arg3,arg4);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_signal_handler_connect_ref':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:47773:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
47773 |   signal_handler_connect_ref(arg1,(char const *)arg2,arg3,arg4);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ 80%] Building CXX object UI/CMakeFiles/obs.dir/window-basic-settings.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 80%] Built target decklink-captions
[ 80%] Building CXX object UI/CMakeFiles/obs.dir/window-basic-interaction.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_queue_task':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:34867:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
34867 |   obs_queue_task(arg1,arg2,arg3,arg4);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ 80%] Linking CXX shared module decklink-ouput-ui.so
[ 80%] Building CXX object UI/CMakeFiles/obs.dir/window-basic-properties.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 80%] Built target decklink-ouput-ui
[ 80%] Building CXX object UI/frontend-plugins/frontend-tools/CMakeFiles/frontend-tools.dir/__/__/properties-view.cpp.o
[ 81%] Building CXX object UI/CMakeFiles/obs.dir/window-basic-auto-config.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 82%] Building CXX object UI/frontend-plugins/frontend-tools/CMakeFiles/frontend-tools.dir/__/__/horizontal-scroll-area.cpp.o
[ 82%] Building CXX object UI/CMakeFiles/obs.dir/window-basic-main-outputs.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 82%] Building CXX object UI/CMakeFiles/obs.dir/window-basic-source-select.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
/build/source/UI/window-basic-main.cpp: In constructor 'OBSBasic::OBSBasic(QWidget*)':
/build/source/UI/window-basic-main.cpp:389:44: warning: suggest parentheses around arithmetic in operand of '|' [-Wparentheses]
  389 |  shrt << QKeySequence(Qt::CTRL | Qt::SHIFT + Qt::Key_Z)
      |                                  ~~~~~~~~~~^~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_calldata_set_data':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:47043:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
47043 |   calldata_set_data(arg1,(char const *)arg2,(void const *)arg3,arg4);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/UI/window-basic-main.cpp: In member function 'void OBSBasic::BroadcastButtonClicked()':
/build/source/UI/window-basic-main.cpp:6352:23: warning: suggest parentheses around '&&' within '||' [-Wparentheses]
 6352 |      !broadcastActive && !outputHandler->StreamingActive()) {
      |      ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/UI/window-basic-main.cpp: In member function 'void OBSBasic::SetupBroadcast()':
/build/source/UI/window-basic-main.cpp:6427:8: warning: unused variable 'auth' [-Wunused-variable]
 6427 |  Auth *auth = GetAuth();
      |        ^~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_calldata_get_data':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:47010:12: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
47010 |   result = (bool)calldata_get_data((struct calldata const *)arg1,(char const *)arg2,arg3,arg4);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ 82%] Building CXX object UI/CMakeFiles/obs.dir/window-basic-settings-stream.cpp.o
[ 83%] Building CXX object UI/CMakeFiles/obs.dir/window-basic-main-screenshot.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 83%] Building CXX object UI/frontend-plugins/frontend-tools/CMakeFiles/frontend-tools.dir/__/__/vertical-scroll-area.cpp.o
[ 83%] Building CXX object UI/CMakeFiles/obs.dir/window-basic-auto-config-test.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_source_replace_missing_file':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:35832:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
35832 |   obs_source_replace_missing_file(arg1,arg2,(char const *)arg3,arg4);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ 83%] Building CXX object UI/frontend-plugins/frontend-tools/CMakeFiles/frontend-tools.dir/__/__/double-slider.cpp.o
[ 83%] Building CXX object UI/CMakeFiles/obs.dir/window-basic-main-scene-collections.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 83%] Building CXX object UI/CMakeFiles/obs.dir/window-basic-main-transitions.cpp.o
[ 83%] Building CXX object UI/CMakeFiles/obs.dir/window-basic-main-dropfiles.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 83%] Building CXX object UI/frontend-plugins/frontend-tools/CMakeFiles/frontend-tools.dir/__/__/slider-ignorewheel.cpp.o
[ 84%] Building CXX object UI/CMakeFiles/obs.dir/window-basic-main-profiles.cpp.o
[ 84%] Building CXX object UI/CMakeFiles/obs.dir/window-basic-main-browser.cpp.o
[ 85%] Building CXX object UI/frontend-plugins/frontend-tools/CMakeFiles/frontend-tools.dir/__/__/combobox-ignorewheel.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 85%] Building CXX object UI/frontend-plugins/frontend-tools/CMakeFiles/frontend-tools.dir/__/__/spinbox-ignorewheel.cpp.o
[ 85%] Building CXX object UI/CMakeFiles/obs.dir/window-basic-main-icons.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_properties_add_button2':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:24839:12: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
24839 |   result = (obs_property_t *)obs_properties_add_button2(arg1,(char const *)arg2,(char const *)arg3,arg4,arg5);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ 85%] Building CXX object UI/frontend-plugins/frontend-tools/CMakeFiles/frontend-tools.dir/__/__/qt-wrappers.cpp.o
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_os_dlclose':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:49185:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
49185 |   os_dlclose(arg1);
      |   ^~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_os_end_high_performance':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:49308:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
49308 |   os_end_high_performance((void const *)arg1);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_bfree':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:48122:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
48122 |   bfree(arg1);
      |   ^~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_obj_is_private':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:34515:12: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
34515 |   result = (bool)obs_obj_is_private(arg1);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_obj_get_id':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:34455:20: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
34455 |   result = (char *)obs_obj_get_id(arg1);
      |                    ^~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_obj_invalid':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:34475:12: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
34475 |   result = (bool)obs_obj_invalid(arg1);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_obj_get_type':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:34435:12: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
34435 |   result = (enum obs_obj_type)obs_obj_get_type(arg1);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ 85%] Building CXX object UI/frontend-plugins/frontend-tools/CMakeFiles/frontend-tools.dir/scripts.cpp.o
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_obj_get_data':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:34495:12: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
34495 |   result = (void *)obs_obj_get_data(arg1);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ 85%] Building CXX object UI/CMakeFiles/obs.dir/window-basic-status-bar.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_gs_indexbuffer_create':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:8617:12: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
 8617 |   result = (gs_indexbuffer_t *)gs_indexbuffer_create(arg1,arg2,arg3,arg4);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_properties_set_param':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:24290:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
24290 |   obs_properties_set_param(arg1,arg2,arg3);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ 85%] Building CXX object UI/CMakeFiles/obs.dir/window-basic-adv-audio.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 85%] Building CXX object UI/frontend-plugins/frontend-tools/CMakeFiles/frontend-tools.dir/auto-scene-switcher-nix.cpp.o
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_add_raw_video_callback':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:34627:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
34627 |   obs_add_raw_video_callback((struct video_scale_info const *)arg1,arg2,arg3);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_source_add_caption_callback':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:37438:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
37438 |   obs_source_add_caption_callback(arg1,arg2,arg3);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_source_enum_full_tree':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:36686:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
36686 |   obs_source_enum_full_tree(arg1,arg2,arg3);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_display_remove_draw_callback':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:35163:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
35163 |   obs_display_remove_draw_callback(arg1,arg2,arg3);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_source_remove_caption_callback':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:37471:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
37471 |   obs_source_remove_caption_callback(arg1,arg2,arg3);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_property_set_modified_callback2':
[ 86%] Building CXX object UI/CMakeFiles/obs.dir/window-basic-transform.cpp.o
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:25011:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
25011 |   obs_property_set_modified_callback2(arg1,arg2,arg3);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_source_add_audio_capture_callback':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:37372:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
37372 |   obs_source_add_audio_capture_callback(arg1,arg2,arg3);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_display_add_draw_callback':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:35130:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
35130 |   obs_display_add_draw_callback(arg1,arg2,arg3);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_source_remove_audio_capture_callback':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:37405:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
37405 |   obs_source_remove_audio_capture_callback(arg1,arg2,arg3);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_scene_enum_items':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:40062:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
40062 |   obs_scene_enum_items(arg1,arg2,arg3);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_sceneitem_group_enum_items':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:42361:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
42361 |   obs_sceneitem_group_enum_items(arg1,arg2,arg3);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_source_enum_active_sources':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:36620:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
36620 |   obs_source_enum_active_sources(arg1,arg2,arg3);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_load_sources':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:34371:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
34371 |   obs_load_sources(arg1,arg2,arg3);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_scene_atomic_update':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:40394:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
40394 |   obs_scene_atomic_update(arg1,arg2,arg3);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_source_enum_active_tree':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:36653:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
36653 |   obs_source_enum_active_tree(arg1,arg2,arg3);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_data_array_enum':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:21327:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
21327 |   obs_data_array_enum(arg1,arg2,arg3);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ 86%] Building CXX object UI/CMakeFiles/obs.dir/window-basic-preview.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_gs_device_loss_data_set':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:3029:26: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
 3029 |   if (arg1) (arg1)->data = arg2;
      |             ~~~~~~~~~~~~~^~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_enum_encoders':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:33976:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
33976 |   obs_enum_encoders(arg1,arg2);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_enum_scenes':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:33898:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
33898 |   obs_enum_scenes(arg1,arg2);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_enum_outputs':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:33950:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
33950 |   obs_enum_outputs(arg1,arg2);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_enum_services':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:34002:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
34002 |   obs_enum_services(arg1,arg2);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_hotkey_update_atomic':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:28667:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
28667 |   obs_hotkey_update_atomic(arg1,arg2);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_enum_audio_monitoring_devices':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:34541:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
34541 |   obs_enum_audio_monitoring_devices(arg1,arg2);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_base_set_log_handler':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:48353:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
48353 |   base_set_log_handler(arg1,arg2);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_gs_tvertarray_array_set':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:3516:27: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
 3516 |   if (arg1) (arg1)->array = arg2;
      |             ~~~~~~~~~~~~~~^~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_gs_indexbuffer_flush_direct':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:10547:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
10547 |   gs_indexbuffer_flush_direct(arg1,(void const *)arg2);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_enum_hotkey_bindings':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:28507:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
28507 |   obs_enum_hotkey_bindings(arg1,arg2);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ 86%] Building CXX object UI/CMakeFiles/obs.dir/window-basic-about.cpp.o
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_enum_hotkeys':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:28481:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
28481 |   obs_enum_hotkeys(arg1,arg2);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_gs_enum_adapters':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:6845:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
 6845 |   gs_enum_adapters(arg1,arg2);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_enum_modules':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:33406:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
33406 |   obs_enum_modules(arg1,arg2);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_base_set_crash_handler':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:48379:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
48379 |   base_set_crash_handler(arg1,arg2);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_enum_all_sources':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:33924:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
33924 |   obs_enum_all_sources(arg1,arg2);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_remove_raw_video_callback':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:34653:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
34653 |   obs_remove_raw_video_callback(arg1,arg2);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_hotkey_set_callback_routing_func':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:28599:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
28599 |   obs_hotkey_set_callback_routing_func(arg1,arg2);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ 86%] Building CXX object UI/CMakeFiles/obs.dir/window-importer.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 87%] Building CXX object UI/CMakeFiles/obs.dir/media-controls.cpp.o
[ 87%] Building CXX object UI/CMakeFiles/obs.dir/window-namedialog.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_property_button_clicked':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:25069:12: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
25069 |   result = (bool)obs_property_button_clicked(arg1,arg2);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /nix/store/7rfaw11na5ajdgwr55ffzwfibbrdpk8z-glibc-2.33-56-dev/include/string.h:519,
                 from /nix/store/5bh6rpya1ar6l49vrhx1rg58dsa42906-python3-3.9.6/include/python3.9/Python.h:30,
                 from /build/source/build/deps/obs-scripting/obspython/CMakeFiles/_obspython.dir/obspythonPYTHON_wrap.c:150:
In function 'strncpy',
    inlined from 'SWIG_Python_FixMethods' at /build/source/build/deps/obs-scripting/obspython/CMakeFiles/_obspython.dir/obspythonPYTHON_wrap.c:56770:15,
    inlined from 'PyInit__obspython' at /build/source/build/deps/obs-scripting/obspython/CMakeFiles/_obspython.dir/obspythonPYTHON_wrap.c:56865:3:
/nix/store/7rfaw11na5ajdgwr55ffzwfibbrdpk8z-glibc-2.33-56-dev/include/bits/string_fortified.h:95:10: warning: '__builtin_strncpy' output truncated before terminating nul copying 10 bytes from a string of the same length [-Wstringop-truncation]
   95 |   return __builtin___strncpy_chk (__dest, __src, __len,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   96 |       __glibc_objsize (__dest));
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
[ 87%] Building CXX object UI/CMakeFiles/obs.dir/window-log-reply.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 87%] Building CXX object UI/CMakeFiles/obs.dir/window-projector.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 87%] Building CXX object UI/CMakeFiles/obs.dir/window-remux.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 88%] Building CXX object UI/CMakeFiles/obs.dir/window-missing-files.cpp.o
[ 89%] Linking CXX shared module frontend-tools.so
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 89%] Building CXX object UI/CMakeFiles/obs.dir/auth-base.cpp.o
[ 89%] Linking CXX shared module _obspython.so
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 89%] Built target _obspython
[ 89%] Building CXX object UI/CMakeFiles/obs.dir/auth-oauth.cpp.o
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_obs_save_sources_filtered':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:34415:12: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
34415 |   result = (obs_data_array_t *)obs_save_sources_filtered(arg1,arg2);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ 89%] Built target frontend-tools
[ 89%] Building CXX object UI/CMakeFiles/obs.dir/auth-listener.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 89%] Building CXX object UI/CMakeFiles/obs.dir/source-tree.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_os_dlsym':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:49166:12: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
49166 |   result = (void *)os_dlsym(arg1,(char const *)arg2);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ 90%] Building CXX object UI/CMakeFiles/obs.dir/scene-tree.cpp.o
[ 90%] Building CXX object UI/CMakeFiles/obs.dir/properties-view.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 90%] Building CXX object UI/CMakeFiles/obs.dir/focus-list.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 90%] Building CXX object UI/CMakeFiles/obs.dir/menu-button.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 91%] Building CXX object UI/CMakeFiles/obs.dir/double-slider.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 91%] Building CXX object UI/CMakeFiles/obs.dir/slider-ignorewheel.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 91%] Building CXX object UI/CMakeFiles/obs.dir/combobox-ignorewheel.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 91%] Building CXX object UI/CMakeFiles/obs.dir/spinbox-ignorewheel.cpp.o
[ 91%] Building CXX object UI/CMakeFiles/obs.dir/record-button.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 92%] Building CXX object UI/CMakeFiles/obs.dir/ui-validation.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 92%] Building CXX object UI/CMakeFiles/obs.dir/url-push-button.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 92%] Building CXX object UI/CMakeFiles/obs.dir/volume-control.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 92%] Building CXX object UI/CMakeFiles/obs.dir/adv-audio-control.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 92%] Building CXX object UI/CMakeFiles/obs.dir/item-widget-helpers.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 93%] Building CXX object UI/CMakeFiles/obs.dir/context-bar-controls.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 93%] Building CXX object UI/CMakeFiles/obs.dir/horizontal-scroll-area.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 93%] Building CXX object UI/CMakeFiles/obs.dir/vertical-scroll-area.cpp.o
[ 93%] Building CXX object UI/CMakeFiles/obs.dir/visibility-item-widget.cpp.o
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c: In function '_wrap_gs_cubetexture_set_image':
/build/source/build/deps/obs-scripting/obslua/CMakeFiles/obslua.dir/obsluaLUA_wrap.c:8101:3: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
 8101 |   gs_cubetexture_set_image(arg1,arg2,(void const *)arg3,arg4,arg5);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 94%] Building CXX object UI/CMakeFiles/obs.dir/slider-absoluteset-style.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 94%] Building CXX object UI/CMakeFiles/obs.dir/qt-display.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 94%] Building CXX object UI/CMakeFiles/obs.dir/crash-report.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 94%] Building CXX object UI/CMakeFiles/obs.dir/hotkey-edit.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 94%] Building CXX object UI/CMakeFiles/obs.dir/source-label.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 95%] Building CXX object UI/CMakeFiles/obs.dir/remote-text.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 95%] Building CXX object UI/CMakeFiles/obs.dir/audio-encoders.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 95%] Building CXX object UI/CMakeFiles/obs.dir/qt-wrappers.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 95%] Building CXX object UI/CMakeFiles/obs.dir/log-viewer.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 95%] Building CXX object UI/CMakeFiles/obs.dir/obs-proxy-style.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 96%] Building CXX object UI/CMakeFiles/obs.dir/locked-checkbox.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 96%] Linking CXX shared module obslua.so
[ 96%] Building CXX object UI/CMakeFiles/obs.dir/visibility-checkbox.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 96%] Built target obslua
[ 96%] Building CXX object UI/CMakeFiles/obs.dir/media-slider.cpp.o
[ 96%] Building CXX object UI/CMakeFiles/obs.dir/undo-stack-obs.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 97%] Building CXX object UI/CMakeFiles/obs.dir/importers/importers.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 97%] Building CXX object UI/CMakeFiles/obs.dir/importers/classic.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 97%] Building CXX object UI/CMakeFiles/obs.dir/importers/sl.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 97%] Building CXX object UI/CMakeFiles/obs.dir/importers/studio.cpp.o
[ 97%] Building CXX object UI/CMakeFiles/obs.dir/importers/xsplit.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 98%] Building CXX object UI/CMakeFiles/obs.dir/qrc_obs.cpp.o
<command-line>: warning: "DL_OPENGL" redefined
<command-line>: note: this is the location of the previous definition
[ 98%] Linking CXX executable obs
[ 98%] Built target obs
make: *** [Makefile:156: all] Error 2
```

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
