### PR TITLE
[staging] gfortran: default to same gcc version as stdenv

### DIFF
--- a/pkgs/development/libraries/mpich/default.nix
+++ b/pkgs/development/libraries/mpich/default.nix
@@ -22,6 +22,9 @@ stdenv.mkDerivation  rec {
     "--enable-shared"
     "--enable-sharedlib"
     "--with-pm=${withPm}"
+  ] ++ lib.optionals (lib.versionAtLeast gfortran.version "10") [
+    "FFLAGS=-fallow-argument-mismatch" # https://github.com/pmodels/mpich/issues/4300
+    "FCFLAGS=-fallow-argument-mismatch"
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/mvapich/default.nix
+++ b/pkgs/development/libraries/mvapich/default.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation rec {
     "--enable-threads=multiple"
     "--enable-hybrid"
     "--enable-shared"
+    "FFLAGS=-fallow-argument-mismatch" # fix build with gfortran 10
   ] ++ optional useSlurm "--with-pm=slurm"
     ++ optional (network == "ethernet") "--with-device=ch3:sock"
     ++ optionals (network == "infiniband") [ "--with-device=ch3:mrail" "--with-rdma=gen2" ]

--- a/pkgs/development/libraries/netcdf-fortran/default.nix
+++ b/pkgs/development/libraries/netcdf-fortran/default.nix
@@ -15,6 +15,9 @@ stdenv.mkDerivation rec {
     ++ lib.optional stdenv.isDarwin CoreFoundation;
   doCheck = true;
 
+  FFLAGS = [ "-std=legacy" ];
+  FCFLAGS = [ "-std=legacy" ];
+
   meta = with lib; {
     description = "Fortran API to manipulate netcdf files";
     homepage = "https://www.unidata.ucar.edu/software/netcdf/";

--- a/pkgs/development/libraries/physics/qcdnum/default.nix
+++ b/pkgs/development/libraries/physics/qcdnum/default.nix
@@ -12,6 +12,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ gfortran ];
   buildInputs = [ zlib ];
 
+  FFLAGS = [
+    "-std=legacy" # fix build with gfortran 10
+  ];
+
   enableParallelBuilding = true;
 
   meta = {

--- a/pkgs/development/libraries/qrupdate/default.nix
+++ b/pkgs/development/libraries/qrupdate/default.nix
@@ -25,12 +25,14 @@ stdenv.mkDerivation rec {
       "LAPACK=-L${lapack}/lib -llapack"
       "BLAS=-L${blas}/lib -lblas"
       "PREFIX=${placeholder "out"}"
-      ${lib.optionalString blas.isILP64
-      # If another application intends to use qrupdate compiled with blas with
-      # 64 bit support, it should add this to it's FFLAGS as well. See (e.g):
-      # https://savannah.gnu.org/bugs/?50339
-      "FFLAGS=-fdefault-integer-8"
-      }
+      "FFLAGS=${toString ([
+        "-std=legacy"
+      ] ++ lib.optionals blas.isILP64 [
+        # If another application intends to use qrupdate compiled with blas with
+        # 64 bit support, it should add this to it's FFLAGS as well. See (e.g):
+        # https://savannah.gnu.org/bugs/?50339
+        "-fdefault-integer-8"
+      ])}"
     )
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12351,8 +12351,14 @@ with pkgs;
 
   gcc_latest = gcc11;
 
-  # aarch64-darwin doesn't support earlier gcc
-  gfortran = if (stdenv.isDarwin && stdenv.isAarch64) then gfortran11 else gfortran9;
+  # Use the same GCC version as the one from stdenv by default
+  gfortran = wrapCC (gccStdenv.cc.cc.override {
+    name = "gfortran";
+    langFortran = true;
+    langCC = false;
+    langC = false;
+    profiledCompiler = false;
+  });
 
   gfortran48 = wrapCC (gcc48.cc.override {
     name = "gfortran";


### PR DESCRIPTION
This is a more expected default behavior, so that the unversioned
gcc/gfortran toplevel attrs have the same version. It's also more
robust in cases where C and Fortran objects are being linked together.

With this commit, gcc.version == gfortran.version == "10.3.0"
(on x86_64-linux), bumping the default gfortran version from 9 to 10.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
