### PR TITLE
k6: 0.31.1 -> 0.35.0

### DIFF
--- a/pkgs/development/tools/k6/default.nix
+++ b/pkgs/development/tools/k6/default.nix
@@ -1,25 +1,31 @@
-{ lib, buildGoPackage, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "k6";
-  version = "0.31.1";
-
-  goPackagePath = "github.com/loadimpact/k6";
+  version = "0.35.0";
 
   src = fetchFromGitHub {
-    owner = "loadimpact";
+    owner = "grafana";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-wngOG0uSNoUU+88oShDpCgPpzuevzJxcwzSzWS3PzAw=";
+    sha256 = "sha256-mSVU/0OdlEfGWxO6Gn/Ji7k2pMO5jWTfxFujN08bZjU=";
   };
 
   subPackages = [ "./" ];
 
+  vendorSha256 = null;
+
+  doCheck = true;
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/k6 version | grep ${version} > /dev/null
+  '';
+
   meta = with lib; {
     description = "A modern load testing tool, using Go and JavaScript";
     homepage = "https://k6.io/";
-    changelog = "https://github.com/loadimpact/k6/releases/tag/v${version}";
+    changelog = "https://github.com/grafana/k6/releases/tag/v${version}";
     license = licenses.agpl3Plus;
-    maintainers = with maintainers; [ offline ];
+    maintainers = with maintainers; [ offline bryanasdev000 ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update to the latest release, also add myself as maintainer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
