### PR TITLE
telescope: 0.5.2 → 0.6.1

### DIFF
--- a/pkgs/applications/networking/browsers/telescope/default.nix
+++ b/pkgs/applications/networking/browsers/telescope/default.nix
@@ -7,17 +7,18 @@
 , libressl
 , ncurses
 , autoreconfHook
+, buildPackages
 }:
 
 stdenv.mkDerivation rec {
   pname = "telescope";
-  version = "0.5.2";
+  version = "0.6.1";
 
   src = fetchFromGitHub {
     owner = "omar-polo";
     repo = pname;
     rev = version;
-    sha256 = "sha256-AdbFJfoicQUgJ9kesIWZ9ygttyjjDeC0UHRI98GwoZ8=";
+    sha256 = "sha256-r2+jvmnW9EeQf/2X2cOxnOa+HGuGHV6YMftT2MxbSYQ=";
   };
 
   nativeBuildInputs = [
@@ -30,6 +31,10 @@ stdenv.mkDerivation rec {
     libevent
     libressl
     ncurses
+  ];
+
+  configureFlags = [
+    "HOSTCC=${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}cc"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
* [changelog](https://github.com/omar-polo/telescope/releases)
* fix cross-compilation (https://github.com/omar-polo/telescope/issues/5)
* fix crash on darwin (https://github.com/omar-polo/telescope/pull/4)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [x] x86_64-darwin
  - [x] aarch64-darwin (cross)
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
