### PR TITLE
quickemu: 2.2.7 -> 3.11 (WfW)

### DIFF
--- a/pkgs/development/quickemu/default.nix
+++ b/pkgs/development/quickemu/default.nix
@@ -22,6 +22,7 @@
 let
   runtimePaths = [
     qemu
+    edk2
     gnugrep
     jq
     lsb-release
@@ -41,13 +42,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "quickemu";
-  version = "2.3.2";
+  version = "3.11";
 
   src = fetchFromGitHub {
     owner = "quickemu-project";
     repo = pname;
     rev = version;
-    sha256 = "sha256-15cilf7ccj88c9f4qw1b5mjzgi2f3c854b4xlz1k22xdlx8zwd3f";
+    sha256 = "sha256-1oCgUZ2YB4Ib+8Bhpw90bnRXrQz0Y+a6r/yUvPhOjvc=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/development/quickemu/default.nix
+++ b/pkgs/development/quickemu/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , stdenv
 , makeWrapper
+, edk2
 , qemu
 , gnugrep
 , lsb-release
@@ -20,7 +21,6 @@
 }:
 let
   runtimePaths = [
-    edk2
     qemu
     gnugrep
     jq

--- a/pkgs/development/quickemu/default.nix
+++ b/pkgs/development/quickemu/default.nix
@@ -20,6 +20,7 @@
 }:
 let
   runtimePaths = [
+    edk2
     qemu
     gnugrep
     jq
@@ -40,13 +41,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "quickemu";
-  version = "2.2.7";
+  version = "2.3.2";
 
   src = fetchFromGitHub {
-    owner = "wimpysworld";
+    owner = "quickemu-project";
     repo = pname;
     rev = version;
-    sha256 = "sha256-TNG1pCePsi12QQafhayhj+V5EXq+v7qmaW5v5X8ER6s=";
+    sha256 = "sha256-15cilf7ccj88c9f4qw1b5mjzgi2f3c854b4xlz1k22xdlx8zwd3f";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -65,7 +66,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Quickly create and run optimised Windows, macOS and Linux desktop virtual machines";
-    homepage = "https://github.com/wimpysworld/quickemu";
+    homepage = "https://github.com/quickemu-project/quickemu";
     license = licenses.mit;
     maintainers = with maintainers; [ fedx-sudo ];
   };


### PR DESCRIPTION
[Updated 2021-12-09]
- Bump version to quickemu 3.11 WfW to include newer upstream work
- Support for NixOS 21.11
- Fixed link to edk2 commit below

Additional changes
- Added edk2 dependency introduced in [commit b6db417](https://github.com/quickemu-project/quickemu/commit/b6db417b814a277f0e039ca010e29a703881dff3)
- Github repo owner was renamed from "wimpysworld" to "quickemu-project"
