### PR TITLE
zpool-iostat-viz: init at unstable-2021-11-13

### DIFF
--- a/pkgs/tools/filesystems/zpool-iostat-viz/default.nix
+++ b/pkgs/tools/filesystems/zpool-iostat-viz/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+, installShellFiles
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "zpool-iostat-viz";
+  version = "unstable-2021-11-13";
+
+  src = fetchFromGitHub {
+    owner = "chadmiller";
+    repo = pname;
+    rev = "cdd8f3d882ab7a9990fb2d26af3e5b2bcc4bb312";
+    sha256 = "sha256-vNXD5SauBpCtP7VPTumQ0/wXfW0PjtooS21cjpAole8=";
+  };
+
+  nativeBuildInputs = [
+    installShellFiles
+    python3Packages.wrapPython
+  ];
+
+  # There is no setup.py
+  dontConfigure = true;
+  dontBuild = true;
+  doCheck = false;
+
+  installPhase = ''
+    wrapPythonPrograms
+    install -D zpool-iostat-viz $out/bin/zpool-iostat-viz
+    installManPage zpool-iostat-viz.1
+  '';
+
+  meta = with lib; {
+    description = "\"zpool iostats\" for humans; find the slow parts of your ZFS pool";
+    homepage = "https://github.com/chadmiller/zpool-iostat-viz";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ julm ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11190,6 +11190,8 @@ with pkgs;
 
   zmap = callPackage ../tools/security/zmap { };
 
+  zpool-iostat-viz = callPackage ../tools/filesystems/zpool-iostat-viz { };
+
 
   ### SHELLS
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Packaging https://github.com/chadmiller/zpool-iostat-viz

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

FYI, @chadmiller