### PR TITLE
pamix: fix pending upstream inclusion for ncurses-6.3

### DIFF
--- a/pkgs/applications/audio/pamix/default.nix
+++ b/pkgs/applications/audio/pamix/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub
+{ lib, stdenv, fetchFromGitHub, fetchpatch
 , pkg-config, cmake
 , libpulseaudio, ncurses }:
 
@@ -12,6 +12,21 @@ stdenv.mkDerivation rec {
     rev    = version;
     sha256 = "1d44ggnwkf2gff62959pj45v3a2k091q8v154wc5pmzamam458wp";
   };
+
+  patches = [
+    # Fix pending upstream inclusion for ncurses-6.3 support:
+    #  https://github.com/patroclos/PAmix/pull/73
+    (fetchpatch {
+      name = "ncurses-6.3-p1.patch";
+      url = "https://github.com/patroclos/PAmix/commit/3400b9c048706c572373e4617b4d5fcdb8dd2505.patch";
+      sha256 = "0rw56a844pz876ad9p8hfvn2fkd5rh29gpp47h55g08spf0vwb2z";
+    })
+    (fetchpatch {
+      name = "ncurses-6.3-p2.patch";
+      url = "https://github.com/patroclos/PAmix/commit/5ef67fc5ef6fc0dc0b48ff07ba48093881561d9c.patch";
+      sha256 = "0f8shpdv2swxdz04bkqgmkvl6c17r5mn4slzr7xd6pvw8hh51p4h";
+    })
+  ];
 
   preConfigure = ''
     substituteInPlace CMakeLists.txt --replace "/etc" "$out/etc/xdg"

--- a/pkgs/applications/audio/pamix/default.nix
+++ b/pkgs/applications/audio/pamix/default.nix
@@ -14,8 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    # Fix pending upstream inclusion for ncurses-6.3 support:
-    #  https://github.com/patroclos/PAmix/pull/73
+    # ncurses-6.3 support, included in next release
     (fetchpatch {
       name = "ncurses-6.3-p1.patch";
       url = "https://github.com/patroclos/PAmix/commit/3400b9c048706c572373e4617b4d5fcdb8dd2505.patch";


### PR DESCRIPTION
Without the change the build fails as:

    src/pamix_ui.cpp:132:25: error: format not a string literal and no format arguments [-Werror=format-security]
      132 |                 mvprintw(curY, curX + remainingChars + 1, displayName.c_str());
          |                 ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
