### PR TITLE
mcomix: fix invalid .desktop icon name

### DIFF
--- a/pkgs/applications/graphics/mcomix3/default.nix
+++ b/pkgs/applications/graphics/mcomix3/default.nix
@@ -47,7 +47,8 @@ python3.pkgs.buildPythonApplication rec {
     runHook preInstall
 
     substituteInPlace mime/*.desktop \
-      --replace "Exec=mcomix" "Exec=mcomix3"
+      --replace "Exec=mcomix" "Exec=mcomix3" \
+      --replace "Icon=mcomix" "Icon=${pname}"
     ${python3.executable} installer.py --srcdir=mcomix --target=$libdir
     mv $libdir/mcomix/mcomixstarter.py $out/bin/${pname}
     mv $libdir/mcomix/comicthumb.py $out/bin/comicthumb


### PR DESCRIPTION
###### Motivation for this change

The existing packaging renames the application icon without updating the `mcomix.desktop` entry that points to it. This means applications following https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html won't find the icon (they look for [mcomix](https://github.com/multiSnow/mcomix3/blob/gtk3/mime/mcomix.desktop#L16-L17)). 

PR updates the `mcomix.desktop` file to reference match the name of the packages icon `mcomix3` as renamed [here](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/graphics/mcomix3/default.nix#L70).

Note you may need to run `update-desktop-database` for the change to work. [home-manager does this](https://github.com/nix-community/home-manager/blob/4fa1ba72a39da509399cce43995e4c1e1960ce9c/modules/misc/xdg-mime.nix#L53-L56)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
