### PR TITLE
cardinal: init at unstable-2022-01-29

### DIFF
--- a/pkgs/applications/audio/cardinal/default.nix
+++ b/pkgs/applications/audio/cardinal/default.nix
@@ -1,0 +1,139 @@
+{
+  stdenv
+, fetchFromGitHub
+, fetchzip
+, freetype
+, jansson
+, lib
+, libGL
+, libX11
+, libXcursor
+, libXext
+, libarchive
+, libsamplerate
+, pkg-config
+, speexdsp
+, libXrandr
+, liblo
+, mesa
+, python3
+}:
+
+let
+  # The package repo vendors some of the package dependencies as submodules.
+  # Others are downloaded with `make deps`. Due to previous issues with the
+  # `glfw` submodule and because we can not access the network when
+  # building in a sandbox, we fetch the dependency source manually.
+  pfft-source = fetchzip {
+    url = "https://vcvrack.com/downloads/dep/pffft.zip";
+    sha256 = "sha256-gYaumUeXYf3axAexGqWI/tYBs1dyebjAESo4o/DTjCA=";
+  };
+  nanovg-source = fetchFromGitHub {
+    owner = "memononen";
+    repo = "nanovg";
+    rev = "0bebdb314aff9cfa28fde4744bcb037a2b3fd756";
+    sha256 = "sha256-HmQhCE/zIKc3f+Zld229s5i5MWzRrBMF9gYrn8JVQzg=";
+  };
+  nanosvg-source = fetchFromGitHub {
+    owner = "memononen";
+    repo = "nanosvg";
+    rev = "25241c5a8f8451d41ab1b02ab2d865b01600d949";
+    sha256 = "sha256-b/aBmvuvKScF8zSkyF1tuqL9hov4XVLzKLTpr6p7mIQ=";
+  };
+  osdialog-source = fetchFromGitHub {
+    owner = "AndrewBelt";
+    repo = "osdialog";
+    rev = "c92e8ad0e0b660cd693cf159ec9cb717bb4fd6cc";
+    sha256 = "sha256-NmSgzFv8RY5CFeW33LaIudDCyanQb++5kUf1bcd/ZHg=";
+  };
+  oui-blendish-source = fetchFromGitHub {
+    owner = "AndrewBelt";
+    repo = "oui-blendish";
+    rev = "2fc6405883f8451944ed080547d073c8f9f31898";
+    sha256 = "sha256-/QZFZuI5kSsEvSfMJlcqB1HiZ9Vcf3vqLqWIMEgxQK8=";
+  };
+  QuickJS-source = fetchFromGitHub {
+    owner = "JerrySievert";
+    repo = "QuickJS";
+    rev = "b70d5344013836544631c361ae20569b978176c9";
+    sha256 = "sha256-hSWOGTmTJgtHVSBlEpv7w1qiyTgoAI1d7bQ66q59mik=";
+  };
+in
+
+stdenv.mkDerivation rec {
+  name = "cardinal-${version}";
+  version = "unstable-2022-01-29";
+
+  src = fetchFromGitHub {
+    owner = "DISTRHO";
+    repo = "cardinal";
+    rev = "756271f1d280db4e1b56f041612609014d14b478";
+    sha256 = "sha256-BZoeyrajVR5Gfj6QfLoV390y4MzgzxTpD+zsabW3bcg=";
+    fetchSubmodules = true;
+  };
+
+  prePatch = ''
+    # As we can't use `make dep` to set up the dependencies (as explained
+    # above), we do it here manually
+    mkdir -p src/Rack/dep/include
+
+    cp -r ${pfft-source} src/Rack/dep/jpommier-pffft-source
+    cp -r ${nanovg-source}/* src/Rack/dep/nanovg
+    cp -r ${nanosvg-source}/* src/Rack/dep/nanosvg
+    cp -r ${osdialog-source}/* src/Rack/dep/osdialog
+    cp -r ${oui-blendish-source}/* src/Rack/dep/oui-blendish
+    mkdir -p src/Rack/dep/QuickJS
+    cp -r ${QuickJS-source }/* src/Rack/dep/QuickJS
+
+
+    cp src/Rack/dep/jpommier-pffft-source/*.h src/Rack/dep/include
+    cp src/Rack/dep/nanosvg/**/*.h src/Rack/dep/include
+    cp src/Rack/dep/nanovg/src/*.h src/Rack/dep/include
+    cp src/Rack/dep/osdialog/*.h src/Rack/dep/include
+    cp src/Rack/dep/oui-blendish/*.h src/Rack/dep/include
+    cp src/Rack/dep/QuickJS/*.h src/Rack/dep/include
+
+    # substituteInPlace src/Rack/dep/oui-blendish/blendish.h --replace '#error "nanovg.h must be included first."' '#include "../include/nanovg.h"'
+    # substituteInPlace src/Rack/dep/include/blendish.h --replace '#error "nanovg.h must be included first."' '#include "nanovg.h"'
+
+    substituteInPlace src/Rack/dep/oui-blendish/blendish.h --replace '#ifndef NANOVG_H' '#include "../include/nanovg.h"
+#ifndef NANOVG_H '
+    substituteInPlace src/Rack/dep/include/blendish.h --replace '#ifndef NANOVG_H' '#include "nanovg.h"
+#ifndef NANOVG_H '
+
+    patchShebangs ./dpf/utils/generate-ttl.sh
+  '';
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    freetype
+    jansson
+    libGL
+    libX11
+    libXcursor
+    libXext
+    libarchive
+    libsamplerate
+    speexdsp
+    libXrandr
+    libXrandr
+    liblo
+    mesa
+    python3
+  ];
+
+  makeFlags = [
+    "SYSDEPS=true"
+    "PREFIX=$(out)"
+  ];
+
+  meta = {
+    description = "Plugin wrapper around VCV Rack";
+    homepage = "https://github.com/DISTRHO/cardinal";
+    license = lib.licenses.gpl3;
+    maintainers = [ lib.maintainers.magnetophon ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24582,6 +24582,8 @@ with pkgs;
 
   carddav-util = callPackage ../tools/networking/carddav-util { };
 
+  cardinal = callPackage ../applications/audio/cardinal { };
+
   carla = libsForQt5.callPackage ../applications/audio/carla { };
 
   castor = callPackage ../applications/networking/browsers/castor { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is a package for [Cardinal](https://github.com/DISTRHO/Cardinal), an LV2 plugin version of [VCV-Rack](https://github.com/VCVRack/Rack/).

Ping the maintainers of VCV in Nixpkgs:
@moredread and @nathyong.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
