### PR TITLE
[21.11] Revert "nixos/test/boot: nix verify -> nix store verify"

### DIFF
--- a/nixos/tests/boot.nix
+++ b/nixos/tests/boot.nix
@@ -36,7 +36,7 @@ let
             machine = create_machine(${machineConfig})
             machine.start()
             machine.wait_for_unit("multi-user.target")
-            machine.succeed("nix store verify --no-trust -r --option experimental-features nix-command /run/current-system")
+            machine.succeed("nix verify -r --no-trust /run/current-system")
 
             with subtest("Check whether the channel got installed correctly"):
                 machine.succeed("nix-instantiate --dry-run '<nixpkgs>' -A hello")


### PR DESCRIPTION
###### Motivation for this change

This reverts commit 6a4d2207b12c10b768a70f5d57d7dc2e216414eb on `release-21.11` branch.

https://hydra.nixos.org/job/nixos/release-21.11/tested#tabs-constituents
https://hydra.nixos.org/build/159784284
https://hydra.nixos.org/build/159784106
https://hydra.nixos.org/build/159785457
https://hydra.nixos.org/build/159783832

```
machine: must succeed: nix store verify --no-trust -r --option experimental-features nix-command /run/current-system
machine # error: 'store' is not a recognised command
machine # Try 'nix --help' for more information.
```

###### Things done

None.