### PR TITLE
ms-dotnettools-csharp: 1.23.15 -> 1.23.16 and add Darwin support

### DIFF
--- a/pkgs/misc/vscode-extensions/ms-dotnettools-csharp/default.nix
+++ b/pkgs/misc/vscode-extensions/ms-dotnettools-csharp/default.nix
@@ -52,8 +52,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "csharp";
     publisher = "ms-dotnettools";
-    version = "1.23.15";
-    sha256 = "0b74jr45zl7lzirjgj8s2lbf3viy9pbwlgjh055rcwmy77wcml1x";
+    version = "1.23.16";
+    sha256 = "sha256-fM4vcSMi2tEjIox9Twh2sRiFhXgAeRwAM9to3vtcSqI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/misc/vscode-extensions/ms-dotnettools-csharp/default.nix
+++ b/pkgs/misc/vscode-extensions/ms-dotnettools-csharp/default.nix
@@ -38,7 +38,13 @@ let
     rtDepsBinSrcs."${bSrcName}__${stdenv.targetPlatform.system}";
 
   omnisharp = rtDepBinSrcByName "OmniSharp";
-  vsdbg = rtDepBinSrcByName "Debugger";
+  vsdbgs = [
+    (rtDepBinSrcByName "Debugger")
+  ] ++ lib.optionals (stdenv.isDarwin) [
+  # Include the aarch64-darwin debugger binaries on x86_64-darwin.  Even though OmniSharp will be
+  # running under Rosetta 2, debugging will fail to start if both sets of binaries are not present.
+    (rtDepsBinSrcs."Debugger__aarch64-darwin")
+  ];
   razor = rtDepBinSrcByName "Razor";
 in
 
@@ -112,20 +118,28 @@ vscode-utils.buildVscodeMarketplaceExtension {
     chmod a+x "$omnisharp_dir/run"
     touch "$omnisharp_dir/install.Lock"
 
+  '' + builtins.concatStringsSep "\n" (map (vsdbg: ''
     declare vsdbg_dir="$PWD/${vsdbg.installPath}"
     unzip_to "${vsdbg.bin-src}" "$vsdbg_dir"
     chmod a+x "$vsdbg_dir/vsdbg-ui"
     chmod a+x "$vsdbg_dir/vsdbg"
     touch "$vsdbg_dir/install.complete"
     touch "$vsdbg_dir/install.Lock"
-    patchelf_common "$vsdbg_dir/vsdbg"
-    patchelf_common "$vsdbg_dir/vsdbg-ui"
 
+  '') vsdbgs) + ''
     declare razor_dir="$PWD/${razor.installPath}"
     unzip_to "${razor.bin-src}" "$razor_dir"
     chmod a+x "$razor_dir/rzls"
     touch "$razor_dir/install.Lock"
+
+  '' + lib.optionalString stdenv.isLinux ''
+    patchelf_common "$vsdbg_dir/vsdbg"
+    patchelf_common "$vsdbg_dir/vsdbg-ui"
     patchelf_common "$razor_dir/rzls"
+
+  '' + lib.optionalString stdenv.isDarwin ''
+    substituteInPlace $omnisharp_dir/etc/config \
+      --replace "libmono-native-compat.dylib" "libmono-native.dylib"
   '';
 
   meta = with lib; {
@@ -133,6 +147,6 @@ vscode-utils.buildVscodeMarketplaceExtension {
     homepage = "https://github.com/OmniSharp/omnisharp-vscode";
     license = licenses.mit;
     maintainers = [ maintainers.jraygauthier ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
   };
 }

--- a/pkgs/misc/vscode-extensions/ms-dotnettools-csharp/rt-deps-bin-srcs.json
+++ b/pkgs/misc/vscode-extensions/ms-dotnettools-csharp/rt-deps-bin-srcs.json
@@ -1,27 +1,27 @@
 {
   "OmniSharp__x86_64-darwin": {
-    "installPath": ".omnisharp/1.37.15",
+    "installPath": ".omnisharp/1.37.16",
     "binaries": [
       "./mono.osx",
       "./run"
     ],
     "urls": [
-      "https://download.visualstudio.microsoft.com/download/pr/4fbf71ce-5375-4ca9-b70d-8024ba1b9e0a/bc6ac844afef87eedaab5191f11dc374/omnisharp-osx-1.37.15.zip",
-      "https://roslynomnisharp.blob.core.windows.net/releases/1.37.15/omnisharp-osx-1.37.15.zip"
+      "https://download.visualstudio.microsoft.com/download/pr/03c32aa6-7c7a-4936-82a0-fd8f816d112f/0ea1ea1eae48552a1992ed6df782353a/omnisharp-osx-1.37.16.zip",
+      "https://roslynomnisharp.blob.core.windows.net/releases/1.37.16/omnisharp-osx-1.37.16.zip"
     ],
-    "sha256": "03n3x70ml2xjm7ns58giv5kn2h4y689iyjzz4mw5vcnil5fwq8ng"
+    "sha256": "0hhgfx7zs1rljhn3n9c7lci7j15yp2448z3f1d3c47a95l1hmlip"
   },
   "OmniSharp__x86_64-linux": {
-    "installPath": ".omnisharp/1.37.15",
+    "installPath": ".omnisharp/1.37.16",
     "binaries": [
       "./mono.linux-x86_64",
       "./run"
     ],
     "urls": [
-      "https://download.visualstudio.microsoft.com/download/pr/4fbf71ce-5375-4ca9-b70d-8024ba1b9e0a/b96375395e639233d546a4937be3bd32/omnisharp-linux-x64-1.37.15.zip",
-      "https://roslynomnisharp.blob.core.windows.net/releases/1.37.15/omnisharp-linux-x64-1.37.15.zip"
+      "https://download.visualstudio.microsoft.com/download/pr/03c32aa6-7c7a-4936-82a0-fd8f816d112f/9ae3ed99fc0c41c7139751dde6f2bc78/omnisharp-linux-x64-1.37.16.zip",
+      "https://roslynomnisharp.blob.core.windows.net/releases/1.37.16/omnisharp-linux-x64-1.37.16.zip"
     ],
-    "sha256": "0pchywkxy8niq0i6gq2r43cmf58blfhhj8w8zyibf0m9h09h165s"
+    "sha256": "0a2basc6dw42fnjv9zz93ff0bsw2i3446gvcjx5mn5d8dasi483i"
   },
   "Debugger__x86_64-darwin": {
     "installPath": ".debugger/x86_64",

--- a/pkgs/misc/vscode-extensions/ms-dotnettools-csharp/rt-deps-bin-srcs.json
+++ b/pkgs/misc/vscode-extensions/ms-dotnettools-csharp/rt-deps-bin-srcs.json
@@ -1,4 +1,16 @@
 {
+  "OmniSharp__x86_64-darwin": {
+    "installPath": ".omnisharp/1.37.15",
+    "binaries": [
+      "./mono.osx",
+      "./run"
+    ],
+    "urls": [
+      "https://download.visualstudio.microsoft.com/download/pr/4fbf71ce-5375-4ca9-b70d-8024ba1b9e0a/bc6ac844afef87eedaab5191f11dc374/omnisharp-osx-1.37.15.zip",
+      "https://roslynomnisharp.blob.core.windows.net/releases/1.37.15/omnisharp-osx-1.37.15.zip"
+    ],
+    "sha256": "03n3x70ml2xjm7ns58giv5kn2h4y689iyjzz4mw5vcnil5fwq8ng"
+  },
   "OmniSharp__x86_64-linux": {
     "installPath": ".omnisharp/1.37.15",
     "binaries": [
@@ -10,6 +22,42 @@
       "https://roslynomnisharp.blob.core.windows.net/releases/1.37.15/omnisharp-linux-x64-1.37.15.zip"
     ],
     "sha256": "0pchywkxy8niq0i6gq2r43cmf58blfhhj8w8zyibf0m9h09h165s"
+  },
+  "Debugger__x86_64-darwin": {
+    "installPath": ".debugger/x86_64",
+    "binaries": [
+      "./vsdbg-ui",
+      "./vsdbg"
+    ],
+    "urls": [
+      "https://download.visualstudio.microsoft.com/download/pr/49f44239-bd47-4fb5-91be-4c91d7638fff/c1122f7141735472d9583c1124024c55/coreclr-debug-osx-x64.zip",
+      "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-23-14/coreclr-debug-osx-x64.zip"
+    ],
+    "sha256": "08z3k0h25gdsbmlxwayd94672hp2z7zmwdmd0nyr9j82izj3ci2m"
+  },
+  "Debugger__aarch64-darwin": {
+    "installPath": ".debugger/arm64",
+    "binaries": [
+      "./vsdbg-ui",
+      "./vsdbg"
+    ],
+    "urls": [
+      "https://download.visualstudio.microsoft.com/download/pr/49f44239-bd47-4fb5-91be-4c91d7638fff/96a88189c7904a517f3bb59b2dba8bd1/coreclr-debug-osx-arm64.zip",
+      "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-23-14/coreclr-debug-osx-arm64.zip"
+    ],
+    "sha256": "113kz02ihvb4y5fj01wamqz2jsql2q7n7f55s9kzs9dsrmq5ffa0"
+  },
+  "Debugger__aarch64-linux": {
+    "installPath": ".debugger",
+    "binaries": [
+      "./vsdbg-ui",
+      "./vsdbg"
+    ],
+    "urls": [
+      "https://download.visualstudio.microsoft.com/download/pr/49f44239-bd47-4fb5-91be-4c91d7638fff/7a723bfbda6d196c52084226b6835b36/coreclr-debug-linux-arm64.zip",
+      "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-23-14/coreclr-debug-linux-arm64.zip"
+    ],
+    "sha256": "1d4a5q3f7qfk3jq2i4f6g50i9i4z8z7g8ss083y9n5c1yj3629kw"
   },
   "Debugger__x86_64-linux": {
     "installPath": ".debugger",
@@ -32,5 +80,15 @@
       "https://download.visualstudio.microsoft.com/download/pr/b8678010-2cd7-4201-a5e7-ba57920607d5/b846e9c7d7afdba54a72fae1dcb6c42c/razorlanguageserver-linux-x64-6.0.0-preview.5.21358.6.zip"
     ],
     "sha256": "0gb36nlb7fgcv03a0awna1qyrsky6ys5gkpsmvxc5j35f1yq337b"
+  },
+  "Razor__x86_64-darwin": {
+    "installPath": ".razor",
+    "binaries": [
+      "./rzls"
+    ],
+    "urls": [
+      "https://download.visualstudio.microsoft.com/download/pr/b8678010-2cd7-4201-a5e7-ba57920607d5/ad846449769eb2ae810d0236823a6aaa/razorlanguageserver-osx-x64-6.0.0-preview.5.21358.6.zip"
+    ],
+    "sha256": "0iqinpwwlqwajdq4i1qbb9hfpfmgy17av95bpw02ad2f9fnyh572"
   }
 }

--- a/pkgs/misc/vscode-extensions/ms-dotnettools-csharp/update-bin-srcs
+++ b/pkgs/misc/vscode-extensions/ms-dotnettools-csharp/update-bin-srcs
@@ -10,7 +10,7 @@ scriptDir=$(cd "$(dirname "$0")"; pwd)
 
 declare extPublisher="ms-dotnettools"
 declare extName="csharp"
-declare defaultExtVersion="1.23.15"
+declare defaultExtVersion="1.23.16"
 declare extVersion="${1:-$defaultExtVersion}"
 
 formatExtRuntimeDeps \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

OmniSharp is required by Ionide, but it’s not currently available for Darwin. This change adds support for Darwin (including the debugger on aarch64-darwin).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
