### PR TITLE
cppe, python3Packages.cppe: fix build with clang

### DIFF
--- a/pkgs/development/libraries/science/chemistry/cppe/default.nix
+++ b/pkgs/development/libraries/science/chemistry/cppe/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, cmake }:
+{ stdenv, lib, fetchFromGitHub, cmake, llvmPackages }:
 
 stdenv.mkDerivation rec {
   pname = "cppe";
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-guM7+ZWDJLcAUJtPkKLvC4LYSA2eBvER7cgwPZ7FxHw=";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ]
+    ++ lib.optionals stdenv.cc.isClang [ llvmPackages.openmp ];
 
   cmakeFlags = [ "-DCMAKE_INSTALL_LIBDIR=lib" ];
 

--- a/pkgs/development/python-modules/cppe/default.nix
+++ b/pkgs/development/python-modules/cppe/default.nix
@@ -1,5 +1,6 @@
 { buildPythonPackage
 , lib
+, stdenv
 , cmake
 , cppe
 , eigen
@@ -12,6 +13,7 @@
 , pandas
 , polarizationsolver
 , pytest
+, llvmPackages
 }:
 
 buildPythonPackage rec {
@@ -31,7 +33,12 @@ buildPythonPackage rec {
 
   dontUseCmakeConfigure = true;
 
-  buildInputs = [ pybind11 ];
+  buildInputs = [ pybind11 ]
+    ++ lib.optional stdenv.cc.isClang llvmPackages.openmp;
+
+  NIX_CFLAGS_LINK = lib.optional stdenv.cc.isClang "-lomp";
+
+  hardeningDisable = lib.optional stdenv.cc.isClang "strictoverflow";
 
   checkInputs = [
     pytest


### PR DESCRIPTION
###### Motivation for this change
ZHF: #144627 @NixOS/nixos-release-managers 

A few tweaks to get this going on clang/darwin, mostly around openmp.

Need to feed `-lomp` manually to the python package's link stage as it attempts some compiler flag detection and receives an error when attempting to use `-lomp` because it's trying to use it in a build call rather than a linking call.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
