### PR TITLE
[21.11] haskell.compiler.*: mark as unsupported on aarch64-darwin

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.7-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.7-binary.nix
@@ -397,6 +397,11 @@ stdenv.mkDerivation rec {
     # `pkgsMusl`.
     platforms = builtins.attrNames ghcBinDists.${distSetName};
     hydraPlatforms = builtins.filter (p: minimal || p != "aarch64-linux") platforms;
+    # While GHC >= 8.10.7 builds and works to an extent on aarch64-darwin,
+    # there are multiple unresolved issues degrading the quality of the
+    # `haskellPackages` set. As such, we can't call it a supported platform.
+    # Use `config.allowUnsupportedSystem` if you are feeling adventurous.
+    badPlatforms = [ "aarch64-darwin" ];
     maintainers = with lib.maintainers; [
       prusnak
       domenkozar

--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -347,6 +347,11 @@ stdenv.mkDerivation (rec {
     ] ++ lib.teams.haskell.members;
     timeout = 24 * 3600;
     inherit (ghc.meta) license platforms;
+    # While GHC >= 8.10.7 builds and works to an extent on aarch64-darwin,
+    # there are multiple unresolved issues degrading the quality of the
+    # `haskellPackages` set. As such, we can't call it a supported platform.
+    # Use `config.allowUnsupportedSystem` if you are feeling adventurous.
+    badPlatforms = [ "aarch64-darwin" ];
   };
 
 } // lib.optionalAttrs targetPlatform.useAndroidPrebuilt {

--- a/pkgs/development/compilers/ghc/9.0.1.nix
+++ b/pkgs/development/compilers/ghc/9.0.1.nix
@@ -312,6 +312,11 @@ stdenv.mkDerivation (rec {
     ] ++ lib.teams.haskell.members;
     timeout = 24 * 3600;
     inherit (ghc.meta) license platforms;
+    # While GHC >= 8.10.7 builds and works to an extent on aarch64-darwin,
+    # there are multiple unresolved issues degrading the quality of the
+    # `haskellPackages` set. As such, we can't call it a supported platform.
+    # Use `config.allowUnsupportedSystem` if you are feeling adventurous.
+    badPlatforms = [ "aarch64-darwin" ];
   };
 
 } // lib.optionalAttrs targetPlatform.useAndroidPrebuilt {

--- a/pkgs/development/compilers/ghc/9.2.1.nix
+++ b/pkgs/development/compilers/ghc/9.2.1.nix
@@ -315,6 +315,11 @@ stdenv.mkDerivation (rec {
     ] ++ lib.teams.haskell.members;
     timeout = 24 * 3600;
     inherit (ghc.meta) license platforms;
+    # While GHC >= 8.10.7 builds and works to an extent on aarch64-darwin,
+    # there are multiple unresolved issues degrading the quality of the
+    # `haskellPackages` set. As such, we can't call it a supported platform.
+    # Use `config.allowUnsupportedSystem` if you are feeling adventurous.
+    badPlatforms = [ "aarch64-darwin" ];
   };
 
 } // lib.optionalAttrs targetPlatform.useAndroidPrebuilt {

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -334,6 +334,11 @@ stdenv.mkDerivation (rec {
     inherit (ghc.meta) license platforms;
     # ghcHEAD times out on aarch64-linux on Hydra.
     hydraPlatforms = builtins.filter (p: p != "aarch64-linux") ghc.meta.platforms;
+    # While GHC >= 8.10.7 builds and works to an extent on aarch64-darwin,
+    # there are multiple unresolved issues degrading the quality of the
+    # `haskellPackages` set. As such, we can't call it a supported platform.
+    # Use `config.allowUnsupportedSystem` if you are feeling adventurous.
+    badPlatforms = [ "aarch64-darwin" ];
   };
 
   dontStrip = (targetPlatform.useAndroidPrebuilt || targetPlatform.isWasm);


### PR DESCRIPTION
While GHC now can be bootstrapped and built on aarch64-darwin, it seems
to work only to an extent. All sorts of strange issues have manifested
themselves in `haskellPackages` and downstream usage which leads me to
conclude that it would be misleading to call it supported on this
platform, especially in a stable channel. To give a few examples,
separate bin outputs just don't work in general [1] and `opt` fails
for unknown reasons in some derivations [2]. As I don't own any
appropriate hardware, I have tried tackling these issues by staring into
my crystal ball, but so far to no avail (even worse, new issues [3] have
cropped up due to changes that should have been an improvement).

Given these circumstances, I'm not willing to call GHC supported on
aarch64-darwin for the stable channel. I'm (for now) hopeful that we can
improve the situation on `master` going forward, but it is not
guaranteed that these changes will be backportable without a ton of
effort.

Should it turn out that we can't resolve these issues or maintain GHC's
aarch64-darwin support due to a lack of contributors going forward, I am
also prepared to drop aarch64-darwin support completely. While it has
been proclaimed a Tier 3 platform, I would argue that the “popular”
package GHC has never been working, at least not properly.

1. https://github.com/NixOS/nixpkgs/issues/140774
2. https://matrix.to/#/!RbXGJhHMsnQcNIDFWN:nixos.org/$C6FK74EajqSTk58JzriYpQJ9f6x3UH3tIREcn04Y-rM?via=nixos.org&via=matrix.org&via=tchncs.de
3. https://github.com/srid/haskell-template/issues/1#issuecomment-982134929

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
