### PR TITLE
init python/pass2csv: init at 0.3.2

### DIFF
--- a/pkgs/development/python-modules/pass2csv/default.nix
+++ b/pkgs/development/python-modules/pass2csv/default.nix
@@ -1,0 +1,22 @@
+{ buildPythonApplication, fetchFromGitHub, python-gnupg, lib}:
+
+buildPythonApplication rec {
+  pname = "pass2csv";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    repo = pname;
+    owner = "reinefjord";
+    rev = "v${version}";
+    sha256 = "sha256:1al2y2x4cwvaz9kcxfyqfvbnr99dykiycg2h6kgwqmh5hih0y221";
+  };
+
+  propagatedBuildInputs = [ python-gnupg ];
+
+  meta = with lib; {
+    description = "Export pass(1), 'the standard unix password manager', to CSV.";
+    homepage = "https://github.com/reinefjord/pass2csv";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Scriptkiddi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5574,6 +5574,8 @@ in {
 
   passlib = callPackage ../development/python-modules/passlib { };
 
+  pass2csv = callPackage ../development/python-modules/pass2csv { };
+
   paste = callPackage ../development/python-modules/paste { };
 
   pastedeploy = callPackage ../development/python-modules/pastedeploy { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Wanted to use pass2csv on nix

###### Things done
The version is set to 0.3.1 but rev from master is used, because a patch for nixos packaging was merged to master but no new version was released. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

