### PR TITLE
vmware-horizon-client: 2106.1 -> 2111

### DIFF
--- a/pkgs/applications/networking/remote/vmware-horizon-client/default.nix
+++ b/pkgs/applications/networking/remote/vmware-horizon-client/default.nix
@@ -1,57 +1,40 @@
 { stdenv
 , lib
-, at-spi2-atk
-, atk
 , buildFHSUserEnv
-, cairo
-, dbus
 , fetchurl
-, fontconfig
-, freetype
-, gdk-pixbuf
-, glib
 , gsettings-desktop-schemas
-, gtk2
-, gtk3-x11
-, harfbuzz
-, liberation_ttf
-, libjpeg
-, libtiff
-, libudev0-shim
-, libuuid
-, libX11
-, libXcursor
-, libXext
-, libXi
-, libXinerama
-, libxkbfile
-, libxml2
-, libXrandr
-, libXrender
-, libXScrnSaver
-, libxslt
-, libXtst
 , makeDesktopItem
 , makeWrapper
-, pango
-, pcsclite
-, pixman
-, zlib
+, writeTextDir
+, configText ? ""
 }:
 let
-  version = "2106.1";
+  version = "2111";
 
   sysArch =
     if stdenv.hostPlatform.system == "x86_64-linux" then "x64"
     else throw "Unsupported system: ${stdenv.hostPlatform.system}";
   # The downloaded archive also contains ARM binaries, but these have not been tested.
 
+  # For USB support, ensure that /var/run/vmware/<YOUR-UID>
+  # exists and is owned by you. Then run vmware-usbarbitrator as root.
+  bins = [ "vmware-view" "vmware-usbarbitrator" ];
+
+  # This forces the default GTK theme (Adwaita) because Horizon is prone to
+  # UI usability issues when using non-default themes, such as Adwaita-dark.
+  wrapBinCommands = name: ''
+    makeWrapper "$out/bin/${name}" "$out/bin/${name}_wrapper" \
+    --set GTK_THEME Adwaita \
+    --suffix XDG_DATA_DIRS : "${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}" \
+    --suffix LD_LIBRARY_PATH : "$out/lib/vmware/view/crtbora:$out/lib/vmware"
+  '';
+
   vmwareHorizonClientFiles = stdenv.mkDerivation {
     name = "vmwareHorizonClientFiles";
     inherit version;
     src = fetchurl {
-      url = "https://download3.vmware.com/software/view/viewclients/CART22FQ2/VMware-Horizon-Client-Linux-2106.1-8.3.1-18435609.tar.gz";
-      sha256 = "b42ddb9d7e9c8d0f8b86b69344fcfca45251c5a5f1e06a18a3334d5a04e18c39";
+      url = "https://download3.vmware.com/software/view/viewclients/CART22FH2/VMware-Horizon-Client-Linux-2111-8.4.0-18957622.tar.gz";
+      sha256 = "2f79d2d8d34e6f85a5d21a3350618c4763d60455e7d68647ea40715eaff486f7";
     };
     nativeBuildInputs = [ makeWrapper ];
     installPhase = ''
@@ -65,27 +48,19 @@ let
       # Deleting the bundled library is the simplest way to force it to use our version.
       rm "$out/lib/vmware/gcc/libstdc++.so.6"
 
-      # This libjpeg library interferes with Chromium, so we will be using ours instead.
-      rm $out/lib/vmware/libjpeg.*
-
       # This library causes the program to core-dump occasionally. Use ours instead.
       rm $out/lib/vmware/view/crtbora/libcairo.*
 
-      # Force the default GTK theme (Adwaita) because Horizon is prone to
-      # UI usability issues when using non-default themes, such as Adwaita-dark.
-      makeWrapper "$out/bin/vmware-view" "$out/bin/vmware-view_wrapper" \
-          --set GTK_THEME Adwaita \
-          --suffix XDG_DATA_DIRS : "${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}" \
-          --suffix LD_LIBRARY_PATH : "$out/lib/vmware/view/crtbora:$out/lib/vmware"
+      ${lib.concatMapStrings wrapBinCommands bins}
     '';
   };
 
-  vmwareFHSUserEnv = buildFHSUserEnv {
-    name = "vmware-view";
+  vmwareFHSUserEnv = name: buildFHSUserEnv {
+    inherit name;
 
-    runScript = "${vmwareHorizonClientFiles}/bin/vmware-view_wrapper";
+    runScript = "${vmwareHorizonClientFiles}/bin/${name}_wrapper";
 
-    targetPkgs = pkgs: [
+    targetPkgs = pkgs: with pkgs; [
       at-spi2-atk
       atk
       cairo
@@ -99,25 +74,29 @@ let
       harfbuzz
       liberation_ttf
       libjpeg
+      libpulseaudio
       libtiff
       libudev0-shim
       libuuid
-      libX11
-      libXcursor
-      libXext
-      libXi
-      libXinerama
-      libxkbfile
+      libv4l
       libxml2
-      libXrandr
-      libXrender
-      libXScrnSaver
-      libXtst
       pango
       pcsclite
       pixman
       vmwareHorizonClientFiles
+      xorg.libX11
+      xorg.libXcursor
+      xorg.libXext
+      xorg.libXi
+      xorg.libXinerama
+      xorg.libxkbfile
+      xorg.libXrandr
+      xorg.libXrender
+      xorg.libXScrnSaver
+      xorg.libXtst
       zlib
+
+      (writeTextDir "etc/vmware/config" configText)
     ];
   };
 
@@ -125,20 +104,25 @@ let
     name = "vmware-view";
     desktopName = "VMware Horizon Client";
     icon = "${vmwareHorizonClientFiles}/share/icons/vmware-view.png";
-    exec = "${vmwareFHSUserEnv}/bin/vmware-view %u";
+    exec = "${vmwareFHSUserEnv "vmware-view"}/bin/vmware-view %u";
     mimeType = "x-scheme-handler/vmware-view";
   };
 
+  binLinkCommands = lib.concatMapStringsSep
+    "\n"
+    (bin: "ln -s ${vmwareFHSUserEnv bin}/bin/${bin} $out/bin/")
+    bins;
+
 in
 stdenv.mkDerivation {
-  name = "vmware-view";
+  name = "vmware-horizon-client";
 
   dontUnpack = true;
 
   installPhase = ''
     mkdir -p $out/bin $out/share/applications
-    cp "${desktopItem}"/share/applications/* $out/share/applications/
-    ln -s "${vmwareFHSUserEnv}/bin/vmware-view" "$out/bin/"
+    cp ${desktopItem}/share/applications/* $out/share/applications/
+    ${binLinkCommands}
   '';
 
   unwrapped = vmwareHorizonClientFiles;
@@ -146,10 +130,11 @@ stdenv.mkDerivation {
   passthru.updateScript = ./update.sh;
 
   meta = with lib; {
+    mainProgram = "vmware-view";
     description = "Allows you to connect to your VMware Horizon virtual desktop";
     homepage = "https://www.vmware.com/go/viewclients";
     license = licenses.unfree;
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ buckley310 ];
   };
 }


### PR DESCRIPTION

###### Motivation for this change
While updating, I also fixed these things, which were unavailable before:
1, real-time audio/video support (microphone/webcam)
2, allow USB passthrough
3, adds a `configText` argument which will be presented as the contents of `/etc/vmware/config` to horizon

A module / systemd service can take care of this in the future, but right now in order to get USB passthrough working, the user must manually run the following commands before launching the horizon client:

```
sudo mkdir -p "/var/run/vmware/$UID"
sudo chown "$USER" "/var/run/vmware/$UID"
sudo vmware-usbarbitrator
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
