### PR TITLE
facedetect: use Python 3

### DIFF
--- a/pkgs/tools/graphics/facedetect/default.nix
+++ b/pkgs/tools/graphics/facedetect/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, python2Packages }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, python3Packages }:
 
 stdenv.mkDerivation rec {
   pname = "facedetect";
@@ -11,14 +11,22 @@ stdenv.mkDerivation rec {
     sha256 = "0mddh71cjbsngpvjli406ndi2x613y39ydgb8bi4z1jp063865sd";
   };
 
-  buildInputs = [ python2Packages.python python2Packages.wrapPython ];
-  pythonPath = [ python2Packages.numpy python2Packages.opencv4 ];
+  patches = [
+    (fetchpatch {
+      name = "python3-support.patch";
+      url = "https://gitlab.com/wavexx/facedetect/-/commit/8037d4406eb76dd5c106819f72c3562f8b255b5b.patch";
+      sha256 = "1752k37pbkigiwglx99ba9360ahzzrrb65a8d77k3xs4c3bcmk2p";
+    })
+  ];
+
+  buildInputs = [ python3Packages.python python3Packages.wrapPython ];
+  pythonPath = [ python3Packages.numpy python3Packages.opencv4 ];
 
   dontConfigure = true;
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace facedetect \
-      --replace /usr/share/opencv "${python2Packages.opencv4}/share/opencv4"
+      --replace /usr/share/opencv "${python3Packages.opencv4}/share/opencv4"
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Switch from Python 2 to Python 3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
