### PR TITLE
Revert "nixosTests.keymap.qwertz: reduce platforms in `tested`"

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -92,7 +92,7 @@ in rec {
         (onFullSupported "nixos.tests.keymap.dvorak")
         (onFullSupported "nixos.tests.keymap.dvorak-programmer")
         (onFullSupported "nixos.tests.keymap.neo")
-        (onSystems ["x86_64-linux"] "nixos.tests.keymap.qwertz")
+        (onFullSupported "nixos.tests.keymap.qwertz")
         (onFullSupported "nixos.tests.latestKernel.login")
         (onFullSupported "nixos.tests.lightdm")
         (onFullSupported "nixos.tests.login")


### PR DESCRIPTION
Reverts NixOS/nixpkgs#147715

with https://github.com/NixOS/nixpkgs/pull/148491

we should no longer need to disable the qwertz tests