### PR TITLE
python3Packages.adblock: 0.5.0 -> 0.5.1

### DIFF
--- a/pkgs/development/python-modules/adblock/default.nix
+++ b/pkgs/development/python-modules/adblock/default.nix
@@ -1,12 +1,12 @@
-{ stdenv
-, lib
+{ lib
+, stdenv
 , fetchFromGitHub
 , buildPythonPackage
 , rustPlatform
 , pkg-config
 , openssl
 , publicsuffix-list
-, isPy27
+, pythonOlder
 , libiconv
 , CoreFoundation
 , Security
@@ -16,34 +16,46 @@
 
 buildPythonPackage rec {
   pname = "adblock";
-  version = "0.5.0";
-  disabled = isPy27;
+  version = "0.5.1";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.6";
 
   # Pypi only has binary releases
   src = fetchFromGitHub {
     owner = "ArniDagur";
     repo = "python-adblock";
     rev = version;
-    sha256 = "sha256-JjmMfL24778T6LCuElXsD7cJxQ+RkqbNEnEqwoN24WE=";
+    sha256 = "sha256-f6PmEHVahQv8t+WOkE8DO2emivHG2t14hUSIf/l8omY=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-w+/W4T3ukRHNpCPjhlHZLPn6sgCpz4QHVD8VW+Rw5BI=";
+    hash = "sha256-x0mcykHWhheD2ycELcfR1ZQ/6WfFQzY+L/LmMipP4Rc=";
   };
 
-  format = "pyproject";
+  nativeBuildInputs = [
+    pkg-config
+  ] ++ (with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ]);
 
-  nativeBuildInputs = [ pkg-config ]
-    ++ (with rustPlatform; [ cargoSetupHook maturinBuildHook ]);
-
-  buildInputs = [ openssl ]
-    ++ lib.optionals stdenv.isDarwin [ libiconv CoreFoundation Security ];
+  buildInputs = [
+    openssl
+  ] ++ lib.optionals stdenv.isDarwin [
+    libiconv
+    CoreFoundation
+    Security
+  ];
 
   PSL_PATH = "${publicsuffix-list}/share/publicsuffix/public_suffix_list.dat";
 
-  checkInputs = [ pytestCheckHook toml ];
+  checkInputs = [
+    pytestCheckHook
+    toml
+  ];
 
   preCheck = ''
     # import from $out instead
@@ -55,12 +67,15 @@ buildPythonPackage rec {
     "tests/test_typestubs.py"
   ];
 
-  pythonImportsCheck = [ "adblock" "adblock.adblock" ];
+  pythonImportsCheck = [
+    "adblock"
+    "adblock.adblock"
+  ];
 
   meta = with lib; {
-    description = "Python wrapper for Brave's adblocking library, which is written in Rust";
+    description = "Python wrapper for Brave's adblocking library";
     homepage = "https://github.com/ArniDagur/python-adblock/";
     maintainers = with maintainers; [ petabyteboy dotlambda ];
-    license = with licenses; [ asl20 mit ];
+    license = with licenses; [ asl20 /* or */ mit ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.5.1

Change log: https://github.com/ArniDagur/python-adblock/blob/master/CHANGELOG.md#051---2021-06-26

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
