### PR TITLE
wayland: 1.19.0 -> 1.20.0

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -130,6 +130,8 @@ buildStdenv.mkDerivation ({
   inherit src unpackPhase meta;
 
   patches = [
+    # Upstream bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1745560:
+    ./fix-build-with-wayland-1.20.patch
   ] ++
   lib.optional (lib.versionAtLeast version "86") ./env_var_for_system_dir-ff86.patch ++
   lib.optional (lib.versionAtLeast version "90") ./no-buildconfig-ffx90.patch ++

--- a/pkgs/applications/networking/browsers/firefox/fix-build-with-wayland-1.20.patch
+++ b/pkgs/applications/networking/browsers/firefox/fix-build-with-wayland-1.20.patch
@@ -1,0 +1,13 @@
+diff --git a/widget/gtk/mozwayland/mozwayland.c b/widget/gtk/mozwayland/mozwayland.c
+index 7a448e6..7792581 100644
+--- a/widget/gtk/mozwayland/mozwayland.c
++++ b/widget/gtk/mozwayland/mozwayland.c
+@@ -200,3 +200,8 @@ MOZ_EXPORT int wl_list_empty(const struct wl_list* list) { return -1; }
+
+ MOZ_EXPORT void wl_list_insert_list(struct wl_list* list,
+                                     struct wl_list* other) {}
++
++MOZ_EXPORT struct wl_proxy *
++wl_proxy_marshal_flags(struct wl_proxy *proxy, uint32_t opcode,
++                      const struct wl_interface *interface, uint32_t version,
++                      uint32_t flags, ...) { return NULL; }

--- a/pkgs/development/libraries/SDL2/Fix-build-against-wayland-1.20.patch
+++ b/pkgs/development/libraries/SDL2/Fix-build-against-wayland-1.20.patch
@@ -1,0 +1,43 @@
+From a31d1f1683ef2e9c063c3fa1db79d111cca99414 Mon Sep 17 00:00:00 2001
+From: David Redondo <kde@david-redondo.de>
+Date: Fri, 10 Dec 2021 16:22:34 +0100
+Subject: [PATCH] Fix build against wayland 1.20
+
+Fixes #5088
+
+(cherry picked from commit e2ade2bfc46d915cd306c63c830b81d800b2575f)
+---
+ src/video/wayland/SDL_waylanddyn.h | 2 ++
+ src/video/wayland/SDL_waylandsym.h | 4 ++++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/src/video/wayland/SDL_waylanddyn.h b/src/video/wayland/SDL_waylanddyn.h
+index 485a9c19f..37070e946 100644
+--- a/src/video/wayland/SDL_waylanddyn.h
++++ b/src/video/wayland/SDL_waylanddyn.h
+@@ -81,6 +81,8 @@ void SDL_WAYLAND_UnloadSymbols(void);
+ #define wl_proxy_add_listener (*WAYLAND_wl_proxy_add_listener)
+ #define wl_proxy_marshal_constructor (*WAYLAND_wl_proxy_marshal_constructor)
+ #define wl_proxy_marshal_constructor_versioned (*WAYLAND_wl_proxy_marshal_constructor_versioned)
++#define wl_proxy_marshal_flags (*WAYLAND_wl_proxy_marshal_flags)
++#define wl_proxy_marshal_array_flags (*WAYLAND_wl_proxy_marshal_array_flags)
+
+ #define wl_seat_interface (*WAYLAND_wl_seat_interface)
+ #define wl_surface_interface (*WAYLAND_wl_surface_interface)
+diff --git a/src/video/wayland/SDL_waylandsym.h b/src/video/wayland/SDL_waylandsym.h
+index c4c189d3c..789f49e27 100644
+--- a/src/video/wayland/SDL_waylandsym.h
++++ b/src/video/wayland/SDL_waylandsym.h
+@@ -71,6 +71,10 @@ SDL_WAYLAND_SYM(struct wl_proxy *, wl_proxy_marshal_constructor, (struct wl_prox
+ SDL_WAYLAND_MODULE(WAYLAND_CLIENT_1_10)
+ SDL_WAYLAND_SYM(struct wl_proxy *, wl_proxy_marshal_constructor_versioned, (struct wl_proxy *proxy, uint32_t opcode, const struct wl_interface *interface, uint32_t version, ...))
+
++SDL_WAYLAND_MODULE(WAYLAND_CLIENT_1_20)
++SDL_WAYLAND_SYM(struct wl_proxy*, wl_proxy_marshal_flags, (struct wl_proxy *proxy, uint32_t opcode, const struct wl_interface *interfac, uint32_t version, uint32_t flags, ...))
++SDL_WAYLAND_SYM(struct wl_proxy*, wl_proxy_marshal_array_flags, (struct wl_proxy *proxy, uint32_t opcode, const struct wl_interface *interface, uint32_t version,  uint32_t flags, union wl_argument *args))
++
+ SDL_WAYLAND_INTERFACE(wl_seat_interface)
+ SDL_WAYLAND_INTERFACE(wl_surface_interface)
+ SDL_WAYLAND_INTERFACE(wl_shm_pool_interface)
+--
+2.33.1

--- a/pkgs/development/libraries/SDL2/default.nix
+++ b/pkgs/development/libraries/SDL2/default.nix
@@ -35,7 +35,11 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
   outputBin = "dev"; # sdl-config
 
-  patches = [ ./find-headers.patch ];
+  patches = [
+    ./find-headers.patch
+    # To fix the build with wayland 1.20.0:
+    ./Fix-build-against-wayland-1.20.patch
+  ];
 
   # Fix with mesa 19.2: https://bugzilla.libsdl.org/show_bug.cgi?id=4797
   postPatch = ''

--- a/pkgs/development/libraries/wayland/default.nix
+++ b/pkgs/development/libraries/wayland/default.nix
@@ -30,19 +30,14 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "wayland";
-  version = "1.19.0";
+  version = "1.20.0";
 
   src = fetchurl {
     url = "https://wayland.freedesktop.org/releases/${pname}-${version}.tar.xz";
-    sha256 = "05bd2vphyx8qwa1mhsj1zdaiv4m4v94wrlssrn0lad8d601dkk5s";
+    sha256 = "09c7rpbwavjg4y16mrfa57gk5ix6rnzpvlnv1wp7fnbh9hak985q";
   };
 
   patches = [
-    # Picked from upstream 'main' branch for Darwin support.
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/wayland/wayland/-/commit/f452e41264387dee4fd737cbf1af58b34b53941b.patch";
-      sha256 = "00mk32a01vgn31sm3wk4p8mfwvqv3xv02rxvdj1ygnzgb1ac62r7";
-    })
     (substituteAll {
       src = ./0001-add-placeholder-for-nm.patch;
       nm = "${stdenv.cc.targetPrefix}nm";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Announcements:
- Alpha: https://lists.freedesktop.org/archives/wayland-devel/2021-November/042026.html
- Beta: https://lists.freedesktop.org/archives/wayland-devel/2021-November/042036.html
- RC1: https://lists.freedesktop.org/archives/wayland-devel/2021-December/042053.html
- Final: https://lists.freedesktop.org/archives/wayland-devel/2021-December/042064.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
