### PR TITLE
opensnitch, opensnitch-ui: 1.3.6 > 1.4.3

### DIFF
--- a/pkgs/tools/networking/opensnitch/daemon.nix
+++ b/pkgs/tools/networking/opensnitch/daemon.nix
@@ -1,6 +1,8 @@
 { buildGoModule
 , fetchFromGitHub
 , fetchpatch
+, protobuf
+, go-protobuf
 , pkg-config
 , libnetfilter_queue
 , libnfnetlink
@@ -12,13 +14,13 @@
 
 buildGoModule rec {
   pname = "opensnitch";
-  version = "1.3.6";
+  version = "1.4.3";
 
   src = fetchFromGitHub {
     owner = "evilsocket";
     repo = "opensnitch";
     rev = "v${version}";
-    sha256 = "sha256-Cgo+bVQQeUZuYYhA1WSqlLyQQGAeXbbNno9LS7oNvhI=";
+    sha256 = "1c2v2x8hfqk524sa42vry74lda4lg6ii40ljk2qx9j2f69446sva";
   };
 
   patches = [
@@ -29,15 +31,21 @@ buildGoModule rec {
       url = "https://github.com/evilsocket/opensnitch/commit/8a3f63f36aa92658217bbbf46d39e6d20b2c0791.patch";
       sha256 = "sha256-WkwjKTQZppR0nqvRO4xiQoKZ307NvuUwoRx+boIpuTg=";
     })
+    # Upstream has inconsistent vendoring
+    ./go-mod.patch
   ];
 
   modRoot = "daemon";
 
-  vendorSha256 = "sha256-LMwQBFkHg1sWIUITLOX2FZi5QUfOivvrkcl9ELO3Trk=";
-
-  nativeBuildInputs = [ pkg-config makeWrapper ];
-
   buildInputs = [ libnetfilter_queue libnfnetlink ];
+
+  nativeBuildInputs = [ pkg-config protobuf go-protobuf makeWrapper ];
+
+  vendorSha256 = "sha256-sTfRfsvyiFk1bcga009W6jD6RllrySRAU6B/8mF6+ow=";
+
+  preBuild = ''
+    make -C ../proto ../daemon/ui/protocol/ui.pb.go
+  '';
 
   postBuild = ''
     mv $GOPATH/bin/daemon $GOPATH/bin/opensnitchd

--- a/pkgs/tools/networking/opensnitch/go-mod.patch
+++ b/pkgs/tools/networking/opensnitch/go-mod.patch
@@ -1,0 +1,24 @@
+diff --git a/daemon/go.mod b/daemon/go.mod
+index ec21c04..a859bfb 100644
+--- a/daemon/go.mod
++++ b/daemon/go.mod
+@@ -5,17 +5,12 @@ go 1.14
+ require (
+ 	github.com/evilsocket/ftrace v1.2.0
+ 	github.com/fsnotify/fsnotify v1.4.7
+-	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
+-	github.com/golang/protobuf v1.5.0
+ 	github.com/google/gopacket v1.1.14
+ 	github.com/google/nftables v0.0.0-20210514154851-a285acebcad3
+ 	github.com/iovisor/gobpf v0.2.0
+ 	github.com/vishvananda/netlink v1.1.0
+-	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df // indirect
+-	golang.org/x/net v0.0.0-20190311183353-d8887717615a
+-	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 // indirect
+-	golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444 // indirect
+-	golang.org/x/text v0.3.0 // indirect
++	golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271
++	golang.org/x/sys v0.0.0-20191029155521-f43be2a4598c
+ 	google.golang.org/grpc v1.27.0
+ 	google.golang.org/protobuf v1.26.0
+ )

--- a/pkgs/tools/networking/opensnitch/ui.nix
+++ b/pkgs/tools/networking/opensnitch/ui.nix
@@ -6,16 +6,19 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "opensnitch-ui";
-  version = "1.3.6";
+  version = "1.4.3";
 
   src = fetchFromGitHub {
     owner = "evilsocket";
     repo = "opensnitch";
     rev = "v${version}";
-    sha256 = "sha256-Cgo+bVQQeUZuYYhA1WSqlLyQQGAeXbbNno9LS7oNvhI=";
+    sha256 = "sha256-amtDSDJOyNSxmJICEqN5lKhGyfF5C6I0EWViB1EXW7A=";
   };
 
-  nativeBuildInputs = [ wrapQtAppsHook ];
+  nativeBuildInputs = [
+    python3Packages.pyqt5
+    wrapQtAppsHook
+  ];
 
   propagatedBuildInputs = with python3Packages; [
     grpcio-tools
@@ -25,12 +28,21 @@ python3Packages.buildPythonApplication rec {
     pyinotify
   ];
 
+  preBuild = ''
+    make -C ../proto ../ui/opensnitch/ui_pb2.py
+    pyrcc5 -o opensnitch/resources_rc.py opensnitch/res/resources.qrc
+  '';
+
   preConfigure = ''
     cd ui
   '';
 
   preCheck = ''
     export PYTHONPATH=opensnitch:$PYTHONPATH
+  '';
+
+  postInstall = ''
+    mv $out/lib/python3.9/site-packages/usr/* $out/
   '';
 
   dontWrapQtApps = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
In this PR I would like to address following bug https://github.com/NixOS/nixpkgs/issues/148168 and continue the work of this PR https://github.com/NixOS/nixpkgs/pull/118329

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
