### PR TITLE
gnome.mutter: fix libdir path

### DIFF
--- a/pkgs/desktops/gnome/core/mutter/default.nix
+++ b/pkgs/desktops/gnome/core/mutter/default.nix
@@ -136,7 +136,7 @@ let self = stdenv.mkDerivation rec {
   PKG_CONFIG_UDEV_UDEVDIR = "${placeholder "out"}/lib/udev";
 
   passthru = {
-    libdir = "${self}/lib/mutter-8";
+    libdir = "${self}/lib/mutter-9";
 
     tests = {
       libdirExists = runCommand "mutter-libdir-exists" {} ''


### PR DESCRIPTION
~~Maybe it is still too early to prepare Pantheon 7 updates?~~ Anyway I accidently found this again...

- Previous PR: #131311