### PR TITLE
OpenJDK: Fix incorrect version for macOS aarch64

### DIFF
--- a/pkgs/development/compilers/openjdk/darwin/17.nix
+++ b/pkgs/development/compilers/openjdk/darwin/17.nix
@@ -12,7 +12,7 @@ let
 
     aarch64-darwin = {
       arch = "aarch64";
-      zuluVersion = "17.30.19";
+      zuluVersion = "17.30.15";
       jdkVersion = "17.0.1";
       sha256 = "sha256-zhBCXOnO/fsj6+q+vAlEz7QVMRFKLVvYnjwZzFz6mRM=";
     };


### PR DESCRIPTION
It looks like using `17.30.19` for `aarch64-darwin` is wrong.

There is currently no `17.30.19` in https://cdn.azul.com/zulu/bin/

The sha256 seems to match the `17.30.15` macOS aarch64 file.

My guess is that either:
* there was a version `17.30.19` with the same hash that was removed.
* the `.30.19` for `aarch64` was copied over from `16.nix` (there is a `16.30.19`), the
  `sha256` was calculated using the `17.30.15` (perhaps with `nix-prefetch-git`) and
  the file did not need to be downloaded when testing since it was already in the store.

