### PR TITLE
gnuradio: 3.9.3.0 -> 3.9.4.0

### DIFF
--- a/pkgs/applications/radio/gnuradio/default.nix
+++ b/pkgs/applications/radio/gnuradio/default.nix
@@ -46,13 +46,13 @@
 , pname ? "gnuradio"
 , versionAttr ? {
   major = "3.9";
-  minor = "3";
+  minor = "4";
   patch = "0";
 }
 }:
 
 let
-  sourceSha256 = "sha256-jVfExv1CcnlOaaj/XtnfhWAHnQsshZJ1l/zXo0uovdo=";
+  sourceSha256 = "sha256-O+37CyF0IVPdUB1e68HsaXD0T2VsOLPXOpLNlRYEXUk=";
   featuresInfo = {
     # Needed always
     basic = {
@@ -78,6 +78,9 @@ let
     doxygen = {
       native = [ doxygen ];
       cmakeEnableFlag = "DOXYGEN";
+    };
+    man-pages = {
+      cmakeEnableFlag = "MANPAGES";
     };
     python-support = {
       pythonRuntime = [ python.pkgs.six ];
@@ -269,11 +272,6 @@ stdenv.mkDerivation rec {
   patches = [
     # Not accepted upstream, see https://github.com/gnuradio/gnuradio/pull/5227
     ./modtool-newmod-permissions.patch
-    (fetchpatch {
-      # https://github.com/gnuradio/gnuradio/pull/5225
-      url = "https://github.com/gnuradio/gnuradio/commit/4cef46e3ea0faf04e05ca1a5846cd1568fa51bb2.patch";
-      sha256 = "sha256-6AlGbtD1S0c3I9JSoLTMP4YqwDU17i2j+XRkuR+QTuc=";
-    })
   ];
   passthru = shared.passthru // {
     # Deps that are potentially overriden and are used inside GR plugins - the same version must


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).