### PR TITLE
tcptrack: fix build on ncurses-6.3

### DIFF
--- a/pkgs/development/tools/misc/tcptrack/default.nix
+++ b/pkgs/development/tools/misc/tcptrack/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "tcptrack";
-  version = "1.4.3+unstable=2017-04-29";
+  version = "unstable-2017-04-29";
 
   src = fetchFromGitHub {
     owner = "bchretien";

--- a/pkgs/development/tools/misc/tcptrack/default.nix
+++ b/pkgs/development/tools/misc/tcptrack/default.nix
@@ -1,15 +1,25 @@
-{ lib, stdenv, fetchFromGitHub, ncurses, libpcap }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, ncurses, libpcap }:
 
 stdenv.mkDerivation rec {
   pname = "tcptrack";
-  version = "1.4.3";
+  version = "1.4.3+unstable=2017-04-29";
 
   src = fetchFromGitHub {
     owner = "bchretien";
     repo = "tcptrack";
-    rev = "d05fe08154ff1e46578e92be49e4cfa2c6543283";
-    sha256 = "08lh3l67wn4kq9q0nfspc7rj0jvp9dzwjgxpvqliwcif8cy5mi45";
+    rev = "2b096ac103af2884bbd7648cff8adcbadbda9394";
+    sha256 = "0084g9s0ynv1az67j08q9nz4p07bqqz9k6w5lprzj3ljlh0x10gj";
   };
+
+  patches = [
+    # Fix pending upstream inclusion for ncurses-6.3 support:
+    #  https://github.com/bchretien/tcptrack/pull/10
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://github.com/bchretien/tcptrack/commit/409007afbce8ec5a81312a2a4123dd83b62b4494.patch";
+      sha256 = "00641jyr52ksww5bbzvxlprmbb36jnvzg2w1aj1jgnm75jiajcfc";
+    })
+  ];
 
   buildInputs = [ ncurses libpcap ];
 


### PR DESCRIPTION
Without the change the build fails on ncurses-6.3 as:

    TextUI.cc: In member function 'void TextUI::drawui()':
    TextUI.cc:312:34: error: format '%d' expects argument of type 'int',
     but argument 2 has type 'time_t' {aka 'long int'} [-Werror=format]
      312 |                         printw("%ds",ic->getIdleSeconds());
          |                                 ~^   ~~~~~~~~~~~~~~~~~~~~
          |                                  int                   time_t {aka long int}
          |                                 %ld
