### PR TITLE
treewide: use pname&version instead of name

### DIFF
--- a/pkgs/os-specific/linux/v86d/default.nix
+++ b/pkgs/os-specific/linux/v86d/default.nix
@@ -5,14 +5,16 @@
 , klibc
 }:
 
-stdenv.mkDerivation rec {
-  name = "v86d-${version}-${kernel.version}";
-  version = "0.1.10";
+let
+  pversion = "0.1.10";
+in stdenv.mkDerivation rec {
+  pname = "v86d";
+  version = "${pversion}-${kernel.version}";
 
   src = fetchFromGitHub {
     owner = "mjanusz";
     repo = "v86d";
-    rev = "v86d-${version}";
+    rev = "v86d-${pversion}";
     hash = "sha256-95LRzVbO/DyddmPwQNNQ290tasCGoQk7FDHlst6LkbA=";
   };
 

--- a/pkgs/os-specific/linux/vendor-reset/default.nix
+++ b/pkgs/os-specific/linux/vendor-reset/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, kernel, lib }:
 
 stdenv.mkDerivation rec {
-  name = "vendor-reset-${version}-${kernel.version}";
-  version = "unstable-2021-02-16";
+  pname = "vendor-reset";
+  version = "unstable-2021-02-16-${kernel.version}";
 
   src = fetchFromGitHub {
     owner = "gnif";

--- a/pkgs/os-specific/linux/virtualbox/default.nix
+++ b/pkgs/os-specific/linux/virtualbox/default.nix
@@ -1,7 +1,8 @@
 { stdenv, virtualbox, kernel }:
 
 stdenv.mkDerivation {
-  name = "virtualbox-modules-${virtualbox.version}-${kernel.version}";
+  pname = "virtualbox-modules";
+  version = "${virtualbox.version}-${kernel.version}";
   src = virtualbox.modsrc;
   hardeningDisable = [
     "fortify" "pic" "stackprotector"

--- a/pkgs/os-specific/linux/x86_energy_perf_policy/default.nix
+++ b/pkgs/os-specific/linux/x86_energy_perf_policy/default.nix
@@ -1,7 +1,8 @@
 { lib, stdenv, kernel }:
 
 stdenv.mkDerivation {
-  name = "x86_energy_perf_policy-${kernel.version}";
+  pname = "x86_energy_perf_policy";
+  version = kernel.version;
 
   src = kernel.src;
 

--- a/pkgs/servers/openafs/1.8/module.nix
+++ b/pkgs/servers/openafs/1.8/module.nix
@@ -23,8 +23,9 @@ let
 
 in
 stdenv.mkDerivation {
-  name = "openafs-${version}-${kernel.modDirVersion}";
-  inherit version src;
+  pname = "openafs";
+  version = "${version}-${kernel.modDirVersion}";
+  inherit src;
 
   nativeBuildInputs = [ autoconf automake flex libtool_2 perl which bison ]
     ++ kernel.moduleBuildDependencies;

--- a/pkgs/servers/openafs/1.9/module.nix
+++ b/pkgs/servers/openafs/1.9/module.nix
@@ -10,8 +10,9 @@ let
   kernelBuildDir = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
 
 in stdenv.mkDerivation {
-  name = "openafs-${version}-${kernel.modDirVersion}";
-  inherit version src;
+  pname = "openafs";
+  version = "${version}-${kernel.modDirVersion}";
+  inherit src;
 
   nativeBuildInputs = [ autoconf automake flex libtool_2 perl which bison ]
     ++ kernel.moduleBuildDependencies;

--- a/pkgs/shells/zsh/zsh-better-npm-completion/default.nix
+++ b/pkgs/shells/zsh/zsh-better-npm-completion/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  name = "zsh-better-npm-completion";
+  pname = "zsh-better-npm-completion";
   version = "unstable-2019-11-19";
 
   src = fetchFromGitHub {

--- a/pkgs/shells/zsh/zsh-deer/default.nix
+++ b/pkgs/shells/zsh/zsh-deer/default.nix
@@ -1,10 +1,8 @@
 { lib, stdenv, fetchFromGitHub, perl }:
 
-let
+stdenv.mkDerivation rec {
+  pname = "deer";
   version = "1.4";
-  name = "deer-${version}";
-in stdenv.mkDerivation {
-  inherit name;
 
   src = fetchFromGitHub {
     owner = "Vifon";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#103997

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
