### PR TITLE
python3Packages.myfitnesspal: 1.16.4 -> 1.16.5

### DIFF
--- a/pkgs/development/python-modules/myfitnesspal/default.nix
+++ b/pkgs/development/python-modules/myfitnesspal/default.nix
@@ -1,34 +1,67 @@
-{ lib, fetchPypi, buildPythonPackage
-, blessed, keyring, keyrings-alt, lxml, measurement, python-dateutil, requests, six, rich
-, pytestCheckHook, mock, nose }:
+{ lib
+, fetchPypi
+, buildPythonPackage
+, blessed
+, keyring
+, keyrings-alt
+, lxml
+, measurement
+, python-dateutil
+, requests
+, six
+, rich
+, pytestCheckHook
+, mock
+, nose
+}:
 
 # TODO: Define this package in "all-packages.nix" using "toPythonApplication".
 # This currently errors out, complaining about not being able to find "etree" from "lxml" even though "lxml" is defined in "propagatedBuildInputs".
 
 buildPythonPackage rec {
   pname = "myfitnesspal";
-  version = "1.16.4";
+  version = "1.16.5";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "44b31623fd71fedd891c3f66be3bc1caa6f1caf88076a75236ab74f8807f6ae5";
+    sha256 = "sha256-v7lYaZLHxQs3/2uJnj+9y0xCXfPO1C38jLwzF7IMbb0=";
   };
 
-  # Remove overly restrictive version constraints
+  propagatedBuildInputs = [
+    blessed
+    keyring
+    keyrings-alt
+    lxml
+    measurement
+    python-dateutil
+    requests
+    six
+    rich
+  ];
+
+  checkInputs = [
+    mock
+    nose
+    pytestCheckHook
+  ];
+
   postPatch = ''
-    sed -i 's/keyring>=.*/keyring/' requirements.txt
-    sed -i 's/keyrings.alt>=.*/keyrings.alt/' requirements.txt
-    sed -i 's/rich>=.*/rich/' requirements.txt
+    # Remove overly restrictive version constraints
+    sed -i -e "s/>=.*//" requirements.txt
   '';
 
-  propagatedBuildInputs = [ blessed keyring keyrings-alt lxml measurement python-dateutil requests six rich ];
+  disabledTests = [
+    # Integration tests require an account to be set
+    "test_integration"
+  ];
 
-  # Integration tests require an account to be set
-  disabledTests = [ "test_integration" ];
-  checkInputs = [ pytestCheckHook mock nose ];
+  pythonImportsCheck = [
+    "myfitnesspal"
+  ];
 
   meta = with lib; {
-    description = "Access your meal tracking data stored in MyFitnessPal programatically";
+    description = "Python module to access meal tracking data stored in MyFitnessPal";
     homepage = "https://github.com/coddingtonbear/python-myfitnesspal";
     license = licenses.mit;
     maintainers = with maintainers; [ bhipple ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.16.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
