### PR TITLE
paperwork: 2.0.3 -> 2.1.0

### DIFF
--- a/pkgs/applications/office/paperwork/openpaperwork-core.nix
+++ b/pkgs/applications/office/paperwork/openpaperwork-core.nix
@@ -2,7 +2,7 @@
 
 , isPy3k, isPyPy
 
-, distro, setuptools
+, distro, setuptools, psutil
 
 , pkgs
 }:
@@ -25,6 +25,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     distro
     setuptools
+    psutil
   ];
 
   nativeBuildInputs = [ pkgs.gettext pkgs.which ];

--- a/pkgs/applications/office/paperwork/openpaperwork-gtk.nix
+++ b/pkgs/applications/office/paperwork/openpaperwork-gtk.nix
@@ -38,6 +38,7 @@ buildPythonPackage rec {
     pygobject3
     pkgs.poppler_gi
     pkgs.gtk3
+    pkgs.libhandy
     distro
     pkgs.pango
     openpaperwork-core

--- a/pkgs/applications/office/paperwork/paperwork-backend.nix
+++ b/pkgs/applications/office/paperwork/paperwork-backend.nix
@@ -6,7 +6,7 @@
 , isPyPy
 
 , pyenchant
-, simplebayes
+, scikit-learn
 , pypillowfight
 , pycountry
 , whoosh
@@ -41,7 +41,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     pyenchant
-    simplebayes
+    scikit-learn
     pypillowfight
     pycountry
     whoosh
@@ -61,12 +61,12 @@ buildPythonPackage rec {
     export HOME=$(mktemp -d)
   '';
 
-  nativeBuildInputs = [ pkgs.gettext pkgs.which ];
+  nativeBuildInputs = [ pkgs.gettext pkgs.which pkgs.shared-mime-info ];
   preBuild = ''
     make l10n_compile
   '';
 
-  checkInputs = [ openpaperwork-gtk psutil ];
+  checkInputs = [ openpaperwork-gtk psutil pkgs.libreoffice ];
 
   meta = {
     description = "Backend part of Paperwork (Python API, no UI)";

--- a/pkgs/applications/office/paperwork/src.nix
+++ b/pkgs/applications/office/paperwork/src.nix
@@ -1,13 +1,13 @@
 {fetchFromGitLab}:
 rec {
-  version = "2.0.3";
+  version = "2.1.0";
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     repo = "paperwork";
     group = "World";
     owner = "OpenPaperwork";
     rev = version;
-    sha256 = "02c2ysca75j59v87n1axqfncvs167kmdr40m0f05asdh2akwrbi9";
+    sha256 = "0d1cw6k1giqs8ji8h3h97ckb134s8pszgip0nac5hmw0mvqq84xa";
   };
   sample_documents = fetchFromGitLab {
     domain = "gitlab.gnome.org";
@@ -15,8 +15,8 @@ rec {
     group = "World";
     owner = "OpenPaperwork";
     # https://gitlab.gnome.org/World/OpenPaperwork/paperwork/-/blob/master/paperwork-gtk/src/paperwork_gtk/model/help/screenshot.sh see TEST_DOCS_TAG
-    rev = "1.0";
-    sha256 = "155nhw2jmlgfi6c3wm241vrr3yma6lw85k9lxn844z96kyi7wbpr";
+    rev = "2.1";
+    sha256 = "0m79fgc1ycsj0q0alqgr0axn16klz1sfs2km1h83zn3kysqcs6xr";
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

update. a way better label guesser :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
