### PR TITLE
junicode: 1.002 -> 1.003

### DIFF
--- a/pkgs/data/fonts/junicode/default.nix
+++ b/pkgs/data/fonts/junicode/default.nix
@@ -1,22 +1,26 @@
-{ lib, fetchzip }:
+{ lib, fetchFromGitHub }:
 
 let
   pname = "junicode";
-  version = "1.002";
-in fetchzip {
+  version = "1.003";
+in
+fetchFromGitHub {
   name = "${pname}-${version}";
 
-  url = "mirror://sourceforge/junicode/junicode/junicode-${version}/junicode-${version}.zip";
+  owner = "psb1558";
+  repo = "Junicode-font";
+  rev = "55d816d91a5e19795d9b66edec478379ee2b9ddb";
 
   postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/junicode-ttf
+    local out_ttf=$out/share/fonts/junicode-ttf
+    mkdir -p $out_ttf
+    tar -f $downloadedFile -C $out_ttf --wildcards -x '*.ttf' --strip=2
   '';
 
-  sha256 = "1n170gw41lr0zr5958z5cgpg6i1aa7kj7iq9s6gdh1cqq7hhgd08";
+  sha256 = "1v334gljmidh58kmrarz5pf348b0ac7vh25f1xs3gyvn78khh5nw";
 
   meta = {
-    homepage = "http://junicode.sourceforge.net/";
+    homepage = "https://github.com/psb1558/Junicode-font";
     description = "A Unicode font for medievalists";
     maintainers = with lib.maintainers; [ ivan-timokhin ];
     license = lib.licenses.ofl;


### PR DESCRIPTION
Development of the font has moved from Sourceforge to GitHub, mostly
in preparation for the 2.0 version, but the 1.003 release is also
tagged there, hence the homepage change.

Release notes are here:
https://github.com/psb1558/Junicode-font/releases/tag/v1.003
and they are profoundly uninformative.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
