### PR TITLE
fetchFromSourcehut: allow recursive fetching

### DIFF
--- a/doc/builders/fetchers.chapter.md
+++ b/doc/builders/fetchers.chapter.md
@@ -82,4 +82,11 @@ This is used with repo.or.cz repositories. The arguments expected are very simil
 
 ## `fetchFromSourcehut` {#fetchfromsourcehut}
 
-This is used with sourcehut repositories. The arguments expected are very similar to fetchFromGitHub above. Don't forget the tilde (~) in front of the user name!
+This is used with sourcehut repositories. Similar to `fetchFromGitHub` above,
+it expects `owner`, `repo`, `rev` and `sha256`, but don't forget the tilde (~)
+in front of the username! Expected arguments also include `vc` ("git" (default)
+or "hg"), `domain` and `fetchSubmodules`.
+
+If `fetchSubmodules` is `true`, `fetchFromSourcehut` uses `fetchgit`
+or `fetchhg` with `fetchSubmodules` or `fetchSubrepos` set to `true`,
+respectively. Otherwise the fetcher uses `fetchzip`.

--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -310,6 +310,15 @@
           files.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <literal>fetchFromSourcehut</literal> now allows fetching
+          repositories recursively using <literal>fetchgit</literal> or
+          <literal>fetchhg</literal> if the argument
+          <literal>fetchSubmodules</literal> is set to
+          <literal>true</literal>.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
 </section>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -116,3 +116,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 - The `services.stubby` module was converted to a [settings-style](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md) configuration.
 
 - The option `services.duplicati.dataDir` has been added to allow changing the location of duplicati's files.
+
+- `fetchFromSourcehut` now allows fetching repositories recursively
+  using `fetchgit` or `fetchhg` if the argument `fetchSubmodules`
+  is set to `true`.

--- a/pkgs/build-support/fetchsourcehut/default.nix
+++ b/pkgs/build-support/fetchsourcehut/default.nix
@@ -1,10 +1,11 @@
-{ fetchzip, lib }:
+{ fetchgit, fetchhg, fetchzip, lib }:
 
 { owner
 , repo, rev
 , domain ? "sr.ht"
 , vc ? "git"
 , name ? "source"
+, fetchSubmodules ? false
 , ... # For hash agility
 } @ args:
 
@@ -14,12 +15,36 @@ assert (lib.assertOneOf "vc" vc [ "hg" "git" ]);
 
 let
   baseUrl = "https://${vc}.${domain}/${owner}/${repo}";
-
-in fetchzip (recursiveUpdate {
-  inherit name;
-  url = "${baseUrl}/archive/${rev}.tar.gz";
-  meta.homepage = "${baseUrl}/";
-  extraPostFetch = optionalString (vc == "hg") ''
-    rm -f "$out/.hg_archival.txt"
-  ''; # impure file; see #12002
-} (removeAttrs args [ "owner" "repo" "rev" "domain" "vc" ])) // { inherit rev; }
+  baseArgs = {
+    inherit name;
+  } // removeAttrs args [
+    "owner" "repo" "rev" "domain" "vc" "name" "fetchSubmodules"
+  ];
+  vcArgs = baseArgs // {
+    inherit rev;
+    url = baseUrl;
+  };
+  fetcher = if fetchSubmodules then vc else "zip";
+  cases = {
+    git = {
+      fetch = fetchgit;
+      arguments = vcArgs // { fetchSubmodules = true; };
+    };
+    hg = {
+      fetch = fetchhg;
+      arguments = vcArgs // { fetchSubrepos = true; };
+    };
+    zip = {
+      fetch = fetchzip;
+      arguments = baseArgs // {
+        url = "${baseUrl}/archive/${rev}.tar.gz";
+        extraPostFetch = optionalString (vc == "hg") ''
+          rm -f "$out/.hg_archival.txt"
+        ''; # impure file; see #12002
+      };
+    };
+  };
+in cases.${fetcher}.fetch cases.${fetcher}.arguments // {
+  inherit rev;
+  meta.homepage = "${baseUrl}";
+}


### PR DESCRIPTION
###### Motivation for this change

To be used for GH-140265

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
