### PR TITLE
kodi: fix cross build

### DIFF
--- a/pkgs/applications/video/kodi/unwrapped.nix
+++ b/pkgs/applications/video/kodi/unwrapped.nix
@@ -198,10 +198,10 @@ in stdenv.mkDerivation {
     '' + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
       # Need these tools on the build system when cross compiling,
       # hacky, but have found no other way.
-      CXX=${stdenv.cc.targetPrefix}c++ LD=ld make -C tools/depends/native/JsonSchemaBuilder
+      CXX=$CXX_FOR_BUILD LD=ld make -C tools/depends/native/JsonSchemaBuilder
       cmakeFlags+=" -DWITH_JSONSCHEMABUILDER=$PWD/tools/depends/native/JsonSchemaBuilder/bin"
 
-      CXX=${stdenv.cc.targetPrefix}c++ LD=ld make EXTRA_CONFIGURE= -C tools/depends/native/TexturePacker
+      CXX=$CXX_FOR_BUILD LD=ld make EXTRA_CONFIGURE= -C tools/depends/native/TexturePacker
       cmakeFlags+=" -DWITH_TEXTUREPACKER=$PWD/tools/depends/native/TexturePacker/bin"
     '';
 

--- a/pkgs/applications/video/kodi/wrapper.nix
+++ b/pkgs/applications/video/kodi/wrapper.nix
@@ -22,7 +22,7 @@ buildEnv {
   paths = [ kodi ] ++ addons;
   pathsToLink = [ "/share" ];
 
-  buildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   postBuild = ''
     mkdir $out/bin


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
kodi doesn't cross-compile.
```
> checking whether we are cross compiling... configure: error: in `/build/source/tools/depends/native/JsonSchemaBuilder/native':
> configure: error: cannot run C++ compiled programs.
> If you meant to cross compile, use `--host'.
> See `config.log' for more details
> make: *** [Makefile:30: native] Error 77
> make: Leaving directory '/build/source/tools/depends/native/JsonSchemaBuilder'
```
```
error: attribute 'runtimeShell' missing
```

###### Things done
Built kodi with optional features disabled. Also the dependency `lirc` would bring in `libftdi` and the default `jre_headless` would bring in `gtk3`, both having cross-compile issues as well.
```
nix build -I nixpkgs=./ --impure --expr '(
import <nixpkgs> {
  overlays = [ (self: super: { 
    lirc = null; 
    kodi = super.kodi.override {
      waylandSupport = true;
      x11Support = false;
      gbmSupport = false;
      dbusSupport = false;
      joystickSupport = false;
      nfsSupport = false;
      pulseSupport = false;
      sambaSupport = false;
      udevSupport = false;
      usbSupport = false;
      vdpauSupport = false;
      jre_headless = self.buildPackages.adoptopenjdk-jre-openj9-bin-11;
    };
  }) ]; 
} ).pkgsCross.aarch64-multiplatform.kodi'
```
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
       Tested by building an aarch64 sdImage containing kodi-wayland. It runs fine, though I only tested basic functionality (menus, local media)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

credits to @telent (https://github.com/telent/nixelec/blob/main/configuration.nix#L100)