### PR TITLE
nodePackages: move to nodejs-14_x, regenerate

### DIFF
--- a/pkgs/development/node-packages/composition.nix
+++ b/pkgs/development/node-packages/composition.nix
@@ -2,7 +2,7 @@
 
 {pkgs ? import <nixpkgs> {
     inherit system;
-  }, system ? builtins.currentSystem, nodejs ? pkgs."nodejs-12_x"}:
+  }, system ? builtins.currentSystem, nodejs ? pkgs."nodejs-14_x"}:
 
 let
   nodeEnv = import ./node-env.nix {

--- a/pkgs/development/node-packages/generate.sh
+++ b/pkgs/development/node-packages/generate.sh
@@ -3,7 +3,7 @@ set -eu -o pipefail
 cd "$( dirname "${BASH_SOURCE[0]}" )"
 node2nix=$(nix-build ../../.. -A nodePackages.node2nix)
 rm -f ./node-env.nix
-${node2nix}/bin/node2nix -i node-packages.json -o node-packages.nix -c composition.nix
+${node2nix}/bin/node2nix -i node-packages.json -o node-packages.nix -c composition.nix --pkg-name nodejs-14_x
 # using --no-out-link in nix-build argument would cause the
 # gc to run before the script finishes
 # which would cause a failure

--- a/pkgs/development/node-packages/generate.sh
+++ b/pkgs/development/node-packages/generate.sh
@@ -1,9 +1,20 @@
 #!/usr/bin/env bash
+
 set -eu -o pipefail
+
 cd "$( dirname "${BASH_SOURCE[0]}" )"
+
 node2nix=$(nix-build ../../.. -A nodePackages.node2nix)
+
 rm -f ./node-env.nix
-${node2nix}/bin/node2nix -i node-packages.json -o node-packages.nix -c composition.nix --pkg-name nodejs-14_x
+
+# Track the latest active nodejs LTS here: https://nodejs.org/en/about/releases/
+${node2nix}/bin/node2nix \
+    -i node-packages.json \
+    -o node-packages.nix \
+    -c composition.nix \
+    --pkg-name nodejs-14_x
+
 # using --no-out-link in nix-build argument would cause the
 # gc to run before the script finishes
 # which would cause a failure

--- a/pkgs/misc/vscode-extensions/rust-analyzer/default.nix
+++ b/pkgs/misc/vscode-extensions/rust-analyzer/default.nix
@@ -6,6 +6,8 @@
 , nodePackages
 , moreutils
 , esbuild
+, pkg-config
+, libsecret
 , setDefaultServerPath ? true
 }:
 
@@ -22,7 +24,11 @@ let
 
     releaseTag = rust-analyzer.version;
 
-    nativeBuildInputs = [ jq moreutils esbuild ];
+    nativeBuildInputs = [
+      jq moreutils esbuild
+      # Required by `keytar`, which is a dependency of `vsce`.
+      pkg-config libsecret
+    ];
 
     # Follows https://github.com/rust-analyzer/rust-analyzer/blob/41949748a6123fd6061eb984a47f4fe780525e63/xtask/src/dist.rs#L39-L65
     postInstall = ''
@@ -34,7 +40,9 @@ let
       ' package.json | sponge package.json
 
       mkdir -p $vsix
-      npx vsce package -o $vsix/${pname}.zip
+      # vsce ask for continue due to missing LICENSE.md
+      # Should be removed after https://github.com/rust-analyzer/rust-analyzer/commit/acd5c1f19bf7246107aaae7b6fe3f676a516c6d2
+      echo y | npx vsce package -o $vsix/${pname}.zip
     '';
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
We should probably try to track the active LTS release of NodeJS for the package set, if that works.

If not, then we should at least move to nodejs 14.x, since 12.x will be EOL before the 22.05 release.

I added an optioniated reformatting commit for `generate.sh`, but that's totally optional and I don't mind if we don't want to reformat things unnecesarily.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
