### PR TITLE
qt514.qtbase: add fix build for gcc-11 (upstream backports)

### DIFF
--- a/pkgs/development/libraries/qt-5/5.14/default.nix
+++ b/pkgs/development/libraries/qt-5/5.14/default.nix
@@ -68,6 +68,8 @@ let
       ./qtbase.patch.d/0009-qtbase-qtpluginpath.patch
       ./qtbase.patch.d/0010-qtbase-assert.patch
       ./qtbase.patch.d/0011-fix-header_module.patch
+
+      ./qtbase.patch.d/qtbase-corelibs-limit.patch
     ];
     qtdeclarative = [ ./qtdeclarative.patch ];
     qtlocation = [ ./qtlocation-gcc-9.patch ];

--- a/pkgs/development/libraries/qt-5/5.14/qtbase.patch.d/qtbase-corelibs-limit.patch
+++ b/pkgs/development/libraries/qt-5/5.14/qtbase.patch.d/qtbase-corelibs-limit.patch
@@ -1,0 +1,35 @@
+https://github.com/qt/qtbase/commit/9c56d4da2ff631a8c1c30475bd792f6c86bda53c.patch
+https://github.com/qt/qtbase/commit/813a928c7c3cf98670b6043149880ed5c955efb9.patch
+
+with conflicts fixed.
+--- a/src/corelib/global/qendian.h
++++ b/src/corelib/global/qendian.h
+@@ -44,6 +44,8 @@
+ #include <QtCore/qfloat16.h>
+ #include <QtCore/qglobal.h>
+ 
++#include <limits>
++
+ // include stdlib.h and hope that it defines __GLIBC__ for glibc-based systems
+ #include <stdlib.h>
+ #include <string.h>
+--- a/src/corelib/global/qfloat16.h
++++ b/src/corelib/global/qfloat16.h
+@@ -44,5 +44,6 @@
+ #include <QtCore/qglobal.h>
+ #include <QtCore/qmetatype.h>
++#include <limits>
+ #include <string.h>
+ 
+ #if defined(QT_COMPILER_SUPPORTS_F16C) && defined(__AVX2__) && !defined(__F16C__)
+--- a/src/corelib/text/qbytearraymatcher.h
++++ b/src/corelib/text/qbytearraymatcher.h
+@@ -42,6 +42,8 @@
+ 
+ #include <QtCore/qbytearray.h>
+ 
++#include <limits>
++
+ QT_BEGIN_NAMESPACE
+ 
+ 


### PR DESCRIPTION
Without the change build on `gcc-11` fails as:

    $ nix build --impure --expr 'with import ./. {}; qt514.qtbase.override { stdenv = gcc11Stdenv; }'
    ...
    src/corelib/global/qendian.h:333:54: error: incomplete type 'std::numeric_limits' used in nested name specifier
      333 |     { return QSpecialInteger(std::numeric_limits<T>::min()); }
          |                                                      ^~~

Not applying patches as is as they have minor whitespace conflicts.