### PR TITLE
abricotine: init at 1.0.0

### DIFF
--- a/pkgs/applications/editors/abricotine/default.nix
+++ b/pkgs/applications/editors/abricotine/default.nix
@@ -1,0 +1,77 @@
+{ stdenv, lib, fetchurl, copyDesktopItems, makeDesktopItem, makeWrapper
+, writeShellScriptBin, electron }:
+
+let
+  # This script is mandatory to make this application work
+  # without user intervention. The reasoning is specified below:
+  # https://github.com/NixOS/nixpkgs/issues/148152#issuecomment-983773905
+  exec_script = writeShellScriptBin "exec_script" ''
+    #!/usr/bin/env bash
+
+    set -euo pipefail
+
+    CONFIG_PATH="$HOME/.config/Abricotine"
+
+    if [ ! -d "$CONFIG_PATH" ]; then
+        SOURCE_SUBPATH="/opt/abricotine/resources/app.asar.unpacked/default"
+        mkdir -p "$CONFIG_PATH/app"
+        cp -R "$1$SOURCE_SUBPATH/dict" "$CONFIG_PATH/app/dict"
+        cp -R "$1$SOURCE_SUBPATH/lang" "$CONFIG_PATH/app/lang"
+        cp -R "$1$SOURCE_SUBPATH/templates" "$CONFIG_PATH/app/templates"
+        cp -R "$1$SOURCE_SUBPATH/themes" "$CONFIG_PATH/app/themes"
+        chmod -R u+w "$CONFIG_PATH/app/"
+    fi
+  '';
+
+in stdenv.mkDerivation rec {
+  pname = "abricotine";
+  version = "1.0.0";
+
+  src = fetchurl {
+    url = "https://github.com/brrd/abricotine/releases/download/${version}/abricotine-${version}-linux-x64.tar.gz";
+    sha256 = "sha256-87vudcf1vAnkRVRoaVguHHoJwMJpsiM5+c/3m9lIxRc=";
+  };
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = "abricotine";
+      icon = "abricotine";
+      comment = meta.description;
+      desktopName = "Abricotine";
+      genericName = "Markdown Editor";
+    })
+  ];
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/opt/abricotine $out/share/pixmaps
+    cp -r . $out/opt/abricotine
+
+    # Icons dir does not follow typical structure
+    cp $out/opt/abricotine/icons/abricotine.svg $out/share/pixmaps/
+
+    makeWrapper ${electron}/bin/electron $out/bin/abricotine \
+      --run "${exec_script}/bin/exec_script $out" \
+      --add-flags $out/opt/abricotine/resources/app.asar
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Markdown editor with inline preview";
+    homepage = "https://abricotine.brrd.fr/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ wolfangaukang ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1166,6 +1166,10 @@ with pkgs;
 
   yaft = callPackage ../applications/terminal-emulators/yaft { };
 
+  abricotine = callPackage ../applications/editors/abricotine {
+    electron = electron_6;
+  };
+
   aldo = callPackage ../applications/radio/aldo { };
 
   almanah = callPackage ../applications/misc/almanah { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#148152. To consider:
- Uses Electron 6
- Needs a very lengthy workaround to work, as stated on the package request.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
