### PR TITLE
[Backport release-21.05] qemu, runInLinuxVM: fix KVM availability check

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, fetchpatch, python, zlib, pkg-config, glib
 , perl, pixman, vde2, alsaLib, texinfo, flex
 , bison, lzo, snappy, libaio, gnutls, nettle, curl, ninja, meson
-, makeWrapper, autoPatchelfHook
+, makeWrapper, autoPatchelfHook, runtimeShell
 , attr, libcap, libcap_ng
 , CoreServices, Cocoa, Hypervisor, rez, setfile
 , numaSupport ? stdenv.isLinux && !stdenv.isAarch32, numactl
@@ -233,9 +233,12 @@ stdenv.mkDerivation rec {
 
   # Add a ‘qemu-kvm’ wrapper for compatibility/convenience.
   postInstall = ''
+    cp -- $emitKvmWarningsPath $out/libexec/emit-kvm-warnings
+    chmod a+x -- $out/libexec/emit-kvm-warnings
     if [ -x $out/bin/qemu-system-${stdenv.hostPlatform.qemuArch} ]; then
       makeWrapper $out/bin/qemu-system-${stdenv.hostPlatform.qemuArch} \
                   $out/bin/qemu-kvm \
+                  --run $out/libexec/emit-kvm-warnings \
                   --add-flags "\$([ -r /dev/kvm -a -w /dev/kvm ] && echo -enable-kvm)"
     fi
   '';
@@ -246,6 +249,26 @@ stdenv.mkDerivation rec {
 
   # Builds in ~3h with 2 cores, and ~20m with a big-parallel builder.
   requiredSystemFeatures = [ "big-parallel" ];
+
+  emitKvmWarnings = ''
+    #!${runtimeShell}
+    WARNCOL='\033[1;35m'
+    NEUTRALCOL='\033[0m'
+    WARNING="''${WARNCOL}warning:''${NEUTRALCOL}"
+    if [ ! -e /dev/kvm ]; then
+      echo -e "''${WARNING} KVM is not available - execution will be slow" >&2
+      echo "Consider installing KVM for hardware-accelerated execution." >&2
+      echo "If KVM is already installed make sure the kernel module is loaded." >&2
+    elif [ ! -r /dev/kvm -o ! -w /dev/kvm ]; then
+      echo -e "''${WARNING} /dev/kvm is not read-/writable - execution will be slow" >&2
+      echo "/dev/kvm needs to be read-/writable by the user executing QEMU." >&2
+      echo "" >&2
+      echo "For hardware-acceleration inside the nix build sandbox /dev/kvm" >&2
+      echo "must be world-read-/writable (rw-rw-rw-)." >&2
+    fi
+  '';
+
+  passAsFile = [ "emitKvmWarnings" ];
 
   meta = with lib; {
     homepage = "http://www.qemu.org/";

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -236,7 +236,7 @@ stdenv.mkDerivation rec {
     if [ -x $out/bin/qemu-system-${stdenv.hostPlatform.qemuArch} ]; then
       makeWrapper $out/bin/qemu-system-${stdenv.hostPlatform.qemuArch} \
                   $out/bin/qemu-kvm \
-                  --add-flags "\$([ -e /dev/kvm ] && echo -enable-kvm)"
+                  --add-flags "\$([ -r /dev/kvm -a -w /dev/kvm ] && echo -enable-kvm)"
     fi
   '';
 


### PR DESCRIPTION
This backports #125948 to `release-21.05` since the label-triggered automatic process for that failed.

I removed the change from `-cpu max` to `-cpu qemu64` (aaecb3b239df058363d3dcdcf3f92f7b8d4e2b9f) here since 21.05 has qemu 6.0. and not the 6.1 release, which needs that workaround.

I'm assuming `21.05` should still get the other changes, please just close this PR if not.