### PR TITLE
pure-ftpd: 1.0.49 -> 1.0.50

### DIFF
--- a/pkgs/servers/ftp/pure-ftpd/default.nix
+++ b/pkgs/servers/ftp/pure-ftpd/default.nix
@@ -2,25 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "pure-ftpd";
-  version = "1.0.49";
+  version = "1.0.50";
 
   src = fetchurl {
     url = "https://download.pureftpd.org/pub/pure-ftpd/releases/pure-ftpd-${version}.tar.gz";
-    sha256 = "19cjr262n6h560fi9nm7l1srwf93k34bp8dp1c6gh90bqxcg8yvn";
+    sha256 = "08zas1kg5pnckl28gs7q29952pjfyj8rj59bq96hscqbni7gkqmb";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "CVE-2020-9274.patch";
-      url = "https://github.com/jedisct1/pure-ftpd/commit/8d0d42542e2cb7a56d645fbe4d0ef436e38bcefa.patch";
-      sha256 = "1yd84p6bd4rf21hg3kqpi2a02cac6dz5ag4xx3c2dl5vbzhr5a8k";
-    })
-    (fetchpatch {
-      name = "CVE-2020-9365.patch";
-      url = "https://github.com/jedisct1/pure-ftpd/commit/bf6fcd4935e95128cf22af5924cdc8fe5c0579da.patch";
-      sha256 = "003klx7j82qf92qr1dxg32v5r2bhhywplynd3xil1lbcd3s3mqhi";
-    })
-  ];
 
   buildInputs = [ openssl ];
 

--- a/pkgs/servers/ftp/pure-ftpd/default.nix
+++ b/pkgs/servers/ftp/pure-ftpd/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, openssl, fetchpatch }:
+{ lib, stdenv, fetchurl, openssl, pam, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "pure-ftpd";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "08zas1kg5pnckl28gs7q29952pjfyj8rj59bq96hscqbni7gkqmb";
   };
 
-  buildInputs = [ openssl ];
+  buildInputs = [ openssl pam ];
 
   configureFlags = [ "--with-tls" ];
 
@@ -18,6 +18,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.pureftpd.org";
     license = licenses.isc; # with some parts covered by BSD3(?)
     maintainers = [ ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-40524

Also enable for darwin while we're at it because it's easy enough.

I've got the patch lined up for 21.11 and 21.05, so no backport label.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
