### PR TITLE
blender: 2.93.5 -> 3.0.0, keep old as blender_2_93, refactor, support wayland

### DIFF
--- a/pkgs/applications/misc/blender/2.93.nix
+++ b/pkgs/applications/misc/blender/2.93.nix
@@ -4,11 +4,11 @@
 , glew, gmp, ilmbase, jemalloc, libharu, libjpeg, libpng
 , libsamplerate, libsndfile, libtiff, opencolorio, openexr
 , openimagedenoise, openimageio2, openjpeg, opensubdiv
-, potrace, pugixml, python3, tbb, zlib, zstd
+, potrace, pugixml, python3, tbb, zlib
 
 # Linux specific:
 , libGL, libGLU, libX11, libXext, libXi, libXrender, libXxf86vm
-, openxr-loader, openvdb, openal
+, openxr-loader, openvdb, openal, ocl-icd
 
 # Darwin specific:
 , Cocoa, CoreGraphics, ForceFeedback, llvmPackages, OpenAL, OpenGL, SDL
@@ -18,7 +18,7 @@
 , libjack2
 
 , cudaSupport ? config.cudaSupport or false
-, cudatoolkit_11, addOpenGLRunpath
+, cudatoolkit, addOpenGLRunpath
 
 , colladaSupport ? true
 , opencollada
@@ -28,17 +28,24 @@
 }:
 
 let
+  optix = fetchzip {
+    # As a reference check the URL against this package in the ArchLinux repo
+    # and against what OpenShadingLanguage has in its github workflows
+    url = "https://developer.download.nvidia.com/redist/optix/v7.0/OptiX-7.0.0-include.zip";
+    sha256 = "1b3ccd3197anya2bj3psxdrvrpfgiwva5zfv2xmyrl73nb2dvfr7";
+  };
+
   numpyPath = "${python3.pkgs.numpy}/${python3.sitePackages}";
 in
 stdenv.mkDerivation rec {
   pname = "blender";
-  version = "3.0.0";
+  version = "2.93.5";
 
   # We use fetchurl here instead of fetchzip,
   # so that source is available at the https://tarballs.nixos.org
   src = fetchurl {
     url = "https://download.blender.org/source/${pname}-${version}.tar.xz";
-    sha256 = "sha256-UPDzK834gloSulyNhTtubGstpl7wHoWOpZAKBszL8cs=";
+    sha256 = "1fsw8w80h8k5w4zmy659bjlzqyn5i198hi1kbpzfrdn8psxg2bfj";
   };
 
   patches = lib.optionals stdenv.isDarwin [ ./darwin.patch ];
@@ -52,7 +59,7 @@ stdenv.mkDerivation rec {
     alembic boost embree ffmpeg fftw freetype gettext glew
     gmp ilmbase jemalloc libharu libjpeg libpng libsamplerate
     libsndfile libtiff opencolorio openexr openimagedenoise
-    openimageio2 openjpeg potrace pugixml python3 tbb zlib zstd
+    openimageio2 openjpeg potrace pugixml python3 tbb zlib
     (opensubdiv.override { inherit cudaSupport; })
   ]
   ++ lib.optionals stdenv.isLinux [
@@ -66,7 +73,7 @@ stdenv.mkDerivation rec {
     OpenAL OpenGL
   ]
   ++ lib.optionals jackaudioSupport [ libjack2 ]
-  ++ lib.optionals cudaSupport [ cudatoolkit_11 ]
+  ++ lib.optionals cudaSupport [ cudatoolkit ]
   ++ lib.optionals colladaSupport [ opencollada ]
   ++ lib.optionals spaceNavSupport [ libspnav ];
 
@@ -85,6 +92,10 @@ stdenv.mkDerivation rec {
       --replace '${"$"}{LIBDIR}/python' ${python3} \
       --replace '${"$"}{LIBDIR}/opencollada' ${opencollada} \
       --replace '${"$"}{PYTHON_LIBPATH}/site-packages/numpy' ${numpyPath}/numpy
+  ''
+  + lib.optionalString stdenv.isLinux ''
+    substituteInPlace extern/clew/src/clew.c \
+      --replace '"libOpenCL.so"' '"${ocl-icd}/lib/libOpenCL.so"'
   '';
 
   cmakeFlags = [
@@ -106,7 +117,11 @@ stdenv.mkDerivation rec {
   # Clang doesn't support "-export-dynamic"
   ++ lib.optionals stdenv.cc.isClang [ "-DPYTHON_LINKFLAGS=" ]
   ++ lib.optionals jackaudioSupport [ "-DWITH_JACK=ON" ]
-  ++ lib.optionals cudaSupport [ "-DWITH_CYCLES_CUDA_BINARIES=ON" ];
+  ++ lib.optionals cudaSupport [
+    "-DWITH_CYCLES_CUDA_BINARIES=ON"
+    "-DWITH_CYCLES_DEVICE_OPTIX=ON"
+    "-DOPTIX_ROOT_DIR=${optix}"
+  ];
 
   # Since some dependencies are built with gcc 6, we need gcc 6's libstdc++
   # in our RPATH. Sigh.
@@ -143,7 +158,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.blender.org";
     # They comment two licenses: GPLv2 and Blender License, but they say:
     # "We've decided to cancel the BL offering for an indefinite period."
-    # CUDA toolkit is unfree.
+    # OptiX, enabled with cudaSupport, is non-free.
     license = with licenses; [ gpl2Plus ]
       ++ lib.optionals cudaSupport [ unfree ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ];

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -1,142 +1,138 @@
-{ config, stdenv, lib, fetchurl, fetchzip, boost, cmake, ffmpeg, gettext, glew
-, ilmbase, libXi, libX11, libXext, libXrender
-, libjpeg, libpng, libsamplerate, libsndfile
-, libtiff, libGLU, libGL, openal, opencolorio, openexr, openimagedenoise, openimageio2, openjpeg, python39Packages
-, openvdb, libXxf86vm, tbb, alembic
-, zlib, fftw, opensubdiv, freetype, jemalloc, ocl-icd, addOpenGLRunpath
-, jackaudioSupport ? false, libjack2
-, cudaSupport ? config.cudaSupport or false, cudatoolkit
-, colladaSupport ? true, opencollada
-, spaceNavSupport ? stdenv.isLinux, libspnav
-, makeWrapper
-, pugixml, llvmPackages, SDL, Cocoa, CoreGraphics, ForceFeedback, OpenAL, OpenGL
-, potrace
-, openxr-loader
-, embree, gmp, libharu
+{ stdenv, lib, config, fetchzip, fetchurl, cmake, makeWrapper
+# Common:
+, alembic, boost, embree, ffmpeg, fftw, freetype, gettext
+, glew, gmp, ilmbase, jemalloc, libharu, libjpeg, libpng
+, libsamplerate, libsndfile, libtiff, opencolorio, openexr
+, openimagedenoise, openimageio2, openjpeg, opensubdiv
+, potrace, pugixml, python3, tbb, zlib
+
+# Linux specific:
+, libGL, libGLU, libX11, libXext, libXi, libXrender, libXxf86vm
+, openxr-loader, openvdb, openal, ocl-icd
+
+# Darwin specific:
+, Cocoa, CoreGraphics, ForceFeedback, llvmPackages, OpenAL, OpenGL, SDL
+
+# Optional:
+, jackaudioSupport ? false
+, libjack2
+
+, cudaSupport ? config.cudaSupport or false
+, cudatoolkit, addOpenGLRunpath
+
+, colladaSupport ? true
+, opencollada
+
+, spaceNavSupport ? stdenv.isLinux
+, libspnav
 }:
 
-with lib;
 let
-  python = python39Packages.python;
   optix = fetchzip {
+    # As a reference check the URL against this package in the ArchLinux repo
+    # and against what OpenShadingLanguage has in its github workflows
     url = "https://developer.download.nvidia.com/redist/optix/v7.0/OptiX-7.0.0-include.zip";
     sha256 = "1b3ccd3197anya2bj3psxdrvrpfgiwva5zfv2xmyrl73nb2dvfr7";
   };
 
+  numpyPath = "${python3.pkgs.numpy}/${python3.sitePackages}";
 in
 stdenv.mkDerivation rec {
   pname = "blender";
   version = "2.93.5";
 
+  # We use fetchurl here instead of fetchzip,
+  # so that source is available at the https://tarballs.nixos.org
   src = fetchurl {
     url = "https://download.blender.org/source/${pname}-${version}.tar.xz";
     sha256 = "1fsw8w80h8k5w4zmy659bjlzqyn5i198hi1kbpzfrdn8psxg2bfj";
   };
 
-  patches = lib.optional stdenv.isDarwin ./darwin.patch;
+  patches = lib.optionals stdenv.isDarwin [ ./darwin.patch ];
 
-  nativeBuildInputs = [ cmake makeWrapper python39Packages.wrapPython llvmPackages.llvm.dev ]
-    ++ optionals cudaSupport [ addOpenGLRunpath ];
-  buildInputs =
-    [ boost ffmpeg gettext glew ilmbase
-      freetype libjpeg libpng libsamplerate libsndfile libtiff
-      opencolorio openexr openimagedenoise openimageio2 openjpeg python zlib fftw jemalloc
-      alembic
-      (opensubdiv.override { inherit cudaSupport; })
-      tbb
-      embree
-      gmp
-      pugixml
-      potrace
-      libharu
-    ]
-    ++ (if (!stdenv.isDarwin) then [
-      libXi libX11 libXext libXrender
-      libGLU libGL openal
-      libXxf86vm
-      openxr-loader
-      # OpenVDB currently doesn't build on darwin
-      openvdb
-    ]
-    else [
-      llvmPackages.openmp SDL Cocoa CoreGraphics ForceFeedback OpenAL OpenGL
-    ])
-    ++ optional jackaudioSupport libjack2
-    ++ optional cudaSupport cudatoolkit
-    ++ optional colladaSupport opencollada
-    ++ optional spaceNavSupport libspnav;
-  pythonPath = with python39Packages; [ numpy requests ];
+  nativeBuildInputs = [
+    cmake makeWrapper python3.pkgs.wrapPython llvmPackages.llvm.dev
+  ]
+  ++ lib.optionals cudaSupport [ addOpenGLRunpath ];
+
+  buildInputs = [
+    alembic boost embree ffmpeg fftw freetype gettext glew
+    gmp ilmbase jemalloc libharu libjpeg libpng libsamplerate
+    libsndfile libtiff opencolorio openexr openimagedenoise
+    openimageio2 openjpeg potrace pugixml python3 tbb zlib
+    (opensubdiv.override { inherit cudaSupport; })
+  ]
+  ++ lib.optionals stdenv.isLinux [
+    libGL libGLU libX11 libXext libXi libXrender libXxf86vm
+    openal openxr-loader
+    # OpenVDB currently doesn't build on darwin
+    openvdb
+  ]
+  ++ lib.optionals stdenv.isDarwin [
+    llvmPackages.openmp Cocoa CoreGraphics ForceFeedback SDL
+    OpenAL OpenGL
+  ]
+  ++ lib.optionals jackaudioSupport [ libjack2 ]
+  ++ lib.optionals cudaSupport [ cudatoolkit ]
+  ++ lib.optionals colladaSupport [ opencollada ]
+  ++ lib.optionals spaceNavSupport [ libspnav ];
+
+  pythonPath = with python3.pkgs; [ numpy requests ];
 
   postPatch = ''
     # allow usage of dynamically linked embree
     rm build_files/cmake/Modules/FindEmbree.cmake
-  '' +
-    (if stdenv.isDarwin then ''
-      : > build_files/cmake/platform/platform_apple_xcode.cmake
-      substituteInPlace source/creator/CMakeLists.txt \
-        --replace '${"$"}{LIBDIR}/python' \
-                  '${python}' \
-        --replace '${"$"}{LIBDIR}/openmp' \
-                  '${llvmPackages.openmp}'
-      substituteInPlace build_files/cmake/platform/platform_apple.cmake \
-        --replace '${"$"}{LIBDIR}/python' \
-                  '${python}' \
-        --replace '${"$"}{LIBDIR}/opencollada' \
-                  '${opencollada}' \
-        --replace '${"$"}{PYTHON_LIBPATH}/site-packages/numpy' \
-                  '${python39Packages.numpy}/${python.sitePackages}/numpy'
-    '' else ''
-      substituteInPlace extern/clew/src/clew.c --replace '"libOpenCL.so"' '"${ocl-icd}/lib/libOpenCL.so"'
-    '');
+  ''
+  + lib.optionalString stdenv.isDarwin ''
+    : > build_files/cmake/platform/platform_apple_xcode.cmake
+    substituteInPlace source/creator/CMakeLists.txt \
+      --replace '${"$"}{LIBDIR}/python' ${python3} \
+      --replace '${"$"}{LIBDIR}/openmp' ${llvmPackages.openmp}
+    substituteInPlace build_files/cmake/platform/platform_apple.cmake \
+      --replace '${"$"}{LIBDIR}/python' ${python3} \
+      --replace '${"$"}{LIBDIR}/opencollada' ${opencollada} \
+      --replace '${"$"}{PYTHON_LIBPATH}/site-packages/numpy' ${numpyPath}/numpy
+  ''
+  + lib.optionalString stdenv.isLinux ''
+    substituteInPlace extern/clew/src/clew.c \
+      --replace '"libOpenCL.so"' '"${ocl-icd}/lib/libOpenCL.so"'
+  '';
 
-  cmakeFlags =
-    [
-      "-DWITH_ALEMBIC=ON"
-      "-DWITH_MOD_OCEANSIM=ON"
-      "-DWITH_CODEC_FFMPEG=ON"
-      "-DWITH_CODEC_SNDFILE=ON"
-      "-DWITH_INSTALL_PORTABLE=OFF"
-      "-DWITH_FFTW3=ON"
-      "-DWITH_SDL=OFF"
-      "-DWITH_OPENCOLORIO=ON"
-      "-DWITH_OPENSUBDIV=ON"
-      "-DPYTHON_LIBRARY=${python.libPrefix}"
-      "-DPYTHON_LIBPATH=${python}/lib"
-      "-DPYTHON_INCLUDE_DIR=${python}/include/${python.libPrefix}"
-      "-DPYTHON_VERSION=${python.pythonVersion}"
-      "-DWITH_PYTHON_INSTALL=OFF"
-      "-DWITH_PYTHON_INSTALL_NUMPY=OFF"
-      "-DPYTHON_NUMPY_PATH=${python39Packages.numpy}/${python.sitePackages}"
-      "-DPYTHON_NUMPY_INCLUDE_DIRS=${python39Packages.numpy}/${python.sitePackages}/numpy/core/include"
-      "-DWITH_PYTHON_INSTALL_REQUESTS=OFF"
-      "-DWITH_OPENVDB=ON"
-      "-DWITH_TBB=ON"
-      "-DWITH_IMAGE_OPENJPEG=ON"
-      "-DWITH_OPENCOLLADA=${if colladaSupport then "ON" else "OFF"}"
-    ]
-    ++ optionals stdenv.isDarwin [
-      "-DWITH_CYCLES_OSL=OFF" # requires LLVM
-      "-DWITH_OPENVDB=OFF" # OpenVDB currently doesn't build on darwin
+  cmakeFlags = [
+    "-DWITH_INSTALL_PORTABLE=OFF"
+    "-DWITH_SDL=OFF"
+    "-DWITH_PYTHON_INSTALL=OFF"
+    "-DPYTHON_INCLUDE_DIR=${python3}/include/${python3.libPrefix}"
+    "-DPYTHON_LIBPATH=${python3}/lib"
+    "-DPYTHON_LIBRARY=${python3.libPrefix}"
+    "-DPYTHON_NUMPY_INCLUDE_DIRS=${numpyPath}/numpy/core/include"
+    "-DPYTHON_NUMPY_PATH=${numpyPath}"
+    "-DPYTHON_VERSION=${python3.pythonVersion}"
+  ]
+  ++ lib.optionals stdenv.isDarwin [
+    "-DWITH_CYCLES_OSL=OFF" # requires LLVM
+    "-DWITH_OPENVDB=OFF" # OpenVDB currently doesn't build on darwin
+    "-DLIBDIR=/does-not-exist"
+  ]
+  # Clang doesn't support "-export-dynamic"
+  ++ lib.optionals stdenv.cc.isClang [ "-DPYTHON_LINKFLAGS=" ]
+  ++ lib.optionals jackaudioSupport [ "-DWITH_JACK=ON" ]
+  ++ lib.optionals cudaSupport [
+    "-DWITH_CYCLES_CUDA_BINARIES=ON"
+    "-DWITH_CYCLES_DEVICE_OPTIX=ON"
+    "-DOPTIX_ROOT_DIR=${optix}"
+  ];
 
-      "-DLIBDIR=/does-not-exist"
-    ]
-    # Clang doesn't support "-export-dynamic"
-    ++ optional stdenv.cc.isClang "-DPYTHON_LINKFLAGS="
-    ++ optional jackaudioSupport "-DWITH_JACK=ON"
-    ++ optional cudaSupport [
-      "-DWITH_CYCLES_CUDA_BINARIES=ON"
-      "-DWITH_CYCLES_DEVICE_OPTIX=ON"
-      "-DOPTIX_ROOT_DIR=${optix}"
-    ];
+  # Since some dependencies are built with gcc 6, we need gcc 6's libstdc++
+  # in our RPATH. Sigh.
+  NIX_LDFLAGS = lib.optionalString cudaSupport "-rpath ${stdenv.cc.cc.lib}/lib";
 
-  NIX_CFLAGS_COMPILE = "-I${ilmbase.dev}/include/OpenEXR -I${python}/include/${python.libPrefix}";
+  blenderExecutable = placeholder "out" + (
+    if stdenv.isDarwin
+    then "/Applications/Blender.app/Contents/MacOS/Blender"
+    else "/bin/blender"
+  );
 
-  # Since some dependencies are built with gcc 6, we need gcc 6's
-  # libstdc++ in our RPATH. Sigh.
-  NIX_LDFLAGS = optionalString cudaSupport "-rpath ${stdenv.cc.cc.lib}/lib";
-
-  blenderExecutable =
-    placeholder "out" + (if stdenv.isDarwin then "/Applications/Blender.app/Contents/MacOS/Blender" else "/bin/blender");
   postInstall = lib.optionalString stdenv.isDarwin ''
     mkdir $out/Applications
     mv $out/Blender.app $out/Applications
@@ -148,9 +144,9 @@ stdenv.mkDerivation rec {
       --add-flags '--python-use-system-env'
   '';
 
-  # Set RUNPATH so that libcuda and libnvrtc in /run/opengl-driver(-32)/lib can be
-  # found. See the explanation in libglvnd.
-  postFixup = optionalString cudaSupport ''
+  # Set RUNPATH so that libcuda and libnvrtc in /run/opengl-driver(-32)/lib
+  # can be found. See the explanation in libglvnd.
+  postFixup = lib.optionalString cudaSupport ''
     for program in $out/bin/blender $out/bin/.blender-wrapped; do
       isELF "$program" || continue
       addOpenGLRunpath "$program"
@@ -160,10 +156,11 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "3D Creation/Animation/Publishing System";
     homepage = "https://www.blender.org";
-    # They comment two licenses: GPLv2 and Blender License, but they
-    # say: "We've decided to cancel the BL offering for an indefinite period."
+    # They comment two licenses: GPLv2 and Blender License, but they say:
+    # "We've decided to cancel the BL offering for an indefinite period."
     # OptiX, enabled with cudaSupport, is non-free.
-    license = with licenses; [ gpl2Plus ] ++ optional cudaSupport unfree;
+    license = with licenses; [ gpl2Plus ]
+      ++ lib.optionals cudaSupport [ unfree ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
     maintainers = with maintainers; [ goibhniu veprbl ];
   };

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -25,6 +25,9 @@
 
 , spaceNavSupport ? stdenv.isLinux
 , libspnav
+
+, waylandSupport ? false
+, dbus, libffi, libxkbcommon, pkg-config, wayland, wayland-protocols
 }:
 
 let
@@ -64,6 +67,9 @@ stdenv.mkDerivation rec {
   ++ lib.optionals stdenv.isDarwin [
     llvmPackages.openmp Cocoa CoreGraphics ForceFeedback SDL
     OpenAL OpenGL
+  ]
+  ++ lib.optionals waylandSupport [
+    dbus libffi libxkbcommon pkg-config wayland wayland-protocols
   ]
   ++ lib.optionals jackaudioSupport [ libjack2 ]
   ++ lib.optionals cudaSupport [ cudatoolkit_11 ]
@@ -106,6 +112,7 @@ stdenv.mkDerivation rec {
   # Clang doesn't support "-export-dynamic"
   ++ lib.optionals stdenv.cc.isClang [ "-DPYTHON_LINKFLAGS=" ]
   ++ lib.optionals jackaudioSupport [ "-DWITH_JACK=ON" ]
+  ++ lib.optionals waylandSupport [ "-DWITH_GHOST_WAYLAND=ON" ]
   ++ lib.optionals cudaSupport [ "-DWITH_CYCLES_CUDA_BINARIES=ON" ];
 
   # Since some dependencies are built with gcc 6, we need gcc 6's libstdc++

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24220,6 +24220,10 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Cocoa CoreGraphics ForceFeedback OpenAL OpenGL;
   };
 
+  blender_2_93 = callPackage  ../applications/misc/blender {
+    inherit (darwin.apple_sdk.frameworks) Cocoa CoreGraphics ForceFeedback OpenAL OpenGL;
+  };
+
   blflash = callPackage ../tools/misc/blflash { };
 
   blogc = callPackage ../applications/misc/blogc { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24220,7 +24220,7 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Cocoa CoreGraphics ForceFeedback OpenAL OpenGL;
   };
 
-  blender_2_93 = callPackage  ../applications/misc/blender {
+  blender_2_93 = callPackage  ../applications/misc/blender/2.93.nix {
     inherit (darwin.apple_sdk.frameworks) Cocoa CoreGraphics ForceFeedback OpenAL OpenGL;
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://www.blender.org/download/releases/3-0/

Blender 3.0 removed support for OpenCL rendering, so we should probably keep old version for now.  

OptiX support had to be removed because publicly available version is too old.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
