### PR TITLE
gptfdisk: fix build against upcoming ncurses-6.3

### DIFF
--- a/pkgs/tools/system/gptfdisk/default.nix
+++ b/pkgs/tools/system/gptfdisk/default.nix
@@ -11,6 +11,12 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-ldGYVvAE2rxLjDQrJhLo0KnuvdUgBClxiDafFS6dxt8=";
   };
 
+  patches = [
+    # fix build failure against ncurses-6.3 (pending upstream inclusion):
+    #  https://sourceforge.net/p/gptfdisk/mailman/message/37392412/
+    ./ncurses-6.3.patch
+  ];
+
   postPatch = ''
     patchShebangs gdisk_test.sh
   '' + lib.optionalString stdenv.isDarwin ''

--- a/pkgs/tools/system/gptfdisk/ncurses-6.3.patch
+++ b/pkgs/tools/system/gptfdisk/ncurses-6.3.patch
@@ -1,0 +1,96 @@
+From 9d5032d1487a8fe6ef7229d413418a27e32a28e5 Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <slyich@gmail.com>
+Date: Mon, 1 Nov 2021 07:51:10 +0000
+Subject: [PATCH:gptfdisk] gptcurses.cc: always use "%s"-style format for printf()-style
+ functions
+
+`ncuses-6.3` added printf-style function attributes and now makes
+it easier to catch cases when user input is used in palce of format
+string when built with CFLAGS=-Werror=format-security:
+
+    gptcurses.cc:274:10: error:
+        format not a string literal and no format arguments [-Werror=format-security]
+      274 |    printw(theLine.c_str());
+          |    ~~~~~~^~~~~~~~~~~~~~~~~
+
+Let's wrap all the missing places with "%s" format.
+---
+ gptcurses.cc | 24 ++++++++++++------------
+ 1 file changed, 12 insertions(+), 12 deletions(-)
+
+--- a/gptcurses.cc
++++ b/gptcurses.cc
+@@ -239,22 +239,22 @@ Space* GPTDataCurses::ShowSpace(int spaceNum, int lineNum) {
+       ClearLine(lineNum);
+       if (space->partNum == -1) { // space is empty
+          move(lineNum, 12);
+-         printw(BytesToIeee((space->lastLBA - space->firstLBA + 1), blockSize).c_str());
++         printw("%s", BytesToIeee((space->lastLBA - space->firstLBA + 1), blockSize).c_str());
+          move(lineNum, 24);
+          printw("free space");
+       } else { // space holds a partition
+          move(lineNum, 3);
+          printw("%d", space->partNum + 1);
+          move(lineNum, 12);
+-         printw(BytesToIeee((space->lastLBA - space->firstLBA + 1), blockSize).c_str());
++         printw("%s", BytesToIeee((space->lastLBA - space->firstLBA + 1), blockSize).c_str());
+          move(lineNum, 24);
+-         printw(space->origPart->GetTypeName().c_str());
++         printw("%s", space->origPart->GetTypeName().c_str());
+          move(lineNum, 50);
+          #ifdef USE_UTF16
+          space->origPart->GetDescription().extract(0, 39, temp, 39);
+-         printw(temp);
++         printw("%s", temp);
+          #else
+-         printw(space->origPart->GetDescription().c_str());
++         printw("%s", space->origPart->GetDescription().c_str());
+          #endif
+       } // if/else
+    } // if
+@@ -271,10 +271,10 @@ int GPTDataCurses::DisplayParts(int selected) {
+ 
+    move(lineNum++, 0);
+    theLine = "Part. #     Size        Partition Type            Partition Name";
+-   printw(theLine.c_str());
++   printw("%s", theLine.c_str());
+    move(lineNum++, 0);
+    theLine = "----------------------------------------------------------------";
+-   printw(theLine.c_str());
++   printw("%s", theLine.c_str());
+    numToShow = LINES - RESERVED_TOP - RESERVED_BOTTOM;
+    pageNum = selected / numToShow;
+    for (i = pageNum * numToShow; i <= (pageNum + 1) * numToShow - 1; i++) {
+@@ -636,7 +636,7 @@ void GPTDataCurses::DisplayOptions(char selectedKey) {
+          } // if/else
+       } // for
+       move(LINES - 1, (COLS - optionDesc.length()) / 2);
+-      printw(optionDesc.c_str());
++      printw("%s", optionDesc.c_str());
+       currentKey = selectedKey;
+    } // if
+ } // GPTDataCurses::DisplayOptions()
+@@ -748,11 +748,11 @@ void GPTDataCurses::DrawMenu(void) {
+ 
+    clear();
+    move(0, (COLS - title.length()) / 2);
+-   printw(title.c_str());
++   printw("%s", title.c_str());
+    move(2, (COLS - drive.length()) / 2);
+-   printw(drive.c_str());
++   printw("%s", drive.c_str());
+    move(3, (COLS - size.str().length()) / 2);
+-   printw(size.str().c_str());
++   printw("%s", size.str().c_str());
+    DisplayParts(currentSpaceNum);
+ } // DrawMenu
+ 
+@@ -802,7 +802,7 @@ void PromptToContinue(void) {
+ void Report(string theText) {
+    clear();
+    move(0, 0);
+-   printw(theText.c_str());
++   printw("%s", theText.c_str());
+    move(LINES - 2, (COLS - 29) / 2);
+    printw("Press any key to continue....");
+    cbreak();


### PR DESCRIPTION
On ncurses-6.3 with extra printf() annotations gcc now detects
use of user input in place of format strings:

    gptcurses.cc:274:10: error:
        format not a string literal and no format arguments [-Werror=format-security]
      274 |    printw(theLine.c_str());
          |    ~~~~~~^~~~~~~~~~~~~~~~~
