### PR TITLE
haskellPackages.ncurses: mark as broken

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -3316,6 +3316,9 @@ broken-packages:
   - NaturalSort
   - naver-translate
   - nbt
+  # ncurses was not updated since 2016, needs a port to ncurses-6.3
+  # upstream: https://github.com/NixOS/nixpkgs/pull/148629
+  - ncurses
   - neat
   - needle
   - neet

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -3316,8 +3316,6 @@ broken-packages:
   - NaturalSort
   - naver-translate
   - nbt
-  # ncurses was not updated since 2016, needs a port to ncurses-6.3
-  # upstream: https://github.com/NixOS/nixpkgs/pull/148629
   - ncurses
   - neat
   - needle

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -2251,6 +2251,7 @@ dont-distribute-packages:
  - numhask-histogram
  - numhask-range
  - numhask-test
+ - nyan
  - nymphaea
  - oath
  - obd
@@ -2687,6 +2688,7 @@ dont-distribute-packages:
  - scp-streams
  - scrabble-bot
  - scrapbook
+ - scroll
  - sde-solver
  - seakale-postgresql
  - seakale-tests


### PR DESCRIPTION
Without the change the build fails as:

    dist/build/UI/NCurses/Enums.chs.h:140: (column 25) [ERROR]  >>> Unknown identifier!
      Cannot find a definition for `KEY_EVENT' in the header file.
