### PR TITLE
pinta: 1.6 -> 1.7.1

### DIFF
--- a/pkgs/applications/graphics/pinta/default.nix
+++ b/pkgs/applications/graphics/pinta/default.nix
@@ -11,7 +11,7 @@ let
 in
 buildDotnetPackage rec {
   baseName = "Pinta";
-  version = "1.6";
+  version = "1.7.1";
 
   outputFiles = [ "bin/*" ];
   buildInputs = [ gtksharp mono-addins gettext ];
@@ -21,7 +21,7 @@ buildDotnetPackage rec {
     owner = "PintaProject";
     repo = "Pinta";
     rev = version;
-    sha256 = "0vgswy981c7ys4q7js5k85sky7bz8v32wsfq3br4j41vg92pw97d";
+    sha256 = "sha256-yRp/dpJ9T4DieqHTj3vhyuASPGe4vjHw0rSXFrTNZVc=";
   };
 
   # Remove version information from nodes <Reference Include="... Version=... ">
@@ -74,6 +74,8 @@ buildDotnetPackage rec {
       --replace _Comment Comment \
       --replace _GenericName GenericName \
       --replace _X-GNOME-FullName X-GNOME-FullName
+    substitute xdg/pinta.appdata.xml.in xdg/pinta.appdata.xml \
+      --replace _p p
 
     xbuild /target:CompileTranslations Pinta.Install.proj
     xbuild /target:Install Pinta.Install.proj


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Our current derivation is more than 6 years old.

Closes issue: https://github.com/NixOS/nixpkgs/issues/148181

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
