### PR TITLE
sumneko-lua-language-server: Add darwin support

### DIFF
--- a/pkgs/development/tools/sumneko-lua-language-server/default.nix
+++ b/pkgs/development/tools/sumneko-lua-language-server/default.nix
@@ -1,5 +1,7 @@
-{ lib, stdenv, fetchFromGitHub, ninja, makeWrapper }:
-
+{ lib, stdenv, fetchFromGitHub, ninja, makeWrapper, darwin }:
+let
+  target = if stdenv.isDarwin then "macOS" else "Linux";
+in
 stdenv.mkDerivation rec {
   pname = "sumneko-lua-language-server";
   version = "2.5.1";
@@ -17,12 +19,32 @@ stdenv.mkDerivation rec {
     makeWrapper
   ];
 
+  buildInputs = lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.CoreFoundation
+    darwin.apple_sdk.frameworks.Foundation
+  ];
+
   preBuild = ''
     cd 3rd/luamake
+  ''
+  + lib.optionalString stdenv.isDarwin ''
+    # Needed for the test
+    export HOME=/var/empty
+    # This package uses the program clang for C and C++ files. The language
+    # is selected via the command line argument -std, but this do not work
+    # in combination with the nixpkgs clang wrapper. Therefor we have to
+    # find all c++ compiler statements and replace $cc (which expands to
+    # clang) with clang++.
+    sed -i compile/ninja/macos.ninja \
+      -e '/c++/s,$cc,clang++,' \
+      -e '/test.lua/s,= .*,= true,' \
+      -e '/ldl/s,$cc,clang++,'
+    sed -i scripts/compiler/gcc.lua \
+      -e '/cxx_/s,$cc,clang++,'
   '';
 
   ninjaFlags = [
-    "-fcompile/ninja/linux.ninja"
+    "-fcompile/ninja/${lib.toLower target}.ninja"
   ];
 
   postBuild = ''
@@ -33,15 +55,15 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    install -Dt "$out"/share/lua-language-server/bin/Linux bin/Linux/lua-language-server
-    install -m644 -t "$out"/share/lua-language-server/bin/Linux bin/Linux/*.*
+    install -Dt "$out"/share/lua-language-server/bin/${target} bin/${target}/lua-language-server
+    install -m644 -t "$out"/share/lua-language-server/bin/${target} bin/${target}/*.*
     install -m644 -t "$out"/share/lua-language-server {debugger,main}.lua
     cp -r locale meta script "$out"/share/lua-language-server
 
     # necessary for --version to work:
     install -m644 -t "$out"/share/lua-language-server changelog.md
 
-    makeWrapper "$out"/share/lua-language-server/bin/Linux/lua-language-server \
+    makeWrapper "$out"/share/lua-language-server/bin/${target}/lua-language-server \
       $out/bin/lua-language-server \
       --add-flags "-E $out/share/lua-language-server/main.lua \
       --logpath='~/.cache/sumneko_lua/log' \
@@ -55,7 +77,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/sumneko/lua-language-server";
     license = licenses.mit;
     maintainers = with maintainers; [ mjlbach ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     mainProgram = "lua-language-server";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I want to use this package on a darwin system. The derivation for non darwin is the same as before.

see also https://github.com/NixOS/nixpkgs/pull/120527

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
