### PR TITLE
elixir-ls: 0.8.1 -> 0.9.0

### DIFF
--- a/pkgs/development/beam-modules/elixir-ls/default.nix
+++ b/pkgs/development/beam-modules/elixir-ls/default.nix
@@ -2,23 +2,25 @@
 # Based on the work of Hauleth
 # None of this would have happened without him
 
-mixRelease rec {
+let
   pname = "elixir-ls";
-  version = "0.8.1";
-  inherit elixir;
-
+  pinData = lib.importJSON ./pin.json;
+  version = pinData.version;
   src = fetchFromGitHub {
     owner = "elixir-lsp";
     repo = "elixir-ls";
     rev = "v${version}";
-    sha256 = "sha256-KlZq12RCor9GrwA8QMP3R+jUQ/xFHRjkLwwkvthiMU0=";
+    sha256 = pinData.sha256;
     fetchSubmodules = true;
   };
+in
+mixRelease  {
+  inherit pname version src elixir;
 
   mixFodDeps = fetchMixDeps {
     pname = "mix-deps-${pname}";
     inherit src version elixir;
-    sha256 = "sha256-OzjToAg+q/ybCyqzNFk28OBsItjFTbdPi416EPh2qX0=";
+    sha256 = pinData.depsSha256;
   };
 
   # elixir_ls is an umbrella app

--- a/pkgs/development/beam-modules/elixir-ls/pin.json
+++ b/pkgs/development/beam-modules/elixir-ls/pin.json
@@ -1,0 +1,5 @@
+{
+  "version": "0.9.0",
+  "sha256": "sha256-dHHmA9TAM5YEfbUoujgy1XLzdh7zGWhR9SsFoTnKX48=",
+  "depsSha256": "sha256-YkZ/tp537ULKfXka4IdD+RgLlXuv6ayxdYn9KFyXrr4="
+}

--- a/pkgs/development/beam-modules/elixir-ls/update.sh
+++ b/pkgs/development/beam-modules/elixir-ls/update.sh
@@ -2,31 +2,30 @@
 #! nix-shell -i oil -p jq sd nix-prefetch-github ripgrep
 
 # TODO set to `verbose` or `extdebug` once implemented in oil
-shopt --set xtrace
+set -x
 
-var directory = $(dirname $0 | xargs realpath)
-var owner = "elixir-lsp"
-var repo = "elixir-ls"
-var latest_rev = $(curl -q https://api.github.com/repos/${owner}/${repo}/releases/latest | \
+const directory = $(dirname $0 | xargs realpath)
+const owner = "elixir-lsp"
+const repo = "elixir-ls"
+const latest_rev = $(curl -q https://api.github.com/repos/${owner}/${repo}/releases/latest | \
   jq -r '.tag_name')
-var latest_version = $(echo $latest_rev | sd 'v' '')
-var current_version = $(nix-instantiate -A elixir_ls.version --eval --json | jq -r)
-if ("$latest_version" == "$current_version") {
+const latest_version = $(echo $latest_rev | sd 'v' '')
+const current_version = $(jq -r '.version' $directory/pin.json)
+if ("$latest_version" === "$current_version") {
   echo "elixir-ls is already up-to-date"
   return 0
 } else {
-  var tarball_meta = $(nix-prefetch-github $owner $repo --rev "$latest_rev")
-  var tarball_hash = "sha256-$(echo $tarball_meta | jq -r '.sha256')"
-  var sha256s = $(rg '"sha256-.+"' $directory/default.nix | sd '.+"(.+)";' '$1' )
-  echo $sha256s | read --line :github_sha256
-  echo $sha256s | tail -n 1 | read --line :old_mix_sha256
-  sd 'version = ".+"' "version = \"$latest_version\"" "$directory/default.nix"
-  sd "sha256 = \"$github_sha256\"" "sha256 = \"$tarball_hash\"" "$directory/default.nix"
-  sd "sha256 = \"$old_mix_sha256\"" "sha256 = \"\"" "$directory/default.nix"
+  const tarball_meta = $(nix-prefetch-github $owner $repo --rev "$latest_rev")
+  const tarball_hash = "sha256-$(echo $tarball_meta | jq -r '.sha256')"
+  const sha256s = $(rg '"sha256-.+"' $directory/default.nix | sd '.+"(.+)";' '$1' )
 
-  var new_mix_hash = $(nix-build -A elixir_ls.mixFodDeps 2>&1 | \
+  jq ".version = \"$latest_version\" | \
+      .\"sha256\" = \"$tarball_hash\" | \
+      .\"depsSha256\" = \"\"" $directory/pin.json | sponge $directory/pin.json
+
+  const new_mix_hash = $(nix-build -A elixir_ls.mixFodDeps 2>&1 | \
     tail -n 1 | \
     sd '\s+got:\s+' '')
 
-  sd "sha256 = \"\"" "sha256 = \"$new_mix_hash\"" "$directory/default.nix"
+  jq ".depsSha256 = \"$new_mix_hash\"" $directory/pin.json | sponge $directory/pin.json
 }


### PR DESCRIPTION
###### Motivation for this change

elixir ls has just been updated. https://github.com/elixir-lsp/elixir-ls/releases/tag/v0.9.0
I also rewrote the update script to be a little better and use a separate file for data.

@NixOS/beam might be interested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
