### PR TITLE
Wike: fix: provide right python version instead of patching source

### DIFF
--- a/pkgs/applications/misc/wike/default.nix
+++ b/pkgs/applications/misc/wike/default.nix
@@ -7,14 +7,12 @@
 , libhandy, webkitgtk, glib-networking
 , gnome, dconf
 }:
-let
-  pythonEnv = python3.withPackages (p: with p; [
-    pygobject3
-    requests
-  ]);
-in stdenv.mkDerivation rec {
+
+python3.pkgs.buildPythonApplication rec {
   pname = "wike";
   version = "1.7.1";
+  format = "other";
+  strictDeps = false; # https://github.com/NixOS/nixpkgs/issues/56943
 
   src = fetchFromGitHub {
     owner = "hugolabe";
@@ -35,7 +33,6 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [
     glib
-    pythonEnv
     gtk3
     libhandy
     webkitgtk
@@ -44,10 +41,13 @@ in stdenv.mkDerivation rec {
     dconf
   ];
 
+  propagatedBuildInputs = with python3.pkgs; [
+    requests
+    pygobject3
+  ];
+
   postPatch = ''
     patchShebangs build-aux/meson/postinstall.py
-    substituteInPlace src/wike.in    --replace "@PYTHON@" "${pythonEnv}/bin/python"
-    substituteInPlace src/wike-sp.in --replace "@PYTHON@" "${pythonEnv}/bin/python"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Currently, we are patching source for right python path
Better is provide it in propagatedBuildInputs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


@samalws
