### PR TITLE
openrussian-cli: force lua 5.3

### DIFF
--- a/pkgs/misc/openrussian-cli/default.nix
+++ b/pkgs/misc/openrussian-cli/default.nix
@@ -25,12 +25,6 @@ stdenv.mkDerivation rec {
 
   dontConfigure = true;
 
-  # Disable check as it's too slow.
-  # doCheck = true;
-
-  #This is needed even though it's the default for some reason.
-  checkTarget = "check";
-
   # Can't use "make install" here
   installPhase = ''
     runHook preInstall

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8286,7 +8286,9 @@ with pkgs;
 
   openrgb = libsForQt5.callPackage ../applications/misc/openrgb { };
 
-  openrussian-cli = callPackage ../misc/openrussian-cli { };
+  openrussian-cli = callPackage ../misc/openrussian-cli {
+    luaPackages = lua53Packages;
+  };
 
   opensc = callPackage ../tools/security/opensc {
     inherit (darwin.apple_sdk.frameworks) Carbon PCSC;


### PR DESCRIPTION
###### Motivation for this change

Running with the default (5.2.4) causes errors such as:
```
/nix/store/hgbxpic3vq9hsqk9ndi8xm5blmz1gk79-lua-5.2.4/bin/lua: error loading module 'luasql.sqlite3' from file '/nix/store/fmyyrpv9wwinabdfad7ddx60r4mq3vmd-lua5.2-luasql-sqlite3-2.6.0-1/lib/lua/5.2/luasql/sqlite3.so':
        /nix/store/fmyyrpv9wwinabdfad7ddx60r4mq3vmd-lua5.2-luasql-sqlite3-2.6.0-1/lib/lua/5.2/luasql/sqlite3.so: undefined symbol: lua_isinteger
stack traceback:
        [C]: in ?
        [C]: in function 'require'
        openrussian.lu
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
