### PR TITLE
vimPlugins.nvim-treesitter{,-textobjects}: use default branch and update

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -41,12 +41,12 @@ final: prev:
 
   aerial-nvim = buildVimPluginFrom2Nix {
     pname = "aerial.nvim";
-    version = "2021-11-28";
+    version = "2021-12-01";
     src = fetchFromGitHub {
       owner = "stevearc";
       repo = "aerial.nvim";
-      rev = "f92674de63d82accbed4f4a853925ec1d75e8cff";
-      sha256 = "0njyhpn29z5s6xx25flk0pf53ifpdwznasdryi0bnri25pfv29hq";
+      rev = "ab68f4f07b0f382f61b14b67599a59b1f6fead87";
+      sha256 = "1jlav2mbsizwnkkgp1v15sw765q24kc5sss34y16hdxsap6113vd";
     };
     meta.homepage = "https://github.com/stevearc/aerial.nvim/";
   };
@@ -197,12 +197,12 @@ final: prev:
 
   aurora = buildVimPluginFrom2Nix {
     pname = "aurora";
-    version = "2021-11-27";
+    version = "2021-11-29";
     src = fetchFromGitHub {
       owner = "ray-x";
       repo = "aurora";
-      rev = "d98ee14f18c7e117f8221aea83c51d713a080076";
-      sha256 = "05azpx3q49j9c2qli0n15dby0xn88pfij36xfsnwy2wrbs5c2k0d";
+      rev = "1607b4c100f9c466fc0208e936421a0202025457";
+      sha256 = "1rx1ggy54j71pp5ihv8zb3wqq69b26v65q1snv6hlabar02hrl1r";
     };
     meta.homepage = "https://github.com/ray-x/aurora/";
   };
@@ -473,12 +473,12 @@ final: prev:
 
   chadtree = buildVimPluginFrom2Nix {
     pname = "chadtree";
-    version = "2021-11-28";
+    version = "2021-12-01";
     src = fetchFromGitHub {
       owner = "ms-jpq";
       repo = "chadtree";
-      rev = "f56b751e3b04b3146f90f892047fb63623eb6ca6";
-      sha256 = "0lxz0xir8zy7p5bs5z6vf9nxy91n6pxjqvf5iql7yfhc9hhaasf4";
+      rev = "d034dcc738c8fd2217199e5db76066223ab8750c";
+      sha256 = "1s97snn5g5bd3sfqj5n2a76f0r9d3ywi0q08xbxv6y3p83c1dn10";
     };
     meta.homepage = "https://github.com/ms-jpq/chadtree/";
   };
@@ -605,12 +605,12 @@ final: prev:
 
   cmp-cmdline = buildVimPluginFrom2Nix {
     pname = "cmp-cmdline";
-    version = "2021-11-22";
+    version = "2021-12-01";
     src = fetchFromGitHub {
       owner = "hrsh7th";
       repo = "cmp-cmdline";
-      rev = "e5aa12620b6cae9ba5ce27aed2c47a99b81f004f";
-      sha256 = "03zjy4xwzm1898pabz0gzydc5zlcnsprkqlk0aavz0aw21mmywkh";
+      rev = "29ca81a6f0f288e6311b3377d9d9684d22eac2ec";
+      sha256 = "0yzh0jdys1bn1c2mqm410c0ndyyyxpmigzdrkhnkv78b16vjyhq6";
     };
     meta.homepage = "https://github.com/hrsh7th/cmp-cmdline/";
   };
@@ -689,12 +689,12 @@ final: prev:
 
   cmp-omni = buildVimPluginFrom2Nix {
     pname = "cmp-omni";
-    version = "2021-09-28";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "hrsh7th";
       repo = "cmp-omni";
-      rev = "3fec8a57d6d230c81d24c03dd80e97c62d4eda63";
-      sha256 = "018lzqxdcw78ckqm16jn0wh3pv9pjl6abcj1q2svfalmim0h6a87";
+      rev = "580d07d32242d542e365d2732eddd2dbb7374aff";
+      sha256 = "1d6j1ddfb9xijsljskb04s3kan3sg8lmbv1qal5hmhrwi8x65dwg";
     };
     meta.homepage = "https://github.com/hrsh7th/cmp-omni/";
   };
@@ -713,12 +713,12 @@ final: prev:
 
   cmp-path = buildVimPluginFrom2Nix {
     pname = "cmp-path";
-    version = "2021-11-27";
+    version = "2021-11-29";
     src = fetchFromGitHub {
       owner = "hrsh7th";
       repo = "cmp-path";
-      rev = "4fe14cf56288200614950fe57525ac6340f49d5a";
-      sha256 = "1f48pnmwnr93frggpqd0m6vnpkj1frn3vnnp5ljwi86mlc4p4ag4";
+      rev = "e30d3fdee650a07330654efab1951b2f1b91435e";
+      sha256 = "1sf79aqq41qbz69b29yzyn27qb9x8spyqxpay8fgzhn8jfkapvxv";
     };
     meta.homepage = "https://github.com/hrsh7th/cmp-path/";
   };
@@ -737,12 +737,12 @@ final: prev:
 
   cmp-tabnine = buildVimPluginFrom2Nix {
     pname = "cmp-tabnine";
-    version = "2021-11-28";
+    version = "2021-11-29";
     src = fetchFromGitHub {
       owner = "tzachar";
       repo = "cmp-tabnine";
-      rev = "d52a25de3417139d5b0e1624f15c60df0565c75f";
-      sha256 = "1vx0zb41c39k7ba6slkic8w9f91l5070yzja6l14pyngq55h5mdw";
+      rev = "e03ad3d788b0d76293b3a7601e0abf988d6d3859";
+      sha256 = "13kkgvlnzjh57ynpyj1vw1dgs4zf4y2cq4c1mf3g51782qgf0kxp";
     };
     meta.homepage = "https://github.com/tzachar/cmp-tabnine/";
   };
@@ -1002,12 +1002,12 @@ final: prev:
 
   compe-tmux = buildVimPluginFrom2Nix {
     pname = "compe-tmux";
-    version = "2021-11-25";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "andersevenrud";
       repo = "compe-tmux";
-      rev = "d7c6daa59a0d5940f85f110d8e59fdf9b0cef5d1";
-      sha256 = "14j1fc1c43lpj24gflw1b594n601al8clkcpjpql7rl3dbmh3dc9";
+      rev = "5106ae2d3c93d37173ccb3b917bebb9845e3d3e6";
+      sha256 = "1svhj1n17y70ns9d0hc9a3dvxb1nmpii5vgificgpwqfmkws4dak";
     };
     meta.homepage = "https://github.com/andersevenrud/compe-tmux/";
   };
@@ -1170,12 +1170,12 @@ final: prev:
 
   crates-nvim = buildVimPluginFrom2Nix {
     pname = "crates.nvim";
-    version = "2021-11-28";
+    version = "2021-11-29";
     src = fetchFromGitHub {
       owner = "saecki";
       repo = "crates.nvim";
-      rev = "b1de088782d8ad225728fcb79cfa889f8ff3edf9";
-      sha256 = "1cjlf1yqdd1il0wjbhmgflqp761ybkpbaaw318564b8hvmxknwxk";
+      rev = "cdfb2df434ff57a00f2f3f90dc5c6e11c2bd3079";
+      sha256 = "0f7wwn3x579qm0klq4h2hmmvh5srb1fvsgmcnhm2il4j2mgdhykh";
     };
     meta.homepage = "https://github.com/saecki/crates.nvim/";
   };
@@ -1362,12 +1362,12 @@ final: prev:
 
   deol-nvim = buildVimPluginFrom2Nix {
     pname = "deol.nvim";
-    version = "2021-11-06";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "Shougo";
       repo = "deol.nvim";
-      rev = "feb1269a56628accc1ec74f4d5e0ea91b80fe9f9";
-      sha256 = "0nnbj538vd99rb4cjfs6xxx6c1n7aflpw92zkz9if1xhfw4jqfzc";
+      rev = "e9db6ec1c53797eea0571f4374bee79bcca5db40";
+      sha256 = "0hlbr4dvh8irif6xa24dwj0l1wx8djfx72dq1wx4y16af4wgkkfv";
     };
     meta.homepage = "https://github.com/Shougo/deol.nvim/";
   };
@@ -1640,12 +1640,12 @@ final: prev:
 
   diffview-nvim = buildVimPluginFrom2Nix {
     pname = "diffview.nvim";
-    version = "2021-11-26";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "sindrets";
       repo = "diffview.nvim";
-      rev = "f92d27b22bd5bfa47903ac91de5077263ce816ea";
-      sha256 = "03yawkbh6fxm9wf5nfj2wblcdwxjs4gjcqrp96k9xyjf58ggrlsi";
+      rev = "2c0f5af509a9e0f42430c0b561ab7e49aec84f72";
+      sha256 = "16ap4kdb5gghnn6x9fiafphpr7gvkq5baiba0vzxiv8h2la0jhw1";
     };
     meta.homepage = "https://github.com/sindrets/diffview.nvim/";
   };
@@ -1712,12 +1712,12 @@ final: prev:
 
   edge = buildVimPluginFrom2Nix {
     pname = "edge";
-    version = "2021-11-11";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "sainnhe";
       repo = "edge";
-      rev = "f2c8e3d2a72f3763e3ea9c620a118e73e2146fb1";
-      sha256 = "08v10j0hirqcj2r2fcw8b04v8bpwj1kp887pq8vs5f57ncqzl8x7";
+      rev = "80be959e1840b0a49dda09775610cc3c366b8f3c";
+      sha256 = "136akfkblxc4myyb7l6gs8zszrgn2is8b0692v16xbql3i4d708n";
     };
     meta.homepage = "https://github.com/sainnhe/edge/";
   };
@@ -2219,12 +2219,12 @@ final: prev:
 
   git-worktree-nvim = buildVimPluginFrom2Nix {
     pname = "git-worktree.nvim";
-    version = "2021-11-24";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "ThePrimeagen";
       repo = "git-worktree.nvim";
-      rev = "62d2be7e0bf5a594a547efa1ab962c930f448e2d";
-      sha256 = "1k1bz9hvbqxankfr038fbmxrmjr1zcnn3j7mchzcj4pfx5x3ny3g";
+      rev = "508a33853b9cc14c67cc042d2f4876d6db636b68";
+      sha256 = "0n1mn3fnmxddgj0j4041ia2fnnhsfknl4ks88llabg8k0kcxvzmi";
     };
     meta.homepage = "https://github.com/ThePrimeagen/git-worktree.nvim/";
   };
@@ -2243,24 +2243,24 @@ final: prev:
 
   gitlinker-nvim = buildVimPluginFrom2Nix {
     pname = "gitlinker.nvim";
-    version = "2021-11-15";
+    version = "2021-11-29";
     src = fetchFromGitHub {
       owner = "ruifm";
       repo = "gitlinker.nvim";
-      rev = "003ee482a25118cdac73faea8bd35df0399e8f8f";
-      sha256 = "0zpy1cpviia9l4z3b87534arnxfja48bjhqqb88mxjzm9gkc4rbf";
+      rev = "a11e5fa14bbb438f59a3744bff53a3ad78eecd71";
+      sha256 = "0s17alrjqbdyk7jxg6jyb4xwmr9741a2r3306ywx6qsl9pk3n0p2";
     };
     meta.homepage = "https://github.com/ruifm/gitlinker.nvim/";
   };
 
   gitsigns-nvim = buildVimPluginFrom2Nix {
     pname = "gitsigns.nvim";
-    version = "2021-11-19";
+    version = "2021-12-01";
     src = fetchFromGitHub {
       owner = "lewis6991";
       repo = "gitsigns.nvim";
-      rev = "95845ef39ce0a98f68cdfdcf7dd586c5e965acc7";
-      sha256 = "0hzzwsc9y8z71d82j2sbhhl5vxp1xmd8ki0km746jcigfaaagdll";
+      rev = "9678750f209671551c335c4f22658a6554c2f439";
+      sha256 = "1i8xlj40a80p3s7pkxqqdxpfz0330akfqd7q2rr4gakqc927aqgy";
     };
     meta.homepage = "https://github.com/lewis6991/gitsigns.nvim/";
   };
@@ -2327,12 +2327,12 @@ final: prev:
 
   goto-preview = buildVimPluginFrom2Nix {
     pname = "goto-preview";
-    version = "2021-11-17";
+    version = "2021-11-29";
     src = fetchFromGitHub {
       owner = "rmagatti";
       repo = "goto-preview";
-      rev = "817bae89f75c8f061f7c0198ce392dca5d16ac94";
-      sha256 = "0pxz7mrl4fsdi6pyk7zizxb7g3a11n8s36ndg3l9qsbihfxiqk5y";
+      rev = "308fb0fc4810ddd29209d2840cd92c68a5bd005e";
+      sha256 = "0nlww4f8v5w05qz44pw3hdapkfm22gp12733pp634r1hi6ga0kdj";
     };
     meta.homepage = "https://github.com/rmagatti/goto-preview/";
   };
@@ -2387,24 +2387,24 @@ final: prev:
 
   gruvbox-material = buildVimPluginFrom2Nix {
     pname = "gruvbox-material";
-    version = "2021-11-11";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "sainnhe";
       repo = "gruvbox-material";
-      rev = "a25c5294013d58e4fde6b72d94a5f77e3330f0cc";
-      sha256 = "0k4baphl8x6fy8hqidr7g8mw6w1cjhwsgjmsd9v72a9ikl4z22vq";
+      rev = "fb27ccbd20cc1eda04e181f22c722977bdf9c934";
+      sha256 = "0hi99gjirhfcv3l8jay0ay3qk9w2mhv06y6afxvx0jk64wr8mr1q";
     };
     meta.homepage = "https://github.com/sainnhe/gruvbox-material/";
   };
 
   gruvbox-nvim = buildVimPluginFrom2Nix {
     pname = "gruvbox.nvim";
-    version = "2021-11-22";
+    version = "2021-11-29";
     src = fetchFromGitHub {
       owner = "ellisonleao";
       repo = "gruvbox.nvim";
-      rev = "c69b98d5defbe998627be2175e2ce7707fd73dc0";
-      sha256 = "0wha77kmci0923qin5k6ximmfs8pf6viz22h5yl7abc3wi294vzb";
+      rev = "8efd28ff057c24b8179e0ace9e12f57141a7f6b0";
+      sha256 = "0kqal8ddxam5hiczf6pakmx1dxk2zbf32l2hk27jcscj0q7npxc7";
     };
     meta.homepage = "https://github.com/ellisonleao/gruvbox.nvim/";
   };
@@ -2627,12 +2627,12 @@ final: prev:
 
   indent-blankline-nvim = buildVimPluginFrom2Nix {
     pname = "indent-blankline.nvim";
-    version = "2021-11-20";
+    version = "2021-12-01";
     src = fetchFromGitHub {
       owner = "lukas-reineke";
       repo = "indent-blankline.nvim";
-      rev = "caf7f61e94525bbd97e32f118efd6c0722430616";
-      sha256 = "1gdnw6scph18ihkiscyh51lbdaj5m6hlq5wggammpzi7pj2gqmar";
+      rev = "0f8df7e43f0cae4c44e0e8383436ad602f333419";
+      sha256 = "13jqcl54ijdzk3r17fmr2zzzjxn1njwfhipaaxyk7p6qqi1hphgj";
     };
     meta.homepage = "https://github.com/lukas-reineke/indent-blankline.nvim/";
   };
@@ -2928,12 +2928,12 @@ final: prev:
 
   lean-nvim = buildVimPluginFrom2Nix {
     pname = "lean.nvim";
-    version = "2021-11-25";
+    version = "2021-12-01";
     src = fetchFromGitHub {
       owner = "Julian";
       repo = "lean.nvim";
-      rev = "5d23a7a83b1a8ccdbf1b27927172d5fdcbdf0dd5";
-      sha256 = "0p6f8wwiniin1ah1ds2c5n9pq6qmy6hk0f10iil4bim5ng08yvwn";
+      rev = "0283251541b44508cf80a25be660d1a856cbe9de";
+      sha256 = "16nvzgx6h11br4v5vw1sjm0lv84727xlxrfs9zc54whxhs4bscd8";
     };
     meta.homepage = "https://github.com/Julian/lean.nvim/";
   };
@@ -3240,12 +3240,12 @@ final: prev:
 
   luasnip = buildVimPluginFrom2Nix {
     pname = "luasnip";
-    version = "2021-11-28";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "l3mon4d3";
       repo = "luasnip";
-      rev = "e63b58600f91681f744fc180ae13ce2800b5e29a";
-      sha256 = "1sc7v2g1dfw5sls8iddi10w5ba2n7j24k77abarw7y6rwfmnzlrh";
+      rev = "f40a378f969de864289399334017c98875100799";
+      sha256 = "002wwfyiydr9r240c1x9zxs1dgym4zkwv0zk7pm6ivc67287avp9";
     };
     meta.homepage = "https://github.com/l3mon4d3/luasnip/";
   };
@@ -3828,12 +3828,12 @@ final: prev:
 
   neovim-ayu = buildVimPluginFrom2Nix {
     pname = "neovim-ayu";
-    version = "2021-11-23";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "Shatur";
       repo = "neovim-ayu";
-      rev = "3e4d6d427b6353dcf3569ba02abdcf4c6f532621";
-      sha256 = "1gr0476ibsdp3n31xab3wkmfff09f1zgicyizjnbck7lbin1v3xi";
+      rev = "0f203f0b7964170f0dd2610ccb2307dc03d6dffd";
+      sha256 = "1qsr5i2zc7ika9v6b16771lxbyaajciabmyc0n96c4fzgc584h3a";
     };
     meta.homepage = "https://github.com/Shatur/neovim-ayu/";
   };
@@ -4008,12 +4008,12 @@ final: prev:
 
   nord-nvim = buildVimPluginFrom2Nix {
     pname = "nord.nvim";
-    version = "2021-11-07";
+    version = "2021-12-01";
     src = fetchFromGitHub {
       owner = "shaunsingh";
       repo = "nord.nvim";
-      rev = "c9265653e7fbf70326d671b37c7c89e4fa2b8093";
-      sha256 = "0cn8gxzk9l4nmfxr97xrcz8sd0vrzv827mw499nlpai1z8xqj318";
+      rev = "d96e7e3fa955ef89788f4d6e14cdff07a162cf15";
+      sha256 = "0fn3ijhyjdvy4aq12hwgg5mpmh2vfd848bycz0gpifkigmhb1dwj";
     };
     meta.homepage = "https://github.com/shaunsingh/nord.nvim/";
   };
@@ -4056,12 +4056,12 @@ final: prev:
 
   null-ls-nvim = buildVimPluginFrom2Nix {
     pname = "null-ls.nvim";
-    version = "2021-11-26";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "jose-elias-alvarez";
       repo = "null-ls.nvim";
-      rev = "b07ce47f02c7b12ad65bfb4da215c6380228a959";
-      sha256 = "0j9iawg8hv1aqd68k7n22hm6rs0ia862vxvkq3y10b0xiagcvfyr";
+      rev = "357b9a1afedd0d708b48fc1f39fffb92a73840a3";
+      sha256 = "0lfhfri2507mkp8d6klwkhkxi2mdzjywkx910pbc0lmzcvfsprna";
     };
     meta.homepage = "https://github.com/jose-elias-alvarez/null-ls.nvim/";
   };
@@ -4128,12 +4128,12 @@ final: prev:
 
   nvim-bqf = buildVimPluginFrom2Nix {
     pname = "nvim-bqf";
-    version = "2021-11-27";
+    version = "2021-11-29";
     src = fetchFromGitHub {
       owner = "kevinhwang91";
       repo = "nvim-bqf";
-      rev = "d82e784a36160028b245576213100c888be503f0";
-      sha256 = "1y0g2y9fbxy5bq1wp8g36irsjhhvkbkcj6nfmbiaichizsl5zmz8";
+      rev = "eb044199ce46ff597da6efc7d3e4d3bf7e7b17aa";
+      sha256 = "14viwfxiazqc8k1zrabqhwv3yxv1ycvcwk7ql2gpnxp3fak3rp8g";
     };
     meta.homepage = "https://github.com/kevinhwang91/nvim-bqf/";
   };
@@ -4164,12 +4164,12 @@ final: prev:
 
   nvim-cmp = buildVimPluginFrom2Nix {
     pname = "nvim-cmp";
-    version = "2021-11-27";
+    version = "2021-12-01";
     src = fetchFromGitHub {
       owner = "hrsh7th";
       repo = "nvim-cmp";
-      rev = "092fb66b6ddb4b12b9b542d105d7af40e4fbd9f2";
-      sha256 = "0fa4y4zyrg6amsfjivs9zb9wlh1zlcjmh7va8mbghccmi72lpl92";
+      rev = "a61c36a639a1662a5d27b1a88086b9c91d7d49a8";
+      sha256 = "0a8b9i7sg71hw25r3k1g7niajp3x4qivb33i14gi991p87mdnmfq";
     };
     meta.homepage = "https://github.com/hrsh7th/nvim-cmp/";
   };
@@ -4248,12 +4248,12 @@ final: prev:
 
   nvim-dap-ui = buildVimPluginFrom2Nix {
     pname = "nvim-dap-ui";
-    version = "2021-11-27";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "rcarriga";
       repo = "nvim-dap-ui";
-      rev = "052f3424daba36984f506de80532121b01e07ff5";
-      sha256 = "076qrh2jskqfbpr31bmp9l3l855659p4j6yd4mmzm71xwv020049";
+      rev = "a5183531c2b29199a8a0ad0187697ee7c9cdcee2";
+      sha256 = "0hvj2jknbr87fg14hnm28l3gpccpgkhf7czsjvi5qjqi1bi3s12j";
     };
     meta.homepage = "https://github.com/rcarriga/nvim-dap-ui/";
   };
@@ -4308,24 +4308,24 @@ final: prev:
 
   nvim-highlite = buildVimPluginFrom2Nix {
     pname = "nvim-highlite";
-    version = "2021-11-24";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "Iron-E";
       repo = "nvim-highlite";
-      rev = "b9bbef6204bbb143d45fd457a07f211cb38f9679";
-      sha256 = "19r828px9ix31ai0ydxqi7ymp4cpabk23ligglnki4pc34bhw55q";
+      rev = "639c167541202fcbf41ed5cec619ce0fcf1d5ab8";
+      sha256 = "1dcwbzw6rfh5h2yxl17jy5szqp2fmjcss3sfcznis1ccdggh9wnr";
     };
     meta.homepage = "https://github.com/Iron-E/nvim-highlite/";
   };
 
   nvim-hlslens = buildVimPluginFrom2Nix {
     pname = "nvim-hlslens";
-    version = "2021-11-22";
+    version = "2021-12-01";
     src = fetchFromGitHub {
       owner = "kevinhwang91";
       repo = "nvim-hlslens";
-      rev = "8aa60ec837eb40689ff1f67e050bd8662202d5be";
-      sha256 = "1vjjn1kh4gflp1r97ix7rs4frlk8w9z0k0vfyif0pzl24f8dsvxq";
+      rev = "2e2a5f041cb5a9acf3e6ae61735b32fa877ae69e";
+      sha256 = "0swrx2ipcxd01df0aplm3066mvy2ad9mj07cybgz4g1qh5f7mpim";
     };
     meta.homepage = "https://github.com/kevinhwang91/nvim-hlslens/";
   };
@@ -4392,12 +4392,12 @@ final: prev:
 
   nvim-lspconfig = buildVimPluginFrom2Nix {
     pname = "nvim-lspconfig";
-    version = "2021-11-28";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "neovim";
       repo = "nvim-lspconfig";
-      rev = "d9aa848da3905e0f8153e546d7b630d3d13e0435";
-      sha256 = "16j5xk75vbi7gdw822dc1xr0a3wlr5b1fimm8d8h5naydx5fvpfc";
+      rev = "622b155fb608d5366658de12a08b3050f5ca5772";
+      sha256 = "0sadswm4bywsr4vznknqpdzq00jb5zdk1b3gv2g5m938y417pim7";
     };
     meta.homepage = "https://github.com/neovim/nvim-lspconfig/";
   };
@@ -4428,12 +4428,12 @@ final: prev:
 
   nvim-notify = buildVimPluginFrom2Nix {
     pname = "nvim-notify";
-    version = "2021-11-28";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "rcarriga";
       repo = "nvim-notify";
-      rev = "9ac4202ed3c5afa92498b83dd28dcde19576ab1f";
-      sha256 = "0ic4vicm7a63h7gs4w4fz2fg4clkd4q1zag7kdklwg7qyrdnacn9";
+      rev = "36012703049bc7be9d4de97cb96c6d17ccf978cd";
+      sha256 = "0gv3czqrcbbyvcvhz3lb0xzyc2agxf20wgc0mxwsvcn9339ymzmw";
     };
     meta.homepage = "https://github.com/rcarriga/nvim-notify/";
   };
@@ -4452,12 +4452,12 @@ final: prev:
 
   nvim-scrollview = buildVimPluginFrom2Nix {
     pname = "nvim-scrollview";
-    version = "2021-10-09";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "dstein64";
       repo = "nvim-scrollview";
-      rev = "fb35d9d7b52985baac5d77ec52d6b6b35403fb8a";
-      sha256 = "013gmwrcanvsa95jgl4xd5agci7j05w9yvqayns83gxbsbl7bsjs";
+      rev = "b962a67f6bb5ac7c415003748f2088b522ca4390";
+      sha256 = "1krj8jjd5x0f5bfzhhasxisp6kxf0jq5nilx5ik4fl6az3p5q2za";
     };
     meta.homepage = "https://github.com/dstein64/nvim-scrollview/";
   };
@@ -4512,12 +4512,12 @@ final: prev:
 
   nvim-treesitter = buildVimPluginFrom2Nix {
     pname = "nvim-treesitter";
-    version = "2021-09-17";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "nvim-treesitter";
       repo = "nvim-treesitter";
-      rev = "47cfda2c6711077625c90902d7722238a8294982";
-      sha256 = "14di7qm37m176r0qsbb0vmc3csya72rd5bszm6yk7lby8izfnqxa";
+      rev = "8d1547f0bcd0831876678eeb238c3ba9a528189b";
+      sha256 = "141ns7ap27v1ybly2jbpp4qi1p1m1g9cfja545iyb1x1936wzcya";
     };
     meta.homepage = "https://github.com/nvim-treesitter/nvim-treesitter/";
   };
@@ -4560,12 +4560,12 @@ final: prev:
 
   nvim-treesitter-textobjects = buildVimPluginFrom2Nix {
     pname = "nvim-treesitter-textobjects";
-    version = "2021-11-26";
+    version = "2021-11-27";
     src = fetchFromGitHub {
       owner = "nvim-treesitter";
       repo = "nvim-treesitter-textobjects";
-      rev = "380561ee746eac6791d148c6de459f4d92b2fa33";
-      sha256 = "08sy36gd3bdz3s69dxlck2a8952cn0gdvb3i3dppm0skjz8d353f";
+      rev = "6311b7eeebad214747018a95896f53f0c2485ef0";
+      sha256 = "0ndb3hmyr0vrg25178rpbwby7zzjfda5bw63ix5d9b77zk6896ab";
     };
     meta.homepage = "https://github.com/nvim-treesitter/nvim-treesitter-textobjects/";
   };
@@ -4704,12 +4704,12 @@ final: prev:
 
   onedarkpro-nvim = buildVimPluginFrom2Nix {
     pname = "onedarkpro.nvim";
-    version = "2021-11-25";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "olimorris";
       repo = "onedarkpro.nvim";
-      rev = "4ea622fb56fc0df026e12c768f761bb832bba02d";
-      sha256 = "0684q3h3arzcm4m33gxskc96jc5g6y4kdqzzh75hxq0bilfdvy63";
+      rev = "d644c85b0193a76c86fe591e378329987f984661";
+      sha256 = "19rw1n01qlfil6i2c0m1md12dql6caplx7apqxbgnwxbbawc4ps1";
     };
     meta.homepage = "https://github.com/olimorris/onedarkpro.nvim/";
   };
@@ -4776,12 +4776,12 @@ final: prev:
 
   packer-nvim = buildVimPluginFrom2Nix {
     pname = "packer.nvim";
-    version = "2021-11-03";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "wbthomason";
       repo = "packer.nvim";
-      rev = "7f62848f3a92eac61ae61def5f59ddb5e2cc6823";
-      sha256 = "1sgrwm271pnvw9anl1y8x94bz0w7qvi3bdiqh1wpwvsqic73frq3";
+      rev = "db3c3e3379613443d94e677a6ac3f61278e36e47";
+      sha256 = "0zn6a11j2fp8lmc6kkkmi5nmz4xmrnrymdxpzrxmq8a5iw9cg2bg";
     };
     meta.homepage = "https://github.com/wbthomason/packer.nvim/";
   };
@@ -5329,12 +5329,12 @@ final: prev:
 
   SchemaStore-nvim = buildVimPluginFrom2Nix {
     pname = "SchemaStore.nvim";
-    version = "2021-11-19";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "b0o";
       repo = "SchemaStore.nvim";
-      rev = "a522e1d4affddefd824daefcfe42a7e2cab6626f";
-      sha256 = "1h5q33b6bgmj9zf7fm5kbx95gp49jcn8af9rm5jn5bc0b3l7nzls";
+      rev = "cdf9fd7a8cb41ad89e8f7dcccdd4a79d186f1f54";
+      sha256 = "18irbz0lcg6a8iv7qpyzjssk7j7fvw57jwn9c4w59k5h53yhz0kq";
     };
     meta.homepage = "https://github.com/b0o/SchemaStore.nvim/";
   };
@@ -5546,12 +5546,12 @@ final: prev:
 
   sonokai = buildVimPluginFrom2Nix {
     pname = "sonokai";
-    version = "2021-11-11";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "sainnhe";
       repo = "sonokai";
-      rev = "30dd4ae6f844ab0f53ba93eea61068f87886eb03";
-      sha256 = "0hwcar6c6n3fvli9pmx1ycvk4128f47hl07c7y7hxzy2rks7s3j8";
+      rev = "563280b529405e86464ce0554872f7dc6b6c3f92";
+      sha256 = "0syhr5a8jmzv1bv9zpmbqzblpgva6cxgnxkifpd9xvsy63dd0q96";
     };
     meta.homepage = "https://github.com/sainnhe/sonokai/";
   };
@@ -5679,12 +5679,12 @@ final: prev:
 
   srcery-vim = buildVimPluginFrom2Nix {
     pname = "srcery-vim";
-    version = "2021-11-17";
+    version = "2021-11-29";
     src = fetchFromGitHub {
       owner = "srcery-colors";
       repo = "srcery-vim";
-      rev = "3d86afaa61aa45ca8d849494d9f8ceb5fc424353";
-      sha256 = "16wx3wgmrslpsm1h5fskik2lkas390fj2gjz3vwii4c5mz2ijr9m";
+      rev = "fca1c02b29d5f54f063122270f3e5ea8777ca958";
+      sha256 = "0a5rra4al18m3f175awz118gilg3cqx8i3k1mr0657n5hvkxbs9d";
     };
     meta.homepage = "https://github.com/srcery-colors/srcery-vim/";
   };
@@ -6089,12 +6089,12 @@ final: prev:
 
   telescope-nvim = buildVimPluginFrom2Nix {
     pname = "telescope.nvim";
-    version = "2021-11-28";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "nvim-telescope";
       repo = "telescope.nvim";
-      rev = "ed4adba6d0083a14cabf5837f2511b2617a45593";
-      sha256 = "1ippixq77irl2dslnf4if31v59ij6ycij0bbl6q1ghpvkqkryd81";
+      rev = "ef245548a858690fa8f2db1f1a0eaf41b93a6ef6";
+      sha256 = "1fsbd4cjc13f1mylpg7i4rdsqj2y4ib2kzph91xnnjf6zsi6bmp0";
     };
     meta.homepage = "https://github.com/nvim-telescope/telescope.nvim/";
   };
@@ -6246,12 +6246,12 @@ final: prev:
 
   tokyonight-nvim = buildVimPluginFrom2Nix {
     pname = "tokyonight.nvim";
-    version = "2021-10-22";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "folke";
       repo = "tokyonight.nvim";
-      rev = "2981e4bd0919305675d8d665f9a20281bb33ed06";
-      sha256 = "15kv5g1srqsayryf3x469sl2bgaq69ni31imp7yi7dfvmzlxf6q1";
+      rev = "3cbf86cf045ea19253f9c8614863e22beb531868";
+      sha256 = "0b5r1nsb9gllg75gqr27jj8ksmd42lzfv6alk60fqw6l98avvzr3";
     };
     meta.homepage = "https://github.com/folke/tokyonight.nvim/";
   };
@@ -6462,12 +6462,12 @@ final: prev:
 
   vifm-vim = buildVimPluginFrom2Nix {
     pname = "vifm.vim";
-    version = "2021-11-17";
+    version = "2021-12-01";
     src = fetchFromGitHub {
       owner = "vifm";
       repo = "vifm.vim";
-      rev = "31c80d4f77056e89cabd9ea3e617feea076499f8";
-      sha256 = "0p64fr5l5khs4p7d677zkjq6j81mxkh5aailzk9jr82q5sskv3wf";
+      rev = "a737e93a97254681473313a606c66cc810291a87";
+      sha256 = "0b59rhngw1xwv0pccwsql7gyrmj55b7c4bkighqkk3kd0mbqy4qh";
     };
     meta.homepage = "https://github.com/vifm/vifm.vim/";
   };
@@ -6978,12 +6978,12 @@ final: prev:
 
   vim-buffergator = buildVimPluginFrom2Nix {
     pname = "vim-buffergator";
-    version = "2018-05-02";
+    version = "2021-11-28";
     src = fetchFromGitHub {
       owner = "jeetsukumaran";
       repo = "vim-buffergator";
-      rev = "947b60dca4d4fc6a041a6ec84b17ca6736d1b916";
-      sha256 = "0g7ymflzfdsj5793s32gc83bidqys5dxmw455viwpqgmgjxnar5c";
+      rev = "0514af606a3b41bbe82c33875179b53300a3cb86";
+      sha256 = "1g1g2agj9dzgrk6ccr4ampyrsqjs4j6gqmvv75avq7q068glglzz";
     };
     meta.homepage = "https://github.com/jeetsukumaran/vim-buffergator/";
   };
@@ -7458,12 +7458,12 @@ final: prev:
 
   vim-dispatch = buildVimPluginFrom2Nix {
     pname = "vim-dispatch";
-    version = "2021-11-25";
+    version = "2021-11-27";
     src = fetchFromGitHub {
       owner = "tpope";
       repo = "vim-dispatch";
-      rev = "9d8b2327bc7054fcc81fcdc6e8e94639a63f9b25";
-      sha256 = "1hwcp6kz7hb0fawdb59ppg852zw2hjvmx9l9mh92b0zq72h7rq9w";
+      rev = "f2ae53daaab394dfe3ffe5a0d8a80420f46d81c7";
+      sha256 = "1yrmxpy9dfzgrjqfzzprz2layrcz45a2hf9yzxd3q76gr5qmf1kx";
     };
     meta.homepage = "https://github.com/tpope/vim-dispatch/";
   };
@@ -7938,12 +7938,12 @@ final: prev:
 
   vim-git = buildVimPluginFrom2Nix {
     pname = "vim-git";
-    version = "2021-11-26";
+    version = "2021-11-28";
     src = fetchFromGitHub {
       owner = "tpope";
       repo = "vim-git";
-      rev = "ca5c6d07d23573c7ed0ef85d891c86d45545a6fc";
-      sha256 = "18f1i10r8hqldl0d00p102niwn0pz7dfbnwx0hyhhjrv109pcjv3";
+      rev = "56285b71871e16e214480042c729b12d193f3537";
+      sha256 = "1z9gp8ljrh1vwwq461h2kdf4bgg7nkjpi5nd3y7g3f850glph293";
     };
     meta.homepage = "https://github.com/tpope/vim-git/";
   };
@@ -8672,12 +8672,12 @@ final: prev:
 
   vim-liquid = buildVimPluginFrom2Nix {
     pname = "vim-liquid";
-    version = "2021-09-24";
+    version = "2021-11-28";
     src = fetchFromGitHub {
       owner = "tpope";
       repo = "vim-liquid";
-      rev = "dd5243a34e97c15e1a128b6ec440a0368e583900";
-      sha256 = "0kn4w2i83fwhjcpmj1zym9hr4lvl27vcl0f1cz3n3lv3jhr7g7zg";
+      rev = "fd2f0017fbc50f214db2f57c207c34cda3aa1522";
+      sha256 = "1z9bmcx13py56phr8djdnykw3a933chhv6ypcfigkjp6cyqkj1mc";
     };
     meta.homepage = "https://github.com/tpope/vim-liquid/";
   };
@@ -8732,12 +8732,12 @@ final: prev:
 
   vim-lsp = buildVimPluginFrom2Nix {
     pname = "vim-lsp";
-    version = "2021-11-02";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "prabirshrestha";
       repo = "vim-lsp";
-      rev = "0c8a35d899202f7a7d94aefd290f3c7a1590e9c5";
-      sha256 = "02h2z8j1w083hjvgafxrclz0a1r2q4lrsc56yllswpk8yq1x30pb";
+      rev = "a91419ea0ace6f791a43e0697946599fe7a9ae60";
+      sha256 = "0rs3f8nfw8qyhl61y56qv7k96l0wprybx56bdbhqpjzan0ir3ci6";
     };
     meta.homepage = "https://github.com/prabirshrestha/vim-lsp/";
   };
@@ -8841,12 +8841,12 @@ final: prev:
 
   vim-matchup = buildVimPluginFrom2Nix {
     pname = "vim-matchup";
-    version = "2021-11-24";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "andymass";
       repo = "vim-matchup";
-      rev = "2c3227b3de50d248ad6c8900b3e12f1dd21994ac";
-      sha256 = "129bqyg611swh9rhahvfybc9n0wdrgkknk0b2bx1zx634078n9x8";
+      rev = "ef044ee012baa01d6f4ad79a04eeb5edb5bc7d84";
+      sha256 = "19hfg4ihx36rs14mcmr60s6mk1v28db2aba2w44cnisq4mm6y4qy";
     };
     meta.homepage = "https://github.com/andymass/vim-matchup/";
   };
@@ -9753,12 +9753,12 @@ final: prev:
 
   vim-sandwich = buildVimPluginFrom2Nix {
     pname = "vim-sandwich";
-    version = "2021-11-28";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "machakann";
       repo = "vim-sandwich";
-      rev = "17eb132421e7e4915a2b9b67c1034ee4581fb13a";
-      sha256 = "1cvm31iaqlmwvyrx3lb3gkky70zsn3h1b1z1vicr96sn0hqp903q";
+      rev = "cfe8b70e4f404e3bbb9d4e97e082a4294a5762a4";
+      sha256 = "0mcx85knnfmyjz0lbz6zbrv6gry8d9bp2z21af7riz93g7zi01z7";
     };
     meta.homepage = "https://github.com/machakann/vim-sandwich/";
   };
@@ -10426,12 +10426,12 @@ final: prev:
 
   vim-tpipeline = buildVimPluginFrom2Nix {
     pname = "vim-tpipeline";
-    version = "2021-11-12";
+    version = "2021-12-01";
     src = fetchFromGitHub {
       owner = "vimpostor";
       repo = "vim-tpipeline";
-      rev = "be9cd2c8cd007088f69019f18fb61aff457adb8c";
-      sha256 = "1r2wvkgziil4bik3g7b19cscg17skhx98pgsvm2m00czrrfdxq6v";
+      rev = "109fd94dcb15a37a21735ac458071ab2dfacd4f3";
+      sha256 = "1s1xk9wvcznj2sffdfkwr599jypyrsjmqs93lgxiq224sj2161j9";
     };
     meta.homepage = "https://github.com/vimpostor/vim-tpipeline/";
   };
@@ -10486,12 +10486,12 @@ final: prev:
 
   vim-ultest = buildVimPluginFrom2Nix {
     pname = "vim-ultest";
-    version = "2021-11-28";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "rcarriga";
       repo = "vim-ultest";
-      rev = "30738e5101a3070e622c33c7ca2a026c5cf1a7ad";
-      sha256 = "0lxv56668rbd104l0q8pzf2wlwffzvp2w4zxis790p2rivqaaasf";
+      rev = "f925585c8cd6d062b62ba94cd0a4d9bc1d61844c";
+      sha256 = "0mz721biz6yqipy5c3ab1aqmacs1kn5glv10jlj0sdmzwjziqrgi";
     };
     meta.homepage = "https://github.com/rcarriga/vim-ultest/";
   };
@@ -10906,12 +10906,12 @@ final: prev:
 
   vimspector = buildVimPluginFrom2Nix {
     pname = "vimspector";
-    version = "2021-11-24";
+    version = "2021-11-29";
     src = fetchFromGitHub {
       owner = "puremourning";
       repo = "vimspector";
-      rev = "93ccc361334c4de1095a9a2b59d3a212d227e3e0";
-      sha256 = "079pg4nabj6q7kkv3wv73998zvyhwsqfkn8c12y84h664l460265";
+      rev = "49ad167416e58bdfadc181e3cc225683c8a82851";
+      sha256 = "0hqc0jpgm1z9qm25fzk5ygjr6467jw9bf9iigv78g505qp4g3l8z";
       fetchSubmodules = true;
     };
     meta.homepage = "https://github.com/puremourning/vimspector/";
@@ -10919,12 +10919,12 @@ final: prev:
 
   vimtex = buildVimPluginFrom2Nix {
     pname = "vimtex";
-    version = "2021-11-24";
+    version = "2021-11-30";
     src = fetchFromGitHub {
       owner = "lervag";
       repo = "vimtex";
-      rev = "d9e05f5e8010ce43670d19655058a6dc8cad300e";
-      sha256 = "1a79qsyv7j269vlnm0b81x07p8c5dwxwyq7bqal3cm0ifsmy78w7";
+      rev = "3e079a1a35235847c6d767df5709fc246a2f05f8";
+      sha256 = "04zrll1lk93yxcalygdp1iry85jp5jrsplkh40d50kgz4mkl5nf2";
     };
     meta.homepage = "https://github.com/lervag/vimtex/";
   };

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -558,8 +558,8 @@ nvim-telescope/telescope-z.nvim@main
 nvim-telescope/telescope.nvim
 nvim-treesitter/completion-treesitter
 nvim-treesitter/nvim-treesitter-refactor
-nvim-treesitter/nvim-treesitter-textobjects@0.5-compat
-nvim-treesitter/nvim-treesitter@0.5-compat
+nvim-treesitter/nvim-treesitter-textobjects
+nvim-treesitter/nvim-treesitter
 nvim-treesitter/playground
 oberblastmeister/neuron.nvim
 oberblastmeister/termwrapper.nvim


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The usage of `0.5-compat` branch is no longer needed per #148040.

Tested via `neovim`.

###### Things done

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>63 packages built:</summary>
  <ul>
    <li>spacevim</li>
    <li>vimPlugins.SchemaStore-nvim</li>
    <li>vimPlugins.aerial-nvim</li>
    <li>vimPlugins.aurora</li>
    <li>vimPlugins.chadtree</li>
    <li>vimPlugins.cmp-cmdline</li>
    <li>vimPlugins.cmp-omni</li>
    <li>vimPlugins.cmp-path</li>
    <li>vimPlugins.cmp-tabnine</li>
    <li>vimPlugins.compe-tmux</li>
    <li>vimPlugins.completion-treesitter</li>
    <li>vimPlugins.crates-nvim</li>
    <li>vimPlugins.deol-nvim</li>
    <li>vimPlugins.diffview-nvim</li>
    <li>vimPlugins.edge</li>
    <li>vimPlugins.git-worktree-nvim</li>
    <li>vimPlugins.gitlinker-nvim</li>
    <li>vimPlugins.gitsigns-nvim</li>
    <li>vimPlugins.goto-preview</li>
    <li>vimPlugins.gruvbox-material</li>
    <li>vimPlugins.gruvbox-nvim</li>
    <li>vimPlugins.indent-blankline-nvim</li>
    <li>vimPlugins.lean-nvim</li>
    <li>vimPlugins.luasnip</li>
    <li>vimPlugins.neovim-ayu</li>
    <li>vimPlugins.nord-nvim</li>
    <li>vimPlugins.null-ls-nvim</li>
    <li>vimPlugins.nvim-bqf</li>
    <li>vimPlugins.nvim-cmp</li>
    <li>vimPlugins.nvim-dap-ui</li>
    <li>vimPlugins.nvim-highlite</li>
    <li>vimPlugins.nvim-hlslens</li>
    <li>vimPlugins.nvim-lspconfig</li>
    <li>vimPlugins.nvim-notify</li>
    <li>vimPlugins.nvim-scrollview</li>
    <li>vimPlugins.nvim-treesitter</li>
    <li>vimPlugins.nvim-treesitter-textobjects</li>
    <li>vimPlugins.onedarkpro-nvim</li>
    <li>vimPlugins.packer-nvim</li>
    <li>vimPlugins.refactoring-nvim</li>
    <li>vimPlugins.sonokai</li>
    <li>vimPlugins.srcery-vim</li>
    <li>vimPlugins.telescope-cheat-nvim</li>
    <li>vimPlugins.telescope-frecency-nvim</li>
    <li>vimPlugins.telescope-fzf-native-nvim</li>
    <li>vimPlugins.telescope-fzf-writer-nvim</li>
    <li>vimPlugins.telescope-fzy-native-nvim</li>
    <li>vimPlugins.telescope-nvim</li>
    <li>vimPlugins.telescope-symbols-nvim</li>
    <li>vimPlugins.telescope-z-nvim</li>
    <li>vimPlugins.tokyonight-nvim</li>
    <li>vimPlugins.vifm-vim</li>
    <li>vimPlugins.vim-buffergator</li>
    <li>vimPlugins.vim-dispatch</li>
    <li>vimPlugins.vim-git</li>
    <li>vimPlugins.vim-liquid</li>
    <li>vimPlugins.vim-lsp</li>
    <li>vimPlugins.vim-matchup</li>
    <li>vimPlugins.vim-sandwich</li>
    <li>vimPlugins.vim-tpipeline</li>
    <li>vimPlugins.vim-ultest</li>
    <li>vimPlugins.vimspector</li>
    <li>vimPlugins.vimtex</li>
  </ul>
</details>


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
