### PR TITLE
amazon-qldb-shell: init at 2.0.0

### DIFF
--- a/pkgs/development/tools/amazon-qldb-shell/default.nix
+++ b/pkgs/development/tools/amazon-qldb-shell/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, clang
+, cmake
+, fetchFromGitHub
+, llvmPackages
+, rustPlatform
+, testVersion
+}:
+
+let
+  pname = "amazon-qldb-shell";
+  version = "2.0.0";
+  package = rustPlatform.buildRustPackage {
+    inherit pname version;
+
+    src = fetchFromGitHub {
+      owner = "awslabs";
+      repo = pname;
+      rev = "v${version}";
+      sha256 = "sha256-Pnm1HxEjjNKpS3tTymtOXxUF7EEnWM+7WBsqeaG8seA=";
+    };
+
+    nativeBuildInputs = [ clang cmake ];
+    buildInputs = [ llvmPackages.libclang ];
+
+    cargoSha256 = "sha256-EUqGSKcGnhrdLn8ystaLkkR31RjEvjW6vRzKPMK77e8=";
+
+    LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+
+    passthru.tests.version = testVersion { inherit package; };
+
+    meta = with lib; {
+      description = "An interface to send PartiQL statements to Amazon Quantum Ledger Database (QLDB)";
+      homepage = "https://github.com/awslabs/amazon-qldb-shell";
+      license = licenses.asl20;
+      maintainers = [ maintainers.terlar ];
+    };
+  };
+in
+package

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1258,6 +1258,8 @@ with pkgs;
 
   amazon-ecs-cli = callPackage ../tools/virtualization/amazon-ecs-cli { };
 
+  amazon-qldb-shell = callPackage ../development/tools/amazon-qldb-shell { };
+
   amber = callPackage ../tools/text/amber {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This package is missing from nixpkgs and when working with Amazon QLDB, it is a handy tool to have.

Relevant links:
- https://docs.aws.amazon.com/qldb/latest/developerguide/data-shell.html
- https://github.com/awslabs/amazon-qldb-shell

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
