### PR TITLE
python3Packages.pydelijn: support for async_timeout >4

### DIFF
--- a/pkgs/development/python-modules/devolo-plc-api/default.nix
+++ b/pkgs/development/python-modules/devolo-plc-api/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "devolo-plc-api";
-  version = "0.6.4";
+  version = "0.7.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.8";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "2Fake";
     repo = "devolo_plc_api";
     rev = "v${version}";
-    sha256 = "sha256-hlIHNVJG/2hU5psGXhi05SCupORfgIjB+YT/ZlJEqFM=";
+    sha256 = "sha256-qzjH52bKQ/oSFd580V92uE2/Z2g+2nLh/JXOXYqVfSY=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;

--- a/pkgs/development/python-modules/pydelijn/default.nix
+++ b/pkgs/development/python-modules/pydelijn/default.nix
@@ -10,6 +10,8 @@
 buildPythonPackage rec {
   pname = "pydelijn";
   version = "0.6.1";
+  format = "setuptools";
+
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
@@ -23,10 +25,21 @@ buildPythonPackage rec {
     pytz
   ];
 
+  postPatch = ''
+    # Remove with next release
+    substituteInPlace setup.py \
+      --replace "async_timeout>=3.0.1,<4.0" "async_timeout>=3.0.1"
+    # https://github.com/bollewolle/pydelijn/pull/11
+    substituteInPlace pydelijn/common.py \
+      --replace ", loop=self.loop" ""
+  '';
+
   # Project has no tests
   doCheck = false;
 
-  pythonImportsCheck = [ "pydelijn" ];
+  pythonImportsCheck = [
+    "pydelijn"
+  ];
 
   meta = with lib; {
     description = "Python package to retrieve realtime data of passages at stops of De Lijn";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/160237934)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
