### PR TITLE
meshlab: 2020.12 -> 2021.10

### DIFF
--- a/pkgs/applications/graphics/meshlab/default.nix
+++ b/pkgs/applications/graphics/meshlab/default.nix
@@ -14,17 +14,21 @@
 , levmar
 , qhull
 , cmake
+, cgal_5
+, boost17x
+, mpfr
+, xercesc
 }:
 
 mkDerivation rec {
   pname = "meshlab";
-  version = "2020.12";
+  version = "2021.10";
 
   src = fetchFromGitHub {
     owner = "cnr-isti-vclab";
     repo = "meshlab";
     rev = "Meshlab-${version}";
-    sha256 = "QrnqXEVqI1ADUYWalZ0h/0+xS+gDZTinm0weT39onw0=";
+    sha256 = "14rrd8qrf91k89y6w2mn1r9zcfnwd0mir6g4dlgvr04i77hj4lk4";
     fetchSubmodules = true; # for vcglib
   };
 
@@ -41,6 +45,10 @@ mkDerivation rec {
     gmp
     levmar
     qhull
+    cgal_5
+    boost17x
+    mpfr
+    xercesc
   ];
 
   nativeBuildInputs = [ cmake ];
@@ -61,6 +69,7 @@ mkDerivation rec {
     # disable when available in nixpkgs
     "-DALLOW_BUNDLED_OPENCTM=ON"
     "-DALLOW_BUNDLED_SSYNTH=ON"
+    "-DALLOW_BUNDLED_BOOST=OFF"
     # some plugins are disabled unless these are on
     "-DALLOW_BUNDLED_NEWUOA=ON"
     "-DALLOW_BUNDLED_LEVMAR=ON"


### PR DESCRIPTION
###### Motivation for this change

Updating.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
