### PR TITLE
julia: switch from python2 to python3

### DIFF
--- a/pkgs/development/compilers/julia/1.0.nix
+++ b/pkgs/development/compilers/julia/1.0.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchpatch, fetchurl, fetchzip
 # build tools
-, gfortran, m4, makeWrapper, patchelf, perl, which, python2
+, gfortran, m4, makeWrapper, patchelf, perl, which, python3
 , cmake
 # libjulia dependencies
 , libunwind, readline, utf8proc, zlib
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
     sha256 = src_sha256;
   };
 
-  nativeBuildInputs = [ cmake curl gfortran m4 makeWrapper patchelf perl python2 which ];
+  nativeBuildInputs = [ cmake curl gfortran m4 makeWrapper patchelf perl python3 which ];
   # cmake is only used to build the bundled deps
   dontUseCmakeConfigure = true;
 

--- a/pkgs/development/compilers/julia/1.5.nix
+++ b/pkgs/development/compilers/julia/1.5.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchzip
 # build tools
-, gfortran, m4, makeWrapper, patchelf, perl, which, python2, cmake
+, gfortran, m4, makeWrapper, patchelf, perl, which, python3, cmake
 # libjulia dependencies
 , libunwind, readline, utf8proc, zlib
 # standard library dependencies
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     zlib
   ] ++ lib.optionals stdenv.isDarwin [CoreServices ApplicationServices];
 
-  nativeBuildInputs = [ curl gfortran m4 makeWrapper patchelf perl python2 which cmake ];
+  nativeBuildInputs = [ curl gfortran m4 makeWrapper patchelf perl python3 which cmake ];
 
   makeFlags =
     let


### PR DESCRIPTION
Julia does not actually require python2; it just requires any version of python [that is equal to or greater than 2.7](https://github.com/JuliaLang/julia/blob/master/doc/src/devdocs/build/build.md#required-build-tools-and-external-libraries).

This changes the python dependency from python2 to python3.

I have verified that julia-1.0 builds with this change.  julia-1.5 is marked as broken in nixpkgs, so I have not tested it (but I would be very surprised if this change broke it further).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#148779

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (julia-1.0 only)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [xcccccchulekhgdivjgnetcbtfbhluvhfrevcgfrfbfvt
- ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
