### PR TITLE
goaccess: 1.5.2 -> 1.5.3

### DIFF
--- a/pkgs/tools/misc/goaccess/default.nix
+++ b/pkgs/tools/misc/goaccess/default.nix
@@ -1,29 +1,51 @@
-{ lib, stdenv, fetchurl, ncurses, gettext, openssl, withGeolocation ? true, libmaxminddb }:
+{ lib
+, stdenv
+, autoreconfHook
+, fetchFromGitHub
+, gettext
+, libmaxminddb
+, ncurses
+, openssl
+, withGeolocation ? true
+}:
 
 stdenv.mkDerivation rec {
-  version = "1.5.2";
+  version = "1.5.3";
   pname = "goaccess";
 
-  src = fetchurl {
-    url = "https://tar.goaccess.io/goaccess-${version}.tar.gz";
-    sha256 = "sha256-oM4vk5OyYiSE5GnpWoCd/VKt5NQgBJHkPt4fy1KrHIo=";
+  src = fetchFromGitHub {
+    owner = "allinurl";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-TgreyBlV86K6P0W9WeLUW6RbcHpuOFW2fj2cCe7nWHE=";
   };
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  buildInputs = [
+    ncurses
+    openssl
+  ] ++ lib.optionals withGeolocation [
+    libmaxminddb
+  ] ++ lib.optionals stdenv.isDarwin [
+    gettext
+  ];
 
   configureFlags = [
     "--enable-utf8"
     "--with-openssl"
-  ] ++ lib.optionals withGeolocation [ "--enable-geoip=mmdb" ];
+  ] ++ lib.optionals withGeolocation [
+    "--enable-geoip=mmdb"
+  ];
 
-  buildInputs = [ ncurses openssl ]
-    ++ lib.optionals withGeolocation [ libmaxminddb ]
-    ++ lib.optionals stdenv.isDarwin [ gettext ];
-
-  meta = {
+  meta = with lib; {
     description = "Real-time web log analyzer and interactive viewer that runs in a terminal in *nix systems";
-    homepage    = "https://goaccess.io";
-    changelog   = "https://github.com/allinurl/goaccess/raw/v${version}/ChangeLog";
-    license     = lib.licenses.mit;
-    platforms   = lib.platforms.linux ++ lib.platforms.darwin;
-    maintainers = with lib.maintainers; [ ederoyd46 ];
+    homepage = "https://goaccess.io";
+    changelog = "https://github.com/allinurl/goaccess/raw/v${version}/ChangeLog";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ederoyd46 ];
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.5.3

Change log: https://github.com/allinurl/goaccess/blob/master/ChangeLog

- Switch to GitHub
- Update ordering
- Run `nixpkgs-fmt`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
