### PR TITLE
velero: 1.7.0 -> 1.7.1

### DIFF
--- a/pkgs/applications/networking/cluster/velero/default.nix
+++ b/pkgs/applications/networking/cluster/velero/default.nix
@@ -2,26 +2,23 @@
 
 buildGoModule rec {
   pname = "velero";
-  # When updating, change the commit underneath
-  version = "1.7.0";
-  commit = "9e52260568430ecb77ac38a677ce74267a8c2176";
+  version = "1.7.1";
 
 
   src = fetchFromGitHub {
     owner = "vmware-tanzu";
     repo = "velero";
     rev = "v${version}";
-    sha256 = "sha256-n5Rk+Fyb6yAI5sRZi+WE1KyQZyGryZSP4yd/gmmsQxw=";
+    sha256 = "sha256-Jz3Tp5FqpmPuBscRB0KleQxtCvB43qmeLZNtGPnjuL0=";
   };
 
   ldflags = [
     "-s" "-w"
     "-X github.com/vmware-tanzu/velero/pkg/buildinfo.Version=${version}"
-    "-X github.com/vmware-tanzu/velero/pkg/buildinfo.GitSHA=${commit}"
     "-X github.com/vmware-tanzu/velero/pkg/buildinfo.GitTreeState=clean"
   ];
 
-  vendorSha256 = "sha256-qsRbwLKNnuQRIsx0+sfOfR2OQ0+el0vptxz7mMew7zY=";
+  vendorSha256 = "sha256-fX9FeoIkxxSi3dl5W2MZLz5vN1VHkPNpTBGRxGP5Qx8=";
 
   excludedPackages = [ "issue-template-gen" "crd-gen" "release-tools" "velero-restic-restore-helper" "v1" "v1beta1" ];
 


### PR DESCRIPTION
###### Motivation for this change

Update to the latest release, also removes GitSHA from velero version output

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
