### PR TITLE
Revert "google-compute-engine: 20190124 -> 20200113.0 (#131761)"

### DIFF
--- a/pkgs/tools/virtualization/google-compute-engine/default.nix
+++ b/pkgs/tools/virtualization/google-compute-engine/default.nix
@@ -3,85 +3,26 @@
 , buildPythonPackage
 , bash
 , bashInteractive
+, systemd
 , util-linux
 , boto
 , setuptools
 , distro
-, stdenv
-, pythonOlder
-, pytestCheckHook
 }:
 
-let
-  guest-configs = stdenv.mkDerivation rec {
-    pname = "guest-configs";
-    version = "20210702.00";
-
-    src = fetchFromGitHub {
-      owner = "GoogleCloudPlatform";
-      repo = "guest-configs";
-      rev = version;
-      sha256 = "1965kdrb1ig3z4qwzvyzx1fb4282ak5vgxcvvg5k9c759pzbc5nn";
-    };
-
-    buildInputs = [ bash ];
-
-    dontConfigure = true;
-    dontBuild = true;
-
-    installPhase = ''
-      runHook preInstall
-
-      # allows to install the package in `services.udev.packages` in NixOS
-      mkdir -p $out/lib/udev $out/bin
-
-      cp -r "src/lib/udev/rules.d" $out/lib/udev
-      cp "src/lib/udev/google_nvme_id" $out/bin
-
-      for rules in $out/lib/udev/*.rules; do
-        substituteInPlace "$rules" \
-          --replace /bin/sh "${bash}/bin/sh" \
-          --replace /bin/umount "${util-linux}/bin/umount" \
-          --replace /usr/bin/logger "${util-linux}/bin/logger"
-      done
-
-      # sysctl snippets will be used by google-compute-config.nix
-      cp -r "src/etc/sysctl.d" $out
-
-      patchShebangs $out/bin/*
-
-      runHook postInstall
-    '';
-  };
-in
 buildPythonPackage rec {
   pname = "google-compute-engine";
-  version = "20200113.0";
+  version = "20190124";
 
   src = fetchFromGitHub {
     owner = "GoogleCloudPlatform";
     repo = "compute-image-packages";
-    rev = "506b9a0dbffec5620887660cd42c57b3cbbadba6";
-    sha256 = "0lmc426mvrajghpavhs6hwl19mgnnh08ziqx5yi15fzpnvwmb8vz";
+    rev = version;
+    sha256 = "08cy0jd463kng6hwbd3nfldsp4dpd2lknlvdm88cq795wy0kh4wp";
   };
 
-  buildInputs = [ bash guest-configs ];
-  propagatedBuildInputs = [ (if pythonOlder "3.7" then boto else distro) setuptools ];
-
-  preBuild = ''
-    cd packages/python-google-compute-engine
-  '';
-
-  disabledTests = [
-    "testExtractInterfaceMetadata"
-    "testCallDhclientIpv6"
-    "testWriteConfig"
-    "testCreateInterfaceMapNetifaces"
-    "testCreateInterfaceMapSysfs"
-    "testGetNetworkInterface"
-  ];
-
-  checkInputs = [ pytestCheckHook ];
+  buildInputs = [ bash ];
+  propagatedBuildInputs = [ boto setuptools distro ];
 
   postPatch = ''
     for file in $(find google_compute_engine -type f); do
@@ -91,15 +32,33 @@ buildPythonPackage rec {
         --replace /sbin/hwclock "${util-linux}/bin/hwclock"
       # SELinux tool ???  /sbin/restorecon
     done
+
+    substituteInPlace google_config/udev/64-gce-disk-removal.rules \
+      --replace /bin/sh "${bash}/bin/sh" \
+      --replace /bin/umount "${util-linux}/bin/umount" \
+      --replace /usr/bin/logger "${util-linux}/bin/logger"
   '';
 
+  postInstall = ''
+    # allows to install the package in `services.udev.packages` in NixOS
+    mkdir -p $out/lib/udev/rules.d
+    cp -r google_config/udev/*.rules $out/lib/udev/rules.d
+
+    # sysctl snippets will be used by google-compute-config.nix
+    mkdir -p $out/sysctl.d
+    cp google_config/sysctl/*.conf $out/sysctl.d
+
+    patchShebangs $out/bin/*
+  '';
+
+  doCheck = false;
   pythonImportsCheck = [ "google_compute_engine" ];
 
   meta = with lib; {
     description = "Google Compute Engine tools and services";
     homepage = "https://github.com/GoogleCloudPlatform/compute-image-packages";
     license = licenses.asl20;
-    maintainers = with maintainers; [ cpcloud zimbatm ];
+    maintainers = with maintainers; [ zimbatm ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5924,7 +5924,7 @@ with pkgs;
 
   google-clasp = callPackage ../development/misc/google-clasp { };
 
-  google-compute-engine = with python3.pkgs; toPythonApplication google-compute-engine;
+  google-compute-engine = with python38.pkgs; toPythonApplication google-compute-engine;
 
   google-compute-engine-oslogin = callPackage ../tools/virtualization/google-compute-engine-oslogin { };
 


### PR DESCRIPTION
###### Motivation for this change
This reverts commit 1748291445122f91aa305de48704fc384c1e6f20.

This upgrade broke the google-compute-config module. See https://github.com/NixOS/nixpkgs/pull/144761 for more info.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
