### PR TITLE
morgen: init at 2.4.3

### DIFF
--- a/pkgs/applications/office/morgen/default.nix
+++ b/pkgs/applications/office/morgen/default.nix
@@ -1,0 +1,59 @@
+{ lib, stdenv, fetchurl, dpkg, autoPatchelfHook, makeWrapper, electron
+, nodePackages, alsa-lib, gtk3, libxshmfence, mesa, nss }:
+
+stdenv.mkDerivation rec {
+  pname = "morgen";
+  version = "2.4.3";
+
+  src = fetchurl {
+    url = "https://download.todesktop.com/210203cqcj00tw1/morgen-${version}.deb";
+    sha256 = "sha256-IWGeb0+IiFNYJ+jQAzGYfQ5FnrbR6HIpynS9jgd5/mY=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    makeWrapper
+    nodePackages.asar
+  ];
+
+  buildInputs = [ alsa-lib gtk3 libxshmfence mesa nss ];
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  unpackCmd = ''
+    dpkg-deb -x ${src} ./morgen-${pname}
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mv usr $out
+    mv opt $out
+
+    asar extract $out/opt/Morgen/resources/app.asar "$TMP/work"
+    # 1. Fixes path for todesktop-runtime-config.json
+    # 2. Fixes startup script
+    substituteInPlace $TMP/work/dist/main.js \
+      --replace "process.resourcesPath,\"todesktop-runtime-config.json" "\"$out/opt/Morgen/resources/todesktop-runtime-config.json" \
+      --replace "Exec=\"+process.execPath+\"" "Exec=$out/bin/morgen"
+    asar pack --unpack='{*.node,*.ftz,rect-overlay}' "$TMP/work" $out/opt/Morgen/resources/app.asar
+
+    substituteInPlace $out/share/applications/morgen.desktop \
+      --replace '/opt/Morgen' $out/bin
+
+    makeWrapper ${electron}/bin/electron $out/bin/morgen \
+      --add-flags $out/opt/Morgen/resources/app.asar
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "All-in-one Calendars, Tasks and Scheduler";
+    homepage = "https://morgen.so/download";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ wolfangaukang ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7696,6 +7696,10 @@ with pkgs;
 
   mole = callPackage ../tools/networking/mole { };
 
+  morgen = callPackage ../applications/office/morgen {
+    electron = electron_15;
+  };
+
   mosh = callPackage ../tools/networking/mosh { };
 
   mpage = callPackage ../tools/text/mpage { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#131496

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
