### PR TITLE
vice: 3.1 -> 3.5

### DIFF
--- a/pkgs/misc/emulators/vice/default.nix
+++ b/pkgs/misc/emulators/vice/default.nix
@@ -1,20 +1,63 @@
-{ lib, stdenv, fetchurl, bison, flex, perl, libpng, giflib, libjpeg, alsa-lib, readline, libGLU, libGL, libXaw
-, pkg-config, gtk2, SDL, autoreconfHook, makeDesktopItem
+{ lib
+, stdenv
+, fetchurl
+, bison
+, flex
+, perl
+, libpng
+, giflib
+, libjpeg
+, alsa-lib
+, readline
+, libGLU
+, libGL
+, libXaw
+, pkg-config
+, gtk2
+, SDL
+, SDL_image
+, autoreconfHook
+, makeDesktopItem
+, dos2unix
+, xa
+, file
 }:
 
 stdenv.mkDerivation rec {
   pname = "vice";
-  version = "3.1";
+  version = "3.5";
 
   src = fetchurl {
     url = "mirror://sourceforge/vice-emu/vice-${version}.tar.gz";
-    sha256 = "0h0jbml02s2a36hr78dxv1zshmfhxp1wadpcdl09aq416fb1bf1y";
+    sha256 = "sha256-Vrl4+q64solgMr1gTQPDUBACGH7vHKWM7O1A8Rpl3A4=";
   };
 
-  buildInputs = [ bison flex perl libpng giflib libjpeg alsa-lib readline libGLU libGL
-    pkg-config gtk2 SDL autoreconfHook libXaw ];
+  nativeBuildInputs = [
+    autoreconfHook
+    bison
+    dos2unix
+    file
+    flex
+    pkg-config
+  ];
+
+  buildInputs = [
+    alsa-lib
+    giflib
+    gtk2
+    libGL
+    libGLU
+    libXaw
+    libjpeg
+    libpng
+    perl
+    readline
+    SDL
+    SDL_image
+    xa
+  ];
   dontDisableStatic = true;
-  configureFlags = [ "--enable-fullscreen --enable-gnomeui" ];
+  configureFlags = [ "--enable-fullscreen" "--enable-gnomeui" "--disable-pdf-docs" ];
 
   desktopItem = makeDesktopItem {
     name = "vice";
@@ -28,16 +71,10 @@ stdenv.mkDerivation rec {
   preBuild = ''
     for i in src/resid src/resid-dtv
     do
-        mkdir -pv $i/src
-        ln -sv ../../wrap-u-ar.sh $i/src
+      mkdir -pv $i/src
+      ln -sv ../../wrap-u-ar.sh $i/src
     done
   '';
-  patchPhase = ''
-    # Disable font-cache update
-    sed -i -e "s|install: install-data-am|install-no: install-data-am|" data/fonts/Makefile.am
-  '';
-
-  #NIX_LDFLAGS = "-lX11 -L${libX11}/lib";
 
   postInstall = ''
     mkdir -p $out/share/applications
@@ -46,7 +83,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Commodore 64, 128 and other emulators";
-    homepage = "http://www.viceteam.org";
+    homepage = "https://vice-emu.sourceforge.io/";
     license = lib.licenses.gpl2Plus;
     maintainers = [ lib.maintainers.sander ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#123292

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
