### PR TITLE
Draft: nixos/jellyfin: use  upstream jellyfin unit

### DIFF
--- a/nixos/modules/services/misc/jellyfin.nix
+++ b/nixos/modules/services/misc/jellyfin.nix
@@ -44,6 +44,9 @@ in
   };
 
   config = mkIf cfg.enable {
+
+    systemd.packages = [ cfg.package ]; # will this get merged at systemd level?
+
     systemd.services.jellyfin = {
       description = "Jellyfin Media Server";
       after = [ "network.target" ];
@@ -55,45 +58,6 @@ in
         StateDirectory = "jellyfin";
         CacheDirectory = "jellyfin";
         ExecStart = "${cfg.package}/bin/jellyfin --datadir '/var/lib/${StateDirectory}' --cachedir '/var/cache/${CacheDirectory}'";
-        Restart = "on-failure";
-
-        # Security options:
-
-        NoNewPrivileges = true;
-
-        AmbientCapabilities = "";
-        CapabilityBoundingSet = "";
-
-        # ProtectClock= adds DeviceAllow=char-rtc r
-        DeviceAllow = "";
-
-        LockPersonality = true;
-
-        PrivateTmp = true;
-        PrivateDevices = true;
-        PrivateUsers = true;
-
-        ProtectClock = true;
-        ProtectControlGroups = true;
-        ProtectHostname = true;
-        ProtectKernelLogs = true;
-        ProtectKernelModules = true;
-        ProtectKernelTunables = true;
-
-        RemoveIPC = true;
-
-        RestrictNamespaces = true;
-        # AF_NETLINK needed because Jellyfin monitors the network connection
-        RestrictAddressFamilies = [ "AF_NETLINK" "AF_INET" "AF_INET6" ];
-        RestrictRealtime = true;
-        RestrictSUIDSGID = true;
-
-        SystemCallArchitectures = "native";
-        SystemCallErrorNumber = "EPERM";
-        SystemCallFilter = [
-          "@system-service"
-          "~@cpu-emulation" "~@debug" "~@keyring" "~@memlock" "~@obsolete" "~@privileged" "~@setuid"
-        ];
       };
     };
 

--- a/pkgs/servers/jellyfin/default.nix
+++ b/pkgs/servers/jellyfin/default.nix
@@ -109,6 +109,14 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
+  # what about /etc/default/jellyfin here?
+  postInstall = ''
+    mkdir -p $out/lib/systemd/system
+
+    substitute debian/jellyfin.service $out/lib/systemd/system/jellyfin.service \
+      --replace "/usr/bin/jellyfin" "$out/bin/jellyfin"
+  '';
+
   passthru.tests = {
     smoke-test = nixosTests.jellyfin;
   };


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/141298

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* nixpkgs added aggressive hardening to the jellyfin unit, this breaks hardware acceleration (see https://github.com/NixOS/nixpkgs/pull/147305 and https://github.com/NixOS/nixpkgs/issues/141298)
* Jellyfin offers an upstream unit. The hardening we implemented has now been accepted by upstream (https://github.com/jellyfin/jellyfin/pull/6953)
* So we should make use of the upstream unit! 

 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
