### PR TITLE
gitflow: embed path to coreutils into the wrapper

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/gitflow/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitflow/default.nix
@@ -22,7 +22,8 @@ stdenv.mkDerivation rec {
   postInstall = ''
     wrapProgram $out/bin/git-flow \
       --set FLAGS_GETOPT_CMD ${pkgs.getopt}/bin/getopt \
-      --suffix PATH : ${pkgs.git}/bin
+      --suffix PATH : ${pkgs.git}/bin \
+      --prefix PATH : ${pkgs.coreutils}/bin
   '';
 
   meta = with lib; {


### PR DESCRIPTION
gitflow is shell script and does not work without common tools (e.g readlink)
in PATH or with busybox instead of coreutils.

Busybox version of readlink does not support "-e" option. Probably it can be
replaced with "-f", but I didn't check.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
