### PR TITLE
dozenal: disable parallel build

### DIFF
--- a/pkgs/applications/misc/dozenal/default.nix
+++ b/pkgs/applications/misc/dozenal/default.nix
@@ -21,6 +21,14 @@ stdenv.mkDerivation rec {
   patches = [ ./lua-header.patch ];
   preBuild = "cd dozenal";
   buildInputs = [ ncurses hdate lua5_2 ];
+
+  # Parallel builds fail due to no dependencies between subdirs.
+  # As a result some subdirs are atempted to build twice:
+  #   ../dec/dec.c:39:10: fatal error: conv.h: No such file or directory
+  # Let's disable parallelism until it's fixed upstream:
+  #  https://gitlab.com/dgoodmaniii/dozenal/-/issues/8
+  enableParallelBuilding = false;
+
   # I remove gdozdc, as I didn't figure all it's dependency yet.
   postInstall = "rm $out/bin/gdozdc";
 


### PR DESCRIPTION
Parallel build fails for missing dependencies in subdirectories:

    ../doz/doz.c:39:10: fatal error: conv.h: No such file or directory
       39 | #include "conv.h"
          |          ^~~~~~~~

Let's explicitly disable parallelism until upstream fixes it.