### PR TITLE
python3Packages.meross-iot: init at 0.4.3.0

### DIFF
--- a/pkgs/development/python-modules/meross-iot/default.nix
+++ b/pkgs/development/python-modules/meross-iot/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, fetchFromGitHub
+, paho-mqtt
+, pytestCheckHook
+, pythonOlder
+, requests
+, retrying
+}:
+
+buildPythonPackage rec {
+  pname = "meross-iot";
+  version = "0.4.3.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "albertogeniola";
+    repo = "MerossIot";
+    rev = version;
+    sha256 = "sha256-PZ1+Bjw7k6EFZEuPhbkGrdQzdLGiM4U0ecAAN8SxWU4=";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    paho-mqtt
+    requests
+    retrying
+  ];
+
+  # Test require network access
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "meross_iot"
+  ];
+
+  meta = with lib; {
+    description = "Python library to interact with Meross devices";
+    homepage = "https://github.com/albertogeniola/MerossIot";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/proxy-py/default.nix
+++ b/pkgs/development/python-modules/proxy-py/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, openssl
+, paramiko
+, pytest-asyncio
+, pytest-mock
+, pytestCheckHook
+, pythonOlder
+, setuptools-scm
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "proxy-py";
+  version = "2.3.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "abhinavsingh";
+    repo = "proxy.py";
+    rev = "v${version}";
+    sha256 = "sha256-qqwb3t8/xicDGfO6l843qRwh0yUfthnOIhgNeKIbEO4=";
+  };
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    paramiko
+    typing-extensions
+  ];
+
+  checkInputs = [
+    openssl
+    pytest-asyncio
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d);
+  '';
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "typing-extensions==3.7.4.3" "typing-extensions"
+  '';
+
+  pythonImportsCheck = [
+    "proxy"
+  ];
+
+  meta = with lib; {
+    description = "Python proxy framework";
+    homepage = "https://github.com/abhinavsingh/proxy.py";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-json-report/default.nix
+++ b/pkgs/development/python-modules/pytest-json-report/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytest
+, pytest-metadata
+, pytest-xdist
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-json-report";
+  version = "1.4.1";
+
+  src = fetchFromGitHub {
+    owner = "numirias";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-OS9ASUp9iJ12Ovr931RQU/DHEAXqbgcRMCBP4h+GAhk=";
+  };
+
+  buildInputs = [
+    pytest
+  ];
+
+  propagatedBuildInputs = [
+    pytest-metadata
+  ];
+
+  checkInputs = [
+    pytest-xdist
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # pytest-flaky is not available at the moment
+    "test_bug_31"
+  ];
+
+  pythonImportsCheck = [
+    "pytest_jsonreport"
+  ];
+
+  meta = with lib; {
+    description = "Pytest plugin to report test results as JSON";
+    homepage = "https://github.com/numirias/pytest-json-report";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6125,6 +6125,8 @@ in {
 
   proxmoxer = callPackage ../development/python-modules/proxmoxer { };
 
+  proxy-py = callPackage ../development/python-modules/proxy-py { };
+
   psautohint = callPackage ../development/python-modules/psautohint { };
 
   psd-tools = callPackage ../development/python-modules/psd-tools { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4797,6 +4797,8 @@ in {
 
   merkletools = callPackage ../development/python-modules/merkletools { };
 
+  meross-iot = callPackage ../development/python-modules/meross-iot { };
+
   mesa = callPackage ../development/python-modules/mesa { };
 
   meshio = callPackage ../development/python-modules/meshio { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7445,6 +7445,8 @@ in {
 
   pytest-isort = callPackage ../development/python-modules/pytest-isort { };
 
+  pytest-json-report = callPackage ../development/python-modules/pytest-json-report { };
+
   pytest-lazy-fixture = callPackage ../development/python-modules/pytest-lazy-fixture { };
 
   pytest-localserver = callPackage ../development/python-modules/pytest-localserver { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library to interact with Meross devices

https://github.com/albertogeniola/MerossIot

`proxy-py` and `python-json-report` are test requirements. Unfortunately we can't run the tests (network access).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
