### PR TITLE
sonixd: init at 0.14.0

### DIFF
--- a/pkgs/applications/audio/sonixd/default.nix
+++ b/pkgs/applications/audio/sonixd/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, fetchurl
+, appimageTools
+}:
+
+appimageTools.wrapType2 rec {
+  pname = "sonixd";
+  version = "0.14.0";
+
+  src = fetchurl {
+    url = "https://github.com/jeffvli/sonixd/releases/download/v${version}/Sonixd-${version}-linux-x86_64.AppImage";
+    sha256 = "sha256-q+26Ut5wN9gFDBdqirR+he/ppu/b1wiqq23WkcRAQd4=";
+  };
+
+  extraInstallCommands = ''
+    mv $out/bin/sonixd-${version} $out/bin/sonixd
+  '';
+
+  meta = with lib; {
+    description = "Full-featured Subsonic/Jellyfin compatible desktop music player";
+    homepage = "https://github.com/jeffvli/sonixd";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ onny ];
+    platforms = [ "x86_64-linux" ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25882,6 +25882,8 @@ with pkgs;
 
   singularity = callPackage ../applications/virtualization/singularity { };
 
+  sonixd = callPackage ../applications/audio/sonixd { };
+
   spectmorph = callPackage ../applications/audio/spectmorph { };
 
   smallwm = callPackage ../applications/window-managers/smallwm { };


### PR DESCRIPTION
###### Motivation for this change

This PR adds the Subsonic and Jellyfin desktop music player [Sonixd](https://github.com/jeffvli/sonixd).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
