### PR TITLE
maintainers: winterqt -> winter

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12466,7 +12466,7 @@
     githubId = 6016963;
     name = "Patrick Winter";
   };
-  winterqt = {
+  winter = {
     email = "nixos@winter.cafe";
     github = "winterqt";
     githubId = 78392041;

--- a/pkgs/tools/misc/bottom-rs/default.nix
+++ b/pkgs/tools/misc/bottom-rs/default.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage rec {
     description = "Fantastic (maybe) CLI for translating between bottom and human-readable text";
     homepage = "https://github.com/bottom-software-foundation/bottom-rs";
     license = licenses.mit;
-    maintainers = with maintainers; [ winterqt ];
+    maintainers = with maintainers; [ winter ];
     mainProgram = "bottomify";
   };
 }

--- a/pkgs/tools/networking/p2p/jesec-rtorrent/libtorrent.nix
+++ b/pkgs/tools/networking/p2p/jesec-rtorrent/libtorrent.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/jesec/libtorrent";
     description = "A BitTorrent library written in C++ for *nix, with focus on high performance and good code (jesec's fork)";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ winterqt AndersonTorres ];
+    maintainers = with maintainers; [ winter AndersonTorres ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/networking/p2p/jesec-rtorrent/rtorrent.nix
+++ b/pkgs/tools/networking/p2p/jesec-rtorrent/rtorrent.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
     description = "An ncurses client for libtorrent, ideal for use with screen, tmux, or dtach (jesec's fork)";
     homepage = "https://github.com/jesec/rtorrent";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ winterqt AndersonTorres ];
+    maintainers = with maintainers; [ winter AndersonTorres ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I prefer `winter` over `winterqt` when possible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
