### PR TITLE
libpulsar: init at 2.9.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2418,6 +2418,23 @@
     githubId = 5510514;
     name = "Conrad Mearns";
   };
+  corbanr = {
+    email = "corban@raunco.co";
+    github = "CorbanR";
+    githubId = 1918683;
+    matrix = "@corbansolo:matrix.org";
+    name = "Corban Raun";
+    keys = [
+      {
+        longkeyid = "rsa4096/0xA697A56F1F151189";
+        fingerprint = "6607 0B24 8CE5 64ED 22CE  0950 A697 A56F 1F15 1189";
+      }
+      {
+        longkeyid = "ed25519/0x230F4AC153F90F29";
+        fingerprint = "D8CB 816A B678 A4E6 1EC7  5325 230F 4AC1 53F9 0F29";
+      }
+    ];
+  };
   couchemar = {
     email = "couchemar@yandex.ru";
     github = "couchemar";

--- a/pkgs/development/libraries/libpulsar/default.nix
+++ b/pkgs/development/libraries/libpulsar/default.nix
@@ -1,0 +1,102 @@
+{ lib
+, clang-tools
+, llvmPackages
+, boost17x
+, protobuf
+, python3Support ? false
+, python3
+, log4cxxSupport ? false
+, log4cxx
+, snappySupport ? false
+, snappy
+, zlibSupport ? true
+, zlib
+, zstdSupport ? true
+, zstd
+, gtest
+, gtestSupport ? false
+, cmake
+, curl
+, fetchurl
+, jsoncpp
+, openssl
+, pkg-config
+, stdenv
+}:
+
+let
+  /*
+    Check if null or false
+    Example:
+    let result = enableFeature null
+    => "OFF"
+    let result = enableFeature false
+    => "OFF"
+    let result = enableFeature «derivation»
+    => "ON"
+  */
+  enableCmakeFeature = p: if (p == null || p == false) then "OFF" else "ON";
+
+  # Not really sure why I need to do this.. If I call clang-tools without the override it defaults to a different version and fails
+  clangTools = clang-tools.override { inherit stdenv llvmPackages; };
+  # If boost has python enabled, then boost-python package will be installed which is used by libpulsars python wrapper
+  boost = if python3Support then boost17x.override { inherit stdenv; enablePython = python3Support; python = python3; } else boost17x;
+  defaultOptionals = [ boost protobuf ]
+    ++ lib.optional python3Support python3
+    ++ lib.optional snappySupport snappy.dev
+    ++ lib.optional zlibSupport zlib
+    ++ lib.optional zstdSupport zstd
+    ++ lib.optional log4cxxSupport log4cxx;
+
+in
+stdenv.mkDerivation rec {
+  pname = "libpulsar";
+  version = "2.9.1";
+
+  src = fetchurl {
+    hash = "sha512-NKHiL7D/Lmnn6ICpQyUmmQYQETz4nZPJU9/4LMRDUQ3Pck6qDh+t6CRk+b9UQ2Vb0jvPIGTjEsSp2nC7TJk3ug==";
+    url = "mirror://apache/pulsar/pulsar-${version}/apache-pulsar-${version}-src.tar.gz";
+  };
+
+  sourceRoot = "apache-pulsar-${version}-src/pulsar-client-cpp";
+
+  # clang-tools needed for clang-format
+  nativeBuildInputs = [ cmake pkg-config clangTools ]
+    ++ defaultOptionals
+    ++ lib.optional gtestSupport gtest.dev;
+
+  buildInputs = [ jsoncpp openssl curl ]
+    ++ defaultOptionals;
+
+  # Needed for GCC on Linux
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=return-type" ];
+
+  cmakeFlags = [
+    "-DBUILD_TESTS=${enableCmakeFeature gtestSupport}"
+    "-DBUILD_PYTHON_WRAPPER=${enableCmakeFeature python3Support}"
+    "-DUSE_LOG4CXX=${enableCmakeFeature log4cxxSupport}"
+    "-DClangTools_PATH=${clangTools}/bin"
+  ];
+
+  enableParallelBuilding = true;
+  doInstallCheck = true;
+  installCheckPhase = ''
+    echo ${lib.escapeShellArg ''
+      #include <pulsar/Client.h>
+      int main (int argc, char **argv) {
+        pulsar::Client client("pulsar://localhost:6650");
+        return 0;
+      }
+    ''} > test.cc
+    $CXX test.cc -L $out/lib -I $out/include -lpulsar -o test
+  '';
+
+  meta = with lib; {
+    homepage = "https://pulsar.apache.org/docs/en/client-libraries-cpp";
+    description = "Apache Pulsar C++ library";
+
+    platforms = platforms.all;
+    license = licenses.asl20;
+    maintainers = [ maintainers.corbanr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18523,6 +18523,8 @@ with pkgs;
 
   libptytty = callPackage ../development/libraries/libptytty { };
 
+  libpulsar = callPackage ../development/libraries/libpulsar { };
+
   libpwquality = callPackage ../development/libraries/libpwquality { };
 
   libqalculate = callPackage ../development/libraries/libqalculate {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adding corbanr user to maintainers/maintainer-list.nix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
