### PR TITLE
driftctl: 0.17.0 -> 0.18.0 and clean up the expression

### DIFF
--- a/pkgs/applications/networking/cluster/driftctl/default.nix
+++ b/pkgs/applications/networking/cluster/driftctl/default.nix
@@ -23,12 +23,12 @@ buildGoModule rec {
     # and remove corresponding flags from --help, so things look tidy.
     find -name driftctl.go | \
       xargs sed -i -e '/("no-version-check"/ d'  -e '/("disable-telemetry"/ d'
-
-    # Presumably it can be done with ldflags, but I failed to find incantation
-    # that would work, we here we go old-school.
-    find -name version.go | xargs sed -i -e 's/"dev"/"${version}"/'
-    find -name build.go | xargs sed -i -e 's/"dev"/"release"/'
   '';
+
+  ldflags = [
+    "-X github.com/cloudskiff/driftctl/build.env=release"
+    "-X github.com/cloudskiff/driftctl/pkg/version.version=v${version}"
+  ];
 
   meta = with lib; {
     description = "Tool to track infrastructure drift";

--- a/pkgs/applications/networking/cluster/driftctl/default.nix
+++ b/pkgs/applications/networking/cluster/driftctl/default.nix
@@ -5,7 +5,7 @@ buildGoModule rec {
   version = "0.18.0";
 
   src = fetchFromGitHub {
-    owner = "cloudskiff";
+    owner = "snyk";
     repo = "driftctl";
     rev = "v${version}";
     sha256 = "sha256:1k9mx3yh5qza5rikg38ls78gbi4mw8ar4c1x9ij863w1c28fdzlb";
@@ -14,14 +14,14 @@ buildGoModule rec {
   vendorSha256 = "sha256:0dajz1xbf607l9y5kby4kh7h28v4b3jjmnjsf6cys46pcgxa0zw3";
 
   ldflags = [
-    "-X github.com/cloudskiff/driftctl/build.enableUsageReporting=false"
-    "-X github.com/cloudskiff/driftctl/build.env=release"
-    "-X github.com/cloudskiff/driftctl/pkg/version.version=v${version}"
+    "-X github.com/snyk/driftctl/build.enableUsageReporting=false"
+    "-X github.com/snyk/driftctl/build.env=release"
+    "-X github.com/snyk/driftctl/pkg/version.version=v${version}"
   ];
 
   meta = with lib; {
     description = "Tool to track infrastructure drift";
-    homepage = "https://github.com/cloudskiff/driftctl";
+    homepage = "https://github.com/snyk/driftctl";
     license = licenses.asl20;
     maintainers = with maintainers; [ kaction ];
   };

--- a/pkgs/applications/networking/cluster/driftctl/default.nix
+++ b/pkgs/applications/networking/cluster/driftctl/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "driftctl";
-  version = "0.17";
+  version = "0.18.0";
 
   src = fetchFromGitHub {
     owner = "cloudskiff";
     repo = "driftctl";
     rev = "v${version}";
-    sha256 = "sha256-JloeRoW+1tepSJzhcOQu38TDQfY10NtG2EyeVhP26BQ=";
+    sha256 = "sha256:1k9mx3yh5qza5rikg38ls78gbi4mw8ar4c1x9ij863w1c28fdzlb";
   };
 
-  vendorSha256 = "sha256-aaJ5fpS+BiVq1K8OxN+/CBD96wy3flGDhch8O2ACIh8=";
+  vendorSha256 = "sha256:0dajz1xbf607l9y5kby4kh7h28v4b3jjmnjsf6cys46pcgxa0zw3";
 
   postUnpack = ''
     # Without this, tests fail to locate aws/3.19.0.json

--- a/pkgs/applications/networking/cluster/driftctl/default.nix
+++ b/pkgs/applications/networking/cluster/driftctl/default.nix
@@ -14,19 +14,6 @@ buildGoModule rec {
   vendorSha256 = "sha256:0dajz1xbf607l9y5kby4kh7h28v4b3jjmnjsf6cys46pcgxa0zw3";
 
   postUnpack = ''
-    # Without this, tests fail to locate aws/3.19.0.json
-    for prefix in /                        \
-                  /pkg                     \
-                  /pkg/analyser            \
-                  /pkg/alerter             \
-                  /pkg/remote              \
-                  /pkg/middlewares         \
-                  /pkg/cmd/scan/output     \
-                  /pkg/iac/terraform/state \
-                  /pkg/iac/supplier ; do
-      mkdir -p ./source/$prefix/github.com/cloudskiff
-      ln -sf $PWD/source ./source/$prefix/github.com/cloudskiff/driftctl
-    done
 
     # Disable check for latest version and telemetry, which are opt-out.
     # Making it out-in is quite a job, and why bother?
@@ -41,10 +28,6 @@ buildGoModule rec {
     # that would work, we here we go old-school.
     find -name version.go | xargs sed -i -e 's/"dev"/"${version}"/'
     find -name build.go | xargs sed -i -e 's/"dev"/"release"/'
-
-    # Fix the tests that checks for dev-dev.
-    find -name version_test.go | xargs sed -i -e 's/"dev-dev/"${version}/'
-    find -name driftctl_test.go | xargs sed -i -e 's/"dev-dev/"${version}/'
   '';
 
   meta = with lib; {

--- a/pkgs/applications/networking/cluster/driftctl/default.nix
+++ b/pkgs/applications/networking/cluster/driftctl/default.nix
@@ -13,19 +13,8 @@ buildGoModule rec {
 
   vendorSha256 = "sha256:0dajz1xbf607l9y5kby4kh7h28v4b3jjmnjsf6cys46pcgxa0zw3";
 
-  postUnpack = ''
-
-    # Disable check for latest version and telemetry, which are opt-out.
-    # Making it out-in is quite a job, and why bother?
-    find -name '*.go' \
-      | xargs sed -i 's,https://2lvzgmrf2e.execute-api.eu-west-3.amazonaws.com/,https://0.0.0.0/,g'
-
-    # and remove corresponding flags from --help, so things look tidy.
-    find -name driftctl.go | \
-      xargs sed -i -e '/("no-version-check"/ d'  -e '/("disable-telemetry"/ d'
-  '';
-
   ldflags = [
+    "-X github.com/cloudskiff/driftctl/build.enableUsageReporting=false"
     "-X github.com/cloudskiff/driftctl/build.env=release"
     "-X github.com/cloudskiff/driftctl/pkg/version.version=v${version}"
   ];


### PR DESCRIPTION
###### Motivation for this change

Hi there, I've improved many things on driftctl side to make nix packaging a way more easier.

- `driftctl: 0.17.0 -> 0.18.0` Bump driftctl to the latest version
- `driftctl: Remove useless test workarounds` Should be fixed with : https://github.com/cloudskiff/driftctl/pull/1237 and https://github.com/cloudskiff/driftctl/pull/1236
- `driftctl: Remove dirty sed in flavor of ldflags` We already use ldflags for that purpose, this is cleaner than a sed
- `driftctl: Better way to disable telemetry` We added a single entry point to disable all telemetry related stuff here https://github.com/cloudskiff/driftctl/pull/1238. 
- Apply changes since driftctl moved from `cloudskiff` org to `snyk`

Happy to discuss about the latest one and the policy we want to have about telemetry and OSS community 🙏🏻 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
