### PR TITLE
eclipses: Refactor eclipse plugin support to leverage p2

### DIFF
--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -4,6 +4,10 @@
 , webkitgtk ? null  # for internal web browser
 , buildEnv, runCommand
 , callPackage
+
+
+
+,fetchzip
 }:
 
 assert stdenv ? glibc;
@@ -146,39 +150,48 @@ in rec {
 
   # Function that assembles a complete Eclipse environment from an
   # Eclipse package and list of Eclipse plugins.
-  eclipseWithPlugins = { eclipse, plugins ? [], jvmArgs ? [] }:
+  eclipseWithPlugins = { eclipse, plugins, jvmArgs ? [] }:
     let
-      # Gather up the desired plugins.
-      pluginEnv = buildEnv {
-        name = "eclipse-plugins";
-        paths =
-          with lib;
-            filter (x: x ? isEclipsePlugin) (closePropagation plugins);
-      };
-
-      # Prepare the JVM arguments to add to the ini file. We here also
-      # add the property indicating the plugin directory.
-      dropinPropName = "org.eclipse.equinox.p2.reconciler.dropins.directory";
-      dropinProp = "-D${dropinPropName}=${pluginEnv}/eclipse/dropins";
-      jvmArgsText = lib.concatStringsSep "\n" (jvmArgs ++ [dropinProp]);
-
-      # Base the derivation name on the name of the underlying
-      # Eclipse.
-      name = (lib.meta.appendToName "with-plugins" eclipse).name;
-    in
-      runCommand name { nativeBuildInputs = [ makeWrapper ]; } ''
-        mkdir -p $out/bin $out/etc
-
-        # Prepare an eclipse.ini with the plugin directory.
-        cat ${eclipse}/eclipse/eclipse.ini - > $out/etc/eclipse.ini <<EOF
-        ${jvmArgsText}
-        EOF
-
-        makeWrapper ${eclipse}/bin/eclipse $out/bin/eclipse \
-          --add-flags "--launcher.ini $out/etc/eclipse.ini"
-
-        ln -s ${eclipse}/share $out/
+      p2Director = ''
+        $out/bin/eclipse \
+          -nosplash \
+          -configuration /build/configuration \
+          -application org.eclipse.equinox.p2.director \
       '';
+      jvmArgsText = lib.strings.concatStrings (map (arg: "${arg}\n") jvmArgs);
+
+      join = strings: lib.strings.concatStringsSep "," strings;
+      pluginRepository = plugin:
+        join (["file:${plugin.out}"] ++ (map pluginRepository plugin.dependencies));
+      pluginInstallIU = plugin:
+        # collect all installable units if none are provided
+        if plugin ? installableUnits
+        then join plugin.installableUnits
+        else ''$(
+          ${p2Director} \
+            -repository '${pluginRepository plugin}' \
+            -list \
+            -listFormat '[''${id},]' \
+            | awk -F'[][]' '{printf $2}'
+        )'';
+      repository = join (map pluginRepository plugins);
+      installIU = join (map pluginInstallIU plugins);
+    in
+      eclipse.overrideAttrs (oldAttrs: {
+        buildCommand = oldAttrs.buildCommand + ''
+          ${p2Director} \
+            -destination $out/eclipse \
+            -repository "${repository}" \
+            -installIU "${installIU}" \
+            -tag AddIUs || {
+              cat /build/configuration/*.log
+              exit 1
+            }
+          cat << EOF >> $out/eclipse/eclipse.ini
+          ${jvmArgsText}
+          EOF
+        '';
+      });
 
   ### Plugins
 

--- a/pkgs/applications/editors/eclipse/plugins.nix
+++ b/pkgs/applications/editors/eclipse/plugins.nix
@@ -1,14 +1,33 @@
-{ lib, stdenv, fetchurl, fetchzip, unzip }:
+{ lib, stdenv, fetchurl, fetchzip, zip, unzip, xmlstarlet, eclipses }:
 
 rec {
 
-  # A primitive builder of Eclipse plugins. This function is intended
-  # to be used when building more advanced builders.
+  sanitizeUpdateSite = outDir: ''
+    workDir=/build/sanitizeTmp
+    mkdir $workDir
+    pushd $workDir
+    unzip "${outDir}/artifacts.jar"
+    unzip "${outDir}/content.jar"
+    xmlstarlet edit \
+      --inplace \
+      --update "/repository/properties/property[@name='p2.timestamp']/@value" \
+      --value "0" \
+      artifacts.xml content.xml
+    touch artifacts.xml content.xml -t '197001010100'
+    zip -X - artifacts.xml > "${outDir}/artifacts.jar"
+    zip -X - content.xml > "${outDir}/content.jar"
+    popd
+  '';
+
+  # A primitive builder of Eclipse update sites. This function is intended
+  # to be used when building more advanced builders. An Eclipse "plugin" in
+  # nixpkgs is a p2 update site containing a set of features and bundles to
+  # be installed together.
   buildEclipsePluginBase =  { name
                             , buildInputs ? []
                             , passthru ? {}
                             , ... } @ attrs:
-    stdenv.mkDerivation (attrs // {
+    stdenv.mkDerivation ({ dependencies = []; } // attrs // {
       name = "eclipse-plugin-" + name;
 
       buildInputs = buildInputs ++ [ unzip ];
@@ -18,77 +37,126 @@ rec {
       } // passthru;
     });
 
-  # Helper for the common case where we have separate feature and
-  # plugin JARs.
-  buildEclipsePlugin =
-    { name, srcFeature, srcPlugin ? null, srcPlugins ? [], ... } @ attrs:
-      assert srcPlugin == null -> srcPlugins != [];
-      assert srcPlugin != null -> srcPlugins == [];
+  # Mirror a subset of a p2 update site containing the given features and
+  # plugins.
+  mirrorEclipsePlugins = { pname
+                         , version
+                         , repository ? null
+                         , artifactRepository ? null
+                         , metadataRepository ? null
+                         , installableUnit ? null
+                         , installableUnits ? null
+                         , eclipse ? eclipses.eclipse-sdk
+                         , hash
+                         , ... } @ attrs:
+    assert (artifactRepository == null) == (metadataRepository == null);
+    assert (repository == null) != (artifactRepository == null);
+    assert (installableUnit == null) || (installableUnits == null);
 
-      let
+    let
+      ius = map (iu: if builtins.isAttrs iu then iu else { id = iu; version = version; }) (
+        if installableUnit != null
+        then [ installableUnit ]
+        else if installableUnits != null
+        then installableUnits
+        else []
+      );
+      iuEntries = (lib.strings.concatStrings (map (iu: ''<iu id="${iu.id}" version="${iu.version}" />'') ius));
 
-        pSrcs = if (srcPlugin != null) then [ srcPlugin ] else srcPlugins;
+    in
+      buildEclipsePluginBase (attrs // rec {
+        name = "${pname}-${version}";
+        inherit version;
 
-      in
+        buildCommand = ''
+          mkdir -p $out
+          echo '
+            <project name="${name}" default="mirror" basedir="'$out'">
+              <target name="mirror">
+                <p2.mirror raw="true">
+                  <source>
+                    ${if repository != null then "<repository location=\"${repository}\" />" else ""}
+                    ${if metadataRepository != null then "<repository location=\"${metadataRepository}\" kind=\"metadata\" />" else ""}
+                    ${if artifactRepository != null then "<repository location=\"${artifactRepository}\" kind=\"artifact\" />" else ""}
+                  </source>
+                  <destination compressed="true" name="${name}" location="file:'$out'" />
+                  ${iuEntries}
+                  <slicingOptions followStrict="true"/>
+                </p2.mirror>
+              </target>
+            </project>' > /build/build.xml
+          ${eclipse}/bin/eclipse \
+            -noSplash \
+            -configuration /build/configuration \
+            -application org.eclipse.ant.core.antRunner \
+            -buildfile /build/build.xml || {
+              cat /build/configuration/*.log
+              exit 1
+            }
+        '' + (sanitizeUpdateSite "$out");
 
-        buildEclipsePluginBase (attrs // {
-          srcs = [ srcFeature ] ++ pSrcs;
+        nativeBuildInputs = [ zip eclipse xmlstarlet ];
+        outputHash = hash;
+        outputHashMode = "recursive";
 
-          buildCommand = ''
-            dropinDir="$out/eclipse/dropins/${name}"
+        installableUnits = map (iu: "${iu.id}/${iu.version}") ius;
 
-            mkdir -p $dropinDir/features
-            unzip ${srcFeature} -d $dropinDir/features/
+        inherit repository artifactRepository metadataRepository;
+      });
 
-            mkdir -p $dropinDir/plugins
-            for plugin in ${toString pSrcs}; do
-              cp -v $plugin $dropinDir/plugins/$(stripHash $plugin)
-            done
-          '';
-        });
+  # Publish the given plugin and feature jars as a p2 update site.
+  buildEclipsePlugin = { name
+                       , srcFeature ? null
+                       , srcFeatures ? []
+                       , srcPlugin ? null
+                       , srcPlugins ? []
+                       , eclipse ? eclipses.eclipse-sdk
+                       , ... } @ attrs:
+    assert (srcPlugin == null) != (srcPlugins == []);
+    assert (srcFeature != null) -> (srcFeatures == []);
 
-  # Helper for the case where the build directory has the layout of an
-  # Eclipse update site, that is, it contains the directories
-  # `features` and `plugins`. All features and plugins inside these
-  # directories will be installed.
+    let
+      fSrcs = if (srcFeature != null) then [ srcFeature ] else srcFeatures;
+      pSrcs = if (srcPlugin != null) then [ srcPlugin ] else srcPlugins;
+
+    in
+      buildEclipsePluginBase (attrs // {
+        srcs = fSrcs ++ pSrcs;
+
+        buildCommand = ''
+          mkdir features
+          for feature in ${toString fSrcs}; do
+            cp -v $feature features/$(stripHash $feature)
+          done
+
+          mkdir plugins
+          for plugin in ${toString pSrcs}; do
+            cp -v $plugin plugins/$(stripHash $plugin)
+          done
+
+          ${eclipse}/bin/eclipse \
+            -noSplash \
+            -configuration /build/configuration \
+            -application org.eclipse.equinox.p2.publisher.FeaturesAndBundlesPublisher \
+            -metadataRepository file:$out \
+            -artifactRepository file:$out \
+            -publishArtifacts \
+            -source . \
+            -compress || {
+              cat /build/configuration/*.log
+              exit 1
+            }
+        '';
+
+        nativeBuildInputs = [ eclipse ];
+      });
+
+  # Helper for the case where the build directory is already a p2 update site.
   buildEclipseUpdateSite = { name, ... } @ attrs:
     buildEclipsePluginBase (attrs // {
       dontBuild = true;
       doCheck = false;
-
-      installPhase = ''
-        dropinDir="$out/eclipse/dropins/${name}"
-
-        # Install features.
-        cd features
-        for feature in *.jar; do
-          featureName=''${feature%.jar}
-          mkdir -p $dropinDir/features/$featureName
-          unzip $feature -d $dropinDir/features/$featureName
-        done
-        cd ..
-
-        # Install plugins.
-        mkdir -p $dropinDir/plugins
-
-        # A bundle should be unpacked if the manifest matches this
-        # pattern.
-        unpackPat="Eclipse-BundleShape:\\s*dir"
-
-        cd plugins
-        for plugin in *.jar ; do
-          pluginName=''${plugin%.jar}
-          manifest=$(unzip -p $plugin META-INF/MANIFEST.MF)
-
-          if [[ $manifest =~ $unpackPat ]] ; then
-            mkdir $dropinDir/plugins/$pluginName
-            unzip $plugin -d $dropinDir/plugins/$pluginName
-          else
-            cp -v $plugin $dropinDir/plugins/
-          fi
-        done
-        cd ..
-      '';
+      installPhase = "cp -r . $out";
     });
 
   acejump = buildEclipsePlugin rec {
@@ -135,19 +203,13 @@ rec {
     };
   };
 
-  antlr-runtime_4_5 = buildEclipsePluginBase rec {
+  antlr-runtime_4_5 = buildEclipsePlugin rec {
     name = "antlr-runtime-4.5.3";
 
-    src = fetchurl {
+    srcPlugin = fetchurl {
       url = "https://www.antlr.org/download/${name}.jar";
       sha256 = "0lm78i2annlczlc2cg5xvby0g1dyl0sh1y5xc2pymjlmr67a1g4k";
     };
-
-    buildCommand = ''
-      dropinDir="$out/eclipse/dropins/"
-      mkdir -p $dropinDir
-      cp -v $src $dropinDir/${name}.jar
-    '';
 
     meta = with lib; {
       description = "A powerful parser generator for processing structured text or binary files";
@@ -157,19 +219,13 @@ rec {
     };
   };
 
-  antlr-runtime_4_7 = buildEclipsePluginBase rec {
+  antlr-runtime_4_7 = buildEclipsePlugin rec {
     name = "antlr-runtime-4.7.1";
 
-    src = fetchurl {
+    srcPlugin = fetchurl {
       url = "https://www.antlr.org/download/${name}.jar";
       sha256 = "07f91mjclacrvkl8a307w2abq5wcqp0gcsnh0jg90ddfpqcnsla3";
     };
-
-    buildCommand = ''
-      dropinDir="$out/eclipse/dropins/"
-      mkdir -p $dropinDir
-      cp -v $src $dropinDir/${name}.jar
-    '';
 
     meta = with lib; {
       description = "A powerful parser generator for processing structured text or binary files";
@@ -181,15 +237,16 @@ rec {
 
   anyedittools = buildEclipsePlugin rec {
     name = "anyedit-${version}";
-    version = "2.7.1.201709201439";
+    version-core = "2.7.1";
+    version = "${version-core}.201709201439";
 
     srcFeature = fetchurl {
-      url = "http://andrei.gmxhome.de/eclipse/features/AnyEditTools_${version}.jar";
+      url = "https://github.com/iloveeclipse/anyedittools/releases/download/${version-core}/AnyEditTools_${version}.jar";
       sha256 = "1wqzl7wq85m9gil8rnvly45ps0a2m0svw613pg6djs5i7amhnayh";
     };
 
     srcPlugin = fetchurl {
-      url = "https://github.com/iloveeclipse/anyedittools/releases/download/2.7.1/de.loskutov.anyedit.AnyEditTools_${version}.jar";
+      url = "https://github.com/iloveeclipse/anyedittools/releases/download/${version-core}/de.loskutov.anyedit.AnyEditTools_${version}.jar";
       sha256 = "03iyb6j2srq74iigmg7dk098c2svyv0ygdfql5jqr44a32n07k8q";
     };
 
@@ -221,6 +278,19 @@ rec {
       license = licenses.epl10;
       platforms = platforms.all;
     };
+  };
+
+  bndtools = mirrorEclipsePlugins rec {
+    pname = "bndtools";
+    version = "6.1.0.REL-202111221555-g6b7087b";
+
+    repository = "https://bndtools.jfrog.io/bndtools/update-latest";
+    installableUnits = [
+      "bndtools.main.feature.feature.group"
+      "bndtools.m2e.feature.feature.group"
+      "bndtools.pde.feature.feature.group"
+    ];
+    hash = "sha256:163l714zgx2r5yn19m8jsc9jb9rkhq6215n0ml52fiymkkxcfc8k";
   };
 
   bytecode-outline = buildEclipsePlugin rec {
@@ -437,34 +507,16 @@ rec {
     };
   };
 
-  jsonedit = buildEclipsePlugin rec {
-    name = "jsonedit-${version}";
+  jsonedit = mirrorEclipsePlugins rec {
+    pname = "jsonedit";
     version = "1.1.1";
 
-    srcFeature = fetchurl {
-      url = "https://boothen.github.io/Json-Eclipse-Plugin/features/jsonedit-feature_${version}.jar";
-      sha256 = "0zkg8d8x3l5jpfxi0mz9dn62wmy4fjgpwdikj280fvsklmcw5b86";
-    };
-
-    srcPlugins =
-      let
-        fetch = { n, h }:
-          fetchurl {
-            url = "https://boothen.github.io/Json-Eclipse-Plugin/plugins/jsonedit-${n}_${version}.jar";
-            sha256 = h;
-          };
-      in
-        map fetch [
-          { n = "core"; h = "0svs0aswnhl26cqw6bmw30cisx4cr50kc5njg272sy5c1dqjm1zq"; }
-          { n = "editor"; h = "1q62dinrbb18aywbvii4mlr7rxa20rdsxxd6grix9y8h9776q4l5"; }
-          { n = "folding"; h = "1qh4ijfb1gl9xza5ydi87v1kyima3a9sh7lncwdy1way3pdhln1y"; }
-          { n = "model"; h = "1pr6k2pdfdwx8jqs7gx7wzn3gxsql3sk6lnjha8m15lv4al6d4kj"; }
-          { n = "outline"; h = "1jgr2g16j3id8v367jbgd6kx6g2w636fbzmd8jvkvkh7y1jgjqxm"; }
-          { n = "preferences"; h = "027fhaqa5xbil6dmhvkbpha3pgw6dpmc2im3nlliyds57mdmdb1h"; }
-          { n = "text"; h = "0clywylyidrxlqs0n816nhgjmk1c3xl7sn904ki4q050amfy0wb2"; }
-        ];
-
-    propagatedBuildInputs = [ antlr-runtime_4_7 ];
+    repository = "https://boothen.github.io/Json-Eclipse-Plugin";
+    installableUnits = [
+      "jsonedit-feature.feature.group"
+      { id = "org.antlr.v4.feature.group"; version = "4.7.1"; }
+    ];
+    hash = "sha256:0af5d26lw1yxck5w73wkv57fpjx49pcx58gpflbrbxl3m5pc6js1";
 
     meta = with lib; {
       description = "Adds support for JSON files to Eclipse";


### PR DESCRIPTION
fixes #142191

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

What this PR does is rework how nixpkgs models a "plugin". (Note that there is a mismatch the language used by nixpkgs and Eclipse, specifically in what they refer to as a "plugin". But this already existed and can't really be fixed without creating confusing inconsistencies or just breaking backwards compat. And it's not really a big problem.)

Previously, the nixpkgs notion of a plugin was just a set of jars. These jars would be dumped into the dropins directory for an Eclipse instance.

The proposed nixpkgs notion of a plugin is a p2 update site, and an (optional) set of ids and versions which index into that update site. This gives Eclipse more information to help it resolve a working runtime.

This allows us to build a plugin derivation by mirroring a p2 update site locally. The problem with this is that a p2 update site is not a fixed resource, so the hash may change! An artifact in a p2 update site, for a given id and version, *is* specified to be a fixed resource, and so the hash shouldn't change, but artifacts can be added to an update site over time. The solution to this problem is to perform only a *partial* mirror, extracting a feature with a specific version and closing over its dependencies. I believe this should be reliable in practice, as the feature->plugin dependencies used are specified with exact versions.

###### Motivation for this change

Practical issues with the previous approach are outlined in #142191. More positively:

- This approach more closely aligns with the Eclipse model as its intended to be used, for what that's worth.
- I think it actually makes packaging eclipse plugins easier in most cases, as package maintainers can just use public-facing update sites as intended, rather than searching for zipped update sites (which aren't always available) or manually trawling for the transitive closure of jar dependencies which constitute a feature.
- The changes should be forwards compatible with 95% existing derivations out in the wild.

###### Problems with this change

There are probably some users out there with custom plugin derivations which will stop working, but hopefully it shouldn't be too much work to fix them. Specifically, derivations which directly call `buildEclipsePluginsBase` won't work, but I think that should be rare, as it's not a user-friendly mechanism to begin with.

There will be other edge-cases too. For instance jsonedit needed changing due to the dependency on the antlr runtime. Since there is no official packaging for the antlr runtime, the jsonedit project repackages it themselves and publishes it in the jsonedit p2 repo. This is fine, but they specify the dependency in such a way that you *have to* use their repackaged version to make the Eclipse resolver happy. This wasn't a problem with the old dropins model as the dropins mechanism is a bit looser with the rules for wiring everything up.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Since there will be a small number of breakages downstream, does this PR warrant release notes? I have tried to keep it compatible as far as possible; most users of Eclipse shouldn't notice.

I've manually tested the changes by configuring an Eclipse instance with the following plugins:
- `bndtools`: to make sure #142191 is actually fixed.
- `jsonedit`, `antlr-runtime_4_5`, `antlr-runtime_4_7`: as these were the only existing plugins which needed changing.
- `yedit`: to check that `buildEclipsePlugin` still works.
- `checkstyle`: to check that `buildEclipseUpdateSite` still works.

They all appeared to be correctly installed and working.

I'm not an expert in Nix packaging so I expect some questionable choices will surface in review! I'll put some of my own comments inline where I wasn't sure about things.