### PR TITLE
privoxy: 3.0.32 -> 3.0.33

### DIFF
--- a/pkgs/tools/networking/privoxy/default.nix
+++ b/pkgs/tools/networking/privoxy/default.nix
@@ -8,11 +8,11 @@
 stdenv.mkDerivation rec {
 
   pname = "privoxy";
-  version = "3.0.32";
+  version = "3.0.33";
 
   src = fetchurl {
     url = "mirror://sourceforge/ijbswa/Sources/${version}%20%28stable%29/${pname}-${version}-stable-src.tar.gz";
-    sha256 = "sha256-xh3kAIxiRF7Bjx8nBAfL8jcuq6k76szcnjI4uy3v7tc=";
+    sha256 = "sha256-BLEE5w2sYVYbndEQaEslD6/IwT2+Q3pg+uGN3ZqIH64=";
   };
 
   hardeningEnable = [ "pie" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://www.openwall.com/lists/oss-security/2021/12/09/1
https://lists.privoxy.org/pipermail/privoxy-announce/2021-December/000009.html

<details>
<summary>The NixOS Test is somewhat flaky for me:</summary>
<pre>
machine: must succeed: curl -sfL http://example.com/how-are-you? | tee /dev/stderr
machine # [   11.057703] systemd[1]: Started Nginx Web Server.
machine # [   11.094168] systemd[1]: Reached target Multi-User System.
machine # [   11.108728] systemd[1]: Startup finished in 4.883s (kernel) + 6.224s (userspace) = 11.107s.
machine # [   11.195484] privoxy[766]: 2021-12-09 12:12:44.245 7fc65ee4a640 Actions: +change-x-forwarded-for{block} +client-header-tagger{css-requests} +client-header-tagger{image-requests} +client-header-tagger{range-requests} +filter{positive} +hide-from-header{block} +https-inspection +set-image-blocker{pattern}
machine: output:
Test "Privoxy can filter http requests" failed with error: "command `curl -sfL http://example.com/how-are-you? | tee /dev/stderr` failed (exit code 22)"
cleanup
kill machine (pid 8)
machine # [   11.232864] privoxy[766]: 2021-12-09 12:12:44.276 7fc65ee4a640 Actions: +change-x-forwarded-for{block} +client-header-tagger{css-requests} +client-header-tagger{image-requests} +client-header-tagger{range-requests} +filter{positive} +hide-from-header{block} +https-inspection +set-image-blocker{pattern}qemu-system-x86_64: terminating on signal 15 from pid 6 (/nix/store/k0z9n599k02hab8qjjp3ljw065iwjcvg-python3-3.9.6/bin/python3)
(finished: cleanup, in 0.03 seconds)
builder for '/nix/store/khs4wr72q03czdjylbgalqfv451mcihy-vm-test-run-privoxy.drv' failed with exit code 1
</pre>
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
