### PR TITLE
pcsclite: 1.9.4 -> 1.9.5

### DIFF
--- a/pkgs/tools/security/pcsclite/default.nix
+++ b/pkgs/tools/security/pcsclite/default.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "pcsclite";
-  version = "1.9.4";
+  version = "1.9.5";
 
   outputs = [ "bin" "out" "dev" "doc" "man" ];
 
   src = fetchurl {
     url = "https://pcsclite.apdu.fr/files/pcsc-lite-${version}.tar.bz2";
-    sha256 = "sha256:0jqwnpywk9ka3q88b1k93p8s0xhmx1isdpcqa80nd8p04z1am34a";
+    sha256 = "sha256:024x0hadn0kc0m9yz3l2pqzc5mdqyza9lmckg0bn4xak6frzkqwy";
   };
 
   patches = [ ./no-dropdir-literals.patch ];

--- a/pkgs/tools/security/pcsclite/no-dropdir-literals.patch
+++ b/pkgs/tools/security/pcsclite/no-dropdir-literals.patch
@@ -1,8 +1,8 @@
 diff --git a/src/hotplug_libudev.c b/src/hotplug_libudev.c
-index a8ba1b8..a53700b 100644
+index 51bd95f..84f959b 100644
 --- a/src/hotplug_libudev.c
 +++ b/src/hotplug_libudev.c
-@@ -119,7 +119,8 @@ static LONG HPReadBundleValues(void)
+@@ -120,7 +120,8 @@ static LONG HPReadBundleValues(void)
  
  	if (NULL == hpDir)
  	{
@@ -12,7 +12,7 @@ index a8ba1b8..a53700b 100644
  		Log1(PCSC_LOG_ERROR, "Disabling USB support for pcscd.");
  		return -1;
  	}
-@@ -722,7 +723,7 @@ ULONG HPRegisterForHotplugEvents(void)
+@@ -741,7 +742,7 @@ ULONG HPRegisterForHotplugEvents(void)
  
  	if (driverSize <= 0)
  	{
@@ -22,10 +22,10 @@ index a8ba1b8..a53700b 100644
  		Log1(PCSC_LOG_INFO, "Disabling USB support for pcscd");
  		return 0;
 diff --git a/src/hotplug_libusb.c b/src/hotplug_libusb.c
-index eff8519..8dd496d 100644
+index 0ada9f5..d49a407 100644
 --- a/src/hotplug_libusb.c
 +++ b/src/hotplug_libusb.c
-@@ -138,7 +138,8 @@ static LONG HPReadBundleValues(void)
+@@ -142,7 +142,8 @@ static LONG HPReadBundleValues(void)
  
  	if (hpDir == NULL)
  	{
@@ -35,7 +35,7 @@ index eff8519..8dd496d 100644
  		Log1(PCSC_LOG_ERROR, "Disabling USB support for pcscd.");
  		return -1;
  	}
-@@ -265,7 +266,8 @@ static LONG HPReadBundleValues(void)
+@@ -282,7 +283,8 @@ static LONG HPReadBundleValues(void)
  
  	if (driverSize == 0)
  	{
@@ -45,29 +45,3 @@ index eff8519..8dd496d 100644
  		Log1(PCSC_LOG_INFO, "Disabling USB support for pcscd");
  	}
  #ifdef DEBUG_HOTPLUG
-diff --git a/src/hotplug_linux.c b/src/hotplug_linux.c
-index bf69af8..64b0ed7 100644
---- a/src/hotplug_linux.c
-+++ b/src/hotplug_linux.c
-@@ -130,8 +130,8 @@ static LONG HPReadBundleValues(void)
- 
- 	if (hpDir == NULL)
- 	{
--		Log1(PCSC_LOG_INFO,
--			"Cannot open PC/SC drivers directory: " PCSCLITE_HP_DROPDIR);
-+		Log2(PCSC_LOG_INFO, "Cannot open PC/SC drivers directory: %s",
-+			PCSCLITE_HP_DROPDIR);
- 		Log1(PCSC_LOG_INFO, "Disabling USB support for pcscd.");
- 		return -1;
- 	}
-@@ -219,8 +219,8 @@ end:
- 
- 	if (bundleSize == 0)
- 	{
--		Log1(PCSC_LOG_INFO,
--			"No bundle files in pcsc drivers directory: " PCSCLITE_HP_DROPDIR);
-+		Log2(PCSC_LOG_INFO, "No bundle files in pcsc drivers directory: %s",
-+			PCSCLITE_HP_DROPDIR);
- 		Log1(PCSC_LOG_INFO, "Disabling USB support for pcscd");
- 	}
- 


### PR DESCRIPTION
###### Motivation for this change

This version fixes #148538 plus a bunch of other less interesting things.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
