### PR TITLE
osticket: add module

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -19,8 +19,15 @@
   </section>
   <section xml:id="sec-release-22.05-new-services">
     <title>New Services</title>
-    <para>
-    </para>
+    <itemizedlist spacing="compact">
+      <listitem>
+        <para>
+          <literal>osticket</literal>: sets up the https://osticket.com
+          support ticketing system, also enabling mysql, phpfpm and
+          nginx.
+        </para>
+      </listitem>
+    </itemizedlist>
   </section>
   <section xml:id="sec-release-22.05-incompatibilities">
     <title>Backward Incompatibilities</title>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -8,10 +8,12 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 ## New Services {#sec-release-22.05-new-services}
 
+- `osticket`: sets up the https://osticket.com support ticketing system, also enabling mysql, phpfpm and nginx.
+
 ## Backward Incompatibilities {#sec-release-22.05-incompatibilities}
 
 - `pkgs.ghc` now refers to `pkgs.targetPackages.haskellPackages.ghc`.
-  This *only* makes a difference if you are cross-compiling and will
+  This _only_ makes a difference if you are cross-compiling and will
   ensure that `pkgs.ghc` always runs on the host platform and compiles
   for the target platform (similar to `pkgs.gcc` for example).
   `haskellPackages.ghc` still behaves as before, running on the build

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -572,6 +572,7 @@
   ./services/misc/octoprint.nix
   ./services/misc/ombi.nix
   ./services/misc/osrm.nix
+  ./services/misc/osticket/default.nix
   ./services/misc/owncast.nix
   ./services/misc/packagekit.nix
   ./services/misc/paperless-ng.nix

--- a/nixos/modules/services/misc/osticket/default.nix
+++ b/nixos/modules/services/misc/osticket/default.nix
@@ -138,7 +138,7 @@ in
         };
 
         # Provide php for patch-shebangs
-        buildInputs = [ myPhp fakeGit ];
+        nativeBuildInputs = [ myPhp fakeGit ];
 
         patchPhase = ''
           # Patch the location of the config file and the version

--- a/nixos/modules/services/misc/osticket/default.nix
+++ b/nixos/modules/services/misc/osticket/default.nix
@@ -1,0 +1,282 @@
+{ config, lib, pkgs, ... }:
+
+let
+  version = "1.15.4";
+  sha256 = "1nic4sg7n1q3fr4sj2j7xgv3a5p1gq4xccmx5msci1wwx62mfjfw";
+  user = "osticket";
+  stateDir = "/var/lib/${user}";
+
+  inherit (lib) mkDefault mkEnableOption mkForce mkIf mkMerge mkOption;
+  inherit (lib)
+    concatStringsSep literalExpression mapAttrsToList optional optionals
+    optionalString types;
+  inherit (pkgs) fetchFromGitHub;
+
+  cfg = config.services.osticket;
+
+in
+{
+  # interface
+  options = {
+    services.osticket = {
+      enable = mkEnableOption "the osTicket issue tracker with mysql and phpfpm+nginx";
+
+      withSetup = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Include the setup wizard. Set this to false after setup.
+        '';
+      };
+
+      favicon = mkOption {
+        type = with types; nullOr path;
+        default = null;
+        description = ''
+          Path to custom favicon PNG image. This will be added to the page &lt;HEAD&gt; sections.
+        '';
+      };
+
+      # TODO make this nicer wrt getting the plugins, perhaps ship all plugins by default + allow extra
+      plugins = mkOption {
+        type = with types; attrsOf path;
+        default = { };
+        description = ''
+          attrset with paths to plugins, like in nixos/modules/services/misc/osticket/plugins.nix
+        '';
+      };
+
+      enablePolling = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether to run email polling.";
+      };
+
+      poolConfig = mkOption {
+        type = with types; attrsOf (oneOf [ str int bool ]);
+        default = {
+          "pm" = "dynamic";
+          "pm.max_children" = 32;
+          "pm.start_servers" = 1;
+          "pm.min_spare_servers" = 1;
+          "pm.max_spare_servers" = 2;
+          "pm.max_requests" = 500;
+          "php_value[date.timezone]" = "UTC";
+          "php_value[upload_max_filesize]" = "10M";
+          # Redirect worker stdout and stderr into main error log. If not set, stdout and
+          # stderr will be redirected to /dev/null according to FastCGI specs.
+          # Default Value: no
+          "catch_workers_output" = true;
+          "clear_env" = false;
+          "env[\"SHELL_VERBOSITY\"]" = 3;
+        };
+        description = ''
+          Options for the osTicket PHP pool. See the documentation on <literal>php-fpm.conf</literal>
+          for details on configuration directives.
+        '';
+      };
+
+      virtualHost = mkOption {
+        type = types.submodule (import ../../web-servers/nginx/vhost-options.nix);
+        example = literalExpression ''
+          {
+            serverName = "osticket.example.org";
+            forceSSL = true;
+            enableACME = true;
+          }
+        '';
+        description = ''
+          Nginx configuration can be done by adapting <option>services.nginx.virtualHosts</option>.
+          See <xref linkend="opt-services.nginx.virtualHosts"/> for further information.
+        '';
+      };
+
+    };
+  };
+
+  # implementation
+  config = mkIf cfg.enable (
+    let
+      group = config.services.nginx.group;
+      fpm = config.services.phpfpm.pools.${user};
+
+      myPhp = pkgs.php74.buildEnv {
+        extensions = { enabled, all }:
+          enabled ++ (with all; [
+            apcu
+            gd
+            gettext
+            imap
+            json
+            mysqli
+            mbstring
+            # required but already in enabled
+            # xml
+            # Needed for Slack plugin
+            # TODO extensions function on plugin definition
+            #   that then gets mapped and joined
+            curl
+          ]);
+        # extraConfig = "memory_limit=256M";
+      };
+
+      # The deploy uses git to get the version
+      fakeGit = pkgs.writeScriptBin "git" ''
+        #!${pkgs.stdenv.shell}
+        echo ${version}
+      '';
+
+      pkg = pkgs.stdenv.mkDerivation rec {
+        inherit version;
+        pname = "osTicket";
+
+        src = fetchFromGitHub {
+          inherit sha256;
+          owner = "osTicket";
+          repo = "osTicket";
+          rev = "v${version}";
+        };
+
+        # Provide php for patch-shebangs
+        buildInputs = [ myPhp fakeGit ];
+
+        patchPhase = ''
+          # Patch the location of the config file and the version
+          sed -i -e "s|INCLUDE_DIR.'ost-config.php'|'${stateDir}/ost-config.php'|" -e "s|define('GIT_VERSION', '\\$git')|define('GIT_VERSION', '${version}')|" bootstrap.php
+          sed -i "s|../include|${stateDir}|" setup/install.php
+
+          # Pre-populate the database settings for setup.
+          # The password is not used but required.
+          sed -i "s|'dbhost'=>'localhost'|'dbhost'=>'localhost','dbuser'=>'${user}','dbpass'=>'${user}','dbname'=>'${user}'|" setup/inc/install.inc.php
+
+          # Add script header for cron
+          sed -i '1i\#!/usr/bin/env php' api/cron.php
+        '' + optionalString (cfg.favicon != null) ''
+          cp ${cfg.favicon} images/favicon.png
+          # Savings for 16x16 are tiny, just remove
+          sed -i -e '/16x16/d' -e 's/oscar-favicon-32x32.png/favicon.png/' -e 's/ sizes="32x32"//' include/client/header.inc.php include/staff/header.inc.php
+        '';
+
+        installPhase = ''
+          mkdir -p $out/public
+          php manage.php deploy ${
+            optionalString cfg.withSetup "--setup"
+          } -i $out/include $out/public
+          chmod a+x $out/public/manage.php $out/public/api/cron.php $out/public/api/pipe.php
+          mkdir -p $out/bin
+          ln -s ../public/manage.php $out/bin/osticket_manage
+          ln -s ../public/api/cron.php $out/bin/osticket_cron
+          ln -s ../public/api/pipe.php $out/bin/osticket_pipe
+        '' + (concatStringsSep "\n" (mapAttrsToList
+          (name: path: "ln -s ${path} $out/include/plugins/${name}")
+          cfg.plugins));
+
+        meta = with pkgs.lib; {
+          homepage = "https://osticket.com/";
+          description = "Issue tracking system";
+          platforms = platforms.linux;
+          maintainers = [ maintainers.wmertens ];
+          license = licenses.gpl2;
+        };
+      };
+
+    in
+    {
+      users.users.${user} = {
+        group = group;
+        useDefaultShell = true;
+        isSystemUser = true;
+        packages = [ myPhp pkg pkgs.mariadb ];
+      };
+
+      systemd.tmpfiles.rules = [
+        "d '${stateDir}' 0750 ${user} ${group} - -"
+        "C '${stateDir}/ost-config.php' ${
+        if cfg.withSetup then "0640" else "0440"
+      } ${user} ${group} - ${pkg}/include/ost-sampleconfig.php"
+      ];
+
+      # It would be nice to replace this with fetchmail which has IMAP IDLE
+      # That way, tickets would be seen immediately
+      systemd.services."${user}-cron" = mkIf cfg.enablePolling {
+        description = "osTicket email polling";
+        script = "${pkg}/bin/osticket_cron";
+        # We run this every minute but osTicket has its own timers
+        startAt = "*:0/1";
+        serviceConfig = {
+          Type = "oneshot";
+          User = user;
+          Group = group;
+          TimeoutStartSec = "1m";
+        };
+      };
+
+      services.phpfpm.pools.${user} = {
+        inherit user group;
+        phpPackage = myPhp;
+        settings = {
+          "listen.owner" = config.services.nginx.user;
+          "listen.group" = config.services.nginx.group;
+        } // cfg.poolConfig;
+      };
+
+      services.mysql = {
+        enable = true;
+        package = pkgs.mariadb;
+        ensureDatabases = [ "osticket" ];
+        ensureUsers = [{
+          name = "osticket";
+          ensurePermissions = { "osticket.*" = "ALL PRIVILEGES"; };
+        }];
+      };
+
+      services.nginx = {
+        enable = true;
+
+        recommendedGzipSettings = mkDefault true;
+        recommendedOptimisation = mkDefault true;
+        recommendedProxySettings = mkDefault true;
+        recommendedTlsSettings = mkDefault true;
+
+        virtualHosts.${cfg.virtualHost.serverName} = mkMerge [
+          cfg.virtualHost
+          {
+            root = mkForce "${pkg}/public";
+
+            locations = {
+              "/" = { index = "index.php"; };
+
+              # Deny access to apache .ht* files (nginx doesn't use these)
+              "~ /.ht" = { return = "403"; };
+
+              # /api/*.* should be handled by /api/http.php if the requested file does not exist
+              "/api" = {
+                tryFiles = "$uri $uri/ /api/http.php$is_args$args";
+              };
+
+              # /apps/*.* should be handled by /apps/dispatcher.php if the requested file does not exist
+              "/apps" = {
+                tryFiles = "$uri $uri/ /apps/dispatcher.php$is_args$args";
+              };
+
+              "~ [^/]\\.php($|/)" = {
+                fastcgiParams =
+                  { PATH_INFO = "$fastcgi_path_info"; };
+
+                extraConfig = ''
+                  fastcgi_pass unix:${fpm.socket};
+
+                  fastcgi_split_path_info ^(.+\.php)(/.*)$;
+                  if (!-f $document_root$fastcgi_script_name) {
+                      return 404;
+                  }
+                '';
+              };
+            };
+          }
+        ];
+
+      };
+    }
+  );
+}

--- a/nixos/modules/services/misc/osticket/default.nix
+++ b/nixos/modules/services/misc/osticket/default.nix
@@ -200,7 +200,7 @@ in
       # That way, tickets would be seen immediately
       systemd.services."${user}-cron" = mkIf cfg.enablePolling {
         description = "osTicket email polling";
-        script = "${pkg}/bin/osticket_cron";
+        serviceConfig.ExecStart = "${myPhp}/bin/php ${pkg}/api/cron.php";
         # We run this every minute but osTicket has its own timers
         startAt = "*:0/1";
         serviceConfig = {

--- a/nixos/modules/services/misc/osticket/plugins.nix
+++ b/nixos/modules/services/misc/osticket/plugins.nix
@@ -1,0 +1,9 @@
+{ fetchFromGitHub, ... }:
+{
+  slack = fetchFromGitHub {
+    owner = "clonemeagain";
+    repo = "osticket-slack";
+    rev = "235436a8fb92168f01fa4d4e55336d203c6eded4";
+    sha256 = "sha256:0ffy8spkq24kgbqi89l5paxv1ba8m2ky3qph8bs4pz04j89g0b2r";
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add osTicket, a nice support ticketing system with email support, as a module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### To Do

- [ ] move derivation into separate package
- [ ] make OST_CONFIG, like in the [mediawiki](https://github.com/NixOS/nixpkgs/blob/0699530f08290f34c532beedd66046825d9756fa/pkgs/servers/web-apps/mediawiki/default.nix#L27) package
- [ ] do not make cron.php executable
- [ ] override favicon via nginx
- [ ] pick plugins via derivation `pkgs.osticket.withPackages (p: with p; [ slack ])`
