### PR TITLE
python3Packages.django-sites: run tests

### DIFF
--- a/pkgs/development/python-modules/django-sites/default.nix
+++ b/pkgs/development/python-modules/django-sites/default.nix
@@ -1,31 +1,40 @@
-{ lib, buildPythonPackage, fetchPypi, django }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, django
+, django-jinja
+, python
+}:
 
 buildPythonPackage rec {
   pname = "django-sites";
   version = "0.11";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1cbee714fdf2bfbe92e4f5055de4e6c41b64ebb32e1f96b1016c0748210928b8";
+  src = fetchFromGitHub {
+    owner = "niwinz";
+    repo = "django-sites";
+    rev = version;
+    sha256 = "sha256-MQtQC+9DyS1ICXXovbqPpkKIQ5wpuJDgq3Lcd/1kORU=";
   };
-  # LICENSE file appears to be missing from pypi package, but expected by the installer
-  # https://github.com/niwinz/django-sites/issues/11
-  postPatch = ''
-    touch LICENSE
+
+  propagatedBuildInputs = [
+    django
+  ];
+
+  checkInputs = [
+    django-jinja
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    ${python.interpreter} runtests.py
+
+    runHook postCheck
   '';
 
-  propagatedBuildInputs = [ django ];
-
-  # required files for test don't seem to be included in pypi package, full source for 0.10
-  # version doesn't appear to be present on github
-  # https://github.com/niwinz/django-sites/issues/9
-  doCheck = false;
-
   meta = {
-    description = ''
-      Alternative implementation of django "sites" framework
-      based on settings instead of models.
-    '';
+    description = "Alternative implementation of django sites framework";
     homepage = "https://github.com/niwinz/django-sites";
     license = lib.licenses.bsd3;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
