### PR TITLE
libudev-zero: init at 1.0.0

### DIFF
--- a/pkgs/development/libraries/libudev-zero/default.nix
+++ b/pkgs/development/libraries/libudev-zero/default.nix
@@ -1,0 +1,38 @@
+{ lib, stdenv, fetchFromGitHub, fetchpatch }:
+
+stdenv.mkDerivation rec {
+  pname = "libudev-zero";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "illiliti";
+    repo = "libudev-zero";
+    rev = version;
+    sha256 = "0mln7iwyz7lxz8dx7bx7b47j6yws1dvfq35qsdcwg3wwmd4ngsz6";
+  };
+
+  patches = [
+    # Fix static.
+    # https://github.com/illiliti/libudev-zero/pull/48
+    (fetchpatch {
+      url = "https://github.com/illiliti/libudev-zero/commit/505c61819b371a1802e054fe2601e64f2dc6d79e.patch";
+      sha256 = "0y06rgjv73dd7fi3a0dlabcc8ryk3yhbsyrrhnnn3v36y1wz6m0g";
+    })
+  ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  # Just let the installPhase build stuff, because there's no
+  # non-install target that builds everything anyway.
+  dontBuild = true;
+
+  installTargets = lib.optionals stdenv.hostPlatform.isStatic "install-static";
+
+  meta = with lib; {
+    homepage = "https://github.com/illiliti/libudev-zero";
+    description = "Daemonless replacement for libudev";
+    maintainers = with maintainers; [ qyliss shamilton ];
+    license = licenses.isc;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18326,6 +18326,8 @@ with pkgs;
 
   libubox = callPackage ../development/libraries/libubox { };
 
+  libudev-zero = callPackage ../development/libraries/libudev-zero { };
+
   libuecc = callPackage ../development/libraries/libuecc { };
 
   libui = callPackage ../development/libraries/libui {


### PR DESCRIPTION
libudev-zero is a daemonless reimplementation of udev, that is of additional interest to us in Nixpkgs because (currently with a small upstreamable build system patch) it's possible to build it statically, which systemd's udev is unlikely to support in the near future[1].

In future, it might be good to default to using libudev-zero in pkgsStatic, but for now let's just introduce the package, so people doing static builds can at least use it themselves using overrides or overlays.

@SCOTT-HAMILTON, I've added you as a maintainer here because of #136107 — if you'd rather not be, just say.

[1]: https://github.com/systemd/systemd/pull/20621#issuecomment-912014839

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
