### PR TITLE
plag: init at unstable-2021-12-01

### DIFF
--- a/pkgs/tools/networking/plag/default.nix
+++ b/pkgs/tools/networking/plag/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+}:
+
+stdenv.mkDerivation rec {
+  version = "unstable-2021-12-01";
+  pname = "plag";
+
+  src = fetchFromGitLab {
+    owner = "qratorlabs";
+    repo = "plag";
+    rev = "d860bc330ce039d1eb1e5e9fd257bd4a0f8ed48b";
+    sha256 = "06q2ydix48k3c8k3dqimg7r33g4aq3nyg46g6qajgvafgnfk1r39";
+  };
+
+  installPhase = ''
+    install -Dm755 plagmax "$out/bin/plagmax"
+    install -Dm755 plageq "$out/bin/plaggeq"
+  '';
+
+  meta = with lib; {
+    description = "Aggregate a list of IPv4 and IPv6 prefixes";
+    homepage = "https://gitlab.com/qratorlabs/plag/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ _0x4A6F ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8630,6 +8630,8 @@ with pkgs;
 
   pk2cmd = callPackage ../tools/misc/pk2cmd { };
 
+  plag = callPackage ../tools/networking/plag { };
+
   plantuml = callPackage ../tools/misc/plantuml { };
 
   plantuml-server = callPackage ../tools/misc/plantuml-server { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add [plag](https://gitlab.com/qratorlabs/plag) to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
