### PR TITLE
Surge-XT: unstable-2021-11-07 -> unstable-2021-12-11

### DIFF
--- a/pkgs/applications/audio/surge-XT/default.nix
+++ b/pkgs/applications/audio/surge-XT/default.nix
@@ -1,27 +1,87 @@
-{ stdenv, lib, fetchFromGitHub, cmake, pkg-config, cairo, libxkbcommon, xcbutilcursor, xcbutilkeysyms, xcbutil, libXrandr, libXinerama, libXcursor, alsa-lib, libjack2
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, alsa-lib
+, freetype
+, libjack2
+, lv2
+, libX11
+, libXcursor
+, libXext
+, libXinerama
+, libXrandr
 }:
 
+let
+  juce-lv2 = stdenv.mkDerivation {
+    pname = "juce-lv2";
+    version = "unstable-2021-12-11";
+
+    # lv2 branch
+    src = fetchFromGitHub {
+      owner = "lv2-porting-project";
+      repo = "JUCE";
+      rev = "5106d9d77b892c22afcb9379c13982f270429e2e";
+      sha256 = "sha256-bpZJ5NEDRfMtmx0RkKQFZWqS/SnYAFRhrDg9MSphh4c=";
+    };
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    installPhase = ''
+      cp -r . $out
+    '';
+  };
+in
 stdenv.mkDerivation rec {
   pname = "surge-XT";
-  version = "unstable-2021-11-07";
+  version = "unstable-2021-12-11";
 
   src = fetchFromGitHub {
     owner = "surge-synthesizer";
     repo = "surge";
-    rev = "ed93833eb44b177c977e3a7b878ffdd9bf9f24e5";
-    sha256 = "0b164659ksl6h5nn7jja5zccx2mwzibqs6b7hg8l98gpcy9fi5r2";
+    rev = "320f68543d0279c11cea8dc7f5170399cccc9602";
     fetchSubmodules = true;
+    sha256 = "sha256-Jcs5FpX5AZl72aKYNbRcfYqb2PRt0r1pQXk957xk0aM=";
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [ cairo libxkbcommon xcbutilcursor xcbutilkeysyms xcbutil libXrandr libXinerama libXcursor alsa-lib libjack2 ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
 
-  installPhase = ''
-    cd ..
-    cmake --build build --config Release --target install
+  buildInputs = [
+    alsa-lib
+    freetype
+    libjack2
+    lv2
+    libX11
+    libXcursor
+    libXext
+    libXinerama
+    libXrandr
+  ];
+
+  cmakeFlags = [
+    "-DJUCE_SUPPORTS_LV2=ON"
+    "-DSURGE_JUCE_PATH=${juce-lv2}"
+  ];
+
+  # JUCE dlopen's these at runtime, crashes without them
+  NIX_LDFLAGS = (toString [
+    "-lX11"
+    "-lXext"
+    "-lXcursor"
+    "-lXinerama"
+    "-lXrandr"
+  ]);
+
+  # see https://github.com/NixOS/nixpkgs/pull/149487#issuecomment-991747333
+  postPatch = ''
+    export XDG_DOCUMENTS_DIR=$(mktemp -d)
   '';
-
-  doInstallCheck = false;
 
   meta = with lib; {
     description = "LV2 & VST3 synthesizer plug-in (previously released as Vember Audio Surge)";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
