### PR TITLE
bashup-events: rm shellcheck from checkPhase

### DIFF
--- a/pkgs/development/libraries/bashup-events/generic.nix
+++ b/pkgs/development/libraries/bashup-events/generic.nix
@@ -3,7 +3,6 @@
   lib
 , resholvePackage
 , bash
-, shellcheck
 , doCheck ? true
 , doInstallCheck ? true
   # variant-specific
@@ -50,12 +49,10 @@ resholvePackage rec {
   '';
 
   inherit doCheck;
-  checkInputs = [ shellcheck bash ];
+  checkInputs = [ bash ];
 
-  # check based on https://github.com/bashup/events/blob/master/.dkrc
   checkPhase = ''
     runHook preCheck
-    SHELLCHECK_OPTS='-e SC2016,SC2145' ${shellcheck}/bin/shellcheck ./bashup.events
     ${bash}/bin/bash -n ./bashup.events
     ${bash}/bin/bash ./bashup.events
     runHook postCheck


### PR DESCRIPTION
###### Motivation for this change
An advance in shellcheck started causing [new failures here](https://hydra.nixos.org/build/160746794/nixlog/1), which inspired me to think a little more lucidly and realize it's a bad idea to shellcheck something that isn't maintainer-developed. The outcomes are all annoying timewasters. :[

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
