### PR TITLE
gmp, gmp5: add patch for CVE-2021-43618

### DIFF
--- a/pkgs/development/libraries/gmp/5.1.3-CVE-2021-43618.patch
+++ b/pkgs/development/libraries/gmp/5.1.3-CVE-2021-43618.patch
@@ -1,0 +1,20 @@
+Based on https://gmplib.org/repo/gmp-6.2/raw-rev/561a9c25298e,
+adapted for 5.x by ris
+
+diff -r e1fd9db13b47 -r 561a9c25298e mpz/inp_raw.c
+--- a/mpz/inp_raw.c	Tue Dec 22 23:49:51 2020 +0100
++++ b/mpz/inp_raw.c	Thu Oct 21 19:06:49 2021 +0200
+@@ -81,8 +81,11 @@
+ 
+   abs_csize = ABS (csize);
+ 
++  if (UNLIKELY (abs_csize > ~(mp_bitcnt_t) 0 / 8))
++    return 0; /* Bit size overflows */
++
+   /* round up to a multiple of limbs */
+-  abs_xsize = (abs_csize*8 + GMP_NUMB_BITS-1) / GMP_NUMB_BITS;
++  abs_xsize = ((mp_bitcnt_t)abs_csize*8 + GMP_NUMB_BITS-1) / GMP_NUMB_BITS;
+ 
+   if (abs_xsize != 0)
+     {
+

--- a/pkgs/development/libraries/gmp/5.1.x.nix
+++ b/pkgs/development/libraries/gmp/5.1.x.nix
@@ -22,7 +22,11 @@ let self = stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ m4 ];
 
-  patches = if stdenv.isDarwin then [ ./need-size-t.patch ] else null;
+  patches = [
+    ./5.1.3-CVE-2021-43618.patch
+  ] ++ lib.optionals stdenv.isDarwin [
+    ./need-size-t.patch
+  ];
 
   configureFlags = [
     "--with-pic"

--- a/pkgs/development/libraries/gmp/6.2.1-CVE-2021-43618.patch
+++ b/pkgs/development/libraries/gmp/6.2.1-CVE-2021-43618.patch
@@ -1,0 +1,19 @@
+https://gmplib.org/repo/gmp-6.2/raw-rev/561a9c25298e
+
+diff -r e1fd9db13b47 -r 561a9c25298e mpz/inp_raw.c
+--- a/mpz/inp_raw.c	Tue Dec 22 23:49:51 2020 +0100
++++ b/mpz/inp_raw.c	Thu Oct 21 19:06:49 2021 +0200
+@@ -88,8 +88,11 @@
+ 
+   abs_csize = ABS (csize);
+ 
++  if (UNLIKELY (abs_csize > ~(mp_bitcnt_t) 0 / 8))
++    return 0; /* Bit size overflows */
++
+   /* round up to a multiple of limbs */
+-  abs_xsize = BITS_TO_LIMBS (abs_csize*8);
++  abs_xsize = BITS_TO_LIMBS ((mp_bitcnt_t) abs_csize * 8);
+ 
+   if (abs_xsize != 0)
+     {
+

--- a/pkgs/development/libraries/gmp/6.x.nix
+++ b/pkgs/development/libraries/gmp/6.x.nix
@@ -20,6 +20,8 @@ let self = stdenv.mkDerivation rec {
     sha256 = "0z2ddfiwgi0xbf65z4fg4hqqzlhv0cc6hdcswf3c6n21xdmk5sga";
   };
 
+  patches = [ ./6.2.1-CVE-2021-43618.patch ];
+
   #outputs TODO: split $cxx due to libstdc++ dependency
   # maybe let ghc use a version with *.so shared with rest of nixpkgs and *.a added
   # - see #5855 for related discussion


### PR DESCRIPTION
###### Motivation for this change
#147877 https://nvd.nist.gov/vuln/detail/CVE-2021-43618

No upstream release yet.

~The issue looks like it applies to 5.x too but the patch will need a minor alteration I'll look at separately.~ added patch now.

Technically this is only an issue for 32bit ABIs so in theory I could apply this patch conditionally to reduce the rebuild burden, but it doesn't seem worth it as staging generally has to rebuild almost everything anyway.

Successfully built the _early_ version of gmp on the stated platforms and `pkgsi686Linux`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
