### PR TITLE
[staging] python/pythonNamespacesSetupHook: add  to addtional files to remove

### DIFF
--- a/pkgs/development/interpreters/python/hooks/python-namespaces-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-namespaces-hook.sh
@@ -24,6 +24,12 @@ pythonNamespacesHook() {
                 rm -v "$pathToRemove"
             fi
 
+            # remove ${pname}-${version}-${python-interpeter}-nspkg.pth
+            if [ -z ${dontRemovePth-} ]; then
+                # .pth files are located in the parent directory of a module
+                @findutils@/bin/find ${constructedPath}/../ -name '*-nspkg.pth' -exec rm -v "{}" +
+            fi
+
             # remove __pycache__/ entry, can be interpreter specific. E.g. __init__.cpython-38.pyc
             # use null characters to perserve potential whitespace in filepath
             if [ -d "$pycachePath" ]; then


### PR DESCRIPTION
###### Motivation for this change
The use of  `*-nspkg.pth` files interferes with path lookup with PYTHONPATH. Recently had issues with google-* packages, and paste + pastescripts on #https://github.com/NixOS/nixpkgs/pull/147426

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
