### PR TITLE
WIP remove Python 2 packages

### DIFF
--- a/pkgs/tools/networking/cjdns/default.nix
+++ b/pkgs/tools/networking/cjdns/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, nodejs, which, python27, util-linux, nixosTests }:
+{ lib, stdenv, fetchFromGitHub, nodejs, which, python3, util-linux, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "cjdns";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "NOmk+vMZ8i0E2MjrUzksk+tkJ9XVVNEXlE5OOTNa+Y0=";
   };
 
-  buildInputs = [ which python27 nodejs ] ++
+  buildInputs = [ which python3 nodejs ] ++
     # for flock
     lib.optional stdenv.isLinux util-linux;
 
@@ -21,12 +21,8 @@ stdenv.mkDerivation rec {
     + "bash do";
   installPhase = ''
     install -Dt "$out/bin/" cjdroute makekeys privatetopublic publictoip6
-    sed -i 's,/usr/bin/env node,'$(type -P node), \
-      $(find contrib -name "*.js")
-    sed -i 's,/usr/bin/env python,'$(type -P python), \
-      $(find contrib -type f)
     mkdir -p $out/share/cjdns
-    cp -R contrib tools node_build node_modules $out/share/cjdns/
+    cp -R tools node_build node_modules $out/share/cjdns/
   '';
 
   passthru.tests.basic = nixosTests.cjdns;


### PR DESCRIPTION
**THIS IS A DRAFT PR, DO NOT REVIEW** This is my personal playground for now because there is no other easy way to get a list of all affected packages.

###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/140168#issuecomment-932773517

Apparently, that didn't really happen for some reason, so let's do it now. Yes, 6 a.m. is the correct time for those things :)

Also, this is not a graceful operation. I'll just go and rip off everything that still depends on Python 2, unless it has so dependents that there is no way around patching. (I've already been warned about Gtk2)

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
