### PR TITLE
space-cadet-pinball: init at unstable-2021-12-02

### DIFF
--- a/pkgs/games/space-cadet-pinball/default.nix
+++ b/pkgs/games/space-cadet-pinball/default.nix
@@ -1,0 +1,51 @@
+{ lib, stdenv, fetchFromGitHub, fetchzip
+, cmake, SDL2, SDL2_mixer
+, unrar-wrapper, makeWrapper
+}:
+
+let
+  assets = (fetchzip {
+    url = "https://archive.org/download/SpaceCadet_Plus95/Space_Cadet.rar";
+    sha256 = "sha256-fC+zsR8BY6vXpUkVd6i1jF0IZZxVKVvNi6VWCKT+pA4=";
+    stripRoot = false;
+  }).overrideAttrs (old: {
+    nativeBuildInputs = old.nativeBuildInputs ++ [ unrar-wrapper ];
+  });
+in
+stdenv.mkDerivation rec {
+  pname = "SpaceCadetPinball";
+  version = "unstable-2021-12-02";
+
+  src = fetchFromGitHub {
+    owner = "k4zmu2a";
+    repo = pname;
+    rev = "de13d4e326b2dfa8e6dfb59815c0a8b9657f942d";
+    sha256 = "sha256-/nk4kNsmL1z2rKgV1dh9gcVjp8xJwovhE6/u2aNl/fA=";
+  };
+
+  buildInputs = [
+    SDL2
+    SDL2_mixer
+    cmake
+    makeWrapper
+  ];
+
+  postInstall = ''
+    mkdir -p $out/lib/SpaceCadetPinball
+    install ${assets}/*.{DAT,DOC,MID,BMP,INF} ${assets}/Sounds/*.WAV $out/lib/SpaceCadetPinball
+
+    # Assets are loaded from the directory of the program is stored in
+    # https://github.com/k4zmu2a/SpaceCadetPinball/blob/de13d4e326b2dfa8e6dfb59815c0a8b9657f942d/SpaceCadetPinball/winmain.cpp#L119
+    mv $out/bin/SpaceCadetPinball $out/lib/SpaceCadetPinball
+    makeWrapper $out/lib/SpaceCadetPinball/SpaceCadetPinball $out/bin/SpaceCadetPinball
+  '';
+
+  meta = with lib; {
+    description = "Reverse engineering of 3D Pinball for Windows – Space Cadet, a game bundled with Windows";
+    homepage = "https://github.com/k4zmu2a/SpaceCadetPinball";
+    # The assets are unfree while the code is labeled as MIT
+    license = with licenses; [ unfree mit ];
+    maintainers = [ maintainers.hqurve ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3598,6 +3598,8 @@ with pkgs;
 
   spacevim = callPackage ../applications/editors/spacevim { };
 
+  space-cadet-pinball = callPackage ../games/space-cadet-pinball { };
+
   ssmsh = callPackage ../tools/admin/ssmsh { };
 
   stacs = callPackage ../tools/security/stacs { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/k4zmu2a/SpaceCadetPinball

I believe that initiating on this commit (rather than Release 2.0) is preferred since build support for linux was only recently added (https://github.com/k4zmu2a/SpaceCadetPinball/commit/de13d4e326b2dfa8e6dfb59815c0a8b9657f942d)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
