### PR TITLE
[21.11] libjxl: add patch for CVE-2021-22564

### DIFF
--- a/pkgs/development/libraries/libjxl/default.nix
+++ b/pkgs/development/libraries/libjxl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub
+{ stdenv, lib, fetchFromGitHub, fetchpatch
 , asciidoc
 , brotli
 , cmake
@@ -28,6 +28,20 @@ stdenv.mkDerivation rec {
     # There are various submodules in `third_party/`.
     fetchSubmodules = true;
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2021-22564.prerequisite.patch";
+      url = "https://github.com/libjxl/libjxl/commit/482d0a24f891c641caae4369676ed303406dccac.patch";
+      sha256 = "1c0nm667jahzr04iyfkg7zjj0wf7igc8m0l5gczl50zbxgz17vmp";
+      includes = [ "lib/jxl/base/random.h" ];
+    })
+    (fetchpatch {
+      name = "CVE-2021-22564.patch";
+      url = "https://github.com/libjxl/libjxl/commit/e6497057899269bb40f54a26729826a55d857fd7.patch";
+      sha256 = "0yybl7dhhz0wawczmmka3ikysxz5ispj1b7z6bc7bp91glc0hk47";
+    })
+  ];
 
   # hydra's darwin machines run into https://github.com/libjxl/libjxl/issues/408
   # unless we disable highway's tests


### PR DESCRIPTION
###### Motivation for this change
#147887 https://nvd.nist.gov/vuln/detail/CVE-2021-22564
See #144394 for master.

Patching is explicitly mentioned by upstream as an option.

Not vulnerable to CVE-2021-22563 as it affected versions starting from 0.6.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
