### PR TITLE
llvmPackages_13.clang: revert D100879 and re-enable jemalloc for firefox

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -27,9 +27,8 @@
 , ltoSupport ? (stdenv.isLinux && stdenv.is64bit), overrideCC, buildPackages
 , gssSupport ? true, libkrb5
 , pipewireSupport ? waylandSupport && webrtcSupport, pipewire
-# Workaround: disabled since currently jemalloc causes crashes with LLVM 13.
-# https://bugzilla.mozilla.org/show_bug.cgi?id=1741454
-, jemallocSupport ? false, jemalloc
+# Jemalloc could reduce memory consumption.
+, jemallocSupport ? true, jemalloc
 
 ## privacy-related options
 

--- a/pkgs/development/compilers/llvm/13/clang/default.nix
+++ b/pkgs/development/compilers/llvm/13/clang/default.nix
@@ -37,6 +37,11 @@ let
       ./purity.patch
       # https://reviews.llvm.org/D51899
       ./gnu-install-dirs.patch
+      # Revert of https://reviews.llvm.org/D100879
+      # The malloc alignment assumption is incorrect for jemalloc and causes
+      # mis-compilation in firefox.
+      # See: https://bugzilla.mozilla.org/show_bug.cgi?id=1741454
+      ./revert-malloc-alignment-assumption.patch
       (substituteAll {
         src = ../../clang-11-12-LLVMgold-path.patch;
         libllvmLibdir = "${libllvm.lib}/lib";

--- a/pkgs/development/compilers/llvm/13/clang/revert-malloc-alignment-assumption.patch
+++ b/pkgs/development/compilers/llvm/13/clang/revert-malloc-alignment-assumption.patch
@@ -1,0 +1,78 @@
+--- b/include/clang/Basic/TargetInfo.h
++++ a/include/clang/Basic/TargetInfo.h
+@@ -612,8 +612,8 @@
+   }
+ 
+   /// Return the largest alignment for which a suitably-sized allocation with
++  /// '::operator new(size_t)' is guaranteed to produce a correctly-aligned
++  /// pointer.
+-  /// '::operator new(size_t)' or 'malloc' is guaranteed to produce a
+-  /// correctly-aligned pointer.
+   unsigned getNewAlign() const {
+     return NewAlign ? NewAlign : std::max(LongDoubleAlign, LongLongAlign);
+   }
+--- b/lib/CodeGen/CGCall.cpp
++++ a/lib/CodeGen/CGCall.cpp
+@@ -2048,24 +2048,6 @@
+       // allows it to work on indirect virtual function calls.
+       if (AttrOnCallSite && TargetDecl->hasAttr<NoMergeAttr>())
+         FuncAttrs.addAttribute(llvm::Attribute::NoMerge);
+-
+-      // Add known guaranteed alignment for allocation functions.
+-      if (unsigned BuiltinID = Fn->getBuiltinID()) {
+-        switch (BuiltinID) {
+-        case Builtin::BIaligned_alloc:
+-        case Builtin::BIcalloc:
+-        case Builtin::BImalloc:
+-        case Builtin::BImemalign:
+-        case Builtin::BIrealloc:
+-        case Builtin::BIstrdup:
+-        case Builtin::BIstrndup:
+-          RetAttrs.addAlignmentAttr(Context.getTargetInfo().getNewAlign() /
+-                                    Context.getTargetInfo().getCharWidth());
+-          break;
+-        default:
+-          break;
+-        }
+-      }
+     }
+ 
+     // 'const', 'pure' and 'noalias' attributed functions are also nounwind.
+--- b/test/CodeGen/alloc-fns-alignment.c
++++ /dev/null
+@@ -1,35 +0,0 @@
+-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm < %s | FileCheck %s --check-prefix=ALIGN16
+-// RUN: %clang_cc1 -triple x86_64-windows-msvc      -emit-llvm < %s | FileCheck %s --check-prefix=ALIGN16
+-// RUN: %clang_cc1 -triple i386-apple-darwin        -emit-llvm < %s | FileCheck %s --check-prefix=ALIGN16
+-// RUN: %clang_cc1 -triple i386-unknown-linux-gnu   -emit-llvm < %s | FileCheck %s --check-prefix=ALIGN8
+-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fno-builtin-malloc  -emit-llvm < %s  | FileCheck %s --check-prefix=NOBUILTIN-MALLOC
+-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fno-builtin-calloc  -emit-llvm < %s  | FileCheck %s --check-prefix=NOBUILTIN-CALLOC
+-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fno-builtin-realloc -emit-llvm < %s  | FileCheck %s --check-prefix=NOBUILTIN-REALLOC
+-
+-typedef __SIZE_TYPE__ size_t;
+-
+-void *malloc(size_t);
+-void *calloc(size_t, size_t);
+-void *realloc(void *, size_t);
+-
+-void *malloc_test(size_t n) {
+-  return malloc(n);
+-}
+-
+-void *calloc_test(size_t n) {
+-  return calloc(1, n);
+-}
+-
+-void *raalloc_test(void *p, size_t n) {
+-  return realloc(p, n);
+-}
+-
+-// ALIGN16: align 16 i8* @malloc
+-// ALIGN16: align 16 i8* @calloc
+-// ALIGN16: align 16 i8* @realloc
+-// ALIGN8: align 8 i8* @malloc
+-// ALIGN8: align 8 i8* @calloc
+-// ALIGN8: align 8 i8* @realloc
+-// NOBUILTIN-MALLOC: declare i8* @malloc
+-// NOBUILTIN-CALLOC: declare i8* @calloc
+-// NOBUILTIN-REALLOC: declare i8* @realloc


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Revert the [D100879](https://reviews.llvm.org/D100879) which causes #146382, so that we could re-enable `jemalloc` for `firefox` again.

Currently we disabled `jemalloc` in #146784 as a temporary workaround. But I found it makes `firefox` consumes significant more memory. As a simple comparison, I created an empty profile and run `firefox` with 5 tabs of https://github.com/NixOS/nixpkgs and 5 tabs of https://youtube.com . After loaded and stabilized, `firefox` without `jemalloc` consumes 3.30GiB+-1% RSS, while the `jemalloc` one consumes 2.94GiB+-2% RSS, which is ~10% reduction. (They both don't use any swap space)

The test and benchmarks are done by `cherry-pick`ing this PR to `master`.
`staging` one is still building.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
