### PR TITLE
runescape-launcher: Use package from archive.org + add myself as maintainer

### DIFF
--- a/pkgs/games/runescape-launcher/default.nix
+++ b/pkgs/games/runescape-launcher/default.nix
@@ -10,8 +10,9 @@ let
     pname = "runescape-launcher";
     version = "2.2.9";
 
+    # upstream is https://content.runescape.com/downloads/ubuntu/pool/non-free/r/${pname}/${pname}_${version}_amd64.deb
     src = fetchurl {
-      url = "https://content.runescape.com/downloads/ubuntu/pool/non-free/r/${pname}/${pname}_${version}_amd64.deb";
+      url = "https://archive.org/download/${pname}_${version}_amd64/${pname}_${version}_amd64.deb";
       sha256 = "10ly44lbgbbqc65lx7mhfzfjaiz1xj0mfjqlwlxz0sdjyw4a6ij6";
     };
 
@@ -89,23 +90,23 @@ in
   * FHS simulates a classic linux shell
   */
   buildFHSUserEnv {
-   name = "RuneScape";
-   targetPkgs = pkgs: [
-     runescape
-     dpkg glibc gcc-unwrapped
-     libSM libXxf86vm libX11 glib pango cairo gtk2-x11 zlib openssl
-     libpulseaudio
-     xorg.libX11
-     SDL2 xorg_sys_opengl libGL
-   ];
-   multiPkgs = pkgs: [ libGL ];
-   runScript = "runescape-launcher";
+    name = "RuneScape";
+    targetPkgs = pkgs: [
+      runescape
+      dpkg glibc gcc-unwrapped
+      libSM libXxf86vm libX11 glib pango cairo gtk2-x11 zlib openssl
+      libpulseaudio
+      xorg.libX11
+      SDL2 xorg_sys_opengl libGL
+    ];
+    multiPkgs = pkgs: [ libGL ];
+    runScript = "runescape-launcher";
 
-   meta = with lib; {
-     description = "Launcher for RuneScape 3";
-     homepage = "https://www.runescape.com/";
-     license = licenses.unfree;
-     maintainers = with maintainers; [ grburst ];
-     platforms = [ "x86_64-linux" ];
-   };
-}
+    meta = with lib; {
+      description = "RuneScape Game Client (NXT) - Launcher for RuneScape 3";
+      homepage = "https://www.runescape.com/";
+      license = licenses.unfree;
+      maintainers = with maintainers; [ grburst ];
+      platforms = [ "x86_64-linux" ];
+    };
+  }

--- a/pkgs/games/runescape-launcher/default.nix
+++ b/pkgs/games/runescape-launcher/default.nix
@@ -12,7 +12,7 @@ let
 
     src = fetchurl {
       url = "https://content.runescape.com/downloads/ubuntu/pool/non-free/r/${pname}/${pname}_${version}_amd64.deb";
-      sha256 = "0r5v1pwh0aas31b1d3pkrc8lqmqz9b4fml2b4kxmg5xzp677h271";
+      sha256 = "10ly44lbgbbqc65lx7mhfzfjaiz1xj0mfjqlwlxz0sdjyw4a6ij6";
     };
 
     nativeBuildInputs = [
@@ -76,7 +76,7 @@ let
       description = "Launcher for RuneScape 3, the current main RuneScape";
       homepage = "https://www.runescape.com/";
       license = licenses.unfree;
-      maintainers = with lib.maintainers; [ grburst ];
+      maintainers = with maintainers; [ grburst ];
       platforms = [ "x86_64-linux" ];
     };
   };
@@ -100,4 +100,12 @@ in
    ];
    multiPkgs = pkgs: [ libGL ];
    runScript = "runescape-launcher";
+
+   meta = with lib; {
+     description = "Launcher for RuneScape 3";
+     homepage = "https://www.runescape.com/";
+     license = licenses.unfree;
+     maintainers = with maintainers; [ grburst ];
+     platforms = [ "x86_64-linux" ];
+   };
 }

--- a/pkgs/games/runescape-launcher/default.nix
+++ b/pkgs/games/runescape-launcher/default.nix
@@ -10,10 +10,11 @@ let
     pname = "runescape-launcher";
     version = "2.2.9";
 
+    # Packages: https://content.runescape.com/downloads/ubuntu/dists/trusty/non-free/binary-amd64/Packages
     # upstream is https://content.runescape.com/downloads/ubuntu/pool/non-free/r/${pname}/${pname}_${version}_amd64.deb
     src = fetchurl {
       url = "https://archive.org/download/${pname}_${version}_amd64/${pname}_${version}_amd64.deb";
-      sha256 = "10ly44lbgbbqc65lx7mhfzfjaiz1xj0mfjqlwlxz0sdjyw4a6ij6";
+      sha256 = "1zilpxh8k8baylbl9nqq9kgjiv2xzw4lizbgcmzky5rhmych8n4g";
     };
 
     nativeBuildInputs = [


### PR DESCRIPTION
Signed-off-by: GRBurst <GRBurst@protonmail.com>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add myself as maintainer.

Question here: The downloaded (fetchurl) package does change over time, even though the version does not. I am wondering if it is possible to ignore the hash or have some other control mechanisms. Any advice?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
