### PR TITLE
buildOcamlJane: use fetchFromGitHub

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/async-rpc-kernel.nix
+++ b/pkgs/development/ocaml-modules/janestreet/async-rpc-kernel.nix
@@ -4,7 +4,7 @@
 
 buildOcamlJane {
   pname = "async_rpc_kernel";
-  hash = "0pvys7giqix1nfidw1f4i3r94cf03ba1mvhadpm2zpdir3av91sw";
+  hash = "0000000000000000000000000000000000000000000000000000";
   propagatedBuildInputs = [ async_kernel bin_prot core_kernel fieldslib
     ppx_assert ppx_bench ppx_driver ppx_expect ppx_inline_test ppx_jane
     sexplib typerep variantslib ];

--- a/pkgs/development/ocaml-modules/janestreet/bin_prot.nix
+++ b/pkgs/development/ocaml-modules/janestreet/bin_prot.nix
@@ -4,7 +4,7 @@ buildOcamlJane {
   pname = "bin_prot";
   version = "113.33.03";
   minimumSupportedOcamlVersion = "4.02";
-  hash = "0jlarpfby755j0kikz6vnl1l6q0ga09b9zrlw6i84r22zchnqdsh";
+  hash = "0000000000000000000000000000000000000000000000000000";
 
   propagatedBuildInputs = [ type_conv ];
 

--- a/pkgs/development/ocaml-modules/janestreet/buildOcamlJane.nix
+++ b/pkgs/development/ocaml-modules/janestreet/buildOcamlJane.nix
@@ -1,4 +1,4 @@
-{ buildOcaml, opaline, js_build_tools, ocaml_oasis, fetchurl } :
+{ buildOcaml, opaline, js_build_tools, ocaml_oasis, fetchFromGitHub } :
 
 { pname, version ? "113.33.03", buildInputs ? [],
   hash ? "",
@@ -7,8 +7,10 @@
 
 buildOcaml (args // {
   inherit pname version minimumSupportedOcamlVersion;
-  src = fetchurl {
-    url = "https://github.com/janestreet/${pname}/archive/${version}.tar.gz";
+  src = fetchFromGitHub {
+    owner = "janestreet";
+    repo = pname;
+    rev = version;
     sha256 = hash;
   };
 

--- a/pkgs/development/ocaml-modules/janestreet/core_bench.nix
+++ b/pkgs/development/ocaml-modules/janestreet/core_bench.nix
@@ -7,7 +7,7 @@
 
 buildOcamlJane {
   pname = "core_bench";
-  hash = "1d1ainpakgsf5rg8dvar12ksgilqcc4465jr8gf7fz5mmn0mlifj";
+  hash = "0000000000000000000000000000000000000000000000000000";
   propagatedBuildInputs =
     [ core core_extended textutils ];
 

--- a/pkgs/development/ocaml-modules/janestreet/fieldslib.nix
+++ b/pkgs/development/ocaml-modules/janestreet/fieldslib.nix
@@ -6,7 +6,7 @@ buildOcamlJane {
 
   minimumSupportedOcamlVersion = "4.02";
 
-  hash = "0mkbix32f8sq32q81hb10z2q31bw5f431jxv0jafbdrif0vr6xqd";
+  hash = "0000000000000000000000000000000000000000000000000000";
 
   propagatedBuildInputs = [ type_conv ];
 

--- a/pkgs/development/ocaml-modules/janestreet/ppx-assert.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-assert.nix
@@ -3,7 +3,7 @@
 
 buildOcamlJane {
   pname = "ppx_assert";
-  hash = "0n7fa1j79ykbkhp8xz0ksg5096asri5d0msshsaqhw5fz18chvz4";
+  hash = "0000000000000000000000000000000000000000000000000000";
   propagatedBuildInputs =
     [ ppx_compare ppx_core ppx_driver ppx_here ppx_sexp_conv ppx_tools
       ppx_type_conv sexplib ];

--- a/pkgs/development/ocaml-modules/janestreet/ppx-bench.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-bench.nix
@@ -4,7 +4,7 @@
 buildOcamlJane {
   pname = "ppx_bench";
   minimumSupportedOcamlVersion = "4.02";
-  hash = "1l5jlwy1d1fqz70wa2fkf7izngp6nx3g4s9bmnd6ca4dx1x5bksk";
+  hash = "0000000000000000000000000000000000000000000000000000";
 
   hasSharedObjects = true;
 

--- a/pkgs/development/ocaml-modules/janestreet/ppx-bin-prot.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-bin-prot.nix
@@ -3,7 +3,7 @@
 
 buildOcamlJane {
   pname = "ppx_bin_prot";
-  hash = "0kwmrrrybdkmphqczsr3lg3imsxcjb8iy41syvn44s3kcjfyyzbz";
+  hash = "0000000000000000000000000000000000000000000000000000";
   propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv bin_prot ];
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-compare.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-compare.nix
@@ -3,7 +3,7 @@
 
 buildOcamlJane {
   pname = "ppx_compare";
-  hash = "05cnwxfxm8201lpfmcqkcqfy6plh5c2151jbj4qsnxhlvvjli459";
+  hash = "0000000000000000000000000000000000000000000000000000";
   propagatedBuildInputs =
     [ppx_core ppx_driver ppx_tools ppx_type_conv ];
 

--- a/pkgs/development/ocaml-modules/janestreet/ppx-custom-printf.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-custom-printf.nix
@@ -3,7 +3,7 @@
 
 buildOcamlJane {
   pname = "ppx_custom_printf";
-  hash = "06y85m6ky376byja4w7gdwd339di5ag0xrf0czkylzjsnylhdr85";
+  hash = "0000000000000000000000000000000000000000000000000000";
 
   propagatedBuildInputs = [ ppx_core ppx_driver ppx_sexp_conv ppx_tools ];
 

--- a/pkgs/development/ocaml-modules/janestreet/ppx-enumerate.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-enumerate.nix
@@ -3,7 +3,7 @@
 
 buildOcamlJane {
   pname = "ppx_enumerate";
-  hash = "0m11921q2pjzkwckf21fynd2qfy83n9jjsgks23yagdai8a7ym16";
+  hash = "0000000000000000000000000000000000000000000000000000";
   propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv ];
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-expect.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-expect.nix
@@ -5,7 +5,7 @@
 
 buildOcamlJane {
   pname = "ppx_expect";
-  hash = "0cwagb4cj3x1vsr19kyfa9pxlvaz9a5v863cahi5glinsh4mzgdx";
+  hash = "0000000000000000000000000000000000000000000000000000";
   propagatedBuildInputs =
     [ ppx_assert ppx_compare ppx_core ppx_custom_printf ppx_driver
       ppx_fields_conv ppx_here ppx_inline_test ppx_sexp_conv ppx_tools

--- a/pkgs/development/ocaml-modules/janestreet/ppx-fields-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-fields-conv.nix
@@ -3,7 +3,7 @@
 
 buildOcamlJane {
   pname = "ppx_fields_conv";
-  hash = "11w9wfjgkv7yxv3rwlwi6m193zan6rhmi45q7n3ddi2s8ls3gra7";
+  hash = "0000000000000000000000000000000000000000000000000000";
   propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv ];
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-here.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-here.nix
@@ -3,7 +3,7 @@
 
 buildOcamlJane {
   pname = "ppx_here";
-  hash = "1mzdgn8k171zkwmbizf1a48l525ny0w3363c7gknpnifcinxniiw";
+  hash = "0000000000000000000000000000000000000000000000000000";
   propagatedBuildInputs = [ ppx_core ppx_driver ];
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-inline-test.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-inline-test.nix
@@ -3,7 +3,7 @@
 
 buildOcamlJane {
   pname = "ppx_inline_test";
-  hash = "0ygapa54i0wwcj3jcqwiimrc6z0b7aafgjhbk37h6vvclnm5n7f6";
+  hash = "0000000000000000000000000000000000000000000000000000";
   propagatedBuildInputs = [ ppx_core ppx_driver ppx_tools ];
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-jane.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-jane.nix
@@ -7,7 +7,7 @@
 
 buildOcamlJane {
   pname = "ppx_jane";
-  hash  = "1la0rp8fhzfglwb15gqh1pl1ld8ls4cnidaw9mjc5q1hb0yj1qd9";
+  hash  = "0000000000000000000000000000000000000000000000000000";
   propagatedBuildInputs =
     [ ppx_assert ppx_bench ppx_bin_prot ppx_compare ppx_custom_printf
       ppx_driver ppx_enumerate ppx_expect ppx_fail ppx_fields_conv

--- a/pkgs/development/ocaml-modules/janestreet/ppx-let.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-let.nix
@@ -3,7 +3,7 @@
 
 buildOcamlJane {
   pname = "ppx_let";
-  hash = "0whnfq4rgkq4apfqnvc100wlk25pmqdyvy6s21dsn3fcm9hff467";
+  hash = "0000000000000000000000000000000000000000000000000000";
   propagatedBuildInputs = [ ppx_core ppx_driver ];
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-optcomp.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-optcomp.nix
@@ -3,7 +3,7 @@
 
 buildOcamlJane {
   pname = "ppx_optcomp";
-  hash = "09m2x2a5ics4bz1j29n5slhh1rlyhcwdfmf44v1jfxcby3f0riwd";
+  hash = "0000000000000000000000000000000000000000000000000000";
   propagatedBuildInputs =
     [ ppx_core ppx_tools ];
 

--- a/pkgs/development/ocaml-modules/janestreet/ppx-pipebang.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-pipebang.nix
@@ -3,7 +3,7 @@
 
 buildOcamlJane {
   pname = "ppx_pipebang";
-  hash = "0k25bhj9ziiw89xvs4svz7cgazbbmprba9wbic2llffg55fp7acc";
+  hash = "0000000000000000000000000000000000000000000000000000";
   propagatedBuildInputs = [ ppx_core ppx_driver ppx_tools ];
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-sexp-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-sexp-conv.nix
@@ -3,7 +3,7 @@
 
 buildOcamlJane {
   pname = "ppx_sexp_conv";
-  hash = "1kgbmlc11w5jhbhmy5n0f734l44zwyry48342dm5qydi9sfzcgq2";
+  hash = "0000000000000000000000000000000000000000000000000000";
   propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv sexplib];
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-sexp-message.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-sexp-message.nix
@@ -3,7 +3,7 @@
 
 buildOcamlJane {
   pname = "ppx_sexp_message";
-  hash = "0inbff25qii868p141jb1y8n3vjfyz66jpnsl9nma6nkkyjkp05j";
+  hash = "0000000000000000000000000000000000000000000000000000";
   propagatedBuildInputs = [ ppx_core ppx_driver ppx_here ppx_sexp_conv ppx_tools ];
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-sexp-value.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-sexp-value.nix
@@ -3,7 +3,7 @@
 
 buildOcamlJane {
   pname = "ppx_sexp_value";
-  hash = "04602ppqfwx33ghjywam00hlqqzsz4d99r60k9q0v1mynk9pjhj0";
+  hash = "0000000000000000000000000000000000000000000000000000";
   propagatedBuildInputs = [ ppx_core ppx_driver ppx_here ppx_sexp_conv ppx_tools ];
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-typerep-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-typerep-conv.nix
@@ -3,7 +3,7 @@
 
 buildOcamlJane {
   pname = "ppx_typerep_conv";
-  hash = "0dldlx73r07j6w0i7h4hxly0v678naa79na5rafsk2974gs5ih9g";
+  hash = "0000000000000000000000000000000000000000000000000000";
   propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv typerep ];
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-variants-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-variants-conv.nix
@@ -3,7 +3,7 @@
 
 buildOcamlJane {
   pname = "ppx_variants_conv";
-  hash = "0kgal8b9yh7wrd75hllb9fyl6zbksfnr9k7pykpzdm3js98dirhn";
+  hash = "0000000000000000000000000000000000000000000000000000";
   propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv sexplib variantslib ];
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/janestreet/sexplib.nix
+++ b/pkgs/development/ocaml-modules/janestreet/sexplib.nix
@@ -5,7 +5,7 @@ buildOcamlJane {
   pname = "sexplib";
   version = "113.33.03";
 
-  hash = "1klar4qw4s7bj47ig7kxz2m4j1q3c60pfppis4vxrxv15r0kfh22";
+  hash = "0000000000000000000000000000000000000000000000000000";
 
   propagatedBuildInputs = [ type_conv ];
 

--- a/pkgs/development/ocaml-modules/janestreet/typerep.nix
+++ b/pkgs/development/ocaml-modules/janestreet/typerep.nix
@@ -6,7 +6,7 @@ buildOcamlJane {
 
   minimumSupportedOcamlVersion = "4.00";
 
-  hash = "1ss34nq20vfgx8hwi5sswpmn3my9lvrpdy5dkng746xchwi33ar7";
+  hash = "0000000000000000000000000000000000000000000000000000";
 
   propagatedBuildInputs = [ type_conv ];
 

--- a/pkgs/development/ocaml-modules/janestreet/variantslib.nix
+++ b/pkgs/development/ocaml-modules/janestreet/variantslib.nix
@@ -6,7 +6,7 @@ buildOcamlJane {
 
   minimumSupportedOcamlVersion = "4.00";
 
-  hash = "1hv0f75msrryxsl6wfnbmhc0n8kf7qxs5f82ry3b8ldb44s3wigp";
+  hash = "0000000000000000000000000000000000000000000000000000";
 
   propagatedBuildInputs = [ type_conv ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
