### PR TITLE
update modsecurity packages

### DIFF
--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -252,8 +252,8 @@ in
       name = "modsecurity-nginx";
       owner = "SpiderLabs";
       repo = "ModSecurity-nginx";
-      rev = "v1.0.1";
-      sha256 = "0cbb3g3g4v6q5zc6an212ia5kjjad62bidnkm8b70i4qv1615pzf";
+      rev = "v1.0.2";
+      sha256 = "sha256-UXiitc3jZlgXlCsDPS+xEFLNRVgRbn8BCCXUEqAWlII=";
     };
     inputs = [ pkgs.curl pkgs.geoip pkgs.libmodsecurity pkgs.libxml2 pkgs.lmdb pkgs.yajl ];
   };

--- a/pkgs/tools/security/libmodsecurity/default.nix
+++ b/pkgs/tools/security/libmodsecurity/default.nix
@@ -1,34 +1,57 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config
-, doxygen, perl, valgrind
-, curl, geoip, libxml2, lmdb, lua, pcre, yajl }:
+{ lib, stdenv, fetchFromGitHub
+, autoreconfHook, bison, flex, pkg-config
+, curl, geoip, libmaxminddb, libxml2, lmdb, lua, pcre
+, ssdeep, valgrind, yajl
+}:
 
 stdenv.mkDerivation rec {
   pname = "libmodsecurity";
-  version = "3.0.4";
+  version = "3.0.6";
 
   src = fetchFromGitHub {
     owner = "SpiderLabs";
     repo = "ModSecurity";
-    fetchSubmodules = true;
     rev = "v${version}";
-    sha256 = "07vry10cdll94sp652hwapn0ppjv3mb7n2s781yhy7hssap6f2vp";
+    sha256 = "sha256-V+NBT2YN8qO3Px8zEzSA2ZsjSf1pv8+VlLxYlrpqfGg=";
+    fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ autoreconfHook pkg-config doxygen ];
+  nativeBuildInputs = [ autoreconfHook bison flex pkg-config ];
+  buildInputs = [ curl geoip libmaxminddb libxml2 lmdb lua pcre ssdeep valgrind yajl ];
 
-  buildInputs = [ perl valgrind curl geoip libxml2 lmdb lua pcre yajl ];
+  outputs = [ "out" "dev" ];
 
   configureFlags = [
-    "--enable-static"
+    "--enable-parser-generation"
     "--with-curl=${curl.dev}"
     "--with-libxml=${libxml2.dev}"
+    "--with-lmdb=${lmdb.out}"
+    "--with-maxmind=${libmaxminddb}"
     "--with-pcre=${pcre.dev}"
-    "--with-yajl=${yajl}"
+    "--with-ssdeep=${ssdeep}"
   ];
+
+  postPatch = ''
+    substituteInPlace build/lmdb.m4 \
+      --replace "\''${path}/include/lmdb.h" "${lmdb.dev}/include/lmdb.h" \
+      --replace "lmdb_inc_path=\"\''${path}/include\"" "lmdb_inc_path=\"${lmdb.dev}/include\""
+    substituteInPlace build/ssdeep.m4 \
+      --replace "/usr/local/libfuzzy" "${ssdeep}/lib" \
+      --replace "\''${path}/include/fuzzy.h" "${ssdeep}/include/fuzzy.h" \
+      --replace "ssdeep_inc_path=\"\''${path}/include\"" "ssdeep_inc_path=\"${ssdeep}/include\""
+    substituteInPlace modsecurity.conf-recommended \
+      --replace "SecUnicodeMapFile unicode.mapping 20127" "SecUnicodeMapFile $out/share/modsecurity/unicode.mapping 20127"
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/modsecurity
+    cp ${src}/{AUTHORS,CHANGES,LICENSE,README.md,modsecurity.conf-recommended,unicode.mapping} $out/share/modsecurity
+  '';
 
   enableParallelBuilding = true;
 
   meta = with lib; {
+    homepage = "https://github.com/SpiderLabs/ModSecurity";
     description = ''
       ModSecurity v3 library component.
     '';
@@ -40,7 +63,6 @@ stdenv.mkDerivation rec {
       the ModSecurity SecRules format and apply them to HTTP content provided
       by your application via Connectors.
     '';
-    homepage = "https://modsecurity.org/";
     license = licenses.asl20;
     platforms = platforms.all;
     maintainers = with maintainers; [ izorkin ];

--- a/pkgs/tools/security/modsecurity-crs/default.nix
+++ b/pkgs/tools/security/modsecurity-crs/default.nix
@@ -1,0 +1,42 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  version = "3.3.2";
+  pname = "modsecurity-crs";
+
+  src = fetchFromGitHub {
+    owner = "coreruleset";
+    repo = "coreruleset";
+    rev = "v${version}";
+    sha256 = "sha256-m/iVLhk2y5BpYu8EwC2adrrDnbaVCQ0SE25ltvMokCw=";
+  };
+
+  installPhase = ''
+    install -D -m444 -t $out/rules ${src}/rules/*.conf
+    install -D -m444 -t $out/rules ${src}/rules/*.data
+    install -D -m444 -t $out/share/doc/modsecurity-crs ${src}/*.md
+    install -D -m444 -t $out/share/doc/modsecurity-crs ${src}/{CHANGES,INSTALL,LICENSE}
+    install -D -m444 -t $out/share/modsecurity-crs ${src}/rules/*.example
+    install -D -m444 -t $out/share/modsecurity-crs ${src}/crs-setup.conf.example
+    cat > $out/share/modsecurity-crs/modsecurity-crs.load.example <<EOF
+    ##
+    ## This is a sample file for loading OWASP CRS's rules.
+    ##
+    Include /etc/modsecurity/crs/crs-setup.conf
+    IncludeOptional /etc/modsecurity/crs/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
+    Include $out/rules/*.conf
+    IncludeOptional /etc/modsecurity/crs/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf
+    EOF
+  '';
+
+  meta = with lib; {
+    homepage = "https://coreruleset.org";
+    description = ''
+      The OWASP ModSecurity Core Rule Set is a set of generic attack detection
+      rules for use with ModSecurity or compatible web application firewalls.
+    '';
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ izorkin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7881,6 +7881,8 @@ with pkgs;
 
   modsecurity_standalone = callPackage ../tools/security/modsecurity { };
 
+  modsecurity-crs = callPackage ../tools/security/modsecurity-crs { };
+
   molly-guard = callPackage ../os-specific/linux/molly-guard { };
 
   molotov = callPackage ../applications/video/molotov {};


### PR DESCRIPTION
###### Motivation for this change
Update libmodsecurity to 3.0.6
Update nginx modsecurity module to 1.0.2
Add OWASP ModSecurity Core Rule Set

cc @ajs124 @dasJ @Mic92

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
