### PR TITLE
python3Packages.build: 0.5.1 -> 0.7.0

### DIFF
--- a/pkgs/development/python-modules/build/default.nix
+++ b/pkgs/development/python-modules/build/default.nix
@@ -5,7 +5,6 @@
 , filelock
 , flit-core
 , importlib-metadata
-, isPy3k
 , packaging
 , pep517
 , pytest-mock
@@ -14,19 +13,21 @@
 , pytestCheckHook
 , pythonOlder
 , toml
-, typing ? null
+, tomli
 }:
 
 buildPythonPackage rec {
   pname = "build";
-  version = "0.5.1";
+  version = "0.7.0";
   format = "pyproject";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "pypa";
     repo = pname;
     rev = version;
-    sha256 = "15hc9mbxsngfc9n805x8rk7yqbxnw12mpk6hfwcsldnfii1vg2ph";
+    sha256 = "sha256-kT3Gax/ZCeV8Kb7CBArGWn/qzVSVdMRUoid/8cAovnE=";
   };
 
   nativeBuildInputs = [
@@ -34,35 +35,44 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    toml
-    pep517
     packaging
-  ] ++ lib.optionals (!isPy3k) [
-    typing
+    pep517
+    tomli
   ] ++ lib.optionals (pythonOlder "3.8") [
     importlib-metadata
   ];
 
   checkInputs = [
     filelock
+    toml
     pytest-mock
     pytest-rerunfailures
     pytest-xdist
     pytestCheckHook
   ];
 
+  pytestFlagsArray = [
+    "-n"
+    "$NIX_BUILD_CORES"
+  ];
+
   disabledTests = [
-    "test_isolation"
-    "test_isolated_environment_install"
+    # Tests often fail with StopIteration
+    "test_isolat"
     "test_default_pip_is_never_too_old"
     "test_build"
+    "test_with_get_requires"
     "test_init"
+    "test_output"
+    "test_wheel_metadata"
   ] ++ lib.optionals stdenv.isDarwin [
-    # expects Apple's python and its quirks
+    # Expects Apple's Python and its quirks
     "test_can_get_venv_paths_with_conflicting_default_scheme"
   ];
 
-  pythonImportsCheck = [ "build" ];
+  pythonImportsCheck = [
+    "build"
+  ];
 
   meta = with lib; {
     description = "Simple, correct PEP517 package builder";
@@ -71,7 +81,7 @@ buildPythonPackage rec {
       is a simple build tool and does not perform any dependency management.
     '';
     homepage = "https://github.com/pypa/build";
-    maintainers = with maintainers; [ fab ];
     license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.7.0

Change log: https://github.com/pypa/build/blob/main/CHANGELOG.rst#070-16-09-2021

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
