### PR TITLE
xmonad_0_17_0: add @ento's updated xmonad nix compatibility patch

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -223,6 +223,7 @@ self: super: builtins.intersectAttrs super {
 
   # Nix-specific workaround
   xmonad = appendPatch ./patches/xmonad-nix.patch (dontCheck super.xmonad);
+  xmonad_0_17_0 = appendPatch ./patches/xmonad_0_17_0-nix.patch (super.xmonad_0_17_0);
 
   # wxc supports wxGTX >= 3.0, but our current default version points to 2.8.
   # http://hydra.cryp.to/build/1331287/log/raw

--- a/pkgs/development/haskell-modules/patches/xmonad_0_17_0-nix.patch
+++ b/pkgs/development/haskell-modules/patches/xmonad_0_17_0-nix.patch
@@ -1,0 +1,34 @@
+diff --git a/src/XMonad/Core.hs b/src/XMonad/Core.hs
+index 46a0939..92af53d 100644
+--- a/src/XMonad/Core.hs
++++ b/src/XMonad/Core.hs
+@@ -46,6 +46,7 @@ import Data.Traversable (for)
+ import Data.Time.Clock (UTCTime)
+ import Data.Default.Class
+ import Data.List (isInfixOf)
++import System.Environment (lookupEnv)
+ import System.FilePath
+ import System.IO
+ import System.Info
+@@ -458,7 +459,8 @@ xfork x = io . forkProcess . finally nullStdin $ do
+ -- | Use @xmessage@ to show information to the user.
+ xmessage :: MonadIO m => String -> m ()
+ xmessage msg = void . xfork $ do
+-    executeFile "xmessage" True
++    xmessageBin <- fromMaybe "xmessage" <$> liftIO (lookupEnv "XMONAD_XMESSAGE")
++    executeFile xmessageBin True
+         [ "-default", "okay"
+         , "-xrm", "*international:true"
+         , "-xrm", "*fontSet:-*-fixed-medium-r-normal-*-18-*-*-*-*-*-*-*,-*-fixed-*-*-*-*-18-*-*-*-*-*-*-*,-*-*-*-*-*-*-18-*-*-*-*-*-*-*"
+@@ -654,8 +656,9 @@ compile dirs method =
+         bracket (openFile (errFileName dirs) WriteMode) hClose $ \err -> do
+             let run = runProc (cfgDir dirs) err
+             case method of
+-                CompileGhc ->
+-                    run "ghc" ghcArgs
++                CompileGhc -> do
++                    ghc <- fromMaybe "ghc" <$> (lookupEnv "NIX_GHC")
++                    run ghc ghcArgs
+                 CompileStackGhc stackYaml ->
+                     run "stack" ["build", "--silent", "--stack-yaml", stackYaml] .&&.
+                     run "stack" ("ghc" : "--stack-yaml" : stackYaml : "--" : ghcArgs)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This patch is the [existing patch](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/patches/xmonad-nix.patch) for 0.15.0 updated for 0.17.0. It allows xmonad_0_17_0 to find GHC (and xmessage), and thus recompile itself. Without this, the home-manager module doesn't work properly for example.

Thanks to @ento for updating this patch! All credit goes to him:
https://discourse.nixos.org/t/use-latest-version-of-xmonad-0-17-0/16191/5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
