### PR TITLE
glitter: 1.5.7 -> 1.5.9

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/glitter/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/glitter/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "glitter";
-  version = "1.5.8";
+  version = "1.5.9";
 
   src = fetchFromGitHub {
     owner = "milo123459";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-LQlybr0l6MQiXak8+fwOi7/cuYi/LiFAW1Uulowkb5k=";
+    sha256 = "sha256-jznlGPRYzWND5qdopD4iMz1IgduP8hXV4T+IGkSI3Qg=";
   };
 
-  cargoSha256 = "sha256-RDf0Rby6n8aJyhFft8/t+tDLWeJi7GfIsrL8VjFdy9Y=";
+  cargoSha256 = "sha256-HAEyb2iVGRxaHQhy3zUgmRiBtXHmyxgmmh1R8wwoBs0=";
 
   # tests require it to be in a git repository
   preCheck = ''

--- a/pkgs/applications/version-management/git-and-tools/glitter/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/glitter/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "glitter";
-  version = "1.5.7";
+  version = "1.5.8";
 
   src = fetchFromGitHub {
     owner = "milo123459";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-0hKwGZingOa4nB9VTErbOTSBLc4pcxDUnK5lltVZiYk=";
+    sha256 = "sha256-LQlybr0l6MQiXak8+fwOi7/cuYi/LiFAW1Uulowkb5k=";
   };
 
-  cargoSha256 = "sha256-08heeRIGzPmORh8KTyBx9GPfOZw2RR85PjkGvbaGA50=";
+  cargoSha256 = "sha256-RDf0Rby6n8aJyhFft8/t+tDLWeJi7GfIsrL8VjFdy9Y=";
 
   # tests require it to be in a git repository
   preCheck = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/Milo123459/glitter/compare/v1.5.7...v1.5.9

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
