### PR TITLE
libgphoto2: fix build of all camlibs

### DIFF
--- a/pkgs/development/libraries/libgphoto2/default.nix
+++ b/pkgs/development/libraries/libgphoto2/default.nix
@@ -1,10 +1,18 @@
-{ lib, stdenv, fetchFromGitHub, buildPackages
-, autoreconfHook, pkg-config, gettext
+{ lib
+, stdenv
+, fetchFromGitHub
+, buildPackages
+, autoreconfHook
+, pkg-config
+, gettext
 , libusb1
 , libtool
 , libexif
 , libgphoto2
 , libjpeg
+, curl
+, libxml2
+, gd
 }:
 
 stdenv.mkDerivation rec {
@@ -24,12 +32,16 @@ stdenv.mkDerivation rec {
     autoreconfHook
     gettext
     libtool
+    pkg-config
   ];
 
   buildInputs = [
     libjpeg
     libtool # for libltdl
     libusb1
+    curl
+    libxml2
+    gd
   ];
 
   # These are mentioned in the Requires line of libgphoto's pkg-config file.
@@ -37,17 +49,20 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  postInstall = let
-    executablePrefix = if stdenv.buildPlatform == stdenv.hostPlatform then
-      "$out"
-    else
-      buildPackages.libgphoto2;
-  in ''
-    mkdir -p $out/lib/udev/rules.d
-    ${executablePrefix}/lib/libgphoto2/print-camera-list \
-        udev-rules version 175 group camera \
-        >$out/lib/udev/rules.d/40-gphoto2.rules
-  '';
+  postInstall =
+    let
+      executablePrefix =
+        if stdenv.buildPlatform == stdenv.hostPlatform then
+          "$out"
+        else
+          buildPackages.libgphoto2;
+    in
+    ''
+      mkdir -p $out/lib/udev/rules.d
+      ${executablePrefix}/lib/libgphoto2/print-camera-list \
+          udev-rules version 175 group camera \
+          >$out/lib/udev/rules.d/40-gphoto2.rules
+    '';
 
   meta = {
     homepage = "http://www.gphoto.org/proj/libgphoto2/";


### PR DESCRIPTION
The camlibs `lumix` and `docupen` were excluded from compilation and
bundling due to the missing depdendencies.

File changed ran through `nixpkgs-fmt`.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
