### PR TITLE
python3Packages.pykeyatome: init at 1.1.2

### DIFF
--- a/pkgs/development/python-modules/pykeyatome/default.nix
+++ b/pkgs/development/python-modules/pykeyatome/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, buildPythonPackage
+, fake-useragent
+, fetchFromGitHub
+, pytest-aiohttp
+, pytestCheckHook
+, pythonOlder
+, requests
+, requests-mock
+, responses
+, simplejson
+}:
+
+buildPythonPackage rec {
+  pname = "pykeyatome";
+  version = "1.1.2";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "jugla";
+    repo = "pyKeyAtome";
+    rev = "V${version}";
+    sha256 = "sha256-5aKZaS+BFKR1ldAY3BlS/oqYGz1C+ZRkNL9ez/etWh4=";
+  };
+
+  propagatedBuildInputs = [
+    fake-useragent
+    requests
+    simplejson
+  ];
+
+  checkInputs = [
+    pytest-aiohttp
+    pytestCheckHook
+    requests-mock
+    responses
+  ];
+
+  disabledTests = [
+    # Tests require network access
+    "test_consumption"
+    "test_get_live"
+    "test_login"
+    "test_relog_after_session_down"
+  ];
+
+  pythonImportsCheck = [
+    "pykeyatome"
+  ];
+
+  meta = with lib; {
+    description = "Python module to get data from Atome Key";
+    homepage = "hhttps://github.com/jugla/pyKeyAtome";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6674,6 +6674,8 @@ in {
 
   pykerberos = callPackage ../development/python-modules/pykerberos { };
 
+  pykeyatome = callPackage ../development/python-modules/pykeyatome { };
+
   pykira = callPackage ../development/python-modules/pykira { };
 
   pykka = callPackage ../development/python-modules/pykka { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module to get data from Atome Key

https://github.com/jugla/pyKeyAtome

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
