### PR TITLE
Vscode/vscodium add use wayland

### DIFF
--- a/nixos/tests/vscodium.nix
+++ b/nixos/tests/vscodium.nix
@@ -4,9 +4,7 @@ let
       imports = [ ./common/wayland-cage.nix ];
 
       services.cage.program = ''
-        ${pkgs.vscodium}/bin/codium \
-          --enable-features=UseOzonePlatform \
-          --ozone-platform=wayland
+        ${pkgs.vscodium.override { useWayland = true; }}/bin/codium
       '';
 
       fonts.fonts = with pkgs; [ dejavu_fonts ];

--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -16,6 +16,8 @@
 # sourceExecutableName is the name of the binary in the source archive, over
 # which we have no control
 , sourceExecutableName ? executableName
+
+, useWayland ? false
 }:
 
 let
@@ -100,6 +102,9 @@ let
       # Override the previously determined VSCODE_PATH with the one we know to be correct
       sed -i "/ELECTRON=/iVSCODE_PATH='$out/lib/vscode'" "$out/bin/${executableName}"
       grep -q "VSCODE_PATH='$out/lib/vscode'" "$out/bin/${executableName}" # check if sed succeeded
+
+      substituteInPlace "$out/bin/${executableName}" \
+        --replace '"$ELECTRON" "$CLI"' '"$ELECTRON" "$CLI"${lib.optionalString useWayland " --enable-features=UseOzonePlatform --ozone-platform=wayland"}'
     '') + ''
       runHook postInstall
     '';

--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -103,8 +103,10 @@ let
       sed -i "/ELECTRON=/iVSCODE_PATH='$out/lib/vscode'" "$out/bin/${executableName}"
       grep -q "VSCODE_PATH='$out/lib/vscode'" "$out/bin/${executableName}" # check if sed succeeded
 
-      substituteInPlace "$out/bin/${executableName}" \
-        --replace '"$ELECTRON" "$CLI"' '"$ELECTRON" "$CLI"${lib.optionalString useWayland " --enable-features=UseOzonePlatform --ozone-platform=wayland"}'
+      ${lib.optionalString useWayland ''
+        wrapProgram $out/bin/${executableName} --add-flags \
+          "--enable-features=UseOzonePlatform --ozone-platform=wayland"
+      ''}
     '') + ''
       runHook postInstall
     '';

--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, callPackage, fetchurl, isInsiders ? false }:
+{ stdenv, lib, callPackage, fetchurl, isInsiders ? false, useWayland ? false }:
 
 let
   inherit (stdenv.hostPlatform) system;
@@ -22,6 +22,8 @@ let
   }.${system};
 in
   callPackage ./generic.nix rec {
+    inherit useWayland;
+
     # Please backport all compatible updates to the stable release.
     # This is important for the extension ecosystem.
     version = "1.62.3";

--- a/pkgs/applications/editors/vscode/vscodium.nix
+++ b/pkgs/applications/editors/vscode/vscodium.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, callPackage, fetchurl, nixosTests }:
+{ lib, stdenv, callPackage, fetchurl, nixosTests, useWayland ? false}:
 
 let
   inherit (stdenv.hostPlatform) system;
@@ -27,7 +27,7 @@ let
   }.${system};
 in
   callPackage ./generic.nix rec {
-    inherit sourceRoot;
+    inherit sourceRoot useWayland;
 
     # Please backport all compatible updates to the stable release.
     # This is important for the extension ecosystem.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Wanting to use Vscode/Vscodium in Sway without Xwayland.

###### Things done
Add a `useWayland` option inspired by https://github.com/NixOS/nixpkgs/commit/bcad474c4ad57db4b21885973dc67b493f5730b1
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
