### PR TITLE
gpsprune: 20.4 → 21

### DIFF
--- a/pkgs/applications/misc/gpsprune/default.nix
+++ b/pkgs/applications/misc/gpsprune/default.nix
@@ -1,43 +1,48 @@
-{ fetchurl, lib, stdenv, makeDesktopItem, makeWrapper, unzip, jdk }:
+{ fetchurl, lib, stdenv, makeDesktopItem, makeWrapper, unzip, jre, copyDesktopItems }:
 
 stdenv.mkDerivation rec {
   pname = "gpsprune";
-  version = "20.4";
+  version = "21";
 
   src = fetchurl {
     url = "https://activityworkshop.net/software/gpsprune/gpsprune_${version}.jar";
-    sha256 = "sha256-ZTYkKyu0/axf2uLUmQHRW/2bQ6p2zK7xBF66ozbPS2c=";
+    sha256 = "sha256-FS6nf8K+qfEWDCQwmoxH1laJIONMtwmb/H89SVJtV1E=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ jdk ];
+  dontUnpack = true;
 
-  desktopItem = makeDesktopItem {
-    name = "gpsprune";
-    exec = "gpsprune";
-    icon = "gpsprune";
-    desktopName = "GpsPrune";
-    genericName = "GPS Data Editor";
-    comment = meta.description;
-    categories = "Education;Geoscience;";
-  };
+  nativeBuildInputs = [ makeWrapper copyDesktopItems ];
+  buildInputs = [ jre ];
 
-  buildCommand = ''
-    mkdir -p $out/bin $out/share/java
-    cp -v $src $out/share/java/gpsprune.jar
-    makeWrapper ${jdk}/bin/java $out/bin/gpsprune \
+  desktopItems = [
+    (makeDesktopItem {
+      name = "gpsprune";
+      exec = "gpsprune";
+      icon = "gpsprune";
+      desktopName = "GpsPrune";
+      genericName = "GPS Data Editor";
+      comment = meta.description;
+      categories = "Education;Geoscience;";
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 ${src} $out/share/java/gpsprune.jar
+    makeWrapper ${jre}/bin/java $out/bin/gpsprune \
       --add-flags "-jar $out/share/java/gpsprune.jar"
-    mkdir -p $out/share/applications
-    cp $desktopItem/share/applications"/"* $out/share/applications
     mkdir -p $out/share/pixmaps
     ${unzip}/bin/unzip -p $src tim/prune/gui/images/window_icon_64.png > $out/share/pixmaps/gpsprune.png
+
+    runHook postInstall
   '';
 
   meta = with lib; {
     description = "Application for viewing, editing and converting GPS coordinate data";
     homepage = "https://activityworkshop.net/software/gpsprune/";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.rycee ];
+    maintainers = with maintainers; [ rycee ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
[What's new with GpsPrune](https://activityworkshop.net/software/gpsprune/whats_new.html)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
