### PR TITLE
liboping: fix format arguments for printf()

### DIFF
--- a/pkgs/development/libraries/liboping/default.nix
+++ b/pkgs/development/libraries/liboping/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ncurses ? null, perl ? null, lib }:
+{ stdenv, fetchurl, fetchpatch, ncurses ? null, perl ? null, lib }:
 
 stdenv.mkDerivation rec {
   pname = "liboping";
@@ -13,6 +13,14 @@ stdenv.mkDerivation rec {
     # Add support for ncurses-6.3. A backport of patch pending upstream
     # inclusion: https://github.com/octo/liboping/pull/61
     ./ncurses-6.3.patch
+
+    # Pull pending fix for format arguments mismatch:
+    #  https://github.com/octo/liboping/pull/60
+    (fetchpatch {
+      name = "format-args.patch";
+      url = "https://github.com/octo/liboping/commit/7a50e33f2a686564aa43e4920141e6f64e042df1.patch";
+      sha256 = "118fl3k84m3iqwfp49g5qil4lw1gcznzmyxnfna0h7za2nm50cxw";
+    })
   ];
 
   NIX_CFLAGS_COMPILE = lib.optionalString


### PR DESCRIPTION
Without the change build fails on `ncurses-6.3` as:

  oping.c:1601:38: error: too many arguments for format [-Werror=format-extra-args]
   1601 |                         HOST_PRINTF ("%zu bytes from %s (%s): icmp_seq=%u ttl=%i ",
        |                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
