### PR TITLE
gnomeExtetnsions.ddterm: fix gjs requirement

### DIFF
--- a/pkgs/desktops/gnome/extensions/extensionOverrides.nix
+++ b/pkgs/desktops/gnome/extensions/extensionOverrides.nix
@@ -20,7 +20,7 @@ in
 #
 # Note that all source patches refer to the built extension as published on extensions.gnome.org, and not
 # the upstream repository's sources.
-super: lib.trivial.pipe super [
+super: lib.trivial.pipe super (lib.lists.flatten [
   (patchExtension "caffeine@patapon.info" (old: {
     meta.maintainers = with lib.maintainers; [ eperuffo ];
   }))
@@ -52,15 +52,16 @@ super: lib.trivial.pipe super [
     '';
   }))
 
-  (patchExtension "gnome-shell-screenshot@ttll.de" (old: {
-    # Requires gjs
-    # https://github.com/NixOS/nixpkgs/issues/136112
-    postPatch = ''
-      for file in *.js; do
-        substituteInPlace $file --replace "gjs" "${gjs}/bin/gjs"
-      done
-    '';
-  }))
+  (lib.lists.forEach [ "gnome-shell-screenshot@ttll.de" "ddterm@amezin.github.com" ] ( extension:
+    patchExtension extension (old: {
+      # Requires gjs
+      # https://github.com/NixOS/nixpkgs/issues/136112
+      postPatch = ''
+        for file in *.js; do
+          substituteInPlace $file --replace "gjs" "${gjs}/bin/gjs"
+        done
+      '';
+  })))
 
   (patchExtension "unite@hardpixel.eu" (old: {
     buildInputs = [ xprop ];
@@ -76,4 +77,4 @@ super: lib.trivial.pipe super [
         --replace "GLib.build_filenamev([GLib.DIR_SEPARATOR_S, 'usr', 'share', 'touchegg', 'touchegg.conf'])" "'${touchegg}/share/touchegg/touchegg.conf'"
     '';
   }))
-]
+])


### PR DESCRIPTION
###### Motivation for this change
According to log journal `ddterm` required `gjs`, same as #136112
``` log
Starting ddterm app: ["/run/current-system/sw/share/gnome-shell/extensions/ddterm@amezin.github.com/com.github.amezin.ddterm","--undecorated"]
ddterm app exited with status 127
/run/current-system/sw/share/gnome-shell/extensions/ddterm@amezin.github.com/com.github.amezin.ddterm: line 5: exec: gjs: not found
```

So expand previous solution  

###### Things done

- [x] Tested, as applicable:
  - [Testing Package Updates with](https://nixos.wiki/wiki/Nixpkgs/Create_and_debug_packages#Testing_Package_Updates_with_Nox) | [Nox](https://github.com/NixOS/nixpkgs/blob/nixos-21.11/pkgs/tools/package-management/nox/default.nix#L27)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
