### PR TITLE
asmrepl: init at 1.0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6580,7 +6580,7 @@
     githubId = 4158274;
     name = "Michiel Leenaars";
   };
-  legendofmiracles = {
+  lom = {
     email = "legendofmiracles@protonmail.com";
     matrix = "@legendofmiracles:matrix.org";
     github = "legendofmiracles";

--- a/pkgs/applications/audio/noisetorch/default.nix
+++ b/pkgs/applications/audio/noisetorch/default.nix
@@ -37,6 +37,6 @@ buildGoModule rec {
     homepage = "https://github.com/lawl/NoiseTorch";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ panaeon legendofmiracles ];
+    maintainers = with maintainers; [ panaeon lom ];
   };
 }

--- a/pkgs/applications/graphics/weylus/default.nix
+++ b/pkgs/applications/graphics/weylus/default.nix
@@ -53,6 +53,6 @@ stdenv.mkDerivation rec {
     description = "Use your tablet as graphic tablet/touch screen on your computer";
     homepage = "https://github.com/H-M-H/Weylus";
     license = with licenses; [ agpl3Only ];
-    maintainers = with maintainers; [ legendofmiracles ];
+    maintainers = with maintainers; [ lom ];
   };
 }

--- a/pkgs/applications/misc/ArchiSteamFarm/default.nix
+++ b/pkgs/applications/misc/ArchiSteamFarm/default.nix
@@ -47,6 +47,6 @@ buildDotnetModule rec {
     homepage = "https://github.com/JustArchiNET/ArchiSteamFarm";
     license = licenses.asl20;
     platforms = dotnetCorePackages.aspnetcore_5_0.meta.platforms;
-    maintainers = with maintainers; [ SuperSandro2000 legendofmiracles ];
+    maintainers = with maintainers; [ SuperSandro2000 lom ];
   };
 }

--- a/pkgs/applications/misc/cfm/default.nix
+++ b/pkgs/applications/misc/cfm/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Simple and fast TUI file manager with no dependencies";
     license = licenses.mpl20;
-    maintainers = with maintainers; [ legendofmiracles ];
+    maintainers = with maintainers; [ lom ];
     homepage = "https://github.com/willeccles/cfm";
     platforms = platforms.all;
   };

--- a/pkgs/applications/networking/tmpmail/default.nix
+++ b/pkgs/applications/networking/tmpmail/default.nix
@@ -28,6 +28,6 @@ stdenvNoCC.mkDerivation rec {
     homepage = "https://github.com/sdushantha/tmpmail";
     description = "A temporary email right from your terminal written in POSIX sh ";
     license = licenses.mit;
-    maintainers = [ maintainers.legendofmiracles ];
+    maintainers = [ maintainers.lom ];
   };
 }

--- a/pkgs/applications/video/giph/default.nix
+++ b/pkgs/applications/video/giph/default.nix
@@ -37,7 +37,7 @@ stdenvNoCC.mkDerivation rec {
     homepage = "https://github.com/phisch/giph";
     description = "Simple gif recorder";
     license = licenses.mit;
-    maintainers = [ maintainers.legendofmiracles ];
+    maintainers = [ maintainers.lom ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/video/mpv/scripts/cutter.nix
+++ b/pkgs/applications/video/mpv/scripts/cutter.nix
@@ -42,6 +42,6 @@ stdenvNoCC.mkDerivation {
     homepage = "https://github.com/rushmj/mpv-video-cutter";
     # repo doesn't have a license
     license = licenses.unfree;
-    maintainers = with maintainers; [ legendofmiracles ];
+    maintainers = with maintainers; [ lom ];
   };
 }

--- a/pkgs/applications/window-managers/eww/default.nix
+++ b/pkgs/applications/window-managers/eww/default.nix
@@ -39,7 +39,7 @@ rustPlatform.buildRustPackage rec {
     description = "ElKowars wacky widgets";
     homepage = "https://github.com/elkowar/eww";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda legendofmiracles ];
+    maintainers = with maintainers; [ figsoda lom ];
     broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/interpreters/asmrepl/Gemfile
+++ b/pkgs/development/interpreters/asmrepl/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org' do
+  gem 'asmrepl'
+end

--- a/pkgs/development/interpreters/asmrepl/Gemfile.lock
+++ b/pkgs/development/interpreters/asmrepl/Gemfile.lock
@@ -1,0 +1,18 @@
+GEM
+  specs:
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    asmrepl (1.0.3)
+      fisk (~> 2)
+    fisk (2.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  asmrepl!
+
+BUNDLED WITH
+   2.2.24

--- a/pkgs/development/interpreters/asmrepl/default.nix
+++ b/pkgs/development/interpreters/asmrepl/default.nix
@@ -11,7 +11,7 @@ bundlerApp {
     description = "A REPL for x86-64 assembly language";
     homepage = "https://github.com/tenderlove/asmrepl";
     license = licenses.asl20;
-    maintainers = with maintainers; [ legendofmiracles ];
+    maintainers = with maintainers; [ lom ];
     platforms = platforms.x86_64;
   };
 }

--- a/pkgs/development/interpreters/asmrepl/default.nix
+++ b/pkgs/development/interpreters/asmrepl/default.nix
@@ -1,0 +1,17 @@
+{ lib, bundlerApp, bundlerUpdateScript }:
+
+bundlerApp {
+  pname = "asmrepl";
+  gemdir = ./.;
+  exes = [ "asmrepl" ];
+
+  passthru.updateScript = bundlerUpdateScript "asmrepl";
+
+  meta = with lib; {
+    description = "A REPL for x86-64 assembly language";
+    homepage = "https://github.com/tenderlove/asmrepl";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ legendofmiracles ];
+    platforms = platforms.x86_64;
+  };
+}

--- a/pkgs/development/interpreters/asmrepl/gemset.nix
+++ b/pkgs/development/interpreters/asmrepl/gemset.nix
@@ -1,0 +1,23 @@
+{
+  asmrepl = {
+    dependencies = ["fisk"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "10d0zvkhk3ja48vvx28hfsqfrzfl66vdpmk3gcgb5viy174c72v6";
+      type = "gem";
+    };
+    version = "1.0.3";
+  };
+  fisk = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1mq2a7hjs9xfg514ci0xw90c33rzq1y58ywpnmhp7w767ll6wldd";
+      type = "gem";
+    };
+    version = "2.3.0";
+  };
+}

--- a/pkgs/development/python-modules/python-pidfile/default.nix
+++ b/pkgs/development/python-modules/python-pidfile/default.nix
@@ -27,6 +27,6 @@ buildPythonPackage rec {
     description = "Python context manager for managing pid files";
     homepage = "https://github.com/mosquito/python-pidfile";
     license = with licenses; [ mit ];
-    maintainers = with maintainers; [ legendofmiracles ];
+    maintainers = with maintainers; [ lom ];
   };
 }

--- a/pkgs/games/ddnet/default.nix
+++ b/pkgs/games/ddnet/default.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://ddnet.tw";
     license = licenses.asl20;
-    maintainers = with maintainers; [ sirseruju legendofmiracles ];
+    maintainers = with maintainers; [ sirseruju lom ];
     mainProgram = "DDNet";
   };
 }

--- a/pkgs/games/rpg-cli/default.nix
+++ b/pkgs/games/rpg-cli/default.nix
@@ -20,6 +20,6 @@ rustPlatform.buildRustPackage rec {
     description = "Your filesystem as a dungeon";
     homepage = "https://github.com/facundoolano/rpg-cli";
     license = licenses.mit;
-    maintainers = with maintainers; [ legendofmiracles ];
+    maintainers = with maintainers; [ lom ];
   };
 }

--- a/pkgs/games/steam-tui/default.nix
+++ b/pkgs/games/steam-tui/default.nix
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage rec {
     description = "Rust TUI client for steamcmd";
     homepage = "https://github.com/dmadisetti/steam-tui";
     license = licenses.mit;
-    maintainers = with maintainers; [ legendofmiracles ];
+    maintainers = with maintainers; [ lom ];
     # steam only supports that platform
     platforms = [ "x86_64-linux" ];
   };

--- a/pkgs/misc/cliscord/default.nix
+++ b/pkgs/misc/cliscord/default.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
     description = "Simple command-line tool to send text and files to discord";
     homepage = "https://github.com/somebody1234/cliscord";
     license = licenses.mit;
-    maintainers = with maintainers; [ legendofmiracles ];
+    maintainers = with maintainers; [ lom ];
     mainProgram = "cliscord";
   };
 }

--- a/pkgs/misc/present/default.nix
+++ b/pkgs/misc/present/default.nix
@@ -26,6 +26,6 @@ python3Packages.buildPythonPackage rec {
     description = "A terminal-based presentation tool with colors and effects.";
     homepage = "https://github.com/vinayak-mehta/present";
     license = licenses.asl20;
-    maintainers = with maintainers; [ legendofmiracles ];
+    maintainers = with maintainers; [ lom ];
   };
 }

--- a/pkgs/misc/wiki-tui/default.nix
+++ b/pkgs/misc/wiki-tui/default.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
     description = "A simple and easy to use Wikipedia Text User Interface";
     homepage = "https://github.com/builditluc/wiki-tui";
     license = licenses.mit;
-    maintainers = with maintainers; [ legendofmiracles ];
+    maintainers = with maintainers; [ lom ];
     mainProgram = "wiki-tui";
   };
 }

--- a/pkgs/tools/misc/keymapviz/default.nix
+++ b/pkgs/tools/misc/keymapviz/default.nix
@@ -17,6 +17,6 @@ python3.pkgs.buildPythonApplication rec {
     description = "A qmk keymap.c visualizer";
     homepage = "https://github.com/yskoht/keymapviz";
     license = licenses.mit;
-    maintainers = with maintainers; [ legendofmiracles ];
+    maintainers = with maintainers; [ lom ];
   };
 }

--- a/pkgs/tools/misc/xcp/default.nix
+++ b/pkgs/tools/misc/xcp/default.nix
@@ -20,6 +20,6 @@ rustPlatform.buildRustPackage rec {
     description = "An extended cp(1)";
     homepage = "https://github.com/tarka/xcp";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ legendofmiracles ];
+    maintainers = with maintainers; [ lom ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1996,6 +1996,8 @@ with pkgs;
 
   asmfmt = callPackage ../development/tools/asmfmt { };
 
+  asmrepl = callPackage ../development/interpreters/asmrepl { };
+
   aspcud = callPackage ../tools/misc/aspcud { };
 
   at = callPackage ../tools/system/at { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
