### PR TITLE
buildBazelPackage: Pass --curses=no for terse logs

### DIFF
--- a/pkgs/build-support/build-bazel-package/default.nix
+++ b/pkgs/build-support/build-bazel-package/default.nix
@@ -214,6 +214,7 @@ in stdenv.mkDerivation (fBuildAttrs // {
       --output_base="$bazelOut" \
       --output_user_root="$bazelUserRoot" \
       build \
+      --curses=no \
       -j $NIX_BUILD_CORES \
       "''${copts[@]}" \
       "''${host_copts[@]}" \


### PR DESCRIPTION
###### Motivation for this change

Better logs for Bazel builds.

Old and busted:
```
tensorflow-gpu> [26,429 / 33,887] 12 actions, 11 running
tensorflow-gpu>     Compiling .../xla/service/cpu/simple_orc_jit.cc [for host]; 17s local
tensorflow-gpu>     Compiling .../compiler/xla/client/client_library.cc [for host]; 10s local
tensorflow-gpu>     Compiling .../xla/service/cpu/cpu_executable.cc [for host]; 10s local
tensorflow-gpu>     Compiling .../xla/service/llvm_ir/llvm_util.cc [for host]; 9s local
tensorflow-gpu>     Compiling .../compiler/xla/service/gpu/target_util.cc [for host]; 8s local
tensorflow-gpu>     Compiling .../gpu/llvm_gpu_backend/gpu_backend_lib.cc [for host]; 6s local
tensorflow-gpu>     Compiling .../gpu/llvm_gpu_backend/gpu_backend_lib.cc [for host]; 3s local
tensorflow-gpu>     Compiling .../llvm_gpu_backend/dump_ir_pass.cc [for host]; 2s local ...
tensorflow-gpu> [26,430 / 33,887] 12 actions running
tensorflow-gpu>     Compiling .../xla/service/cpu/simple_orc_jit.cc [for host]; 17s local
tensorflow-gpu>     Compiling .../compiler/xla/client/client_library.cc [for host]; 11s local
tensorflow-gpu>     Compiling .../xla/service/cpu/cpu_executable.cc [for host]; 10s local
tensorflow-gpu>     Compiling .../xla/service/llvm_ir/llvm_util.cc [for host]; 9s local
tensorflow-gpu>     Compiling .../compiler/xla/service/gpu/target_util.cc [for host]; 8s local
tensorflow-gpu>     Compiling .../gpu/llvm_gpu_backend/gpu_backend_lib.cc [for host]; 7s local
tensorflow-gpu>     Compiling .../gpu/llvm_gpu_backend/gpu_backend_lib.cc [for host]; 3s local
tensorflow-gpu>     Compiling .../llvm_gpu_backend/dump_ir_pass.cc [for host]; 3s local ...
tensorflow-gpu> [26,431 / 33,887] 12 actions, 11 running
tensorflow-gpu>     Compiling .../xla/service/cpu/simple_orc_jit.cc [for host]; 18s local
tensorflow-gpu>     Compiling .../compiler/xla/client/client_library.cc [for host]; 11s local
...
```

New hotness:
```
tensorflow-gpu> [0 / 284] [Prepa] Expanding template tensorflow/python/tools/strip_unused
tensorflow-gpu> [127 / 4,509] Compiling com_google_absl/absl/time/civil_time.cc [for host]; 3s local ... (12 actions, 11 running)
tensorflow-gpu> [288 / 5,123] Compiling tensorflow/core/platform/default/mutex.cc [for host]; 3s local ... (12 actions running)
tensorflow-gpu> [337 / 5,123] Compiling com_google_protobuf/src/google/protobuf/descriptor.cc [for host]; 12s local ... (12 actions running)
tensorflow-gpu> [588 / 5,513] Compiling com_google_protobuf/src/google/protobuf/descriptor.pb.cc [for host]; 16s local ... (12 actions running)
tensorflow-gpu> [738 / 5,689] Compiling com_google_protobuf/src/google/protobuf/util/message_differencer.cc [for host]; 8s local ... (12 actions running)
tensorflow-gpu> [985 / 6,148] Compiling com_googlesource_code_re2/re2/regexp.cc [for host]; 4s local ... (12 actions, 11 running)
tensorflow-gpu> [1,610 / 10,436] Compiling mkl_dnn/src/cpu/jit_avx512_common_conv_kernel.cpp [for host]; 9s local ... (12 actions, 11 running)
tensorflow-gpu> [1,644 / 10,436] Compiling mkl_dnn/src/cpu/cpu_engine.cpp [for host]; 23s local ... (12 actions, 11 running)
tensorflow-gpu> [1,676 / 10,436] Compiling mkl_dnn/src/cpu/cpu_engine.cpp [for host]; 60s local ... (12 actions, 11 running)
```

###### Things done

Ran a handful of small local builds, but this should be a no-op in terms of actually changing any behaviour (but of course it's going to trigger a rebuild of Tensorflow).