### PR TITLE
python3Packages.parts: 1.1.2 -> 1.2.0, python3Packages.bitlist: 0.5.1 -> 0.6.0

### DIFF
--- a/pkgs/development/python-modules/bitlist/default.nix
+++ b/pkgs/development/python-modules/bitlist/default.nix
@@ -8,11 +8,12 @@
 
 buildPythonPackage rec {
   pname = "bitlist";
-  version = "0.5.1";
+  version = "0.6.0";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-bX/Z5FBm21gX4ax/HfqD2bNotZyNFX7dHCEN5uZzQJQ=";
+    sha256 = "sha256-LTrn+PCaqob0EGyyv1V1uCBeDQZvIYE1hNPqi4y/zfc=";
   };
 
   propagatedBuildInputs = [
@@ -24,12 +25,9 @@ buildPythonPackage rec {
     nose
   ];
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "parts~=1.0.3" "parts>=1.0.3"
-  '';
-
-  pythonImportsCheck = [ "bitlist" ];
+  pythonImportsCheck = [
+    "bitlist"
+  ];
 
   meta = with lib; {
     description = "Python library for working with little-endian list representation of bit strings";

--- a/pkgs/development/python-modules/fe25519/default.nix
+++ b/pkgs/development/python-modules/fe25519/default.nix
@@ -11,6 +11,7 @@
 buildPythonPackage rec {
   pname = "fe25519";
   version = "1.0.0";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
@@ -28,7 +29,15 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "fe25519" ];
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "bitlist~=0.5.1" "bitlist>=0.5.1" \
+      --replace "parts~=1.1.2" "parts>=1.1.2"
+  '';
+
+  pythonImportsCheck = [
+    "fe25519"
+  ];
 
   meta = with lib; {
     description = "Python field operations for Curve25519's prime";

--- a/pkgs/development/python-modules/fountains/default.nix
+++ b/pkgs/development/python-modules/fountains/default.nix
@@ -17,6 +17,11 @@ buildPythonPackage rec {
     bitlist
   ];
 
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "bitlist~=0.5.1" "bitlist>=0.5.1"
+  '';
+
   # Project has no test
   doCheck = false;
 

--- a/pkgs/development/python-modules/ge25519/default.nix
+++ b/pkgs/development/python-modules/ge25519/default.nix
@@ -12,6 +12,7 @@
 buildPythonPackage rec {
   pname = "ge25519";
   version = "1.0.0";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
@@ -30,7 +31,15 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "ge25519" ];
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "bitlist~=0.5.1" "bitlist>=0.5.1" \
+      --replace "parts~=1.1.2" "parts>=1.1.2"
+  '';
+
+  pythonImportsCheck = [
+    "ge25519"
+  ];
 
   meta = with lib; {
     description = "Python implementation of Ed25519 group elements and operations";

--- a/pkgs/development/python-modules/parts/default.nix
+++ b/pkgs/development/python-modules/parts/default.nix
@@ -5,16 +5,20 @@
 
 buildPythonPackage rec {
   pname = "parts";
-  version = "1.1.2";
+  version = "1.2.0";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "2212129476f6d285c3aaab309b80b83664d13dca5a42c5ca3500bd32130af7ec";
+    sha256 = "sha256-sfeh6KdprW40ZgfItm9oojDlrI4X29+O7pzfafIawB0=";
   };
 
   # Project has no tests
   doCheck = false;
-  pythonImportsCheck = [ "parts" ];
+
+  pythonImportsCheck = [
+    "parts"
+  ];
 
   meta = with lib; {
     description = "Python library for common list functions related to partitioning lists";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream releases

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
