### PR TITLE
python3Packages.pydicom: add missing setuptools runtime dependency

### DIFF
--- a/pkgs/development/python-modules/pydicom/default.nix
+++ b/pkgs/development/python-modules/pydicom/default.nix
@@ -2,11 +2,11 @@
 , stdenv
 , buildPythonPackage
 , fetchFromGitHub
-, isPy27
-, pytest-runner
+, pythonOlder
 , pytestCheckHook
 , numpy
 , pillow
+, setuptools
 }:
 
 let
@@ -20,7 +20,7 @@ let
     sha256 = "sha256-iExy+mUs1uqs/u9N6btlqyP6/TvoPVsuOuzs56zZAS8=";
   };
 
-  # Pydicom needs pydicom-data to run some tests. If these files are downloaded
+  # Pydicom needs pydicom-data to run some tests. If these files aren't downloaded
   # before the package creation, it'll try to download during the checkPhase.
   test_data = fetchFromGitHub {
     owner = "${pname}";
@@ -32,11 +32,11 @@ let
 in
 buildPythonPackage {
   inherit pname version src;
-  disabled = isPy27;
+  disabled = pythonOlder "3.6";
 
-  propagatedBuildInputs = [ numpy pillow ];
+  propagatedBuildInputs = [ numpy pillow setuptools ];
 
-  checkInputs = [ pytest-runner pytestCheckHook ];
+  checkInputs = [ pytestCheckHook ];
 
   # Setting $HOME to prevent pytest to try to create a folder inside
   # /homeless-shelter which is read-only.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Missing dependency, not previously detected due to #133032.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [NA] (Package updates) Added a release notes entry if the change is major or breaking
  - [NA] (Module updates) Added a release notes entry if the change is significant
  - [NA] (Module addition) Added a release notes entry if adding a new NixOS module
  - [NA] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
