### PR TITLE
gnuradioPackages.grnet: init for gr 3.8, 3.9

### DIFF
--- a/pkgs/development/gnuradio-modules/grnet/default.nix
+++ b/pkgs/development/gnuradio-modules/grnet/default.nix
@@ -1,0 +1,84 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, gnuradio
+, cmake
+, pkg-config
+, boost
+, log4cpp
+, python
+, swig
+, mpir
+, gmp
+, doxygen
+, libpcap
+, icu
+, thrift
+}:
+
+let
+  # Each GR major version requires us to pull a specific git revision of the repository
+  version = {
+    "3.7" = {
+      # Last git revision from the `maint-3.7` branch:
+      # https://github.com/ghostop14/gr-grnet/tree/maint-3.7
+      name = "unstable-2019-08-06";
+      gitHash = "beb1cd75d006a982c0a9536e923800c5a0575451";
+    };
+    "3.8" = {
+      # Last git revision from the `maint-3.8` branch:
+      # https://github.com/ghostop14/gr-grnet/tree/maint-3.8
+      name = "unstable-2020-11-20";
+      gitHash = "b02016043b67a15f27134a4f0b0d43f5d1b9ed6d";
+    };
+    "3.9" = {
+      # This revision is taken from the `master` branch.
+      name = "unstable-2020-12-30";
+      gitHash = "e6dfd140cfda715de9bcef4c1116fcacfeb0c606";
+    };
+  }.${gnuradio.versionAttr.major};
+  src = fetchFromGitHub {
+    owner = "ghostop14";
+    repo = "gr-grnet";
+    rev = "${version.gitHash}";
+    sha256 = {
+      "3.7" = "LLQ0Jf0Oapecu9gj4IgxOdK7O/OSbHnwNk000GlODxk=";
+      "3.8" = "vO8l8nV1/yEQf7pKqBbzIg4KkyCyWu+OkKgISyI3PaQ=";
+      "3.9" = "NsL7HCOQmGyexzpH2qbzv8Bq4bsfiDTNEUi96QDOA/g=";
+    }.${gnuradio.versionAttr.major};
+  };
+in
+mkDerivation {
+  pname = "gr-grnet";
+  version = version.name;
+  inherit src;
+
+  buildInputs = [
+    boost
+    log4cpp
+    doxygen
+    mpir
+    gmp
+    libpcap
+    icu
+  ] ++ (if lib.versionAtLeast gnuradio.versionAttr.major "3.9" then with python.pkgs; [
+    pybind11
+    numpy
+  ] else [
+    swig
+    thrift
+    python.pkgs.thrift
+  ]);
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  meta = with lib; {
+    description = "GNURadio TCP/UDP source and sink blocks rewritten in C++/Boost";
+    homepage = "https://github.com/ghostop14/gr-grnet";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ chuangzhu ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/gnuradio-packages.nix
+++ b/pkgs/top-level/gnuradio-packages.nix
@@ -37,6 +37,8 @@ in {
 
   ais = callPackage ../development/gnuradio-modules/ais/default.nix { };
 
+  grnet = callPackage ../development/gnuradio-modules/grnet/default.nix { };
+
   gsm = callPackage ../development/gnuradio-modules/gsm/default.nix { };
 
   nacl = callPackage ../development/gnuradio-modules/nacl/default.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[gr-grnet](https://github.com/ghostop14/gr-grnet) is a set of useful TCP and UDP blocks for GNU Radio.

In this PR I added `grnet` for GNU Radio 3.8 and 3.9. 3.7 isn't added because I failed to build dependencies `python27Packages.{jinja2,flake8}` for GNU Radio 3.7. I'll added the support for 3.7 once these dependencies will be fixed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
