### PR TITLE
stdenv: bootstrap riscv64 (Step 2)

### DIFF
--- a/pkgs/development/compilers/gcc/10/default.nix
+++ b/pkgs/development/compilers/gcc/10/default.nix
@@ -64,6 +64,7 @@ let majorVersion = "10";
     patches =
          optional (targetPlatform != hostPlatform) ../libstdc++-target.patch
       ++ optional noSysDirs ../no-sys-dirs.patch
+      ++ optional (noSysDirs && hostPlatform.isRiscV) ../no-sys-dirs-riscv.patch
       /* ++ optional (hostPlatform != buildPlatform) (fetchpatch { # XXX: Refine when this should be applied
         url = "https://git.busybox.net/buildroot/plain/package/gcc/${version}/0900-remove-selftests.patch?id=11271540bfe6adafbc133caf6b5b902a816f5f02";
         sha256 = ""; # TODO: uncomment and check hash when available.

--- a/pkgs/development/compilers/gcc/11/default.nix
+++ b/pkgs/development/compilers/gcc/11/default.nix
@@ -64,6 +64,7 @@ let majorVersion = "11";
     patches =
          optional (targetPlatform != hostPlatform) ../libstdc++-target.patch
       ++ optional noSysDirs ../no-sys-dirs.patch
+      ++ optional (noSysDirs && hostPlatform.isRiscV) ../no-sys-dirs-riscv.patch
       /* ++ optional (hostPlatform != buildPlatform) (fetchpatch { # XXX: Refine when this should be applied
         url = "https://git.busybox.net/buildroot/plain/package/gcc/${version}/0900-remove-selftests.patch?id=11271540bfe6adafbc133caf6b5b902a816f5f02";
         sha256 = ""; # TODO: uncomment and check hash when available.

--- a/pkgs/development/compilers/gcc/no-sys-dirs-riscv.patch
+++ b/pkgs/development/compilers/gcc/no-sys-dirs-riscv.patch
@@ -1,0 +1,12 @@
+--- a/gcc/config/riscv/linux.h
++++ b/gcc/config/riscv/linux.h
+@@ -69,8 +69,4 @@
+ 
+ #define TARGET_ASM_FILE_END file_end_indicate_exec_stack
+ 
+-#define STARTFILE_PREFIX_SPEC 			\
+-   "/lib" XLEN_SPEC "/" ABI_SPEC "/ "		\
+-   "/usr/lib" XLEN_SPEC "/" ABI_SPEC "/ "	\
+-   "/lib/ "					\
+-   "/usr/lib/ "
++#define STARTFILE_PREFIX_SPEC ""

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -56,6 +56,7 @@ in
     powerpc-linux = /* stagesLinux */ stagesNative;
     powerpc64-linux = stagesLinux;
     powerpc64le-linux = stagesLinux;
+    riscv64-linux = stagesLinux;
     x86_64-darwin = stagesDarwin;
     aarch64-darwin = stagesDarwin;
     x86_64-solaris = stagesNix;

--- a/pkgs/stdenv/linux/bootstrap-files/riscv64.nix
+++ b/pkgs/stdenv/linux/bootstrap-files/riscv64.nix
@@ -1,0 +1,12 @@
+{
+  busybox = import <nix/fetchurl.nix> {
+    url = "http://tarballs.nixos.org/stdenv-linux/riscv64/9bd3cf0063b80428bd85a286205adab4b6ffcbd6/busybox";
+    sha256 = "6f61912f94bc4ef287d1ff48a9521ed16bd07d8d8ec775e471f32c64d346583d";
+    executable = true;
+  };
+
+  bootstrapTools = import <nix/fetchurl.nix> {
+    url = "http://tarballs.nixos.org/stdenv-linux/riscv64/9bd3cf0063b80428bd85a286205adab4b6ffcbd6/bootstrap-tools.tar.xz";
+    sha256 = "5466b19288e980125fc62ebb864d09908ffe0bc50cebe52cfee89acff14d5b9f";
+  };
+}

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -16,6 +16,7 @@
       armv7l-linux = import ./bootstrap-files/armv7l.nix;
       aarch64-linux = import ./bootstrap-files/aarch64.nix;
       mipsel-linux = import ./bootstrap-files/loongson2f.nix;
+      riscv64-linux = import ./bootstrap-files/riscv64.nix;
     };
     musl = {
       aarch64-linux = import ./bootstrap-files/aarch64-musl.nix;


### PR DESCRIPTION
###### Motivation for this change

Follows #115406
Related: #101651

Add bootstrap files from https://hydra.nixos.org/build/159891432 and https://hydra.nixos.org/build/159891436

Currently the two URLs starting with `http://tarballs.nixos.org` are dangling. They should be uploaded before this PR being merged. @grahamc

###### Test steps:
1. (Before two files being uploaded) Fetch bootstrap files built by Hydra and re-add them as FODs to skip currently dangling URLs. They are already available on https://cache.nixos.org
```bash
nix store add-path --name busybox $(nix-store -r /nix/store/2k7r16bgfglv4ygrkmprk611my6n62x7-busybox)
nix store add-file --name bootstrap-tools.tar.xz $(nix-store -r /nix/store/g9vs803cwl3mx5w2fk0sdfmf977vyp9p-bootstrap-tools.tar.xz)
```
2. (If you don't have a native RV machine) Enable binfmt for `riscv64-linux` on your building machine. And apply the binfmt-QEMU patch #143060. It's required to pass all `coreutils` tests.
3. Bootstrap `riscv64-linux` stdenv.
```bash
nix-build . -A stdenv --argstr system riscv64-linux
```
4. Playing around with the new `stdenv`. Or optionally, try to re-bootstrap bootstrap files to confirm the new `stdenv` is fully functional. Note that this would take a long time since QEMU is far slower than cross compilation.
```
nix-build pkgs/stdenv/linux/make-bootstrap-tools.nix -A build --argstr localSystem riscv64-linux
```

###### Things done

I built the new `stdenv` successfully.

Note that currently some basic packages including `nix` and `systemd` won't evaluate due to the usage of outdated `boost`, it would be fixed by #138309 (still in `staging`).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
