### PR TITLE
z3: use cmake build system

### DIFF
--- a/pkgs/applications/science/logic/z3/default.nix
+++ b/pkgs/applications/science/logic/z3/default.nix
@@ -34,14 +34,12 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ python.pkgs.setuptools ];
   enableParallelBuilding = true;
 
-  cmakeFlags = []
-    ++ optional javaBindings ''
-        -DZ3_BUILD_JAVA_BINDINGS=True
-        -DZ3_INSTALL_JAVA_BINDINGS=True
-       ''
-  ;
+  cmakeFlags = lib.optionals javaBindings [
+    "-DZ3_BUILD_JAVA_BINDINGS=True"
+    "-DZ3_INSTALL_JAVA_BINDINGS=True"
+  ];
 
-  outputs = [ "out" "lib" "dev" ] ;
+  outputs = [ "out" "lib" "dev" ];
 
   meta = with lib; {
     description = "A high-performance theorem prover and SMT solver";

--- a/pkgs/applications/science/logic/z3/default.nix
+++ b/pkgs/applications/science/logic/z3/default.nix
@@ -5,13 +5,14 @@
 , python
 , fixDarwinDylibNames
 , javaBindings ? false
-, ocamlBindings ? false
 , pythonBindings ? true
 , jdk ? null
 , ocaml ? null
 , findlib ? null
 , zarith ? null
 }:
+
+assert javaBindings -> jdk != null;
 
 with lib;
 
@@ -27,11 +28,18 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
-  buildInputs = [ cmake ] ;
+  buildInputs = [ cmake ]
+    ++ optional javaBindings jdk
+  ;
   propagatedBuildInputs = [ python.pkgs.setuptools ];
   enableParallelBuilding = true;
 
-  cmakeFlags = [];
+  cmakeFlags = []
+    ++ optional javaBindings ''
+        -DZ3_BUILD_JAVA_BINDINGS=True
+        -DZ3_INSTALL_JAVA_BINDINGS=True
+       ''
+  ;
 
   outputs = [ "out" "lib" "dev" ] ;
 

--- a/pkgs/applications/science/logic/z3/default.nix
+++ b/pkgs/applications/science/logic/z3/default.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, cmake
 , fetchFromGitHub
 , python
 , fixDarwinDylibNames
@@ -11,9 +12,6 @@
 , findlib ? null
 , zarith ? null
 }:
-
-assert javaBindings -> jdk != null;
-assert ocamlBindings -> ocaml != null && findlib != null && zarith != null;
 
 with lib;
 
@@ -29,43 +27,13 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
-  buildInputs = [ python ]
-    ++ optional javaBindings jdk
-    ++ optionals ocamlBindings [ ocaml findlib zarith ]
-  ;
+  buildInputs = [ cmake ] ;
   propagatedBuildInputs = [ python.pkgs.setuptools ];
   enableParallelBuilding = true;
 
-  postPatch = optionalString ocamlBindings ''
-    export OCAMLFIND_DESTDIR=$ocaml/lib/ocaml/${ocaml.version}/site-lib
-    mkdir -p $OCAMLFIND_DESTDIR/stublibs
-  '';
+  cmakeFlags = [];
 
-  configurePhase = concatStringsSep " "
-    (
-      [ "${python.interpreter} scripts/mk_make.py --prefix=$out" ]
-        ++ optional javaBindings "--java"
-        ++ optional ocamlBindings "--ml"
-        ++ optional pythonBindings "--python --pypkgdir=$out/${python.sitePackages}"
-    ) + "\n" + "cd build";
-
-  postInstall = ''
-    mkdir -p $dev $lib
-    mv $out/lib $lib/lib
-    mv $out/include $dev/include
-  '' + optionalString pythonBindings ''
-    mkdir -p $python/lib
-    mv $lib/lib/python* $python/lib/
-    ln -sf $lib/lib/libz3${stdenv.hostPlatform.extensions.sharedLibrary} $python/${python.sitePackages}/z3/lib/libz3${stdenv.hostPlatform.extensions.sharedLibrary}
-  '' + optionalString javaBindings ''
-    mkdir -p $java/share/java
-    mv com.microsoft.z3.jar $java/share/java
-    moveToOutput "lib/libz3java.${stdenv.hostPlatform.extensions.sharedLibrary}" "$java"
-  '';
-
-  outputs = [ "out" "lib" "dev" "python" ]
-    ++ optional javaBindings "java"
-    ++ optional ocamlBindings "ocaml";
+  outputs = [ "out" "lib" "dev" ] ;
 
   meta = with lib; {
     description = "A high-performance theorem prover and SMT solver";


### PR DESCRIPTION
@Artturin This is a stab at converting the build script for Z3 over to the CMake system. There were some problems with the API bindings that I encountered and wasn't sure what the best fix would be:
* The OCaml bindings for Z3 aren't supported by its CMake build system, but the current Z3 recipe offers options to configure those bindings. The [documentation](https://github.com/Z3Prover/z3/blob/master/README-CMake.md) doesn't seem to suggest that there's any way to get the OCaml bindings generated using CMake.
* The Python bindings want to install files to a location outside the Z3 package's install tree. I get a message like:
    ```
    CMake Error at src/api/python/cmake_install.cmake:54 (file):
      file cannot create directory:
      /nix/store/5nxpvrfl0p14l90rx5cjy9190ndlbbzb-python-2.7.18/lib/python2.7/site-packages/z3.
      Maybe need administrative privileges.
    Call Stack (most recent call first):
      src/cmake_install.cmake:204 (include)
      cmake_install.cmake:118 (include)
    ```
    what's the usual approach to dealing with this?