### PR TITLE
pcsclite: 1.9.4 -> 1.9.5

### DIFF
--- a/pkgs/tools/security/pcsclite/default.nix
+++ b/pkgs/tools/security/pcsclite/default.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "pcsclite";
-  version = "1.9.4";
+  version = "1.9.5";
 
   outputs = [ "bin" "out" "dev" "doc" "man" ];
 
   src = fetchurl {
     url = "https://pcsclite.apdu.fr/files/pcsc-lite-${version}.tar.bz2";
-    sha256 = "sha256:0jqwnpywk9ka3q88b1k93p8s0xhmx1isdpcqa80nd8p04z1am34a";
+    sha256 = "sha256-nuP5szNTdWIXeJNVmtT3uNXCPr6Cju9TBWwC2xQEnQg=";
   };
 
   patches = [ ./no-dropdir-literals.patch ];

--- a/pkgs/tools/security/pcsclite/no-dropdir-literals.patch
+++ b/pkgs/tools/security/pcsclite/no-dropdir-literals.patch
@@ -45,29 +45,4 @@ index eff8519..8dd496d 100644
  		Log1(PCSC_LOG_INFO, "Disabling USB support for pcscd");
  	}
  #ifdef DEBUG_HOTPLUG
-diff --git a/src/hotplug_linux.c b/src/hotplug_linux.c
-index bf69af8..64b0ed7 100644
---- a/src/hotplug_linux.c
-+++ b/src/hotplug_linux.c
-@@ -130,8 +130,8 @@ static LONG HPReadBundleValues(void)
- 
- 	if (hpDir == NULL)
- 	{
--		Log1(PCSC_LOG_INFO,
--			"Cannot open PC/SC drivers directory: " PCSCLITE_HP_DROPDIR);
-+		Log2(PCSC_LOG_INFO, "Cannot open PC/SC drivers directory: %s",
-+			PCSCLITE_HP_DROPDIR);
- 		Log1(PCSC_LOG_INFO, "Disabling USB support for pcscd.");
- 		return -1;
- 	}
-@@ -219,8 +219,8 @@ end:
- 
- 	if (bundleSize == 0)
- 	{
--		Log1(PCSC_LOG_INFO,
--			"No bundle files in pcsc drivers directory: " PCSCLITE_HP_DROPDIR);
-+		Log2(PCSC_LOG_INFO, "No bundle files in pcsc drivers directory: %s",
-+			PCSCLITE_HP_DROPDIR);
- 		Log1(PCSC_LOG_INFO, "Disabling USB support for pcscd");
- 	}
  


### PR DESCRIPTION
The patch had to be edited since `hotplug_linux.c` was removed in https://salsa.debian.org/rousseau/PCSC/-/commit/6f8f170db3c88c59a5ddb5ae5319b921a901a6aa

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
