### PR TITLE
elixir_1_13: init at 1.13.0

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -42,7 +42,12 @@ let
       elvis-erlang = callPackage ./elvis-erlang { };
 
       # BEAM-based languages.
-      elixir = elixir_1_12;
+      elixir = elixir_1_13;
+
+      elixir_1_13 = lib'.callElixir ../interpreters/elixir/1.13.nix {
+        inherit erlang;
+        debugInfo = true;
+      };
 
       elixir_1_12 = lib'.callElixir ../interpreters/elixir/1.12.nix {
         inherit erlang;
@@ -64,17 +69,8 @@ let
         debugInfo = true;
       };
 
-      elixir_1_8 = lib'.callElixir ../interpreters/elixir/1.8.nix {
-        erlang = pkgs.beam.interpreters.erlangR23;
-        debugInfo = true;
-      };
-
       # Remove old versions of elixir, when the supports fades out:
       # https://hexdocs.pm/elixir/compatibility-and-deprecations.html
-      elixir_1_7 = lib'.callElixir ../interpreters/elixir/1.7.nix {
-        inherit erlang;
-        debugInfo = true;
-      };
 
       elixir_ls = callPackage ./elixir-ls { inherit elixir fetchMixDeps mixRelease; };
 

--- a/pkgs/development/interpreters/elixir/1.13.nix
+++ b/pkgs/development/interpreters/elixir/1.13.nix
@@ -1,0 +1,9 @@
+{ mkDerivation }:
+
+# How to obtain `sha256`:
+# nix-prefetch-url --unpack https://github.com/elixir-lang/elixir/archive/v${version}.tar.gz
+mkDerivation {
+  version = "1.13.0";
+  sha256 = "1rkrx9kbs2nhkmzydm02r4wkb8wxwmg8iv0nqilpzj0skkxd6k8w";
+  minimumOTPVersion = "22";
+}

--- a/pkgs/development/interpreters/elixir/1.7.nix
+++ b/pkgs/development/interpreters/elixir/1.7.nix
@@ -1,7 +1,0 @@
-{ mkDerivation }:
-
-mkDerivation {
-  version = "1.7.4";
-  sha256 = "0f8j4pib13kffiihagdwl3xqs3a1ak19qz3z8fpyfxn9dnjiinla";
-  minimumOTPVersion = "19";
-}

--- a/pkgs/development/interpreters/elixir/1.8.nix
+++ b/pkgs/development/interpreters/elixir/1.8.nix
@@ -1,7 +1,0 @@
-{ mkDerivation }:
-
-mkDerivation {
-  version = "1.8.2";
-  sha256 = "1n77cpcl2b773gmj3m9s24akvj9gph9byqbmj2pvlsmby4aqwckq";
-  minimumOTPVersion = "20";
-}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13283,7 +13283,7 @@ with pkgs;
   inherit (beam.interpreters)
     erlang erlangR24 erlangR23 erlangR22 erlangR21
     erlang_odbc erlang_javac erlang_odbc_javac erlang_basho_R16B02
-    elixir elixir_1_12 elixir_1_11 elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7
+    elixir elixir_1_13 elixir_1_12 elixir_1_11 elixir_1_10 elixir_1_9
     elixir_ls;
 
   erlang_nox = beam_nox.interpreters.erlang;

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -89,9 +89,9 @@ with beam; {
 
     # Other Beam languages. These are built with `beam.interpreters.erlang`. To
     # access for example elixir built with different version of Erlang, use
-    # `beam.packages.erlangR23.elixir`.
+    # `beam.packages.erlangR24.elixir`.
     inherit (packages.erlang)
-      elixir elixir_1_12 elixir_1_11 elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7 elixir_ls;
+      elixir elixir_1_13 elixir_1_12 elixir_1_11 elixir_1_10 elixir_1_9 elixir_ls;
 
     inherit (packages.erlang) lfe lfe_1_3;
   };


### PR DESCRIPTION
###### Motivation for this change

Elixir 1.13 release (https://hexdocs.pm/elixir/1.13.0/changelog.html)

###### Things done

Set `elixir_1_13` as default elixir version.
Removed `elixir_1_8` `elixir_1_7` (https://hexdocs.pm/elixir/compatibility-and-deprecations.html)

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
