### PR TITLE
linuxPackages*.xmm7360-pci: unbreak for kernels > 5.14

### DIFF
--- a/pkgs/os-specific/linux/xmm7360-pci/516617f9bb63900f1e1a96d8ef58105edb9808a8.patch
+++ b/pkgs/os-specific/linux/xmm7360-pci/516617f9bb63900f1e1a96d8ef58105edb9808a8.patch
@@ -1,0 +1,23 @@
+From 516617f9bb63900f1e1a96d8ef58105edb9808a8 Mon Sep 17 00:00:00 2001
+From: Olav Seyfarth <olav@seyfarth.de>
+Date: Thu, 16 Sep 2021 19:32:04 +0200
+Subject: [PATCH] Update xmm7360.c
+
+Signed-off-by: Olav Seyfarth <nursoda@users.noreply.github.com>
+---
+ xmm7360.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/xmm7360.c b/xmm7360.c
+index ccd149d..af96186 100644
+--- a/xmm7360.c
++++ b/xmm7360.c
+@@ -1272,7 +1272,7 @@ static int xmm7360_tty_write(struct tty_struct *tty,
+ 	return written;
+ }
+ 
+-static int xmm7360_tty_write_room(struct tty_struct *tty)
++static unsigned xmm7360_tty_write_room(struct tty_struct *tty)
+ {
+ 	struct queue_pair *qp = tty->driver_data;
+ 	if (!xmm7360_qp_can_write(qp))

--- a/pkgs/os-specific/linux/xmm7360-pci/704e1ca6421947183be4b1fe9f2f6c54213b60c2.patch
+++ b/pkgs/os-specific/linux/xmm7360-pci/704e1ca6421947183be4b1fe9f2f6c54213b60c2.patch
@@ -1,0 +1,44 @@
+From 704e1ca6421947183be4b1fe9f2f6c54213b60c2 Mon Sep 17 00:00:00 2001
+From: Artur Rojek <contact@artur-rojek.eu>
+Date: Wed, 10 Nov 2021 14:19:08 +0100
+Subject: [PATCH] xmm7360: Add irq handler before device init
+
+Request the irq handler before a call to `xmm7360_dev_init`. This solves
+the `free_netdev` segfault stemming from ring creation timeouts.
+
+Fixes: 0060149958d0 ("Request a single interrupt only")
+Signed-off-by: Artur Rojek <contact@artur-rojek.eu>
+---
+ xmm7360.c | 12 +++++-------
+ 1 file changed, 5 insertions(+), 7 deletions(-)
+
+diff --git a/xmm7360.c b/xmm7360.c
+index ccd149d..ca7c0e6 100644
+--- a/xmm7360.c
++++ b/xmm7360.c
+@@ -1477,12 +1477,6 @@ static int xmm7360_probe(struct pci_dev *dev, const struct pci_device_id *id)
+ 	init_waitqueue_head(&xmm->wq);
+ 	INIT_WORK(&xmm->init_work, xmm7360_dev_init_work);
+ 
+-	pci_set_drvdata(dev, xmm);
+-
+-	ret = xmm7360_dev_init(xmm);
+-	if (ret)
+-		goto fail;
+-
+ 	xmm->irq = pci_irq_vector(dev, 0);
+ 	ret = request_irq(xmm->irq, xmm7360_irq0, 0, "xmm7360", xmm);
+ 	if (ret) {
+@@ -1490,7 +1484,11 @@ static int xmm7360_probe(struct pci_dev *dev, const struct pci_device_id *id)
+ 		goto fail;
+ 	}
+ 
+-	return ret;
++	pci_set_drvdata(dev, xmm);
++
++	ret = xmm7360_dev_init(xmm);
++	if (!ret)
++		return 0;
+ 
+ fail:
+ 	xmm7360_dev_deinit(xmm);

--- a/pkgs/os-specific/linux/xmm7360-pci/72e2d597d19d7b2a4e172637715aa0c14deaee71.patch
+++ b/pkgs/os-specific/linux/xmm7360-pci/72e2d597d19d7b2a4e172637715aa0c14deaee71.patch
@@ -1,0 +1,27 @@
+From 72e2d597d19d7b2a4e172637715aa0c14deaee71 Mon Sep 17 00:00:00 2001
+From: Artur Rojek <contact@artur-rojek.eu>
+Date: Sat, 20 Nov 2021 15:40:46 +0100
+Subject: [PATCH] xmm7360: Drop put_tty_driver
+
+As of v5.15, the `put_tty_driver` alias has been dropped in favor of
+directly calling `tty_driver_kref_put` (9f90a4ddef4e). Apply this change
+in the xmm7360 driver in order to allow building on recent kernels.
+
+Signed-off-by: Artur Rojek <contact@artur-rojek.eu>
+---
+ xmm7360.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/xmm7360.c b/xmm7360.c
+index ccd149d..26858db 100644
+--- a/xmm7360.c
++++ b/xmm7360.c
+@@ -1555,7 +1555,7 @@ static void xmm7360_exit(void)
+ 	pci_unregister_driver(&xmm7360_driver);
+ 	unregister_chrdev_region(xmm_base, 8);
+ 	tty_unregister_driver(xmm7360_tty_driver);
+-	put_tty_driver(xmm7360_tty_driver);
++	tty_driver_kref_put(xmm7360_tty_driver);
+ }
+ 
+ module_init(xmm7360_init);

--- a/pkgs/os-specific/linux/xmm7360-pci/default.nix
+++ b/pkgs/os-specific/linux/xmm7360-pci/default.nix
@@ -11,6 +11,20 @@ stdenv.mkDerivation rec {
     sha256 = "1wdb0phqg9rj9g9ycqdya0m7lx24kzjlh25yw0ifp898ddxrrr0c";
   };
 
+  patches = [
+    # Change xmm7360_tty_write_room to unsigned in xmm7360.c
+    # https://github.com/xmm7360/xmm7360-pci/pull/139
+    ./516617f9bb63900f1e1a96d8ef58105edb9808a8.patch
+
+    # xmm7360: Drop put_tty_driver
+    # https://github.com/xmm7360/xmm7360-pci/pull/152
+    ./72e2d597d19d7b2a4e172637715aa0c14deaee71.patch
+
+    # xmm7360: Add irq handler before device init
+    # https://github.com/xmm7360/xmm7360-pci/pull/149
+    ./704e1ca6421947183be4b1fe9f2f6c54213b60c2.patch
+  ];
+
   makeFlags = [ "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
@@ -24,6 +38,6 @@ stdenv.mkDerivation rec {
     license = licenses.isc;
     maintainers = with maintainers; [ flokli hexa ];
     platforms = platforms.linux;
-    broken = kernel.kernelOlder "4.10" || kernel.kernelAtLeast "5.14";
+    broken = kernel.kernelOlder "4.10";
   };
 }


### PR DESCRIPTION
Continuation of https://github.com/NixOS/nixpkgs/pull/147709.

As of v5.15, the `put_tty_driver` alias has been dropped in favor of
directly calling `tty_driver_kref_put` (9f90a4ddef4e). Apply this change
in the xmm7360 driver in order to allow building on recent kernels:
https://github.com/xmm7360/xmm7360-pci/pull/152

Also, apply some [incompatible pointer type fixes](https://github.com/xmm7360/xmm7360-pci/pull/139)
and [stability fixes](https://github.com/xmm7360/xmm7360-pci/pull/149)
which are queued in that repository.

I successfully built this for 5.14 and 5.15, so let's remove the
isBroken for these versions.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
