### PR TITLE
kernel: Fix overriding

### DIFF
--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -192,7 +192,8 @@ let
     };
   }; # end of configfile derivation
 
-  kernel = (callPackage ./manual-config.nix { inherit buildPackages;  }) (basicArgs // {
+  kernel = callPackage ./manual-config.nix (basicArgs // {
+    inherit buildPackages;
     inherit modDirVersion kernelPatches randstructSeed lib stdenv extraMakeFlags extraMeta configfile;
     pos = builtins.unsafeGetAttrPos "version" args;
 

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -204,16 +204,10 @@ let
     inherit commonStructuredConfig structuredExtraConfig extraMakeFlags isZen isHardened isLibre modDirVersion;
     isXen = lib.warn "The isXen attribute is deprecated. All Nixpkgs kernels that support it now have Xen enabled." true;
     passthru = kernel.passthru // (removeAttrs passthru [ "passthru" ]);
-    tests = let
-      overridableKernel = finalKernel // {
-        override = args:
-          lib.warn (
-            "override is stubbed for NixOS kernel tests, not applying changes these arguments: "
-            + toString (lib.attrNames (if lib.isAttrs args then args else args {}))
-          ) overridableKernel;
-      };
-    in [ (nixosTests.kernel-generic.testsForKernel overridableKernel) ] ++ kernelTests;
+    tests = [ (nixosTests.kernel-generic.testsForKernel finalKernel) ] ++ kernelTests;
   };
 
-  finalKernel = lib.extendDerivation true passthru kernel;
+  finalKernel = kernel.overrideAttrs (old: {
+    passthru = old.passthru // passthru;
+  });
 in finalKernel

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -1,54 +1,51 @@
 { lib, buildPackages, runCommand, nettools, bc, bison, flex, perl, rsync, gmp, libmpc, mpfr, openssl
 , libelf, cpio, elfutils, zstd, gawk, python3Minimal, zlib, pahole
 , writeTextFile
-}:
-
-let
-  readConfig = configfile: import (runCommand "config.nix" {} ''
-    echo "{" > "$out"
-    while IFS='=' read key val; do
-      [ "x''${key#CONFIG_}" != "x$key" ] || continue
-      no_firstquote="''${val#\"}";
-      echo '  "'"$key"'" = "'"''${no_firstquote%\"}"'";' >> "$out"
-    done < "${configfile}"
-    echo "}" >> $out
-  '').outPath;
-in {
-  lib,
   # Allow overriding stdenv on each buildLinux call
-  stdenv,
+, stdenv
   # The kernel version
-  version,
+, version
   # Position of the Linux build expression
-  pos ? null,
+, pos ? null
   # Additional kernel make flags
-  extraMakeFlags ? [],
+, extraMakeFlags ? []
   # The version of the kernel module directory
-  modDirVersion ? version,
+, modDirVersion ? version
   # The kernel source (tarball, git checkout, etc.)
-  src,
+, src
   # a list of { name=..., patch=..., extraConfig=...} patches
-  kernelPatches ? [],
+, kernelPatches ? []
   # The kernel .config file
-  configfile,
+, configfile
   # Manually specified nixexpr representing the config
   # If unspecified, this will be autodetected from the .config
-  config ? lib.optionalAttrs allowImportFromDerivation (readConfig configfile),
+, config ?
+    let
+      readConfig = configfile: import (runCommand "config.nix" {} ''
+        echo "{" > "$out"
+        while IFS='=' read key val; do
+          [ "x''${key#CONFIG_}" != "x$key" ] || continue
+          no_firstquote="''${val#\"}";
+          echo '  "'"$key"'" = "'"''${no_firstquote%\"}"'";' >> "$out"
+        done < "${configfile}"
+        echo "}" >> $out
+      '').outPath;
+    in lib.optionalAttrs allowImportFromDerivation (readConfig configfile)
   # Custom seed used for CONFIG_GCC_PLUGIN_RANDSTRUCT if enabled. This is
   # automatically extended with extra per-version and per-config values.
-  randstructSeed ? "",
+, randstructSeed ? ""
   # Use defaultMeta // extraMeta
-  extraMeta ? {},
+, extraMeta ? {}
 
   # for module compatibility
-  isZen      ? false,
-  isLibre    ? false,
-  isHardened ? false,
+, isZen      ? false
+, isLibre    ? false
+, isHardened ? false
 
   # Whether to utilize the controversial import-from-derivation feature to parse the config
-  allowImportFromDerivation ? false,
+, allowImportFromDerivation ? false
   # ignored
-  features ? null,
+, features ? null
 }:
 
 let


### PR DESCRIPTION
###### Motivation for this change
This was reported in https://github.com/NixOS/nixpkgs/issues/111504 but further complicated in https://github.com/NixOS/nixpkgs/pull/121518

This should clean it up, though I haven't tested it more than just a basic `linuxPackages.kernel` evaluation, as I'm not familiar with how it's all used.

I'd ideally like <s>@samuela</s> @samueldr, @kira-bruneau, @Atemu and @NeQuissimus to take a look at this, as they've been involved in the above two linked issues

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
