### PR TITLE
ocamlPackages.jsonrpc: 1.8.3 → 1.9.1

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
@@ -1,4 +1,4 @@
-{ buildDunePackage, jsonrpc, lsp, re, makeWrapper, dot-merlin-reader }:
+{ lib, buildDunePackage, jsonrpc, lsp, re, makeWrapper, dot-merlin-reader, spawn }:
 
 buildDunePackage {
   pname = "ocaml-lsp-server";
@@ -7,7 +7,8 @@ buildDunePackage {
 
   inherit (lsp) preBuild;
 
-  buildInputs = lsp.buildInputs ++ [ lsp re ];
+  buildInputs = lsp.buildInputs ++ [ lsp re ]
+  ++ lib.optional (lib.versionAtLeast jsonrpc.version "1.9") spawn;
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
@@ -10,10 +10,14 @@
 }:
 
 let params =
-  if lib.versionAtLeast ocaml.version "4.12"
+  if lib.versionAtLeast ocaml.version "4.13"
   then {
-    version = "1.8.3";
-    sha256 = "sha256-WO9ap78XZxJCi04LEBX+r21nfL2UdPiCLRMrJSI7FOk=";
+    version = "1.9.1";
+    sha256 = "sha256:1vnwdpjppihprc8q2i5zcqq7vp67255jclg90ldfvwafgljxn76g";
+  } else if lib.versionAtLeast ocaml.version "4.12"
+  then {
+    version = "1.9.0";
+    sha256 = "sha256:1ac44n6g3rf84gvhcca545avgf9vpkwkkkm0s8ipshfhp4g4jikh";
   } else {
     version = "1.4.1";
     sha256 = "1ssyazc0yrdng98cypwa9m3nzfisdzpp7hqnx684rqj8f0g3gs6f";
@@ -29,7 +33,7 @@ buildDunePackage rec {
   };
 
   useDune2 = true;
-  minimumOCamlVersion = "4.06";
+  minimalOCamlVersion = "4.06";
 
   buildInputs =
     if lib.versionAtLeast version "1.7.0" then


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.13.

cc maintainers @symphorien @marsam

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
