### PR TITLE
gplaycli: 3.26 -> 3.29

### DIFF
--- a/pkgs/development/python-modules/gplaycli/default.nix
+++ b/pkgs/development/python-modules/gplaycli/default.nix
@@ -1,21 +1,21 @@
 { buildPythonPackage, lib, libffi, isPy3k, pyasn1, clint, ndg-httpsclient
-, protobuf, requests, args, gpapi, pyaxmlparser, setuptools, fetchFromGitHub
+, protobuf, requests, args, matlink-gpapi, pyaxmlparser, setuptools, fetchFromGitHub
 }:
 
 buildPythonPackage rec {
   pname = "gplaycli";
-  version = "3.26";
+  version = "3.29";
 
   src = fetchFromGitHub {
     owner = "matlink";
     repo = "gplaycli";
     rev = version;
-    sha256 = "188237d40q35dp5xs7hg4ybhvsyxi0bsqx5dk4ws9007n596in5f";
+    sha256 = "10gc1wr259z5hxyk834wyyggvyh82agfq0zp711s4jf334inp45r";
   };
 
   disabled = !isPy3k;
 
-  propagatedBuildInputs = [ libffi pyasn1 clint ndg-httpsclient protobuf requests args gpapi pyaxmlparser setuptools ];
+  propagatedBuildInputs = [ libffi pyasn1 clint ndg-httpsclient protobuf requests args matlink-gpapi pyaxmlparser setuptools ];
 
   meta = with lib; {
     homepage = "https://github.com/matlink/gplaycli";

--- a/pkgs/development/python-modules/matlink-gpapi/default.nix
+++ b/pkgs/development/python-modules/matlink-gpapi/default.nix
@@ -1,0 +1,35 @@
+{ buildPythonPackage
+, cryptography
+, fetchPypi
+, lib
+, pythonOlder
+, protobuf
+, pycryptodome
+, requests
+}:
+
+buildPythonPackage rec {
+  version = "0.4.4.5";
+  pname = "matlink-gpapi";
+  disabled = pythonOlder "3.3"; # uses shutil.which(), added in 3.3
+
+  src = fetchPypi {
+    inherit version pname;
+    sha256 = "0s45yb2xiq3pc1fh4bygfgly0fsjk5fkc4wckbckn3ddl7v7vz8c";
+  };
+
+  # package doesn't contain unit tests
+  # scripts in ./test require networking
+  doCheck = false;
+
+  pythonImportsCheck = [ "gpapi.googleplay" ];
+
+  propagatedBuildInputs = [ cryptography protobuf pycryptodome requests ];
+
+  meta = with lib; {
+    homepage = "https://github.com/NoMore201/googleplay-api";
+    license = licenses.gpl3Only;
+    description = "Google Play Unofficial Python API";
+    maintainers = with maintainers; [ schnusch ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4719,6 +4719,8 @@ in {
 
   mathlibtools = callPackage ../development/python-modules/mathlibtools { };
 
+  matlink-gpapi = callPackage ../development/python-modules/matlink-gpapi { };
+
   matplotlib = callPackage ../development/python-modules/matplotlib {
     stdenv = if stdenv.isDarwin then pkgs.clangStdenv else pkgs.stdenv;
     inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update. This has a dependency on [matlink-gpapi](https://pypi.org/project/matlink-gpapi/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
