### PR TITLE
fluxcd: 0.23.0 -> 0.24.0

### DIFF
--- a/pkgs/applications/networking/cluster/fluxcd/default.nix
+++ b/pkgs/applications/networking/cluster/fluxcd/default.nix
@@ -1,18 +1,18 @@
 { lib, buildGoModule, fetchFromGitHub, fetchzip, installShellFiles }:
 
 let
-  version = "0.23.0";
-  sha256 = "15j4r43hy3slyahx4am7lj7jns4x3axrcbr9qwiznmk8qbvrzrdy";
-  manifestsSha256 = "10rh0q1la5dq6n9y1yvw9ilj5lhzx8vh1zi2lznfjsvc5niwx7wf";
+  version = "0.24.0";
+  sha256 = "025dynxkfqrnpqrvdq39394biky2ra1mfjirrigamngchifav3b3";
+  manifestsSha256 = "0sbbvv40c66qdrhlvas42qcdmpgg1mb8zzcdrfr5yrkqwxnzis7x";
 
   manifests = fetchzip {
-    url = "https://github.com/fluxcd/flux2/releases/download/v${version}/manifests.tar.gz";
+    url =
+      "https://github.com/fluxcd/flux2/releases/download/v${version}/manifests.tar.gz";
     sha256 = manifestsSha256;
     stripRoot = false;
   };
-in
 
-buildGoModule rec {
+in buildGoModule rec {
   pname = "fluxcd";
   inherit version;
 
@@ -23,15 +23,13 @@ buildGoModule rec {
     inherit sha256;
   };
 
-  vendorSha256 = "sha256-vFm9ai+VWOPLRckKJ7gfD/0iQ8b4o5HNQE4cekb0vA0=";
+  vendorSha256 = "0w1qzsri3dkyzwfh6s13np52j3xzxxhk02pqgfh7297djwbppnbs";
 
   postUnpack = ''
     cp -r ${manifests} source/cmd/flux/manifests
   '';
 
-  patches = [
-    ./patches/disable-tests-ssh_key.patch
-  ];
+  patches = [ ./patches/disable-tests-ssh_key.patch ];
 
   ldflags = [ "-s" "-w" "-X main.VERSION=${version}" ];
 
@@ -39,7 +37,7 @@ buildGoModule rec {
 
   # Required to workaround test error:
   #   panic: mkdir /homeless-shelter: permission denied
-  HOME="$TMPDIR";
+  HOME = "$TMPDIR";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -58,7 +56,8 @@ buildGoModule rec {
   passthru.updateScript = ./update.sh;
 
   meta = with lib; {
-    description = "Open and extensible continuous delivery solution for Kubernetes";
+    description =
+      "Open and extensible continuous delivery solution for Kubernetes";
     longDescription = ''
       Flux is a tool for keeping Kubernetes clusters in sync
       with sources of configuration (like Git repositories), and automating

--- a/pkgs/applications/networking/cluster/fluxcd/patches/disable-tests-ssh_key.patch
+++ b/pkgs/applications/networking/cluster/fluxcd/patches/disable-tests-ssh_key.patch
@@ -1,19 +1,17 @@
-diff --git a/cmd/flux/create_secret_git_test.go b/cmd/flux/create_secret_git_test.go
-index afa34ba..0d22cce 100644
---- a/cmd/flux/create_secret_git_test.go
-+++ b/cmd/flux/create_secret_git_test.go
-@@ -20,16 +20,6 @@ func TestCreateGitSecret(t *testing.T) {
+--- flux/cmd/flux/create_secret_git_test.go.orig	2021-12-07 13:46:21.196278468 +0100
++++ flux/cmd/flux/create_secret_git_test.go	2021-12-07 13:49:51.668566955 +0100
+@@ -20,16 +20,6 @@
  			args:   "create secret git podinfo-auth --url=https://github.com/stefanprodan/podinfo --username=my-username --password=my-password --namespace=my-namespace --export",
  			assert: assertGoldenFile("./testdata/create_secret/git/secret-git-basic.yaml"),
  		},
 -		{
 -			name:   "ssh key",
--			args:   "create secret git podinfo-auth --url=ssh://git@github.com/stefanprodan/podinfo --private-key-file=./testdata/create_secret/git/rsa.private --namespace=my-namespace --export",
+-			args:   "create secret git podinfo-auth --url=ssh://git@github.com/stefanprodan/podinfo --private-key-file=./testdata/create_secret/git/ecdsa.private --namespace=my-namespace --export",
 -			assert: assertGoldenFile("testdata/create_secret/git/git-ssh-secret.yaml"),
 -		},
 -		{
 -			name:   "ssh key with password",
--			args:   "create secret git podinfo-auth --url=ssh://git@github.com/stefanprodan/podinfo --private-key-file=./testdata/create_secret/git/rsa-password.private --password=password --namespace=my-namespace --export",
+-			args:   "create secret git podinfo-auth --url=ssh://git@github.com/stefanprodan/podinfo --private-key-file=./testdata/create_secret/git/ecdsa-password.private --password=password --namespace=my-namespace --export",
 -			assert: assertGoldenFile("testdata/create_secret/git/git-ssh-secret-password.yaml"),
 -		},
  	}


### PR DESCRIPTION
###### Motivation for this change

Update fluxcd to new upstream version.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
