### PR TITLE
matplotlib: 3.4.3 -> 3.5.0

### DIFF
--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchPypi, writeText, buildPythonPackage, isPy3k, pycairo
 , which, cycler, python-dateutil, numpy, pyparsing, sphinx, tornado, kiwisolver
 , freetype, qhull, libpng, pkg-config, mock, pytz, pygobject3, gobject-introspection
-, certifi, pillow
+, certifi, pillow, fonttools, setuptools-scm, setuptools-scm-git-archive
 , enableGhostscript ? true, ghostscript, gtk3
 , enableGtk3 ? false, cairo
 # darwin has its own "MacOSX" backend
@@ -17,27 +17,41 @@ let
 in
 
 buildPythonPackage rec {
-  version = "3.4.3";
+  version = "3.5.0";
   pname = "matplotlib";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "06032j0ccjxldx4z9kf97qps2g36mfgvy1nap3b9n75kzmnm4kzw";
+    sha256 = "1ym6v4d36lsd5bf8p83d1g1yksd5c9hjfxsh52a5bn908hjjm29q";
   };
 
   XDG_RUNTIME_DIR = "/tmp";
+  MPLSETUPCFG = "setup.cfg";
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ which sphinx ]
+  buildInputs = [ which sphinx setuptools-scm setuptools-scm-git-archive ]
     ++ lib.optional enableGhostscript ghostscript
     ++ lib.optional stdenv.isDarwin [ Cocoa ];
 
   propagatedBuildInputs =
     [ cycler python-dateutil numpy pyparsing tornado freetype qhull
-      kiwisolver certifi libpng mock pytz pillow ]
+      kiwisolver certifi libpng mock pytz pillow
+
+      # HACK: there's a dependency cycle:
+      # matplotlib -> fonttools -> pytest-randomly (check) ->
+      # -> factory_boy (check) -> flask (check) -> python-dotenv ->
+      # -> ipython (check) -> matplotlib-inline -> matplotlib
+      #
+      # Instead of trying to unbundle this trainwreck, just build
+      # a second copy of fonttools without the optional deps.
+      (fonttools.overridePythonAttrs(old: {
+        doCheck = false;
+        checkInputs = [];
+      }))
+    ]
     ++ lib.optionals enableGtk3 [ cairo pycairo gtk3 gobject-introspection pygobject3 ]
     ++ lib.optionals enableTk [ tcl tk tkinter libX11 ]
     ++ lib.optionals enableQt [ pyqt5 ];


### PR DESCRIPTION
###### Motivation for this change
New upstream release. Lots of frustration. See commit messages. nixpkgs-review still running, will update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
