### PR TITLE
netdata: 1.31.0 -> 1.32.0, go.d.plugin 0.28.1 -> 0.31.0

### DIFF
--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -16,14 +16,14 @@ with lib;
 let
   go-d-plugin = callPackage ./go.d.plugin.nix {};
 in stdenv.mkDerivation rec {
-  version = "1.31.0";
+  version = "1.32.0";
   pname = "netdata";
 
   src = fetchFromGitHub {
     owner = "netdata";
     repo = "netdata";
     rev = "v${version}";
-    sha256 = "0735cxmljrp8zlkcq7hcxizy4j4xiv7vf782zkz5chn06n38mcik";
+    sha256 = "sha256-U6h61U6/d+X/LfwptlXDofdtRvsrDhtjFwrd7unpZ5s=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/tools/system/netdata/go.d.plugin.nix
+++ b/pkgs/tools/system/netdata/go.d.plugin.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "netdata-go.d.plugin";
-  version = "0.28.1";
+  version = "0.31.0";
 
   src = fetchFromGitHub {
     owner = "netdata";
     repo = "go.d.plugin";
     rev = "v${version}";
-    sha256 = "0i77nvqi3dcby0gr3b06bai170q2ibp5390qfjijrk1yqz6x6sd5";
+    sha256 = "08wyvssd3g6rfqzsbg68aycc4plwggv44052rkyakzna9l5kwby1";
   };
 
-  vendorSha256 = "1q8z4smaxzqd5iwvbnkkr33c3b94rjwa3xjirwlr595g0wn93wc7";
+  vendorSha256 = "sha256-17/f6tAxDD5TgjmwnqAlnQSxDhnFidjsN55/sUMDej8=";
 
   doCheck = false;
 

--- a/pkgs/tools/system/netdata/no-files-in-etc-and-var.patch
+++ b/pkgs/tools/system/netdata/no-files-in-etc-and-var.patch
@@ -28,7 +28,7 @@ diff --git a/collectors/ebpf.plugin/Makefile.am b/collectors/ebpf.plugin/Makefil
 index 18b1fc6c8..b4b0c7852 100644
 --- a/collectors/ebpf.plugin/Makefile.am
 +++ b/collectors/ebpf.plugin/Makefile.am
-@@ -13,7 +13,7 @@ SUFFIXES = .in
+@@ -9,7 +9,7 @@ SUFFIXES = .in
  userebpfconfigdir=$(configdir)/ebpf.d
  
  # Explicitly install directories to avoid permission issues due to umask
@@ -91,11 +91,15 @@ diff --git a/system/Makefile.am b/system/Makefile.am
 index 5323738c9..06e1b6a73 100644
 --- a/system/Makefile.am
 +++ b/system/Makefile.am
-@@ -20,11 +20,10 @@ include $(top_srcdir)/build/subst.inc
+@@ -19,11 +19,9 @@ include $(top_srcdir)/build/subst.inc
  SUFFIXES = .in
  
  dist_config_SCRIPTS = \
 -    edit-config \
+     $(NULL)
+ 
+ dist_config_DATA = \
+-    .install-type \
      $(NULL)
  
  # Explicitly install directories to avoid permission issues due to umask


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I required a newer version of the `go.d.plugin` and tried updating the whole package to the newest version.
The `go.d.plugin` part worked fine, I already tested it.
But the update of Netdata itself fails to build, it tries to change the permissions of `/etc/netdata` and I can't find which Makefile is to blame (I already updated the patch, but apparently forgot something), hopefully someone can help me there?

###### Things done
Update go.d.plugin from 0.28.1 to 0.31.0 and netdata from 1.31.0 to 1.32.0

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
