### PR TITLE
postgresql_{11,12,13,14}: build with support for JIT compilation

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/postgis.nix
+++ b/pkgs/servers/sql/postgresql/ext/postgis.nix
@@ -1,5 +1,5 @@
 { fetchurl
-, lib, stdenv
+, lib, stdenv, llvmPackages_latest
 , perl
 , libxml2
 , postgresql
@@ -26,7 +26,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libxml2 postgresql geos proj gdal json_c protobufc ]
                 ++ lib.optional stdenv.isDarwin libiconv;
-  nativeBuildInputs = [ perl pkg-config ];
+
+  nativeBuildInputs = [ perl pkg-config ]
+    # If building with clang, we need llvm here to prevent the build from failing on `llvm-lto: command not found`
+    ++ lib.optionals stdenv.cc.isClang [ llvmPackages_latest.llvm ];
+
   dontDisableStatic = true;
 
   # postgis config directory assumes /include /lib from the same root for json-c library


### PR DESCRIPTION
###### Motivation for this change

This is a WIP PR for testing PostgreSQL with support for the LLVM-based JIT.

This is based almost entirely on @andir and @dasJ's work in https://github.com/NixOS/nixpkgs/pull/124804. My only real contribution here is to fix the build of `periods` and `postgis` when postgres is built with clang.

I tested only `postgresql_14` (14.1) with extensions `periods` and `postgis` on NixOS 21.11, and did not test other versions, macOS, or other extensions.

I am unable to finish this PR right now, and I also didn't find the JIT very useful, as it caused a GIN `CREATE INDEX` on an expression to use 100GB of RAM and crash the PostgreSQL server. There are similar reports of the JIT causing issues on the web and on the _People, Postgres, Data_ Discord.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
