### PR TITLE
globalprotect-openconnect: use ver rev instead of commit & correct sh…

### DIFF
--- a/pkgs/tools/networking/globalprotect-openconnect/default.nix
+++ b/pkgs/tools/networking/globalprotect-openconnect/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub
-, qmake, qtwebsockets, qtwebengine, wrapQtAppsHook, openconnect
+, cmake, qtwebsockets, qtwebengine, wrapQtAppsHook, openconnect
 }:
 
 stdenv.mkDerivation rec {
@@ -9,26 +9,16 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "yuezk";
     repo = "GlobalProtect-openconnect";
-    rev = "c14a6ad1d2b62f8d297bc4cfbcb1dcea4d99112f";
     fetchSubmodules = true;
-    sha256 = "sha256-M3+YGdN7LuuFEP9n94YJ/UDVhti/VlX0FzYMGeYebP4=";
+    rev = "v${version}";
+    sha256 = "sha256-w2y6DOFgQ8Xpi1abibvRNpEUbBsdvwDMGqlJxQSCpVg=";
   };
 
-  nativeBuildInputs = [ qmake wrapQtAppsHook ];
+  nativeBuildInputs = [ cmake wrapQtAppsHook ];
 
   buildInputs = [ openconnect qtwebsockets qtwebengine ];
 
   patchPhase = ''
-    for f in GPClient/GPClient.pro \
-      GPClient/com.yuezk.qt.gpclient.desktop \
-      GPService/GPService.pro \
-      GPService/dbus/com.yuezk.qt.GPService.service \
-      GPService/systemd/gpservice.service; do
-        substituteInPlace $f \
-          --replace /usr $out \
-          --replace /etc $out/lib;
-    done;
-
     substituteInPlace GPService/gpservice.h \
       --replace /usr/local/bin/openconnect ${openconnect}/bin/openconnect;
   '';


### PR DESCRIPTION
…a256

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Closes https://github.com/NixOS/nixpkgs/issues/148378

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
