### PR TITLE
electrum-ltc: 3.3.8.1 -> 4.0.9.3

### DIFF
--- a/pkgs/applications/misc/electrum/ltc.nix
+++ b/pkgs/applications/misc/electrum/ltc.nix
@@ -1,63 +1,180 @@
 { lib
+, stdenv
 , fetchurl
-, python3Packages
+, fetchFromGitHub
 , wrapQtAppsHook
+, python3
+, zbar
+, secp256k1
+, enableQt ? true
+# for updater.nix
+, writeScript
+, common-updater-scripts
+, bash
+, coreutils
+, curl
+, gnugrep
+, gnupg
+, gnused
+, nix
 }:
 
-python3Packages.buildPythonApplication rec {
+let
+  version = "4.0.9.3";
+
+  libsecp256k1_name =
+    if stdenv.isLinux then "libsecp256k1.so.0"
+    else if stdenv.isDarwin then "libsecp256k1.0.dylib"
+    else "libsecp256k1${stdenv.hostPlatform.extensions.sharedLibrary}";
+
+  libzbar_name =
+    if stdenv.isLinux then "libzbar.so.0"
+    else "libzbar${stdenv.hostPlatform.extensions.sharedLibrary}";
+
+  # Not provided in official source releases, which are what upstream signs.
+  tests = fetchFromGitHub {
+    owner = "pooler";
+    repo = "electrum-ltc";
+    rev = version;
+    sha256 = "sha256-oZjQnrnj8nCaQjrIz8bWNt6Ib8Wu2ZMXHEPfCCy2fjk=";
+
+    extraPostFetch = ''
+      mv $out ./all
+      mv ./all/electrum_ltc/tests $out
+    '';
+  };
+
+  py = python3.override {
+    packageOverrides = self: super: {
+
+      aiorpcx = super.aiorpcx.overridePythonAttrs (oldAttrs: rec {
+        version = "0.18.7";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "1rswrspv27x33xa5bnhrkjqzhv0sknv5kd7pl1vidw9d2z4rx2l0";
+        };
+      });
+    };
+  };
+
+in
+
+python3.pkgs.buildPythonApplication {
   pname = "electrum-ltc";
-  version = "3.3.8.1";
+  inherit version;
 
   src = fetchurl {
     url = "https://electrum-ltc.org/download/Electrum-LTC-${version}.tar.gz";
-    sha256 = "0kxcx1xf6h9z8x0k483d6ykpnmfr30n6z3r6lgqxvbl42pq75li7";
+    sha256 = "sha256-+oox0BGqkvj0OGOKJF8tUoKdsZFeffNb6rTF8E8mo08=";
   };
 
-  nativeBuildInputs = with python3Packages; [ pyqt5 wrapQtAppsHook ];
+  postUnpack = ''
+    # can't symlink, tests get confused
+    cp -ar ${tests} $sourceRoot/electrum_ltc/tests
+  '';
 
-  propagatedBuildInputs = with python3Packages; [
-    pyaes
-    ecdsa
-    pbkdf2
-    requests
-    qrcode
-    py_scrypt
-    pyqt5
-    protobuf
+  prePatch = ''
+    substituteInPlace contrib/requirements/requirements.txt \
+      --replace "dnspython>=2.0,<2.1" "dnspython>=2.0"
+  '';
+
+  nativeBuildInputs = lib.optionals enableQt [ wrapQtAppsHook ];
+
+  propagatedBuildInputs = with py.pkgs; [
+    aiohttp
+    aiohttp-socks
+    aiorpcx
+    attrs
+    bitstring
+    cryptography
     dnspython
     jsonrpclib-pelix
+    matplotlib
+    pbkdf2
+    protobuf
+    py_scrypt
     pysocks
-    trezor
+    qrcode
+    requests
+    tlslite-ng
+    # plugins
     btchip
+    ckcc-protocol
+    keepkey
+    trezor
+  ] ++ lib.optionals enableQt [
+    pyqt5
+    qdarkstyle
   ];
 
   preBuild = ''
     sed -i 's,usr_share = .*,usr_share = "'$out'/share",g' setup.py
-    pyrcc5 icons.qrc -o gui/qt/icons_rc.py
-    # Recording the creation timestamps introduces indeterminism to the build
-    sed -i '/Created: .*/d' gui/qt/icons_rc.py
+    substituteInPlace ./electrum_ltc/ecc_fast.py \
+      --replace ${libsecp256k1_name} ${secp256k1}/lib/libsecp256k1${stdenv.hostPlatform.extensions.sharedLibrary}
+  '' + (if enableQt then ''
+    substituteInPlace ./electrum_ltc/qrscanner.py \
+      --replace ${libzbar_name} ${zbar.lib}/lib/libzbar${stdenv.hostPlatform.extensions.sharedLibrary}
+  '' else ''
+    sed -i '/qdarkstyle/d' contrib/requirements/requirements.txt
+  '');
+
+  postInstall = lib.optionalString stdenv.isLinux ''
+    # Despite setting usr_share above, these files are installed under
+    # $out/nix ...
+    mv $out/${python3.sitePackages}/nix/store"/"*/share $out
+    rm -rf $out/${python3.sitePackages}/nix
+
+    substituteInPlace $out/share/applications/electrum-ltc.desktop \
+      --replace 'Exec=sh -c "PATH=\"\\$HOME/.local/bin:\\$PATH\"; electrum-ltc %u"' \
+                "Exec=$out/bin/electrum-ltc %u" \
+      --replace 'Exec=sh -c "PATH=\"\\$HOME/.local/bin:\\$PATH\"; electrum-ltc --testnet %u"' \
+                "Exec=$out/bin/electrum-ltc --testnet %u"
+
   '';
 
-  preFixup = ''
-    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+  postFixup = lib.optionalString enableQt ''
+    wrapQtApp $out/bin/electrum-ltc
   '';
 
-  checkPhase = ''
+  checkInputs = with python3.pkgs; [ pytestCheckHook pyaes pycryptodomex ];
+
+  pytestFlagsArray = [ "electrum_ltc/tests" ];
+
+  disabledTests = [
+    "test_loop"  # test tries to bind 127.0.0.1 causing permission error
+    "test_is_ip_address"  # fails spuriously https://github.com/spesmilo/electrum/issues/7307
+  ];
+
+  postCheck = ''
     $out/bin/electrum-ltc help >/dev/null
   '';
 
+  passthru.updateScript = import ./update.nix {
+    inherit lib;
+    inherit
+      writeScript
+      common-updater-scripts
+      bash
+      coreutils
+      curl
+      gnupg
+      gnugrep
+      gnused
+      nix
+    ;
+  };
+
   meta = with lib; {
-    description = "Litecoin thin client";
+    description = "Lightweight Litecoin Client";
     longDescription = ''
-      Electrum-LTC is a simple, but powerful Litecoin wallet. A twelve-word
-      security passphrase (or “seed”) leaves intruders stranded and your peace
-      of mind intact. Keep it on paper, or in your head... and never worry
-      about losing your litecoins to theft or hardware failure. No waiting, no
-      lengthy blockchain downloads and no syncing to the network.
+      Electrum-LTC is a simple, but powerful Litecoin wallet. A unique secret
+      phrase (or “seed”) leaves intruders stranded and your peace of mind
+      intact. Keep it on paper, or in your head... and never worry about losing
+      your litecoins to theft or hardware failure.
     '';
     homepage = "https://electrum-ltc.org/";
     license = licenses.mit;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ ];
+    platforms = platforms.all;
+    maintainers = with maintainers; [ lourkeur ];
   };
 }


### PR DESCRIPTION
rewritten based on the `electrum` derivation

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#148190 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
