### PR TITLE
[21.11] nix-update: use nix_2_4

### DIFF
--- a/pkgs/tools/package-management/nix-update/default.nix
+++ b/pkgs/tools/package-management/nix-update/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonApplication
 , fetchFromGitHub
-, nix
+, nix_2_4
 , nix-prefetch
 , nixpkgs-fmt
 , nixpkgs-review
@@ -19,7 +19,7 @@ buildPythonApplication rec {
   };
 
   makeWrapperArgs = [
-    "--prefix" "PATH" ":" (lib.makeBinPath [ nix nix-prefetch nixpkgs-fmt nixpkgs-review ])
+    "--prefix" "PATH" ":" (lib.makeBinPath [ nix_2_4 nix-prefetch nixpkgs-fmt nixpkgs-review ])
   ];
 
   checkPhase = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`nix-update` is broken on `release-21.11`, returning the following error:

```
error: unrecognised flag '--impure'
Try 'nix --help' for more information.
Traceback (most recent call last):
  File "/nix/store/d4a8w1yr4gs8k1ajkmi17d524p28ghz8-nix-update-0.5.0/bin/.nix-update-wrapped", line 9, in <module>
    sys.exit(main())
  File "/nix/store/d4a8w1yr4gs8k1ajkmi17d524p28ghz8-nix-update-0.5.0/lib/python3.9/site-packages/nix_update/__init__.py", line 196, in main
    package = update(options)
  File "/nix/store/d4a8w1yr4gs8k1ajkmi17d524p28ghz8-nix-update-0.5.0/lib/python3.9/site-packages/nix_update/update.py", line 140, in update
    package = eval_attr(opts)
  File "/nix/store/d4a8w1yr4gs8k1ajkmi17d524p28ghz8-nix-update-0.5.0/lib/python3.9/site-packages/nix_update/eval.py", line 89, in eval_attr
    res = run(cmd)
  File "/nix/store/d4a8w1yr4gs8k1ajkmi17d524p28ghz8-nix-update-0.5.0/lib/python3.9/site-packages/nix_update/utils.py", line 35, in run
    return subprocess.run(
  File "/nix/store/5bh6rpya1ar6l49vrhx1rg58dsa42906-python3-3.9.6/lib/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['nix', 'eval', '--json', '--impure', '--experimental-features', 'nix-command', '--expr', '(\n let\n      inputs = (if (builtins.hasAttr "overlays" (builtins.functionArgs (import ./.))) then { overlays = []; } else { });\n    in\n   with import ./. inputs;\n    let\n      pkg = babashka;\n      raw_version_position = builtins.unsafeGetAttrPos "version" pkg;\n\n  position = if pkg ? isRubyGem then\n        raw_version_position\n      else\n        builtins.unsafeGetAttrPos "src" pkg;\n    in {\n     name = pkg.name;\n      old_version = (builtins.parseDrvName pkg.name).version;\n      inherit raw_version_position;\n      filename = position.file;\n      line = position.line;\n      urls = pkg.src.urls or null;\n      url = pkg.src.url or null;\n      rev = pkg.src.url.rev or null;\n      hash = pkg.src.outputHash or null;\n      mod_sha256 = pkg.modSha256 or null;\n      vendor_sha256 = pkg.vendorSha256 or null;\n      cargo_sha256 = pkg.cargoHash or pkg.cargoSha256 or null;\n      tests = builtins.attrNames (pkg.passthru.tests or {});\n    })']' returned non-zero exit status 1.
```

Probably broken on https://github.com/NixOS/nixpkgs/pull/147511. Fix it by using `nix_2_4` instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
