### PR TITLE
[21.05] zydis: add patch for CVE-2021-41253

### DIFF
--- a/pkgs/development/libraries/zydis/default.nix
+++ b/pkgs/development/libraries/zydis/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake }:
 
 stdenv.mkDerivation rec {
   pname = "zydis";
@@ -11,6 +11,14 @@ stdenv.mkDerivation rec {
     sha256 = "0x2lpc33ynd0zzirdxp2lycvg3545wh1ssgy4qlv81471iwwzv6b";
     fetchSubmodules = true;
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2021-41253.patch";
+      url = "https://github.com/zyantific/zydis/commit/330b259583ade789886ce11af2ebcd030097dcbf.patch";
+      sha256 = "137lvqcm5fabv82f11c28skczb0hrmqh7i9a7hj2121p0nd729rr";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
 


### PR DESCRIPTION
###### Motivation for this change
#147913 https://nvd.nist.gov/vuln/detail/CVE-2021-41253

Already fixed in master and 21.11.  #147535  #147593

Structure contents haven't changed since 3.1.0. The same fields that weren't set in 3.2.0 weren't set here. Any code touching fields set by this patch would have previously been working with probably corrupted data anyway.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
