### PR TITLE
cargo-about: 0.4.2 -> 0.4.3, mark broken on darwin

### DIFF
--- a/pkgs/tools/package-management/cargo-about/default.nix
+++ b/pkgs/tools/package-management/cargo-about/default.nix
@@ -1,17 +1,24 @@
-{ lib, rustPlatform, fetchFromGitHub }:
+{ lib, rustPlatform, fetchFromGitHub, pkg-config, zstd, stdenv }:
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-about";
-  version = "0.4.2";
+  version = "0.4.3";
 
   src = fetchFromGitHub {
     owner = "EmbarkStudios";
     repo = "cargo-about";
     rev = version;
-    sha256 = "sha256-QLPqvlMwCdMfUGCVibCGQdI7UkHV1WBfpBi2Kwi3b1Q=";
+    sha256 = "sha256-nNMpCv7pokWK+rCV/jEvTpJNwTtZO5t2+etMRg3XJiQ=";
   };
 
-  cargoSha256 = "sha256-x9hx9wJlcrGo1zuugPYY4G4Os5x8tIOICKnKq8TuevI=";
+  # enable pkg-config feature of zstd
+  cargoPatches = [ ./zstd-pkg-config.patch ];
+
+  cargoSha256 = "sha256-LC4vY/jyIPGY2UpB4LOKCCR/gv8EUfB4nH8h0O9c6iw=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ zstd ];
 
   meta = with lib; {
     description = "Cargo plugin to generate list of all licenses for a crate";
@@ -19,5 +26,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/EmbarkStudios/cargo-about/blob/${version}/CHANGELOG.md";
     license = with licenses; [ mit /* or */ asl20 ];
     maintainers = with maintainers; [ evanjs figsoda ];
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/tools/package-management/cargo-about/zstd-pkg-config.patch
+++ b/pkgs/tools/package-management/cargo-about/zstd-pkg-config.patch
@@ -1,0 +1,39 @@
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -183,6 +183,7 @@ dependencies = [
+  "toml_edit",
+  "twox-hash",
+  "url",
++ "zstd",
+ ]
+ 
+ [[package]]
+@@ -1039,6 +1040,12 @@ version = "0.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+ 
++[[package]]
++name = "pkg-config"
++version = "0.3.22"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
++
+ [[package]]
+ name = "ppv-lite86"
+ version = "0.2.15"
+@@ -1902,4 +1909,5 @@ checksum = "2141bed8922b427761470e6bbfeff255da94fa20b0bbeab0d9297fcaf71e3aa7"
+ dependencies = [
+  "cc",
+  "libc",
++ "pkg-config",
+ ]
+diff --git a/Cargo.toml b/Cargo.toml
+index bf2a896..35cbf7c 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -80,3 +80,5 @@ toml_edit = "0.9"
+ twox-hash = "1.6"
+ # Url parsing
+ url = "2.2"
++
++zstd = { version = "*", features = ["pkg-config"] }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/EmbarkStudios/cargo-about/compare/0.4.2...0.4.3
https://github.com/EmbarkStudios/cargo-about/blob/main/CHANGELOG.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
