### PR TITLE
dave: init at 0.4.0

### DIFF
--- a/pkgs/servers/http/dave/default.nix
+++ b/pkgs/servers/http/dave/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildGoPackage, fetchFromGitHub, mage }:
+
+buildGoPackage rec {
+  pname = "dave";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "micromata";
+    repo = "dave";
+    rev = "v${version}";
+    sha256 = "sha256-wvsW4EwMWAgEV+LPeMhHL4AsuyS5TDMmpD9D4F1nVM4=";
+  };
+
+  goPackagePath = "github.com/micromata/dave";
+
+  subPackages = [ "cmd/dave" "cmd/davecli" ];
+
+  ldflags =
+    [ "-s" "-w" "-X main.version=${version}" "-X main.builtBy=nixpkgs" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/micromata/dave";
+    description =
+      "A totally simple and very easy to configure stand alone webdav server";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lunik1 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2672,6 +2672,8 @@ with pkgs;
 
   datovka = libsForQt5.callPackage ../applications/networking/datovka { };
 
+  dave = callPackage ../servers/http/dave { };
+
   dconf = callPackage ../development/libraries/dconf { };
 
   dcw-gmt = callPackage ../applications/gis/gmt/dcw.nix { };


### PR DESCRIPTION
###### Motivation for this change
Adds the dave webdav server to nixpkgs.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
