### PR TITLE
alda: 1.5.0 -> 2.0.6

### DIFF
--- a/pkgs/development/interpreters/alda/default.nix
+++ b/pkgs/development/interpreters/alda/default.nix
@@ -1,20 +1,34 @@
-{ lib, stdenv, fetchurl, jre }:
+{ lib, stdenv, fetchurl, makeWrapper, jre }:
 
 stdenv.mkDerivation rec {
   pname = "alda";
-  version = "1.5.0";
+  version = "2.0.6";
 
-  src = fetchurl {
-    url = "https://github.com/alda-lang/alda/releases/download/${version}/alda";
-    sha256 = "sha256-OHbOsgYN87ThU7EgjCgxADnOv32qIi+7XwDwcW0dmV0=";
+  src_alda = fetchurl {
+    url = "https://alda-releases.nyc3.digitaloceanspaces.com/${version}/client/linux-amd64/alda";
+    sha256 = "1078hywl3gim5wfgxb0xwbk1dn80ls3i7y33n76qsdd4b0x0sn7i";
+  };
+
+  src_player = fetchurl {
+    url = "https://alda-releases.nyc3.digitaloceanspaces.com/${version}/player/non-windows/alda-player";
+    sha256 = "1g7k2qnh4vcw63604z7zbvhbpn7l1v3m9mx4j4vywfq6qar1r6ck";
   };
 
   dontUnpack = true;
 
-  installPhase = ''
-    install -Dm755 $src $out/bin/alda
-    sed -i -e '1 s!java!${jre}/bin/java!' $out/bin/alda
-  '';
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase =
+    let
+      binPath = lib.makeBinPath [ jre ];
+    in
+    ''
+      install -D $src_alda $out/bin/alda
+      install -D $src_player $out/bin/alda-player
+
+      wrapProgram $out/bin/alda --prefix PATH : $out/bin:${binPath}
+      wrapProgram $out/bin/alda-player --prefix PATH : $out/bin:${binPath}
+    '';
 
   meta = with lib; {
     description = "A music programming language for musicians";
@@ -23,5 +37,4 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.ericdallo ];
     platforms = jre.meta.platforms;
   };
-
 }


### PR DESCRIPTION
###### Motivation for this change

Bump major version number + fix an issue where alda was unable to find the java executable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
