### PR TITLE
python3Packages.colcon-common-extensions: init at 0.2.1

### DIFF
--- a/pkgs/development/python-modules/catkin_pkg/default.nix
+++ b/pkgs/development/python-modules/catkin_pkg/default.nix
@@ -1,0 +1,22 @@
+{ lib, fetchgit, buildPythonPackage, docutils, python-dateutil, pyparsing, mock, flake8 }:
+
+buildPythonPackage rec {
+  pname = "catkin_pkg";
+  version = "0.4.24";
+  src = fetchgit {
+    url = "https://github.com/ros-infrastructure/catkin_pkg.git";
+    rev = "refs/tags/${version}";
+    deepClone = true;
+    sha256 = "+M3lZbpVIsHilPxBvf5g1F+FK4XOs3paqQht99Q899k=";
+  };
+
+  propagatedBuildInputs = [ docutils python-dateutil pyparsing ];
+  checkInputs = [ mock flake8 ];
+
+  meta = with lib; {
+    homepage = "https://github.com/ros-infrastructure/catkin_pkg";
+    description = "Standalone Python library for the Catkin package system.";
+    maintainers = with maintainers; [ nkalupahana ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/colcon-argcomplete/default.nix
+++ b/pkgs/development/python-modules/colcon-argcomplete/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchgit, buildPythonPackage, argcomplete, colcon-core }:
+
+buildPythonPackage rec {
+  pname = "colcon-argcomplete";
+  version = "0.3.3";
+  src = fetchgit {
+    url = "https://github.com/colcon/colcon-argcomplete.git";
+    rev = "refs/tags/${version}";
+    deepClone = true;
+    sha256 = "3I/4ykJzcYXVatwjuDa8JyqWFbcVim7xp14S4UScRtA=";
+  };
+
+  propagatedBuildInputs = [ argcomplete colcon-core ];
+
+  # Tests are disabled because the only
+  # tests are flake8 and spellcheck, which aren't functional tests
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/colcon/colcon-argcomplete";
+    description = "An extension for colcon-core to provide command line completion using argcomplete.";
+    maintainers = with maintainers; [ nkalupahana ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/colcon-bash/default.nix
+++ b/pkgs/development/python-modules/colcon-bash/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchgit, buildPythonPackage, colcon-core }:
+
+buildPythonPackage rec {
+  pname = "colcon-bash";
+  version = "0.4.2";
+  src = fetchgit {
+    url = "https://github.com/colcon/colcon-bash.git";
+    rev = "refs/tags/${version}";
+    deepClone = true;
+    sha256 = "2VLwcEPuuLYd9WwdrPV7qQYOjTV6hBHdS4PRj/G/CYA=";
+  };
+
+  propagatedBuildInputs = [ colcon-core ];
+
+  # Tests are disabled because the only
+  # tests are flake8 and spellcheck, which aren't functional tests
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/colcon/colcon-bash";
+    description = "An extension for colcon-core to provide Bash scripts.";
+    maintainers = with maintainers; [ nkalupahana ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/colcon-cd/default.nix
+++ b/pkgs/development/python-modules/colcon-cd/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchgit, buildPythonPackage, colcon-core, colcon-package-information }:
+
+buildPythonPackage rec {
+  pname = "colcon-cd";
+  version = "0.1.1";
+  src = fetchgit {
+    url = "https://github.com/colcon/colcon-cd.git";
+    rev = "refs/tags/${version}";
+    deepClone = true;
+    sha256 = "pL+PSgHbfLmoGsHiQnPd3y/fW8xjy1DfFJdow5sXgG4=";
+  };
+
+  propagatedBuildInputs = [ colcon-core colcon-package-information ];
+
+  # Run only functional test
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/colcon/colcon-cd";
+    description = "A shell function for colcon-core to change the current working directory.";
+    maintainers = with maintainers; [ nkalupahana ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/colcon-cmake/default.nix
+++ b/pkgs/development/python-modules/colcon-cmake/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchgit, buildPythonPackage, colcon-core, colcon-library-path, colcon-test-result, pytest }:
+
+buildPythonPackage rec {
+  pname = "colcon-cmake";
+  version = "0.2.26";
+  src = fetchgit {
+    url = "https://github.com/colcon/colcon-cmake.git";
+    rev = "refs/tags/${version}";
+    deepClone = true;
+    sha256 = "H8jKNTXDd3HW8FLejgUlmhW1DQXXrZ/HOcHTrhol3ms=";
+  };
+
+  propagatedBuildInputs = [ colcon-core colcon-library-path colcon-test-result ];
+
+  # Run only functional test
+  checkInputs = [ pytest ];
+  checkPhase = "pytest test/test_parse_cmake_version.py";
+
+  meta = with lib; {
+    homepage = "https://github.com/colcon/colcon-cmake";
+    description = "An extension for colcon-core to support CMake projects.";
+    maintainers = with maintainers; [ nkalupahana ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/colcon-common-extensions/default.nix
+++ b/pkgs/development/python-modules/colcon-common-extensions/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchgit, buildPythonPackage, colcon-argcomplete, colcon-bash, colcon-cd, colcon-cmake, colcon-core, colcon-defaults, colcon-devtools, colcon-library-path, colcon-metadata, colcon-notification, colcon-output, colcon-package-information, colcon-package-selection, colcon-parallel-executor, colcon-powershell, colcon-python-setup-py, colcon-recursive-crawl, colcon-ros, colcon-test-result, colcon-zsh }:
+
+buildPythonPackage rec {
+  pname = "colcon-common-extensions";
+  version = "0.2.1";
+  src = fetchgit {
+    url = "https://github.com/colcon/colcon-common-extensions.git";
+    rev = "refs/tags/${version}";
+    deepClone = true;
+    sha256 = "IK9vsCa1xor5Ztas2ZH1GU06OLHu7U92R5W4kynJQCc=";
+  };
+
+  propagatedBuildInputs = [ colcon-argcomplete colcon-bash colcon-cd colcon-cmake colcon-core colcon-defaults colcon-devtools colcon-library-path colcon-metadata colcon-notification colcon-output colcon-package-information colcon-package-selection colcon-parallel-executor colcon-powershell colcon-python-setup-py colcon-recursive-crawl colcon-ros colcon-test-result colcon-zsh ];
+
+  # There are no tests.
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/colcon/colcon-common-extensions";
+    description = "A meta package aggregating colcon-core as well as a set of common extensions.";
+    maintainers = with maintainers; [ nkalupahana ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/colcon-core/default.nix
+++ b/pkgs/development/python-modules/colcon-core/default.nix
@@ -1,0 +1,28 @@
+{ lib, fetchgit, buildPythonPackage, coloredlogs, empy, pytest, pytest-cov, pytest-repeat, pytest-rerunfailures, distlib, mock, flake8, pydocstyle }:
+
+buildPythonPackage rec {
+  pname = "colcon-core";
+  version = "0.6.1";
+  src = fetchgit {
+    url = "https://github.com/colcon/colcon-core.git";
+    rev = "refs/tags/${version}";
+    deepClone = true;
+    sha256 = "/T4wm/GAscYNoCeDWM/Fg1cznzk0bb0c2saIA4HTIbQ=";
+  };
+  propagatedBuildInputs = [ coloredlogs empy distlib pytest pytest-repeat pytest-cov pytest-rerunfailures pydocstyle ];
+
+  postPatch = ''
+    # Remove test that relies on esoteric spell checker
+    # that isn't important for testing code functionality
+    rm test/test_spell_check.py;
+  '';
+
+  checkInputs = [ pytest mock flake8 ];
+  checkPhase = "pytest test";
+  meta = with lib; {
+    homepage = "https://github.com/colcon/colcon-core";
+    description = "Command line tool to build sets of software packages.";
+    maintainers = with maintainers; [ nkalupahana ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/colcon-defaults/default.nix
+++ b/pkgs/development/python-modules/colcon-defaults/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchgit, buildPythonPackage, colcon-core, pyyaml }:
+
+buildPythonPackage rec {
+  pname = "colcon-defaults";
+  version = "0.2.5";
+  src = fetchgit {
+    url = "https://github.com/colcon/colcon-defaults.git";
+    rev = "refs/tags/${version}";
+    deepClone = true;
+    sha256 = "R1gUlmMu5QDl0FX/6GzgjijRXXVE3KOi5jw6l12QlZI=";
+  };
+
+  propagatedBuildInputs = [ colcon-core pyyaml ];
+
+  # Tests are disabled because the only
+  # tests are flake8 and spellcheck, which aren't functional tests
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/colcon/colcon-defaults";
+    description = "An extension for colcon-core to provide custom default values for the command line arguments from a configuration file.";
+    maintainers = with maintainers; [ nkalupahana ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/colcon-devtools/default.nix
+++ b/pkgs/development/python-modules/colcon-devtools/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchgit, buildPythonPackage, colcon-core }:
+
+buildPythonPackage rec {
+  pname = "colcon-devtools";
+  version = "0.2.2";
+  src = fetchgit {
+    url = "https://github.com/colcon/colcon-devtools.git";
+    rev = "refs/tags/${version}";
+    deepClone = true;
+    sha256 = "fvoBWmel4m0vdO4tkltYAe4M14NhsLRp2oKUGroKFSQ=";
+  };
+
+  propagatedBuildInputs = [ colcon-core ];
+
+  # Tests are disabled because the only
+  # tests are flake8 and spellcheck, which aren't functional tests
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/colcon/colcon-devtools";
+    description = "An extension for colcon-core to provide information about the plugin system.";
+    maintainers = with maintainers; [ nkalupahana ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/colcon-library-path/default.nix
+++ b/pkgs/development/python-modules/colcon-library-path/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchgit, buildPythonPackage, colcon-core }:
+
+buildPythonPackage rec {
+  pname = "colcon-library-path";
+  version = "0.2.1";
+  src = fetchgit {
+    url = "https://github.com/colcon/colcon-library-path.git";
+    rev = "refs/tags/${version}";
+    deepClone = true;
+    sha256 = "luLecQcF+saB1JlIuCd6qXVyE9EAYvNjIRLaM7ECWb8=";
+  };
+
+  propagatedBuildInputs = [ colcon-core ];
+
+  # Tests are disabled because the only
+  # tests are flake8 and spellcheck, which aren't functional tests
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/colcon/colcon-library-path";
+    description = "An extension for colcon-core to set an environment variable to find shared libraries at runtime.";
+    maintainers = with maintainers; [ nkalupahana ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/colcon-metadata/default.nix
+++ b/pkgs/development/python-modules/colcon-metadata/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchgit, buildPythonPackage, colcon-core, pyyaml }:
+
+buildPythonPackage rec {
+  pname = "colcon-metadata";
+  version = "0.2.5";
+  src = fetchgit {
+    url = "https://github.com/colcon/colcon-metadata.git";
+    rev = "refs/tags/${version}";
+    deepClone = true;
+    sha256 = "pNbE+KVkVln9rLoJH7jH+s6f8y8a/v0YRIeIRxzsEI8=";
+  };
+
+  propagatedBuildInputs = [ colcon-core pyyaml ];
+
+  # Tests are disabled because the only
+  # tests are flake8 and spellcheck, which aren't functional tests
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/colcon/colcon-metadata";
+    description = "An extension for colcon-core to fetch and manage package metadata from repositories.";
+    maintainers = with maintainers; [ nkalupahana ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/colcon-notification/default.nix
+++ b/pkgs/development/python-modules/colcon-notification/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchgit, buildPythonPackage, colcon-core, notify2 }:
+
+buildPythonPackage rec {
+  pname = "colcon-notification";
+  version = "0.2.13";
+  src = fetchgit {
+    url = "https://github.com/colcon/colcon-notification.git";
+    rev = "refs/tags/${version}";
+    deepClone = true;
+    sha256 = "jCweisrItZnPmLiyns5F9n1WouzwabYwsuHs4RvJkhU=";
+  };
+
+  propagatedBuildInputs = [ colcon-core notify2 ];
+
+  # Tests are disabled because the only
+  # tests are flake8 and spellcheck, which aren't functional tests
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/colcon/colcon-notification";
+    description = "An extension for colcon-core to provide status notifications.";
+    maintainers = with maintainers; [ nkalupahana ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/colcon-output/default.nix
+++ b/pkgs/development/python-modules/colcon-output/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchgit, buildPythonPackage, colcon-core }:
+
+buildPythonPackage rec {
+  pname = "colcon-output";
+  version = "0.2.12";
+  src = fetchgit {
+    url = "https://github.com/colcon/colcon-output.git";
+    rev = "refs/tags/${version}";
+    deepClone = true;
+    sha256 = "FkykRkYgem7x7ey3NFOmlnX6sAPflqpVeYSbbYkbn7I=";
+  };
+
+  propagatedBuildInputs = [ colcon-core ];
+
+  # Tests are disabled because the only
+  # tests are flake8 and spellcheck, which aren't functional tests
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/colcon/colcon-output";
+    description = "An extension for colcon-core to customize the output in various ways.";
+    maintainers = with maintainers; [ nkalupahana ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/colcon-package-information/default.nix
+++ b/pkgs/development/python-modules/colcon-package-information/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchgit, buildPythonPackage, colcon-core }:
+
+buildPythonPackage rec {
+  pname = "colcon-package-information";
+  version = "0.3.3";
+  src = fetchgit {
+    url = "https://github.com/colcon/colcon-package-information.git";
+    rev = "refs/tags/${version}";
+    deepClone = true;
+    sha256 = "f3MHXS2B1gM6CUpC6C6uPoJx+FPWznClJ4HoTM1ch1k=";
+  };
+
+  propagatedBuildInputs = [ colcon-core ];
+
+  # Tests are disabled because the only
+  # tests are flake8 and spellcheck, which aren't functional tests
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/colcon/colcon-package-information";
+    description = "An extension for colcon-core to provide information about the packages.";
+    maintainers = with maintainers; [ nkalupahana ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/colcon-package-selection/default.nix
+++ b/pkgs/development/python-modules/colcon-package-selection/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchgit, buildPythonPackage, colcon-core }:
+
+buildPythonPackage rec {
+  pname = "colcon-package-selection";
+  version = "0.2.10";
+  src = fetchgit {
+    url = "https://github.com/colcon/colcon-package-selection.git";
+    rev = "refs/tags/${version}";
+    deepClone = true;
+    sha256 = "KhvvKs5QUBthc5Zi7IqCcFAb5o1LjtOnYfN7fwj7s5k=";
+  };
+
+  propagatedBuildInputs = [ colcon-core ];
+
+  # Tests are disabled because the only
+  # tests are flake8 and spellcheck, which aren't functional tests
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/colcon/colcon-package-selection";
+    description = "An extension for colcon-core to select a subset of packages for processing.";
+    maintainers = with maintainers; [ nkalupahana ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/colcon-parallel-executor/default.nix
+++ b/pkgs/development/python-modules/colcon-parallel-executor/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchgit, buildPythonPackage, colcon-core }:
+
+buildPythonPackage rec {
+  pname = "colcon-parallel-executor";
+  version = "0.2.4";
+  src = fetchgit {
+    url = "https://github.com/colcon/colcon-parallel-executor.git";
+    rev = "refs/tags/${version}";
+    deepClone = true;
+    sha256 = "Ou0dEAgaHyzVqRxyPAyvIbG8pLqImbCybtLwNgZyTKs=";
+  };
+
+  propagatedBuildInputs = [ colcon-core ];
+
+  # Tests are disabled because the only
+  # tests are flake8 and spellcheck, which aren't functional tests
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/colcon/colcon-parallel-executor";
+    description = "An extension for colcon-core to process packages in parallel.";
+    maintainers = with maintainers; [ nkalupahana ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/colcon-pkg-config/default.nix
+++ b/pkgs/development/python-modules/colcon-pkg-config/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchgit, buildPythonPackage, colcon-core }:
+
+buildPythonPackage rec {
+  pname = "colcon-pkg-config";
+  version = "0.1.0";
+  src = fetchgit {
+    url = "https://github.com/colcon/colcon-pkg-config.git";
+    rev = "refs/tags/${version}";
+    deepClone = true;
+    sha256 = "I+ttyGs9cfI6fuLsrlhmPWagU5DxamAAyGbfdfCH5d4=";
+  };
+
+  propagatedBuildInputs = [ colcon-core ];
+
+  # Tests are disabled because the only
+  # tests are flake8 and spellcheck, which aren't functional tests
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/colcon/colcon-pkg-config";
+    description = "An extension for colcon-core to set an environment variable to find pkg-config files.";
+    maintainers = with maintainers; [ nkalupahana ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/colcon-powershell/default.nix
+++ b/pkgs/development/python-modules/colcon-powershell/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchgit, buildPythonPackage, colcon-core }:
+
+buildPythonPackage rec {
+  pname = "colcon-powershell";
+  version = "0.3.6";
+  src = fetchgit {
+    url = "https://github.com/colcon/colcon-powershell.git";
+    rev = "refs/tags/${version}";
+    deepClone = true;
+    sha256 = "AOnW+mQLF32b5DrkYvuDIX6RxFB3ywbc+GeaWW/rehs=";
+  };
+
+  propagatedBuildInputs = [ colcon-core ];
+
+  # Tests are disabled because the only
+  # tests are flake8 and spellcheck, which aren't functional tests
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/colcon/colcon-powershell";
+    description = "An extension for colcon-core to provide PowerShell scripts.";
+    maintainers = with maintainers; [ nkalupahana ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/colcon-python-setup-py/default.nix
+++ b/pkgs/development/python-modules/colcon-python-setup-py/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchgit, buildPythonPackage, colcon-core }:
+
+buildPythonPackage rec {
+  pname = "colcon-python-setup-py";
+  version = "0.2.7";
+  src = fetchgit {
+    url = "https://github.com/colcon/colcon-python-setup-py.git";
+    rev = "refs/tags/${version}";
+    deepClone = true;
+    sha256 = "Rhvi5CcEAeZ4q1Iicj0GYNf7mfy4TbOXJiawgVYJ854=";
+  };
+
+  propagatedBuildInputs = [ colcon-core ];
+
+  # Tests are disabled because the only
+  # tests are flake8 and spellcheck, which aren't functional tests
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/colcon/colcon-python-setup-py";
+    description = "An extension for colcon-core to identify packages with a setup.py file.";
+    maintainers = with maintainers; [ nkalupahana ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/colcon-recursive-crawl/default.nix
+++ b/pkgs/development/python-modules/colcon-recursive-crawl/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchgit, buildPythonPackage, colcon-core }:
+
+buildPythonPackage rec {
+  pname = "colcon-recursive-crawl";
+  version = "0.2.1";
+  src = fetchgit {
+    url = "https://github.com/colcon/colcon-recursive-crawl.git";
+    rev = "refs/tags/${version}";
+    deepClone = true;
+    sha256 = "idEncvPl6hFp650yV16lhApADmCK+qh1UM8XcviwUMQ=";
+  };
+
+  propagatedBuildInputs = [ colcon-core ];
+
+  # Tests are disabled because the only
+  # tests are flake8 and spellcheck, which aren't functional tests
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/colcon/colcon-recursive-crawl";
+    description = "An extension for colcon-core to recursively crawl for packages.";
+    maintainers = with maintainers; [ nkalupahana ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/colcon-ros/default.nix
+++ b/pkgs/development/python-modules/colcon-ros/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchgit, buildPythonPackage, pytest, colcon-core, colcon-recursive-crawl, catkin_pkg, colcon-pkg-config, colcon-cmake, colcon-python-setup-py }:
+
+buildPythonPackage rec {
+  pname = "colcon-ros";
+  version = "0.3.21";
+  src = fetchgit {
+    url = "https://github.com/colcon/colcon-ros.git";
+    rev = "refs/tags/${version}";
+    deepClone = true;
+    sha256 = "BnlXCO4yTtmyMfvIK8pj/M2NAP1CpGbk77PFsNlwlf0=";
+  };
+
+  propagatedBuildInputs = [ colcon-core colcon-recursive-crawl catkin_pkg colcon-pkg-config colcon-cmake colcon-python-setup-py ];
+
+  # Run only functional test
+  checkInputs = [ pytest ];
+  checkPhase = "pytest test/test_dependency_metadata.py";
+
+  meta = with lib; {
+    homepage = "https://github.com/colcon/colcon-ros";
+    description = "An extension for colcon-core to support ROS packages.";
+    maintainers = with maintainers; [ nkalupahana ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/colcon-test-result/default.nix
+++ b/pkgs/development/python-modules/colcon-test-result/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchgit, buildPythonPackage, colcon-core }:
+
+buildPythonPackage rec {
+  pname = "colcon-test-result";
+  version = "0.3.8";
+  src = fetchgit {
+    url = "https://github.com/colcon/colcon-test-result.git";
+    rev = "refs/tags/${version}";
+    deepClone = true;
+    sha256 = "PJ6I+kMcJJcgOd3ILLLfZit8dPoOebYtha5lcvQDt8o=";
+  };
+
+  propagatedBuildInputs = [ colcon-core ];
+
+  # Tests are disabled because the only
+  # tests are flake8 and spellcheck, which aren't functional tests
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/colcon/colcon-test-result";
+    description = "An extension for colcon-core to provide information about the test results.";
+    maintainers = with maintainers; [ nkalupahana ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/colcon-zsh/default.nix
+++ b/pkgs/development/python-modules/colcon-zsh/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchgit, buildPythonPackage, colcon-core }:
+
+buildPythonPackage rec {
+  pname = "colcon-zsh";
+  version = "0.4.0";
+  src = fetchgit {
+    url = "https://github.com/colcon/colcon-zsh.git";
+    rev = "refs/tags/${version}";
+    deepClone = true;
+    sha256 = "vQJdQMGQGyaLLU6ZctTcxLWFCETi1TiPLGUQPQrVAOk=";
+  };
+
+  propagatedBuildInputs = [ colcon-core ];
+
+  # Tests are disabled because the only
+  # tests are flake8 and spellcheck, which aren't functional tests
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/colcon/colcon-zsh";
+    description = "An extension for colcon-core to provide Z shell scripts.";
+    maintainers = with maintainers; [ nkalupahana ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1697,6 +1697,8 @@ in {
 
   colcon-package-selection = callPackage ../development/python-modules/colcon-package-selection { };
 
+  colcon-parallel-executor = callPackage ../development/python-modules/colcon-parallel-executor { };
+
   collections-extended = callPackage ../development/python-modules/collections-extended { };
 
   colorama = callPackage ../development/python-modules/colorama { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1687,6 +1687,8 @@ in {
 
   colcon-library-path = callPackage ../development/python-modules/colcon-library-path { };
 
+  colcon-metadata = callPackage ../development/python-modules/colcon-metadata { };
+
   collections-extended = callPackage ../development/python-modules/collections-extended { };
 
   colorama = callPackage ../development/python-modules/colorama { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1713,6 +1713,8 @@ in {
 
   colcon-test-result = callPackage ../development/python-modules/colcon-test-result { };
 
+  colcon-zsh = callPackage ../development/python-modules/colcon-zsh { };
+
   collections-extended = callPackage ../development/python-modules/collections-extended { };
 
   colorama = callPackage ../development/python-modules/colorama { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1689,6 +1689,8 @@ in {
 
   colcon-metadata = callPackage ../development/python-modules/colcon-metadata { };
 
+  colcon-notification = callPackage ../development/python-modules/colcon-notification { };
+
   collections-extended = callPackage ../development/python-modules/collections-extended { };
 
   colorama = callPackage ../development/python-modules/colorama { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1699,6 +1699,8 @@ in {
 
   colcon-parallel-executor = callPackage ../development/python-modules/colcon-parallel-executor { };
 
+  colcon-pkg-config = callPackage ../development/python-modules/colcon-pkg-config { };
+
   colcon-powershell = callPackage ../development/python-modules/colcon-powershell { };
 
   colcon-python-setup-py = callPackage ../development/python-modules/colcon-python-setup-py { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1709,6 +1709,8 @@ in {
 
   colcon-recursive-crawl = callPackage ../development/python-modules/colcon-recursive-crawl { };
 
+  colcon-test-result = callPackage ../development/python-modules/colcon-test-result { };
+
   collections-extended = callPackage ../development/python-modules/collections-extended { };
 
   colorama = callPackage ../development/python-modules/colorama { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1695,6 +1695,8 @@ in {
 
   colcon-package-information = callPackage ../development/python-modules/colcon-package-information { };
 
+  colcon-package-selection = callPackage ../development/python-modules/colcon-package-selection { };
+
   collections-extended = callPackage ../development/python-modules/collections-extended { };
 
   colorama = callPackage ../development/python-modules/colorama { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1681,6 +1681,8 @@ in {
 
   colcon-bash = callPackage ../development/python-modules/colcon-bash { };
 
+  colcon-cmake = callPackage ../development/python-modules/colcon-cmake { };
+  
   colcon-core = callPackage ../development/python-modules/colcon-core { };
 
   colcon-defaults = callPackage ../development/python-modules/colcon-defaults { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1675,6 +1675,8 @@ in {
 
   colander = callPackage ../development/python-modules/colander { };
 
+  colcon-core = callPackage ../development/python-modules/colcon-core { };
+
   collections-extended = callPackage ../development/python-modules/collections-extended { };
 
   colorama = callPackage ../development/python-modules/colorama { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1681,6 +1681,8 @@ in {
 
   colcon-bash = callPackage ../development/python-modules/colcon-bash { };
 
+  colcon-cd = callPackage ../development/python-modules/colcon-cd { };
+
   colcon-cmake = callPackage ../development/python-modules/colcon-cmake { };
   
   colcon-core = callPackage ../development/python-modules/colcon-core { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1699,6 +1699,8 @@ in {
 
   colcon-parallel-executor = callPackage ../development/python-modules/colcon-parallel-executor { };
 
+  colcon-powershell = callPackage ../development/python-modules/colcon-powershell { };
+
   collections-extended = callPackage ../development/python-modules/collections-extended { };
 
   colorama = callPackage ../development/python-modules/colorama { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1417,6 +1417,8 @@ in {
 
   catboost = callPackage ../development/python-modules/catboost { };
 
+  catkin_pkg = callPackage ../development/python-modules/catkin_pkg { };
+
   cattrs = callPackage ../development/python-modules/cattrs { };
 
   cbeams = callPackage ../misc/cbeams { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1683,6 +1683,8 @@ in {
 
   colcon-defaults = callPackage ../development/python-modules/colcon-defaults { };
 
+  colcon-devtools = callPackage ../development/python-modules/colcon-devtools { };
+
   collections-extended = callPackage ../development/python-modules/collections-extended { };
 
   colorama = callPackage ../development/python-modules/colorama { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1701,6 +1701,8 @@ in {
 
   colcon-powershell = callPackage ../development/python-modules/colcon-powershell { };
 
+  colcon-python-setup-py = callPackage ../development/python-modules/colcon-python-setup-py { };
+
   collections-extended = callPackage ../development/python-modules/collections-extended { };
 
   colorama = callPackage ../development/python-modules/colorama { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1713,6 +1713,8 @@ in {
 
   colcon-recursive-crawl = callPackage ../development/python-modules/colcon-recursive-crawl { };
 
+  colcon-ros = callPackage ../development/python-modules/colcon-ros { };
+
   colcon-test-result = callPackage ../development/python-modules/colcon-test-result { };
 
   colcon-zsh = callPackage ../development/python-modules/colcon-zsh { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1685,6 +1685,8 @@ in {
 
   colcon-devtools = callPackage ../development/python-modules/colcon-devtools { };
 
+  colcon-library-path = callPackage ../development/python-modules/colcon-library-path { };
+
   collections-extended = callPackage ../development/python-modules/collections-extended { };
 
   colorama = callPackage ../development/python-modules/colorama { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1684,7 +1684,9 @@ in {
   colcon-cd = callPackage ../development/python-modules/colcon-cd { };
 
   colcon-cmake = callPackage ../development/python-modules/colcon-cmake { };
-  
+
+  colcon-common-extensions = callPackage ../development/python-modules/colcon-common-extensions { };
+
   colcon-core = callPackage ../development/python-modules/colcon-core { };
 
   colcon-defaults = callPackage ../development/python-modules/colcon-defaults { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1677,6 +1677,8 @@ in {
 
   colcon-argcomplete = callPackage ../development/python-modules/colcon-argcomplete { };
 
+  colcon-bash = callPackage ../development/python-modules/colcon-bash { };
+
   colcon-core = callPackage ../development/python-modules/colcon-core { };
 
   collections-extended = callPackage ../development/python-modules/collections-extended { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1681,6 +1681,8 @@ in {
 
   colcon-core = callPackage ../development/python-modules/colcon-core { };
 
+  colcon-defaults = callPackage ../development/python-modules/colcon-defaults { };
+
   collections-extended = callPackage ../development/python-modules/collections-extended { };
 
   colorama = callPackage ../development/python-modules/colorama { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1691,6 +1691,8 @@ in {
 
   colcon-notification = callPackage ../development/python-modules/colcon-notification { };
 
+  colcon-output = callPackage ../development/python-modules/colcon-output { };
+
   collections-extended = callPackage ../development/python-modules/collections-extended { };
 
   colorama = callPackage ../development/python-modules/colorama { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1693,6 +1693,8 @@ in {
 
   colcon-output = callPackage ../development/python-modules/colcon-output { };
 
+  colcon-package-information = callPackage ../development/python-modules/colcon-package-information { };
+
   collections-extended = callPackage ../development/python-modules/collections-extended { };
 
   colorama = callPackage ../development/python-modules/colorama { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1675,6 +1675,8 @@ in {
 
   colander = callPackage ../development/python-modules/colander { };
 
+  colcon-argcomplete = callPackage ../development/python-modules/colcon-argcomplete { };
+
   colcon-core = callPackage ../development/python-modules/colcon-core { };
 
   collections-extended = callPackage ../development/python-modules/collections-extended { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1703,6 +1703,8 @@ in {
 
   colcon-python-setup-py = callPackage ../development/python-modules/colcon-python-setup-py { };
 
+  colcon-recursive-crawl = callPackage ../development/python-modules/colcon-recursive-crawl { };
+
   collections-extended = callPackage ../development/python-modules/collections-extended { };
 
   colorama = callPackage ../development/python-modules/colorama { };


### PR DESCRIPTION
###### Motivation for this change

`colcon` is the build system for ROS2 (Robot Operating System), which is the most popular open source robotics framework. In order to build ROS packages, I need `colcon-common-extensions`, a metapackage with `colcon-core` and a set of extensions that make it usable for cross-platform development.

Although this looks like a lot of packages, this is just colcon core + default extensions for robotics + metapackage, so they're all very closely related.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
