### PR TITLE
colmena: init at 0.2.0

### DIFF
--- a/pkgs/tools/admin/colmena/default.nix
+++ b/pkgs/tools/admin/colmena/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, lib, rustPlatform, fetchFromGitHub, installShellFiles, colmena, testVersion }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "colmena";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "zhaofengli";
+    repo = "colmena";
+    rev = "v${version}";
+    sha256 = "sha256-WY8SYapnDcfaoLr1iFgwc9/E7xSfOFN2AvMDpk74AI8=";
+  };
+
+  cargoSha256 = "sha256-ZNSg3hXWKHNQ9yHJS1qW3tFYwzU4ZDa1N0yvoGLmWns=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+    installShellCompletion --cmd colmena \
+      --bash <($out/bin/colmena gen-completions bash) \
+      --zsh <($out/bin/colmena gen-completions zsh) \
+      --fish <($out/bin/colmena gen-completions fish)
+  '';
+
+  # Recursive Nix is not stable yet
+  doCheck = false;
+
+  passthru = {
+    # We guarantee CLI and Nix API stability for the same minor version
+    apiVersion = builtins.concatStringsSep "." (lib.take 2 (lib.splitString "." version));
+
+    tests.version = testVersion { package = colmena; };
+  };
+
+  meta = with lib; {
+    description = "A simple, stateless NixOS deployment tool";
+    homepage = "https://zhaofengli.github.io/colmena/${passthru.apiVersion}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ zhaofengli ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -275,6 +275,8 @@ with pkgs;
 
   corgi = callPackage ../development/tools/corgi { };
 
+  colmena = callPackage ../tools/admin/colmena { };
+
   colobot = callPackage ../games/colobot {};
 
   colorz = callPackage ../tools/misc/colorz { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[Colmena](https://zhaofengli.github.io/colmena/0.2) is a simple, stateless NixOS deployment tool.

This is the first stable release of the tool, submitted here so it can be easily installed from Nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
