### PR TITLE
python3Packages.pywebview: 3.4 -> 3.5

### DIFF
--- a/pkgs/development/python-modules/proxy_tools/default.nix
+++ b/pkgs/development/python-modules/proxy_tools/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "proxy_tools";
+  version = "0.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-zLN1H1KcBH4tilhEDYayBTA88P6BRveE0cvNlPCigBA=";
+  };
+
+  # no tests in pypi
+  doCheck = false;
+  pythonImportsCheck = [ "proxy_tools" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/jtushman/proxy_tools";
+    description = "Simple (hopefuly useful) Proxy (as in the GoF design pattern) implementation for Python";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ jojosch ];
+  };
+}

--- a/pkgs/development/python-modules/pywebview/default.nix
+++ b/pkgs/development/python-modules/pywebview/default.nix
@@ -7,18 +7,19 @@
 , pythonOlder
 , qt5
 , xvfb-run
+, proxy_tools
 }:
 
 buildPythonPackage rec {
   pname = "pywebview";
-  version = "3.4";
+  version = "3.5";
   disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "r0x0r";
     repo = "pywebview";
     rev = version;
-    sha256 = "sha256-3JHwtw8oReolEl4k8cdt7GCVGNkfWWJN6EnZYHxzDO8=";
+    sha256 = "sha256-+At/ToEylSPcLh/u2NHVTXQpMnw+2/afsevg5YAX/4c=";
   };
 
   nativeBuildInputs = [
@@ -27,6 +28,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     pyqtwebengine
+    proxy_tools
   ] ++ lib.optionals (pythonOlder "3.7") [ importlib-resources ];
 
   checkInputs = [
@@ -51,6 +53,8 @@ buildPythonPackage rec {
     xvfb-run -s '-screen 0 800x600x24' ./run.sh
     popd
   '';
+
+  pythonImportsCheck = [ "webview" ];
 
   meta = with lib; {
     homepage = "https://github.com/r0x0r/pywebview";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5813,6 +5813,8 @@ in {
 
   ppdeep = callPackage ../development/python-modules/ppdeep { };
 
+  proxy_tools = callPackage ../development/python-modules/proxy_tools { };
+
   pyaehw4a1 = callPackage ../development/python-modules/pyaehw4a1 { };
 
   pyatag = callPackage ../development/python-modules/pyatag { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest release https://github.com/r0x0r/pywebview/releases/tag/3.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>5 packages built:</summary>
  <ul>
    <li>jellyfin-mpv-shim</li>
    <li>python38Packages.proxy_tools</li>
    <li>python38Packages.pywebview</li>
    <li>python39Packages.proxy_tools</li>
    <li>python39Packages.pywebview</li>
  </ul>
</details>
