### PR TITLE
apfel: build with python3

### DIFF
--- a/pkgs/development/libraries/physics/apfel/default.nix
+++ b/pkgs/development/libraries/physics/apfel/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, gfortran, lhapdf, python2, zlib }:
+{ lib, stdenv, fetchFromGitHub, gfortran, lhapdf, python3, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "apfel";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-szEtSC/NouYlHSjVoX9Hoh7yQ0W82rVccYEF1L2tXoU=";
   };
 
-  buildInputs = [ gfortran lhapdf python2 zlib ];
+  buildInputs = [ gfortran lhapdf python3 zlib ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
Upstream supports python3 since:
https://github.com/scarrazza/apfel/commit/0a75939245ca63e6c02b054be54d822730352984
https://github.com/scarrazza/apfel/commit/50c729f7f1bc98b25fb9799d8012a1544c2c1d3d

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/148779

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
