### PR TITLE
wxmaxima: 21.05.2 -> 21.11.0, and more

### DIFF
--- a/pkgs/applications/science/math/maxima/default.nix
+++ b/pkgs/applications/science/math/maxima/default.nix
@@ -1,24 +1,34 @@
-{ lib, stdenv, fetchurl, fetchpatch, sbcl, texinfo, perl, python3, makeWrapper, autoreconfHook
-, rlwrap ? null, tk ? null, gnuplot ? null, ecl ? null, ecl-fasl ? false
+{ lib
+, stdenv
+, fetchurl
+, fetchpatch
+, texinfo
+, perl
+, python3
+, makeWrapper
+, autoreconfHook
+, rlwrap ? null
+, tk ? null
+, gnuplot ? null
+, ecl ? null
+, ecl-fasl ? false
+, sbcl
 }:
 
 let
-  name    = "maxima";
-  version = "5.45.0";
-
   lisp-compiler = if ecl-fasl then ecl else sbcl;
 
   searchPath =
     lib.makeBinPath
       (lib.filter (x: x != null) [ lisp-compiler rlwrap tk gnuplot ]);
 in
-stdenv.mkDerivation ({
-  inherit version;
-  name = "${name}-${version}";
+stdenv.mkDerivation rec {
+  pname = "maxima";
+  version = "5.45.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/${name}/${name}-${version}.tar.gz";
-    sha256 = "sha256-x2MfMmRIBc67e6/vOrUzHEus0sJ+OE/YgyO1A5pg0Ng=";
+    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "sha256-/pAWJ2lwvvIUoaJENIVYZEUU1/36pPyLnQ6Hr8u059w=";
   };
 
   nativeBuildInputs = [
@@ -67,7 +77,8 @@ stdenv.mkDerivation ({
       sha256 = "06961hn66rhjijfvyym21h39wk98sfxhp051da6gz0n9byhwc6zg";
     })
 
-    # undo https://sourceforge.net/p/maxima/code/ci/f5e9b0f7eb122c4e48ea9df144dd57221e5ea0ca, see see https://trac.sagemath.org/ticket/13364#comment:93
+    # undo https://sourceforge.net/p/maxima/code/ci/f5e9b0f7eb122c4e48ea9df144dd57221e5ea0ca
+    # see https://trac.sagemath.org/ticket/13364#comment:93
     (fetchpatch {
       url = "https://git.sagemath.org/sage.git/plain/build/pkgs/maxima/patches/undoing_true_false_printing_patch.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
       sha256 = "0fvi3rcjv6743sqsbgdzazy9jb6r1p1yq63zyj9fx42wd1hgf7yx";
@@ -100,10 +111,10 @@ stdenv.mkDerivation ({
     ecl = ecl;
   };
 
-  meta = {
+  meta = with lib; {
     description = "Computer algebra system";
     homepage = "http://maxima.sourceforge.net";
-    license = lib.licenses.gpl2;
+    license = licenses.gpl2Plus;
 
     longDescription = ''
       Maxima is a fairly complete computer algebra system written in
@@ -111,7 +122,7 @@ stdenv.mkDerivation ({
       DOE-MACSYMA and licensed under the GPL. Its abilities include
       symbolic integration, 3D plotting, and an ODE solver.
     '';
-
-    platforms = lib.platforms.unix;
+    maintainers = with maintainers; [ doronbehar ];
+    platforms = platforms.unix;
   };
-})
+}

--- a/pkgs/applications/science/math/sage/default.nix
+++ b/pkgs/applications/science/math/sage/default.nix
@@ -15,7 +15,7 @@ let
       sagelib = self.callPackage ./sagelib.nix {
         inherit flint arb;
         inherit sage-src env-locations pynac singular;
-        ecl = maxima-ecl.ecl;
+        inherit (maxima) lisp-compiler;
         linbox = pkgs.linbox.override { withSage = true; };
         pkg-config = pkgs.pkg-config; # not to confuse with pythonPackages.pkg-config
       };
@@ -48,9 +48,8 @@ let
   # the files its looking fore are located. Also see `sage-env`.
   env-locations = callPackage ./env-locations.nix {
     inherit pari_data;
-    inherit singular maxima-ecl;
+    inherit singular maxima;
     inherit three;
-    ecl = maxima-ecl.ecl;
     cysignals = python3.pkgs.cysignals;
     mathjax = nodePackages.mathjax;
   };
@@ -61,22 +60,21 @@ let
     sagelib = python3.pkgs.sagelib;
     sage_docbuild = python3.pkgs.sage_docbuild;
     inherit env-locations;
-    inherit python3 singular palp flint pynac pythonEnv maxima-ecl;
-    ecl = maxima-ecl.ecl;
+    inherit python3 singular palp flint pynac pythonEnv maxima;
     pkg-config = pkgs.pkg-config; # not to confuse with pythonPackages.pkg-config
   };
 
   # The documentation for sage, building it takes a lot of ram.
   sagedoc = callPackage ./sagedoc.nix {
     inherit sage-with-env;
-    inherit python3 maxima-ecl;
+    inherit python3 maxima;
   };
 
   # sagelib with added wrappers and a dependency on sage-tests to make sure thet tests were run.
   sage-with-env = callPackage ./sage-with-env.nix {
     inherit python3 pythonEnv;
     inherit sage-env;
-    inherit pynac singular maxima-ecl;
+    inherit pynac singular maxima;
     inherit three;
     pkg-config = pkgs.pkg-config; # not to confuse with pythonPackages.pkg-config
   };
@@ -118,8 +116,8 @@ let
 
   singular = pkgs.singular.override { inherit flint; };
 
-  maxima-ecl = pkgs.maxima-ecl.override {
-    ecl = pkgs.ecl.override {
+  maxima = pkgs.maxima.override {
+    lisp-compiler = pkgs.ecl.override {
       # "echo syntax error | ecl > /dev/full 2>&1" segfaults in
       # ECL. We apply a patch to fix it (write_error.patch), but it
       # only works if threads are disabled.  sage 9.2 tests this

--- a/pkgs/applications/science/math/sage/env-locations.nix
+++ b/pkgs/applications/science/math/sage/env-locations.nix
@@ -2,13 +2,12 @@
 , pari_data
 , pari
 , singular
-, maxima-ecl
+, maxima
 , conway_polynomials
 , graphs
 , elliptic_curves
 , polytopes_db
 , gap
-, ecl
 , combinatorial_designs
 , jmol
 , mathjax
@@ -30,14 +29,14 @@ writeTextFile rec {
     export SINGULAR_SO='${singular}/lib/libSingular.so'
     export GAP_SO='${gap}/lib/libgap.so'
     export SINGULAR_EXECUTABLE='${singular}/bin/Singular'
-    export MAXIMA_FAS='${maxima-ecl}/lib/maxima/${maxima-ecl.version}/binary-ecl/maxima.fas'
-    export MAXIMA_PREFIX="${maxima-ecl}"
+    export MAXIMA_FAS='${maxima}/lib/maxima/${maxima.version}/binary-ecl/maxima.fas'
+    export MAXIMA_PREFIX="${maxima}"
     export CONWAY_POLYNOMIALS_DATA_DIR='${conway_polynomials}/share/conway_polynomials'
     export GRAPHS_DATA_DIR='${graphs}/share/graphs'
     export ELLCURVE_DATA_DIR='${elliptic_curves}/share/ellcurves'
     export POLYTOPE_DATA_DIR='${polytopes_db}/share/reflexive_polytopes'
     export GAP_ROOT_DIR='${gap}/share/gap/build-dir'
-    export ECLDIR='${ecl}/lib/ecl-${ecl.version}/'
+    export ECLDIR='${maxima.lisp-compiler}/lib/${maxima.lisp-compiler.pname}-${maxima.lisp-compiler.version}/'
     export COMBINATORIAL_DESIGN_DATA_DIR="${combinatorial_designs}/share/combinatorial_designs"
     export CREMONA_MINI_DATA_DIR="${elliptic_curves}/share/cremona"
     export JMOL_DIR="${jmol}/share/jmol" # point to the directory that contains JmolData.jar

--- a/pkgs/applications/science/math/sage/sage-env.nix
+++ b/pkgs/applications/science/math/sage/sage-env.nix
@@ -15,8 +15,7 @@
 , pkg-config
 , pari
 , gap
-, ecl
-, maxima-ecl
+, maxima
 , singular
 , fflas-ffpack
 , givaro
@@ -77,8 +76,8 @@ let
     pkg-config
     pari
     gap
-    ecl
-    maxima-ecl
+    maxima.lisp-compiler
+    maxima
     singular
     giac
     palp

--- a/pkgs/applications/science/math/sage/sage-with-env.nix
+++ b/pkgs/applications/science/math/sage/sage-with-env.nix
@@ -9,7 +9,7 @@
 , singular
 , gap
 , giac
-, maxima-ecl
+, maxima
 , pari
 , gmp
 , gfan
@@ -42,7 +42,7 @@ let
     pari
     gmp
     gfan
-    maxima-ecl
+    maxima
     eclib
     flintqs
     ntl

--- a/pkgs/applications/science/math/sage/sagedoc.nix
+++ b/pkgs/applications/science/math/sage/sagedoc.nix
@@ -1,7 +1,7 @@
 { stdenv
 , sage-with-env
 , python3
-, maxima-ecl
+, maxima
 , tachyon
 , jmol
 , cddlib
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     sage-with-env.env.lib
     python3
-    maxima-ecl
+    maxima
     tachyon
     jmol
     cddlib

--- a/pkgs/applications/science/math/sage/sagelib.nix
+++ b/pkgs/applications/science/math/sage/sagelib.nix
@@ -10,7 +10,7 @@
 , cypari2
 , cysignals
 , cython
-, ecl
+, lisp-compiler
 , eclib
 , ecm
 , flint
@@ -74,7 +74,7 @@ buildPythonPackage rec {
     jupyter_core
     pkg-config
     pip # needed to query installed packages
-    ecl
+    lisp-compiler
   ];
 
   buildInputs = [
@@ -92,7 +92,7 @@ buildPythonPackage rec {
     arb
     brial
     cliquer
-    ecl
+    lisp-compiler
     eclib
     ecm
     fflas-ffpack

--- a/pkgs/applications/science/math/wxmaxima/default.nix
+++ b/pkgs/applications/science/math/wxmaxima/default.nix
@@ -1,21 +1,37 @@
-{ lib, stdenv, fetchFromGitHub
-, wrapGAppsHook, cmake, gettext
-, maxima, wxGTK, gnome }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, wrapGAppsHook
+, cmake
+, gettext
+, maxima
+, wxGTK
+, gnome
+}:
 
 stdenv.mkDerivation rec {
   pname = "wxmaxima";
-  version = "21.05.2";
+  version = "21.11.0";
 
   src = fetchFromGitHub {
     owner = "wxMaxima-developers";
     repo = "wxmaxima";
     rev = "Version-${version}";
-    sha256 = "sha256-HPqdxGrPxe5FZNOimTpAP+c9VpDBkXu3Z1c1Aaf3+UA=";
+    sha256 = "sha256-LwuqldMGsmFR8xrNg5vsrogmdi5ysqEQGWITM460IZk=";
   };
 
-  buildInputs = [ wxGTK maxima gnome.adwaita-icon-theme ];
+  buildInputs = [
+    wxGTK
+    maxima
+    # So it won't embed svg files into headers.
+    gnome.adwaita-icon-theme
+  ];
 
-  nativeBuildInputs = [ wrapGAppsHook cmake gettext ];
+  nativeBuildInputs = [
+    wrapGAppsHook
+    cmake
+    gettext
+  ];
 
   preConfigure = ''
     gappsWrapperArgs+=(--prefix PATH ":" ${maxima}/bin)
@@ -25,6 +41,7 @@ stdenv.mkDerivation rec {
     description = "Cross platform GUI for the computer algebra system Maxima";
     license = licenses.gpl2;
     homepage = "https://wxmaxima-developers.github.io/wxmaxima/";
+    maintainers = with maintainers; [ doronbehar ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/compilers/ecl/default.nix
+++ b/pkgs/development/compilers/ecl/default.nix
@@ -28,7 +28,8 @@ let
   ];
 in
 stdenv.mkDerivation {
-  inherit (s) name version;
+  inherit (s) version;
+  pname = s.baseName;
   inherit nativeBuildInputs propagatedBuildInputs;
 
   src = fetchurl {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31880,12 +31880,10 @@ with pkgs;
    };
 
   maxima = callPackage ../applications/science/math/maxima {
-    ecl = null;
+    lisp-compiler = sbcl;
   };
   maxima-ecl = maxima.override {
-    inherit ecl;
-    ecl-fasl = true;
-    sbcl = null;
+    lisp-compiler = ecl;
   };
 
   mxnet = callPackage ../applications/science/math/mxnet {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).