### PR TITLE
llvmPackages_*.llvm: fix llvm-config-native with static libs

### DIFF
--- a/pkgs/development/compilers/llvm/10/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/10/llvm/default.nix
@@ -81,7 +81,7 @@ in stdenv.mkDerivation (rec {
       --replace 'set(_install_rpath "@loader_path/../''${CMAKE_INSTALL_LIBDIR}''${LLVM_LIBDIR_SUFFIX}" ''${extra_libdir})' ""
   ''
   # Patch llvm-config to return correct library path based on --link-{shared,static}.
-  + optionalString (enableSharedLibraries) ''
+  + ''
     substitute '${./outputs.patch}' ./outputs.patch --subst-var lib
     patch -p1 < ./outputs.patch
   '' + ''

--- a/pkgs/development/compilers/llvm/10/llvm/outputs.patch
+++ b/pkgs/development/compilers/llvm/10/llvm/outputs.patch
@@ -2,23 +2,13 @@ diff --git a/tools/llvm-config/llvm-config.cpp b/tools/llvm-config/llvm-config.c
 index 94d426b..37f7794 100644
 --- a/tools/llvm-config/llvm-config.cpp
 +++ b/tools/llvm-config/llvm-config.cpp
-@@ -333,6 +333,21 @@ int main(int argc, char **argv) {
+@@ -333,6 +333,11 @@ int main(int argc, char **argv) {
      ActiveIncludeOption = "-I" + ActiveIncludeDir;
    }
  
-+  /// Nix-specific multiple-output handling: override ActiveLibDir if --link-shared
++  /// Nix-specific multiple-output handling: override ActiveLibDir
 +  if (!IsInDevelopmentTree) {
-+    bool WantShared = true;
-+    for (int i = 1; i < argc; ++i) {
-+      StringRef Arg = argv[i];
-+      if (Arg == "--link-shared")
-+        WantShared = true;
-+      else if (Arg == "--link-static")
-+        WantShared = false; // the last one wins
-+    }
-+
-+    if (WantShared)
-+      ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
++    ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
 +  }
 +
    /// We only use `shared library` mode in cases where the static library form

--- a/pkgs/development/compilers/llvm/11/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/11/llvm/default.nix
@@ -73,7 +73,7 @@ in stdenv.mkDerivation (rec {
       --replace 'set(_install_rpath "@loader_path/../''${CMAKE_INSTALL_LIBDIR}''${LLVM_LIBDIR_SUFFIX}" ''${extra_libdir})' ""
   ''
   # Patch llvm-config to return correct library path based on --link-{shared,static}.
-  + optionalString (enableSharedLibraries) ''
+  + ''
     substitute '${./outputs.patch}' ./outputs.patch --subst-var lib
     patch -p1 < ./outputs.patch
   '' + ''

--- a/pkgs/development/compilers/llvm/11/llvm/outputs.patch
+++ b/pkgs/development/compilers/llvm/11/llvm/outputs.patch
@@ -2,23 +2,13 @@ diff --git a/tools/llvm-config/llvm-config.cpp b/tools/llvm-config/llvm-config.c
 index 94d426b..37f7794 100644
 --- a/tools/llvm-config/llvm-config.cpp
 +++ b/tools/llvm-config/llvm-config.cpp
-@@ -333,6 +333,21 @@ int main(int argc, char **argv) {
+@@ -333,6 +333,11 @@ int main(int argc, char **argv) {
      ActiveIncludeOption = "-I" + ActiveIncludeDir;
    }
  
-+  /// Nix-specific multiple-output handling: override ActiveLibDir if --link-shared
++  /// Nix-specific multiple-output handling: override ActiveLibDir
 +  if (!IsInDevelopmentTree) {
-+    bool WantShared = true;
-+    for (int i = 1; i < argc; ++i) {
-+      StringRef Arg = argv[i];
-+      if (Arg == "--link-shared")
-+        WantShared = true;
-+      else if (Arg == "--link-static")
-+        WantShared = false; // the last one wins
-+    }
-+
-+    if (WantShared)
-+      ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
++    ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
 +  }
 +
    /// We only use `shared library` mode in cases where the static library form

--- a/pkgs/development/compilers/llvm/12/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/12/llvm/default.nix
@@ -74,7 +74,7 @@ in stdenv.mkDerivation (rec {
       --replace 'set(_install_rpath "@loader_path/../''${CMAKE_INSTALL_LIBDIR}''${LLVM_LIBDIR_SUFFIX}" ''${extra_libdir})' ""
   ''
   # Patch llvm-config to return correct library path based on --link-{shared,static}.
-  + optionalString (enableSharedLibraries) ''
+  + ''
     substitute '${./outputs.patch}' ./outputs.patch --subst-var lib
     patch -p1 < ./outputs.patch
   '' + ''

--- a/pkgs/development/compilers/llvm/12/llvm/outputs.patch
+++ b/pkgs/development/compilers/llvm/12/llvm/outputs.patch
@@ -2,23 +2,13 @@ diff --git a/tools/llvm-config/llvm-config.cpp b/tools/llvm-config/llvm-config.c
 index 94d426b..37f7794 100644
 --- a/tools/llvm-config/llvm-config.cpp
 +++ b/tools/llvm-config/llvm-config.cpp
-@@ -333,6 +333,21 @@ int main(int argc, char **argv) {
+@@ -333,6 +333,11 @@ int main(int argc, char **argv) {
      ActiveIncludeOption = "-I" + ActiveIncludeDir;
    }
  
-+  /// Nix-specific multiple-output handling: override ActiveLibDir if --link-shared
++  /// Nix-specific multiple-output handling: override ActiveLibDir
 +  if (!IsInDevelopmentTree) {
-+    bool WantShared = true;
-+    for (int i = 1; i < argc; ++i) {
-+      StringRef Arg = argv[i];
-+      if (Arg == "--link-shared")
-+        WantShared = true;
-+      else if (Arg == "--link-static")
-+        WantShared = false; // the last one wins
-+    }
-+
-+    if (WantShared)
-+      ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
++    ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
 +  }
 +
    /// We only use `shared library` mode in cases where the static library form

--- a/pkgs/development/compilers/llvm/13/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/13/llvm/default.nix
@@ -68,7 +68,7 @@ in stdenv.mkDerivation (rec {
       --replace 'set(_install_rpath "@loader_path/../''${CMAKE_INSTALL_LIBDIR}''${LLVM_LIBDIR_SUFFIX}" ''${extra_libdir})' ""
   ''
   # Patch llvm-config to return correct library path based on --link-{shared,static}.
-  + optionalString (enableSharedLibraries) ''
+  + ''
     substitute '${./outputs.patch}' ./outputs.patch --subst-var lib
     patch -p1 < ./outputs.patch
   '' + ''

--- a/pkgs/development/compilers/llvm/13/llvm/outputs.patch
+++ b/pkgs/development/compilers/llvm/13/llvm/outputs.patch
@@ -2,23 +2,13 @@ diff --git a/tools/llvm-config/llvm-config.cpp b/tools/llvm-config/llvm-config.c
 index 94d426b..37f7794 100644
 --- a/tools/llvm-config/llvm-config.cpp
 +++ b/tools/llvm-config/llvm-config.cpp
-@@ -333,6 +333,21 @@ int main(int argc, char **argv) {
+@@ -333,6 +333,11 @@ int main(int argc, char **argv) {
      ActiveIncludeOption = "-I" + ActiveIncludeDir;
    }
  
-+  /// Nix-specific multiple-output handling: override ActiveLibDir if --link-shared
++  /// Nix-specific multiple-output handling: override ActiveLibDir
 +  if (!IsInDevelopmentTree) {
-+    bool WantShared = true;
-+    for (int i = 1; i < argc; ++i) {
-+      StringRef Arg = argv[i];
-+      if (Arg == "--link-shared")
-+        WantShared = true;
-+      else if (Arg == "--link-static")
-+        WantShared = false; // the last one wins
-+    }
-+
-+    if (WantShared)
-+      ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
++    ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
 +  }
 +
    /// We only use `shared library` mode in cases where the static library form

--- a/pkgs/development/compilers/llvm/5/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/5/llvm/default.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation ({
       --replace 'set(_install_rpath "@loader_path/../''${CMAKE_INSTALL_LIBDIR}" ''${extra_libdir})' ""
   ''
   # Patch llvm-config to return correct library path based on --link-{shared,static}.
-  + optionalString (enableSharedLibraries) ''
+  + ''
     substitute '${./outputs.patch}' ./outputs.patch --subst-var lib
     patch -p1 < ./outputs.patch
   '' + ''

--- a/pkgs/development/compilers/llvm/5/llvm/outputs.patch
+++ b/pkgs/development/compilers/llvm/5/llvm/outputs.patch
@@ -2,23 +2,13 @@ diff --git a/tools/llvm-config/llvm-config.cpp b/tools/llvm-config/llvm-config.c
 index 94d426b..37f7794 100644
 --- a/tools/llvm-config/llvm-config.cpp
 +++ b/tools/llvm-config/llvm-config.cpp
-@@ -333,6 +333,21 @@ int main(int argc, char **argv) {
+@@ -333,6 +333,11 @@ int main(int argc, char **argv) {
      ActiveIncludeOption = "-I" + ActiveIncludeDir;
    }
  
-+  /// Nix-specific multiple-output handling: override ActiveLibDir if --link-shared
++  /// Nix-specific multiple-output handling: override ActiveLibDir
 +  if (!IsInDevelopmentTree) {
-+    bool WantShared = true;
-+    for (int i = 1; i < argc; ++i) {
-+      StringRef Arg = argv[i];
-+      if (Arg == "--link-shared")
-+        WantShared = true;
-+      else if (Arg == "--link-static")
-+        WantShared = false; // the last one wins
-+    }
-+
-+    if (WantShared)
-+      ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
++    ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
 +  }
 +
    /// We only use `shared library` mode in cases where the static library form

--- a/pkgs/development/compilers/llvm/6/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/6/llvm/default.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation ({
       --replace 'set(_install_rpath "@loader_path/../''${CMAKE_INSTALL_LIBDIR}" ''${extra_libdir})' ""
   ''
   # Patch llvm-config to return correct library path based on --link-{shared,static}.
-  + optionalString (enableSharedLibraries) ''
+  + ''
     substitute '${./outputs.patch}' ./outputs.patch --subst-var lib
     patch -p1 < ./outputs.patch
   '' + ''

--- a/pkgs/development/compilers/llvm/6/llvm/outputs.patch
+++ b/pkgs/development/compilers/llvm/6/llvm/outputs.patch
@@ -2,23 +2,13 @@ diff --git a/tools/llvm-config/llvm-config.cpp b/tools/llvm-config/llvm-config.c
 index 94d426b..37f7794 100644
 --- a/tools/llvm-config/llvm-config.cpp
 +++ b/tools/llvm-config/llvm-config.cpp
-@@ -333,6 +333,21 @@ int main(int argc, char **argv) {
+@@ -333,6 +333,11 @@ int main(int argc, char **argv) {
      ActiveIncludeOption = "-I" + ActiveIncludeDir;
    }
  
-+  /// Nix-specific multiple-output handling: override ActiveLibDir if --link-shared
++  /// Nix-specific multiple-output handling: override ActiveLibDir
 +  if (!IsInDevelopmentTree) {
-+    bool WantShared = true;
-+    for (int i = 1; i < argc; ++i) {
-+      StringRef Arg = argv[i];
-+      if (Arg == "--link-shared")
-+        WantShared = true;
-+      else if (Arg == "--link-static")
-+        WantShared = false; // the last one wins
-+    }
-+
-+    if (WantShared)
-+      ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
++    ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
 +  }
 +
    /// We only use `shared library` mode in cases where the static library form

--- a/pkgs/development/compilers/llvm/7/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/7/llvm/default.nix
@@ -76,7 +76,7 @@ in stdenv.mkDerivation ({
       --replace 'set(_install_rpath "@loader_path/../''${CMAKE_INSTALL_LIBDIR}" ''${extra_libdir})' ""
   ''
   # Patch llvm-config to return correct library path based on --link-{shared,static}.
-  + optionalString (enableSharedLibraries) ''
+  + ''
     substitute '${./outputs.patch}' ./outputs.patch --subst-var lib
     patch -p1 < ./outputs.patch
   '' + ''

--- a/pkgs/development/compilers/llvm/7/llvm/outputs.patch
+++ b/pkgs/development/compilers/llvm/7/llvm/outputs.patch
@@ -2,23 +2,13 @@ diff --git a/tools/llvm-config/llvm-config.cpp b/tools/llvm-config/llvm-config.c
 index 94d426b..37f7794 100644
 --- a/tools/llvm-config/llvm-config.cpp
 +++ b/tools/llvm-config/llvm-config.cpp
-@@ -333,6 +333,21 @@ int main(int argc, char **argv) {
+@@ -333,6 +333,11 @@ int main(int argc, char **argv) {
      ActiveIncludeOption = "-I" + ActiveIncludeDir;
    }
  
-+  /// Nix-specific multiple-output handling: override ActiveLibDir if --link-shared
++  /// Nix-specific multiple-output handling: override ActiveLibDir
 +  if (!IsInDevelopmentTree) {
-+    bool WantShared = true;
-+    for (int i = 1; i < argc; ++i) {
-+      StringRef Arg = argv[i];
-+      if (Arg == "--link-shared")
-+        WantShared = true;
-+      else if (Arg == "--link-static")
-+        WantShared = false; // the last one wins
-+    }
-+
-+    if (WantShared)
-+      ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
++    ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
 +  }
 +
    /// We only use `shared library` mode in cases where the static library form

--- a/pkgs/development/compilers/llvm/8/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/8/llvm/default.nix
@@ -79,7 +79,7 @@ in stdenv.mkDerivation ({
       --replace 'set(_install_rpath "@loader_path/../''${CMAKE_INSTALL_LIBDIR}" ''${extra_libdir})' ""
   ''
   # Patch llvm-config to return correct library path based on --link-{shared,static}.
-  + optionalString (enableSharedLibraries) ''
+  + ''
     substitute '${./outputs.patch}' ./outputs.patch --subst-var lib
     patch -p1 < ./outputs.patch
   '' + ''

--- a/pkgs/development/compilers/llvm/8/llvm/outputs.patch
+++ b/pkgs/development/compilers/llvm/8/llvm/outputs.patch
@@ -2,23 +2,13 @@ diff --git a/tools/llvm-config/llvm-config.cpp b/tools/llvm-config/llvm-config.c
 index 94d426b..37f7794 100644
 --- a/tools/llvm-config/llvm-config.cpp
 +++ b/tools/llvm-config/llvm-config.cpp
-@@ -333,6 +333,21 @@ int main(int argc, char **argv) {
+@@ -333,6 +333,11 @@ int main(int argc, char **argv) {
      ActiveIncludeOption = "-I" + ActiveIncludeDir;
    }
  
-+  /// Nix-specific multiple-output handling: override ActiveLibDir if --link-shared
++  /// Nix-specific multiple-output handling: override ActiveLibDir
 +  if (!IsInDevelopmentTree) {
-+    bool WantShared = true;
-+    for (int i = 1; i < argc; ++i) {
-+      StringRef Arg = argv[i];
-+      if (Arg == "--link-shared")
-+        WantShared = true;
-+      else if (Arg == "--link-static")
-+        WantShared = false; // the last one wins
-+    }
-+
-+    if (WantShared)
-+      ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
++    ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
 +  }
 +
    /// We only use `shared library` mode in cases where the static library form

--- a/pkgs/development/compilers/llvm/9/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/9/llvm/default.nix
@@ -77,7 +77,7 @@ in stdenv.mkDerivation (rec {
       --replace 'set(_install_rpath "@loader_path/../''${CMAKE_INSTALL_LIBDIR}" ''${extra_libdir})' ""
   ''
   # Patch llvm-config to return correct library path based on --link-{shared,static}.
-  + optionalString (enableSharedLibraries) ''
+  + ''
     substitute '${./outputs.patch}' ./outputs.patch --subst-var lib
     patch -p1 < ./outputs.patch
   '' + ''

--- a/pkgs/development/compilers/llvm/9/llvm/outputs.patch
+++ b/pkgs/development/compilers/llvm/9/llvm/outputs.patch
@@ -2,23 +2,13 @@ diff --git a/tools/llvm-config/llvm-config.cpp b/tools/llvm-config/llvm-config.c
 index 94d426b..37f7794 100644
 --- a/tools/llvm-config/llvm-config.cpp
 +++ b/tools/llvm-config/llvm-config.cpp
-@@ -333,6 +333,21 @@ int main(int argc, char **argv) {
+@@ -333,6 +333,11 @@ int main(int argc, char **argv) {
      ActiveIncludeOption = "-I" + ActiveIncludeDir;
    }
  
-+  /// Nix-specific multiple-output handling: override ActiveLibDir if --link-shared
++  /// Nix-specific multiple-output handling: override ActiveLibDir
 +  if (!IsInDevelopmentTree) {
-+    bool WantShared = true;
-+    for (int i = 1; i < argc; ++i) {
-+      StringRef Arg = argv[i];
-+      if (Arg == "--link-shared")
-+        WantShared = true;
-+      else if (Arg == "--link-static")
-+        WantShared = false; // the last one wins
-+    }
-+
-+    if (WantShared)
-+      ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
++    ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
 +  }
 +
    /// We only use `shared library` mode in cases where the static library form

--- a/pkgs/development/compilers/llvm/git/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/git/llvm/default.nix
@@ -60,7 +60,7 @@ in stdenv.mkDerivation (rec {
       --replace 'set(_install_rpath "@loader_path/../''${CMAKE_INSTALL_LIBDIR}''${LLVM_LIBDIR_SUFFIX}" ''${extra_libdir})' ""
   ''
   # Patch llvm-config to return correct library path based on --link-{shared,static}.
-  + optionalString (enableSharedLibraries) ''
+  + ''
     substitute '${./outputs.patch}' ./outputs.patch --subst-var lib
     patch -p1 < ./outputs.patch
   '' + ''

--- a/pkgs/development/compilers/llvm/git/llvm/outputs.patch
+++ b/pkgs/development/compilers/llvm/git/llvm/outputs.patch
@@ -2,23 +2,13 @@ diff --git a/tools/llvm-config/llvm-config.cpp b/tools/llvm-config/llvm-config.c
 index 94d426b..37f7794 100644
 --- a/tools/llvm-config/llvm-config.cpp
 +++ b/tools/llvm-config/llvm-config.cpp
-@@ -333,6 +333,21 @@ int main(int argc, char **argv) {
+@@ -333,6 +333,11 @@ int main(int argc, char **argv) {
      ActiveIncludeOption = "-I" + ActiveIncludeDir;
    }
  
-+  /// Nix-specific multiple-output handling: override ActiveLibDir if --link-shared
++  /// Nix-specific multiple-output handling: override ActiveLibDir
 +  if (!IsInDevelopmentTree) {
-+    bool WantShared = true;
-+    for (int i = 1; i < argc; ++i) {
-+      StringRef Arg = argv[i];
-+      if (Arg == "--link-shared")
-+        WantShared = true;
-+      else if (Arg == "--link-static")
-+        WantShared = false; // the last one wins
-+    }
-+
-+    if (WantShared)
-+      ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
++    ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
 +  }
 +
    /// We only use `shared library` mode in cases where the static library form

--- a/pkgs/development/compilers/llvm/rocm/llvm/outputs.patch
+++ b/pkgs/development/compilers/llvm/rocm/llvm/outputs.patch
@@ -2,23 +2,13 @@ diff --git a/tools/llvm-config/llvm-config.cpp b/tools/llvm-config/llvm-config.c
 index 94d426b..37f7794 100644
 --- a/tools/llvm-config/llvm-config.cpp
 +++ b/tools/llvm-config/llvm-config.cpp
-@@ -333,6 +333,21 @@ int main(int argc, char **argv) {
+@@ -333,6 +333,11 @@ int main(int argc, char **argv) {
      ActiveIncludeOption = "-I" + ActiveIncludeDir;
    }
  
-+  /// Nix-specific multiple-output handling: override ActiveLibDir if --link-shared
++  /// Nix-specific multiple-output handling: override ActiveLibDir
 +  if (!IsInDevelopmentTree) {
-+    bool WantShared = true;
-+    for (int i = 1; i < argc; ++i) {
-+      StringRef Arg = argv[i];
-+      if (Arg == "--link-shared")
-+        WantShared = true;
-+      else if (Arg == "--link-static")
-+        WantShared = false; // the last one wins
-+    }
-+
-+    if (WantShared)
-+      ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
++    ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
 +  }
 +
    /// We only use `shared library` mode in cases where the static library form


### PR DESCRIPTION
Since both static and shared libs are installed to the same `lib`
output, we override the ActiveLibDir unconditionally.

Fixes `llvm-config-native --link-static --libs`

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/148117

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
