### PR TITLE
virtualisation.image: init

### DIFF
--- a/nixos/modules/virtualisation/make-image.nix
+++ b/nixos/modules/virtualisation/make-image.nix
@@ -1,0 +1,88 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.virtualisation.image;
+in
+{
+  options = {
+    virtualisation.image = {
+      diskSize = mkOption {
+        type = with types; either (enum [ "auto" ]) ints.positive;
+        default = "auto";
+        example = 8192;
+        description = ''
+          The disk size of the image in MiB.
+        '';
+      };
+      additionalDiskSpace = mkOption {
+        type = types.int;
+        default = 512;
+        example = 1024;
+        description = ''
+          Additional disk space in MiB to be added to the image if <literal>virtualisation.qcow.baseImageSize</literal> is set to <literal>auto</literal>.
+        '';
+      };
+      bootPartitionSize = mkOption {
+        type = types.int.positive;
+        default = 256;
+        example = 512;
+        description = ''
+          The size of the boot partition in MiB, only takes effect if <literal>virtualisation.qcow.partitionTableType</literal> is set to <literal>efi</literal> or <literalhybrid</literal>.
+        '';
+      };
+      partitionTableType = mkOption {
+        type = types.enum [ "legacy" "efi" "legacy+gpt" "hybrid" "none" ];
+        default = "legacy";
+        example = "efi";
+        description = ''
+          Type of partition table to use for the image, available options are <literal>legacy</literal>, <literal>efi</literal>, <literal>legacy+gpt</literal>, <literal>hybrid</literal> or <literal>none</literal>. For additional information about each option: <link>https://github.com/NixOS/nixpkgs/blob/master/nixos/lib/make-disk-image.nix#L32</link>.
+        '';
+      };
+      name = mkOption {
+        type = types.str;
+        default = "${cfg.format}-image";
+        example = "my-custom-nixos-image";
+        description = ''
+          The name of the produced disk image.
+        '';
+      };
+      format = mkOption {
+        type = types.enum [ "qcow2" "qcow2-compressed" "vdi" "vpc" "raw" ];
+        default = "raw";
+        example = "qcow2";
+        description = ''
+          The disk image format to be produced, one of <literal>qcow2</literal>, <literal>qcow2-compressed</literal>, <literal>vdi</literal>, <literal>vpc</literal>, <literal>raw</literal>.
+        '';
+      };
+      copyConfigFile = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        description = ''
+          Initial NixOS configuration file to be copied to <literal>/etc/nixos/configuration.nix</literal> on the produced disk image.
+        '';
+      };
+      file = mkOption {
+        readOnly = true;
+        type = types.path;
+        description = ''
+          The generated image derivation, for use by other modules and expressions.
+        '';
+      };
+    };
+  };
+
+  config = {
+    virtualisation.image.file = import ../../lib/make-disk-image.nix {
+      inherit lib config pkgs;
+      name = cfg.name;
+      format = cfg.format;
+      diskSize = "${toString cfg.diskSize}";
+      additionalSpace = "${toString cfg.additionalDiskSpace}M";
+      bootSize = "${toString cfg.bootPartitionSize}M";
+      partitionTableType = cfg.partitionTableType;
+      configFile = cfg.copyConfigFile;
+    };
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Added module which can be used to create customizable disk images.
Initial idea of creating this module was for using a similar functionality in [nixos-generators](https://github.com/nix-community/nixos-generators/pull/127).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
