### PR TITLE
elm-test-rs: init at 2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13389,4 +13389,10 @@
     github = "vdot0x23";
     githubId = 40716069;
   };
+  jpagex = {
+    name = "Jérémy Pagé";
+    email = "contact@jeremypage.me";
+    github = "jpagex";
+    githubId = 635768;
+  };
 }

--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -2,7 +2,7 @@
 , haskell, haskellPackages, nodejs
 , fetchurl, fetchpatch, makeWrapper, writeScriptBin
   # Rust dependecies
-, curl, rustPlatform, openssl, pkg-config, Security
+, curl, rustPlatform, openssl, pkg-config, Security, darwin
 }:
 let
   fetchElmDeps = import ./fetchElmDeps.nix { inherit stdenv lib fetchurl; };
@@ -109,6 +109,17 @@ let
         homepage = "https://github.com/zwilias/elm-json";
         license = licenses.mit;
         maintainers = [ maintainers.turbomack ];
+      };
+    };
+
+    elm-test-rs = import ./packages/elm-test-rs.nix {
+      inherit lib rustPlatform fetchurl openssl stdenv Security darwin;
+    } // {
+      meta = with lib; {
+        description = "Fast and portable executable to run your Elm tests";
+        homepage = "https://github.com/mpizenberg/elm-test-rs";
+        license = licenses.bsd3;
+        maintainers = [ maintainers.jpagex ];
       };
     };
   };

--- a/pkgs/development/compilers/elm/packages/elm-test-rs.nix
+++ b/pkgs/development/compilers/elm/packages/elm-test-rs.nix
@@ -1,0 +1,18 @@
+{ lib, rustPlatform, fetchurl, openssl, stdenv, Security, darwin }:
+rustPlatform.buildRustPackage rec {
+  pname = "elm-test-rs";
+  version = "2.0";
+
+  src = fetchurl {
+    url = "https://github.com/mpizenberg/elm-test-rs/archive/v${version}.tar.gz";
+    sha256 = "sha256:1manr42w613r9vyji7pxx5gb08jcgkdxv29qqylrqlwxa8d5dcid";
+  };
+
+  buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security darwin.apple_sdk.frameworks.CoreServices ];
+
+  cargoSha256 = "sha256:1dpdlzv96kpc25yf5jgsz9qldghyw35x382qpxhkadkn5dryzjvd";
+  verifyCargoDeps = true;
+
+  # Tests perform networking and therefore can't work in sandbox
+  doCheck = false;
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I would like to add [elm-test-rs](https://github.com/mpizenberg/elm-test-rs) to Nixpkgs.

This is an alternative to `elm-test` written in Rust by @mpizenberg.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


@turboMaCk I took inspiration on what you have done for `elm-json`. Maybe you can double-check?
@mpizenberg Let me know if it is OK for you to publish on Nixpkgs.