### PR TITLE
genmap: init 1.3.0

### DIFF
--- a/pkgs/applications/science/biology/genmap/default.nix
+++ b/pkgs/applications/science/biology/genmap/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, gtest
+, which
+}:
+
+stdenv.mkDerivation rec {
+  pname = "genmap";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "cpockrandt";
+    repo = "genmap";
+    rev = "genmap-v${version}";
+    fetchSubmodules = true;
+    sha256 = "sha256-7sIKBRMNzyCrZ/c2nXkknb6a5YsXe6DRE2IFhp6AviY=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  doCheck = true;
+  patches = [ ./gtest.patch ];
+  checkInputs = [ gtest which ];
+  preCheck = "make genmap_algo_test";
+
+  # disable benchmarks
+  preConfigure = ''
+    echo > benchmarks/CMakeLists.txt
+  '';
+
+  meta = {
+    description = "Ultra-fast computation of genome mappability";
+    license = lib.licenses.bsd3;
+    homepage = "https://github.com/cpockrandt/genmap";
+    maintainers = with lib.maintainers; [ jbedo ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/applications/science/biology/genmap/gtest.patch
+++ b/pkgs/applications/science/biology/genmap/gtest.patch
@@ -1,0 +1,30 @@
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index 67ec8f9..ed0b2e0 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -2,23 +2,14 @@
+ #  GenMap tests
+ # ===========================================================================
+ 
+-include (ExternalProject)
+-ExternalProject_Add (googletest
+-                     PREFIX "${CMAKE_CURRENT_BINARY_DIR}/googletest"
+-                     GIT_REPOSITORY "https://github.com/google/googletest.git"
+-                     INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}"
+-                     CMAKE_ARGS "-DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}"
+-                     GIT_TAG release-1.10.0
+-                     UPDATE_DISCONNECTED YES)
+ 
+ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}") # TODO: --coverage
+ add_executable (genmap_algo_test tests.cpp)
+-add_dependencies (genmap_algo_test googletest)
+ 
+ include_directories (${CMAKE_CURRENT_BINARY_DIR}/include)
+ target_link_libraries (genmap_algo_test ${SEQAN_LIBRARIES})
+-target_link_libraries (genmap_algo_test ${CMAKE_CURRENT_BINARY_DIR}/lib/libgtest.a)
+-target_link_libraries (genmap_algo_test ${CMAKE_CURRENT_BINARY_DIR}/lib/libgtest_main.a)
++target_link_libraries (genmap_algo_test -lgtest)
++target_link_libraries (genmap_algo_test -lgtest_main)
+ target_link_libraries (genmap_algo_test pthread)
+ 
+ add_test(NAME algo_test COMMAND genmap_algo_test)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5507,6 +5507,8 @@ with pkgs;
 
   genimage = callPackage ../tools/filesystems/genimage { };
 
+  genmap = callPackage ../applications/science/biology/genmap { };
+
   geonkick = callPackage ../applications/audio/geonkick {};
 
   gerrit = callPackage ../applications/version-management/gerrit { };


### PR DESCRIPTION
###### Motivation for this change

Nixpkgs is currently missing software for computing genome mappability.
Genmap compiles easily and is fast.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
