### PR TITLE
quickemu: 2.2.7 -> 3.11

### DIFF
--- a/pkgs/development/quickemu/default.nix
+++ b/pkgs/development/quickemu/default.nix
@@ -17,6 +17,9 @@
 , xdg-user-dirs
 , xrandr
 , zsync
+, OVMF
+, quickemu
+, testVersion
 }:
 let
   runtimePaths = [
@@ -40,14 +43,19 @@ in
 
 stdenv.mkDerivation rec {
   pname = "quickemu";
-  version = "2.2.7";
+  version = "3.11";
 
   src = fetchFromGitHub {
-    owner = "wimpysworld";
-    repo = pname;
+    owner = "quickemu-project";
+    repo = "quickemu";
     rev = version;
-    sha256 = "sha256-TNG1pCePsi12QQafhayhj+V5EXq+v7qmaW5v5X8ER6s=";
+    sha256 = "1xwf9vwbr57wmyxfcqzl1jnmfx3ffh7sfqf0zcdq41wqkm8s106n";
   };
+
+  patches = [
+    ./efi_vars_ensure_writable.patch
+    ./input_overrides.patch
+  ];
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -56,16 +64,21 @@ stdenv.mkDerivation rec {
 
     install -Dm755 -t "$out/bin" quickemu quickget macrecovery
 
-   for f in quickget macrecovery quickemu; do
-    wrapProgram $out/bin/$f --prefix PATH : "${lib.makeBinPath runtimePaths}"
-   done
+    for f in quickget macrecovery quickemu; do
+      wrapProgram $out/bin/$f \
+        --prefix PATH : "${lib.makeBinPath runtimePaths}" \
+        --set ENV_EFI_CODE "${OVMF.fd}/FV/OVMF_CODE.fd" \
+        --set ENV_EFI_VARS "${OVMF.fd}/FV/OVMF_VARS.fd"
+    done
 
     runHook postInstall
   '';
 
+  passthru.tests = testVersion { package = quickemu; };
+
   meta = with lib; {
     description = "Quickly create and run optimised Windows, macOS and Linux desktop virtual machines";
-    homepage = "https://github.com/wimpysworld/quickemu";
+    homepage = "https://github.com/quickemu-project/quickemu";
     license = licenses.mit;
     maintainers = with maintainers; [ fedx-sudo ];
   };

--- a/pkgs/development/quickemu/efi_vars_ensure_writable.patch
+++ b/pkgs/development/quickemu/efi_vars_ensure_writable.patch
@@ -1,0 +1,13 @@
+diff --git a/quickemu b/quickemu
+index a9a60a5..1a932ac 100755
+--- a/quickemu
++++ b/quickemu
+@@ -197,7 +197,7 @@ function efi_vars() {
+ 
+   if [ ! -e "${VARS_OUT}" ]; then
+     if [ -e "${VARS_IN}" ]; then
+-      cp "${VARS_IN}" "${VARS_OUT}"
++      cp "${VARS_IN}" "${VARS_OUT}" && chmod +w "${VARS_OUT}"
+     else
+       echo "ERROR! ${VARS_IN} was not found. Please install edk2."
+       exit 1

--- a/pkgs/development/quickemu/input_overrides.patch
+++ b/pkgs/development/quickemu/input_overrides.patch
@@ -1,0 +1,28 @@
+diff --git a/quickemu b/quickemu
+index 1a932ac..ab2f752 100755
+--- a/quickemu
++++ b/quickemu
+@@ -383,7 +383,10 @@ function vm_boot() {
+     # https://bugzilla.redhat.com/show_bug.cgi?id=1929357#c5
+     case ${secureboot} in
+       on)
+-        if [ -e "/usr/share/OVMF/OVMF_CODE_4M.secboot.fd" ]; then
++        if [[ ${ENV_EFI_CODE_SECURE} && ${ENV_EFI_CODE_SECURE-x} ]] && [[ ${ENV_EFI_VARS_SECURE} && ${ENV_EFI_VARS_SECURE-x} ]]; then
++          EFI_CODE="${ENV_EFI_CODE_SECURE}"
++          efi_vars "${ENV_EFI_VARS_SECURE}" "${EFI_VARS}"
++        elif [ -e "/usr/share/OVMF/OVMF_CODE_4M.secboot.fd" ]; then
+           EFI_CODE="/usr/share/OVMF/OVMF_CODE_4M.secboot.fd"
+           efi_vars "/usr/share/OVMF/OVMF_VARS_4M.fd" "${EFI_VARS}"
+         elif [ -e "/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd" ]; then
+@@ -402,7 +405,10 @@ function vm_boot() {
+         fi
+         ;;
+       *)
+-        if [ -e "/usr/share/OVMF/OVMF_CODE_4M.fd" ]; then
++        if [[ ${ENV_EFI_CODE} && ${ENV_EFI_CODE-x} ]] && [[ ${ENV_EFI_VARS} && ${ENV_EFI_VARS-x} ]]; then
++          EFI_CODE="${ENV_EFI_CODE}"
++          efi_vars "${ENV_EFI_VARS}" "${EFI_VARS}"
++        elif [ -e "/usr/share/OVMF/OVMF_CODE_4M.fd" ]; then
+           EFI_CODE="/usr/share/OVMF/OVMF_CODE_4M.fd"
+           efi_vars "/usr/share/OVMF/OVMF_VARS_4M.fd" "${EFI_VARS}"
+         elif [ -e "/usr/share/edk2/ovmf/OVMF_CODE.fd" ]; then


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Upgrade to [3.11](https://github.com/quickemu-project/quickemu/releases/tag/3.11) incorporating these [changes](https://github.com/quickemu-project/quickemu/compare/2.2.7...3.11).

- updated project home
- add testVersion
 
- works on existing and new macOS VMs
- hardcoded paths for OVMF Firmware `/usr/share/OVMF` breaks !macOS


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
