### PR TITLE
soft-serve: init at 0.1.0

### DIFF
--- a/pkgs/servers/soft-serve/default.nix
+++ b/pkgs/servers/soft-serve/default.nix
@@ -1,0 +1,33 @@
+{ lib, buildGoModule, fetchFromGitHub, makeWrapper, git }:
+
+buildGoModule rec {
+  pname = "soft-serve";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "charmbracelet";
+    repo = "soft-serve";
+    rev = "v${version}";
+    sha256 = "0z88699q34a9cbhcz12y2qs2qrspfd8yx4ay0r8jzvkgax9ylrlk";
+  };
+
+  vendorSha256 = "1g2iznfh08l23i81x7g2bhc7l8cppshzlyynxik4jshswlpv80sr";
+
+  doCheck = false;
+
+  ldflags = [ "-s" "-w" "-X=main.Version=${version}" ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/soft \
+      --prefix PATH : "${lib.makeBinPath [ git ]}"
+  '';
+
+  meta = with lib; {
+    description = "A tasty, self-hosted Git server for the command line";
+    homepage = "https://github.com/charmbracelet/soft-serve";
+    license = licenses.mit;
+    maintainers = with maintainers; [ penguwin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21129,6 +21129,8 @@ with pkgs;
 
   quark = callPackage ../servers/http/quark { };
 
+  soft-serve = callPackage ../servers/soft-serve { };
+
   sympa = callPackage ../servers/mail/sympa { };
 
   system-sendmail = lowPrio (callPackage ../servers/mail/system-sendmail { });


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add soft-serve, a tasty, self-hosted Git server for the command line to the nixpkgs collection 🍦

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
