### PR TITLE
alsa-ucm-conf: backport upstream fix for https://github.com/alsa-proj…

### DIFF
--- a/pkgs/os-specific/linux/alsa-project/alsa-ucm-conf/0001-HDA-improve-init.conf-Capture-volume-switches.patch
+++ b/pkgs/os-specific/linux/alsa-project/alsa-ucm-conf/0001-HDA-improve-init.conf-Capture-volume-switches.patch
@@ -1,0 +1,43 @@
+From 920e2a276e6799640e43596e6b3e2c5c260700c5 Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Thu, 2 Dec 2021 14:49:10 +0100
+Subject: [PATCH 1/3] HDA: improve init.conf (Capture volume, switches)
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+(cherry picked from commit 9de93b08a41e3d04abde9ca00e893b4505cf9c38)
+---
+ ucm2/HDA-Intel/init.conf | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/ucm2/HDA-Intel/init.conf b/ucm2/HDA-Intel/init.conf
+index 6310eb3..a190e98 100644
+--- a/ucm2/HDA-Intel/init.conf
++++ b/ucm2/HDA-Intel/init.conf
+@@ -26,6 +26,7 @@ If.speaker {
+ 	}
+ 	True.BootSequence [
+ 		cset "name='Speaker Playback Volume' 60%"
++		cset "name='Speaker Playback Switch' off"
+ 	]
+ }
+ 
+@@ -36,5 +37,16 @@ If.headphone {
+ 	}
+ 	True.BootSequence [
+ 		cset "name='Headphone Playback Volume' 60%"
++		cset "name='Headphone Playback Switch' off"
++	]
++}
++
++If.capture {
++	Condition {
++		Type ControlExists
++		Control "name='Capture Volume'"
++	}
++	True.BootSequence [
++		cset "name='Capture Volume' 60%"
+ 	]
+ }
+-- 
+2.31.1
+

--- a/pkgs/os-specific/linux/alsa-project/alsa-ucm-conf/0002-HDA-improve-support-for-HDAudio-Gigabyte-ALC1220Dual.patch
+++ b/pkgs/os-specific/linux/alsa-project/alsa-ucm-conf/0002-HDA-improve-support-for-HDAudio-Gigabyte-ALC1220Dual.patch
@@ -1,0 +1,248 @@
+From 96832f857fcce0c469316a01db644d8002834eda Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Thu, 2 Dec 2021 19:12:05 +0100
+Subject: [PATCH 2/3] HDA: improve support for
+ HDAudio-Gigabyte-ALC1220DualCodecs
+
+BugLink: https://github.com/alsa-project/alsa-ucm-conf/pull/48
+Fixes: https://github.com/alsa-project/alsa-ucm-conf/issues/123
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+(cherry picked from commit 7dda1e21fff6163abfd681380b054f514b3b43bc)
+---
+ ucm2/HDA-Intel/HDAudio-DualCodecs.conf |   8 +-
+ ucm2/HDA-Intel/HiFi-dual.conf          | 133 ++++++++++++++-----------
+ 2 files changed, 79 insertions(+), 62 deletions(-)
+
+diff --git a/ucm2/HDA-Intel/HDAudio-DualCodecs.conf b/ucm2/HDA-Intel/HDAudio-DualCodecs.conf
+index 6fd7bd1..db867e1 100644
+--- a/ucm2/HDA-Intel/HDAudio-DualCodecs.conf
++++ b/ucm2/HDA-Intel/HDAudio-DualCodecs.conf
+@@ -5,14 +5,12 @@ SectionUseCase."HiFi" {
+ 	Comment "Default"
+ }
+ 
++Include.init1.File "/HDA/init.conf"
++
+ BootSequence [
+-	cset "name='Headphone Playback Volume' 60%"
+-	cset "name='Headphone Playback Switch' off"
+-	cset "name='Speaker Playback Volume' 60%"
+-	cset "name='Speaker Playback Switch' on"
+ 	cset "name='Front Playback Volume' 100%"
+ 	cset "name='Front Playback Switch' on"
+ 	cset "name='Rear-Panel Capture Volume' 100%"
+ 	cset "name='Rear-Panel Capture Switch' on"
+-	cset "name='Input Source' Rear Mic"
++	cset "name='Input Source' 'Rear Mic'"
+ ]
+diff --git a/ucm2/HDA-Intel/HiFi-dual.conf b/ucm2/HDA-Intel/HiFi-dual.conf
+index f2c6915..7dcd6b0 100644
+--- a/ucm2/HDA-Intel/HiFi-dual.conf
++++ b/ucm2/HDA-Intel/HiFi-dual.conf
+@@ -4,42 +4,51 @@ SectionVerb {
+ 	}
+ 
+ 	EnableSequence [
+-		cset "name='Front Playback Volume' 100%"
+-		cset "name='Front Playback Switch' on"
+-		cset "name='Rear-Panel Capture Volume' 100%"
+-		cset "name='Rear-Panel Capture Switch' on"
++		cset "name='Front Playback Switch' off"
++		cset "name='Rear-Panel Capture Switch' off"
+ 		cset "name='Headphone Playback Switch' off"
+-		cset "name='Speaker Playback Switch' off"
+ 	]
+ 
+ 	DisableSequence [
+-		cset "name='Front Playback Volume' 0"
+ 		cset "name='Front Playback Switch' off"
+-		cset "name='Rear-Panel Capture Volume' 0"
++		cset "name='Front-Panel Capture Switch' off"
+ 		cset "name='Rear-Panel Capture Switch' off"
+ 	]
+ }
+ 
+-SectionDevice."Speaker" {
+-	Comment "Speaker"
+-
+-	Value {
+-		PlaybackPriority 100
+-		PlaybackPCM "hw:${CardId},4"
+-		PlaybackMixerElem "Speaker"
++If.speaker {
++	Condition {
++		Type ControlExists
++		Control "name='Speaker Volume Switch'"
+ 	}
++	True {
++		SectionVerb {
++			EnableSequence [
++				cset "name='Speaker Playback Switch' on"
++			]
++			DisableSequence [
++				cset "name='Speaker Playback Switch' off"
++			]
++		}
+ 
+-	EnableSequence [
+-		cset "name='Speaker Playback Switch' on"
+-	]
++		SectionDevice."Speaker" {
++			Comment "Speaker"
+ 
+-	DisableSequence [
+-		cset "name='Speaker Playback Switch' off"
+-	]
++			Value {
++				PlaybackPriority 100
++				PlaybackPCM "hw:${CardId},4"
++				PlaybackMixerElem "Speaker"
++			}
+ 
+-	ConflictingDevice [
+-		"Headphones"
+-	]
++			DisableSequence [
++				cset "name='Speaker Playback Switch' off"
++			]
++
++			ConflictingDevice [
++				"Headphones"
++			]
++		}
++	}
+ }
+ 
+ SectionDevice."Line1" {
+@@ -48,22 +57,31 @@ SectionDevice."Line1" {
+ 	Value {
+ 		PlaybackPriority 200
+ 		PlaybackPCM "hw:${CardId}"
+-		JackControl "Line Out Jack"
+-		JackHWMute "Speaker"
++	}
++
++	If.0 {
++		Condition {
++			Type ControlExists
++			Control "name='Front Playback Switch'"
++		}
++		True {
++			Value {
++				PlaybackMixerElem "Front"
++				JackControl "Line Out Front Jack"
++			}
++		}
++		False {
++			Value {
++				JackControl "Line Out Jack"
++				JackHWMute "Speaker"
++			}
++		}
+ 	}
+ }
+ 
+ SectionDevice."Headphones" {
+ 	Comment "Headphones"
+ 
+-	Value {
+-		PlaybackPriority 300
+-		PlaybackPCM "hw:${CardId},4"
+-		PlaybackMixerElem "Headphone"
+-		JackControl "Front Headphone Jack"
+-		JackHWMute "Speaker"
+-	}
+-
+ 	EnableSequence [
+ 		cset "name='Headphone Playback Switch' on"
+ 	]
+@@ -72,20 +90,26 @@ SectionDevice."Headphones" {
+ 		cset "name='Headphone Playback Switch' off"
+ 	]
+ 
+-	ConflictingDevice [
+-		"Speaker"
+-	]
++	Value {
++		PlaybackPriority 300
++		PlaybackPCM "hw:${CardId},4"
++		PlaybackMixerElem "Headphone"
++		JackControl "Front Headphone Jack"
++	}
++
++	If.speaker {
++		Condition {
++			Type ControlExists
++			Control "name='Speaker Volume Switch'"
++		}
++		True.Value.JackHWMute "Speaker"
++	}
++
+ }
+ 
+ SectionDevice."Line2" {
+ 	Comment "Rear Line In"
+ 
+-	Value {
+-		CapturePriority 200
+-		CapturePCM "hw:${CardId}"
+-		JackControl "Line Jack"
+-	}
+-
+ 	ConflictingDevice [
+ 		"Mic2"
+ 	]
+@@ -94,16 +118,12 @@ SectionDevice."Line2" {
+ 		cset "name='Input Source' Line"
+ 	]
+ 
+-	If.0 {
+-		Condition {
+-			Type ControlExists
+-			Control "name='Line Boost Volume'"
+-		}
+-		True {
+-			EnableSequence [
+-				cset "name='Line Boost Volume' 3"
+-			]
+-		}
++	Value {
++		CapturePriority 200
++		CapturePCM "hw:${CardId}"
++		CaptureMixerElem "Rear-Panel"
++		CaptureMasterElem "Line Boost"
++		JackControl "Line Jack"
+ 	}
+ }
+ 
+@@ -113,16 +133,14 @@ SectionDevice."Mic2" {
+ 	Value {
+ 		CapturePriority 300
+ 		CapturePCM "hw:${CardId}"
++		CaptureMixerElem "Rear-Panel"
++		CaptureMasterElem "Rear Mic Boost"
+ 		JackHWMute "Line2"
+ 		JackControl "Rear Mic Jack"
+ 	}
+ 
+-	ConflictingDevice [
+-		"Line2"
+-	]
+-
+ 	EnableSequence [
+-		cset "name='Input Source' Rear Mic"
++		cset "name='Input Source' 'Rear Mic'"
+ 	]
+ }
+ 
+@@ -133,6 +151,7 @@ SectionDevice."Mic1" {
+ 		CapturePriority 100
+ 		CapturePCM "hw:${CardId},4"
+ 		CaptureMixerElem "Front-Panel"
++		CaptureMasterElem "Front Mic Boost"
+ 		JackControl "Front Mic Jack"
+ 	}
+ }
+-- 
+2.31.1
+

--- a/pkgs/os-specific/linux/alsa-project/alsa-ucm-conf/0003-HDA-patch-to-work-with-v1.2.5.1.patch
+++ b/pkgs/os-specific/linux/alsa-project/alsa-ucm-conf/0003-HDA-patch-to-work-with-v1.2.5.1.patch
@@ -1,0 +1,30 @@
+From dc40ceee75b46e6809b6a8d10c892b09e71018ce Mon Sep 17 00:00:00 2001
+From: Zane van Iperen <zane@zanevaniperen.com>
+Date: Sat, 4 Dec 2021 03:35:05 +1000
+Subject: [PATCH 3/3] HDA: patch to work with v1.2.5.1
+
+---
+ ucm2/HDA-Intel/HDAudio-DualCodecs.conf | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/ucm2/HDA-Intel/HDAudio-DualCodecs.conf b/ucm2/HDA-Intel/HDAudio-DualCodecs.conf
+index db867e1..73a6250 100644
+--- a/ucm2/HDA-Intel/HDAudio-DualCodecs.conf
++++ b/ucm2/HDA-Intel/HDAudio-DualCodecs.conf
+@@ -1,11 +1,11 @@
+-Syntax 2
++Syntax 3
+ Comment "HDAudio with dual HD-audio codecs"
+ SectionUseCase."HiFi" {
+ 	File "HiFi-dual.conf"
+ 	Comment "Default"
+ }
+ 
+-Include.init1.File "/HDA/init.conf"
++Include.init1.File "/HDA-Intel/init.conf"
+ 
+ BootSequence [
+ 	cset "name='Front Playback Volume' 100%"
+-- 
+2.31.1
+

--- a/pkgs/os-specific/linux/alsa-project/alsa-ucm-conf/default.nix
+++ b/pkgs/os-specific/linux/alsa-project/alsa-ucm-conf/default.nix
@@ -9,6 +9,12 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-WEGkRBZty/R523UTA9vDVW9oUIWsfgDwyed1VnYZXZc=";
   };
 
+  patches = [
+    ./0001-HDA-improve-init.conf-Capture-volume-switches.patch
+    ./0002-HDA-improve-support-for-HDAudio-Gigabyte-ALC1220Dual.patch
+    ./0003-HDA-patch-to-work-with-v1.2.5.1.patch
+  ];
+
   dontBuild = true;
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Backporting an upstream fix for https://github.com/alsa-project/alsa-ucm-conf/issues/123

Usually I'd just carry this patch as an overlay in my local tree, but it's a rebuild-the-world kind of patch...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
