### PR TITLE
mozillavpn: init at 2.7.1

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -163,6 +163,15 @@
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://github.com/mozilla-mobile/mozilla-vpn-client">mozillavpn</link>,
+          the client for the
+          <link xlink:href="https://vpn.mozilla.org/">Mozilla VPN</link>
+          service. Available as
+          <link xlink:href="options.html#opt-services.mozillavpn">services.mozillavpn</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://github.com/mgumz/mtr-exporter">mtr-exporter</link>,
           a Prometheus exporter for mtr metrics. Available as
           <link xlink:href="options.html#opt-services.mtr-exporter.enable">services.mtr-exporter</link>.

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -49,6 +49,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [K40-Whisperer](https://www.scorchworks.com/K40whisperer/k40whisperer.html), a program to control cheap Chinese laser cutters. Available as [programs.k40-whisperer.enable](options.html#opt-programs.k4-whisperer.enable). Users must add themselves to the `k40` group to be able to access the device.
 
+- [mozillavpn](https://github.com/mozilla-mobile/mozilla-vpn-client), the client for the [Mozilla VPN](https://vpn.mozilla.org/) service. Available as [services.mozillavpn](options.html#opt-services.mozillavpn).
+
 - [mtr-exporter](https://github.com/mgumz/mtr-exporter), a Prometheus exporter for mtr metrics. Available as [services.mtr-exporter](options.html#opt-services.mtr-exporter.enable).
 
 - [tetrd](https://tetrd.app), share your internet connection from your device to your PC and vice versa through a USB cable. Available at [services.tetrd](#opt-services.tetrd.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -805,6 +805,7 @@
   ./services/networking/mosquitto.nix
   ./services/networking/monero.nix
   ./services/networking/morty.nix
+  ./services/networking/mozillavpn.nix
   ./services/networking/miredo.nix
   ./services/networking/mstpd.nix
   ./services/networking/mtprotoproxy.nix

--- a/nixos/modules/services/networking/mozillavpn.nix
+++ b/nixos/modules/services/networking/mozillavpn.nix
@@ -1,0 +1,19 @@
+{ config, lib, pkgs, ... }:
+
+{
+  options.services.mozillavpn.enable = lib.mkOption {
+    type = lib.types.bool;
+    default = false;
+    description = ''
+      Enable the Mozilla VPN daemon.
+    '';
+  };
+
+  config = lib.mkIf config.services.mozillavpn.enable {
+    environment.systemPackages = [ pkgs.mozillavpn ];
+    services.dbus.packages = [ pkgs.mozillavpn ];
+    systemd.packages = [ pkgs.mozillavpn ];
+  };
+
+  meta.maintainers = with lib.maintainers; [ andersk ];
+}

--- a/pkgs/tools/networking/mozillavpn/default.nix
+++ b/pkgs/tools/networking/mozillavpn/default.nix
@@ -1,0 +1,111 @@
+{ buildGoModule
+, fetchFromGitHub
+, go
+, lib
+, pkg-config
+, polkit
+, python3
+, qmake
+, qtbase
+, qtcharts
+, qtgraphicaleffects
+, qtnetworkauth
+, qtquickcontrols2
+, qttools
+, qtwebsockets
+, stdenv
+, which
+, wireguard-tools
+, wrapQtAppsHook
+}:
+
+let
+  glean_parser_4_1_1 = python3.pkgs.buildPythonPackage rec {
+    pname = "glean_parser";
+    version = "4.1.1";
+    src = python3.pkgs.fetchPypi {
+      inherit pname version;
+      hash = "sha256-4noazRqjjJNI2kTO714kSp70jZpWmqHWR2vnkgAftLE=";
+    };
+    nativeBuildInputs = with python3.pkgs; [ setuptools-scm ];
+    propagatedBuildInputs = with python3.pkgs; [
+      appdirs
+      click
+      diskcache
+      jinja2
+      jsonschema
+      pyyaml
+      setuptools
+      yamllint
+    ];
+    postPatch = ''
+      substituteInPlace setup.py --replace '"pytest-runner", ' ""
+    '';
+    doCheck = false;
+  };
+
+  pname = "mozillavpn";
+  version = "2.7.1";
+  src = fetchFromGitHub {
+    owner = "mozilla-mobile";
+    repo = "mozilla-vpn-client";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    hash = "sha256-i551UkCOwWnioe1YgCNZAlYiQJ4YDDBMoDZhfbkLTbs=";
+  };
+
+  netfilter-go-modules = (buildGoModule {
+    inherit pname version src;
+    vendorSha256 = "sha256-KFYMim5U8WlJHValvIBQgEN+17SDv0JVbH03IiyfDc0=";
+    modRoot = "linux/netfilter";
+  }).go-modules;
+
+in
+stdenv.mkDerivation {
+  inherit pname version src;
+
+  buildInputs = [
+    polkit
+    qtbase
+    qtcharts
+    qtgraphicaleffects
+    qtnetworkauth
+    qtquickcontrols2
+    qtwebsockets
+  ];
+  nativeBuildInputs = [
+    glean_parser_4_1_1
+    go
+    pkg-config
+    python3
+    python3.pkgs.pyyaml
+    qmake
+    qttools
+    which
+    wrapQtAppsHook
+  ];
+
+  postPatch = ''
+    for file in linux/*.service linux/extra/*.desktop src/platforms/linux/daemon/*.service; do
+      substituteInPlace "$file" --replace /usr/bin/mozillavpn "$out/bin/mozillavpn"
+    done
+  '';
+
+  preBuild = ''
+    ln -s '${netfilter-go-modules}' linux/netfilter/vendor
+    python3 scripts/generate_glean.py
+    python3 scripts/importLanguages.py
+  '';
+
+  qmakeFlags = [ "USRPATH=$(out)" "ETCPATH=$(out)/etc" ];
+  qtWrapperArgs =
+    [ "--prefix" "PATH" ":" (lib.makeBinPath [ wireguard-tools ]) ];
+
+  meta = {
+    description = "Client for the Mozilla VPN service";
+    homepage = "https://vpn.mozilla.org/";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ andersk ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4985,6 +4985,8 @@ with pkgs;
 
   mcrcon = callPackage ../tools/networking/mcrcon {};
 
+  mozillavpn = libsForQt5.callPackage ../tools/networking/mozillavpn { };
+
   mozwire = callPackage ../tools/networking/mozwire {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Motivation for this change

Package the [client](https://github.com/mozilla-mobile/mozilla-vpn-client) for the [Mozilla VPN](https://vpn.mozilla.org) service.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
