### PR TITLE
nss: 3.72 -> 3.73, fix CVE-2021-43527

### DIFF
--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -27,7 +27,7 @@ let
   #       It will rebuild itself using the version of this package (NSS) and if
   #       an update is required do the required changes to the expression.
   #       Example: nix-shell ./maintainers/scripts/update.nix --argstr package cacert
-  version = "3.72";
+  version = "3.73";
 
 in
 stdenv.mkDerivation rec {
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://mozilla/security/nss/releases/NSS_${lib.replaceStrings [ "." ] [ "_" ] version}_RTM/src/${pname}-${version}.tar.gz";
-    sha256 = "bqYKn/ET5JPqKrJfQep1qfvRCveQPyb3A9rIaAcy0C4=";
+    sha256 = "1rfqjq02rfv0ycdmvic51pi093rg33zb8kpqkvddf44vv9l3lvan";
   };
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];


### PR DESCRIPTION
Update done by running the `nss` and `cacert` update scripts, then
running nixpkgs-check to validate things look good enough to be thrown
at hydra

###### Motivation for this change

https://googleprojectzero.blogspot.com/2021/12/this-shouldnt-have-happened.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested: by running a randomly-picked nixos test, as they basically all depend on nss
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### nixpkgs-check report

**version:** `nixpkgs-check v0.1.0` on NixOS 21.05, sandbox = "true"
**packages declared changed:** {"nss", "nssTools"}
**manual tests declared performed:**
 * 😢 not built on NixOS
 * 😢 not built on MacOS
 * 😢 not built on Other Linux distributions

**complies with contributing.md:** ✔ yes
**package nss:** ✔ continued building
**package nssTools:** ✔ continued building
**closure size for nss:** ✔ increased by 224 B, from 50.3 MB to 50.3 MB
**tests of nss:** 😢 there are no tests

**closure size for nssTools:** ✔ increased by 39.8 KB, from 96.0 MB to 96.0 MB
**tests of nssTools:** 😢 there are no tests