### PR TITLE
cargo-wipe: 0.3.1 -> 0.3.2

### DIFF
--- a/pkgs/development/tools/rust/cargo-wipe/default.nix
+++ b/pkgs/development/tools/rust/cargo-wipe/default.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-wipe";
-  version = "0.3.1";
+  version = "0.3.2";
 
   src = fetchFromGitHub {
     owner = "mihai-dinculescu";
     repo = "cargo-wipe";
     rev = "v${version}";
-    sha256 = "sha256-sVekfGHg2wspP5/zJzXTXupspwJr4hQBucY5+8iUjUQ=";
+    sha256 = "sha256-AlmXq2jbU8mQ23Q64a8QiKXwiWkIfr98vAoq7FLImhA=";
   };
 
-  cargoSha256 = "sha256-IzEurJcPoM/JMQlSL7N84wzZddNpynrsjQEOUNms2YQ=";
+  cargoSha256 = "sha256-vsN4cM4Q9LX1ZgAA5x7PupOTh0IcjI65xzuCPjy8YOs=";
 
   passthru = {
     updateScript = nix-update-script {


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
