### PR TITLE
alfaview: init at 8.32.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/alfaview/default.nix
+++ b/pkgs/applications/networking/instant-messengers/alfaview/default.nix
@@ -1,0 +1,78 @@
+{ stdenv, lib, fetchurl, dpkg, autoPatchelfHook, makeWrapper
+, alsa-lib, dbus, fontconfig, freetype, glib, gst_all_1, libGL
+, libinput, libpulseaudio, libsecret, libtiff, libxkbcommon
+, mesa, openssl, systemd, xorg }:
+
+stdenv.mkDerivation rec {
+  pname = "alfaview";
+  version = "8.32.0";
+
+  src = fetchurl {
+    url = "https://production-alfaview-assets.alfaview.com/stable/linux/${pname}_${version}.deb";
+    sha256 = "sha256-cBf/9MdNXhFRYPAOhQQ8j3rpY4JYh/+NyA7Eji9/E9Q=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    alsa-lib
+    dbus
+    fontconfig
+    freetype
+    glib
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-base
+    libGL
+    libinput
+    libpulseaudio
+    libsecret
+    libtiff
+    libxkbcommon
+    mesa
+    openssl
+    stdenv.cc.cc
+    systemd
+    xorg.libX11
+    xorg.xcbutilwm
+    xorg.xcbutilimage
+    xorg.xcbutilkeysyms
+    xorg.xcbutilrenderutil
+  ];
+
+  libPath = lib.makeLibraryPath buildInputs;
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  unpackPhase = ''
+    dpkg-deb -x ${src} ./
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mv usr $out
+    mv opt $out
+
+    substituteInPlace $out/share/applications/alfaview.desktop \
+      --replace "/opt/alfaview" "$out/bin" \
+      --replace "/usr/share/pixmaps/alfaview_production.png" alfaview_production
+
+    makeWrapper $out/opt/alfaview/alfaview $out/bin/alfaview \
+      --prefix LD_LIBRARY_PATH : ${libPath}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Video-conferencing application, specialized in virtual online meetings, seminars, training sessions and conferences";
+    homepage = "https://alfaview.com";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ wolfangaukang ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23989,6 +23989,8 @@ with pkgs;
 
   alembic = callPackage ../development/libraries/alembic {};
 
+  alfaview = callPackage ../applications/networking/instant-messengers/alfaview { };
+
   alchemy = callPackage ../applications/graphics/alchemy { };
 
   alock = callPackage ../misc/screensavers/alock { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#147916

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
