### PR TITLE
pythonPackages.nose-randomly: fix tests on Darwin

### DIFF
--- a/pkgs/development/python-modules/nose-randomly/default.nix
+++ b/pkgs/development/python-modules/nose-randomly/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildPythonPackage
 , fetchPypi
 , nose
@@ -16,9 +17,10 @@ buildPythonPackage rec {
 
   checkInputs = [ numpy nose ];
 
-  checkPhase = ''
-    nosetests
-  '';
+  checkPhase = if stdenv.isDarwin then ''
+    # Work around "OSError: AF_UNIX path too long"
+    TMPDIR="/tmp" nosetests
+  '' else "nosetests";
 
   meta = with lib; {
     description = "Nose plugin to randomly order tests and control random.seed";

--- a/pkgs/development/python-modules/nose-randomly/default.nix
+++ b/pkgs/development/python-modules/nose-randomly/default.nix
@@ -20,7 +20,9 @@ buildPythonPackage rec {
   checkPhase = if stdenv.isDarwin then ''
     # Work around "OSError: AF_UNIX path too long"
     TMPDIR="/tmp" nosetests
-  '' else "nosetests";
+  '' else ''
+    nosetests
+  '';
 
   meta = with lib; {
     description = "Nose plugin to randomly order tests and control random.seed";


### PR DESCRIPTION
###### Motivation for this change

Similar to https://github.com/NixOS/nixpkgs/pull/145276 and a few others before that, the tmp path is too long on macOS.

I'd open an issue upstream, but the repo is archived.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).