### PR TITLE
nextcloud-client: 3.3.6 -> 3.4.0

### DIFF
--- a/pkgs/applications/networking/nextcloud-client/0001-When-creating-the-autostart-entry-do-not-use-an-abso.patch
+++ b/pkgs/applications/networking/nextcloud-client/0001-When-creating-the-autostart-entry-do-not-use-an-abso.patch
@@ -1,26 +1,24 @@
-From bade623bb98c957d9a274df75b58296beb8ae6a7 Mon Sep 17 00:00:00 2001
-From: Marvin Dostal <maffinmaffinmaffinmaffin@gmail.com>
-Date: Sun, 17 Oct 2021 21:26:51 +0200
+From 54255deceaaaf118e9daadc3dd9f517c33bdd658 Mon Sep 17 00:00:00 2001
+From: Ilan Joselevich <personal@ilanjoselevich.com>
+Date: Tue, 30 Nov 2021 22:50:43 +0200
 Subject: [PATCH] When creating the autostart entry, do not use an absolute
- path
 
 ---
  src/common/utility_unix.cpp | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/common/utility_unix.cpp b/src/common/utility_unix.cpp
-index 010408395..16964c64f 100644
+index 887213f09..c66468306 100644
 --- a/src/common/utility_unix.cpp
 +++ b/src/common/utility_unix.cpp
-@@ -83,7 +83,7 @@ void setLaunchOnStartup_private(const QString &appName, const QString &guiName,
-         ts << QLatin1String("[Desktop Entry]") << endl
-            << QLatin1String("Name=") << guiName << endl
-            << QLatin1String("GenericName=") << QLatin1String("File Synchronizer") << endl
--           << QLatin1String("Exec=\"") << executablePath << "\" --background" << endl
+@@ -88,7 +88,7 @@ void setLaunchOnStartup_private(const QString &appName, const QString &guiName,
+         ts << QLatin1String("[Desktop Entry]\n")
+            << QLatin1String("Name=") << guiName << QLatin1Char('\n')
+            << QLatin1String("GenericName=") << QLatin1String("File Synchronizer\n")
+-           << QLatin1String("Exec=\"") << executablePath << "\" --background\n"
 +           << QLatin1String("Exec=") << "nextcloud --background" << endl
-            << QLatin1String("Terminal=") << "false" << endl
-            << QLatin1String("Icon=") << APPLICATION_ICON_NAME << endl
-            << QLatin1String("Categories=") << QLatin1String("Network") << endl
+            << QLatin1String("Terminal=") << "false\n"
+            << QLatin1String("Icon=") << APPLICATION_ICON_NAME << QLatin1Char('\n')
+            << QLatin1String("Categories=") << QLatin1String("Network\n")
 -- 
-2.31.1
-
+2.33.1

--- a/pkgs/applications/networking/nextcloud-client/default.nix
+++ b/pkgs/applications/networking/nextcloud-client/default.nix
@@ -21,13 +21,13 @@
 
 mkDerivation rec {
   pname = "nextcloud-client";
-  version = "3.3.6";
+  version = "3.4.0";
 
   src = fetchFromGitHub {
     owner = "nextcloud";
     repo = "desktop";
     rev = "v${version}";
-    sha256 = "sha256-HhFm8rIsDaV4QmvHplbj49gf1vYCZyBl8WH5bvRHT7I=";
+    sha256 = "sha256-+b+DJwbYegbeoQmcdBg5Y7rJmKwPjz2XRUroP55ZO+g=";
   };
 
   patches = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/nextcloud/desktop/releases/tag/v3.4.0

Tested sync
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
