### PR TITLE
autorandr: install zsh completions

### DIFF
--- a/pkgs/tools/misc/autorandr/default.nix
+++ b/pkgs/tools/misc/autorandr/default.nix
@@ -2,13 +2,16 @@
 , python3Packages
 , fetchFromGitHub
 , systemd
-, xrandr }:
+, xrandr
+, installShellFiles }:
 
 stdenv.mkDerivation rec {
   pname = "autorandr";
   version = "1.11";
 
   buildInputs = [ python3Packages.python ];
+
+  nativeBuildInputs = [ installShellFiles ];
 
   # no wrapper, as autorandr --batch does os.environ.clear()
   buildPhase = ''
@@ -23,7 +26,12 @@ stdenv.mkDerivation rec {
     runHook preInstall
     make install TARGETS='autorandr' PREFIX=$out
 
-    make install TARGETS='bash_completion' DESTDIR=$out/share/bash-completion/completions
+    # zsh completions exist but currently have no make target, use
+    # installShellCompletions for both
+    # see https://github.com/phillipberndt/autorandr/issues/197
+    installShellCompletion --cmd autorandr \
+        --bash contrib/bash_completion/autorandr \
+        --zsh contrib/zsh_completion/_autorandr
 
     make install TARGETS='autostart_config' PREFIX=$out DESTDIR=$out
 


### PR DESCRIPTION
autorandr includes functional zsh completions upstream they just lack
a make target to install the relevant file. For some consistency use the
direct file for both zsh and bash rather than just zsh. Note this
changes the resulting bash completion filename from just 'autorandr' to
'autorandr.bash'

See https://github.com/phillipberndt/autorandr/issues/197

###### Motivation for this change

Add working auto completion for `autorandr` to zsh.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
