### PR TITLE
sysdig: fix pending upstream inclusion for ncurses-6.3

### DIFF
--- a/pkgs/os-specific/linux/sysdig/default.nix
+++ b/pkgs/os-specific/linux/sysdig/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, kernel, installShellFiles
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, kernel, installShellFiles
 , luajit, ncurses, perl, jsoncpp, libb64, openssl, curl, jq, gcc, elfutils, tbb, protobuf, grpc
 }:
 
@@ -13,6 +13,19 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-lYjMvxMIReANNwMr62u881Nugrs9piOaN3EmrvGzRns=";
   };
+
+  patches = [
+    # Fix pending upstream inclusion for ncurses-6.3 support:
+    #  https://github.com/draios/sysdig/pull/1810
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/draios/sysdig/commit/1e37fffe0337b8f8f8e0b5345db2f8631851c209.patch";
+      sha256 = "sha256-T+yC6iXQ3MY+ub0c+Hv+cC18PV8YlAOKB6YB1Hdm7Yc=";
+      # change 'a/userspace/sinspui' for 'a/userspace/libsinsp' to follow upstream rename.
+      stripLen = 3;
+      extraPrefix = "userspace/libsinsp/";
+    })
+  ];
 
   nativeBuildInputs = [ cmake perl installShellFiles ];
   buildInputs = [


### PR DESCRIPTION
Without the change the build fails as:

    sysdig/userspace/sinspui/cursescomponents.cpp: In member function 'void curses_textbox::print_no_data()':
    sysdig/userspace/sinspui/cursescomponents.cpp:878:15: error: format not a string literal and no format arguments [-Werror=format-security]
      878 |   wstr.c_str());
          |               ^
