### PR TITLE
ocamlPackages.lablgl: 1.05 → 1.06

### DIFF
--- a/pkgs/development/ocaml-modules/lablgl/default.nix
+++ b/pkgs/development/ocaml-modules/lablgl/default.nix
@@ -1,33 +1,35 @@
-{lib, stdenv, fetchurl, ocaml, lablgtk, findlib, libGLU, libGL, freeglut, camlp4 } :
+{ lib, stdenv, fetchFromGitHub, ocaml, findlib, libGLU, libGL, freeglut } :
 
-let
-  pname = "lablgl";
-in
+if !lib.versionAtLeast ocaml.version "4.03"
+then throw "lablgl is not available for OCaml ${ocaml.version}"
+else
 
 stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
-  version = "1.05";
+  pname = "ocaml${ocaml.version}-lablgl";
+  version = "1.06";
 
-  src = fetchurl {
-    url = "http://wwwfun.kurims.kyoto-u.ac.jp/soft/lsl/dist/lablgl-${version}.tar.gz";
-    sha256 = "0qabydd219i4ak7hxgc67496qnnscpnydya2m4ijn3cpbgih7zyq";
+  src = fetchFromGitHub {
+    owner = "garrigue";
+    repo = "lablgl";
+    rev = "v${version}";
+    sha256 = "sha256:141kc816iv59z96738i3vn9m9iw9g2zhi45hk4cchpwd99ar5l6k";
   };
 
-  buildInputs = [ocaml findlib lablgtk freeglut camlp4];
+  buildInputs = [ ocaml findlib freeglut ];
   propagatedBuildInputs = [ libGLU libGL ];
 
   patches = [ ./Makefile.config.patch ./META.patch ];
 
   preConfigure = ''
+    mkdir -p $out/bin
+    mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/stublibs
     substituteInPlace Makefile.config \
-      --subst-var-by BINDIR $out/bin \
-      --subst-var-by INSTALLDIR $out/lib/ocaml/${ocaml.version}/site-lib/lablgl \
-      --subst-var-by DLLDIR $out/lib/ocaml/${ocaml.version}/site-lib/lablgl \
+      --subst-var-by BINDIR $out/bin/ \
+      --subst-var-by INSTALLDIR $out/lib/ocaml/${ocaml.version}/site-lib/lablgl/ \
+      --subst-var-by DLLDIR $out/lib/ocaml/${ocaml.version}/site-lib/stublibs/ \
       --subst-var-by TKINCLUDES "" \
       --subst-var-by XINCLUDES ""
   '';
-
-  createFindlibDestdir = true;
 
   buildFlags = [ "lib" "libopt" "glut" "glutopt" ];
 


### PR DESCRIPTION
###### Motivation for this change

Drop dependency on camlp4

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
