### PR TITLE
python3Packages.ocrmypdf: 12.7.2 -> 13.0.0

### DIFF
--- a/pkgs/development/python-modules/ocrmypdf/default.nix
+++ b/pkgs/development/python-modules/ocrmypdf/default.nix
@@ -8,7 +8,6 @@
 , importlib-metadata
 , importlib-resources
 , jbig2enc
-, leptonica
 , pdfminer
 , pikepdf
 , pillow
@@ -30,7 +29,7 @@
 
 buildPythonPackage rec {
   pname = "ocrmypdf";
-  version = "12.7.2";
+  version = "13.0.0";
 
   src = fetchFromGitHub {
     owner = "jbarlow83";
@@ -42,7 +41,7 @@ buildPythonPackage rec {
     extraPostFetch = ''
       rm "$out/.git_archival.txt"
     '';
-    sha256 = "sha256-+mh7NgAk7R/94FXjRV+SLy478pZwYLLS8HwCazEbMf4=";
+    sha256 = "sha256-W5RFCWKDIRrsgHZL8uSOQWvEltLbqYAweZkgIZZrSIo=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
@@ -52,7 +51,6 @@ buildPythonPackage rec {
       src = ./paths.patch;
       gs = "${lib.getBin ghostscript}/bin/gs";
       jbig2 = "${lib.getBin jbig2enc}/bin/jbig2";
-      liblept = "${lib.getLib leptonica}/lib/liblept${stdenv.hostPlatform.extensions.sharedLibrary}";
       pngquant = "${lib.getBin pngquant}/bin/pngquant";
       tesseract = "${lib.getBin tesseract4}/bin/tesseract";
       unpaper = "${lib.getBin unpaper}/bin/unpaper";

--- a/pkgs/development/python-modules/ocrmypdf/paths.patch
+++ b/pkgs/development/python-modules/ocrmypdf/paths.patch
@@ -1,30 +1,17 @@
 diff --git a/src/ocrmypdf/_exec/ghostscript.py b/src/ocrmypdf/_exec/ghostscript.py
-index 5c357f1b..f459763a 100644
+index 1146cc5f..43f3915c 100644
 --- a/src/ocrmypdf/_exec/ghostscript.py
 +++ b/src/ocrmypdf/_exec/ghostscript.py
-@@ -25,28 +25,7 @@ from ocrmypdf.subprocess import get_version, run, run_polling_stderr
+@@ -40,15 +40,7 @@ For details see:
+ # Most reliable what to get the bitness of Python interpreter, according to Python docs
+ _is_64bit = sys.maxsize > 2 ** 32
  
- log = logging.getLogger(__name__)
- 
--missing_gs_error = """
-----------------------------------------------------------------------
--This error normally occurs when ocrmypdf find can't Ghostscript.
--Please ensure Ghostscript is installed and its location is added to
--the system PATH environment variable.
--
--For details see:
--    https://ocrmypdf.readthedocs.io/en/latest/installation.html
-----------------------------------------------------------------------
--"""
--
 -_gswin = None
 -if os.name == 'nt':
--    _gswin = which('gswin64c')
--    if not _gswin:
--        _gswin = which('gswin32c')
--        if not _gswin:
--            raise MissingDependencyError(missing_gs_error)
--    _gswin = Path(_gswin).stem
+-    if _is_64bit:
+-        _gswin = 'gswin64c'
+-    else:
+-        _gswin = 'gswin32c'
 -
 -GS = _gswin if _gswin else 'gs'
 -del _gswin
@@ -86,19 +73,19 @@ index ca8a4542..d0544174 100644
              '--skip-if-larger',
              '--quality',
 diff --git a/src/ocrmypdf/_exec/tesseract.py b/src/ocrmypdf/_exec/tesseract.py
-index 33ead41e..5840f7c1 100644
+index a3688f65..61f54465 100644
 --- a/src/ocrmypdf/_exec/tesseract.py
 +++ b/src/ocrmypdf/_exec/tesseract.py
-@@ -78,7 +78,7 @@ class TesseractVersion(StrictVersion):
+@@ -75,7 +75,7 @@ class TesseractVersion(StrictVersion):
  
  
- def version():
+ def version() -> str:
 -    return get_version('tesseract', regex=r'tesseract\s(.+)')
 +    return get_version('@tesseract@', regex=r'tesseract\s(.+)')
  
  
  def has_user_words():
-@@ -100,7 +100,7 @@ def get_languages():
+@@ -97,7 +97,7 @@ def get_languages():
          msg += output
          return msg
  
@@ -107,7 +94,7 @@ index 33ead41e..5840f7c1 100644
      try:
          proc = run(
              args_tess,
-@@ -122,7 +122,7 @@ def get_languages():
+@@ -119,7 +119,7 @@ def get_languages():
  
  
  def tess_base_args(langs: List[str], engine_mode: Optional[int]) -> List[str]:
@@ -117,7 +104,7 @@ index 33ead41e..5840f7c1 100644
          args.extend(['-l', '+'.join(langs)])
      if engine_mode is not None:
 diff --git a/src/ocrmypdf/_exec/unpaper.py b/src/ocrmypdf/_exec/unpaper.py
-index 3c3ae72c..d269966a 100644
+index aec365c2..cc5cb7e4 100644
 --- a/src/ocrmypdf/_exec/unpaper.py
 +++ b/src/ocrmypdf/_exec/unpaper.py
 @@ -31,7 +31,7 @@ log = logging.getLogger(__name__)
@@ -138,23 +125,3 @@ index 3c3ae72c..d269966a 100644
  
      with TemporaryDirectory() as tmpdir:
          input_pnm, output_pnm = _setup_unpaper_io(Path(tmpdir), input_file)
-diff --git a/src/ocrmypdf/leptonica.py b/src/ocrmypdf/leptonica.py
-index e4814f1a..fdaf7ea4 100644
---- a/src/ocrmypdf/leptonica.py
-+++ b/src/ocrmypdf/leptonica.py
-@@ -33,14 +33,7 @@ from ocrmypdf.lib._leptonica import ffi
- 
- logger = logging.getLogger(__name__)
- 
--if os.name == 'nt':
--    from ocrmypdf.subprocess._windows import shim_env_path
--
--    libname = 'liblept-5'
--    os.environ['PATH'] = shim_env_path()
--else:
--    libname = 'lept'
--_libpath = find_library(libname)
-+_libpath = '@liblept@'
- if not _libpath:
-     raise MissingDependencyError(
-         """

--- a/pkgs/development/python-modules/pikepdf/default.nix
+++ b/pkgs/development/python-modules/pikepdf/default.nix
@@ -24,7 +24,7 @@
 
 buildPythonPackage rec {
   pname = "pikepdf";
-  version = "4.0.2";
+  version = "4.1.0";
   disabled = ! isPy3k;
 
   src = fetchFromGitHub {
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     extraPostFetch = ''
       rm "$out/.git_archival.txt"
     '';
-    sha256 = "sha256-bUf9fef/YQsSj78kwoKl5a3zOjpeKWla9YY0azk0lIQ=";
+    sha256 = "sha256-8l3IDC2EhoNTImaTTjkBYhwbSBDC3PVLbdgs4txZOKc=";
   };
 
   patches = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
