### PR TITLE
heroic: init at 1.10.3

### DIFF
--- a/pkgs/games/heroic/default.nix
+++ b/pkgs/games/heroic/default.nix
@@ -1,0 +1,38 @@
+{ lib, fetchurl, appimageTools, python }:
+
+let
+  pname = "heroic";
+  version = "1.10.3";
+  name = "${pname}-${version}";
+  src = fetchurl {
+    url = "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/download/v${version}/Heroic-${version}.AppImage";
+    sha256 = "sha256-0VQ5rSGGsEAsOLB4H/Hn2w7wCOrCSoVFzCBqNV5NyVE=";
+  };
+  appimageContents = appimageTools.extractType2 { inherit name src; };
+
+in appimageTools.wrapType2 {
+  inherit name src;
+
+  extraInstallCommands = ''
+    mv $out/bin/${name} $out/bin/${pname}
+
+    mkdir -p $out/share/${pname}
+    cp -a ${appimageContents}/locales $out/share/${pname}
+    cp -a ${appimageContents}/resources $out/share/${pname}
+
+    install -m 444 -D ${appimageContents}/heroic.desktop -t $out/share/applications
+
+    cp -a ${appimageContents}/usr/share/icons $out/share/
+
+    substituteInPlace $out/share/applications/heroic.desktop \
+      --replace 'Exec=AppRun' 'Exec=heroic'
+  '';
+
+  meta = with lib; {
+    description = "A Native GUI Epic Games Launcher for Linux, Windows and Mac";
+    homepage = "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ wolfangaukang ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3144,6 +3144,8 @@ with pkgs;
 
   hebcal = callPackage ../tools/misc/hebcal {};
 
+  heroic = callPackage ../games/heroic {};
+
   hexio = callPackage ../development/tools/hexio { };
 
   hexyl = callPackage ../tools/misc/hexyl { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#131620. Only thing that I have no idea on how to solve is `[2:1203/105250.437442:ERROR:browser_main_loop.cc(269)] Gtk: gtk_widget_add_accelerator: assertion 'GTK_IS_ACCEL_GROUP (accel_group)' failed`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
