### PR TITLE
xrgears: fix existing version & update

### DIFF
--- a/pkgs/applications/graphics/xrgears/default.nix
+++ b/pkgs/applications/graphics/xrgears/default.nix
@@ -12,18 +12,19 @@
 , SDL2
 , makeWrapper
 , libGL
+, glib
 }:
 
 stdenv.mkDerivation rec {
   pname = "xrgears";
-  version = "unstable-2020-04-15";
+  version = "unstable-2021-06-19";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "monado";
     repo = "demos/xrgears";
-    rev = "d0bee35fbf8f181e8313f1ead13d88c4fb85c154";
-    sha256 = "1k0k8dkclyiav99kf0933kyd2ymz3hs1p0ap2wbciq9s62jgz29i";
+    rev = "6331b98e065494995c9cc4b48ccdd9d5ccaef461";
+    sha256 = "sha256-buw2beTPIWScq+3VQjUyF+uOwS6VF+mnAPHZ2eFGZjc=";
   };
 
   nativeBuildInputs = [
@@ -40,6 +41,7 @@ stdenv.mkDerivation rec {
     openxr-loader
     vulkan-headers
     vulkan-loader
+    glib
   ];
 
   fixupPhase = ''

--- a/pkgs/applications/graphics/xrgears/default.nix
+++ b/pkgs/applications/graphics/xrgears/default.nix
@@ -9,6 +9,9 @@
 , vulkan-headers
 , vulkan-loader
 , xxd
+, SDL2
+, makeWrapper
+, libGL
 }:
 
 stdenv.mkDerivation rec {
@@ -29,6 +32,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     xxd
+    makeWrapper
   ];
 
   buildInputs = [
@@ -37,6 +41,11 @@ stdenv.mkDerivation rec {
     vulkan-headers
     vulkan-loader
   ];
+
+  fixupPhase = ''
+    wrapProgram $out/bin/xrgears \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ SDL2 libGL ]}
+  '';
 
   meta = with lib; {
     homepage = "https://gitlab.freedesktop.org/monado/demos/xrgears";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Split off into two commits for easy cherry picking.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
