### PR TITLE
git-quickfix: 0.0.4 -> 0.0.5

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-quickfix/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-quickfix/default.nix
@@ -10,13 +10,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "git-quickfix";
-  version = "0.0.4";
+  version = "0.0.5";
 
   src = fetchFromGitHub {
     owner = "siedentop";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-JdRlrNzWMPS3yG1UvKKtHVRix3buSm9jfSoAUxP35BY=";
+    sha256 = "sha256-LDA94pH5Oodf80mEENoURh+MJSg122SVWFVo9i1TEQg=";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
     libiconv
   ];
 
-  cargoSha256 = "sha256-ENeHPhEBniR9L3J5el6QZrIS1Q4O0pNiSzJqP1aQS9Q=";
+  cargoSha256 = "sha256-QTPy0w45AawEU4fHf2FMGpL3YM+iTNnyiI4+mDJzWaE=";
 
   meta = with lib; {
     description = "Quickfix allows you to commit changes in your git repository to a new branch without leaving the current branch";


### PR DESCRIPTION
###### Motivation for this change

Updates git-quickfix to the 0.0.5 release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
