### PR TITLE
ddccontrol: 0.5.2 -> 0.6.0

### DIFF
--- a/nixos/modules/services/hardware/ddccontrol.nix
+++ b/nixos/modules/services/hardware/ddccontrol.nix
@@ -20,6 +20,9 @@ in
   ###### implementation
 
   config = lib.mkIf cfg.enable {
+    # Load the i2c-dev module
+    boot.kernelModules = [ "i2c_dev" ];
+
     # Give users access to the "gddccontrol" tool
     environment.systemPackages = [
       pkgs.ddccontrol

--- a/pkgs/tools/misc/ddccontrol/default.nix
+++ b/pkgs/tools/misc/ddccontrol/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "ddccontrol";
-  version = "0.5.2";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "ddccontrol";
     repo = "ddccontrol";
-    rev = "0.5.2";
-    sha256 = "sha256-kul0sjbwbCwadvrccG3KwL/fKWACFUg74QGvgfWE4FQ=";
+    rev = version;
+    sha256 = "00pmnzvd4l3w6chzw41mrf1pd7lrcwi1n7320bnq20rn8hsnbnxk";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/misc/ddccontrol/default.nix
+++ b/pkgs/tools/misc/ddccontrol/default.nix
@@ -39,10 +39,17 @@ stdenv.mkDerivation rec {
   ];
 
   prePatch = ''
-    oldPath="\$""{datadir}/ddccontrol-db"
-    newPath="${ddccontrol-db}/share/ddccontrol-db"
-    sed -i -e "s|$oldPath|$newPath|" configure.ac
-    sed -i -e "s/chmod 4711/chmod 0711/" src/ddcpci/Makefile*
+    substituteInPlace configure.ac              \
+      --replace                                 \
+      "\$""{datadir}/ddccontrol-db"             \
+      "${ddccontrol-db}/share/ddccontrol-db"
+
+    substituteInPlace src/ddcpci/Makefile.am    \
+       --replace "chmod 4711" "chmod 0711"
+  '' + lib.optionalString (lib.versionAtLeast "0.6.0" version) ''
+    # Upstream PR: https://github.com/ddccontrol/ddccontrol/pull/115
+    substituteInPlace src/lib/Makefile.am       \
+      --replace "/etc/" "\$""{sysconfdir}/"
   '';
 
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change

- Fix configuration issues which prevented ddccontrol from working for me.
- Updates ddccontrol to [0.6.0](https://github.com/ddccontrol/ddccontrol/releases/tag/0.6.0).
 
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - N/A [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - N/A [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - N/A (Package updates) Added a release notes entry if the change is major or breaking
  - N/A (Module updates) Added a release notes entry if the change is significant
  - N/A (Module addition) Added a release notes entry if adding a new NixOS module
  - N/A (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I tested the ddccontrol nixos service via `gddccontrol`.

This PR is suitable for backporting to 22.11.

cc: @pakhfn 