### PR TITLE
golly: 3.3 -> 4.1

### DIFF
--- a/pkgs/applications/science/misc/golly/default.nix
+++ b/pkgs/applications/science/misc/golly/default.nix
@@ -1,31 +1,47 @@
-{lib, stdenv, fetchurl, wxGTK, perl, python2, zlib, libGLU, libGL, libX11}:
+{lib, stdenv, fetchurl, wxGTK, perl, python3, zlib, libGLU, libGL, libX11, SDL2}:
 stdenv.mkDerivation rec {
   pname = "golly";
-  version = "3.3";
+  version = "4.1";
 
   src = fetchurl {
-    sha256 = "1j3ksnar4rdam4xiyspgyrs1pifbvxfxkrn65brkwxpx39mpgzc8";
+    sha256 = "1j30dpzy6wh8fv1j2750hzc6wb0nhk83knl9fapccxgxw9n5lrbc";
     url="mirror://sourceforge/project/golly/golly/golly-${version}/golly-${version}-src.tar.gz";
   };
 
   buildInputs = [
-    wxGTK perl python2 zlib libGLU libGL libX11
+    wxGTK perl python3 zlib libGLU libGL libX11 SDL2
   ];
 
   setSourceRoot = ''
-    sourceRoot=$(echo */gui-wx/configure)
+    sourceRoot=$(echo */gui-wx/)
   '';
 
-  # Link against Python explicitly as it is needed for scripts
+  postPatch = ''
+    sed -e '/gollydir =/agollydir += "/../share/golly/";' -i wxgolly.cpp
+    grep share/golly wxgolly.cpp
+
+    sed -e 's@PYTHON_SHLIB@${python3}/lib/libpython3.so@' -i wxprefs.cpp
+    sed -e 's@PERL_SHLIB@'"$(find "${perl}/lib/" -name libperl.so)"'@' -i wxprefs.cpp
+    ! grep _SHLIB *.cpp
+
+    grep /lib/libpython wxprefs.cpp
+    grep /libperl wxprefs.cpp
+  '';
+
   makeFlags=[
-    "AM_LDFLAGS="
+    "-f" "makefile-gtk"
+    "ENABLE_SOUND=1" "ENABLE_PERL=1"
   ];
-  NIX_LDFLAGS="-l${python2.libPrefix} -lperl";
-  preConfigure=''
-    export NIX_LDFLAGS="$NIX_LDFLAGS -L$(dirname "$(find ${perl} -name libperl.so)")"
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE
-      -DPYTHON_SHLIB=$(basename "$(
-        readlink -f ${python2}/lib/libpython*.so)")"
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    cp ../golly ../bgolly "$out/bin"
+
+    mkdir -p "$out/share/doc/golly/"
+    cp ../docs/*  "$out/share/doc/golly/"
+
+    mkdir -p "$out/share/golly"
+    cp -r ../{Help,Patterns,Scripts,Rules} "$out/share/golly"
   '';
 
   meta = {

--- a/pkgs/build-support/upstream-updater/update-walker-service-specific.sh
+++ b/pkgs/build-support/upstream-updater/update-walker-service-specific.sh
@@ -1,5 +1,5 @@
 SF_redirect () {
-  redirect
+  redirect 99
   process 'http://[a-z]+[.]dl[.]sourceforge[.]net/' 'mirror://sourceforge/'
   process '[?].*' ''
 }

--- a/pkgs/build-support/upstream-updater/update-walker.sh
+++ b/pkgs/build-support/upstream-updater/update-walker.sh
@@ -69,8 +69,8 @@ version_link () {
 
 redirect () {
   CURRENT_URL="$(curl -I -L --max-redirs "${1:-99}" "$CURRENT_URL" | 
-    grep -E '^Location: ' | position_choice "${2:-999999}" "$3" |
-    sed -e 's/^Location: //; s/\r//')"
+    grep -E '^[Ll]ocation: ' | position_choice "${2:-999999}" "$3" |
+    sed -e 's/^[Ll]ocation: //; s/\r//')"
   echo "Redirected: $*"
   echo "URL: $CURRENT_URL" >&2
 }


### PR DESCRIPTION
###### Motivation for this change

Major upstream release

Seems not breaking; functionality tested, including scripts; will self-merge once CI passes

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
