### PR TITLE
vscode-with-system-extensions: WIP

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -71,7 +71,8 @@ let
     buildInputs = [ libsecret libXScrnSaver libxshmfence ]
       ++ lib.optionals (!stdenv.isDarwin) ([ gtk2 at-spi2-atk ] ++ atomEnv.packages);
 
-    runtimeDependencies = lib.optional (stdenv.isLinux) [ (lib.getLib systemd) fontconfig.lib libdbusmenu ];
+    runtimeDependencies = [ stdenv.cc.libc ]
+     ++ lib.optional (stdenv.isLinux) [ (lib.getLib systemd) fontconfig.lib libdbusmenu ];
 
     nativeBuildInputs = [unzip] ++ lib.optionals (!stdenv.isDarwin) [ autoPatchelfHook wrapGAppsHook ];
 

--- a/pkgs/applications/editors/vscode/with-system-extensions.nix
+++ b/pkgs/applications/editors/vscode/with-system-extensions.nix
@@ -1,0 +1,151 @@
+{ lib, stdenv, runCommand, buildEnv, vscode, makeWrapper, libredirect-self
+, vscodeExtensions ? [] }:
+
+/*
+  ```bash
+  $ nix-shell -I nixpkgs=. -E 'with (import <nixpkgs> {}); vscode-with-system-extensions.override {vscodeExtensions = with vscode-extensions; [bbenoist.nix]; }'
+  $ rm -rf "$PWD/build" &&  out="$PWD/build" genericBuild
+  ```
+
+  ```bash
+  $ nix-build -I nixpkgs=. -E 'with (import <nixpkgs> {}); vscode-with-system-extensions.override {vscodeExtensions = with vscode-extensions; [bbenoist.nix ms-vsliveshare.vsliveshare]; }'
+  ```
+*/
+
+let
+  inherit (vscode) executableName longName;
+  wrappedPkgVersion = lib.getVersion vscode;
+  wrappedPkgName = lib.removeSuffix "-${wrappedPkgVersion}" vscode.name;
+
+  combinedExtensionsDrv = buildEnv {
+    name = "vscode-extensions";
+    paths = vscodeExtensions;
+  };
+
+in
+
+# When no extensions are requested, we simply redirect to the original
+# non-wrapped vscode executable.
+runCommand "${wrappedPkgName}-with-system-extensions-${wrappedPkgVersion}" {
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ vscode ];
+  dontPatchELF = true;
+  dontStrip = true;
+  meta = vscode.meta;
+} ''
+  symlink_reinstall_as_real_copy() {
+    declare sl_f="''${1?}"
+    if ! [[ -L "$sl_f" ]]; then
+      1>&2 printf -- "ERROR: Won't reinstall '%s'." "$sl_f"
+      1>&2 printf -- " -> Not a symlink."
+    fi
+    declare in_f
+    in_f="$(realpath "$sl_f")";
+    unlink "$sl_f"
+    cp "$in_f" "$sl_f"
+  }
+
+  symlink_reinstall_as_real_mut_dir() {
+    declare sl_f="''${1?}"
+    if ! [[ -L "$sl_f" ]]; then
+      1>&2 printf -- "ERROR: Won't reinstall '%s'." "$sl_f"
+      1>&2 printf -- " -> Not a symlink."
+    fi
+    declare in_f
+    in_f="$(realpath "$sl_f")";
+    unlink "$sl_f"
+    cp -r "$in_f" "$sl_f"
+    chmod -R u+w "$sl_f"
+  }
+
+  symlinks_expand_dir() {
+    declare curr_dir="''${1?}"
+    if ! [[ -L "$curr_dir" ]]; then
+      1>&2 printf -- "ERROR: Cannot expand '%s'." "$curr_dir"
+      1>&2 printf -- " -> Not a symlink."
+    fi
+    declare in_dir
+    in_dir="$(realpath "$curr_dir")"
+
+    unlink "$curr_dir"
+    mkdir -p "$curr_dir"
+
+    declare f
+    declare bn
+    for f in $(find "$in_dir" -mindepth 1 -maxdepth 1); do
+      bn="$(basename "$f")"
+      ln -sT "$f" "$curr_dir/$bn"
+    done
+  }
+
+  symlinks_expand_from_dir_to_sub_dirs() {
+    declare start_dir="''${1?}"
+    shift 1
+
+    declare curr_dir="$start_dir"
+    symlinks_expand_dir "$curr_dir"
+
+    declare seg_to_ext_dir=( "$@" )
+    for s in "''${seg_to_ext_dir[@]}"; do
+      curr_dir="$curr_dir/$s"
+      symlinks_expand_dir "$curr_dir"
+    done
+  }
+
+  mkdir -p "$out"
+  ln -sT "${vscode}/lib" "$out/lib"
+
+  symlinks_expand_from_dir_to_sub_dirs "$out/lib" "vscode" "resources" "app" "extensions"
+
+  declare in_ext_dir="${combinedExtensionsDrv}/share/vscode/extensions"
+
+  if [[ -e "$in_ext_dir" ]]; then
+    for f in $(find "${combinedExtensionsDrv}/share/vscode/extensions" -mindepth 1 -maxdepth 1); do
+      bn="$(basename "$f")";
+      out_f="$out/lib/vscode/resources/app/extensions/$bn"
+      if [[ -e "$out_f" ]]; then
+        # 1>&2 printf -- "ERROR: System extension '%s' already exist." "$out_f"
+        # 1>&2 printf -- " -> Not allowed to be replaced by '%s'." "$f"
+        # false
+
+        # Silently replace existing system package with extension.
+        unlink "$out_f"
+      fi
+      ln -sT "$f" "$out_f"
+    done
+  fi
+
+  # Works fine. This seems to be required not to use symlinks.
+  symlink_reinstall_as_real_mut_dir "$out/lib/vscode/resources/app/out"
+
+  # Workaround awaiting <https://github.com/electron/electron/issues/31121>.
+  # It the current time, it is impossible to share an electron binary
+  # between 2 apps.
+  # TODO: Avoid this copy by using a 'LD_PRELOAD' trick. Launching
+  # with 'strace', I can see the following query for the current
+  # executable:
+  # 'readlink("/proc/self/exe", "/home/rgauthier/dev/nixpkgs_latest/build/lib/vscode/code", 4096) = 56'.
+  # Example at 'pkgs/build-support/libredirect/libredirect.c'.
+  symlink_reinstall_as_real_copy "$out/lib/vscode/code"
+
+
+  # TODO: Investigate. Causes trouble.
+  # declare code_exe="$out/lib/vscode/code"
+  # declare real_code_exe="$(realpath "$code_exe")"
+  # unlink "$code_exe"
+  # makeWrapper \
+  #   "$real_code_exe" \
+  #   "$code_exe" \
+  #   --set NIX_SELF_REDIRECTS "''${real_code_exe}=''${code_exe}" \
+  #   --set LD_PRELOAD "${libredirect-self}/lib/libredirect-self.so"
+
+  ln -sT "${vscode}/share" "$out/share"
+
+  mkdir -p "$out/bin"
+  for f in $(find "${vscode}/bin" -mindepth 1 -maxdepth 1); do
+    bn="$(basename "$f")"
+    out_f="$out/bin/$bn"
+    install "$f" "$out_f"
+    substituteInPlace "$out_f" --replace "${vscode}" "$out"
+  done
+''

--- a/pkgs/build-support/libredirect-self/default.nix
+++ b/pkgs/build-support/libredirect-self/default.nix
@@ -1,0 +1,89 @@
+{ stdenv, lib }:
+
+stdenv.mkDerivation rec {
+  pname = "libredirect-self";
+  version = "0";
+
+  unpackPhase = ''
+    cp ${./libredirect-self.c} libredirect-self.c
+    cp ${./test.c} test.c
+  '';
+
+  libName = "libredirect-self" + stdenv.targetPlatform.extensions.sharedLibrary;
+
+  outputs = ["out" "hook"];
+
+  buildPhase = ''
+    runHook preBuild
+
+    $CC -Wall -std=c99 -O3 -fPIC -ldl -shared \
+      ${lib.optionalString stdenv.isDarwin "-Wl,-install_name,$out/lib/$libName"} \
+      -o "$libName" \
+      libredirect-self.c
+
+    if [ -n "$doInstallCheck" ]; then
+      $CC -Wall -std=c99 -O3 test.c -o test
+    fi
+
+    runHook postBuild
+  '';
+
+  # We want to retain debugging info to be able to use GDB on libredirect-self.so
+  # to more easily investigate which function overrides are missing or why
+  # existing ones do not have the intended effect.
+  dontStrip = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -vD "$libName" "$out/lib/$libName"
+
+    # Provide a setup hook that injects our library into every process.
+    mkdir -p "$hook/nix-support"
+    cat <<SETUP_HOOK > "$hook/nix-support/setup-hook"
+    ${if stdenv.isDarwin then ''
+    export DYLD_INSERT_LIBRARIES="$out/lib/$libName"
+    '' else ''
+    export LD_PRELOAD="$out/lib/$libName"
+    ''}
+    SETUP_HOOK
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    (
+      source "$hook/nix-support/setup-hook"
+
+      declare ori_self_exe="$PWD/test"
+      export NIX_TEST_ORI_SELF_EXE="$ori_self_exe"
+
+      # Changed case.
+      NIX_TEST_EXP_SELF_EXE="/foo/bar/test" \
+      NIX_SELF_REDIRECTS="''${ori_self_exe}=/foo/bar/test" \
+        ./test
+
+      # Unchanged case no preload.
+      NIX_TEST_EXP_SELF_EXE="$ori_self_exe" \
+        ./test
+
+      # Unchanged case with preload.
+      NIX_TEST_EXP_SELF_EXE="$ori_self_exe" \
+      NIX_SELF_REDIRECTS="''${ori_self_exe}-does-not-exist=/foo/bar/test" \
+        ./test
+    )
+  '';
+
+  meta = with lib; {
+    platforms = platforms.unix;
+    description = "An LD_PRELOAD library to change perceived '/proc/self/exe'";
+    longDescription = ''
+      libredirect-self is an LD_PRELOAD library to change the '/proc/self/exe'
+      value (linux) observed by running executables of the process based on the value
+      of $NIX_SELF_REDIRECTS, a colon-separated list of path prefixes to be rewritten,
+      e.g. "/ori/a=/new/a:/ori/b=/new/b".
+    '';
+  };
+}

--- a/pkgs/build-support/libredirect-self/libredirect-self.c
+++ b/pkgs/build-support/libredirect-self/libredirect-self.c
@@ -1,0 +1,117 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <dlfcn.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/param.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <string.h>
+#include <spawn.h>
+#include <dirent.h>
+
+#define MAX_REDIRECTS 128
+
+#ifdef __APPLE__
+  struct dyld_interpose {
+    const void * replacement;
+    const void * replacee;
+  };
+  #define WRAPPER(ret, name) static ret _libredirect_self_wrapper_##name
+  #define LOOKUP_REAL(name) &name
+  #define WRAPPER_DEF(name) \
+    __attribute__((used)) static struct dyld_interpose _libredirect_self_interpose_##name \
+      __attribute__((section("__DATA,__interpose"))) = { &_libredirect_self_wrapper_##name, &name };
+#else
+  #define WRAPPER(ret, name) ret name
+  #define LOOKUP_REAL(name) dlsym(RTLD_NEXT, #name)
+  #define WRAPPER_DEF(name)
+#endif
+
+static int nrRedirects = 0;
+static char * from[MAX_REDIRECTS];
+static char * to[MAX_REDIRECTS];
+
+static int isInitialized = 0;
+
+// FIXME: might run too late.
+static void init() __attribute__((constructor));
+
+static void init()
+{
+    if (isInitialized) return;
+
+    char * spec = getenv("NIX_SELF_REDIRECTS");
+    if (!spec) return;
+
+    // Ensure we only run this code once.
+    // We do not do `unsetenv("NIX_SELF_REDIRECTS")` to ensure that redirects
+    // also get initialized for subprocesses.
+    isInitialized = 1;
+
+    char * spec2 = malloc(strlen(spec) + 1);
+    strcpy(spec2, spec);
+
+    char * pos = spec2, * eq;
+    while ((eq = strchr(pos, '='))) {
+        *eq = 0;
+        from[nrRedirects] = pos;
+        pos = eq + 1;
+        to[nrRedirects] = pos;
+        nrRedirects++;
+        if (nrRedirects == MAX_REDIRECTS) break;
+        char * end = strchr(pos, ':');
+        if (!end) break;
+        *end = 0;
+        pos = end + 1;
+    }
+
+}
+
+static size_t rewrite_to_out_arg(
+    const char * path_buf, size_t path_bufsize, char * buf, size_t bufsize)
+{
+    const int redirect_count = (path_buf == NULL) ? 0 : nrRedirects;
+    int cp_len;
+
+    for (int n = 0; n < redirect_count; ++n) {
+        const size_t len = strlen(from[n]);
+        if (strncmp(path_buf, from[n], MIN(path_bufsize, len)) != 0) continue;
+
+        cp_len = snprintf(buf, bufsize, "%s%s", to[n], path_buf + len);
+        if (0 > cp_len) abort();
+        return cp_len;
+    }
+
+    cp_len = snprintf(buf, MIN(path_bufsize, bufsize), "%s", path_buf);
+    if (0 > cp_len) abort();
+    return cp_len;
+}
+
+WRAPPER(ssize_t, readlink)(const char * path, char * buf, size_t bufsize)
+{
+    int (*readlink_real) (const char *, char *, size_t) = LOOKUP_REAL(readlink);
+
+    const char* self_exe_symlink_path = "/proc/self/exe";
+    int len = strlen(self_exe_symlink_path);
+    // TODO: What would it be on OSX?
+    if (strncmp(path, self_exe_symlink_path, len) != 0)
+    {
+        // Nothing special to do, simply forward to real.
+        return readlink_real(path, buf, bufsize);
+    }
+
+    char temp_buf[PATH_MAX];
+    ssize_t result = readlink_real(path, temp_buf, PATH_MAX);
+    if (result < 0) {
+        return result;
+    }
+    return rewrite_to_out_arg(temp_buf, PATH_MAX, buf, bufsize);
+}
+WRAPPER_DEF(readlink)
+
+// TODO: Should we handle this as well?
+// ssize_t readlinkat(int dirfd, const char *path, char *buf, size_t bufsiz); /* flags=AT_SYMLINK_NOFOLLOW */

--- a/pkgs/build-support/libredirect-self/test.c
+++ b/pkgs/build-support/libredirect-self/test.c
@@ -1,0 +1,83 @@
+#define _GNU_SOURCE
+#include <assert.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <limits.h>
+
+#include <sys/types.h>
+
+static const char* _getenv_or_abort(const char* envvar_name) {
+    const char* out = getenv(envvar_name);
+    if (!out) {
+        fprintf(stderr, "Environment variable '%s' was not found.\n", envvar_name);
+        abort();
+    }
+    return out;
+}
+
+static void test_readlink_proc_self_exe(void) {
+    const char* exp_exe_path = _getenv_or_abort("NIX_TEST_EXP_SELF_EXE");
+    const int exp_exe_path_len = strlen(exp_exe_path);
+    const ssize_t exp_ret = exp_exe_path_len;
+
+    char act_link_path[PATH_MAX];
+    memset(act_link_path, 0, sizeof(act_link_path));
+
+    const ssize_t ret = readlink("/proc/self/exe", act_link_path, PATH_MAX);
+
+    assert(ret == exp_ret);
+    assert(strncmp(act_link_path, exp_exe_path, exp_exe_path_len) == 0);
+}
+
+static void test_readlink_other_link_exist(void) {
+    const char* exp_exe_path = _getenv_or_abort("PWD");
+    const int exp_exe_path_len = strlen(exp_exe_path);
+    const ssize_t exp_ret = exp_exe_path_len;
+
+    char act_link_path[PATH_MAX];
+    memset(act_link_path, 0, sizeof(act_link_path));
+
+    const ssize_t ret = readlink("/proc/self/cwd", act_link_path, PATH_MAX);
+
+    assert(ret == exp_ret);
+    assert(strncmp(act_link_path, exp_exe_path, exp_exe_path_len) == 0);
+}
+
+static void test_readlink_other_file_does_not_exist(void) {
+    const char* exp_exe_path = "";
+    const int exp_exe_path_len = strlen(exp_exe_path);
+    const ssize_t exp_ret = -1;
+
+    char act_link_path[PATH_MAX];
+    memset(act_link_path, 0, sizeof(act_link_path));
+
+    const ssize_t ret = readlink("/proc/self/does-not-exists", act_link_path, PATH_MAX);
+
+    assert(ret == exp_ret);
+    assert(strncmp(act_link_path, exp_exe_path, exp_exe_path_len) == 0);
+}
+
+static void test_readlink_other_file_not_a_link(void) {
+    const char* exp_exe_path = "";
+    const int exp_exe_path_len = strlen(exp_exe_path);
+    const ssize_t exp_ret = -1;
+
+    char act_link_path[PATH_MAX];
+    memset(act_link_path, 0, sizeof(act_link_path));
+
+    const ssize_t ret = readlink("/proc/self/status", act_link_path, PATH_MAX);
+
+    assert(ret == exp_ret);
+    assert(strncmp(act_link_path, exp_exe_path, exp_exe_path_len) == 0);
+}
+
+int main(int argc, char *argv[])
+{
+    test_readlink_proc_self_exe();
+    test_readlink_other_link_exist();
+    test_readlink_other_file_does_not_exist();
+    test_readlink_other_file_not_a_link();
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -663,6 +663,8 @@ with pkgs;
 
   libredirect = callPackage ../build-support/libredirect { };
 
+  libredirect-self = callPackage ../build-support/libredirect-self { };
+
   madonctl = callPackage ../applications/misc/madonctl { };
 
   maelstrom = callPackage ../games/maelstrom { };
@@ -28996,6 +28998,7 @@ with pkgs;
   vscode-fhsWithPackages = vscode.fhsWithPackages;
 
   vscode-with-extensions = callPackage ../applications/editors/vscode/with-extensions.nix {};
+  vscode-with-system-extensions = callPackage ../applications/editors/vscode/with-system-extensions.nix {};
 
   vscode-utils = callPackage ../misc/vscode-extensions/vscode-utils.nix {};
 


### PR DESCRIPTION
This is a **work in progress / draft**, an idea that I had for quite some time and I finally got some time to implement.

This **works really well** (on both stable and unstable) and **leave room for you to install extensions dynamically** while profiting from our nixpkgs integrated extensions set (which is sometimes required).

However, major thing (in my opinion) that remain is that I **wasn't able to avoid the big ~126MiB electron copy**. Also some cleanup required depending on the chosen solution. Note that this will get reclaimed back on `nix-store --optimise` (hardlinking both copies), however I would prefer to avoid this.

I wanted to **get some fresh ideas how to get rid of this copy**. I tried some `LD_PRELOAD` patch but this was a failure, the programs fails to load. The ideal would be that **upstream do something about it** (see [[Feature Request]: Add an option to specify the resource directory · Issue #31121 · electron/electron](https://github.com/electron/electron/issues/31121)), however that might not happen soon unless we feed them with some well crafted PR (which I wasn't yet able to do). **Patching our copy is not yet an option** as we're **not yet building electron ourselves from sources** (see #17073).

To make it work on stable, you need to add the following lines as well (after the `code` electron binary copy):

```bash
# For some reason the following is required on stable 21.09 but not unstable
# as of 2021/12/01:
symlink_reinstall_as_real_copy "$out/lib/vscode/resources/app/node_modules.asar"
```

Here's a ref to the issue comment that gave me this idea in the first place:

 -  [Allow extensions to be installed for all users · Issue #56614 · microsoft/vscode](https://github.com/microsoft/vscode/issues/56614)

     -  [Dampfwalze commented on Sep 23](https://github.com/microsoft/vscode/issues/56614#issuecomment-697961001)

         >  In the install directory of VSCode is an extensions folder in
         >  \Microsoft VS Code\resources\app\extensions. Simply copy all
         >  necessary extensions in here and you are good to go!
 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Allow users to dynamically install extension while still being backed by our fine well integrated extension set.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Extra system / builtin extensions are all displayed in vscode's extensions pane (`ctrl+shift+x`) alongside other builtins when typing `@builtin` in the search box. Extensions all seem to work fine (I am currently working with a huge set of extra builtin extensions  `> 20`).

