### PR TITLE
conway_polynomials, elliptic_curves: use Python 3

### DIFF
--- a/pkgs/data/misc/conway_polynomials/default.nix
+++ b/pkgs/data/misc/conway_polynomials/default.nix
@@ -1,13 +1,11 @@
 { lib, stdenv
 , fetchurl
-, python2
+, python3
 }:
 
 stdenv.mkDerivation rec {
   pname = "conway_polynomials";
   version = "0.5";
-
-  pythonEnv = python2.withPackages (ps: with ps; [ six ]);
 
   src = fetchurl {
     url = "mirror://sageupstream/conway_polynomials/conway_polynomials-${version}.tar.bz2";
@@ -16,8 +14,8 @@ stdenv.mkDerivation rec {
 
   # Script that creates the "database" (nested python array) and pickles it
   spkg-install = fetchurl {
-    url = "https://git.sagemath.org/sage.git/plain/build/pkgs/conway_polynomials/spkg-install.py?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
-    sha256 = "0m12nfb37j3bn4bp06ddgnyp2d6z0hg5f83pbbjszxw7vxs33a82";
+    url = "https://git.sagemath.org/sage.git/plain/build/pkgs/conway_polynomials/spkg-install.py?id=9.2";
+    sha256 = "1bwnqasnyv793hxg29viing4dnliz29grkhldsirq19d509yk1fs";
   };
 
   installPhase = ''
@@ -31,7 +29,7 @@ stdenv.mkDerivation rec {
     export SAGE_SHARE="$out/share"
     export PYTHONPATH=$PWD
 
-    ${pythonEnv.interpreter} ${spkg-install}
+    ${python3.interpreter} ${spkg-install}
   '';
 
   meta = with lib; {

--- a/pkgs/data/misc/elliptic_curves/default.nix
+++ b/pkgs/data/misc/elliptic_curves/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv
 , fetchurl
-, python2
+, python3
 }:
 
 stdenv.mkDerivation rec {
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     export SAGE_SHARE="$out/share"
     export PYTHONPATH=$PWD
 
-    ${python2.interpreter} ${spkg-install}
+    ${python3.interpreter} ${spkg-install}
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

#148779

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
