### PR TITLE
mrtrix: 3.0.2 -> unstable-2021-11-25

### DIFF
--- a/pkgs/applications/science/biology/mrtrix/default.nix
+++ b/pkgs/applications/science/biology/mrtrix/default.nix
@@ -1,17 +1,17 @@
 { stdenv, lib, fetchFromGitHub, python, makeWrapper
 , eigen, fftw, libtiff, libpng, zlib, ants, bc
 , qt5, libGL, libGLU, libX11, libXext
-, withGui ? true }:
+, withGui ? true, less }:
 
 stdenv.mkDerivation rec {
   pname = "mrtrix";
-  version = "3.0.2";
+  version = "unstable-2021-11-25";
 
   src = fetchFromGitHub {
     owner  = "MRtrix3";
     repo   = "mrtrix3";
-    rev    = version;
-    sha256 = "0p4d1230j6664rnb9l65cpyfj9ncbcm39yv1r9y77br9rkkv1za3";
+    rev    = "994498557037c9e4f7ba67f255820ef84ea899d9";
+    sha256 = "sha256-8eFDS5z4ZxMzi9Khk90KAS4ndma/Syd6JDXM2Fpr0M8=";
     fetchSubmodules = true;
   };
 
@@ -44,6 +44,9 @@ stdenv.mkDerivation rec {
 
     substituteInPlace ./run_tests  \
       --replace 'git submodule update --init $datadir >> $LOGFILE 2>&1' ""
+
+    substituteInPlace ./build  \
+      --replace '"less -RX "' '"${less}/bin/less -RX "'
   '';
 
   configurePhase = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The latest stable version fails to build with latest eigen (> 3).
https://github.com/MRtrix3/mrtrix3/pull/2368

Update to latest unstable master to fix build.
https://hydra.nixos.org/build/158660746

ZHF: #144627

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
