### PR TITLE
escrotum: 2019-06-10 -> 2020-12-07

### DIFF
--- a/pkgs/tools/graphics/escrotum/default.nix
+++ b/pkgs/tools/graphics/escrotum/default.nix
@@ -1,18 +1,35 @@
-{ lib, python2Packages, fetchFromGitHub
+{ lib, python3Packages, fetchFromGitHub
+, gtk3
+, pango
+, gobject-introspection
+, wrapGAppsHook
 }:
 
-with python2Packages; buildPythonApplication {
+with python3Packages; buildPythonApplication {
   pname = "escrotum";
-  version = "unstable-2019-06-10";
+  version = "unstable-2020-12-07";
 
   src = fetchFromGitHub {
     owner  = "Roger";
     repo   = "escrotum";
-    rev    = "f6c300315cb4402e37f16b56aad2d206e24c5281";
-    sha256 = "0x7za74lkwn3v6j9j04ifgdwdlx9akh1izkw7vkkzj9ag9qjrzb0";
+    rev    = "a41d0f11bb6af4f08e724b8ccddf8513d905c0d1";
+    sha256 = "sha256-z0AyTbOEE60j/883X17mxgoaVlryNtn0dfEB0C18G2s=";
   };
 
-  propagatedBuildInputs = [ pygtk numpy ];
+  buildInputs = [
+    gtk3
+    pango
+  ];
+
+  nativeBuildInputs = [
+    gobject-introspection
+    wrapGAppsHook
+  ];
+
+  propagatedBuildInputs = [ pygobject3 xcffib pycairo numpy ];
+
+  # Cannot find pango without strictDeps = false
+  strictDeps = false;
 
   outputs = [ "out" "man" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Requires update to remove python2 dependency. See https://github.com/NixOS/nixpkgs/issues/148779

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
