### PR TITLE
zola: 0.15.0 -> 0.15.2

### DIFF
--- a/pkgs/applications/misc/zola/default.nix
+++ b/pkgs/applications/misc/zola/default.nix
@@ -15,16 +15,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "zola";
-  version = "0.15.1";
+  version = "0.15.2";
 
   src = fetchFromGitHub {
     owner = "getzola";
     repo = "zola";
     rev = "v${version}";
-    sha256 = "04wvav9qpp5hsk3frf2bqxnnvbq5b4ix0c4sia4x89cbpr1z14yp";
+    sha256 = "sha256-X4J3T/ob0NfCFxddadBtsPsDhfvesg6/sBJybWeubMM=";
   };
 
-  cargoSha256 = "1s58rbiw16rilnhzacqvzlgmcy5kzrn5v61bfi06a0yqkz8zzykv";
+  cargoSha256 = "sha256-0tynm/DTX2oiqZOdWjRBGPk8IPIN07x2+FCXQmQ4Fzo=";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/applications/misc/zola/default.nix
+++ b/pkgs/applications/misc/zola/default.nix
@@ -9,20 +9,22 @@
 , CoreServices
 , installShellFiles
 , libsass
+, zola
+, testVersion
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "zola";
-  version = "0.15.0";
+  version = "0.15.1";
 
   src = fetchFromGitHub {
     owner = "getzola";
     repo = "zola";
     rev = "v${version}";
-    sha256 = "152ydi2gxfhyqsw6i79f9h1xwvwfq729likbagjy5z2bv822m44v";
+    sha256 = "04wvav9qpp5hsk3frf2bqxnnvbq5b4ix0c4sia4x89cbpr1z14yp";
   };
 
-  cargoSha256 = "0bv2yyqy9l896p0dk1668ayw3xf71h9ddyymimx44j6nw389fxx3";
+  cargoSha256 = "1s58rbiw16rilnhzacqvzlgmcy5kzrn5v61bfi06a0yqkz8zzykv";
 
   nativeBuildInputs = [
     cmake
@@ -46,13 +48,13 @@ rustPlatform.buildRustPackage rec {
       --bash completions/zola.bash
   '';
 
+  passthru.tests.version = testVersion { package = zola; };
+
   meta = with lib; {
     description = "A fast static site generator with everything built-in";
     homepage = "https://www.getzola.org/";
     changelog = "https://github.com/getzola/zola/raw/v${version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ dandellion dywedir _0x4A6F ];
-    # set because of unstable-* version
-    mainProgram = "zola";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Upgrade to [0.15.2](https://github.com/getzola/zola/releases/tag/v0.15.2) incorporating these [changes](https://github.com/getzola/zola/compare/v0.15.0...v0.15.2).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
