### PR TITLE
haskell.compiler.*: only set CLANG to match llc/opt

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -214,13 +214,10 @@ stdenv.mkDerivation (rec {
   '' + lib.optionalString useLLVM ''
     export LLC="${lib.getBin llvmPackages.llvm}/bin/llc"
     export OPT="${lib.getBin llvmPackages.llvm}/bin/opt"
-  '' + lib.optionalString (targetCC.isClang || (useLLVM && stdenv.targetPlatform.isDarwin)) (let
-    # LLVM backend on Darwin needs clang, if we are already using clang, might as well set the environment variable.
-    # See also https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/codegens.html#llvm-code-generator-fllvm
-    clang = if targetCC.isClang then targetCC else llvmPackages.clang;
-  in ''
-    export CLANG="${clang}/bin/${clang.targetPrefix}clang"
-  '') + ''
+  '' + lib.optionalString (useLLVM && stdenv.targetPlatform.isDarwin) ''
+    # LLVM backend on Darwin needs clang: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/codegens.html#llvm-code-generator-fllvm
+    export CLANG="${llvmPackages.clang}/bin/${llvmPackages.clang.targetPrefix}clang"
+  '' + ''
 
     echo -n "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure

--- a/pkgs/development/compilers/ghc/8.8.4.nix
+++ b/pkgs/development/compilers/ghc/8.8.4.nix
@@ -219,13 +219,10 @@ stdenv.mkDerivation (rec {
   '' + lib.optionalString useLLVM ''
     export LLC="${lib.getBin llvmPackages.llvm}/bin/llc"
     export OPT="${lib.getBin llvmPackages.llvm}/bin/opt"
-  '' + lib.optionalString (targetCC.isClang || (useLLVM && stdenv.targetPlatform.isDarwin)) (let
-    # LLVM backend on Darwin needs clang, if we are already using clang, might as well set the environment variable.
-    # See also https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/codegens.html#llvm-code-generator-fllvm
-    clang = if targetCC.isClang then targetCC else llvmPackages.clang;
-  in ''
-    export CLANG="${clang}/bin/${clang.targetPrefix}clang"
-  '') + ''
+  '' + lib.optionalString (useLLVM && stdenv.targetPlatform.isDarwin) ''
+    # LLVM backend on Darwin needs clang: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/codegens.html#llvm-code-generator-fllvm
+    export CLANG="${llvmPackages.clang}/bin/${llvmPackages.clang.targetPrefix}clang"
+  '' + ''
 
     echo -n "${buildMK dontStrip}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure

--- a/pkgs/development/compilers/ghc/9.0.1.nix
+++ b/pkgs/development/compilers/ghc/9.0.1.nix
@@ -180,13 +180,10 @@ stdenv.mkDerivation (rec {
   '' + lib.optionalString useLLVM ''
     export LLC="${lib.getBin llvmPackages.llvm}/bin/llc"
     export OPT="${lib.getBin llvmPackages.llvm}/bin/opt"
-  '' + lib.optionalString (targetCC.isClang || (useLLVM && stdenv.targetPlatform.isDarwin)) (let
-    # LLVM backend on Darwin needs clang, if we are already using clang, might as well set the environment variable.
-    # See also https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/codegens.html#llvm-code-generator-fllvm
-    clang = if targetCC.isClang then targetCC else llvmPackages.clang;
-  in ''
-    export CLANG="${clang}/bin/${clang.targetPrefix}clang"
-  '') + ''
+  '' + lib.optionalString (useLLVM && stdenv.targetPlatform.isDarwin) ''
+    # LLVM backend on Darwin needs clang: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/codegens.html#llvm-code-generator-fllvm
+    export CLANG="${llvmPackages.clang}/bin/${llvmPackages.clang.targetPrefix}clang"
+  '' + ''
 
     echo -n "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure

--- a/pkgs/development/compilers/ghc/9.2.1.nix
+++ b/pkgs/development/compilers/ghc/9.2.1.nix
@@ -180,13 +180,10 @@ stdenv.mkDerivation (rec {
   '' + lib.optionalString useLLVM ''
     export LLC="${lib.getBin llvmPackages.llvm}/bin/llc"
     export OPT="${lib.getBin llvmPackages.llvm}/bin/opt"
-  '' + lib.optionalString (targetCC.isClang || (useLLVM && stdenv.targetPlatform.isDarwin)) (let
-    # LLVM backend on Darwin needs clang, if we are already using clang, might as well set the environment variable.
-    # See also https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/codegens.html#llvm-code-generator-fllvm
-    clang = if targetCC.isClang then targetCC else llvmPackages.clang;
-  in ''
-    export CLANG="${clang}/bin/${clang.targetPrefix}clang"
-  '') + ''
+  '' + lib.optionalString (useLLVM && stdenv.targetPlatform.isDarwin) ''
+    # LLVM backend on Darwin needs clang: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/codegens.html#llvm-code-generator-fllvm
+    export CLANG="${llvmPackages.clang}/bin/${llvmPackages.clang.targetPrefix}clang"
+  '' + ''
 
     echo -n "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -194,13 +194,10 @@ stdenv.mkDerivation (rec {
   '' + lib.optionalString useLLVM ''
     export LLC="${lib.getBin llvmPackages.llvm}/bin/llc"
     export OPT="${lib.getBin llvmPackages.llvm}/bin/opt"
-  '' + lib.optionalString (targetCC.isClang || (useLLVM && stdenv.targetPlatform.isDarwin)) (let
-    # LLVM backend on Darwin needs clang, if we are already using clang, might as well set the environment variable.
-    # See also https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/codegens.html#llvm-code-generator-fllvm
-    clang = if targetCC.isClang then targetCC else llvmPackages.clang;
-  in ''
-    export CLANG="${clang}/bin/${clang.targetPrefix}clang"
-  '') + ''
+  '' + lib.optionalString (useLLVM && stdenv.targetPlatform.isDarwin) ''
+    # LLVM backend on Darwin needs clang: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/codegens.html#llvm-code-generator-fllvm
+    export CLANG="${llvmPackages.clang}/bin/${llvmPackages.clang.targetPrefix}clang"
+  '' + ''
 
     # otherwise haddock fails when generating the compiler docs
     export LANG=C.UTF-8


### PR DESCRIPTION
* By taking clang from llvmPackages we make sure there is no version
  mismatch between LLVM (where llc and opt come from) and clang (which
  previously would be taken from stdenv on darwin for example).

* Only pass CLANG if useLLVM is true. Previously we also set this if
  targetCC was clang. This would cause potentially confusing behavior if
  llc and opt as well as clang are provided via PATH (and GHC is
  compiled with useLLVM == false), because clang from PATH would be
  ignored, but not llc and opt.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
