### PR TITLE
nixos/dave: init

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -19,8 +19,16 @@
   </section>
   <section xml:id="sec-release-22.05-new-services">
     <title>New Services</title>
-    <para>
-    </para>
+    <itemizedlist spacing="compact">
+      <listitem>
+        <para>
+          <link xlink:href="https://github.com/micromata/dave">dave</link>,
+          a totally simple and very easy to configure stand alone WebDAV
+          server. Available as
+          <link linkend="opt-dave.enable">dave</link>.
+        </para>
+      </listitem>
+    </itemizedlist>
   </section>
   <section xml:id="sec-release-22.05-incompatibilities">
     <title>Backward Incompatibilities</title>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -8,6 +8,9 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 ## New Services {#sec-release-22.05-new-services}
 
+- [dave](https://github.com/micromata/dave), a totally simple and very easy to
+  configure stand alone WebDAV server. Available as [dave](#opt-dave.enable).
+
 ## Backward Incompatibilities {#sec-release-22.05-incompatibilities}
 
 - `pkgs.ghc` now refers to `pkgs.targetPackages.haskellPackages.ghc`.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -666,6 +666,7 @@
   ./services/monitoring/zabbix-proxy.nix
   ./services/monitoring/zabbix-server.nix
   ./services/network-filesystems/cachefilesd.nix
+  ./services/network-filesystems/dave.nix
   ./services/network-filesystems/davfs2.nix
   ./services/network-filesystems/drbd.nix
   ./services/network-filesystems/glusterfs.nix

--- a/nixos/modules/services/network-filesystems/dave.nix
+++ b/nixos/modules/services/network-filesystems/dave.nix
@@ -1,0 +1,159 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.dave;
+  settingsFormat = pkgs.formats.yaml { };
+in
+{
+  options.services.dave = {
+    enable = mkEnableOption "dave WebDAV server";
+
+    user = mkOption {
+      type = types.str;
+      default = "dave-webdav";
+      description = ''
+        User account under which dave runs.
+
+        <note><para>
+          If left as the default value this user will automatically be created
+          on system activation, otherwise you are responsible for
+          ensuring the user exists before the dave service starts.
+        </para></note>
+      '';
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "dave-webdav";
+      description = ''
+        Group under which dave runs.
+
+        <note><para>
+          If left as the default value this user will automatically be created
+          on system activation, otherwise you are responsible for
+          ensuring the user exists before the dave service starts.
+        </para></note>
+      '';
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to automatically open the specified ports in the firewall.
+      '';
+    };
+
+    settings = mkOption {
+      type = types.submodule {
+        freeformType = settingsFormat.type;
+
+        options = {
+          address = mkOption {
+            type = types.str;
+            default = "127.0.0.1";
+            description = "The bind address.";
+          };
+          port = mkOption {
+            type = types.port;
+            default = 8000;
+            description = "The listening port.";
+          };
+          dir = mkOption {
+            type = types.str;
+            description = "The provided base dir.";
+          };
+        };
+      };
+      default = { };
+      example = {
+        address = "127.0.0.1";
+        port = 8000;
+        dir = "/home/webdav";
+        prefix = "/webdav";
+        users = {
+          user = {
+            password =
+              "$2a$10$yITzSSNJZAdDZs8iVBQzkuZCzZ49PyjTiPIrmBUKUpB0pwX7eySvW";
+            subdir = "/user";
+          };
+          admin = {
+            password =
+              "$2a$10$DaWhagZaxWnWAOXY0a55.eaYccgtMOL3lGlqI3spqIBGyM0MD.EN6";
+          };
+        };
+      };
+      description = ''
+        Configuration for dave. See
+        <link xlink:href="https://github.com/micromata/dave/blob/master/Readme.md"/>
+        for supported values.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users = {
+      users = mkIf (cfg.user == "dave-webdav") {
+        dave-webdav = {
+          description = "dave webdav server user";
+          isSystemUser = true;
+          group = cfg.group;
+        };
+      };
+      groups = mkIf (cfg.group == "dave-webdav") { dave-webdav = { }; };
+    };
+
+    systemd =
+      let workDir = "/run/dave";
+      in
+      {
+        services.dave = {
+          description = "dave - The simple webdav server";
+          after = [ "network.target" ];
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig = {
+            ExecStart = "${pkgs.dave}/bin/dave";
+            WorkingDirectory = workDir;
+
+            User = cfg.user;
+            Group = cfg.group;
+
+            CapabilityBoundingSet = "";
+            LockPersonality = true;
+            MemoryDenyWriteExecute = true;
+            NoNewPrivileges = true;
+            PrivateDevices = true;
+            PrivateTmp = true;
+            ProcSubset = "pid";
+            ProtectClock = true;
+            ProtectControlGroups = true;
+            ProtectHostname = true;
+            ProtectKernelLogs = true;
+            ProtectKernelModules = true;
+            ProtectKernelTunables = true;
+            ProtectProc = "invisible";
+            ProtectSystem = "strict";
+            ReadWritePaths = [ cfg.settings.dir ];
+            RemoveIPC = true;
+            RestrictNamespaces = true;
+            RestrictRealtime = true;
+            RestrictSUIDSGID = true;
+            SystemCallArchitectures = "native";
+            SystemCallErrorNumber = "EPERM";
+            SystemCallFilter = "@system-service";
+          };
+        };
+
+        tmpfiles.rules = [
+          "L+ ${workDir}/config.yaml - - - - ${
+          settingsFormat.generate "dave-config" cfg.settings
+        }"
+        ];
+      };
+
+    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.settings.port ];
+  };
+}
+


### PR DESCRIPTION
###### Motivation for this change

WIP module for the dave WebDAV server.

Uses `/run/dave` as a working directory as `dave` requires the config file to be in its working directory. Maybe there is a more appropriate solution?

TODO:
 - [x] See if there is a better workaround for the `config.yaml` problem (ask upstream for ability to specify config location?)
 - [x] Harden systemd service
 - [ ] (Maybe) introduce a high-level option to automatically configure [TLS](https://github.com/micromata/dave#tls)
 - [x] Add release notes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
