### PR TITLE
jetbrains.gateway: init at 213.5744.213

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -69,6 +69,24 @@ let
       };
     });
 
+  buildGateway = { name, version, src, license, description, wmClass, ... }:
+    (mkJetBrainsProduct {
+      inherit name version src wmClass jdk;
+      product = "Gateway";
+      meta = with lib; {
+        homepage = "https://www.jetbrains.com/remote-development/gateway/";
+        inherit description license;
+        longDescription = ''
+          Experience a new compact application that connects you to
+          any of your remote machines  via SSH without any hassle.
+          It serves as a single entry point to all your remote work,
+          and you don’t even need to have a JetBrains IDE installed.
+        '';
+        maintainers = with maintainers; [ ];
+        platforms = platforms.linux;
+      };
+    });
+
   buildGoland = { name, version, src, license, description, wmClass, ... }:
     (mkJetBrainsProduct {
       inherit name version src wmClass jdk;
@@ -273,6 +291,19 @@ in
     };
     wmClass = "jetbrains-datagrip";
     update-channel = "DataGrip RELEASE";
+  };
+
+  gateway = buildGateway rec {
+    name = "gateway-${version}";
+    version = "213.5744.213";
+    description = "Remote Development";
+    license = lib.licenses.unfree;
+    src = fetchurl {
+      url = "https://download-cdn.jetbrains.com/idea/gateway/JetBrainsGateway-${version}.tar.gz";
+      sha256 = "d48d661d163f76b5313b1aad287ddfc3dffea97421a15ae39c4770d8baf2f6ea";
+    };
+    wmClass = "jetbrains-gateway";
+    update-channel = "JetBrains Gateway RELEASE";
   };
 
   goland = buildGoland rec {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Addition of JetBrains gateway IDE

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
