### PR TITLE
env-lscolors: init at unstable-2021-07-27

### DIFF
--- a/pkgs/tools/misc/env-lscolors/default.nix
+++ b/pkgs/tools/misc/env-lscolors/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation {
+  pname = "env-lscolors";
+  version = "unstable-2022-05-05"; # upstream don't do releases
+
+  src = fetchFromGitHub {
+    owner = "trapd00r";
+    repo = "LS_COLORS";
+    rev = "7271a7a8135c1e8a82584bfc9a8ebc227c5c6b2b";
+    sha256 = "0gs2qmdxvvgs5ck2j8b6i8dqc5q91m8xrvc2ajvlhcr7in0n9iw5";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/lscolors
+    cp LS_COLORS $out/share/lscolors/LS_COLORS
+    dircolors -b LS_COLORS > $out/share/lscolors/lscolors.sh
+  '';
+
+  meta = with lib; {
+    description = "Coloring configuration for GNU ls for many filetypes";
+    homepage = "https://github.com/trapd00r/LS_COLORS";
+    license = licenses.artistic2;
+    maintainers = with maintainers; [ kaction ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3746,6 +3746,8 @@ with pkgs;
 
   envsubst = callPackage ../tools/misc/envsubst { };
 
+  env-lscolors = callPackage ../tools/misc/env-lscolors { };
+
   er-patcher = callPackage ../tools/games/er-patcher { };
 
   errcheck = callPackage ../development/tools/errcheck { };


### PR DESCRIPTION
This derivation builds value of LS_COLORS environment variable that makes GNU
ls (and some other tools) to highlight different files (distinguished by
extension) with different colors. 256 color terminal is required.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
