### PR TITLE
[staging-next] Revert "util-linux: fix static build"

### DIFF
--- a/pkgs/os-specific/linux/util-linux/default.nix
+++ b/pkgs/os-specific/linux/util-linux/default.nix
@@ -1,10 +1,7 @@
 { lib, stdenv, fetchurl, pkg-config, zlib, shadow, libcap_ng
 , ncurses ? null, pam, systemd ? null
 , nlsSupport ? true
-, audit ? null
 }:
-
-assert stdenv.hostPlatform.isStatic -> audit != null;
 
 stdenv.mkDerivation rec {
   pname = "util-linux";
@@ -60,17 +57,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs =
     [ zlib pam libcap_ng ]
-    ++ lib.filter (p: p != null) [ ncurses systemd ]
-    # not sure how util-linux is linking with linux-pam,
-    # probably just with a simplistic -lpam.
-    # linux-pam doesn't seem to have a .pc file so I can't
-    # add -laudit to the Requires.private.
-    # libaudit is also needed directly anyway cf login-utils/login.c
-    # and sys-utils/hwclock.c, not sure how we got it working
-    # without audit on dynamic builds.
-    ++ lib.optionals stdenv.hostPlatform.isStatic [ audit ];
-
-  NIX_CFLAGS_LINK = lib.optionalString stdenv.hostPlatform.isStatic "-laudit";
+    ++ lib.filter (p: p != null) [ ncurses systemd ];
 
   doCheck = false; # "For development purpose only. Don't execute on production system!"
 


### PR DESCRIPTION
This reverts commit 1f0ef842ca88a57613faf1ef4cd9a5d4e77efd81.  The underlying issue was fixed in 2ebeb02a99a ("stdenv/setup: tell libtool about library paths"), so we don't need a workaround in util-linux any more.

@SCOTT-HAMILTON, https://github.com/NixOS/nixpkgs/pull/144749 was merged two days before https://github.com/NixOS/nixpkgs/pull/147429 was opened.  Since static stuff is moving quite quickly in Nixpkgs at the moment, it's worth checking whether an issue still exists on staging before submitting a fix.
