### PR TITLE
crow-translate: 2.8.7 → 2.9.1

### DIFF
--- a/pkgs/applications/misc/crow-translate/default.nix
+++ b/pkgs/applications/misc/crow-translate/default.nix
@@ -34,8 +34,8 @@ let
   qonlinetranslator = fetchFromGitHub {
     owner = "crow-translate";
     repo = "QOnlineTranslator";
-    rev = "df89083d2f680a8f856b1df00b8846f995cf1fae";
-    sha256 = "sha256-I64KGInnYd/QdI5kANJERsF95wMvRlr8kgQhUqXXN/0=";
+    rev = "1.5.2";
+    sha256 = "sha256-iGi25aKwff2hNNx6o4kHZV8gVbEQcMgpTTvop3CoLjM=";
   };
   circleflags = fetchFromGitHub {
     owner = "HatScripts";
@@ -52,13 +52,13 @@ let
 in
 mkDerivation rec {
   pname = "crow-translate";
-  version = "2.8.7";
+  version = "2.9.1";
 
   src = fetchFromGitHub {
     owner = "crow-translate";
     repo = pname;
     rev = version;
-    sha256 = "sha256-0bq9itbFyzdOhdNuUtdCYLTCIhc91MM+YRhJgXC5PPw=";
+    sha256 = "sha256-7Zb6PZO8eLeGPEZD37ja+LZydIQdsgy5gMAMtlS4k5Y=";
   };
 
   patches = [

--- a/pkgs/applications/misc/crow-translate/dont-fetch-external-libs.patch
+++ b/pkgs/applications/misc/crow-translate/dont-fetch-external-libs.patch
@@ -1,8 +1,8 @@
 diff --git i/CMakeLists.txt w/CMakeLists.txt
-index faa9417..059b899 100644
+index 375b17c..106efa9 100644
 --- i/CMakeLists.txt
 +++ w/CMakeLists.txt
-@@ -101,13 +101,11 @@ qt5_add_translation(QM_FILES
+@@ -114,13 +114,11 @@ qt5_add_translation(QM_FILES
  )
  
  configure_file(src/cmake.h.in cmake.h)
@@ -19,7 +19,7 @@ index faa9417..059b899 100644
      src/addlanguagedialog.cpp
      src/addlanguagedialog.ui
 diff --git i/cmake/ExternalLibraries.cmake w/cmake/ExternalLibraries.cmake
-index e2501e1..e15ce6c 100644
+index c92e745..f265f03 100644
 --- i/cmake/ExternalLibraries.cmake
 +++ w/cmake/ExternalLibraries.cmake
 @@ -2,34 +2,28 @@ include(FetchContent)
@@ -46,7 +46,7 @@ index e2501e1..e15ce6c 100644
  
  FetchContent_Declare(QOnlineTranslator
 -    GIT_REPOSITORY https://github.com/crow-translate/QOnlineTranslator
--    GIT_TAG df89083d2f680a8f856b1df00b8846f995cf1fae
+-    GIT_TAG 1.5.2
 +    SOURCE_DIR @qonlinetranslator@
  )
  

--- a/pkgs/applications/misc/crow-translate/fix-qttranslations-path.patch
+++ b/pkgs/applications/misc/crow-translate/fix-qttranslations-path.patch
@@ -1,13 +1,13 @@
 diff --git i/src/settings/appsettings.cpp w/src/settings/appsettings.cpp
-index aa8b357..15e4f74 100644
+index a73371b..b9d66ca 100644
 --- i/src/settings/appsettings.cpp
 +++ w/src/settings/appsettings.cpp
-@@ -81,7 +81,7 @@ void AppSettings::applyLanguage(QLocale::Language lang)
-     QLocale::setDefault(locale);
- 
-     s_appTranslator.load(locale, QStringLiteral(PROJECT_NAME), QStringLiteral("_"), QStandardPaths::locate(QStandardPaths::AppDataLocation, QStringLiteral("translations"), QStandardPaths::LocateDirectory));
--    s_qtTranslator.load(locale, QStringLiteral("qtbase"), QStringLiteral("_"), QLibraryInfo::location(QLibraryInfo::TranslationsPath));
-+    s_qtTranslator.load(locale, QStringLiteral("qtbase"), QStringLiteral("_"), QLatin1String("@qttranslations@/translations"));
+@@ -75,7 +75,7 @@ void AppSettings::applyLocale(const QLocale &locale)
+     const QLocale newLocale = locale == defaultLocale() ? QLocale::system() : locale;
+     QLocale::setDefault(newLocale);
+     s_appTranslator.load(newLocale, QStringLiteral(PROJECT_NAME), QStringLiteral("_"), QStandardPaths::locate(QStandardPaths::AppDataLocation, QStringLiteral("translations"), QStandardPaths::LocateDirectory));
+-    s_qtTranslator.load(newLocale, QStringLiteral("qt"), QStringLiteral("_"), QLibraryInfo::location(QLibraryInfo::TranslationsPath));
++    s_qtTranslator.load(newLocale, QStringLiteral("qt"), QStringLiteral("_"), QLatin1String("@qttranslations@/translations"));
  }
  
- QLocale::Language AppSettings::defaultLanguage()
+ QLocale AppSettings::defaultLocale()


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/crow-translate/crow-translate/releases)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
