### PR TITLE
WIP filament: init at 1.15.0

### DIFF
--- a/pkgs/development/libraries/filament/default.nix
+++ b/pkgs/development/libraries/filament/default.nix
@@ -1,0 +1,53 @@
+{ clang11Stdenv, fetchFromGitHub, cmake, file, ninja, python3, lib
+, libXext, libXi, libglvnd, libxcb, libX11, libXxf86vm
+, darwin
+}:
+
+clang11Stdenv.mkDerivation rec {
+  pname = "filament";
+  version = "1.15.0";
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "filament";
+    rev = "v${version}";
+    sha256 = "1w11avrla9j1cjm58gm7hvf7xs5f40vjfhx2c251x6siq652zw3i";
+  };
+
+  cmakeFlags = lib.optionals clang11Stdenv.isLinux [
+    "-DUSE_STATIC_LIBCXX=OFF"
+  ];
+
+  preConfigure = ''
+    patchShebangs --build $(find -name '*.py' -or -name '*.sh')
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    file
+    ninja
+    python3
+  ];
+
+  buildInputs = [
+  ] ++ lib.optionals clang11Stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+    Cocoa
+    Foundation
+    ForceFeedback
+    OpenGL
+  ]) ++ lib.optionals clang11Stdenv.isLinux [
+    libX11
+    libXext
+    libXi
+    libXxf86vm
+    libglvnd
+    libxcb
+  ];
+
+  meta = with lib; {
+    homepage = "https://google.github.io/filament/";
+    description = "Filament is a real-time physically based rendering engine for Android, iOS, Windows, Linux, macOS, and WebGL2";
+    license = licenses.asl20;
+    maintainers = [ maintainers.lucus16 ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16215,6 +16215,8 @@ with pkgs;
   fftwFloat = fftwSinglePrec; # the configure option is just an alias
   fftwLongDouble = fftw.override { precision = "long-double"; };
 
+  filament = callPackage ../development/libraries/filament { };
+
   filter-audio = callPackage ../development/libraries/filter-audio {};
 
   filtron = callPackage ../servers/filtron {};


### PR DESCRIPTION
###### Motivation for this change

Filament is a cross-platform physically based rendering engine.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
