### PR TITLE
yasm: fix cross build

### DIFF
--- a/pkgs/development/compilers/yasm/default.nix
+++ b/pkgs/development/compilers/yasm/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchurl}:
+{lib, stdenv, fetchurl, buildPackages}:
 
 stdenv.mkDerivation rec {
   pname = "yasm";
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     url = "https://www.tortall.net/projects/yasm/releases/yasm-${version}.tar.gz";
     sha256 = "0gv0slmm0qpq91za3v2v9glff3il594x5xsrbgab7xcmnh0ndkix";
   };
+
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   meta = with lib; {
     homepage = "http://www.tortall.net/projects/yasm/";


### PR DESCRIPTION
Yasm needs a compiler for the build host available for building the
internal 'genperf' tool.

This fixes cross-compiling yasm. Tested by compiling yasm for
aarch64 on x86_64.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Cross compiling yasm for aarch64 led to this problem:
```
cc  -I.  \
  -c -o genperf.o `test -f tools/genperf/genperf.c || echo './'`tools/genperf/genperf.c
/nix/store/a54wrar1jym1d8yvlijq0l2gghmy8szz-bash-5.1-p12/bin/bash: line 1: cc: command not found
make: *** [Makefile:4065: genperf.o] Error 127
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
    ```
    nix build -f ./ --arg crossSystem '{ config = "aarch64-unknown-linux-gnu"; }' yasm
    ```
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
