### PR TITLE
passerine: 0.9.2 → 0.9.3

### DIFF
--- a/pkgs/development/compilers/passerine/default.nix
+++ b/pkgs/development/compilers/passerine/default.nix
@@ -7,15 +7,15 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "vrtbl";
     repo = "passerine";
-    rev = "30757a528c1656c15ed3403d355d2b9dee028991";
-    sha256 = "1vffnl5472gsskq9065cifh4fk52z602sb448ghf1xq9n98drdjf";
+    rev = "v${version}";
+    hash = "sha256-TrbcULIJ9+DgQ4QsLYD5okxHoIusGJDw1PqJQwq1zu0=";
   };
 
-  cargoSha256 = "0bd8d5k6d6vwmlsbfkvxx1xbkb9wqihpnmym1lnhk875997hxsq3";
+  cargoHash = "sha256-A+sOT0rloAktDdVXe2HEPK25euh9T7c0rXybZmZpqC0=";
 
   meta = with lib; {
     description = "A small extensible programming language designed for concise expression with little code";
-    homepage = "https://github.com/vrtbl/passerine";
+    homepage = "https://www.passerine.io/";
     license = licenses.mit;
     maintainers = with maintainers; [ siraben ];
   };

--- a/pkgs/development/compilers/passerine/default.nix
+++ b/pkgs/development/compilers/passerine/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "passerine";
-  version = "0.9.2";
+  version = "0.9.3";
 
   src = fetchFromGitHub {
     owner = "vrtbl";
     repo = "passerine";
-    rev = "dd8a6f5efc5dcb03d45b102f61cc8a50d46e8e98";
-    sha256 = "sha256-/QzqKLkxAVqvTY4Uft1qk7nJat6nozykB/4X1YGqu/I=";
+    rev = "30757a528c1656c15ed3403d355d2b9dee028991";
+    sha256 = "1vffnl5472gsskq9065cifh4fk52z602sb448ghf1xq9n98drdjf";
   };
 
-  cargoSha256 = "sha256-8WiiDLIJ/abXELF8S+4s+BPA/Lr/rpKmC1NWPCLzQWA=";
+  cargoSha256 = "0bd8d5k6d6vwmlsbfkvxx1xbkb9wqihpnmym1lnhk875997hxsq3";
 
   meta = with lib; {
     description = "A small extensible programming language designed for concise expression with little code";


### PR DESCRIPTION
Signed-off-by: Kozova1 <mug66kk@gmail.com>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Passerine has released a new version and hasn't been updated yet for a while.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [X] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
