### PR TITLE
postgresqlPackages.pg_auto_failover: upstream fix for ncurses-6.3

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_auto_failover.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_auto_failover.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, postgresql, openssl, zlib, readline, libkrb5 }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, postgresql, openssl, zlib, readline, libkrb5 }:
 
 stdenv.mkDerivation rec {
   pname = "pg_auto_failover";
@@ -10,6 +10,16 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-hGpcHV4ai9mxaJ/u/o9LNFWPGsW22W7ak2pbvAUgmwU=";
   };
+
+  patches = [
+    # Pull upstream fix for ncurses-6.3 support:
+    #  https://github.com/citusdata/pg_auto_failover/pull/830
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/citusdata/pg_auto_failover/commit/fc92546965437a6d5f82ed9a6bdc8204a3bca725.patch";
+      sha256 = "sha256-t4DC/d/2s/Mc44rpFxBMOWGhACG0s5wAWyeDD7Mefo8=";
+    })
+  ];
 
   buildInputs = [ postgresql openssl zlib readline libkrb5 ];
 


### PR DESCRIPTION
Without the change the build fails as:

    watch.c:673:2: error: format not a string literal and no format arguments [-Werror=format-security]
      673 |  mvprintw(r, context->cols - strlen(help), help);
          |  ^~~~~~~~
