### PR TITLE
reStream: 1.1 -> 1.2.0

### DIFF
--- a/pkgs/applications/misc/remarkable/restream/default.nix
+++ b/pkgs/applications/misc/remarkable/restream/default.nix
@@ -20,8 +20,6 @@ stdenv.mkDerivation rec {
     sha256 = "0vyj0kng8c9inv2rbw1qdr43ic15s5x8fvk9mbw0vpc6g723x99g";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
-
   dontConfigure = true;
   dontBuild = true;
 
@@ -34,10 +32,22 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  postInstall = ''
-    # `ffmpeg-full` is used here to bring in `ffplay`, which is used to display
-    # the reMarkable framebuffer
-    wrapProgram "$out/bin/restream" --suffix PATH ":" "${lib.makeBinPath [ ffmpeg-full lz4 openssh netcat ]}"
+  postInstall = let
+    deps = [
+      # `ffmpeg-full` is used here to bring in `ffplay`, which is used
+      # to display the reMarkable framebuffer
+      ffmpeg-full
+      lz4
+      openssh
+      # Libressl netcat brings in `nc` which used for --uncompressed mode.
+      netcat
+    ];
+  in ''
+    # This `sed` command has the same effect as `wrapProgram`, except
+    # without .restream-wrapped store paths appearing everywhere.
+    sed -i \
+      '2i export PATH=$PATH''${PATH:+':'}${lib.makeBinPath deps}' \
+      "$out/bin/restream"
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/remarkable/restream/default.nix
+++ b/pkgs/applications/misc/remarkable/restream/default.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "restream";
-  version = "1.1";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "rien";
     repo = pname;
     rev = version;
-    sha256 = "18z17chl7r5dg12xmr3f9gbgv97nslm8nijigd03iysaj6dhymp3";
+    sha256 = "0vyj0kng8c9inv2rbw1qdr43ic15s5x8fvk9mbw0vpc6g723x99g";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/applications/misc/remarkable/restream/default.nix
+++ b/pkgs/applications/misc/remarkable/restream/default.nix
@@ -5,6 +5,7 @@
 , ffmpeg-full
 , fetchFromGitHub
 , openssh
+, netcat
 , makeWrapper
 }:
 
@@ -36,7 +37,7 @@ stdenv.mkDerivation rec {
   postInstall = ''
     # `ffmpeg-full` is used here to bring in `ffplay`, which is used to display
     # the reMarkable framebuffer
-    wrapProgram "$out/bin/restream" --suffix PATH ":" "${lib.makeBinPath [ ffmpeg-full lz4 openssh ]}"
+    wrapProgram "$out/bin/restream" --suffix PATH ":" "${lib.makeBinPath [ ffmpeg-full lz4 openssh netcat ]}"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Updates reStream to [1.2.0](https://github.com/rien/reStream/releases/tag/1.2.0) which has bug fixes.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - N/A [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I also modified how the shell script wrapping is done, so that the `restream --help` page looks better. Unsure how acceptable this method is - the general issue for that is #60260.
