### PR TITLE
python3Packages.terraformpy

### DIFF
--- a/pkgs/development/python-modules/schematics/default.nix
+++ b/pkgs/development/python-modules/schematics/default.nix
@@ -1,0 +1,47 @@
+{ lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  pytest-runner,
+  pytestCheckHook,
+  python-dateutil,
+  pymongo,
+  mock,
+  coverage
+}:
+
+buildPythonPackage rec {
+  pname = "schematics";
+  version = "2.1.1";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-jclKcX/4QbRCuWKdKq97Wo3q10Rbkt7/R8AJQTwnwVk=";
+  };
+
+  nativeBuildInputs = [
+    pytest-runner
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    python-dateutil
+    pymongo
+    mock
+    coverage
+  ];
+
+  # mo_installer is not maintained and not required for running this
+  # package
+  postPatch = ''
+    substituteInPlace setup.py --replace "'mo_installer'," ""
+  '';
+
+  meta = with lib; {
+    description = "Python Data Structures for Humans";
+    homepage = "https://github.com/schematics/schematics";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/terraformpy/default.nix
+++ b/pkgs/development/python-modules/terraformpy/default.nix
@@ -1,0 +1,43 @@
+{ lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  schematics,
+  six,
+  pytest,
+  pytest-mock,
+  pytest-cov,
+}:
+
+buildPythonPackage rec {
+  pname = "terraformpy";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "NerdWalletOSS";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-cm7t2H7g01cptNspgTr3NI8Fk1ryWEUwdGnLZC1cN6A=";
+  };
+
+  propagatedBuildInputs = [
+    six
+    schematics
+  ];
+
+  checkInputs = [
+    pytest
+    pytest-cov
+    pytest-mock
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "Terraformpy is a library and command line tool to supercharge your Terraform configs using a full fledged Python environment";
+    homepage = "https://github.com/NerdWalletOSS/terraformpy";
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9365,6 +9365,8 @@ in {
 
   tern = callPackage ../development/python-modules/tern { };
 
+  terraformpy = callPackage ../development/python-modules/terraformpy { };
+
   tesla-wall-connector = callPackage ../development/python-modules/tesla-wall-connector { };
 
   teslajsonpy = callPackage ../development/python-modules/teslajsonpy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8534,6 +8534,8 @@ in {
 
   schema-salad = callPackage ../development/python-modules/schema-salad { };
 
+  schematics = callPackage ../development/python-modules/schematics { };
+
   schiene = callPackage ../development/python-modules/schiene { };
 
   scikit-bio = callPackage ../development/python-modules/scikit-bio { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Starting to play around with terraformpy wanted to contribute the packaged libraries.

###### Things done

 - python3Packages.schematics
 - python3Packages.terraformpy

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
