### PR TITLE
doc/manual,CONTRIBUTING.md: add treewide change syntax

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ under the terms of [COPYING](COPYING), which is an MIT-like license.
 * Format the commit messages in the following way:
 
   ```
-  (pkg-name | nixos/<module>): (from -> to | init at version | refactor | etc)
+  ((<pkg-name> | treewide) | nixos/(<module> | treewide)): (from -> to | init at version | refactor | etc)
 
   (Motivation for change. Additional information.)
   ```
@@ -28,6 +28,8 @@ under the terms of [COPYING](COPYING), which is an MIT-like license.
   * nixos/hydra: add bazBaz option
 
     Dual baz behavior is needed to do foo.
+  * nixos/treewide: escape pkgs reference in examples and descriptions
+  * treewide: gnome2.gtk -> gtk2
   * nixos/nginx: refactor config generation
 
     The old config generation system used impure shell scripts and could break in specific circumstances (see #1234).
@@ -41,6 +43,10 @@ under the terms of [COPYING](COPYING), which is an MIT-like license.
 * `meta.maintainers` must be set.
 
 See the nixpkgs manual for more details on [standard meta-attributes](https://nixos.org/nixpkgs/manual/#sec-standard-meta-attributes) and on how to [submit changes to nixpkgs](https://nixos.org/nixpkgs/manual/#chap-submitting-changes).
+
+### Treewide changes
+
+Changes that affect a large portion of the tree should be prefixed with `treewide:` or `nixos/treewide`.
 
 ## Writing good commit messages
 

--- a/doc/contributing/submitting-changes.chapter.md
+++ b/doc/contributing/submitting-changes.chapter.md
@@ -28,7 +28,7 @@
 - Format the commit in a following way:
 
   ```
-  (pkg-name | nixos/<module>): (from -> to | init at version | refactor | etc)
+  ((<pkg-name> | treewide) | nixos/(<module> | treewide)): (from -> to | init at version | refactor | etc)
   Additional information.
   ```
 
@@ -36,6 +36,8 @@
     - `nginx: init at 2.0.1`
     - `firefox: 54.0.1 -> 55.0`
     - `nixos/hydra: add bazBaz option`
+    - `nixos/treewide: escape pkgs reference in examples and descriptions`
+    - `treewide: gnome2.gtk -> gtk2`
     - `nixos/nginx: refactor config generation`
 
 - Test your changes. If you work with


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/147441#issuecomment-986340870

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
