### PR TITLE
python3Packages.reolink: init at 0.0.53

### DIFF
--- a/pkgs/development/python-modules/reolink/default.nix
+++ b/pkgs/development/python-modules/reolink/default.nix
@@ -1,0 +1,67 @@
+{ lib
+, aiohttp
+, aiounittest
+, buildPythonPackage
+, fetchFromGitHub
+, ffmpeg-python
+, pytestCheckHook
+, pythonOlder
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "reolink";
+  version = "0.0.53";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "fwestenberg";
+    repo = pname;
+    # https://github.com/fwestenberg/reolink/issues/78
+    rev = "0053";
+    sha256 = "sha256-kEG+kRTWaC6eQbmlasAWIESFdKPoxQCdZLRrQwb2aRU=";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    ffmpeg-python
+    requests
+  ];
+
+  checkInputs = [
+    aiounittest
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    # Packages in nixpkgs is different than the module name
+    substituteInPlace setup.py \
+      --replace "ffmpeg" "ffmpeg-python"
+  '';
+
+  pytestFlagsArray = [
+    "test.py"
+  ];
+
+  disabledTests = [
+    # Tests require network access
+    "test1_settings"
+    "test2_states"
+    "test3_images"
+    "test4_properties"
+    "test_succes"
+  ];
+
+  pythonImportsCheck = [
+    "reolink"
+  ];
+
+  meta = with lib; {
+    description = "Python module to interact with the Reolink IP camera API";
+    homepage = "https://github.com/fwestenberg/reolink";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8194,6 +8194,8 @@ in {
 
   rencode = callPackage ../development/python-modules/rencode { };
 
+  reolink = callPackage ../development/python-modules/reolink { };
+
   reparser = callPackage ../development/python-modules/reparser { };
 
   repeated_test = callPackage ../development/python-modules/repeated_test { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module to interact with the Reolink IP camera API

https://github.com/fwestenberg/reolink

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
