### PR TITLE
passky-desktop: init at 5.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -417,6 +417,16 @@
     github = "akho";
     githubId = 104951;
   };
+  akkesm = {
+    name = "Alessandro Barenghi";
+    email = "alessandro.barenghi@tuta.io";
+    github = "akkesm";
+    githubId = 56970006;
+    keys = [{
+      longkeyid = "ed25519/0x0D6BFC01D45EDADD";
+      fingerprint = "50E2 669C AB38 2F4A 5F72  1667 0D6B FC01 D45E DADD";
+    }];
+  };
   akru = {
     email = "mail@akru.me";
     github = "akru";

--- a/pkgs/applications/misc/passky-desktop/default.nix
+++ b/pkgs/applications/misc/passky-desktop/default.nix
@@ -1,0 +1,59 @@
+{ lib, stdenv, fetchurl, appimageTools, undmg }:
+
+let
+  pname = "passky-desktop";
+  version = "5.0.0";
+
+  srcs = {
+    x86_64-linux = fetchurl {
+      url = "https://github.com/Rabbit-Company/Passky-Desktop/releases/download/v${version}/Passky-${version}.AppImage";
+      sha256 = "19sy9y2bcxrf10ifszinh4yn32q3032h3d1qxm046zffzl069807";
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://github.com/Rabbit-Company/Passky-Desktop/releases/download/v${version}/Passky-${version}.dmg";
+      sha256 = "sha256-lclJOaYe+2XeKhJb2WcOAzjBMzK3YEmlS4rXuRUJYU0=";
+    };
+  };
+  src = srcs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  appimageContents = appimageTools.extract { inherit pname version src; };
+  meta = with lib; {
+    homepage = "https://passky.org";
+    downloadPage = "https://github.com/Rabbit-Company/Passky-Desktop/releases";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ akkesm ];
+    platforms = builtins.attrNames srcs;
+  };
+
+  linux = appimageTools.wrapType2 {
+    inherit pname version src meta;
+
+    extraInstallCommands = ''
+      mv $out/bin/${pname}-${version} $out/bin/${pname}
+
+      install -D ${appimageContents}/passky.desktop \
+        $out/share/applications/${pname}.desktop
+
+      substituteInPlace $out/share/applications/${pname}.desktop \
+        --replace 'Exec=AppRun' 'Exec=${pname}'
+
+      cp -r ${appimageContents}/usr/share/icons $out/share
+    '';
+  };
+
+  darwin = stdenv.mkDerivation {
+    inherit pname version src meta;
+
+    nativeBuildInputs = [ undmg ];
+
+    sourceRoot = ".";
+
+    installPhase = ''
+      mkdir -p $out/Applications
+      cp -r *.app $out/Applications
+    '';
+  };
+in
+if stdenv.isDarwin
+  then darwin
+  else linux

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25862,6 +25862,8 @@ with pkgs;
 
   pass-secret-service = callPackage ../applications/misc/pass-secret-service { };
 
+  passky-desktop = callPackage ../applications/misc/passky-desktop { };
+
   pinboard = with python3Packages; toPythonApplication pinboard;
 
   pinboard-notes-backup = haskell.lib.compose.justStaticExecutables haskellPackages.pinboard-notes-backup;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[Passky](https://github.com/Rabbit-Company/Passky-Desktop) is a cloud based password manager with an option for self-hosting, similar to Bitwarden. This is a package for the desktop client.

It's an electron app, I almost managed to build it from source but it ended up bugged. Wrapping the Appimage works.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
