### PR TITLE
python3Packages.markdown-it-py: 1.1.0 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/jupytext/default.nix
+++ b/pkgs/development/python-modules/jupytext/default.nix
@@ -1,23 +1,23 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pythonOlder
 , GitPython
-, jupyter-packaging
 , jupyter-client
+, jupyter-packaging
 , jupyterlab
 , markdown-it-py
 , mdit-py-plugins
 , nbformat
 , notebook
 , pytestCheckHook
+, pythonOlder
 , pyyaml
 , toml
 }:
 
 buildPythonPackage rec {
   pname = "jupytext";
-  version = "1.11.2";
+  version = "1.13.2";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
@@ -26,10 +26,14 @@ buildPythonPackage rec {
     owner = "mwouts";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-S2SKAC2oT4VIVMMDbu/Puo87noAgnQs1hh88JphutA8=";
+    sha256 = "sha256-S2SKAC2oT4VIVMMDbu/Puo87noAgnQs1hh88JphutA8=";
   };
 
-  buildInputs = [ jupyter-packaging jupyterlab ];
+  buildInputs = [
+    jupyter-packaging
+    jupyterlab
+  ];
+
   propagatedBuildInputs = [
     markdown-it-py
     mdit-py-plugins
@@ -39,16 +43,32 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    pytestCheckHook
     GitPython
     jupyter-client
     notebook
+    pytestCheckHook
   ];
-  # Tests that use a Jupyter notebook require $HOME to be writable.
-  HOME = "$TMPDIR";
-  # Pre-commit tests expect the source directory to be a Git repository.
-  pytestFlagsArray = [ "--ignore-glob='tests/test_pre_commit_*.py'" ];
-  pythonImportsCheck = [ "jupytext" "jupytext.cli" ];
+
+  postPatch = ''
+    # https://github.com/mwouts/jupytext/pull/885
+    substituteInPlace setup.py \
+      --replace "markdown-it-py[plugins]>=1.0.0b3,<2.0.0" "markdown-it-py[plugins]>=1.0"
+  '';
+
+  preCheck = ''
+    # Tests that use a Jupyter notebook require $HOME to be writable
+    export HOME=$(mktemp -d);
+  '';
+
+  pytestFlagsArray = [
+    # Pre-commit tests expect the source directory to be a Git repository
+    "--ignore-glob='tests/test_pre_commit_*.py'"
+  ];
+
+  pythonImportsCheck = [
+    "jupytext"
+    "jupytext.cli"
+  ];
 
   meta = with lib; {
     description = "Jupyter notebooks as Markdown documents, Julia, Python or R scripts";

--- a/pkgs/development/python-modules/markdown-it-py/default.nix
+++ b/pkgs/development/python-modules/markdown-it-py/default.nix
@@ -1,19 +1,20 @@
 { lib
+, attrs
 , buildPythonPackage
 , fetchFromGitHub
-, pytestCheckHook
-, pythonOlder
-, attrs
 , linkify-it-py
+, mdurl
 , psutil
 , pytest-benchmark
 , pytest-regressions
+, pytestCheckHook
+, pythonOlder
 , typing-extensions
 }:
 
 buildPythonPackage rec {
   pname = "markdown-it-py";
-  version = "1.1.0";
+  version = "2.0.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
@@ -22,11 +23,16 @@ buildPythonPackage rec {
     owner = "executablebooks";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0h7rn3rcqfwmnqs97qczwkw9w5g4df8bgn6sw7k149svfqgrkf56";
+    sha256 = "sha256-ahg+aAVpAh07PZ1mfrne0EP9K2J4tb8eLp5XXFpWp00=";
   };
 
-  propagatedBuildInputs = [ attrs linkify-it-py ]
-    ++ lib.optional (pythonOlder "3.8") typing-extensions;
+  propagatedBuildInputs = [
+    attrs
+    linkify-it-py
+    mdurl
+  ] ++ lib.optional (pythonOlder "3.8") [
+    typing-extensions
+  ];
 
   checkInputs = [
     psutil
@@ -34,11 +40,14 @@ buildPythonPackage rec {
     pytest-regressions
     pytestCheckHook
   ];
-  pythonImportsCheck = [ "markdown_it" ];
+
+  pythonImportsCheck = [
+    "markdown_it"
+  ];
 
   meta = with lib; {
-    description = "Markdown parser done right";
-    homepage = "https://markdown-it-py.readthedocs.io/en/latest";
+    description = "Markdown parser in Python";
+    homepage = "https://markdown-it-py.readthedocs.io/";
     changelog = "https://github.com/executablebooks/markdown-it-py/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ bhipple ];

--- a/pkgs/development/python-modules/mdformat/default.nix
+++ b/pkgs/development/python-modules/mdformat/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "mdformat";
-  version = "0.7.10";
+  version = "0.7.11";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "executablebooks";
     repo = pname;
     rev = version;
-    sha256 = "sha256-Zw7ZGV/Hd0MRxxQVwkjtE6MJXNLQ0A0PJlQr4x9h2ww=";
+    sha256 = "sha256-EhMoGSCtlEcm1+1aHn9DhBnLQvolhq62SMF/AdaY1/E=";
   };
 
   nativeBuildInputs = [
@@ -41,7 +41,16 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "mdformat" ];
+  disabledTests = [
+    # AssertionError
+    "test_no_codeblock_trailing_newline"
+    # Issue with upper/lower case
+    "default_style.md-options0"
+  ];
+
+  pythonImportsCheck = [
+    "mdformat"
+  ];
 
   meta = with lib; {
     description = "CommonMark compliant Markdown formatter";

--- a/pkgs/development/python-modules/mdit-py-plugins/default.nix
+++ b/pkgs/development/python-modules/mdit-py-plugins/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "mdit-py-plugins";
-  version = "0.2.8";
+  version = "0.3.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
@@ -18,13 +18,21 @@ buildPythonPackage rec {
     owner = "executablebooks";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-MXQjaVDuguGbmby6BQnrTdpq6Mih3HabXuyFxf9jB18=";
+    sha256 = "sha256-3zFSTjqwjUV6+fU6falYbIzj/Hp7E/9EXKZIi00tkg4=";
   };
 
-  propagatedBuildInputs = [ markdown-it-py ];
+  propagatedBuildInputs = [
+    markdown-it-py
+  ];
 
-  checkInputs = [ pytestCheckHook pytest-regressions ];
-  pythonImportsCheck = [ "mdit_py_plugins" ];
+  checkInputs = [
+    pytestCheckHook
+    pytest-regressions
+  ];
+
+  pythonImportsCheck = [
+    "mdit_py_plugins"
+  ];
 
   meta = with lib; {
     description = "Collection of core plugins for markdown-it-py";

--- a/pkgs/development/python-modules/mdurl/default.nix
+++ b/pkgs/development/python-modules/mdurl/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flit-core
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "mdurl";
+  version = "0.1.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "hukkin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-AVklWFc4o5R9OzS9BYauuOaxm89P/Ih5l3Vrb2P0El4=";
+  };
+
+  nativeBuildInputs = [
+    flit-core
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "mdurl"
+  ];
+
+  meta = with lib; {
+    description = "URL utilities for markdown-it";
+    homepage = "https://github.com/hukkin/mdurl";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4761,6 +4761,8 @@ in {
 
   mdit-py-plugins = callPackage ../development/python-modules/mdit-py-plugins { };
 
+  mdurl = callPackage ../development/python-modules/mdurl { };
+
   MDP = callPackage ../development/python-modules/mdp { };
 
   measurement = callPackage ../development/python-modules/measurement { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.0.0

Change log: https://github.com/executablebooks/markdown-it-py/releases/tag/v2.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
