### PR TITLE
python3Packages.graphviz: 0.18.1 -> 0.19.1

### DIFF
--- a/pkgs/development/python-modules/graphviz/default.nix
+++ b/pkgs/development/python-modules/graphviz/default.nix
@@ -8,13 +8,14 @@
 , makeFontsConf
 , freefont_ttf
 , mock
-, pytestCheckHook
+, pytest
 , pytest-mock
+, python
 }:
 
 buildPythonPackage rec {
   pname = "graphviz";
-  version = "0.18.1";
+  version = "0.19.1";
 
   disabled = pythonOlder "3.6";
 
@@ -23,7 +24,7 @@ buildPythonPackage rec {
     owner = "xflr6";
     repo = "graphviz";
     rev = version;
-    sha256 = "sha256-Y3w9btjYvKfcEQGuAzV+o6edJ9VmVcWhc+ICOqy87uM=";
+    sha256 = "sha256-pE1lsx/r/BjvW5W2niDx/UeRXxx4kvCyHzAUAG3bdGc=";
   };
 
   patches = [
@@ -43,10 +44,18 @@ buildPythonPackage rec {
     fontDirectories = [ freefont_ttf ];
   };
 
-  checkInputs = [ mock pytestCheckHook pytest-mock ];
+  checkInputs = [
+    mock
+    pytest
+    pytest-mock
+  ];
 
-  preCheck = ''
-    export HOME=$TMPDIR
+  checkPhase = ''
+    runHook preCheck
+
+    HOME=$TMPDIR ${python.interpreter} run-tests.py
+
+    runHook postCheck
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/graphviz/paths.patch
+++ b/pkgs/development/python-modules/graphviz/paths.patch
@@ -1,36 +1,36 @@
 diff --git a/graphviz/backend/dot_command.py b/graphviz/backend/dot_command.py
-index 1e123d1..41e19c2 100644
+index 60654bd..2c62b47 100644
 --- a/graphviz/backend/dot_command.py
 +++ b/graphviz/backend/dot_command.py
-@@ -11,7 +11,7 @@ from . import _common
- __all__ = ['command']
+@@ -9,7 +9,7 @@ from .. import parameters
  
- #: :class:`pathlib.Path` of layout command (``Path('dot')``).
+ __all__ = ['DOT_BINARY', 'command']
+ 
 -DOT_BINARY = pathlib.Path('dot')
 +DOT_BINARY = pathlib.Path('@graphviz@/bin/dot')
  
  
  def command(engine: str, format_: str, *,
 diff --git a/graphviz/backend/unflattening.py b/graphviz/backend/unflattening.py
-index 5ed25d6..8d2faf8 100644
+index a386b8c..883cdc6 100644
 --- a/graphviz/backend/unflattening.py
 +++ b/graphviz/backend/unflattening.py
 @@ -11,7 +11,7 @@ from . import execute
- __all__ = ['unflatten']
  
- #: :class:`pathlib.Path` of unflatten command (``Path('unflatten')``).
+ __all__ = ['UNFLATTEN_BINARY', 'unflatten']
+ 
 -UNFLATTEN_BINARY = pathlib.Path('unflatten')
 +UNFLATTEN_BINARY = pathlib.Path('@graphviz@/bin/unflatten')
  
  
- def unflatten(source: str,
+ @_tools.deprecate_positional_args(supported_number=1)
 diff --git a/graphviz/backend/viewing.py b/graphviz/backend/viewing.py
-index 6d4a4d1..2cc6cd8 100644
+index fde74a6..6f29b68 100644
 --- a/graphviz/backend/viewing.py
 +++ b/graphviz/backend/viewing.py
-@@ -54,7 +54,7 @@ def view_darwin(filepath, *, quiet: bool) -> None:
- @tools.attach(view, 'freebsd')
- def view_unixoid(filepath, *, quiet: bool) -> None:
+@@ -55,7 +55,7 @@ def view_darwin(filepath: typing.Union[os.PathLike, str], *,
+ def view_unixoid(filepath: typing.Union[os.PathLike, str], *,
+                  quiet: bool) -> None:
      """Open filepath in the user's preferred application (linux, freebsd)."""
 -    cmd = ['xdg-open', filepath]
 +    cmd = ['@xdgutils@/bin/xdg-open', filepath]


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/xflr6/graphviz/blob/0.19/CHANGES.rst


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
