### PR TITLE
dpdk: 21.04 -> 21.11 + various small updates

### DIFF
--- a/pkgs/development/libraries/spdk/default.nix
+++ b/pkgs/development/libraries/spdk/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv
-, fetchurl
+, fetchpatch
 , fetchFromGitHub
 , ncurses
 , python3
@@ -14,19 +14,25 @@
 
 stdenv.mkDerivation rec {
   pname = "spdk";
-  version = "21.07";
+  version = "21.10";
 
   src = fetchFromGitHub {
     owner = "spdk";
     repo = "spdk";
     rev = "v${version}";
-    sha256 = "sha256-/hynuYVdzIfiHUUfuuOY8SBJ18DqJr2Fos2JjQQVvbg=";
+    sha256 = "sha256-pFynTbbSF1g58VD9bOhe3c4oCozeqE+35kECTQwDBDM=";
   };
 
   patches = [
     # Backport of upstream patch for ncurses-6.3 support.
     # Will be in next release after 21.10.
     ./ncurses-6.3.patch
+
+    # DPDK 21.11 compatibility.
+    (fetchpatch {
+      url = "https://github.com/spdk/spdk/commit/f72cab94dd35d7b45ec5a4f35967adf3184ca616.patch";
+      sha256 = "sha256-sSetvyNjlM/hSOUsUO3/dmPzAliVcteNDvy34yM5d4A=";
+    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -9,14 +9,14 @@
 
 let
   mod = kernel != null;
-  dpdkVersion = "21.05";
+  dpdkVersion = "21.11";
 in stdenv.mkDerivation rec {
   pname = "dpdk";
   version = "${dpdkVersion}" + lib.optionalString mod "-${kernel.version}";
 
   src = fetchurl {
     url = "https://fast.dpdk.org/rel/dpdk-${dpdkVersion}.tar.xz";
-    sha256 = "sha256-HhJJm0xfzbV8g+X+GE6mvs3ffPCSiTwsXvLvsO7BLws=";
+    sha256 = "sha256-Mkbj7WjuKzaaXYviwGzxCKZp4Vf01Bxby7sha/Wr06E=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -36,9 +36,14 @@ in stdenv.mkDerivation rec {
     libpcap
     numactl
     openssl.dev
-    rdma-core
     zlib
   ] ++ lib.optionals mod kernel.moduleBuildDependencies;
+
+  # Propagated to support current DPDK users in nixpkgs which statically link
+  # with the framework (e.g. odp-dpdk).
+  propagatedBuildInputs = [
+    rdma-core
+  ];
 
   postPatch = ''
     patchShebangs config/arm buildtools

--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -68,7 +68,11 @@ in stdenv.mkDerivation rec {
     rm -f $kmod/lib/modules/${kernel.modDirVersion}/build
   '';
 
-  postInstall = lib.optionalString (withExamples != []) ''
+  postInstall = ''
+    # Remove Sphinx cache files. Not only are they not useful, but they also
+    # contain store paths causing spurious dependencies.
+    rm -rf $out/share/doc/dpdk/html/.doctrees
+  '' + lib.optionalString (withExamples != []) ''
     find examples -type f -executable -exec install {} $out/bin \;
   '';
 

--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -2,7 +2,7 @@
 , kernel
 , fetchurl
 , pkg-config, meson, ninja
-, libbsd, numactl, libbpf, zlib, libelf, jansson, openssl, libpcap
+, libbsd, numactl, libbpf, zlib, libelf, jansson, openssl, libpcap, rdma-core
 , doxygen, python3
 , withExamples ? []
 , shared ? false }:
@@ -36,6 +36,7 @@ in stdenv.mkDerivation rec {
     libpcap
     numactl
     openssl.dev
+    rdma-core
     zlib
   ] ++ lib.optionals mod kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -53,6 +53,7 @@ in stdenv.mkDerivation rec {
   ++ lib.optional (mod && kernel.kernelOlder "5.11") "-Ddisable_drivers=kni"
   ++ lib.optional (!shared) "-Ddefault_library=static"
   ++ lib.optional stdenv.isx86_64 "-Dmachine=nehalem"
+  ++ lib.optional stdenv.isAarch64 "-Dmachine=generic"
   ++ lib.optional mod "-Dkernel_dir=${placeholder "kmod"}/lib/modules/${kernel.modDirVersion}"
   ++ lib.optional (withExamples != []) "-Dexamples=${builtins.concatStringsSep "," withExamples}";
 

--- a/pkgs/os-specific/linux/pktgen/default.nix
+++ b/pkgs/os-specific/linux/pktgen/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   pname = "pktgen";
-  version = "21.05.0";
+  version = "21.11.0";
 
   src = fetchFromGitHub {
     owner = "pktgen";
     repo = "Pktgen-DPDK";
     rev = "pktgen-${version}";
-    sha256 = "sha256-7lLDtbd14olEHO+1BuI6KTEUNRM/zAyRXau/OZbYbGA=";
+    sha256 = "sha256-3z5DSkggHTwjzsRzRG5zzZTcNsn/5YankJT8CKSN8b4=";
   };
 
   nativeBuildInputs = [ meson ninja pkg-config ];
@@ -25,7 +25,6 @@ stdenv.mkDerivation rec {
   RTE_SDK = dpdk;
   GUI = lib.optionalString withGtk "true";
 
-  NIX_CFLAGS_COMPILE = "-msse3";
   # requires symbols from this file
   NIX_LDFLAGS = "-lrte_net_bond";
 
@@ -43,7 +42,7 @@ stdenv.mkDerivation rec {
     description = "Traffic generator powered by DPDK";
     homepage = "http://dpdk.org/";
     license = licenses.bsdOriginal;
-    platforms =  [ "x86_64-linux" ];
+    platforms =  platforms.linux;
     maintainers = [ maintainers.abuibrahim ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Bump DPDK to its latest release (which happens to be LTS too). Add support for Mellanox NICs, fix ARMv8 build, and clean up the dependency tree a bit by removing some unnecessary docs cache files.

Tested on my ARMv8 platform using a ConnectX-4 Lx NIC.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
