### PR TITLE
woeusb-ng: init at 0.2.10

### DIFF
--- a/pkgs/tools/misc/woeusb-ng/default.nix
+++ b/pkgs/tools/misc/woeusb-ng/default.nix
@@ -1,0 +1,32 @@
+{ lib, python3Packages, fetchFromGitHub, p7zip, parted, grub2 }:
+with python3Packages;
+
+buildPythonApplication rec {
+  pname = "woeusb-ng";
+  version = "0.2.10";
+
+  propagatedBuildInputs = [ p7zip parted grub2 termcolor wxPython_4_0 six ];
+
+  src = fetchFromGitHub {
+    owner = "WoeUSB";
+    repo = "WoeUSB-ng";
+    rev = "v${version}";
+    sha256 = "sha256-Nsdk3SMRzj1fqLrp5Na5V3rRDMcIReL8uDb8K2GQNWI=";
+  };
+
+  postInstall = ''
+    # TODO: the gui requires additional polkit-actions to work correctly, therefore it is currently disabled
+    rm $out/bin/woeusbgui
+  '';
+
+  # checks fail, because of polkit-actions and should be reenabled when the gui is fixed.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A tool to create a Windows USB stick installer from a real Windows DVD or image";
+    homepage = "https://github.com/WoeUSB/WoeUSB-ng";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ stunkymonkey ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11010,6 +11010,8 @@ with pkgs;
 
   woeusb = callPackage ../tools/misc/woeusb { };
 
+  woeusb-ng = callPackage ../tools/misc/woeusb-ng { };
+
   wslu = callPackage ../tools/system/wslu { };
 
   chase = callPackage ../tools/system/chase { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`woeusb` is beeing rewritten in python: https://github.com/WoeUSB/WoeUSB-ng

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
