### PR TITLE
xsos: init at 0.7.19

### DIFF
--- a/pkgs/os-specific/linux/xsos/default.nix
+++ b/pkgs/os-specific/linux/xsos/default.nix
@@ -1,0 +1,52 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, makeWrapper
+, installShellFiles
+, dmidecode
+, ethtool
+, pciutils
+, multipath-tools
+, iproute2
+, sysvinit
+}:
+let
+  binPath = [
+    iproute2
+    dmidecode
+    ethtool
+    pciutils
+    multipath-tools
+    iproute2
+    sysvinit
+  ];
+in
+
+stdenv.mkDerivation rec {
+  pname = "xsos";
+  version = "0.7.19";
+
+  src = fetchFromGitHub {
+    owner = "ryran";
+    repo = "xsos";
+    rev = "v${version}";
+    sha256 = "11cc8z3pz4gl0mwl2fc701mn4cgx50fybygx0rvs9bhvb0jnphay";
+  };
+
+  nativeBuildInputs = [ makeWrapper installShellFiles ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -a xsos $out/bin
+    wrapProgram "$out/bin/xsos" --prefix PATH : ${lib.makeBinPath binPath}
+    installShellCompletion --bash --name xsos.bash xsos-bash-completion.bash
+  '';
+
+  meta = with lib; {
+    description = "Summarize system info from sosreports";
+    homepage = "https://github.com/ryran/xsos";
+    license = licenses.gpl3;
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    maintainers = [ maintainers.nixinator ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33815,6 +33815,8 @@ with pkgs;
 
   xcfun = callPackage ../development/libraries/science/chemistry/xcfun { };
 
+  xsos = callPackage ../os-specific/linux/xsos { };
+
   zesarux = callPackage ../misc/emulators/zesarux { };
 
   zk = callPackage ../applications/office/zk {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
