### PR TITLE
NixOS/evalModules legacy cleanup

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -101,6 +101,11 @@ rec {
                   check ? true
                 }:
     let
+      withWarnings = x:
+        lib.warnIf (evalModulesArgs?args) "The args argument to evalModules is deprecated. Please set config._module.args instead."
+        lib.warnIf (evalModulesArgs?check) "The check argument to evalModules is deprecated. Please set config._module.check instead."
+        x;
+
       legacyModules =
         optional (evalModulesArgs?args) {
           config = {
@@ -248,7 +253,7 @@ rec {
         inherit modules specialArgs;
       };
 
-      result = {
+      result = withWarnings {
         options = checked options;
         config = checked (removeAttrs config [ "_module" ]);
         _module = checked (config._module);

--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -81,14 +81,15 @@ let
     };
   };
 
-in rec {
+  nixosWithUserModules = noUserModules.extendModules { modules = allUserModules; };
+
+in {
 
   # Merge the option definitions in all modules, forming the full
   # system configuration.
-  inherit (noUserModules.extendModules { modules = allUserModules; })
-    config options _module type;
+  inherit (nixosWithUserModules) config options _module type;
 
   inherit extraArgs;
 
-  inherit (_module.args) pkgs;
+  inherit (nixosWithUserModules._module.args) pkgs;
 }

--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -52,6 +52,11 @@ let
     };
   };
 
+  withWarnings = x:
+    lib.warnIf (evalConfigArgs?args) "The extraArgs argument to eval-config.nix is deprecated. Please set config._module.args instead."
+    lib.warnIf (evalConfigArgs?check) "The check argument to eval-config.nix is deprecated. Please set config._module.check instead."
+    x;
+
   legacyModules =
     lib.optional (evalConfigArgs?args) {
       config = {
@@ -83,7 +88,7 @@ let
 
   nixosWithUserModules = noUserModules.extendModules { modules = allUserModules; };
 
-in {
+in withWarnings {
 
   # Merge the option definitions in all modules, forming the full
   # system configuration.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The supposedly legacy `args` flags was still used and was not passed along correctly. This PR fixes this at the module system level, at the NixOS level and in the documentation module. While only one of these would be sufficient to solve the issue, it is clear that we should get rid of the redundant code.

 - First and foremost, address the issue raised in https://github.com/NixOS/nixpkgs/pull/144094#issuecomment-984623393.

 - Deprecate the legacy parameters that, combined with #144094, created the problem.
 
 - Simplify the documentation module and make it more complete and accurate.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - **The fix is to simplify, so that a new test case is not necessary**
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
