### PR TITLE
elpa: init at 2021.05.002_bugfix

### DIFF
--- a/pkgs/applications/science/chemistry/cp2k/default.nix
+++ b/pkgs/applications/science/chemistry/cp2k/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, python3, gfortran, blas, lapack
 , fftw, libint, libvori, libxc, mpi, gsl, scalapack, openssh, makeWrapper
-, libxsmm, spglib, which
+, libxsmm, spglib, which, elpa, pkg-config
 } :
 
 let
@@ -19,8 +19,9 @@ in stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ python3 which openssh makeWrapper ];
+  nativeBuildInputs = [ python3 which openssh makeWrapper pkg-config ];
   buildInputs = [
+    elpa
     gfortran
     fftw
     gsl
@@ -60,20 +61,20 @@ in stdenv.mkDerivation rec {
     AR         = ar -r
     DFLAGS     = -D__FFTW3 -D__LIBXC -D__LIBINT -D__parallel -D__SCALAPACK \
                  -D__MPI_VERSION=3 -D__F2008 -D__LIBXSMM -D__SPGLIB \
-                 -D__MAX_CONTR=4 -D__LIBVORI
+                 -D__MAX_CONTR=4 -D__LIBVORI -D__ELPA
     CFLAGS    = -fopenmp
     FCFLAGS    = \$(DFLAGS) -O2 -ffree-form -ffree-line-length-none \
                  -ftree-vectorize -funroll-loops -msse2 \
                  -std=f2008 \
                  -fopenmp -ftree-vectorize -funroll-loops \
                  -I${libxc}/include -I${libxsmm}/include \
-                 -I${libint}/include
+                 -I${libint}/include $(pkg-config --variable=fcflags elpa)
     LIBS       = -lfftw3 -lfftw3_threads \
                  -lscalapack -lblas -llapack \
                  -lxcf03 -lxc -lxsmmf -lxsmm -lsymspg \
                  -lint2 -lstdc++ -lvori \
                  -lgomp -lpthread -lm \
-                 -fopenmp
+                 -fopenmp $(pkg-config --libs elpa)
     LDFLAGS    = \$(FCFLAGS) \$(LIBS)
     EOF
   '';

--- a/pkgs/development/libraries/elpa/default.nix
+++ b/pkgs/development/libraries/elpa/default.nix
@@ -1,0 +1,95 @@
+{ lib, stdenv, fetchurl, autoreconfHook, gfortran, perl
+, mpi, blas, lapack, scalapack, openssh
+# CPU optimizations
+, avxSupport ? stdenv.hostPlatform.avxSupport
+, avx2Support ? stdenv.hostPlatform.avx2Support
+, avx512Support ? stdenv.hostPlatform.avx512Support
+# Enable NIVIA GPU support
+# Note, that this needs to be built on a system with a GPU
+# present for the tests to succeed.
+, enableCuda ? false
+# type of GPU architecture
+, nvidiaArch ? "sm_60"
+, cudatoolkit
+} :
+
+# The standard Scalapack has no iLP64 interface
+assert (!blas.isILP64) && (!lapack.isILP64);
+
+stdenv.mkDerivation rec {
+  pname = "elpa";
+  version = "2021.05.002_bugfix";
+
+  src = fetchurl {
+    url = "https://elpa.mpcdf.mpg.de/software/tarball-archive/Releases/${version}/elpa-${version}.tar.gz";
+    sha256 = "0jr2j1ncslbr7fi47dj58b7afm7kr0sx6jfpfgqb5r5rwn6w9ayy";
+  };
+
+  patches = [
+    # Use a plain name for the pkg-config file
+    ./pkg-config.patch
+  ];
+
+  postPatch = ''
+    patchShebangs ./fdep/fortran_dependencies.pl
+    patchShebangs ./test-driver
+
+    # Fix the test script generator
+    substituteInPlace Makefile.am --replace '#!/bin/bash' '#!${stdenv.shell}'
+  '';
+
+  nativeBuildInputs = [ autoreconfHook perl openssh ];
+
+  buildInputs = [ mpi blas lapack scalapack ]
+    ++ lib.optional enableCuda cudatoolkit;
+
+  preConfigure = ''
+    export FC="mpifort"
+    export CC="mpicc"
+
+    # These need to be set for configure to succeed
+    export FCFLAGS="${lib.optionalString stdenv.hostPlatform.isx86_64 "-msse3 "
+      + lib.optionalString avxSupport "-mavx "
+      + lib.optionalString avx2Support "-mavx2 -mfma "
+      + lib.optionalString avx512Support "-mavx512"}"
+
+    export CFLAGS=$FCFLAGS
+  '';
+
+  configureFlags = [
+    "--with-mpi"
+    "--enable-openmp"
+    "--without-threading-support-check-during-build"
+  ] ++ lib.optional (!avxSupport) "--disable-avx"
+    ++ lib.optional (!avx2Support) "--disable-avx2"
+    ++ lib.optional (!avx512Support) "--disable-avx512"
+    ++ lib.optional (!stdenv.hostPlatform.isx86_64) "--disable-sse"
+    ++ lib.optional stdenv.hostPlatform.isx86_64 "--enable-sse-assembly"
+    ++ lib.optionals enableCuda [  "--enable-nvidia-gpu" "--with-NVIDIA-GPU-compute-capability=${nvidiaArch}" ];
+
+  doCheck = true;
+
+  preCheck = ''
+    #patchShebangs ./
+
+    # make sure the test starts even if we have less than 4 cores
+    export OMPI_MCA_rmaps_base_oversubscribe=1
+
+    # Fix to make mpich run in a sandbox
+    export HYDRA_IFACE=lo
+
+    # Run dual threaded
+    export OMP_NUM_THREADS=2
+
+    # Reduce test problem sizes
+    export TEST_FLAGS="1500 50 16"
+  '';
+
+  meta = with lib; {
+    description = "Eigenvalue Solvers for Petaflop-Applications";
+    homepage = "https://elpa.mpcdf.mpg.de/";
+    license = licenses.lgpl3Only;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.markuskowa ];
+  };
+}

--- a/pkgs/development/libraries/elpa/pkg-config.patch
+++ b/pkgs/development/libraries/elpa/pkg-config.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index a14dd8a..3519a64 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2229,7 +2229,7 @@ if test x"$have_loop_blocking" = x"yes"; then
+ fi
+ 
+ AC_SUBST([SUFFIX])
+-AC_SUBST([PKG_CONFIG_FILE],[elpa${SUFFIX}-${PACKAGE_VERSION}.pc])
++AC_SUBST([PKG_CONFIG_FILE],[elpa.pc])
+ 
+ AC_CONFIG_FILES([
+   Makefile

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2883,6 +2883,8 @@ with pkgs;
 
   elogind = callPackage ../applications/misc/elogind { };
 
+  elpa = callPackage ../development/libraries/elpa { };
+
   enca = callPackage ../tools/text/enca { };
 
   enigma = callPackage ../games/enigma {};


### PR DESCRIPTION
###### Motivation for this change
Add ELPA, an eigenvalue solver for large scale computations and build CP2K with ELPA.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
