### PR TITLE
gnomeExtensions: fix ddterm

### DIFF
--- a/pkgs/desktops/gnome/extensions/extensionOverrides.nix
+++ b/pkgs/desktops/gnome/extensions/extensionOverrides.nix
@@ -1,8 +1,12 @@
 { lib
 , ddcutil
 , gjs
+, gnome
+, gobject-introspection
 , xprop
 , touchegg
+, vte
+, wrapGAppsHook
 }:
 let
   # Helper method to reduce redundancy
@@ -23,6 +27,21 @@ super: lib.trivial.pipe super [
 
   (patchExtension "dash-to-dock@micxgx.gmail.com" (old: {
     meta.maintainers = with lib.maintainers; [ eperuffo jtojnar rhoriguchi ];
+  }))
+
+  (patchExtension "ddterm@amezin.github.com" (old: {
+    # Requires gjs, zenity & vte via the typelib
+    nativeBuildInputs = [ gobject-introspection wrapGAppsHook ];
+    buildInputs = [ vte ];
+    postPatch = ''
+      for file in *.js com.github.amezin.ddterm; do
+        substituteInPlace $file --replace "gjs" "${gjs}/bin/gjs"
+        substituteInPlace $file --replace "zenity" "${gnome.zenity}/bin/zenity"
+      done
+    '';
+    postFixup = ''
+      wrapGApp "$out/share/gnome-shell/extensions/ddterm@amezin.github.com/com.github.amezin.ddterm"
+    '';
   }))
 
   (patchExtension "display-brightness-ddcutil@themightydeity.github.com" (old: {


### PR DESCRIPTION
It needs gjs, zenity & vte.

Fixes #125363.

###### Motivation for this change
The Gnome extension "ddterm" is part of Nixpkgs but does not work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [v] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
