### PR TITLE
rofi-pulse-select: init at 0.2.0

### DIFF
--- a/pkgs/applications/audio/rofi-pulse-select/default.nix
+++ b/pkgs/applications/audio/rofi-pulse-select/default.nix
@@ -1,0 +1,40 @@
+{ stdenv
+, fetchFromGitLab
+, lib
+, makeWrapper
+, ponymix
+, rofi-unwrapped
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rofi-pulse-select";
+  version = "0.2.0";
+
+  src = fetchFromGitLab {
+    owner = "DamienCassou";
+    repo = pname;
+    rev = "${version}";
+    sha256 = "1405v0bh2m8ip9c23l95i8iq2gfrpanc6f4dz17nysdcff2ay2p3";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D --target-directory=$out/bin/ ./rofi-pulse-select
+
+    wrapProgram $out/bin/rofi-pulse-select \
+      --prefix PATH ":" ${lib.makeBinPath [ rofi-unwrapped ponymix ]}
+
+    runHook postInstall
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  meta = with lib; {
+    description = "Rofi-based interface to select source/sink (aka input/output) with PulseAudio";
+    homepage = "https://gitlab.com/DamienCassou/rofi-pulse-select";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ DamienCassou ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27114,6 +27114,8 @@ with pkgs;
 
   rofi-power-menu = callPackage ../applications/misc/rofi-power-menu { };
 
+  rofi-pulse-select = callPackage ../applications/audio/rofi-pulse-select { };
+
   rofi-vpn = callPackage ../applications/networking/rofi-vpn { };
 
   ympd = callPackage ../applications/audio/ympd { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Creation of a package for https://gitlab.com/DamienCassou/rofi-pulse-select

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
