### PR TITLE
jetbrains.dataspell: init at 2022.3.1

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -109,6 +109,22 @@ let
       };
     });
 
+  buildDataSpell = { pname, version, src, license, description, wmClass, ... }:
+    (mkJetBrainsProduct {
+      inherit pname version src wmClass jdk;
+      product = "DataSpell";
+      meta = with lib; {
+        homepage = "https://www.jetbrains.com/dataspell/";
+        inherit description license platforms;
+        longDescription = ''
+          JetBrains DataSpell is an IDE for data science with intelligent
+          Jupyter notebooks, interactive Python scripts, and lots of other
+          built-in tools.
+        '';
+        maintainers = with maintainers; [ sei40kr ];
+      };
+    });
+
   buildGoland = { pname, version, src, license, description, wmClass, ... }:
     (mkJetBrainsProduct {
       inherit pname version src wmClass jdk;
@@ -337,6 +353,19 @@ in
     };
     wmClass = "jetbrains-gateway";
     update-channel = products.gateway.update-channel;
+  };
+
+  dataspell = buildDataSpell rec {
+    pname = "dataspell";
+    version = products.dataspell.version;
+    description = "The IDE for Professional Data Scientists";
+    license = lib.licenses.unfree;
+    src = fetchurl {
+      url = products.dataspell.url;
+      sha256 = products.dataspell.sha256;
+    };
+    wmClass = "jetbrains-dataspell";
+    update-channel = products.dataspell.update-channel;
   };
 
   goland = buildGoland rec {

--- a/pkgs/applications/editors/jetbrains/versions.json
+++ b/pkgs/applications/editors/jetbrains/versions.json
@@ -27,6 +27,15 @@
       "version-major-minor": "2022.3",
       "build_number": "223.6646.21"
     },
+    "dataspell": {
+      "update-channel": "DataSpell RELEASE",
+      "url-template": "https://download.jetbrains.com/python/dataspell-{version}.tar.gz",
+      "version": "2022.3.1",
+      "sha256": "5f35ba820d10b28c4d430206a4b9dd4ed71b2581dcdd99f73fb512266d49482b",
+      "url": "https://download.jetbrains.com/python/dataspell-2022.3.1.tar.gz",
+      "version-major-minor": "2022.1",
+      "build_number": "223.8214.61"
+    },
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}.tar.gz",
@@ -146,6 +155,15 @@
       "version-major-minor": "2022.3",
       "build_number": "223.6646.21"
     },
+    "dataspell": {
+      "update-channel": "DataSpell RELEASE",
+      "url-template": "https://download.jetbrains.com/python/dataspell-{version}.dmg",
+      "version": "2022.3.1",
+      "sha256": "ec54a766a3fa51df2660e0dccf261ec560a3242eb5eeb9851f45449fe6614fee",
+      "url": "https://download.jetbrains.com/python/dataspell-2022.3.1.dmg",
+      "version-major-minor": "2022.1",
+      "build_number": "223.8214.61"
+    },
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}.dmg",
@@ -264,6 +282,15 @@
       "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-223.6646.21-aarch64.dmg",
       "version-major-minor": "2022.3",
       "build_number": "223.6646.21"
+    },
+    "dataspell": {
+      "update-channel": "DataSpell RELEASE",
+      "url-template": "https://download.jetbrains.com/python/dataspell-{version}-aarch64.dmg",
+      "version": "2022.3.1",
+      "sha256": "176bfce793216c1bb6e683b656b58a068e93c6bc6d2f51c0776a151dfa3bec1f",
+      "url": "https://download.jetbrains.com/python/dataspell-2022.3.1-aarch64.dmg",
+      "version-major-minor": "2022.1",
+      "build_number": "223.8214.61"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",


### PR DESCRIPTION
###### Motivation for this change

Add JetBrains Dataspell.

~Needs to merge #148036 before merging this PR.~
-> I confirmed Dataspell works with older JetBrains JDK, so I'm going to close #148036.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
