### PR TITLE
swift: Fix test failure during build

### DIFF
--- a/pkgs/development/compilers/swift/default.nix
+++ b/pkgs/development/compilers/swift/default.nix
@@ -340,7 +340,7 @@ stdenv.mkDerivation {
     # TODO: consider using stress-tester and integration-test.
 
     # Match the wrapped version of Swift to be installed.
-    export LIBRARY_PATH=${icu}/lib:${libgcc}/lib:${libuuid.out}/lib:$l
+    export LIBRARY_PATH=${icu}/lib:${libgcc}/lib:${libuuid.lib}/lib:$l
 
     checkTarget=check-swift-all-${stdenv.hostPlatform.parsed.kernel.name}-${stdenv.hostPlatform.parsed.cpu.name}
     ninjaFlags='-C buildbot_linux/swift-${stdenv.hostPlatform.parsed.kernel.name}-${stdenv.hostPlatform.parsed.cpu.name}'
@@ -363,13 +363,13 @@ stdenv.mkDerivation {
       --set CC $out/bin/clang \
       --suffix C_INCLUDE_PATH : $out/lib/swift/clang/include \
       --suffix CPLUS_INCLUDE_PATH : $out/lib/swift/clang/include \
-      --suffix LIBRARY_PATH : ${icu}/lib:${libgcc}/lib:${libuuid.out}/lib
+      --suffix LIBRARY_PATH : ${icu}/lib:${libgcc}/lib:${libuuid.lib}/lib
 
     wrapProgram $out/bin/swiftc \
       --set CC $out/bin/clang \
       --suffix C_INCLUDE_PATH : $out/lib/swift/clang/include \
       --suffix CPLUS_INCLUDE_PATH : $out/lib/swift/clang/include \
-      --suffix LIBRARY_PATH : ${icu}/lib:${libgcc}/lib:${libuuid.out}/lib
+      --suffix LIBRARY_PATH : ${icu}/lib:${libgcc}/lib:${libuuid.lib}/lib
   '';
 
   # Hack to avoid build and install directories in RPATHs.

--- a/pkgs/development/compilers/swift/default.nix
+++ b/pkgs/development/compilers/swift/default.nix
@@ -340,7 +340,7 @@ stdenv.mkDerivation {
     # TODO: consider using stress-tester and integration-test.
 
     # Match the wrapped version of Swift to be installed.
-    export LIBRARY_PATH=${icu}/lib:${libgcc}/lib:${libuuid.lib}/lib:$l
+    export LIBRARY_PATH=${lib.makeLibraryPath [icu libgcc libuuid]}:$l
 
     checkTarget=check-swift-all-${stdenv.hostPlatform.parsed.kernel.name}-${stdenv.hostPlatform.parsed.cpu.name}
     ninjaFlags='-C buildbot_linux/swift-${stdenv.hostPlatform.parsed.kernel.name}-${stdenv.hostPlatform.parsed.cpu.name}'
@@ -363,13 +363,13 @@ stdenv.mkDerivation {
       --set CC $out/bin/clang \
       --suffix C_INCLUDE_PATH : $out/lib/swift/clang/include \
       --suffix CPLUS_INCLUDE_PATH : $out/lib/swift/clang/include \
-      --suffix LIBRARY_PATH : ${icu}/lib:${libgcc}/lib:${libuuid.lib}/lib
+      --suffix LIBRARY_PATH : ${lib.makeLibraryPath [icu libgcc libuuid]}
 
     wrapProgram $out/bin/swiftc \
       --set CC $out/bin/clang \
       --suffix C_INCLUDE_PATH : $out/lib/swift/clang/include \
       --suffix CPLUS_INCLUDE_PATH : $out/lib/swift/clang/include \
-      --suffix LIBRARY_PATH : ${icu}/lib:${libgcc}/lib:${libuuid.lib}/lib
+      --suffix LIBRARY_PATH : ${lib.makeLibraryPath [icu libgcc libuuid]}
   '';
 
   # Hack to avoid build and install directories in RPATHs.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Swift builds are broken: https://hydra.nixos.org/build/158690854/nixlog/1
In particular the `stdlib/CUUID.swift` test is failing due to a linker error:
```
/nix/store/js66s0xwjnzg0ggi2lq9bcvlk6x2za13-binutils-2.35.2/bin/ld.gold: error: cannot find -luuid
/build/CUUID-da21c4.o:CUUID-da21c4.o:function $s4mainyycfU_ySpys5UInt8V_A15CtGXEfU_: error: undefined reference to 'uuid_generate_random'
clang-10: error: linker command failed with exit code 1 (use -v to see invocation)
<unknown>:0: error: link command failed with exit code 1 (use -v to see invocation)
```

In `LIBRARY_PATH`, `${libuuid.out}/lib` was being used which does not exist as `${libuuid.out}` does not contain a `lib` directory. Switching to `${libuuid.lib}/lib` seems to fix the issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
