### PR TITLE
kalendar: init at 0.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2092,6 +2092,17 @@
     githubId = 12386805;
     name = "Chua Hou";
   };
+  chuangzhu = {
+    name = "Chuang Zhu";
+    email = "chuang@melty.land";
+    matrix = "@chuangzhu:matrix.org";
+    github = "chuangzhu";
+    githubId = 31200881;
+    keys = [{
+      longkeyid = "rsa4096/E838CED81CFFD3F9";
+      fingerprint = "5D03 A5E6 0754 A3E3 CA57 5037 E838 CED8 1CFF D3F9";
+    }];
+  };
   chvp = {
     email = "nixpkgs@cvpetegem.be";
     matrix = "@charlotte:vanpetegem.me";

--- a/pkgs/applications/office/kalendar/default.nix
+++ b/pkgs/applications/office/kalendar/default.nix
@@ -1,0 +1,94 @@
+{ lib
+, mkDerivation
+, fetchFromGitLab
+, cmake
+, extra-cmake-modules
+, makeWrapper
+
+, qtbase
+, qtquickcontrols2
+, qtsvg
+, qtlocation
+, qtdeclarative
+
+, kirigami2
+, kdbusaddons
+, ki18n
+, kcalendarcore
+, kconfigwidgets
+, kwindowsystem
+, kcoreaddons
+, kcontacts
+, kitemmodels
+, kxmlgui
+, knotifications
+, kiconthemes
+, kservice
+, kmime
+, kpackage
+, eventviews
+, calendarsupport
+
+, akonadi
+, akonadi-contacts
+, akonadi-calendar-tools
+, kdepim-runtime
+}:
+
+mkDerivation rec {
+  pname = "kalendar";
+  version = "0.3.1";
+
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "pim";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-foG8j/MRbDZyzM9KmxEARfWUQXMz8ylQgersE1/gtnQ=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    makeWrapper
+  ];
+
+  buildInputs = [
+    qtbase
+    qtquickcontrols2
+    qtsvg
+    qtlocation
+    qtdeclarative
+
+    kirigami2
+    kdbusaddons
+    ki18n
+    kcalendarcore
+    kconfigwidgets
+    kwindowsystem
+    kcoreaddons
+    kcontacts
+    kitemmodels
+    kxmlgui
+    knotifications
+    kiconthemes
+    kservice
+    kmime
+    kpackage
+    eventviews
+    calendarsupport
+
+    akonadi-contacts
+    akonadi-calendar-tools
+  ];
+
+  propagatedUserEnvPkgs = [ akonadi kdepim-runtime ];
+
+  meta = with lib; {
+    description = "A calendar application using Akonadi to sync with external services (Nextcloud, GMail, ...)";
+    homepage = "https://invent.kde.org/pim/kalendar/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ chuangzhu ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24928,6 +24928,8 @@ with pkgs;
 
   icesl = callPackage ../applications/misc/icesl { };
 
+  kalendar = libsForQt5.callPackage ../applications/office/kalendar { };
+
   keepassx = callPackage ../applications/misc/keepassx { };
   keepassx2 = callPackage ../applications/misc/keepassx/2.0.nix { };
   keepassxc = libsForQt5.callPackage ../applications/misc/keepassx/community.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

A calendar application using Akonadi to sync with external services (Nextcloud, GMail, ...)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
