### PR TITLE
gir-rs: unstable-2021-05-05 -> unstable-2021-11-21

### DIFF
--- a/pkgs/development/tools/gir/default.nix
+++ b/pkgs/development/tools/gir/default.nix
@@ -2,17 +2,22 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "gir";
-  version = "unstable-2021-05-05";
+  version = "unstable-2021-11-21";
 
   src = fetchFromGitHub {
     owner = "gtk-rs";
     repo = "gir";
-    rev = "c148542ce89b0bf7cbb9f5ef4179c96a45d022df";
-    sha256 = "0vy366ipwnn0cpp14l1v5g3dpnsr3hd8mjp3333lp0946igfqsy5";
-    leaveDotGit = true; # required for build.rs
+    rev = "a69abbe5ee1a745e554cac9433c65d2ac26a7688";
+    sha256 = "16ygy1bcbcj69x6ss72g9n62qlsd1bacr5hz91f8whw6qm9am46m";
   };
 
-  cargoSha256 = "11as1v88zf0f7l2ngllg5zqycvd05nb4vrsyl1dlarjvbq7fhvv8";
+  cargoSha256 = "14srs2369yryqpkklmfp64fyqxrhf91b2bjy0068nx2myr25m624";
+
+  postPatch = ''
+    rm build.rs
+    sed -i '/build = "build\.rs"/d' Cargo.toml
+    echo "pub const VERSION: &str = \"$version\";" > src/gir_version.rs
+  '';
 
   meta = with lib; {
     description = "Tool to generate rust bindings and user API for glib-based libraries";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
