### PR TITLE
flannel: 0.13.0 -> 0.15.1

### DIFF
--- a/pkgs/tools/networking/flannel/default.nix
+++ b/pkgs/tools/networking/flannel/default.nix
@@ -1,26 +1,33 @@
-{ lib, buildGoPackage, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, nixosTests }:
 
 with lib;
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "flannel";
-  version = "0.13.0";
+  version = "0.15.1";
   rev = "v${version}";
 
-  goPackagePath = "github.com/coreos/flannel";
+  vendorSha256 = null;
 
   src = fetchFromGitHub {
     inherit rev;
-    owner = "coreos";
+    owner = "flannel-io";
     repo = "flannel";
-    sha256 = "0mmswnaybwpf18h832haapcs5b63wn5w2hax0smm3inldiggsbw8";
+    sha256 = "1p4rz4kdiif8i78zgxhw6dd0c1bq159f6l1idvig5apph7zi2bwm";
   };
+
+  ldflags = [ "-X github.com/flannel-io/flannel/version.Version=${rev}" ];
+
+  # TestRouteCache/TestV6RouteCache fail with "Failed to create newns: operation not permitted"
+  doCheck = false;
+
+  passthru.tests = { inherit (nixosTests) flannel; };
 
   meta = {
     description = "Network fabric for containers, designed for Kubernetes";
     license = licenses.asl20;
-    homepage = "https://github.com/coreos/flannel";
-    maintainers = with maintainers; [johanot offline];
+    homepage = "https://github.com/flannel-io/flannel";
+    maintainers = with maintainers; [ johanot offline ];
     platforms = with platforms; linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Several releases recently, the latest of them fixing the [longstanding race condition](https://github.com/flannel-io/flannel/issues/1155) when flannel is used with systemd.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
