### PR TITLE
pleroma: Fix build with elixir 1.13

### DIFF
--- a/pkgs/servers/pleroma/0001-move-result-into-with-guard.patch
+++ b/pkgs/servers/pleroma/0001-move-result-into-with-guard.patch
@@ -1,0 +1,26 @@
+From 8af53101fbeb0d4855ffa2b33069e833abf2e825 Mon Sep 17 00:00:00 2001
+From: Finn Behrens <me@kloenk.dev>
+Date: Tue, 7 Dec 2021 09:18:53 +0100
+Subject: [PATCH] move result into with guard
+
+---
+ lib/pleroma/web/activity_pub/publisher.ex | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/lib/pleroma/web/activity_pub/publisher.ex b/lib/pleroma/web/activity_pub/publisher.ex
+index 4f29a44..849b359 100644
+--- a/lib/pleroma/web/activity_pub/publisher.ex
++++ b/lib/pleroma/web/activity_pub/publisher.ex
+@@ -63,8 +63,7 @@ def publish_one(%{inbox: inbox, json: json, actor: %User{} = actor, id: id} = pa
+         date: date
+       })
+ 
+-    with {:ok, %{status: code}} when code in 200..299 <-
+-           result =
++    with {:ok, %{status: code}} = result when code in 200..299 <-
+              HTTP.post(
+                inbox,
+                json,
+-- 
+2.34.0
+

--- a/pkgs/servers/pleroma/default.nix
+++ b/pkgs/servers/pleroma/default.nix
@@ -17,6 +17,8 @@ beamPackages.mixRelease rec {
     sha256 = "sha256-XYZIf8/Vznl4FvVAOy5GVfTBTCwhfUol/3vWWIDwIxQ=";
   };
 
+  patches = [ ./0001-move-result-into-with-guard.patch ];
+
   mixNixDeps = import ./mix.nix {
     inherit beamPackages lib;
     overrides = (final: prev: {

--- a/pkgs/servers/pleroma/default.nix
+++ b/pkgs/servers/pleroma/default.nix
@@ -209,6 +209,6 @@ beamPackages.mixRelease rec {
     homepage = "https://git.pleroma.social/pleroma/pleroma";
     license = licenses.agpl3;
     maintainers = with maintainers; [ petabyteboy ninjatrappeur yuka ];
-    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Elixir 1.13 fixes scope guards, misused by pleroma

###### Things done
Patch pleroma to build with elixir 1.13

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
