### PR TITLE
zigbee2mqtt: clean up & update script improvements

### DIFF
--- a/pkgs/servers/zigbee2mqtt/default.nix
+++ b/pkgs/servers/zigbee2mqtt/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, stdenv, dataDir ? "/opt/zigbee2mqtt/data", nixosTests }:
+{ pkgs, stdenv, nixosTests }:
 let
   package = (import ./node.nix { inherit pkgs; inherit (stdenv.hostPlatform) system; }).package;
 in

--- a/pkgs/servers/zigbee2mqtt/update.sh
+++ b/pkgs/servers/zigbee2mqtt/update.sh
@@ -1,30 +1,31 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -i bash -p nodePackages.node2nix nodejs-12_x curl jq nix-update
+#! nix-shell -I nixpkgs=../../.. -i bash -p nodePackages.node2nix curl jq nix-update common-updater-scripts
 
-CURRENT_VERSION=$(nix eval --raw '(with import ../../.. {}; zigbee2mqtt.version)')
-TARGET_VERSION=$(curl https://api.github.com/repos/Koenkk/zigbee2mqtt/releases/latest | jq -r ".tag_name")
-ZIGBEE2MQTT=https://github.com/Koenkk/zigbee2mqtt/raw/$TARGET_VERSION
+set -euo pipefail
+
+CURRENT_VERSION=$(nix eval -f ../../.. --raw zigbee2mqtt.version)
+TARGET_VERSION="$(curl https://api.github.com/repos/Koenkk/zigbee2mqtt/releases/latest | jq -r ".tag_name")"
 
 if [[ "$CURRENT_VERSION" == "$TARGET_VERSION" ]]; then
     echo "zigbee2mqtt is up-to-date: ${CURRENT_VERSION}"
     exit 0
 fi
 
+ZIGBEE2MQTT=https://github.com/Koenkk/zigbee2mqtt/raw/$TARGET_VERSION
 curl -LO $ZIGBEE2MQTT/package.json
 curl -LO $ZIGBEE2MQTT/npm-shrinkwrap.json
 
-node2nix --nodejs-12 \
-  -l npm-shrinkwrap.json \
-  -c node.nix \
-  --bypass-cache \
+node2nix \
+  --composition node.nix \
+  --lock npm-shrinkwrap.json \
   --no-copy-node-env \
-  --node-env ../../development/node-packages/node-env.nix
+  --node-env ../../development/node-packages/node-env.nix \
+  --nodejs-14 \
+  --output node-packages.nix
+
 rm package.json npm-shrinkwrap.json
 
-{
-    cd ../../..
-    nix-update --version "$TARGET_VERSION" --build zigbee2mqtt
-}
-
-git add ./default.nix ./node-packages.nix ./node.nix
-git commit -m "zigbee2mqtt: ${CURRENT_VERSION} -> ${TARGET_VERSION}"
+(
+    cd ../../../
+    update-source-version zigbee2mqtt "$TARGET_VERSION"
+)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
These are changes I still had lying around since I last worked on the package.

I failed to update it to a recent version (>1.20.0) since it now wants to use `npm` to build the project at runtime: https://github.com/Koenkk/zigbee2mqtt/blob/master/index.js#L43-L57

In the meantime I've migrated my personal setup to use OCI containers. I don't know how to continue any other way.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
