### PR TITLE
python3Packages.pywal: fix darwin hydra build

### DIFF
--- a/pkgs/development/python-modules/pywal/default.nix
+++ b/pkgs/development/python-modules/pywal/default.nix
@@ -9,22 +9,27 @@ buildPythonPackage rec {
     sha256 = "1drha9kshidw908k7h3gd9ws2bl64ms7bjcsa83pwb3hqa9bkspg";
   };
 
-  preCheck = ''
-    mkdir tmp
-    HOME=$PWD/tmp
-  '';
-
   patches = [
     ./convert.patch
     ./feh.patch
   ];
 
-  # Invalid syntax
-  disabled = !isPy3k;
-
   postPatch = ''
     substituteInPlace pywal/backends/wal.py --subst-var-by convert "${imagemagick}/bin/convert"
     substituteInPlace pywal/wallpaper.py --subst-var-by feh "${feh}/bin/feh"
+  '';
+
+  # Invalid syntax
+  disabled = !isPy3k;
+
+  preCheck = ''
+    mkdir tmp
+    HOME=$PWD/tmp
+
+    for f in tests/test_export.py tests/test_util.py ; do
+      substituteInPlace "$f" \
+        --replace '/tmp/' "$TMPDIR/"
+    done
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
ZHF: #144627

Darwin hydra can fail to access `/tmp`, so replace uses with a proper reference to `$TMPDIR`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
