### PR TITLE
python3Packages.quantum-gateway: init at 0.0.6

### DIFF
--- a/pkgs/development/python-modules/esprima/default.nix
+++ b/pkgs/development/python-modules/esprima/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "esprima";
+  version = "4.0.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "Kronuz";
+    repo = "esprima-python";
+    rev = "v${version}";
+    sha256 = "WtkPCReXhxyr6pOzE9gsdIeBlLk+nSnbxkS3OowEaHo=";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    "test/__main__.py::TestEsprima"
+  ];
+
+  pythonImportsCheck = [
+    "esprima"
+  ];
+
+  meta = with lib; {
+    description = "Python parser for standard-compliant ECMAScript";
+    homepage = "https://github.com/Kronuz/esprima-python";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/quantum-gateway/default.nix
+++ b/pkgs/development/python-modules/quantum-gateway/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, esprima
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
+, requests
+, requests-mock
+, setuptools-scm
+, urllib3
+}:
+
+buildPythonPackage rec {
+  pname = "quantum-gateway";
+  version = "0.0.6";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "cisasteelersfan";
+    repo = "quantum_gateway";
+    rev = version;
+    sha256 = "f2LYOr9xJSfbA/1aHfll5lg7r05o855Zkkk9HuRamP8=";
+  };
+
+  propagatedBuildInputs = [
+    urllib3
+    esprima
+    requests
+  ];
+
+  checkInputs = [
+    requests-mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "quantum_gateway"
+  ];
+
+  meta = with lib; {
+    description = "Python library for interacting with Verizon Fios Quantum gateway devices";
+    homepage = "https://github.com/cisasteelersfan/quantum_gateway";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -682,7 +682,7 @@
     "qld_bushfire" = ps: with ps; [ georss-qld-bushfire-alert-client ];
     "qnap" = ps: with ps; [ ]; # missing inputs: qnapstats
     "qrcode" = ps: with ps; [ pillow ]; # missing inputs: pyzbar
-    "quantum_gateway" = ps: with ps; [ ]; # missing inputs: quantum-gateway
+    "quantum_gateway" = ps: with ps; [ quantum-gateway ];
     "qvr_pro" = ps: with ps; [ ]; # missing inputs: pyqvrpro
     "qwikswitch" = ps: with ps; [ ]; # missing inputs: pyqwikswitch
     "rachio" = ps: with ps; [ pyturbojpeg aiohttp-cors hass-nabucasa rachiopy ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2520,6 +2520,8 @@ in {
 
   eradicate = callPackage ../development/python-modules/eradicate { };
 
+  esprima = callPackage ../development/python-modules/esprima { };
+
   escapism = callPackage ../development/python-modules/escapism { };
 
   etcd = callPackage ../development/python-modules/etcd { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8070,6 +8070,8 @@ in {
 
   quantities = callPackage ../development/python-modules/quantities { };
 
+  quantum-gateway = callPackage ../development/python-modules/quantum-gateway { };
+
   querystring_parser = callPackage ../development/python-modules/querystring-parser { };
 
   questionary = callPackage ../development/python-modules/questionary { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library for interacting with Verizon Fios Quantum gateway devices

https://github.com/cisasteelersfan/quantum_gateway

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
