### PR TITLE
[Backport release-21.11] Fix shairport-sync module to create and set an explicit group

### DIFF
--- a/nixos/modules/services/networking/shairport-sync.nix
+++ b/nixos/modules/services/networking/shairport-sync.nix
@@ -45,6 +45,15 @@ in
         '';
       };
 
+      group = mkOption {
+        type = types.str;
+        default = "shairport";
+        description = ''
+          Group account name under which to run shairport-sync. The account
+          will be created.
+        '';
+      };
+
     };
 
   };
@@ -58,13 +67,17 @@ in
     services.avahi.publish.enable = true;
     services.avahi.publish.userServices = true;
 
-    users.users.${cfg.user} =
-      { description = "Shairport user";
+    users = {
+      users.${cfg.user} = {
+        description = "Shairport user";
         isSystemUser = true;
         createHome = true;
         home = "/var/lib/shairport-sync";
+        group = cfg.group;
         extraGroups = [ "audio" ] ++ optional config.hardware.pulseaudio.enable "pulse";
       };
+      groups.${cfg.group} = {};
+    };
 
     systemd.services.shairport-sync =
       {
@@ -73,6 +86,7 @@ in
         wantedBy = [ "multi-user.target" ];
         serviceConfig = {
           User = cfg.user;
+          Group = cfg.group;
           ExecStart = "${pkgs.shairport-sync}/bin/shairport-sync ${cfg.arguments}";
           RuntimeDirectory = "shairport-sync";
         };


### PR DESCRIPTION
This is a backport of https://github.com/NixOS/nixpkgs/pull/148388 for 21.11

I'm not sure if I'm doing this backport PR correctly or not, let me know if I should have done this differently.  The PR for master doesn't apply cleanly to release-21.11 so I don't think it could have been done via the bot?