### PR TITLE
bore: 0.3.3 -> 0.4.1

### DIFF
--- a/pkgs/tools/networking/bore/default.nix
+++ b/pkgs/tools/networking/bore/default.nix
@@ -2,22 +2,21 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "bore";
-  version = "0.3.3";
+  version = "0.4.1";
 
   src = fetchFromBitbucket {
     owner = "delan";
     repo = "nonymous";
-    rev = version;
-    sha256 = "0gws1f625izrb3armh6bay1k8l9p9csl37jx03yss1r720k4vn2x";
+    rev = "${pname}-${version}";
+    sha256 = "1fdnnx7d18gj4rkv1dc6q379dqabl66zks9i0rjarjwcci8m30d9";
   };
 
-  cargoSha256 = "1n09gcp1y885lz6g2f73zw3fd0fmv7nwlvaqba2yl0kylzk7naa6";
+  cargoSha256 = "1xlbfzmy0wjyz3jpr17r4ma4i79d9b32yqwwi10vrcjzr7vsyhmx";
   cargoBuildFlags = "-p ${pname}";
 
   # FIXME can’t test --all-targets and --doc in a single invocation
-  checkFeatures = [ "std" ];
-
   cargoTestFlags = [ "--all-targets" "--workspace" ];
+  checkFeatures = [ "std" ];
 
   nativeBuildInputs = [ installShellFiles ]
     ++ lib.optional stdenv.isDarwin llvmPackages.libclang;


### PR DESCRIPTION
###### Motivation for this change

New feature release. There are a couple of minor [breaking changes](https://bitbucket.org/delan/nonymous/src/default/RELEASES.md#markdown-header-bore-041-2021-11-28) since 0.3.3, not sure if they need to be [mentioned in the release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2111.section.md#backward-incompatibilities-sec-release-2111-incompatibilities) because this a relatively unknown package with no dependents.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - ~~[NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - ~~or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)~~
  - ~~made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages~~
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] ~~(Package updates) Added a release notes entry if the change is major or breaking~~
  - [ ] ~~(Module updates) Added a release notes entry if the change is significant~~
  - [ ] ~~(Module addition) Added a release notes entry if adding a new NixOS module~~
  - [ ] ~~(Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).