### PR TITLE
promscale: 0.6.2 -> 0.7.1

### DIFF
--- a/pkgs/servers/monitoring/prometheus/promscale/0001-remove-jaeger-test-dep.patch
+++ b/pkgs/servers/monitoring/prometheus/promscale/0001-remove-jaeger-test-dep.patch
@@ -1,0 +1,17 @@
+
+A Promscale test has a dependency on a package which was not intended to be
+vendored, so `go mod vendor` breaks. The dependency is not required to build
+Promscale, so it can be removed.
+
+diff --git a/pkg/tests/end_to_end_tests/trace_query_integration_test.go b/pkg/tests/end_to_end_tests/trace_query_integration_test.go
+index 84a0d08..efbe5e1 100644
+--- a/pkg/tests/end_to_end_tests/trace_query_integration_test.go
++++ b/pkg/tests/end_to_end_tests/trace_query_integration_test.go
+@@ -24,7 +24,6 @@ import (
+ 	ingstr "github.com/timescale/promscale/pkg/pgmodel/ingestor"
+ 	"github.com/timescale/promscale/pkg/pgxconn"
+ 
+-	jaegerQueryApp "github.com/jaegertracing/jaeger/cmd/query/app"
+ 	jaegerQueryService "github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
+ 	jaegerJSONModel "github.com/jaegertracing/jaeger/model/json"
+ )

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21358,7 +21358,7 @@ with pkgs;
     asciidoc = asciidoc-full;
   };
 
-  promscale = callPackage ../servers/monitoring/prometheus/promscale.nix { };
+  promscale = callPackage ../servers/monitoring/prometheus/promscale { };
 
   timescaledb-parallel-copy = callPackage ../development/tools/database/timescaledb-parallel-copy { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
