### PR TITLE
pkg-config: always pass --static in static builds

### DIFF
--- a/pkgs/build-support/pkg-config-wrapper/default.nix
+++ b/pkgs/build-support/pkg-config-wrapper/default.nix
@@ -47,6 +47,9 @@ stdenv.mkDerivation {
   dontBuild = true;
   dontConfigure = true;
 
+  # Additional flags passed to pkg-config.
+  addFlags = lib.optional stdenv.targetPlatform.isStatic "--static";
+
   unpackPhase = ''
     src=$PWD
   '';

--- a/pkgs/build-support/pkg-config-wrapper/pkg-config-wrapper.sh
+++ b/pkgs/build-support/pkg-config-wrapper/pkg-config-wrapper.sh
@@ -18,6 +18,6 @@ if (( ${#role_suffixes[@]} > 0 )); then
     # replace env var with nix-modified one
     PKG_CONFIG_PATH=$PKG_CONFIG_PATH_@suffixSalt@ exec @prog@ "$@"
 else
-    # pkg-config isn't a bonafied dependency so ignore setup hook entirely
+    # pkg-config isn't a real dependency so ignore setup hook entirely
     exec @prog@ "$@"
 fi

--- a/pkgs/build-support/pkg-config-wrapper/pkg-config-wrapper.sh
+++ b/pkgs/build-support/pkg-config-wrapper/pkg-config-wrapper.sh
@@ -12,6 +12,8 @@ if [ -z "${NIX_PKG_CONFIG_WRAPPER_FLAGS_SET_@suffixSalt@:-}" ]; then
     source @out@/nix-support/add-flags.sh
 fi
 
+set -- "$@" @addFlags@
+
 if (( ${#role_suffixes[@]} > 0 )); then
     # replace env var with nix-modified one
     PKG_CONFIG_PATH=$PKG_CONFIG_PATH_@suffixSalt@ exec @prog@ "$@"


### PR DESCRIPTION
By default, pkg-config output will not include Requires.private dependencies (which specify dependencies that only apply when building statically).  It will only do this when passed --static.  In pkgsStatic, let's ensure pkg-config is always operating in static mode, because pkgsStatic will ensure that any libraries pkg-config might find will always be static, and so will always need their Requires.private dependencies.

This is very useful for Meson builds, because otherwise Meson will only pass --static to pkg-config if the dependency was explicitly `"static : true"`, which is not likely to be the case for most stuff we're building.

An alternative proposal was to patch Meson to` add a spe`cial environment variable to force dependencies to be `"static : true"`.  I feel that the approach I've taken here is less invasive.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
