### PR TITLE
libtree: init at 2.0.0

### DIFF
--- a/pkgs/development/libraries/elfio/default.nix
+++ b/pkgs/development/libraries/elfio/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, boost
+}:
+
+stdenv.mkDerivation rec {
+  pname = "elfio";
+  version = "3.9";
+
+  src = fetchFromGitHub {
+    owner = "serge1";
+    repo = "elfio";
+    rev = "Release_${version}";
+    sha256 = "sha256-5O9KnHZXzepp3O1PGenJarrHElWLHgyBvvDig1Hkmo4=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  checkInputs = [ boost ];
+
+  cmakeFlags = [ "-DELFIO_BUILD_TESTS=ON" ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Header-only C++ library for reading and generating files in the ELF binary format";
+    homepage = "https://github.com/serge1/ELFIO";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ prusnak ];
+  };
+}

--- a/pkgs/development/libraries/termcolor/default.nix
+++ b/pkgs/development/libraries/termcolor/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "termcolor";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "ikalnytskyi";
+    repo = "termcolor";
+    rev = "v${version}";
+    sha256 = "sha256-W0hB+lFJ2sm7DsbOzITOtjJuntSM55BfwUunOOS4RcA=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [ "-DTERMCOLOR_TESTS=ON" ];
+
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+    ./test_termcolor
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "Header-only C++ library for printing colored messages";
+    homepage = "https://github.com/ikalnytskyi/termcolor";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ prusnak ];
+  };
+}

--- a/pkgs/development/tools/misc/libtree/default.nix
+++ b/pkgs/development/tools/misc/libtree/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, binutils
+, chrpath
+, cmake
+, cxxopts
+, elfio
+, termcolor
+, gtest
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libtree";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "haampie";
+    repo = "libtree";
+    rev = "v${version}";
+    sha256 = "sha256-j54fUwMkX4x4MwL8gMraguK9GqQRBjCC+W6ojFnQdHQ=";
+  };
+
+  patches = [
+    # add missing include
+    # https://github.com/haampie/libtree/pull/42
+    (fetchpatch {
+      url = "https://github.com/haampie/libtree/commit/219643ff6edcae42c9546b8ba38cfec9d19b034e.patch";
+      sha256 = "sha256-vdFmmBdBiOT3QBcwd3SuiolcaFTFAb88kU1KN8229K0=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace src/main.cpp \
+      --replace "std::string strip = \"strip\";" "std::string strip = \"${binutils}/bin/strip\";" \
+      --replace "std::string chrpath = \"chrpath\";" "std::string chrpath = \"${chrpath}/bin/chrpath\";"
+  '';
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ cxxopts elfio termcolor ];
+
+  doCheck = true;
+
+  checkInputs = [ gtest ];
+
+  cmakeFlags = [ "-DLIBTREE_BUILD_TESTS=ON" ];
+
+  meta = with lib; {
+    description = "Tree ldd with an option to bundle dependencies into a single folder";
+    homepage = "https://github.com/haampie/libtree";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ prusnak rardiol ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9984,6 +9984,8 @@ with pkgs;
 
   telescope = callPackage ../applications/networking/browsers/telescope { };
 
+  termcolor = callPackage ../development/libraries/termcolor { };
+
   termscp = callPackage ../tools/networking/termscp {
     inherit (darwin.apple_sdk.frameworks) Foundation Security;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7312,6 +7312,8 @@ with pkgs;
 
   libtins = callPackage ../development/libraries/libtins { };
 
+  libtree = callPackage ../development/tools/misc/libtree { };
+
   libshout = callPackage ../development/libraries/libshout { };
 
   libqb = callPackage ../development/libraries/libqb { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16093,6 +16093,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Cocoa;
   };
 
+  elfio = callPackage ../development/libraries/elfio { };
+
   enchant1 = callPackage ../development/libraries/enchant/1.x.nix { };
 
   enchant2 = callPackage ../development/libraries/enchant/2.x.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- add new useful tool called libtree (and its dependencies) - https://github.com/haampie/libtree

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
