### PR TITLE
jsonwatch: move to tools

### DIFF
--- a/pkgs/tools/misc/jsonwatch/default.nix
+++ b/pkgs/tools/misc/jsonwatch/default.nix
@@ -1,37 +1,38 @@
 { lib
-, buildPythonPackage
+, stdenv
 , fetchFromGitHub
-, six
-, isPyPy
+, rustPlatform
+, Security
 }:
 
-buildPythonPackage rec {
+rustPlatform.buildRustPackage rec {
   pname = "jsonwatch";
-  version = "0.2.0";
-  disabled = isPyPy; # doesn't find setuptools
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "dbohdan";
-    repo = "jsonwatch";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-yLN6jOxAz+B7zvV3tGT6Nxi17v9ZOtWpbtSi0o1h48U=";
+    sha256 = "sha256-TGW04P8t0mAXza7I7qp6QRXA/MDE3m1dlRC7bMf2dSk=";
   };
 
-  propagatedBuildInputs = [ six ];
+  cargoSha256 = "sha256-Gjb7v3kz11iOml3Ykxhy43KNxzaprgMbb5DpPNChLTc=";
+
+  buildInputs = lib.optional stdenv.isDarwin [
+    Security
+  ];
 
   meta = with lib; {
     description = "Like watch -d but for JSON";
     longDescription = ''
       jsonwatch is a command line utility with which you can track
       changes in JSON data delivered by a shell command or a web
-      (HTTP/HTTPS) API.  jsonwatch requests data from the designated
+      (HTTP/HTTPS) API. jsonwatch requests data from the designated
       source repeatedly at a set interval and displays the
-      differences when the data changes. It is similar in its
-      behavior to how watch(1) with the -d switch works for
-      plain-text data.
+      differences when the data changes.
     '';
     homepage = "https://github.com/dbohdan/jsonwatch";
     license = licenses.mit;
-    platforms = platforms.all;
+    maintainers = with maintainers; [ fab ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6724,6 +6724,10 @@ with pkgs;
 
   json-schema-for-humans = with python3Packages; toPythonApplication json-schema-for-humans;
 
+  jsonwatch = callPackage ../tools/misc/jsonwatch {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   jtc = callPackage ../development/tools/jtc { };
 
   jumpapp = callPackage ../tools/X11/jumpapp {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4095,8 +4095,6 @@ in {
 
   jsonstreams = callPackage ../development/python-modules/jsonstreams { };
 
-  jsonwatch = callPackage ../development/python-modules/jsonwatch { };
-
   jug = callPackage ../development/python-modules/jug { };
 
   junitparser = callPackage ../development/python-modules/junitparser { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
[`jsonwatch`](https://github.com/dbohdan/jsonwatch) was migrated from Python to Rust.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
