### PR TITLE
pcsx2: 2021-10-28 -> 1.7.2105 & wayland support

### DIFF
--- a/pkgs/misc/emulators/pcsx2/default.nix
+++ b/pkgs/misc/emulators/pcsx2/default.nix
@@ -6,6 +6,7 @@
 , glib
 , gtk3
 , harfbuzz
+, lib
 , libaio
 , libpcap
 , libpng
@@ -17,23 +18,23 @@
 , portaudio
 , SDL2
 , soundtouch
-, lib, stdenv
+, stdenv
 , udev
 , wrapGAppsHook
 , wxGTK
 , zlib
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "pcsx2";
-  version = "unstable-2021-10-28";
+  version = "1.7.2105";
 
   src = fetchFromGitHub {
     owner = "PCSX2";
     repo = "pcsx2";
     fetchSubmodules = true;
-    rev = "52eab493591137d830b45337e04c75ff525a31f9";
-    sha256 = "RhAo5Fob8G16jzb9MOAS43vwTkFzf5XupymN0dzeGJU=";
+    rev = "v${version}";
+    hash = "sha256-/A8u7oDIVs0Zmne0ebaXxOeIQbM9pr62KEH6FJR2umk=";
   };
 
   cmakeFlags = [
@@ -68,7 +69,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Playstation 2 emulator";
-    longDescription= ''
+    longDescription = ''
       PCSX2 is an open-source PlayStation 2 (AKA PS2) emulator. Its purpose
       is to emulate the PS2 hardware, using a combination of MIPS CPU
       Interpreters, Recompilers and a Virtual Machine which manages hardware

--- a/pkgs/misc/emulators/pcsx2/default.nix
+++ b/pkgs/misc/emulators/pcsx2/default.nix
@@ -23,6 +23,7 @@
 , wrapGAppsHook
 , wxGTK
 , zlib
+, wayland
 }:
 
 stdenv.mkDerivation rec {
@@ -41,6 +42,7 @@ stdenv.mkDerivation rec {
     "-DDISABLE_ADVANCE_SIMD=TRUE"
     "-DDISABLE_PCSX2_WRAPPER=TRUE"
     "-DPACKAGE_MODE=TRUE"
+    "-DWAYLAND_API=TRUE"
     "-DXDG_STD=TRUE"
   ];
 
@@ -63,6 +65,7 @@ stdenv.mkDerivation rec {
     SDL2
     soundtouch
     udev
+    wayland
     wxGTK
     zlib
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
FIx PCSX2 crashing when run in a Wayland session.

###### Things done
Tested on KDE Wayland.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
