### PR TITLE
ocamlPackages.lablgtk-extras: disable for OCaml ≥ 4.13

### DIFF
--- a/pkgs/development/ocaml-modules/lablgtk-extras/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk-extras/default.nix
@@ -1,11 +1,15 @@
-{ stdenv, lib, fetchFromGitHub, ocaml, findlib, camlp4, config-file, lablgtk, xmlm }:
+{ stdenv, lib, fetchFromGitLab, ocaml, findlib, camlp4, config-file, lablgtk, xmlm }:
 
-assert lib.versionAtLeast (lib.getVersion ocaml) "4.02";
+if !lib.versionAtLeast ocaml.version "4.02"
+|| lib.versionAtLeast ocaml.version "4.13"
+then throw "lablgtk-extras is not available for OCaml ${ocaml.version}"
+else
 
 stdenv.mkDerivation rec {
   version = "1.6";
   name = "ocaml${ocaml.version}-lablgtk-extras-${version}";
-  src = fetchFromGitHub {
+  src = fetchFromGitLab {
+    domain = "framagit.org";
     owner = "zoggy";
     repo = "lablgtk-extras";
     rev = "release-${version}";
@@ -18,9 +22,9 @@ stdenv.mkDerivation rec {
   createFindlibDestdir = true;
 
   meta = {
-    platforms = ocaml.meta.platforms or [];
+    inherit (ocaml.meta) platforms;
     maintainers = with lib.maintainers; [ vbgl ];
-    homepage = "http://gtk-extras.forge.ocamlcore.org/";
+    homepage = "https://framagit.org/zoggy/lablgtk-extras/";
     description = "A collection of libraries and modules useful when developing OCaml/LablGtk2 applications";
     license = lib.licenses.lgpl2Plus;
   };


### PR DESCRIPTION
###### Motivation for this change

#147452

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
