### PR TITLE
uwsgi: fix compiling against php 8, bump to 2.0.20

### DIFF
--- a/pkgs/servers/uwsgi/default.nix
+++ b/pkgs/servers/uwsgi/default.nix
@@ -91,12 +91,15 @@ stdenv.mkDerivation rec {
     inherit python2 python3;
   };
 
+  php8 = builtins.head (builtins.splitVersion php.version) == "8";
+  php8_no_version = ''sed -e "s/ + php_version//" -i plugins/php/uwsgiplugin.py'';
+
   postPatch = ''
     for f in uwsgiconfig.py plugins/*/uwsgiplugin.py; do
       substituteInPlace "$f" \
         --replace pkg-config "$PKG_CONFIG"
     done
-  '';
+  '' + (lib.optionalString php8 php8_no_version);
 
   configurePhase = ''
     export pluginDir=$out/lib/uwsgi

--- a/pkgs/servers/uwsgi/default.nix
+++ b/pkgs/servers/uwsgi/default.nix
@@ -69,6 +69,7 @@ stdenv.mkDerivation rec {
   patches = [
         ./no-ext-session-php_session.h-on-NixOS.patch
         ./additional-php-ldflags.patch
+        ./missing-arginfo-php8.patch # https://github.com/unbit/uwsgi/issues/2356
   ];
 
   nativeBuildInputs = [ python3 pkg-config ];

--- a/pkgs/servers/uwsgi/default.nix
+++ b/pkgs/servers/uwsgi/default.nix
@@ -92,15 +92,15 @@ stdenv.mkDerivation rec {
     inherit python2 python3;
   };
 
-  php8 = builtins.head (builtins.splitVersion php.version) == "8";
-  php8_no_version = ''sed -e "s/ + php_version//" -i plugins/php/uwsgiplugin.py'';
-
   postPatch = ''
     for f in uwsgiconfig.py plugins/*/uwsgiplugin.py; do
       substituteInPlace "$f" \
         --replace pkg-config "$PKG_CONFIG"
     done
-  '' + (lib.optionalString php8 php8_no_version);
+    ${lib.optionalString (lib.versionAtLeast php.version "8") ''
+        sed -e "s/ + php_version//" -i plugins/php/uwsgiplugin.py
+    ''}
+  '';
 
   configurePhase = ''
     export pluginDir=$out/lib/uwsgi

--- a/pkgs/servers/uwsgi/default.nix
+++ b/pkgs/servers/uwsgi/default.nix
@@ -59,11 +59,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "uwsgi";
-  version = "2.0.19.1";
+  version = "2.0.20";
 
   src = fetchurl {
     url = "https://projects.unbit.it/downloads/${pname}-${version}.tar.gz";
-    sha256 = "0256v72b7zr6ds4srpaawk1px3bp0djdwm239w3wrxpw7dzk1gjn";
+    sha256 = "1yfz5h07rxzrqf1rdj5fzhk47idgglxj7kqr8zl8lgcpv1kriaw8";
   };
 
   patches = [

--- a/pkgs/servers/uwsgi/missing-arginfo-php8.patch
+++ b/pkgs/servers/uwsgi/missing-arginfo-php8.patch
@@ -1,0 +1,49 @@
+diff --git a/plugins/php/php_plugin.c b/plugins/php/php_plugin.c
+index ca0ef6c1..00c39b09 100644
+--- a/plugins/php/php_plugin.c
++++ b/plugins/php/php_plugin.c
+@@ -257,6 +257,9 @@ PHP_MINIT_FUNCTION(uwsgi_php_minit) {
+ 	return SUCCESS;
+ }
+ 
++ZEND_BEGIN_ARG_INFO_EX(arginfo_void, 0, 0, 0)
++ZEND_END_ARG_INFO()
++
+ PHP_FUNCTION(uwsgi_version) {
+ 	RETURN_STRING(UWSGI_VERSION);
+ }
+@@ -488,20 +491,20 @@ PHP_FUNCTION(uwsgi_signal) {
+ }
+ 
+ zend_function_entry uwsgi_php_functions[] = {
+-	PHP_FE(uwsgi_version,   NULL)
+-	PHP_FE(uwsgi_setprocname,   NULL)
+-	PHP_FE(uwsgi_worker_id,   NULL)
+-	PHP_FE(uwsgi_masterpid,   NULL)
+-	PHP_FE(uwsgi_signal,   NULL)
+-
+-	PHP_FE(uwsgi_rpc,   NULL)
+-
+-	PHP_FE(uwsgi_cache_get,   NULL)
+-	PHP_FE(uwsgi_cache_set,   NULL)
+-	PHP_FE(uwsgi_cache_update,   NULL)
+-	PHP_FE(uwsgi_cache_del,   NULL)
+-	PHP_FE(uwsgi_cache_clear,   NULL)
+-	PHP_FE(uwsgi_cache_exists,   NULL)
++	PHP_FE(uwsgi_version,   arginfo_void)
++	PHP_FE(uwsgi_setprocname,   arginfo_void)
++	PHP_FE(uwsgi_worker_id,   arginfo_void)
++	PHP_FE(uwsgi_masterpid,   arginfo_void)
++	PHP_FE(uwsgi_signal,   arginfo_void)
++
++	PHP_FE(uwsgi_rpc,   arginfo_void)
++
++	PHP_FE(uwsgi_cache_get,   arginfo_void)
++	PHP_FE(uwsgi_cache_set,   arginfo_void)
++	PHP_FE(uwsgi_cache_update,   arginfo_void)
++	PHP_FE(uwsgi_cache_del,   arginfo_void)
++	PHP_FE(uwsgi_cache_clear,   arginfo_void)
++	PHP_FE(uwsgi_cache_exists,   arginfo_void)
+ 	{ NULL, NULL, NULL},
+ };
+ 


### PR DESCRIPTION
###### Motivation for this change

Current uwsgi 2.0.19.1 is not compatible with PHP 8.x, that support was added in 2.0.20
https://uwsgi-docs.readthedocs.io/en/latest/Changelog-2.0.20.html

Tested building with both php 7.4:
```
nix-build -E 'with import <nixpkgs> {}; uwsgi.override { php=pkgs.php74; plugins=[ "php" ]; }'
```
and php 8:
```
nix-build -E 'with import <nixpkgs> {}; uwsgi.override { plugins=[ "php" ]; }'
```

also patched this issue on top of 2.0.20:
https://github.com/unbit/uwsgi/issues/2356

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

