### PR TITLE
comic-mono: init at 2020-12-28

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -675,6 +675,12 @@
     githubId = 858965;
     name = "Andrew Morsillo";
   };
+  an-empty-string = {
+    name = "Tris Emmy Wilson";
+    email = "tris@tris.fyi";
+    github = "an-empty-string";
+    githubId = 681716;
+  };
   andehen = {
     email = "git@andehen.net";
     github = "andehen";

--- a/pkgs/data/fonts/comic-mono/comic-mono-weight.conf
+++ b/pkgs/data/fonts/comic-mono/comic-mono-weight.conf
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+    <!-- Fix missing/incorrect font weight data in Comic Mono. -->
+
+    <match target="scan">
+        <test name="fullname">
+            <string>Comic Mono</string>
+        </test>
+        <edit name="weight">
+            <const>book</const>
+        </edit>
+    </match>
+</fontconfig>

--- a/pkgs/data/fonts/comic-mono/default.nix
+++ b/pkgs/data/fonts/comic-mono/default.nix
@@ -1,0 +1,35 @@
+{ lib, fetchFromGitHub }:
+
+let
+  version = "2020-12-28";
+in fetchFromGitHub {
+  name = "comic-mono-font-${version}";
+
+  owner = "dtinth";
+  repo = "comic-mono-font";
+  rev = "9a96d04cdd2919964169192e7d9de5012ef66de4";
+
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    tar -z -f $downloadedFile --wildcards -x \*.ttf --one-top-level=$out/share/fonts
+
+    mkdir -p $out/etc/fonts/conf.d
+    ln -s ${./comic-mono-weight.conf} $out/etc/fonts/conf.d/30-comic-mono.conf
+  '';
+
+  hash = "sha256-poMU+WfDZcsyWyFiiXKJ284X22CJlxQIzcJtApnIdAY=";
+
+  meta = with lib; {
+    description = "A legible monospace font that looks like Comic Sans";
+    longDescription = ''
+      A legible monospace font... the very typeface you’ve been trained to
+      recognize since childhood. This font is a fork of Shannon Miwa’s Comic
+      Shanns (version 1).
+    '';
+    homepage = "https://dtinth.github.io/comic-mono-font/";
+
+    license = licenses.mit;
+    maintainers = with maintainers; [ an-empty-string totoroot ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23953,6 +23953,8 @@ with pkgs;
 
   comfortaa = callPackage ../data/fonts/comfortaa {};
 
+  comic-mono = callPackage ../data/fonts/comic-mono { };
+
   comic-neue = callPackage ../data/fonts/comic-neue { };
 
   comic-relief = callPackage ../data/fonts/comic-relief {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Comic Mono is a nice programming font that I use (currently building from a private overlay). There is no open packaging request issue (although I'd open one if I couldn't package it).

The PR also adds myself as a maintainer so the package will build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable: (none are applicable, this package doesn't add anything testable)
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) (N/A)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`) (N/A, no binary files)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes) (N/A)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
