### PR TITLE
datefmt: init at 0.2.1

### DIFF
--- a/pkgs/tools/misc/datefmt/default.nix
+++ b/pkgs/tools/misc/datefmt/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchurl, datefmt, testVersion }:
+
+stdenv.mkDerivation rec {
+  pname = "datefmt";
+  version = "0.2.1";
+
+  src = fetchurl {
+    url = "http://cdn.jb55.com/tarballs/datefmt/datefmt-${version}.tar.gz";
+    sha256 = "5d5e765380afe39eb39d48f752aed748b57dfd843a4947b2a6d18ab9b5e68092";
+  };
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  passthru.tests.version = testVersion { package = datefmt; };
+
+  meta = with lib; {
+    homepage = "https://jb55.com/datefmt";
+    description = "A tool that formats timestamps in text streams";
+    platforms = platforms.all;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ jb55 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2678,6 +2678,8 @@ with pkgs;
 
   howard-hinnant-date = callPackage ../development/libraries/howard-hinnant-date { };
 
+  datefmt = callPackage ../tools/misc/datefmt { };
+
   datefudge = callPackage ../tools/system/datefudge { };
 
   dateutils = callPackage ../tools/misc/dateutils { };


### PR DESCRIPTION
[datefmt](https://jb55.com/datefmt) is a simple C program that formats unix timestamps in text streams

Signed-off-by: William Casarin <jb55@jb55.com>