### PR TITLE
kotatogram-desktop: 1.4.1 -> 1.4.9 and add Darwin support

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
@@ -1,18 +1,49 @@
-{ mkDerivation, lib, fetchFromGitHub, callPackage
-, pkg-config, cmake, ninja, python3, wrapGAppsHook, wrapQtAppsHook
-, qtbase, qtimageformats, gtk3, libsForQt5, lz4, xxHash
-, ffmpeg, openalSoft, minizip, libopus, alsa-lib, libpulseaudio, range-v3
-, tl-expected, hunspell, glibmm, webkitgtk
-# Transitive dependencies:
-, pcre, xorg, util-linux, libselinux, libsepol, libepoxy
-, at-spi2-core, libXtst, libthai, libdatrie
+{ mkDerivation
+, lib
+, fetchFromGitHub
+, callPackage
+, pkg-config
+, cmake
+, ninja
+, python3
+, wrapGAppsHook
+, wrapQtAppsHook
+, qtbase
+, qtimageformats
+, gtk3
+, libsForQt5
+, lz4
+, xxHash
+, ffmpeg
+, openalSoft
+, minizip
+, libopus
+, alsa-lib
+, libpulseaudio
+, range-v3
+, tl-expected
+, hunspell
+, glibmm
+, webkitgtk
+  # Transitive dependencies:
+, pcre
+, xorg
+, util-linux
+, libselinux
+, libsepol
+, libepoxy
+, at-spi2-core
+, libXtst
+, libthai
+, libdatrie
 }:
 
 with lib;
 
 let
-  tg_owt = callPackage ./tg_owt.nix {};
-in mkDerivation rec {
+  tg_owt = callPackage ./tg_owt.nix { };
+in
+mkDerivation rec {
   pname = "kotatogram-desktop";
   version = "1.4.1";
 
@@ -36,13 +67,36 @@ in mkDerivation rec {
   nativeBuildInputs = [ pkg-config cmake ninja python3 wrapGAppsHook wrapQtAppsHook ];
 
   buildInputs = [
-    qtbase qtimageformats gtk3 libsForQt5.kwayland libsForQt5.libdbusmenu lz4 xxHash
-    ffmpeg openalSoft minizip libopus alsa-lib libpulseaudio range-v3
-    tl-expected hunspell glibmm webkitgtk
+    qtbase
+    qtimageformats
+    gtk3
+    libsForQt5.kwayland
+    libsForQt5.libdbusmenu
+    lz4
+    xxHash
+    ffmpeg
+    openalSoft
+    minizip
+    libopus
+    alsa-lib
+    libpulseaudio
+    range-v3
+    tl-expected
+    hunspell
+    glibmm
+    webkitgtk
     tg_owt
     # Transitive dependencies:
-    pcre xorg.libXdmcp util-linux libselinux libsepol libepoxy
-    at-spi2-core libXtst libthai libdatrie
+    pcre
+    xorg.libXdmcp
+    util-linux
+    libselinux
+    libsepol
+    libepoxy
+    at-spi2-core
+    libXtst
+    libthai
+    libdatrie
   ];
 
   cmakeFlags = [ "-DTDESKTOP_API_TEST=ON" ];

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
@@ -33,6 +33,38 @@
 , abseil-cpp
 , microsoft_gsl
 , wayland
+, libicns
+, Cocoa
+, CoreFoundation
+, CoreServices
+, CoreText
+, CoreGraphics
+, CoreMedia
+, OpenGL
+, AudioUnit
+, ApplicationServices
+, Foundation
+, AGL
+, Security
+, SystemConfiguration
+, Carbon
+, AudioToolbox
+, VideoToolbox
+, VideoDecodeAcceleration
+, AVFoundation
+, CoreAudio
+, CoreVideo
+, CoreMediaIO
+, QuartzCore
+, AppKit
+, CoreWLAN
+, WebKit
+, IOKit
+, GSS
+, MediaPlayer
+, IOSurface
+, Metal
+, MetalKit
 , withWebKit ? false
 }:
 
@@ -40,9 +72,20 @@ with lib;
 
 let
   tg_owt = callPackage ./tg_owt.nix {
-    abseil-cpp = abseil-cpp.override {
+    abseil-cpp = (abseil-cpp.override {
+      # abseil-cpp should use the same compiler
+      inherit stdenv;
       cxxStandard = "20";
-    };
+    }).overrideAttrs (_: {
+      # https://github.com/NixOS/nixpkgs/issues/130963
+      NIX_LDFLAGS = optionalString stdenv.isDarwin "-lc++abi";
+    });
+
+    # tg_owt should use the same compiler
+    inherit stdenv;
+
+    inherit Cocoa AppKit IOKit IOSurface Foundation AVFoundation CoreMedia VideoToolbox
+      CoreGraphics CoreVideo OpenGL Metal MetalKit CoreFoundation ApplicationServices;
   };
 in
 stdenv.mkDerivation rec {
@@ -59,35 +102,44 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./shortcuts-binary-path.patch
+    # let it build with nixpkgs 10.12 sdk
+    ./kotato-10.12-sdk.patch
   ];
 
-  postPatch = ''
+  postPatch = optionalString stdenv.isLinux ''
     substituteInPlace Telegram/ThirdParty/libtgvoip/os/linux/AudioInputALSA.cpp \
       --replace '"libasound.so.2"' '"${alsa-lib}/lib/libasound.so.2"'
     substituteInPlace Telegram/ThirdParty/libtgvoip/os/linux/AudioOutputALSA.cpp \
       --replace '"libasound.so.2"' '"${alsa-lib}/lib/libasound.so.2"'
     substituteInPlace Telegram/ThirdParty/libtgvoip/os/linux/AudioPulse.cpp \
       --replace '"libpulse.so.0"' '"${libpulseaudio}/lib/libpulse.so.0"'
-  '' + optionalString withWebKit ''
+  '' + optionalString (stdenv.isLinux && withWebKit) ''
     substituteInPlace Telegram/lib_webview/webview/platform/linux/webview_linux_webkit_gtk.cpp \
       --replace '"libwebkit2gtk-4.0.so.37"' '"${webkitgtk}/lib/libwebkit2gtk-4.0.so.37"'
+  '' + optionalString stdenv.isDarwin ''
+    substituteInPlace Telegram/CMakeLists.txt \
+      --replace 'COMMAND iconutil' 'COMMAND png2icns' \
+      --replace '--convert icns' "" \
+      --replace '--output AppIcon.icns' 'AppIcon.icns' \
+      --replace "\''${appicon_path}" "\''${appicon_path}/icon_16x16.png \''${appicon_path}/icon_32x32.png \''${appicon_path}/icon_128x128.png \''${appicon_path}/icon_256x256.png \''${appicon_path}/icon_512x512.png"
   '';
 
   # We want to run wrapProgram manually (with additional parameters)
-  dontWrapGApps = true;
-  dontWrapQtApps = withWebKit;
+  dontWrapGApps = stdenv.isLinux;
+  dontWrapQtApps = stdenv.isLinux && withWebKit;
 
   nativeBuildInputs = [
     pkg-config
     cmake
     ninja
-    # to build bundled libdispatch
-    clang
     python3
     wrapQtAppsHook
     removeReferencesTo
+  ] ++ optionals stdenv.isLinux [
+    # to build bundled libdispatch
+    clang
     extra-cmake-modules
-  ] ++ optionals withWebKit [
+  ] ++ optionals (stdenv.isLinux && withWebKit) [
     wrapGAppsHook
   ];
 
@@ -95,27 +147,63 @@ stdenv.mkDerivation rec {
     qtbase
     qtimageformats
     qtsvg
-    kwayland
     lz4
     xxHash
     ffmpeg
     openalSoft
     minizip
     libopus
-    alsa-lib
-    libpulseaudio
     range-v3
     tl-expected
-    hunspell
-    glibmm
-    jemalloc
     rnnoise
     tg_owt
     microsoft_gsl
+  ] ++ optionals stdenv.isLinux [
+    kwayland
+    alsa-lib
+    libpulseaudio
+    hunspell
+    glibmm
+    jemalloc
     wayland
-  ] ++ optionals withWebKit [
+  ] ++ optionals (stdenv.isLinux && withWebKit) [
     webkitgtk
+  ] ++ optionals stdenv.isDarwin [
+    Cocoa
+    CoreFoundation
+    CoreServices
+    CoreText
+    CoreGraphics
+    CoreMedia
+    OpenGL
+    AudioUnit
+    ApplicationServices
+    Foundation
+    AGL
+    Security
+    SystemConfiguration
+    Carbon
+    AudioToolbox
+    VideoToolbox
+    VideoDecodeAcceleration
+    AVFoundation
+    CoreAudio
+    CoreVideo
+    CoreMediaIO
+    QuartzCore
+    AppKit
+    CoreWLAN
+    WebKit
+    IOKit
+    GSS
+    MediaPlayer
+    IOSurface
+    Metal
+    libicns
   ];
+
+  # https://github.com/NixOS/nixpkgs/issues/130963
+  NIX_LDFLAGS = optionalString stdenv.isDarwin "-lc++abi";
 
   enableParallelBuilding = true;
 
@@ -124,13 +212,20 @@ stdenv.mkDerivation rec {
     "-DDESKTOP_APP_QT6=OFF"
   ];
 
-  preFixup = ''
-    remove-references-to -t ${stdenv.cc.cc} $out/bin/kotatogram-desktop
-    remove-references-to -t ${microsoft_gsl} $out/bin/kotatogram-desktop
-    remove-references-to -t ${tg_owt.dev} $out/bin/kotatogram-desktop
+  installPhase = optionalString stdenv.isDarwin ''
+    mkdir -p $out/Applications
+    cp -r Kotatogram.app $out/Applications
+    ln -s $out/Applications/Kotatogram.app/Contents/MacOS $out/bin
   '';
 
-  postFixup = optionalString withWebKit ''
+  preFixup = ''
+    binName=${if stdenv.isLinux then "kotatogram-desktop" else "Kotatogram"}
+    remove-references-to -t ${stdenv.cc.cc} $out/bin/$binName
+    remove-references-to -t ${microsoft_gsl} $out/bin/$binName
+    remove-references-to -t ${tg_owt.dev} $out/bin/$binName
+  '';
+
+  postFixup = optionalString (stdenv.isLinux && withWebKit) ''
     # We also use gappsWrapperArgs from wrapGAppsHook.
     wrapProgram $out/bin/kotatogram-desktop \
       "''${gappsWrapperArgs[@]}" \
@@ -149,7 +244,7 @@ stdenv.mkDerivation rec {
       It contains some useful (or purely cosmetic) features, but they could be unstable. A detailed list is available here: https://kotatogram.github.io/changes
     '';
     license = licenses.gpl3;
-    platforms = platforms.linux;
+    platforms = platforms.all;
     homepage = "https://kotatogram.github.io";
     changelog = "https://github.com/kotatogram/kotatogram-desktop/releases/tag/k{version}";
     maintainers = with maintainers; [ ilya-fedin ];

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/kotato-10.12-sdk.patch
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/kotato-10.12-sdk.patch
@@ -1,0 +1,415 @@
+diff --git a/Telegram/SourceFiles/platform/mac/file_bookmark_mac.mm b/Telegram/SourceFiles/platform/mac/file_bookmark_mac.mm
+index 337055443..09604b117 100644
+--- a/Telegram/SourceFiles/platform/mac/file_bookmark_mac.mm
++++ b/Telegram/SourceFiles/platform/mac/file_bookmark_mac.mm
+@@ -12,6 +12,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+ 
+ #include <Cocoa/Cocoa.h>
+ #include <CoreFoundation/CFURL.h>
++#undef check
+ 
+ namespace Platform {
+ namespace {
+diff --git a/Telegram/SourceFiles/platform/mac/specific_mac.mm b/Telegram/SourceFiles/platform/mac/specific_mac.mm
+index 3b4395ae3..7f8ee401f 100644
+--- a/Telegram/SourceFiles/platform/mac/specific_mac.mm
++++ b/Telegram/SourceFiles/platform/mac/specific_mac.mm
+@@ -119,6 +119,7 @@ PermissionStatus GetPermissionStatus(PermissionType type) {
+ 	switch (type) {
+ 	case PermissionType::Microphone:
+ 	case PermissionType::Camera:
++#if 0
+ 		const auto nativeType = (type == PermissionType::Microphone)
+ 			? AVMediaTypeAudio
+ 			: AVMediaTypeVideo;
+@@ -133,6 +134,7 @@ PermissionStatus GetPermissionStatus(PermissionType type) {
+ 					return PermissionStatus::Denied;
+ 			}
+ 		}
++#endif
+ 		break;
+ 	}
+ 	return PermissionStatus::Granted;
+@@ -142,6 +144,7 @@ void RequestPermission(PermissionType type, Fn<void(PermissionStatus)> resultCal
+ 	switch (type) {
+ 	case PermissionType::Microphone:
+ 	case PermissionType::Camera:
++#if 0
+ 		const auto nativeType = (type == PermissionType::Microphone)
+ 			? AVMediaTypeAudio
+ 			: AVMediaTypeVideo;
+@@ -152,6 +155,7 @@ void RequestPermission(PermissionType type, Fn<void(PermissionStatus)> resultCal
+ 				});
+ 			}];
+ 		}
++#endif
+ 		break;
+ 	}
+ 	resultCallback(PermissionStatus::Granted);
+diff --git a/Telegram/SourceFiles/platform/mac/touchbar/items/mac_formatter_item.h b/Telegram/SourceFiles/platform/mac/touchbar/items/mac_formatter_item.h
+index a537929c8..82ef2b837 100644
+--- a/Telegram/SourceFiles/platform/mac/touchbar/items/mac_formatter_item.h
++++ b/Telegram/SourceFiles/platform/mac/touchbar/items/mac_formatter_item.h
+@@ -9,8 +9,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+ 
+ #import <AppKit/NSPopoverTouchBarItem.h>
+ #import <AppKit/NSTouchBar.h>
++#undef check
+ 
+-API_AVAILABLE(macos(10.12.2))
+ @interface TextFormatPopover : NSPopoverTouchBarItem
+ - (id)init:(NSTouchBarItemIdentifier)identifier;
+ @end
+diff --git a/Telegram/SourceFiles/platform/mac/touchbar/items/mac_pinned_chats_item.h b/Telegram/SourceFiles/platform/mac/touchbar/items/mac_pinned_chats_item.h
+index c6a4b886f..d2e0936c0 100644
+--- a/Telegram/SourceFiles/platform/mac/touchbar/items/mac_pinned_chats_item.h
++++ b/Telegram/SourceFiles/platform/mac/touchbar/items/mac_pinned_chats_item.h
+@@ -8,12 +8,12 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+ #pragma once
+ 
+ #include <AppKit/NSImageView.h>
++#undef check
+ 
+ namespace Main {
+ class Session;
+ } // namespace Main
+ 
+-API_AVAILABLE(macos(10.12.2))
+ @interface PinnedDialogsPanel : NSImageView
+ - (id)init:(not_null<Main::Session*>)session
+ 	destroyEvent:(rpl::producer<>)touchBarSwitches;
+diff --git a/Telegram/SourceFiles/platform/mac/touchbar/items/mac_scrubber_item.h b/Telegram/SourceFiles/platform/mac/touchbar/items/mac_scrubber_item.h
+index 27b04467c..b1a7dfbd9 100644
+--- a/Telegram/SourceFiles/platform/mac/touchbar/items/mac_scrubber_item.h
++++ b/Telegram/SourceFiles/platform/mac/touchbar/items/mac_scrubber_item.h
+@@ -9,12 +9,12 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+ 
+ #import <AppKit/NSPopoverTouchBarItem.h>
+ #import <AppKit/NSTouchBar.h>
++#undef check
+ 
+ namespace Window {
+ class Controller;
+ } // namespace Window
+ 
+-API_AVAILABLE(macos(10.12.2))
+ @interface StickerEmojiPopover : NSPopoverTouchBarItem<NSTouchBarDelegate>
+ - (id)init:(not_null<Window::Controller*>)controller
+ 	identifier:(NSTouchBarItemIdentifier)identifier;
+diff --git a/Telegram/SourceFiles/platform/mac/touchbar/mac_touchbar_audio.h b/Telegram/SourceFiles/platform/mac/touchbar/mac_touchbar_audio.h
+index ec4596c67..972461aef 100644
+--- a/Telegram/SourceFiles/platform/mac/touchbar/mac_touchbar_audio.h
++++ b/Telegram/SourceFiles/platform/mac/touchbar/mac_touchbar_audio.h
+@@ -8,8 +8,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+ #pragma once
+ 
+ #import <AppKit/NSTouchBar.h>
++#undef check
+ 
+-API_AVAILABLE(macos(10.12.2))
+ @interface TouchBarAudioPlayer : NSTouchBar<NSTouchBarDelegate>
+ - (rpl::producer<>)closeRequests;
+ @end
+diff --git a/Telegram/SourceFiles/platform/mac/touchbar/mac_touchbar_common.h b/Telegram/SourceFiles/platform/mac/touchbar/mac_touchbar_common.h
+index 52b54de12..ac3857f9b 100644
+--- a/Telegram/SourceFiles/platform/mac/touchbar/mac_touchbar_common.h
++++ b/Telegram/SourceFiles/platform/mac/touchbar/mac_touchbar_common.h
+@@ -9,6 +9,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+ 
+ #import <AppKit/NSImage.h>
+ #import <Foundation/Foundation.h>
++#undef check
+ 
+ namespace TouchBar {
+ 
+diff --git a/Telegram/SourceFiles/platform/mac/touchbar/mac_touchbar_controls.h b/Telegram/SourceFiles/platform/mac/touchbar/mac_touchbar_controls.h
+index 1cc8c832f..c2178c975 100644
+--- a/Telegram/SourceFiles/platform/mac/touchbar/mac_touchbar_controls.h
++++ b/Telegram/SourceFiles/platform/mac/touchbar/mac_touchbar_controls.h
+@@ -20,19 +20,19 @@ struct TrackState;
+ 
+ namespace TouchBar {
+ 
+-[[nodiscard]] API_AVAILABLE(macos(10.12.2))
++[[nodiscard]]
+ NSButton *CreateTouchBarButton(
+ 	NSImage *image,
+ 	rpl::lifetime &lifetime,
+ 	Fn<void()> callback);
+ 
+-[[nodiscard]] API_AVAILABLE(macos(10.12.2))
++[[nodiscard]]
+ NSButton *CreateTouchBarButton(
+ 	const style::icon &icon,
+ 	rpl::lifetime &lifetime,
+ 	Fn<void()> callback);
+ 
+-[[nodiscard]] API_AVAILABLE(macos(10.12.2))
++[[nodiscard]]
+ NSButton *CreateTouchBarButtonWithTwoStates(
+ 	NSImage *icon1,
+ 	NSImage *icon2,
+@@ -41,7 +41,7 @@ NSButton *CreateTouchBarButtonWithTwoStates(
+ 	bool firstState,
+ 	rpl::producer<bool> stateChanged = rpl::never<bool>());
+ 
+-[[nodiscard]] API_AVAILABLE(macos(10.12.2))
++[[nodiscard]]
+ NSButton *CreateTouchBarButtonWithTwoStates(
+ 	const style::icon &icon1,
+ 	const style::icon &icon2,
+@@ -50,14 +50,14 @@ NSButton *CreateTouchBarButtonWithTwoStates(
+ 	bool firstState,
+ 	rpl::producer<bool> stateChanged = rpl::never<bool>());
+ 
+-[[nodiscard]] API_AVAILABLE(macos(10.12.2))
++[[nodiscard]]
+ NSSliderTouchBarItem *CreateTouchBarSlider(
+ 	NSString *itemId,
+ 	rpl::lifetime &lifetime,
+ 	Fn<void(bool, double, double)> callback,
+ 	rpl::producer<Media::Player::TrackState> stateChanged);
+ 
+-[[nodiscard]] API_AVAILABLE(macos(10.12.2))
++[[nodiscard]]
+ NSCustomTouchBarItem *CreateTouchBarTrackPosition(
+ 	NSString *itemId,
+ 	rpl::producer<Media::Player::TrackState> stateChanged);
+diff --git a/Telegram/SourceFiles/platform/mac/touchbar/mac_touchbar_main.h b/Telegram/SourceFiles/platform/mac/touchbar/mac_touchbar_main.h
+index f03546eaf..bc8c63678 100644
+--- a/Telegram/SourceFiles/platform/mac/touchbar/mac_touchbar_main.h
++++ b/Telegram/SourceFiles/platform/mac/touchbar/mac_touchbar_main.h
+@@ -8,6 +8,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+ #pragma once
+ 
+ #import <AppKit/NSTouchBar.h>
++#undef check
+ 
+ namespace Window {
+ class Controller;
+@@ -21,7 +22,6 @@ const auto kPopoverPickerItemIdentifier = @"pickerButtons";
+ 
+ } // namespace TouchBar::Main
+ 
+-API_AVAILABLE(macos(10.12.2))
+ @interface TouchBarMain : NSTouchBar
+ - (id)init:(not_null<Window::Controller*>)controller
+ 	touchBarSwitches:(rpl::producer<>)touchBarSwitches;
+diff --git a/Telegram/SourceFiles/platform/mac/touchbar/mac_touchbar_manager.h b/Telegram/SourceFiles/platform/mac/touchbar/mac_touchbar_manager.h
+index 464f87c9c..9a008c75e 100644
+--- a/Telegram/SourceFiles/platform/mac/touchbar/mac_touchbar_manager.h
++++ b/Telegram/SourceFiles/platform/mac/touchbar/mac_touchbar_manager.h
+@@ -8,6 +8,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+ #pragma once
+ 
+ #import <AppKit/NSTouchBar.h>
++#undef check
+ 
+ namespace Main {
+ class Domain;
+@@ -17,7 +18,6 @@ namespace Window {
+ class Controller;
+ } // namespace Window
+ 
+-API_AVAILABLE(macos(10.12.2))
+ @interface RootTouchBar : NSTouchBar<NSTouchBarDelegate>
+ - (id)init:(rpl::producer<bool>)canApplyMarkdown
+ 	controller:(not_null<Window::Controller*>)controller
+Submodule Telegram/ThirdParty/tgcalls contains modified content
+diff --git a/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/TGRTCDefaultVideoDecoderFactory.mm b/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/TGRTCDefaultVideoDecoderFactory.mm
+index 8a4417b..2d9794e 100644
+--- a/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/TGRTCDefaultVideoDecoderFactory.mm
++++ b/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/TGRTCDefaultVideoDecoderFactory.mm
+@@ -71,7 +71,7 @@
+     if (@available(iOS 11.0, *)) {
+         [result addObject:h265Info];
+     }
+-#else // WEBRTC_IOS
++#elif 0 // WEBRTC_IOS
+     if (@available(macOS 10.13, *)) {
+         [result addObject:h265Info];
+     }
+@@ -101,7 +101,7 @@
+       return [[TGRTCVideoDecoderH265 alloc] init];
+     }
+   }
+-#else // WEBRTC_IOS
++#elif 0 // WEBRTC_IOS
+   if (@available(macOS 10.13, *)) {
+     if ([info.name isEqualToString:kRTCVideoCodecH265Name]) {
+       return [[TGRTCVideoDecoderH265 alloc] init];
+diff --git a/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/TGRTCDefaultVideoEncoderFactory.mm b/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/TGRTCDefaultVideoEncoderFactory.mm
+index 2901417..ac9ec2a 100644
+--- a/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/TGRTCDefaultVideoEncoderFactory.mm
++++ b/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/TGRTCDefaultVideoEncoderFactory.mm
+@@ -76,7 +76,7 @@
+       [result addObject:h265Info];
+     }
+   }
+-#else // WEBRTC_IOS
++#elif 0 // WEBRTC_IOS
+   if (@available(macOS 10.13, *)) {
+     if ([[AVAssetExportSession allExportPresets] containsObject:AVAssetExportPresetHEVCHighestQuality]) {
+       [result addObject:h265Info];
+@@ -112,7 +112,7 @@
+       return [[TGRTCVideoEncoderH265 alloc] initWithCodecInfo:info];
+     }
+   }
+-#else // WEBRTC_IOS
++#elif 0 // WEBRTC_IOS
+   if (@available(macOS 10.13, *)) {
+     if ([info.name isEqualToString:kRTCVideoCodecH265Name]) {
+       return [[TGRTCVideoEncoderH265 alloc] initWithCodecInfo:info];
+diff --git a/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/VideoCameraCapturerMac.mm b/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/VideoCameraCapturerMac.mm
+index de92427..9a5b20d 100644
+--- a/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/VideoCameraCapturerMac.mm
++++ b/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/VideoCameraCapturerMac.mm
+@@ -507,8 +507,7 @@ static tgcalls::DarwinVideoTrackSource *getObjCVideoSource(const rtc::scoped_ref
+ - (void)captureOutput:(AVCaptureOutput *)captureOutput
+     didDropSampleBuffer:(CMSampleBufferRef)sampleBuffer
+          fromConnection:(AVCaptureConnection *)connection {
+-  NSString *droppedReason =
+-      (__bridge NSString *)CMGetAttachment(sampleBuffer, kCMSampleBufferAttachmentKey_DroppedFrameReason, nil);
++  NSString *droppedReason = nil;
+   RTCLogError(@"Dropped sample buffer. Reason: %@", droppedReason);
+ }
+ 
+diff --git a/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/VideoMetalViewMac.mm b/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/VideoMetalViewMac.mm
+index bcabcf7..de7b6c7 100644
+--- a/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/VideoMetalViewMac.mm
++++ b/Telegram/ThirdParty/tgcalls/tgcalls/platform/darwin/VideoMetalViewMac.mm
+@@ -245,9 +245,11 @@ private:
+     layer.framebufferOnly = true;
+     layer.opaque = false;
+ //    layer.cornerRadius = 4;
++#if 0
+     if (@available(macOS 10.13, *)) {
+         layer.displaySyncEnabled = NO;
+     }
++#endif
+ //    layer.presentsWithTransaction = YES;
+     layer.backgroundColor = [NSColor clearColor].CGColor;
+     layer.contentsGravity = kCAGravityResizeAspectFill;
+@@ -334,9 +336,7 @@ private:
+ - (RTCVideoRotation)rtcFrameRotation {
+     if (_rotationOverride) {
+         RTCVideoRotation rotation;
+-        if (@available(macOS 10.13, *)) {
+-            [_rotationOverride getValue:&rotation size:sizeof(rotation)];
+-        } else {
++        {
+             [_rotationOverride getValue:&rotation];
+         }
+         return rotation;
+Submodule Telegram/lib_base contains modified content
+diff --git a/Telegram/lib_base/base/platform/mac/base_global_shortcuts_mac.mm b/Telegram/lib_base/base/platform/mac/base_global_shortcuts_mac.mm
+index 5491702..32befc6 100644
+--- a/Telegram/lib_base/base/platform/mac/base_global_shortcuts_mac.mm
++++ b/Telegram/lib_base/base/platform/mac/base_global_shortcuts_mac.mm
+@@ -128,6 +128,7 @@ bool Available() {
+ }
+ 
+ bool Allowed() {
++#if 0
+ 	if (@available(macOS 10.15, *)) {
+ 		// Input Monitoring is required on macOS 10.15 an later.
+ 		// Even if user grants access, restart is required.
+@@ -141,6 +142,7 @@ bool Allowed() {
+ 		return AXIsProcessTrustedWithOptions(
+ 			(__bridge CFDictionaryRef)options);
+ 	}
++#endif
+ 	return true;
+ }
+ 
+diff --git a/Telegram/lib_base/base/platform/mac/base_info_mac.mm b/Telegram/lib_base/base/platform/mac/base_info_mac.mm
+index 29e368f..ea1f65f 100644
+--- a/Telegram/lib_base/base/platform/mac/base_info_mac.mm
++++ b/Telegram/lib_base/base/platform/mac/base_info_mac.mm
+@@ -203,16 +203,20 @@ void Finish() {
+ }
+ 
+ void OpenInputMonitoringPrivacySettings() {
++#if 0
+ 	if (@available(macOS 10.15, *)) {
+ 		IOHIDRequestAccess(kIOHIDRequestTypeListenEvent);
+ 	}
++#endif
+ 	[[NSWorkspace sharedWorkspace] openURL:PrivacySettingsUrl("Privacy_ListenEvent")];
+ }
+ 
+ void OpenDesktopCapturePrivacySettings() {
++#if 0
+ 	if (@available(macOS 11.0, *)) {
+ 		CGRequestScreenCaptureAccess();
+ 	}
++#endif
+ 	[[NSWorkspace sharedWorkspace] openURL:PrivacySettingsUrl("Privacy_ScreenCapture")];
+ }
+ 
+diff --git a/Telegram/lib_base/base/platform/mac/base_system_media_controls_mac.mm b/Telegram/lib_base/base/platform/mac/base_system_media_controls_mac.mm
+index c86ac77..b081162 100644
+--- a/Telegram/lib_base/base/platform/mac/base_system_media_controls_mac.mm
++++ b/Telegram/lib_base/base/platform/mac/base_system_media_controls_mac.mm
+@@ -271,6 +271,7 @@ void SystemMediaControls::setThumbnail(const QImage &thumbnail) {
+ 	if (thumbnail.isNull()) {
+ 		return;
+ 	}
++#if 0
+ 	if (@available(macOS 10.13.2, *)) {
+ 		const auto copy = thumbnail;
+ 		[_private->info
+@@ -284,6 +285,7 @@ void SystemMediaControls::setThumbnail(const QImage &thumbnail) {
+ 			forKey:MPMediaItemPropertyArtwork];
+ 		updateDisplay();
+ 	}
++#endif
+ }
+ 
+ void SystemMediaControls::setDuration(int duration) {
+@@ -302,10 +304,12 @@ void SystemMediaControls::setVolume(float64 volume) {
+ }
+ 
+ void SystemMediaControls::clearThumbnail() {
++#if 0
+ 	if (@available(macOS 10.13.2, *)) {
+ 		[_private->info removeObjectForKey:MPMediaItemPropertyArtwork];
+ 		updateDisplay();
+ 	}
++#endif
+ }
+ 
+ void SystemMediaControls::clearMetadata() {
+@@ -367,9 +371,11 @@ bool SystemMediaControls::volumeSupported() const {
+ }
+ 
+ bool SystemMediaControls::Supported() {
++#if 0
+ 	if (@available(macOS 10.12.2, *)) {
+ 		return true;
+ 	}
++#endif
+ 	return false;
+ }
+ 
+Submodule Telegram/lib_webrtc contains modified content
+diff --git a/Telegram/lib_webrtc/webrtc/mac/webrtc_media_devices_mac.mm b/Telegram/lib_webrtc/webrtc/mac/webrtc_media_devices_mac.mm
+index 21e93f7..10a3890 100644
+--- a/Telegram/lib_webrtc/webrtc/mac/webrtc_media_devices_mac.mm
++++ b/Telegram/lib_webrtc/webrtc/mac/webrtc_media_devices_mac.mm
+@@ -397,6 +397,7 @@ void MacMediaDevices::videoInputRefreshed() {
+ }
+ 
+ bool MacDesktopCaptureAllowed() {
++#if 0
+ 	if (@available(macOS 11.0, *)) {
+ 		// Screen Recording is required on macOS 10.15 an later.
+ 		// Even if user grants access, restart is required.
+@@ -421,6 +422,7 @@ bool MacDesktopCaptureAllowed() {
+ 		CFRelease(stream);
+ 		return true;
+ 	}
++#endif
+ 	return true;
+ }
+ 

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/shortcuts-binary-path.patch
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/shortcuts-binary-path.patch
@@ -1,0 +1,38 @@
+diff --git a/Telegram/SourceFiles/core/application.cpp b/Telegram/SourceFiles/core/application.cpp
+index 2a092c6ea..de46dd269 100644
+--- a/Telegram/SourceFiles/core/application.cpp
++++ b/Telegram/SourceFiles/core/application.cpp
+@@ -1173,7 +1173,7 @@ void Application::startShortcuts() {
+ 
+ void Application::RegisterUrlScheme() {
+ 	base::Platform::RegisterUrlScheme(base::Platform::UrlSchemeDescriptor{
+-		.executable = cExeDir() + cExeName(),
++		.executable = qsl("kotatogram-desktop"),
+ 		.arguments = qsl("-workdir \"%1\"").arg(cWorkingDir()),
+ 		.protocol = qsl("tg"),
+ 		.protocolName = qsl("Telegram Link"),
+diff --git a/Telegram/SourceFiles/platform/linux/specific_linux.cpp b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+index 26168baa7..00d2525a0 100644
+--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
++++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+@@ -303,19 +303,11 @@ bool GenerateDesktopFile(
+ 
+ 	QFile target(targetFile);
+ 	if (target.open(QIODevice::WriteOnly)) {
+-		fileText = fileText.replace(
+-			QRegularExpression(
+-				qsl("^TryExec=.*$"),
+-				QRegularExpression::MultilineOption),
+-			qsl("TryExec=%1").arg(
+-				QString(cExeDir() + cExeName()).replace('\\', "\\\\")));
+-
+ 		fileText = fileText.replace(
+ 			QRegularExpression(
+ 				qsl("^Exec=kotatogram-desktop(.*)$"),
+ 				QRegularExpression::MultilineOption),
+-			qsl("Exec=%1 -workdir %2\\1").arg(
+-				EscapeShellInLauncher(cExeDir() + cExeName()),
++			qsl("Exec=kotatogram-desktop -workdir %1\\1").arg(
+ 				EscapeShellInLauncher(cWorkingDir())));
+ 
+ 		fileText = fileText.replace(

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/tg_owt-10.12-sdk.patch
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/tg_owt-10.12-sdk.patch
@@ -1,0 +1,55 @@
+diff --git a/src/rtc_base/system/gcd_helpers.m b/src/rtc_base/system/gcd_helpers.m
+index fd9a361f..3a63be6d 100644
+--- a/src/rtc_base/system/gcd_helpers.m
++++ b/src/rtc_base/system/gcd_helpers.m
+@@ -13,9 +13,6 @@
+ dispatch_queue_t RTCDispatchQueueCreateWithTarget(const char *label,
+                                                   dispatch_queue_attr_t attr,
+                                                   dispatch_queue_t target) {
+-  if (@available(iOS 10, macOS 10.12, tvOS 10, watchOS 3, *)) {
+-    return dispatch_queue_create_with_target(label, attr, target);
+-  }
+   dispatch_queue_t queue = dispatch_queue_create(label, attr);
+   dispatch_set_target_queue(queue, target);
+   return queue;
+diff --git a/src/sdk/objc/components/video_codec/nalu_rewriter.cc b/src/sdk/objc/components/video_codec/nalu_rewriter.cc
+index 61c1e7d6..b19f3f91 100644
+--- a/src/sdk/objc/components/video_codec/nalu_rewriter.cc
++++ b/src/sdk/objc/components/video_codec/nalu_rewriter.cc
+@@ -245,10 +245,7 @@ bool H265CMSampleBufferToAnnexBBuffer(
+   int nalu_header_size = 0;
+   size_t param_set_count = 0;
+   OSStatus status = noErr;
+-  if (__builtin_available(macOS 10.13, *)) {
+-    status = CMVideoFormatDescriptionGetHEVCParameterSetAtIndex(
+-        description, 0, nullptr, nullptr, &param_set_count, &nalu_header_size);
+-  } else {
++  {
+     RTC_LOG(LS_ERROR) << "Not supported.";
+     return false;
+   }
+@@ -271,10 +268,7 @@ bool H265CMSampleBufferToAnnexBBuffer(
+     size_t param_set_size = 0;
+     const uint8_t* param_set = nullptr;
+     for (size_t i = 0; i < param_set_count; ++i) {
+-      if (__builtin_available(macOS 10.13, *)) {
+-        status = CMVideoFormatDescriptionGetHEVCParameterSetAtIndex(
+-            description, i, &param_set, &param_set_size, nullptr, nullptr);
+-      } else {
++      {
+         RTC_LOG(LS_ERROR) << "Not supported.";
+         return false;
+       }
+@@ -514,11 +508,7 @@ CMVideoFormatDescriptionRef CreateH265VideoFormatDescription(
+   // Parse the SPS and PPS into a CMVideoFormatDescription.
+   CMVideoFormatDescriptionRef description = nullptr;
+   OSStatus status = noErr;
+-  if (__builtin_available(macOS 10.13, *)) {
+-    status = CMVideoFormatDescriptionCreateFromHEVCParameterSets(
+-        kCFAllocatorDefault, 3, param_set_ptrs, param_set_sizes, 4, nullptr,
+-        &description);
+-  } else {
++  {
+     RTC_LOG(LS_ERROR) << "Not supported.";
+     return nullptr;
+   }

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/tg_owt.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/tg_owt.nix
@@ -9,26 +9,35 @@
 , openssl
 , libopus
 , ffmpeg_4
-, alsa-lib
-, libpulseaudio
 , protobuf
-, xorg
+, openh264
+, usrsctp
+, libvpx
+, libX11
 , libXtst
+, libXcomposite
+, libXdamage
+, libXext
+, libXrender
+, libXrandr
+, libXi
+, glib
+, abseil-cpp
+, pipewire
+, mesa
+, libglvnd
+, libepoxy
 }:
 
-let
-  rev = "2d804d2c9c5d05324c8ab22f2e6ff8306521b3c3";
-  sha256 = "0kz0i381iwsgcc3yzsq7njx3gkqja4bb9fsgc24vhg0md540qhyn";
-
-in
 stdenv.mkDerivation {
   pname = "tg_owt";
-  version = "git-${rev}";
+  version = "unstable-2022-02-26";
 
   src = fetchFromGitHub {
     owner = "desktop-app";
     repo = "tg_owt";
-    inherit rev sha256;
+    rev = "a264028ec71d9096e0aa629113c49c25db89d260";
+    sha256 = "sha256-JR+M+4w0QsQLfIunZ/7W+5Knn+gX+RR3DBrpOz7q44I=";
     fetchSubmodules = true;
   };
 
@@ -41,16 +50,34 @@ stdenv.mkDerivation {
     openssl
     libopus
     ffmpeg_4
-    alsa-lib
-    libpulseaudio
     protobuf
-    xorg.libX11
+    openh264
+    usrsctp
+    libvpx
+    libX11
     libXtst
+    libXcomposite
+    libXdamage
+    libXext
+    libXrender
+    libXrandr
+    libXi
+    glib
+    abseil-cpp
+    pipewire
+    mesa
+    libepoxy
+    libglvnd
   ];
 
-  cmakeFlags = [
-    # Building as a shared library isn't officially supported and currently broken:
-    "-DBUILD_SHARED_LIBS=OFF"
+  enableParallelBuilding = true;
+
+  propagatedBuildInputs = [
+    # Required for linking downstream binaries.
+    abseil-cpp
+    openh264
+    usrsctp
+    libvpx
   ];
 
   meta.license = lib.licenses.bsd3;

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/tg_owt.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/tg_owt.nix
@@ -1,13 +1,27 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, cmake, ninja, yasm
-, libjpeg, openssl, libopus, ffmpeg_4, alsa-lib, libpulseaudio, protobuf
-, xorg, libXtst
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, cmake
+, ninja
+, yasm
+, libjpeg
+, openssl
+, libopus
+, ffmpeg_4
+, alsa-lib
+, libpulseaudio
+, protobuf
+, xorg
+, libXtst
 }:
 
 let
   rev = "2d804d2c9c5d05324c8ab22f2e6ff8306521b3c3";
   sha256 = "0kz0i381iwsgcc3yzsq7njx3gkqja4bb9fsgc24vhg0md540qhyn";
 
-in stdenv.mkDerivation {
+in
+stdenv.mkDerivation {
   pname = "tg_owt";
   version = "git-${rev}";
 
@@ -23,8 +37,15 @@ in stdenv.mkDerivation {
   nativeBuildInputs = [ pkg-config cmake ninja yasm ];
 
   buildInputs = [
-    libjpeg openssl libopus ffmpeg_4 alsa-lib libpulseaudio protobuf
-    xorg.libX11 libXtst
+    libjpeg
+    openssl
+    libopus
+    ffmpeg_4
+    alsa-lib
+    libpulseaudio
+    protobuf
+    xorg.libX11
+    libXtst
   ];
 
   cmakeFlags = [

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/tg_owt.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/tg_owt.nix
@@ -27,6 +27,21 @@
 , mesa
 , libglvnd
 , libepoxy
+, Cocoa
+, AppKit
+, IOKit
+, IOSurface
+, Foundation
+, AVFoundation
+, CoreMedia
+, VideoToolbox
+, CoreGraphics
+, CoreVideo
+, OpenGL
+, Metal
+, MetalKit
+, CoreFoundation
+, ApplicationServices
 }:
 
 stdenv.mkDerivation {
@@ -41,6 +56,11 @@ stdenv.mkDerivation {
     fetchSubmodules = true;
   };
 
+  patches = [
+    # let it build with nixpkgs 10.12 sdk
+    ./tg_owt-10.12-sdk.patch
+  ];
+
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ pkg-config cmake ninja yasm ];
@@ -54,6 +74,8 @@ stdenv.mkDerivation {
     openh264
     usrsctp
     libvpx
+    abseil-cpp
+  ] ++ lib.optionals stdenv.isLinux [
     libX11
     libXtst
     libXcomposite
@@ -63,12 +85,30 @@ stdenv.mkDerivation {
     libXrandr
     libXi
     glib
-    abseil-cpp
     pipewire
     mesa
     libepoxy
     libglvnd
+  ] ++ lib.optionals stdenv.isDarwin [
+    Cocoa
+    AppKit
+    IOKit
+    IOSurface
+    Foundation
+    AVFoundation
+    CoreMedia
+    VideoToolbox
+    CoreGraphics
+    CoreVideo
+    OpenGL
+    Metal
+    MetalKit
+    CoreFoundation
+    ApplicationServices
   ];
+
+  # https://github.com/NixOS/nixpkgs/issues/130963
+  NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-lc++abi";
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26761,9 +26761,17 @@ with pkgs;
 
   kooha = callPackage ../applications/video/kooha { };
 
-  kotatogram-desktop = libsForQt5.callPackage ../applications/networking/instant-messengers/telegram/kotatogram-desktop {
-    # C++20 is required, aarch64 has gcc 9 by default
-    stdenv = if stdenv.isAarch64 then gcc10Stdenv else stdenv;
+  # Qt 5.15 is not default on mac, tdesktop requires 5.15 (and kotatogram subsequently)
+  kotatogram-desktop = libsForQt515.callPackage ../applications/networking/instant-messengers/telegram/kotatogram-desktop {
+    inherit (darwin.apple_sdk.frameworks) Cocoa CoreFoundation CoreServices CoreText CoreGraphics
+      CoreMedia OpenGL AudioUnit ApplicationServices Foundation AGL Security SystemConfiguration
+      Carbon AudioToolbox VideoToolbox VideoDecodeAcceleration AVFoundation CoreAudio CoreVideo
+      CoreMediaIO QuartzCore AppKit CoreWLAN WebKit IOKit GSS MediaPlayer IOSurface Metal MetalKit;
+
+    # C++20 is required, darwin has Clang 7 by default, aarch64 has gcc 9 by default
+    stdenv = if stdenv.isDarwin
+      then llvmPackages_12.libcxxStdenv
+      else if stdenv.isAarch64 then gcc10Stdenv else stdenv;
 
     # tdesktop has random crashes when jemalloc is built with gcc.
     # Apparently, it triggers some bug due to usage of gcc's builtin

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26761,7 +26761,20 @@ with pkgs;
 
   kooha = callPackage ../applications/video/kooha { };
 
-  kotatogram-desktop = libsForQt5.callPackage ../applications/networking/instant-messengers/telegram/kotatogram-desktop { };
+  kotatogram-desktop = libsForQt5.callPackage ../applications/networking/instant-messengers/telegram/kotatogram-desktop {
+    # C++20 is required, aarch64 has gcc 9 by default
+    stdenv = if stdenv.isAarch64 then gcc10Stdenv else stdenv;
+
+    # tdesktop has random crashes when jemalloc is built with gcc.
+    # Apparently, it triggers some bug due to usage of gcc's builtin
+    # functions like __builtin_ffsl by jemalloc when it's built with gcc.
+    jemalloc = (jemalloc.override { stdenv = llvmPackages.stdenv; }).overrideAttrs(_: {
+      # no idea how to fix the tests :(
+      doCheck = false;
+    });
+
+    abseil-cpp = abseil-cpp_202111;
+  };
 
   kpt = callPackage ../applications/networking/cluster/kpt { };
 


### PR DESCRIPTION
###### Motivation for this change
#148654

###### Things done

Package updated to the latest upstream version + tried to enabled building on macos since both tdesktop and kotatogram have upstream mac builds

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
