### PR TITLE
mfcj470dw-cupswrapper: fixed issue #147793

### DIFF
--- a/pkgs/misc/cups/drivers/mfcj470dwcupswrapper/default.nix
+++ b/pkgs/misc/cups/drivers/mfcj470dwcupswrapper/default.nix
@@ -21,8 +21,7 @@ stdenv.mkDerivation rec {
     --replace /etc "$out/etc"
 
     substituteInPlace $WRAPPER \
-    --replace "\`cp " "\`cp -p " \
-    --replace "\`mv " "\`cp -p "
+    --replace "cp " "cp -p "
     '';
 
   buildPhase = ''
@@ -33,11 +32,18 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     TARGETFOLDER=$out/opt/brother/Printers/mfcj470dw/cupswrapper/
-    mkdir -p $out/opt/brother/Printers/mfcj470dw/cupswrapper/
+    PPDFOLDER=$out/share/cups/model/
+    FILTERFOLDER=$out/lib/cups/filter/
+
+    mkdir -p $TARGETFOLDER
+    mkdir -p $PPDFOLDER
+    mkdir -p $FILTERFOLDER
 
     cp brcupsconfpt1/brcupsconfpt1 $TARGETFOLDER
-    cp cupswrapper/cupswrappermfcj470dw $TARGETFOLDER/
-    cp PPD/brother_mfcj470dw_printer_en.ppd $TARGETFOLDER/
+    cp cupswrapper/cupswrappermfcj470dw $TARGETFOLDER
+    cp PPD/brother_mfcj470dw_printer_en.ppd $PPDFOLDER
+
+    ln -s ${mfcj470dwlpr}/lib/cups/filter/brother_lpdwrapper_mfcj470dw $FILTERFOLDER/
     '';
 
   cleanPhase = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Closes #147793 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Tested on Linux x86_64 unstable, added the printer, it now shows up as expected by @mayl. Printed one page.