### PR TITLE
python3Packages.pkutils: 1.1.1. -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/pkutils/default.nix
+++ b/pkgs/development/python-modules/pkutils/default.nix
@@ -1,35 +1,48 @@
 { lib
 , buildPythonPackage
-, isPy3k
 , fetchFromGitHub
-, semver
-  # Check Inputs
 , nose
+, pythonOlder
+, semver
 }:
 
 buildPythonPackage rec {
   pname = "pkutils";
-  version = "1.1.1";
-  disabled = !isPy3k; # some tests using semver fail due to unicode errors on Py2.7
+  version = "2.0.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "reubano";
     repo = "pkutils";
     rev = "v${version}";
-    sha256 = "01yaq9sz6vyxk8yiss6hsmy70qj642cr2ifk0sx1mlh488flcm62";
+    sha256 = "sha256-jvRUjuxlcfmJOX50bnZR/pP2Axe1KDy9/KGXTL4yPxA=";
   };
 
-  propagatedBuildInputs = [ semver ];
+  propagatedBuildInputs = [
+    semver
+  ];
 
-  # Remove when https://github.com/reubano/pkutils/pull/4 merged
+  checkInputs = [
+    nose
+  ];
+
   postPatch = ''
-    substituteInPlace requirements.txt --replace "semver>=2.2.1,<2.7.3" "semver"
+    # Remove when https://github.com/reubano/pkutils/pull/4 merged
+    substituteInPlace requirements.txt \
+      --replace "semver>=2.2.1,<2.7.3" "semver"
   '';
 
-  checkInputs = [ nose ];
-  pythonImportsCheck = [ "pkutils" ];
+  checkPhase = ''
+    runHook preCheck
+    nosetests
+    runHook postCheck
+  '';
 
-  checkPhase = "nosetests";
+  pythonImportsCheck = [
+    "pkutils"
+  ];
 
   meta = with lib; {
     description = "A Python packaging utility library";

--- a/pkgs/development/python-modules/pygogo/default.nix
+++ b/pkgs/development/python-modules/pygogo/default.nix
@@ -10,6 +10,7 @@
 buildPythonPackage rec {
   pname = "pygogo";
   version = "0.13.2";
+  format = "setuptools";
 
   disabled = pythonOlder "3.6";
 
@@ -20,14 +21,31 @@ buildPythonPackage rec {
     sha256 = "19rdf4sjrm5lp1vq1bki21a9lrkzz8sgrfwgjdkq4sgy90hn1jn9";
   };
 
-  nativeBuildInputs = [ pkutils ];
+  nativeBuildInputs = [
+    pkutils
+  ];
 
-  checkInputs = [ nose ];
-  checkPhase = "nosetests";
-  pythonImportsCheck = [ "pygogo" ];
+  checkInputs = [
+    nose
+  ];
+
+  postPatch = ''
+    substituteInPlace dev-requirements.txt \
+      --replace "pkutils>=1.0.0,<2.0.0" "pkutils>=1.0.0"
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    nosetests
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [
+    "pygogo"
+  ];
 
   meta = with lib; {
-    description = "A Python logging library with super powers";
+    description = "Python logging library";
     homepage = "https://github.com/reubano/pygogo/";
     license = licenses.mit;
     maintainers = with maintainers; [ drewrisinger ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
