### PR TITLE
python3Packages.python-izone: 1.1.6 -> 1.1.8

### DIFF
--- a/pkgs/development/python-modules/pytest-aio/default.nix
+++ b/pkgs/development/python-modules/pytest-aio/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, pytest-mypy
+, pytestCheckHook
+, pythonOlder
+, types-setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-aio";
+  version = "1.4.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "ZPG6k+ZNi6FQftIVwr/Lux5rJlo284V/mjtYepNScdQ=";
+  };
+
+  buildInputs = [
+    pytest
+  ];
+
+  checkInputs = [
+    pytest-mypy
+    pytestCheckHook
+    types-setuptools
+  ];
+
+  pythonImportsCheck = [
+    "pytest_aio"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/klen/pytest-aio";
+    description = "Pytest plugin for aiohttp support";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/python-izone/default.nix
+++ b/pkgs/development/python-modules/python-izone/default.nix
@@ -2,26 +2,25 @@
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub
-, fetchpatch
 , aiohttp
 , netifaces
-, asynctest
-, pytest-aiohttp
+, pytest-aio
+, pytest-asyncio
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "python-izone";
-  version = "1.1.6";
+  version = "1.1.8";
   format = "setuptools";
 
-  disabled = pythonOlder "3.5";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "Swamp-Ig";
     repo = "pizone";
     rev = "v${version}";
-    sha256 = "sha256-zgE1ccEPSa9nX0SEMN02VEGfnHexk/+jCJe7ugUL5UA=";
+    sha256 = "sha256-/qPWSTO0PV4lEgwWpgcoBnbUtDUrEVItb4NF9TV2QJU=";
   };
 
   propagatedBuildInputs = [
@@ -30,18 +29,14 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    asynctest
-    pytest-aiohttp
+    pytest-aio
+    pytest-asyncio
     pytestCheckHook
   ];
 
-  patches = [
-    # async_timeout 4.0.0 removes current_task, https://github.com/Swamp-Ig/pizone/pull/15
-    (fetchpatch {
-      name = "remove-current-task.patch";
-      url = "https://github.com/Swamp-Ig/pizone/commit/988998cf009a39938e4ee37079337b0c187977f2.patch";
-      sha256 = "nVCQBMc4ZE7CQsYC986wqvPPyA7zJ/g278jJrpaiAIw=";
-    })
+  disabledTestPaths = [
+    # Test are blocking
+    "tests/test_fullstack.py"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7336,6 +7336,8 @@ in {
     '';
   });
 
+  pytest-aio = callPackage ../development/python-modules/pytest-aio { };
+
   pytest-aiohttp = callPackage ../development/python-modules/pytest-aiohttp { };
 
   pytest-annotate = callPackage ../development/python-modules/pytest-annotate { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.1.8

Change log:
- https://github.com/Swamp-Ig/pizone/releases/tag/v1.1.8
- https://github.com/Swamp-Ig/pizone/releases/tag/v1.1.7

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
