### PR TITLE
podman-compose: 2021-05-18 → 0.1.8

### DIFF
--- a/pkgs/applications/virtualization/podman-compose/default.nix
+++ b/pkgs/applications/virtualization/podman-compose/default.nix
@@ -1,19 +1,15 @@
 { lib, buildPythonApplication, fetchFromGitHub, pyyaml }:
 
 buildPythonApplication rec {
-  version = "0.2.0pre-2021-05-18";
+  version = "0.1.8";
   pname = "podman-compose";
 
   # "This project is still under development." -- README.md
-  #
-  # As of May 2021, the latest release (0.1.5) has fewer than half of all
-  # commits. This project seems to have no release management, so the last
-  # commit is the best one until proven otherwise.
   src = fetchFromGitHub {
     repo = "podman-compose";
     owner = "containers";
-    rev = "62d2024feecf312e9591cc145f49cee9c70ab4fe";
-    sha256 = "17992imkvi6129wvajsp0iz5iicfmh53i20qy2mzz17kcz30r2pp";
+    rev = version;
+    sha256 = "sha256-BN6rG46ejYY6UCNjKYQpxPQGTW3x12zpGDnH2SKn304=";
   };
 
   propagatedBuildInputs = [ pyyaml ];
@@ -21,7 +17,7 @@ buildPythonApplication rec {
   meta = {
     description = "An implementation of docker-compose with podman backend";
     homepage = "https://github.com/containers/podman-compose";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.sikmir ] ++ lib.teams.podman.members;
   };


### PR DESCRIPTION
###### Motivation for this change
0.1.8 released on 2021-11-15. Changelog: https://github.com/containers/podman-compose/compare/62d2024feecf312e9591cc145f49cee9c70ab4fe...0.1.8

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
