### PR TITLE
firefox-(devedition|beta)-bin: 95.0b3 -> 96.0b3

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "95.0b3";
+  version = "96.0b3";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/ach/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/ach/firefox-96.0b3.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "474c94f46fb3985e2f640ad7beaf66c0fa456ad6e3c6943f00dd0b3bc1daa3a4";
+      sha256 = "780a8e746a4a638ab9cfb69b1dca27135cdf64809883551c0e79e0409487660a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/af/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/af/firefox-96.0b3.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "84603f7b1ae9dc78b7fb184fb8130954241a1135d44b90de41f27650e96353b2";
+      sha256 = "44b86759ab9a5bb675d9d05029cef6e0be17eecbe140ad1ce5d0fc554a8dcf36";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/an/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/an/firefox-96.0b3.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "b672065d9b426d2814908d676329deb72b20f403a583228c584a4e95b8d86040";
+      sha256 = "e4d73a06f2a918395c0428c4190cc080dd03a29a74f1677f297b6bd65ad488b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/ar/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/ar/firefox-96.0b3.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "9a62d19d64db198b838c2642d26d70de84205647c7aaed51415495b1c9966b8b";
+      sha256 = "256f2b6d21cccddcaed24b511f71ca4bafdfc08ce989ad1eef45ab9bc009611f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/ast/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/ast/firefox-96.0b3.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "53b73ad75376e2a2c2b6879d30d4039b327ba0f2bf7fe533e8a29f41a4e3b076";
+      sha256 = "bba26f8b77d27c03a969e08d8974ec9f7a85e0237ca3acacc884f945a9b18832";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/az/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/az/firefox-96.0b3.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "d9ddba7695435bf5915e1f17681fb6a55b4a3e9d4e4d2972c32e9ccd4d67163a";
+      sha256 = "da1c22e87189c991ce27929abe2172ccce6f4a25c44e836ee865550e259e6218";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/be/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/be/firefox-96.0b3.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "23e9cfe4005bd235ba112f30be729495fafd7d607b9e67dc9b72b9f2fafa2846";
+      sha256 = "183bce430aa7ed98b72eb4492c5a9cf76a2e9961069140f272e438a5d20debc3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/bg/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/bg/firefox-96.0b3.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "601d6830ddc35f8738a288105741e6c9fc4b2b50e3844287ff8d7f4ff871ded3";
+      sha256 = "145c856566f9063ba861ade8220071623df793b279bf2a3821742f9e0023af74";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/bn/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/bn/firefox-96.0b3.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "bd41e8b261fa553ca1842cb7291539dd04db2d3668a1da317ac32a3ff7d0c322";
+      sha256 = "dce9827d70a5a7d182316d7286bc6cb4b5442d65bb5c3573d04b235b4a18616a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/br/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/br/firefox-96.0b3.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "00f69f471ea3385b89ab0fc54c3816271852f6c99cef9b156f0d124a71abe4c2";
+      sha256 = "0df80c30b78cde55015fab74763c7606f75eff72804166b5095eb321b51fa4da";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/bs/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/bs/firefox-96.0b3.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "288403e57a49651eb31714ff284173a8b3fda3a6d5e67047f97e14f8398fe5a1";
+      sha256 = "1df386c5001327bea3f5675acd52946dab3d0d8ff0bbcf65f8b291ac26a565d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/ca-valencia/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/ca-valencia/firefox-96.0b3.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "266dd8fdcb00ee48c1ed03ccf3d3a478a75123a07490afb4b67cce3bc53ba9e3";
+      sha256 = "c271c6d047c4dee3ea806caec31e2719acaa55aaa608ad86283de45e22cd05f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/ca/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/ca/firefox-96.0b3.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "5f7388056ad409c7acb16061b0d945df95ab41cc767ec4fe777df8726421612a";
+      sha256 = "30a2deb4dd1bb82406731f71001950d01ffbb9aa7a24f333e8f322fb23032f6a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/cak/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/cak/firefox-96.0b3.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "2c315209fe2d966e3abf3eb4b35207fd2479809babbcc210a8e668aaaf6207d4";
+      sha256 = "cbf31b80937ae4a425f4d5507a7f654958e7e93a6c12683c08982a3d14d2ba9a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/cs/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/cs/firefox-96.0b3.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "f5eef4d4141257dc80362a917cef098cefa65deee791decf4d79137ee2f947a3";
+      sha256 = "72c098b2512a40ce3437f7d329b46e648e4fd6e2d2b7ecdd1e3478b090cd50fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/cy/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/cy/firefox-96.0b3.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "a3126e3c83de85459b565aa949ba5d34fd622b8fb7d93c080abada013e59d165";
+      sha256 = "0c05717640e8ff2e0fb52a510dcf3a35db34b911cbc85d2721e7e7e6307f0083";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/da/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/da/firefox-96.0b3.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "066b881606335352011d2001b0766f42af012a8ac7474f24866bfeeb1e181ef0";
+      sha256 = "c29f815b19cc03e7d628fef8c86e4f06862e268b760e230cc7bdd04c2618a852";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/de/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/de/firefox-96.0b3.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "48c557034a1370ece846d0d08e31d068c872e7f6a1d9c83d69e5554561f95b5f";
+      sha256 = "6968c6d591a3b43e169dca16628eb4675b8803b90aaa8f605ae35f2115a75d3e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/dsb/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/dsb/firefox-96.0b3.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "98faa66e3bab14bf28779b36a54657ae3ba69d2c762efe17bd849341d886a2de";
+      sha256 = "47a8cac44c7d813f23ce263e698dad6dad44181c570055973879e57beeb82ee1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/el/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/el/firefox-96.0b3.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "3591b9ed200707f137dd1c65d159b1f2b412a5f5c2cf17e7d7dcadb691ab047f";
+      sha256 = "476fcbf047743ea61d6e68d37a1bf1203d239667faf98abf5192f15e1b13b927";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/en-CA/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/en-CA/firefox-96.0b3.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "9a018a3abadb9266f647a4fd67a4dcaeab611f1ead3d5ce0b9d83a12e1a58eed";
+      sha256 = "26abc7c1e8aeef3e4898e1dcd120651dd30400a6da9a1c2af5ff02b1b406573d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/en-GB/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/en-GB/firefox-96.0b3.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "40e6e0b8e9955e5dc8c89db57484eb8eddf06fa8b38f8b2a3d23c1d724a1e137";
+      sha256 = "66b299656f71875f59287c8da5a3c2b0bca53fb69ca9b0f7a0402ad1eeb1aa87";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/en-US/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/en-US/firefox-96.0b3.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "0ccae3528c97ce6ccd43c21776a85b6e0d485e286814744ae22461cee1a7d79a";
+      sha256 = "37c37849f3d7125da14e3a71c8a9fa522b8756fea7e3e3f8a5792ef7c3285466";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/eo/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/eo/firefox-96.0b3.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "dabe2c119f889c25c97e15bc588027d3220f96bde47db6f55f66e6df6c043133";
+      sha256 = "cd3ea6fbcbc947acbe1767be78a14fdce4c03b0b44d53e3670a0ffc5ba14dc68";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/es-AR/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/es-AR/firefox-96.0b3.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "57e787708d8c3947ca5ab5d5636def8411d2b8884825ac4f2a8253734e6a18e9";
+      sha256 = "f661d48a11f66fc326e86126aa5c0de37311042a454719cc609a1c7ff102e423";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/es-CL/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/es-CL/firefox-96.0b3.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "509749b15d990b1dabd2a01ce3ea25753e57f40f829ca2f391c1135ebab2ad48";
+      sha256 = "056f25729222d95316034f0365679ff449a58e4d77624687cf9417e10b52085f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/es-ES/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/es-ES/firefox-96.0b3.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "d4cc96679b07d33da8cb891d7a0086dc5b00b269a55e8e0c57fbb576642c556b";
+      sha256 = "64da785531a3e2f4b8179f3e9b551723bcce4c1210e184a03c98ec3e2ff1e220";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/es-MX/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/es-MX/firefox-96.0b3.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "07abf9362e1e111f42087367b33df46bbfcb33419785cff32c5a612d7daae1f4";
+      sha256 = "34af4d1a91b7e09e80d2f89730851c508521d6518b0aa2d3ff1924a34f7efba6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/et/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/et/firefox-96.0b3.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "7866ed658f2a8a19636484f8dc4bacd3919324c171628f83d2194761ed738d71";
+      sha256 = "a1b50e3ba15ae806ffd89ef22e12ee85ceda1eb17f458fb7e8abd6c4355a75d3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/eu/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/eu/firefox-96.0b3.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "d5a0dc4d72cd499e62a01b749969158769b42854d03a63802ac2d3fe473cfd15";
+      sha256 = "90ec59ce7774bade28052f4f8b5861476e3fb52878e48c8909d250fb6b6e17ad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/fa/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/fa/firefox-96.0b3.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "52b51ec4f60f428f8bec21485ceace318949a660aca2031879f9d5b2793ef525";
+      sha256 = "3f09ea9568982a451798dece61a8f19131c4c88e98e2c03b1808503051873e73";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/ff/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/ff/firefox-96.0b3.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "84efcb94c8bceeef18f621d2b6c457012a4cae82b85530401f8d3d4a68ee2a0c";
+      sha256 = "a483b0aaf523fe404a6b3ec07611812a5160cf8a5c05b0fee1afa6838e1949a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/fi/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/fi/firefox-96.0b3.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "a30ce074678d5468bfbb675761e6a267d64e05a53691dfde7c2ba63917091723";
+      sha256 = "12e17583c8932cfa6622ff68490e29d9e09d6862e8443ee1cd1d72f21f6516a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/fr/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/fr/firefox-96.0b3.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "005180447c764df009b726696220e84e7e18fe2a90fb35674c613f90ac9806ad";
+      sha256 = "ac3809a3344ac239183a68551eebe5689c53c11c0a399ff4a94452a35ad86c81";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/fy-NL/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/fy-NL/firefox-96.0b3.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "8306484bc7a3095412c5ef9abe0f129a3e12f9cd7a9642da06c5b5cefa939b75";
+      sha256 = "9385c2bed2d3aa9b65651f396d9a2c6f8762dc4295319757f949fc9f04a6c717";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/ga-IE/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/ga-IE/firefox-96.0b3.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "7dbeaddaa6e56a97802fd521b21c0e91911313a178b4e3b52b94c9e6192e82ae";
+      sha256 = "f65df6f4d93a39b5bbb1c4c7827eb094a632dff7255b78affc7cc9794a28d3fa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/gd/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/gd/firefox-96.0b3.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "a8002495345e1339d1f482a622e8d496b2f44d6f0943bbad5502446c72cde9b5";
+      sha256 = "3cbbd914559e96205e665ad46cd9ba193428cd8d83df90c4fd4849cc11db13be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/gl/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/gl/firefox-96.0b3.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "8b7c7ca56394582f1af0e3c53943d96994901f2083d43cccfceeb03d6e40a5fc";
+      sha256 = "7b27f83190cdb84d2d9fca9bcb37bd1128086adfe772e676141fd9960c0de872";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/gn/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/gn/firefox-96.0b3.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "4b35f17e74ce56757dff9cef391cc19348ff4e1d248f19e74156504c3d2ed394";
+      sha256 = "0194000216bb517390d301166c37228e2128f3b15280cf21629fe13de5f536da";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/gu-IN/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/gu-IN/firefox-96.0b3.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "fc1233731682071936aadbfbe8db7d4284f2cf47398421cfb2a8c7a8dfb79752";
+      sha256 = "24c92df984f7eff4f294e27324420b0350c4069acade0a304a3e433ea11fadd7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/he/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/he/firefox-96.0b3.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "47b4dcfacd5d4c8e579757f89d895495321b08115f6b64d025d6129562d66453";
+      sha256 = "5a006adead9f8e647eaebbef8ca56a47116ad2fd1c308c4986aa81bf7618f815";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/hi-IN/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/hi-IN/firefox-96.0b3.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "a6b47c3149701ce4c98cd0df5629b141bba20d143305d036b488a502c0de7bb1";
+      sha256 = "e8d87a8ad9033793e0c25c8954ddc4f405274468a572f46af494847481bedf11";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/hr/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/hr/firefox-96.0b3.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "6e992a34955550b0024f626da789f339e68b6b1701f7d20e1cee39de8c693245";
+      sha256 = "47964a5caec7f8ef0546ecba49e0d995dc9f67947fbcaafaa02789bdaa75e6c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/hsb/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/hsb/firefox-96.0b3.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "6e7927e7f83a64b97ab2371e798443d27d67fcd7b8051f1f7e87bc78407d8ccf";
+      sha256 = "67f89985f60d21b04a9a20449d38d673c45e74e82a1d5762d82713c02d3e63b2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/hu/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/hu/firefox-96.0b3.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "b05cfb354ee26a1c841d4101b5c4fae11e6724bbf50d3c7685d5c67459a4c84f";
+      sha256 = "2716ce5bcfaac25456a144eeff6e6b173600d08016574812abbb315a4d001ca1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/hy-AM/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/hy-AM/firefox-96.0b3.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "246ff4c709da7aebae4afb7625b77bae8ee60e53ce5d04a2c42c0257e8da0e25";
+      sha256 = "c028cfa29f0ea60f284d749dc9818772c074efe3d295590a34a3d6a4548a8f7f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/ia/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/ia/firefox-96.0b3.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "27495fb4fa2cf5308a04a26b26bcc4da5b6153398479a231fbd17162909c9610";
+      sha256 = "5bd24eff8a4d95f27ff8df44d014d007c943a54fd1b5689435a1ce14b7f61375";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/id/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/id/firefox-96.0b3.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "d6ce3a5961a40e82e48a9468163403b0a83de89305977ee38edf5dd3a56e222a";
+      sha256 = "0483ce90f8702febedb73674d3cc23348a4e7ef62445084430636f0c4c1fb287";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/is/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/is/firefox-96.0b3.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "3644ff5170301af31eb05cb9b6d788e9c3f0eac65a45155f03b1cf8d88d465b0";
+      sha256 = "d7b41cb2cd6ae22547d2c4d04dcadd5c4c05a4abf2b51d495baa749d4a2158b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/it/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/it/firefox-96.0b3.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "01c6356d1ce2229a6ec5865687a0ed67c61167889f4a679c5c87f8cb8843322e";
+      sha256 = "f5a5a825787fef1f8c4f2a0f0c013e8d39bf1a08c4523d79069c5fb335c0e5a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/ja/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/ja/firefox-96.0b3.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "37773526605c3f1aeebc6cf0b5cf85f9dc163150a71631b7153c7eac04ac40d5";
+      sha256 = "64d8c649de837049c2f0f73736a74f141de5bf426e11d19f4e0a5553cba6412e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/ka/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/ka/firefox-96.0b3.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "69d7a476b28b6eb08b2dc797e3bdcd75df52e6e356e7efff961a6093b75f53e3";
+      sha256 = "01ba137970e9b538bc09195dc3da66927b56fab6204bcab60a85e03055c80a0d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/kab/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/kab/firefox-96.0b3.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "e912381c7b2d1ed39564cba940bd5b2f80837ecaa9b251844b8ff9ba94d2a839";
+      sha256 = "3a6b4e12f88226b0f19dc066a0f11cadf5a47d87f38540cbcc9f34e82c54290e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/kk/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/kk/firefox-96.0b3.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "31227990f305bab67fb3e0dd1043b55470d188841f981f665d4a8a2493c990f3";
+      sha256 = "ecb9e0e63eb778892ce15d5df03e50bca8948a6e8dc3369b030cb716b172789a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/km/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/km/firefox-96.0b3.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "d4fe8d5720d38750b1d7fffc6aec1e33733bda34783a2f3e190f0c2d8c7e3b11";
+      sha256 = "31968f898a8916705c67e71bc5010cea11bb43e544f27febad644a624b32c773";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/kn/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/kn/firefox-96.0b3.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "7ed2af125efd6da29752350a6f717dc159ef4ec2779615d1ef6a00469e09be92";
+      sha256 = "105f4f83a1e0ed15e568a218d49fe5108462db67cda228e088cde3679dd48e04";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/ko/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/ko/firefox-96.0b3.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "b0a5c394250c62e90831fb890da297708ad7bf7fd1552641a2efbbb807b2dc4d";
+      sha256 = "37932385223cebf7a3f59c362c2abfca321bfab0fd6e5e3da6daa0ec76257784";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/lij/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/lij/firefox-96.0b3.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "75b98e03016f31a16b24efb8333c2b9262efa805dacb942e9421372811d166a2";
+      sha256 = "ae5c8fbc88f15edf60fa1830ca19d32ca3277194c0669717360659da5ad07b68";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/lt/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/lt/firefox-96.0b3.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "6d5a36fd2fe4e9054b8bd58134ea8b9d70fb3205d84c60a6793033f0e4acb38e";
+      sha256 = "104cdce0099e51d71d3ae3b8fd4ec40a256d893450c8fc905035480be5d675d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/lv/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/lv/firefox-96.0b3.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "f605fa3ae318f437849623819702d5cfe6e4f09c8780044ef94601879c31d207";
+      sha256 = "d2e0055207f62681e4cc9c11ae1cd986179af1581af0252604762eed6637e726";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/mk/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/mk/firefox-96.0b3.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "dffdaf569892188c729407d9afda0a6f81c3e550ed7abc0ee8d3da75aa2a0746";
+      sha256 = "8b03198b1d6424a1cd024fe17ce62a99c8b1b8c41798b0e229f802752a3b4551";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/mr/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/mr/firefox-96.0b3.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "e46c0a6320a7660f9e7787aff628ca6a4a7fbdf93454fe58f2caaf1ebd53095e";
+      sha256 = "5f5b132f3292cc0938e28f2c483a03b8ec76a95a306d3a928f2a2bde03f3af76";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/ms/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/ms/firefox-96.0b3.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "c3d7a6c84f5ef041b9914757893af431285946821a288e654a4b7f0c52644613";
+      sha256 = "9ba3cbfd2061d15356ebee861bad6d78be0cb5f4ea0ad9a13170ecdad67981a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/my/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/my/firefox-96.0b3.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "a15fc143278e2c2909ba04d14dda8a9bee23b43e4f121f38f06284d7f718b906";
+      sha256 = "700d224adc519fad23798afe919538ae54d53cfad4a74974ecabdf254afcffba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/nb-NO/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/nb-NO/firefox-96.0b3.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "ca44d0aef673a2fea953841e94504ccf355fce39ab571eac782a750cab794301";
+      sha256 = "a75fa004af0cef3548238264f7997ad60bcb46d415e3e91ff6e9b16bb86a4a9a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/ne-NP/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/ne-NP/firefox-96.0b3.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "656f830a25800190e310d2367ac7ea07f3226c4c7b1cfd0f937dd3056804f540";
+      sha256 = "614d82dbc762f0ef2f565d95e5bff8d4212f8fa8174f294877e0ce155d75fb09";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/nl/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/nl/firefox-96.0b3.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "5e493e4cc81a976bb06bed108d25070ce5add12643de21cd96fd6075cea7cd26";
+      sha256 = "a6b8f0c827443f32c25c478aa11981d714a57fbf752891c2f018fa9542820e6a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/nn-NO/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/nn-NO/firefox-96.0b3.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "ed1e854675b0f2422d240e45ca78d101a5ce787bd9f5ce4905fe7edbd24b776a";
+      sha256 = "6227882b432684768b739058e7f1aa15e92157348e19b36053e70255172f0b04";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/oc/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/oc/firefox-96.0b3.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "12df296c5340caf9264401b33f9c7ff56b366ff1026da5c97769db14cde12d0a";
+      sha256 = "3b2590ff70bf7cf8998dda933506c86515ebdb81b031fb15f925b02d5cf88f04";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/pa-IN/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/pa-IN/firefox-96.0b3.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "d785d9d2f85dfe309757abe0ef0096a968cf01d9c2b148a2aecd1c098a5e1f90";
+      sha256 = "09bbea80b952af6eb5358b2afbc785afbf04ee44a27b38f2f72dc6fa49417086";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/pl/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/pl/firefox-96.0b3.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "92835e4961dabc99e0b803e06338a9a21799764e2713a36c1e4f681d87bd8996";
+      sha256 = "f0ef3e5e72fcf72ff49a5b631bb9216363fb01440da41d939e4b653e84527694";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/pt-BR/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/pt-BR/firefox-96.0b3.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "aaa9f81cdb0ca1b74f6d2f7818d12a952e7ee33d60e047df86ab97508356338f";
+      sha256 = "dfe183f6a40d50e3871f632ec79f397e302fd130c43af2c26c6b24acc114c4fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/pt-PT/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/pt-PT/firefox-96.0b3.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "ed69921f7c65c31d811a7d54003f5ceef2a01c9405d9bf84b31861b9091dcd7b";
+      sha256 = "c12fb2fb918a38a39655f3350676f290151e2fd6e44acff88379f3c4752743cd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/rm/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/rm/firefox-96.0b3.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "405a19aff4a45ffde0f09b94ac6f6c9f2dc97398f4b90b77031ce957a31f8b72";
+      sha256 = "14d1ad150edaa100c535c9b007fccd3bbfc0afe09d3035ada361c202ab31cbf8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/ro/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/ro/firefox-96.0b3.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "aa058e6912b410db1e43aefc3205930a6dff0559b729b0ac80424140020c0053";
+      sha256 = "cd99ae37b4e8552cae7911c86f430900d8d21c96264dc2940c335cc050b8a62f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/ru/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/ru/firefox-96.0b3.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "7cb7ff67c839f41a4a1739075bfd7847d23bbdc62379215db2d822f2367ff84c";
+      sha256 = "0cf0c23c90f24ef417b460f57b566b87e06ad11df178ed3e7006a7a7a8acf7f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/sco/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/sco/firefox-96.0b3.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "e5832ddcd89f443ee9d7e5c211d902c4f96319d53e4647dc1b522c73f3f7e862";
+      sha256 = "58bc7ea18c851d5a88c047bd41b836e9beab1f04289d0fc33e0b1d9fd7e55b3f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/si/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/si/firefox-96.0b3.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "8fe0d2dab49385b643f5aa1e75fe92f6f6e22c731954c9805d96ed6d5f648763";
+      sha256 = "13914c46edc3e5da87c394468cfe83f0811359b2d30d6572b1c3c9726af45c3b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/sk/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/sk/firefox-96.0b3.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "326ae6e05089d85f978581ccdb295a7110ca8bd3355386fa167a816c6c64aa46";
+      sha256 = "818fd12a70a50061c507c8e06d7118ea7d1062ac905f8b70d31010710df642f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/sl/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/sl/firefox-96.0b3.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "f79d40eb29a56120658625e73a1e787999392e5f4f9d7b1138c863d4f416e45c";
+      sha256 = "1d70241ed0cc861c79165a770a73b580496fbbbb6a2530701c02073c9995fc4f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/son/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/son/firefox-96.0b3.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "55dcfbc7dc1798f664dd35e249846edea3dab0b9f803816d7ac7f127f88d430e";
+      sha256 = "3b906867dc5a0ecf4dfb0e034c8e97a3fc39e5d0531ea483c8a408b32df860bc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/sq/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/sq/firefox-96.0b3.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "a8a324f847552c79c17d217ee8b1e620784608899b5d3bf358c1be036c89c761";
+      sha256 = "b23189c437535a4fad78bab37b81d95e3fe5774a8c3c4c6bd6d77d7f785d2e30";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/sr/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/sr/firefox-96.0b3.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "f073d9cfd51f99a6ce113b7659b4e4807459c2708ccbd6b4e94caf86d9575c43";
+      sha256 = "08dde33689c92e2c23971b0aeec581ba420b502a118c45799e35d52087113055";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/sv-SE/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/sv-SE/firefox-96.0b3.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "1e2ce62d0a940d28e92c7252d059c33606b1659cb837c51dce5deac8d7998c62";
+      sha256 = "3a099e8247e4f15879233624489f4df971493bde2019f47a18da3523e0ba142c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/szl/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/szl/firefox-96.0b3.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "d9e0f2f4f3852920a1f539db556fb8cbb7eb563d329befb3619e8892efd442dc";
+      sha256 = "94497a259e974c3c13bf2a74a4a91180710b57402fa47bdead77cece66696b32";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/ta/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/ta/firefox-96.0b3.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "ee8b169ac2e368bfeabb18ad609e99966f192ba50d0cb8c71cf4671e9ba5a8bd";
+      sha256 = "006458ee81bd21b2cd3acd5b7893e90cc97233a3507b2247355b183164771502";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/te/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/te/firefox-96.0b3.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "26b6372b6e235ff3976246b0985c68d0fc4d742961b0fdfc39084fa625412117";
+      sha256 = "a1173235bd09193a5fb6081db6af934ac5cea619bcf612c244423cdfaef75861";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/th/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/th/firefox-96.0b3.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "64cd2e44ccabca972a9ea1837d8aa79bb21dd675c7e205cf9b7978418707762a";
+      sha256 = "ce6a04ad52b0ab49fd4db6724fe43c1f054fec37fe2434536985642fba1999db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/tl/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/tl/firefox-96.0b3.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "b76c0b12ce6ef4a1b25185290d8f35c834220d1106aa4298f0b0026f29874f5b";
+      sha256 = "10f31d9636f9124aefd213ecb06da9be7ddfe70e2413ce66a1c1f84407f33319";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/tr/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/tr/firefox-96.0b3.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "f1029745fe9fc26b3e3d1672c736785bf7d1bc182b5942ad0542d72a87a4b772";
+      sha256 = "c83e8170ef55f271fb9c933505cf66d4e42eb8973d6e1751c903ecda3bc92cd6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/trs/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/trs/firefox-96.0b3.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "cd5115bb83023c0d3a7623b4aa88a093e2ba6f65e4f0275d4af66bffa0ad3bd8";
+      sha256 = "484905693e9e952a56627561f10ab429e7ddd2df5b534252f60aebe52ed41b95";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/uk/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/uk/firefox-96.0b3.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "dcdea5127200c78331f4fa687a4b1a0a7600345e1493a1653296c0399dc9190e";
+      sha256 = "e17d15802c8d94770c6368aac7d46585483353053968c66f40f326dac00587d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/ur/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/ur/firefox-96.0b3.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "88f83c38f0a1a1590e0198ccbd0a48e8d8542bd2f697b3556541ccb49da7aa98";
+      sha256 = "e03b1c472787bf1ccf33568435b7873a4d6e8f43a0b82a01751995e8ccebda9d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/uz/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/uz/firefox-96.0b3.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "bd7e5a47455e79ae84111a85f368528f41c406e154d0453ff197207e75cfdc64";
+      sha256 = "1952bac0df8fb98273d0a4310f3141e928e6718eb1a91baed6d692088f041171";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/vi/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/vi/firefox-96.0b3.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "6cda47f9940c2d8a0f9407f087c26732579bdb852a20b385593e2874cc5fdfc8";
+      sha256 = "4d3a70f4cff2d11dccfeabe15c30ed99b74bf5058ad8f8c795d9bfd2db1dc11c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/xh/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/xh/firefox-96.0b3.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "19a79670ffe4ecbdb577cf87ddf894a60bd447d906cd7f97161cc985fe8b5f80";
+      sha256 = "dd1c33d8a1769f2d4efa39eeb248a7cb6e2993f4b3bee38884fd997d7f20e026";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/zh-CN/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/zh-CN/firefox-96.0b3.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "7930a72c8c667b8e2d7e6ee9df6cfec692e854c6d8fc0f2f096a7a3158da3f9d";
+      sha256 = "623926088fa86ff736832cb35044d7d134ad1f4ff31666ba7dcbc31619c3a07d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-x86_64/zh-TW/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-x86_64/zh-TW/firefox-96.0b3.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "bbc0687aab65d526e71e4050b0df5e7e28c59a046d82720b27d03dfa4efe8409";
+      sha256 = "6276f0e417d45cad209e0f57ac0276f52854f5172f7829684e4c8a49c0e78fde";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/ach/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/ach/firefox-96.0b3.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "3304a4622ba40355058e39efc61be03e7ed804c3f7c10070db639e1382621d47";
+      sha256 = "0412368189b73bf54d5679c22271ca82f47c10ca1288431fdd16a42d51cbfb21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/af/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/af/firefox-96.0b3.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "4659c04c84ddccd3ac85237fc53b63536bcaaf8a1adc984c0468797f926b6557";
+      sha256 = "67060ebdf9d7ce14c45db9edd588f99fe0485971674f791691766127a656575e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/an/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/an/firefox-96.0b3.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "e132e70c080fa4059dcf2b0a5c7d70067d7db51e56137df279f57f18ec0cebd6";
+      sha256 = "2c79a9307bfee1727a19cd212fed10ba02d31ef49bd68a51cf0ca0a7faccf2ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/ar/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/ar/firefox-96.0b3.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "822a3be31a33ff6e2819db3474e9b9fd326a5effe5d7106803528ec234e5cdc4";
+      sha256 = "a6ce4fdcb3716e2f70fb83502fa9e9e90489ac58d26a25627eae7b8402a0562f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/ast/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/ast/firefox-96.0b3.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "23b44191bc18c5412b60958a9dff985f9be1b5ebcdb12444008ea81b61e64e27";
+      sha256 = "21e4519d0403bf3e158eefe6c79d8283f2cc1e0875d91acdb995c0e83c56a9a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/az/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/az/firefox-96.0b3.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "5def55e33abd17ab26f5e96b325b1d32bf16e32c6083e6437dacbdf52231b6d2";
+      sha256 = "0c1eaca5b928c2a1cc5a60a2dbbd624280ed2b55f10446bc886158e95af39199";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/be/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/be/firefox-96.0b3.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "23fa43713fc1e831bbc87bae66ea3fcd3597c60babe96b50bc58caaca2698f86";
+      sha256 = "e7716acc8417dbee838710d3efe670e081712ed3facb26bfa43864a574463ff0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/bg/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/bg/firefox-96.0b3.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "7ef88eb25bf6b37d89b6b90b76b812eacf70e3ed8d6ef2dbb22a469ad4da78a6";
+      sha256 = "a90e61e0b5a31ffb7cebe747e8a6512e68baba210f234913af1ab8e90c79206c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/bn/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/bn/firefox-96.0b3.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "7d9a99a8e4955f746c27b0f54c4d44b30951fe9fbcf106ae7cf43f996e937671";
+      sha256 = "e75ccfcac893ac7d54d8cf849044385ed0749de77dd53be7a1b1686949a4699d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/br/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/br/firefox-96.0b3.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "94368ed9dc4801dccfca01e97dc07b4db309ccce60aa12846c2eeac68e51e6fd";
+      sha256 = "9c2286f7cf0d5052e44ac9aacf139e2c8abe9d212407960663819a8aa8436bd4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/bs/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/bs/firefox-96.0b3.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "1afee889a4d450f373a42416c13305abb2bc2388da8bb3a303a89a418823e01f";
+      sha256 = "ceb98c5fb103e80488f8821027144b0d7124d0f76d360b6139308763a1ca33c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/ca-valencia/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/ca-valencia/firefox-96.0b3.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "0569eb326a77638e004243dcc62108e4f0997f3496b464644526aa7c01042677";
+      sha256 = "f648e363da8ec8caa13ccfcc4d586efe0ac4e0b0d3574d295c95ac81dda937e0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/ca/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/ca/firefox-96.0b3.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "c1987149fdc39a601e15d5f64e8d9ecfef1955debe723f10b49ca65d097480af";
+      sha256 = "06b61c45238b90f8bb838193fb5035dc63c48fba416f16b7ab9463597bb92ab2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/cak/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/cak/firefox-96.0b3.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "72e5ae12cde0a72ae31d393ba637663666edbafaea53740ef806a7fef3d4c140";
+      sha256 = "ae0ce800b1455aa4c607123ead63edf228a55f4bdac14c267746cbb640f60418";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/cs/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/cs/firefox-96.0b3.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "478eb08e62251dc39f92d4a800c11e9724f3600e8f997dae616ac82e85ca1b3b";
+      sha256 = "1d7f47bdc98efaeda62dc2f3d1d16949a8cf3de96dcf87fdc30015ac7fdbbee5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/cy/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/cy/firefox-96.0b3.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "086fa2054f1185c40ff297c747abfc8d9324a08b2e12418632cdcc61fc668b02";
+      sha256 = "4a24c3368e2f88f75f81af2e17050e41160d99b27720517cc34a7772533ddcc6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/da/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/da/firefox-96.0b3.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "b657c66cd373e7644c56e5ae522531ca714fa0f7c529555289c5df45d0bfbd56";
+      sha256 = "5282d6c566361c74d5fb8c8d0f992ba5e929f2183b3abb9d479d7f1d53470dbc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/de/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/de/firefox-96.0b3.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "dddf834e5674b47d8e59bf921ba007067c9aef3d2efbd85634cc2ea72510bdb8";
+      sha256 = "f88988016fc2a8fa5543822d6fb1ad84c57f8f0d8ed2bafcc63552efb2361085";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/dsb/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/dsb/firefox-96.0b3.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "a407dd3b2bd3d986d7d59668fa20b6b2f4f71d3b54332a99142c08f7829aac9e";
+      sha256 = "252a9f2b5b99100abcf4ccaaad9982d48ebf903a7761d36e2aef766985fc0ec6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/el/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/el/firefox-96.0b3.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "8042da6d7c66aa7c45dda5830bfb67877e06a66ae2ead7343c74d51becf56ad5";
+      sha256 = "8e67fef2d4e2cf87a2961c7deebd244a1dfc7863e8474510aa196d54e199b4bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/en-CA/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/en-CA/firefox-96.0b3.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "9d9bd958a6e0854918333f65d6fd8a3ea461d127e5e160500da186a4a907d3e6";
+      sha256 = "a687d4abfeece55bdc35bb000a802ac6a67bad8af6cdcf88802b7d42c486789a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/en-GB/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/en-GB/firefox-96.0b3.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "7fa0b938156a578297d1fc937673142be25f8b3cbbd97480b4be654fe2784b50";
+      sha256 = "27819a8e87dbce94ca4bb2b3465153c6ab974c52bb81b2517fc685b2089548f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/en-US/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/en-US/firefox-96.0b3.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "33d62cbaf991fc592da3f913cfb802f0707b0b1f72dc7416fb1cc22c381b7ae4";
+      sha256 = "21cb440725cf0378021b4a6a858fa3d344b39292a61e4a774d065e9e41668e24";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/eo/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/eo/firefox-96.0b3.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "d374f116d4e769147be1a56c2c6410f1fdaa8d86ed58475562f906b061c0c3b5";
+      sha256 = "ed0bb4aef9a5ff6790bc36f3ec45bf140ff23343a36716bc59fbdf4cb31c0976";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/es-AR/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/es-AR/firefox-96.0b3.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "700457bcb26d5ff2169b9e8c23e6140cffe48742865eee51fbf5d9932c59adeb";
+      sha256 = "436ae41521b50068bb5fc9768936c4a4b77bb0a37f48ddb84cf8946a4a7ea76b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/es-CL/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/es-CL/firefox-96.0b3.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "563af53b075039919e6e15690c089109ea2b846852161e7fafbbc8fe2b20a441";
+      sha256 = "dc354dba3016dbe13ce744fcf654b292254c8fc0f53e55218952c6fbb961fcaa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/es-ES/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/es-ES/firefox-96.0b3.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "0c20971406b742f2b18097909f68224f4cab619ba469aeb8da19bb8cc2ca18e6";
+      sha256 = "87bdfeab9856f13736ead5c3157d05a5d0b73c27a2ad0d7537bb63d994cf9703";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/es-MX/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/es-MX/firefox-96.0b3.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "6ba00dca7e382da326fbe35eaf25312d1b4a85d5baeb64514470d20774a4efae";
+      sha256 = "6dd1f7fcf13e9c651d3359eadb1b8b2c13aca121e294ee5856f663a712438ebb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/et/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/et/firefox-96.0b3.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "cbd3353c4c236ce9b9b65ae322c6d43dbd74a27db638d2a01c4734e34b285e3c";
+      sha256 = "fa5e600d2cddd4c93596baa0bce310cdfee9eef12df808968972382bee32f57e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/eu/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/eu/firefox-96.0b3.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "3eafe56e7675aa503cc036d7adb64981ad7a06bf934c7d6c0ecbc4af8a895441";
+      sha256 = "1b277fc9646ea8d060c1bb554ca04e42b0099c70a44e697990ac4289712eb12d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/fa/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/fa/firefox-96.0b3.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "0dbb9c473b58ce34d3924dc5f8a41065206f06a0993246f111c0da0561352624";
+      sha256 = "370329076e609bcccdda5f472b334cb8dfe3df0e8eb696d22aadaa44f8b0b539";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/ff/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/ff/firefox-96.0b3.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "723bc7955202c4c3425e32045d21177a3d312f41fa4005c3561cd6d959151c10";
+      sha256 = "9b9e685fc94652195b00b5a959e48d81142b7589e0ac9d163c39f07cecadf27d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/fi/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/fi/firefox-96.0b3.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "085f28f412ed53662519fabff853e6515b26427044e935dcf6106716f419c748";
+      sha256 = "f4b851f9a39fcdfea9034edf0f4930632da04d9a3b949c65b682e30dac63cb45";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/fr/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/fr/firefox-96.0b3.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "84e90806913574e980a6538cc6519d201bbe939fb857f34feb05897fa8c69409";
+      sha256 = "e72943c2f034282b73aa136b272dc7e7e9d2bdda5b2c2db045029f05a0e8b14a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/fy-NL/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/fy-NL/firefox-96.0b3.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "8cbcae8c008c679c234c51f56097691e9a9159ba58937c74e38acdb616ae6ba0";
+      sha256 = "e2451341887d6dc51f3aee8c8b9a7dc65277e3cc9df9e2fafacdf67da838e48a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/ga-IE/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/ga-IE/firefox-96.0b3.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "d40a5549c9f8982a8099ef54d0e459bf6d860b30df38b677ac01c16a0a57e330";
+      sha256 = "01a03a21f479475d224fa7559a5b4e98bf978f61f4e472a58b1d1d272cf5fb24";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/gd/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/gd/firefox-96.0b3.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "d5eb63613d83d2ffb5e11cdd21629dba7058ba955f5efbb002a010fbbc677406";
+      sha256 = "b64c925beb57420c5c76c4c4ac78282beabe4a6ad7fee19bd6bd4a9af2153422";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/gl/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/gl/firefox-96.0b3.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "21fd943016e8f8262f1e1873c3761d7bccf75f62c0274b09e441327f35987fa1";
+      sha256 = "250ac76432b7312bc1173ee34a32d0e658c0ea658664eb296b7c5dc2c1fb6ca2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/gn/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/gn/firefox-96.0b3.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "3ce4b7cd3cca655ae114e3b2a8b37e10ce4ef8d7a67f9102ec2c0212cfb069df";
+      sha256 = "bc3a716efd7cdb0538714ba3469a5303a9496b0b1f81d43a41b55434c047c991";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/gu-IN/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/gu-IN/firefox-96.0b3.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "3312ff91d51e10efa1318403796c0f4029723578784a5d51158ae7c316afc4f4";
+      sha256 = "c6d2e017c5269064a5716d54f5df9f2e2dfe621f9f24e7d2a9dd3bfd6b47983e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/he/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/he/firefox-96.0b3.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "f9b24ae14c635b8fae22cd0fce522e0b59f1f98590d697c4cbc82af682751bae";
+      sha256 = "0f3e2947b7e03ab0197af6817774a7e0bb11fd5dcf13df23ad3cb2899da49cba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/hi-IN/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/hi-IN/firefox-96.0b3.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "09629e8ae42901795c05957c179020daf446201237d39c055d611806d0b86b78";
+      sha256 = "161d898a2d74fbb709fb3d19c7444c9892e035c2876f66384c920ae3f76e21f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/hr/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/hr/firefox-96.0b3.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "6bcfd3b48a09e222046ff349ec824e4b60cc7babcf63172482115ccab078cad5";
+      sha256 = "8bf24778507063352156caa82fdbaadfde5c840f2637196d87cd314ee89a3833";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/hsb/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/hsb/firefox-96.0b3.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "7e3d6c90d330752792000aabae8250d23fb7ff12f24adc9c47279db194cc6e54";
+      sha256 = "77f1a913c4e2973593edf6982eaa767185ba4b8ae91c16b967e8f3c7e82d72df";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/hu/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/hu/firefox-96.0b3.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "2fb95d958888fa4247478833ca047ee7ac76e4032b48163ad61ca5597dba1d35";
+      sha256 = "f4ae877d906e7427703df3f219c0c95abffdb995328a80de3b069cbc5eba4a42";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/hy-AM/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/hy-AM/firefox-96.0b3.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "d6d056f2841b6f359dc4ae9e22b9a5e8698a26df574b09cb3c79fa44d1d86790";
+      sha256 = "0d3371fe5359ec1d23dc58e00151ee81838c18a8e9fb665d48c3276ffa34809d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/ia/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/ia/firefox-96.0b3.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "a6360b38bc8d7a7265e3f66ad669bf40bc25770fba8cee29df420c8d396d271c";
+      sha256 = "7194d571e3cd92afbb8e19c5ecfe15e0c0ed4af28961008efeaf5e475ed8c1a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/id/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/id/firefox-96.0b3.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "ef34e9290dbe1e8f362311b43798a78c7455db5e214397e2d7285a38f5599ae7";
+      sha256 = "79a5a4d97a106dafb9ff6ede0e853dbbf24aafbc3f654f5b8244ba2a09ac6ff9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/is/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/is/firefox-96.0b3.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "bf2d2cc1b6735466c70fbd6dd463b240fe17164b6c6a9bea3b6e2839f846699a";
+      sha256 = "fbc2bd2dc236706d1e6599d32a6aef5b4dea0b2dbac4a0d59854205dc66c6958";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/it/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/it/firefox-96.0b3.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "628ef481ebc9996eefc8cd689d6e7ae6a41c4d11be5cfe1e3a08ef05d2bca8fe";
+      sha256 = "5d1b79b6be89b593f79982460bc10d160f8914c4544a802045562547b59ba364";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/ja/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/ja/firefox-96.0b3.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "6cd76540da568857deb06c5b1c6c73003548f9399bfadb25b425a35a30e5eeb9";
+      sha256 = "c55511e3e8546d31230e8735a85e9c2745d3358567e424324bbc850c8f9399b2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/ka/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/ka/firefox-96.0b3.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "811b0f7b73ac2726f6ef5a07d923c29a2821a6f7cacc18e79ead5efb7c4deecc";
+      sha256 = "009a89d79b2020f8e86a9d61b21b5751afd3aae053ce0c037b3cf303f528cec0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/kab/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/kab/firefox-96.0b3.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "d384e7975ad2110e48cc2c17fb14dc8bcfe14fdae481a538c6b66eef627f70d6";
+      sha256 = "06b51518cb8a3ef97c084f1cafaab34a8175b7efab66e16d3f4f1f7d72aa9df4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/kk/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/kk/firefox-96.0b3.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "315d84a82ab42fcd471758191f012e52565cf907409546346a35a46b33af87ab";
+      sha256 = "560b8a7cc248639361ba08996a477d2ef7eab0482f41bba67f0371c841ca490e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/km/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/km/firefox-96.0b3.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "3b0620bcb47b92b7a2e46f52ae6fc306615dd94b85c37e445158eb3161e73ee5";
+      sha256 = "cc0a12c6e2feab652d08d28a27b79a9481209f4c3869372b37f1cc5e27ff8e70";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/kn/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/kn/firefox-96.0b3.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "3e4e906b80f438ec81de41464d898f8a2d23385907d8398afe12e8c6473921a1";
+      sha256 = "25541e2722cdf1621dc42ad529447c31c0e9e8ccf7300f87d89f2e1f91240fd9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/ko/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/ko/firefox-96.0b3.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "d7bedd07d0cae948c4c995930b5fd84f90e84843f7024e93f37af2bec9e5bf2f";
+      sha256 = "cde1314a8135543aa98a9c28c083e3f57700be9990ba2ef780f6dce4a8de6dd3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/lij/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/lij/firefox-96.0b3.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "86b64f383a0f139b7ea280dbc8216a98a2bcfa5b89b59cea9a593830eed2400c";
+      sha256 = "f85d1f85763fac8e748662d1b493cd06dbdac37960785cee0e8946daab10fae6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/lt/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/lt/firefox-96.0b3.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "0d9abd3f952d2a8c5e44bad8e459053d796ab9aa78aef2bed4bc5c9079e9b91c";
+      sha256 = "34ff1895eac6fda351b210ae65b2edbf837ca8a5a5592caa33750ccdf529c6bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/lv/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/lv/firefox-96.0b3.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "de4682948f45b82942a5f544177927d950401ef734d956527528edc098321051";
+      sha256 = "9769e7039a980ae239d242fd6ed4438e7b90e1fd91f7d9ceafd52e8183bde1a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/mk/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/mk/firefox-96.0b3.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "45d25d6f46bb9807cf0b05dd8148049860e7a86c04bc814498e33c68a8958a12";
+      sha256 = "1217469bc4707454ece2ccb422e99e85724845760a4a78205753c07354a2d6aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/mr/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/mr/firefox-96.0b3.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "f29ac0279437c0392dc77ee3176cff58f0d6c5bf2836e0e51877722fffa83cc6";
+      sha256 = "e70d4bb799117c0343a17f57adc733dac1cdbacf30dcfe0ebc195da3de091408";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/ms/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/ms/firefox-96.0b3.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "1d6f1af7b50d0aab0385fee820c3aab54471b19d47ff6384f5198aa6ce01cc16";
+      sha256 = "91bff99d4326c16466ae3c4d1646f14cc8d341cf93c71db6dec117ae24dda154";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/my/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/my/firefox-96.0b3.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "33460df1b8f1db24347b97bb953b8ffa29895c2b048fb1ea3067bb6059122ef1";
+      sha256 = "4efb3b03955ab8cae4925704fef1a1d1ebc20c3bbdbb9332d1be31c2aa0f16a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/nb-NO/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/nb-NO/firefox-96.0b3.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "6c3f0adbf54636e6d9e073d4e3265d54b4fd2f63f716562b7b1c0979f2dd792c";
+      sha256 = "9c01453ebeaa772eb1ad092400ff6da05d6a36d901fe4f9ca9d98bf4c41d2d40";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/ne-NP/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/ne-NP/firefox-96.0b3.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "b0c5ffde1b4e61e67e7eca8dcd91fab8cddb582a8574ac0c9cd68af2ea16ce9d";
+      sha256 = "697bf0266fd4cb19e42619054795bacf4e9a065dfd976086b074be47038f86ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/nl/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/nl/firefox-96.0b3.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "6beed6c4fa2915425f14c510ad979830cfad2fd72166b24df13000b2f8ec111f";
+      sha256 = "7314cfcd476f18054775d03d96787afd4572437c507b0387fe3104e272e66f32";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/nn-NO/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/nn-NO/firefox-96.0b3.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "db6056951f6d1728b63834ce33f004d582d14b16d3b376c22518c4f1c7cc3cd4";
+      sha256 = "3fc8dc069fb41aca43581f3551a485f4659a760a275beac5087f479eba0b4605";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/oc/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/oc/firefox-96.0b3.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "faaa3ac02d5a7baee92e6ed61354df09152ea21d45ca4ed75cf8b8f8efbad154";
+      sha256 = "22ea3193fbdddec8deb897ad5551fd94ceb659cd8493a04db51525c29ffae0c5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/pa-IN/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/pa-IN/firefox-96.0b3.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "5d4d904aa5dd2485ba3e86313604225b077ad962d845f61e6bc6b8eabb6e7f35";
+      sha256 = "2f3dad5c917a28b41fc1ca3365316a281c6e6560283d2002364c2bddad5d7a52";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/pl/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/pl/firefox-96.0b3.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "e5d83fb5fd509bc184fcb5f3adb8fb81fb463f1c2574e4e72955d33a01272920";
+      sha256 = "6334e79bb84d78fad334d9298c8104472ce7297c17d80f28144cf0751c42ac80";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/pt-BR/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/pt-BR/firefox-96.0b3.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "aad23fc465192b61be02b5fc5f01740d20aa996d57791876aa19b7720dd40cd2";
+      sha256 = "8fa05c175f271723e107ecce6d2a7d6b8e5afef5578ead1d6c8ece920d4b0a91";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/pt-PT/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/pt-PT/firefox-96.0b3.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "30b5caf7c87eac3710d111def0de7e54fe526936615749e52c81064a8866e768";
+      sha256 = "7b6751f8883c439f1fefa3b1c220093299f1dbd27b8a49c467113e8200849a72";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/rm/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/rm/firefox-96.0b3.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "90a0e636e2cf1c09509d7fd3b0066b3fd0fd416278e343785d481b7317e1418c";
+      sha256 = "81dced560a8048a4113c3a99ef72137174de6bff64a0ef4f0bd669f3d7f6d89f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/ro/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/ro/firefox-96.0b3.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "5435af6e4e1925bb6acc900c317f1f125913c8bddb1e0f0e6683a9e197d9feab";
+      sha256 = "692746c7919b64f23bc92c00a7e7ba60f54152430887b608b84bcc105a436a33";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/ru/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/ru/firefox-96.0b3.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "97b81dbd06f70809aca62ca6286b9b16146c756b98ceedf637dc7ff63307bde3";
+      sha256 = "52f4b321e3e149fa0317d610f85b4637b464c79b1b2046ceb9dfe2f4e56b6c6f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/sco/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/sco/firefox-96.0b3.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "bcc11d20f0a2e3ded5403a5e61b7eae5358c7b96c5aecbf4c67a00bacf2ec781";
+      sha256 = "3297b5b0d67381d1b7f9c4f76b767c6a5f76388d473afe5e9bf0df94a7bce0d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/si/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/si/firefox-96.0b3.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "b703797f67966452446b7e7201701c660518d61f20a0f68c927352a434b88ebe";
+      sha256 = "bc1eae9950eb6bc6a79fd185835aaf7b3c9394c7d19bfb78348a1f4987315636";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/sk/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/sk/firefox-96.0b3.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "55587531dc284fae18b03ea65ccded3c8b0e36c5f6a2302b46954c11f3bbda79";
+      sha256 = "fdef69d9e24c00616b177dba71e2c5db29f8c945cdba4c3dfbb39753b1f01a72";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/sl/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/sl/firefox-96.0b3.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "f0397fc96c9c46c0962de1c1a009fcbabbb1da6a15aba5568cfc1deee1d127b8";
+      sha256 = "7225b70db5b568634792f18f0f6ddca4ab94e00b225942c6a4f5c4741ac9858c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/son/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/son/firefox-96.0b3.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "f43039295499f068ef3e2ed9138c25cc6343bcbd68e845b58bf3a40cdbb12db6";
+      sha256 = "2c7f228dadbb2b3ecd424ab2e80a532e17e861f92095e5de5ded2006e79e9dc6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/sq/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/sq/firefox-96.0b3.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "7c1ef14292fe2bc8bef11c2730d6604c8b82bf102c024c9560e9fa747961e374";
+      sha256 = "63fec6dfd214dbce4b344ed347eeda9adb489707e06e6a4e1ad6fa828e0da7ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/sr/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/sr/firefox-96.0b3.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "e5f72a3073be18d5a5493f15126895c5d8182489be19fc8704dc1cd92997d17a";
+      sha256 = "8d584d48c4e35bd7ff1438c7a80e0b353bb4871ba946119c36f1fb3bd135518c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/sv-SE/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/sv-SE/firefox-96.0b3.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "27b9c49f5334b06017cd2e953eea41c6a211010b316bbff9dfdf15a7276f293a";
+      sha256 = "d5e7514a67a288e755d7ae30f2dd680e2138e50666fa15c1b710d0a454a51730";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/szl/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/szl/firefox-96.0b3.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "b94dcd8e3442ab29763216ceba888f205ae2a27bb1eb8cd9d5d7473f6fec1f9c";
+      sha256 = "1557cd8173d79820d852d99c0cbb07249c2bf17bb778670e437c4d408329fbc3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/ta/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/ta/firefox-96.0b3.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "fb6150c6231844130fa488ab0dc91fabf4e06d2dd7e9b8a6605689e84f59b027";
+      sha256 = "2001ea5bb925d5a1e845844d03c441c2cea9a61b042df518d16e484a3a7901ba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/te/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/te/firefox-96.0b3.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "07737bb07b4bbea1474084aae0e1733d63f7bb630ee1c51bf006127e1491203e";
+      sha256 = "c9994fe1e9212281fc007ba8f6b703856693deccbc083e17dc94b6da8ed29a72";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/th/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/th/firefox-96.0b3.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "c11be11dc71a2ab9dd30cf2f11c858d7b4d0d28009e0d1ddb210fe2c83c72d4a";
+      sha256 = "8c6b207b23fe66c7506da96df7de25270218ce9ca61bbedd693fc6f69c970d53";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/tl/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/tl/firefox-96.0b3.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "70b6ebd47c72276a4002c4fc390204f8d741e1c04d85e24a53547120b432fc34";
+      sha256 = "c9c7cd8c6195588bfbe1c812425f94e7b2727fa0ab73e247b543cf85ea09b171";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/tr/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/tr/firefox-96.0b3.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "1d8b06c8141fe52e6417262b9a863d40061d3a02bb76b3084144adba86468093";
+      sha256 = "9b7688be959e16f4ed652ddef4cde0bd5b3df391b8c43c33b6234ae5ba404987";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/trs/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/trs/firefox-96.0b3.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "68cd9ec55a3dd9e02fb4cdc5efa1ef5811128aa344bbae7d249be5c5e3a8f661";
+      sha256 = "470596584e9bbf2795624b5baf878955229472450fa7178c9e4612408452b170";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/uk/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/uk/firefox-96.0b3.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "b596c8dd7c495f13980c9f8f8ed8f2dd622f13c9add9a82009b053edc865b34c";
+      sha256 = "814e5c7e9609b6ae72d2c4c0e012d503394ee6c669e777a0e3b4e4dcb4c7612d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/ur/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/ur/firefox-96.0b3.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "ecf825d26894269e22c325116fd22630f6377d8f75931ac078ebb717a0112df0";
+      sha256 = "2113a0313ed3d675bf1adecd574bd0112fa5c03d23f670e522928adea6c97265";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/uz/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/uz/firefox-96.0b3.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "775015befdf60a0b7afd26a8a5c3fe50e72e34ade98915c8f8035c24d9f1a96d";
+      sha256 = "4e759986facde4229324402963e0442d1592147c8f4bdfdcec5ec067e2d0b123";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/vi/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/vi/firefox-96.0b3.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "285a179a4739adfd2a1aab9e83363b79ae61b5765119992175aaabb49c109e5c";
+      sha256 = "c77990635980e56d3856b3793f186a61aaa6da43ee0e0970e7ab06953596f85e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/xh/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/xh/firefox-96.0b3.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "45824831250c36ecc54cbd01dd54451e11f8243b17da30604121f478cb44b634";
+      sha256 = "b4a725703b13e230f84c3a5aa1b9532a7755888a2bf7516b5a0c3a79f70f1ff0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/zh-CN/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/zh-CN/firefox-96.0b3.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "3faa40d7423eb4b3c7a83326dd510efb7446eab17ca792e9006e6e1108d47112";
+      sha256 = "fed127eedb2d7bf82977c9aa3311e40eca083b7fdd6a7e58f44b315e209c3267";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0b3/linux-i686/zh-TW/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0b3/linux-i686/zh-TW/firefox-96.0b3.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "d29c7d36ac4367ad8e0c758ff041602d873c95d962edffbafd132f9ea494e8d9";
+      sha256 = "d29db983e9791aea1dba8f483cf9399ca032fe081e6e8cbb08d9fac3d644c582";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "95.0b3";
+  version = "96.0b3";
   sources = [
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/ach/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/ach/firefox-96.0b3.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "3fd3329cb4813ed6c241067b6c8ee43ab248cb8557ade63d6019a7b77919517f";
+      sha256 = "dd41bff1f1401eb376a3ab26154a42cdc35e409cdde24435737d753b15435fa6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/af/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/af/firefox-96.0b3.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "2681fd38676829807eaca78013535db672a8ccf9cac12ea4b906898b148d680d";
+      sha256 = "963103d54c26d76abeebbc86480836408f8eb7eeee96178ce53d6fc269029603";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/an/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/an/firefox-96.0b3.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "a07a3708c17587dcadab18e10205938311b4a74a668d820fbaf68d6029c86a75";
+      sha256 = "51862a663ea34d9bb1ae78bcf7846f6148dd8004cbdc6ed49c1252590262afe8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/ar/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/ar/firefox-96.0b3.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "02c6f9c848b62b9ef77a9530040c35645cfddbfecad6d479e6845ae93dcfd7a1";
+      sha256 = "24857b772fc0a7b018c0ceb51913b1a76df59ef3a95fd41f464e1c51b5201e6a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/ast/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/ast/firefox-96.0b3.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "8dcc6a6f746a9f4d766a71608fbd67e737fddcaa50cbf53738780913c5762a32";
+      sha256 = "44c45ef6d101d0bf6f57d663ae6943a7d3bce248eb8feb35dacde292b2c3fcf1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/az/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/az/firefox-96.0b3.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "4ada53459d9f5040635b2873d21bb59da37f6fcbe3d389bdd42c3484841a3410";
+      sha256 = "c196437bfc3aa231859ebdd2f335eea4991c4eae6bd3cf9c64f4eb195704b1e3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/be/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/be/firefox-96.0b3.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "81285777b5e76044d3e1bb66ac458cd1ec40d4c6b7cba8ecbb991869b628e33f";
+      sha256 = "a1d1eb29a51a84c2c779bd2090a7a064d1b7d290e0389672351821d414fdd35d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/bg/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/bg/firefox-96.0b3.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "f6b2d858c9a7dce01648b04d653d5835f2d23b660fe199b5e5816d5099c5b2a8";
+      sha256 = "1f78b12ceb1951ca0e354ee04ff6a7893fc7596480b9df1c9eb443800778e033";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/bn/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/bn/firefox-96.0b3.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "0dd4e9ad279a3a70d5aa4df2cbbfc59ce244543d0db5d95d8cdef19851a35c3c";
+      sha256 = "b010759c37cafaa3e296b2b71ab19d2850ed62043c3a04e80b21c4d9e9acd235";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/br/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/br/firefox-96.0b3.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "4f2efcb73678541f3e30f7b7777060787d8f21c7a9a93f401f67d29716686763";
+      sha256 = "5d58e3ad0cf8de459d68b60653af865bc1e11a1b69a6decca9e630675405885c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/bs/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/bs/firefox-96.0b3.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "01be296b46d77a34a2c0548bc1e671a5ac22825a1bd34a280a69b12592800418";
+      sha256 = "d3f1ce059e17f6a14cad30ef2609cffe61bc3495bef3ada1a2941bfd8bbc440f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/ca-valencia/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/ca-valencia/firefox-96.0b3.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "76872161dd216803b8446a69c953c44d6e58aa6efd9ac829d3f07f52f6cb1270";
+      sha256 = "e06cf1c020f3f65e99c4816b054c9f79da55f892dde27d8acde17ebc24fbc840";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/ca/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/ca/firefox-96.0b3.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "b92b2b0c22515639aa14ed6526cc01e328e9a66f646113cc2dd3ab573ee8e5e3";
+      sha256 = "0f9644f78246459e2d7b0c8c1dabc5c33d5d20d2c6d517cee20fb540db501cd6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/cak/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/cak/firefox-96.0b3.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "8e9db7fced10d04d1de472fefdc67b56d1c272d3a5a656d3992f9d2f0aa4cf85";
+      sha256 = "9b78dc607de8f66352a778c05186806b0fed9afa8474fc4f2f9346c4298d0be6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/cs/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/cs/firefox-96.0b3.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "64f70a9be5f426f6ca3c7c3defbb70ef77f7bdd4e0047a171119af3a700342e3";
+      sha256 = "cdc96bf52e2d9d463e1caca4eb567ec723311678233db59d1cb57a2e7e16c593";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/cy/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/cy/firefox-96.0b3.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "64f99c6cd821a36e398be38fad603f804511799cfdf5ee42983f31b616ad9f58";
+      sha256 = "91c833ce44c24d3fa7b90bab56d0994c930649ae39403c6888a85c2e22fda7c8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/da/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/da/firefox-96.0b3.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "355b1cabe8ec16f3d71718f88fbb28675c3a6af222674d6e4da70e6cc4d14094";
+      sha256 = "e8602e1cf72f9b98dceb23694eaeef70a82bf2704cefb4dfa9db380a31eda03d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/de/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/de/firefox-96.0b3.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "60dbc682145d8c3ef5c3526768bbfb495e95d6f2724051acca692e23c4f934ea";
+      sha256 = "4d7ab6dfbc168e1edcf7b06b9da65e88b805cde7adc14519e2139fc811188b24";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/dsb/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/dsb/firefox-96.0b3.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "865e6173162f5120168f449ed56eff83615594e4149d4b7ceb3b42cbfa4cee9f";
+      sha256 = "e0288172d3e7fd5f9d8631cb36a7f69118aed0b3daea8ca6d4bda0eee53a2353";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/el/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/el/firefox-96.0b3.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "a38442cf1402a6e36606bb1fb8ba65a67028cfe57a787a38ed1495aae1adcb95";
+      sha256 = "eccb1283cee2fa9d6b35ed0cf30f789f422094cf2fb17966b9a406026bfea2d5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/en-CA/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/en-CA/firefox-96.0b3.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "f4a717ef12401062a8cf4eb2b220ea18d7999f02052b67b82cefc714b18a8c22";
+      sha256 = "7769bc1d977fec4e0b5362fdfeb0b0f52bab1d0b12b012c90ff2b096209bc7c4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/en-GB/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/en-GB/firefox-96.0b3.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "27c1b9bb1fa53ef22a6f0c31b91a449c81804734da66b30dce4491f8531acfe0";
+      sha256 = "71e3b186ceb1333f4b95429e63abb1c0807a7f1df2c0e8da26b5af866ad077b7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/en-US/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/en-US/firefox-96.0b3.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "43bf184b95b9ff25c415ae9fe533649c0108fe72aee24c56521893d05e2a009a";
+      sha256 = "cb4602feead2f7e7b407e83594ad2edd9de856d334a7f9cfd392a7764adfbbc2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/eo/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/eo/firefox-96.0b3.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "5946960568857d35a1fadb3c3bb2bc9a42dc92e64d6652ceec64acc7e20553f9";
+      sha256 = "36ad536374a186e2d9ff4c2894749ae43c512555ce2fcd5f67b0ee76949a764f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/es-AR/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/es-AR/firefox-96.0b3.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "7380846a63a5b8e8a3471d2af3c26b50719084e0c72253c356280f3e4ca3f508";
+      sha256 = "8f4c854834fe8bffc682f8c29ee674771f70f78d28173cff3beaab13ae637c54";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/es-CL/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/es-CL/firefox-96.0b3.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "6d41074e2c44d1d0ba63c1648697ae2bb1a5254c41da00a1b1f33df1228a0443";
+      sha256 = "3381fa208df76553b85a53cfbd4ced059cfccaea1a8e246a5d0d1c54efed8e8f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/es-ES/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/es-ES/firefox-96.0b3.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "021c5c9c71ac4556de6c7da4cf6b36e1693fcf0746ac57174effbaa61c0f5025";
+      sha256 = "e98d88c0e6350e477404ef14fc7348ee79f25fc9e31ed2031c93b79298fc37fa";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/es-MX/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/es-MX/firefox-96.0b3.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "c2df6f4a405f8b0194d1aefaa3862156b66ff9f488bbb3b720abc20a3fb473cd";
+      sha256 = "26b84f335c5ba6238d69a7537686141188226859d17b0a64c71a1ca0ac9e9d70";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/et/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/et/firefox-96.0b3.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "62bef0b8102b3809c46b792e96c130ecd8c2b5a2c53418d4e9cc72dff78b9b99";
+      sha256 = "9371d5111ee591ea4179c4932e03d1686b4f8555c5b6b1dc110382b43dc046f8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/eu/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/eu/firefox-96.0b3.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "b4932b60aa4e36150dec1d8b7b5ce0a244bb628d37312b7c8a6f0867966e1773";
+      sha256 = "56336434a3be39e71459a3ae990f3dbf826fc53ddd33410b0208e4104fb9948a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/fa/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/fa/firefox-96.0b3.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "ee9418278f0e14c7e97258b8b17d100974457f1c59b9cc9957b9426a9846ddcf";
+      sha256 = "75105b2ec1f269e044332dfd1736edf0919141d3ce7ab979da06ac6a47c361f8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/ff/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/ff/firefox-96.0b3.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "b7c5d0ac455ed9ba1c5258b61e75b742ebf505a97e703d19f6813e1a013bf146";
+      sha256 = "86439e96051f460ac42154274401cf4f50102f89590e67e78024a7e0928a2dcd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/fi/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/fi/firefox-96.0b3.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "ed78862c15000473d37861f592cf878298cddb35fb721f6fd0309a16dc936768";
+      sha256 = "e94714ca233a274a0229bfd6c9e5daceaecd2cab30b8314464b766ac79c1fc2f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/fr/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/fr/firefox-96.0b3.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "f0ed0ffdca130d03b96948c304150aaffd311486040bc8d925b99e34d4039f8f";
+      sha256 = "4b88a49838eb6f479feccbdf3109e3ae7ffb1215a433233d0200fe8713475344";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/fy-NL/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/fy-NL/firefox-96.0b3.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "219a1c17ebb2d41b025eb484a9f2df23068b61e56bd34d6ebfb8227d3ae5e5bc";
+      sha256 = "216868ae9bf52b914063b154015efb07ca384f5a722064ce9ce2ef2191722c80";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/ga-IE/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/ga-IE/firefox-96.0b3.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "793af4d583b68aa0c2102c81f3c677a547af0e335f00713c36580c93396f373e";
+      sha256 = "38fb2079928d7fbe4e8181a14f7c7d955d41fd14f0c73f0122d91c9eb1ef7929";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/gd/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/gd/firefox-96.0b3.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "97adc63c32a0cade64307695305f325e27cd97d3990bf6bc947da01b83872a62";
+      sha256 = "bd70c4241e3e8233458b7ff6bc2893de43e5917284222146a585fce47f785a5c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/gl/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/gl/firefox-96.0b3.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "c05af2043451d2f33d01d75addcb8bb6304e4f30322efc8663aab2373186afab";
+      sha256 = "edac88def8dbbcff4cb4b5c33ab77f48d6b96a8ee1765649913028cd92d4b4a1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/gn/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/gn/firefox-96.0b3.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "715b877ab23020886f7732e17df318d1e482aa7e63952f65fb6459748d53dabb";
+      sha256 = "1dcb25e73b9dd759cba339bd24b769c279c9eac1a4d2b47338ceac82d9e45bb2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/gu-IN/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/gu-IN/firefox-96.0b3.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "8134da66866cb14b2322d7ca346dc00a0ce402cb2931cf33e409ac3f811b0023";
+      sha256 = "122331ecadf4b63319988f781c819f11f905d685f4a549cb08454a9d8478029e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/he/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/he/firefox-96.0b3.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "2bc4ba91f25dd7fc0171f7e8c9ff394aec894a4ab537feb13b0f47810fc35965";
+      sha256 = "45f8c33eff249c9373dcf558648475b171be65db5fefa873f7553ba1ce77f2d3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/hi-IN/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/hi-IN/firefox-96.0b3.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "7d20310861e6da853531130c814d22d6df4ef8c5d4eb8e0519e29f0b3b034ece";
+      sha256 = "9480b304d5c9ec6a10dfd480484dbd01dc41ea1cacee4b05b962d4a5bced4427";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/hr/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/hr/firefox-96.0b3.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "8ebc8898ab223c6f975effe14e8507326bc545990cb55b5e8c0efe186fc3c4cc";
+      sha256 = "a287cf31defa7923a7004451fb2cf72018ee507cfc167a67899624f7b8375d97";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/hsb/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/hsb/firefox-96.0b3.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "f149923e2048412b7e9a4df14479536a2824923e7283b91e14dbb1cd1005816a";
+      sha256 = "792b12bc891d6d6b4e0c14f745641f54e9c50ecc10222ee679a206a4348d0c9c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/hu/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/hu/firefox-96.0b3.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "d27522e4f7695d1189b59e5a4a926bddaf9e1aa6f9e8fddcf78be203d9645807";
+      sha256 = "958a2569663fed2f45205ddb744e4c1a62210b678bae94e2717e8d4a66161788";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/hy-AM/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/hy-AM/firefox-96.0b3.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "4e6b2e9edf9024b1021dc397d60630929e97a6bd1ac3a6851b44ac8ba37f4d01";
+      sha256 = "0bd1b2ab4b063faab90a1c2158d9d0d0fc96f7fc81389f06190af39c9247dc21";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/ia/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/ia/firefox-96.0b3.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "429e1d0cc03abd17effa278a4f64abd4344e1dab0b5475539d406d5283a91dc8";
+      sha256 = "09523f090a020e658e14eaeaafe65a6db0793d389c8dbf0671f9f6d3b291482a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/id/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/id/firefox-96.0b3.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "5e1455b5cceebc1b1d7ee587640a928331f3db6d32228e37d8029376245f7ed1";
+      sha256 = "39460a0d21b63c39c5aed3467a2177441e23f15222abbc44535b96ca2ac869db";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/is/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/is/firefox-96.0b3.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "1e09c27534bc853fd82c1ea0c9eb3a86107f0f29724abf107be2e86c7d10408f";
+      sha256 = "7dc87ec09c0fc046a42c583c6ec84d5116ae71ccce466abdfdf8d88578d4fbf2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/it/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/it/firefox-96.0b3.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "f8d517efd3c88a110beee9e225b6311f2d986e05f91f524623f856b795290cf7";
+      sha256 = "bbc73998584297e0eed998927c574eec7d81aa37530be11e0b68d1b89fdf31fb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/ja/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/ja/firefox-96.0b3.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "73c91c7eced0dc7f2761adbb4c324583d6623b575ff9e6f2af6689308857aa24";
+      sha256 = "6d4c0748a49fe3b14ea9906088ca99e1865002af3bd3fbf1121a67409018a51e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/ka/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/ka/firefox-96.0b3.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "287a53af89cc9e7678d86e9c7341868e98493211ba93597767bb5883be1d5e44";
+      sha256 = "595cb5d60786e691078ae1aa8e76ede002f2895fbfac3d9519467f382ddbbbf4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/kab/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/kab/firefox-96.0b3.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "214d5e113e90ab0a18235aad810e7546704a805a8761b5c53332b28167376708";
+      sha256 = "59b28149d3724582a5b4c0b4898bda5818d762020eccc4f40d4054cc6752fc62";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/kk/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/kk/firefox-96.0b3.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "257047f79489b815883e6890e6e4620f2710cf937668d9a1c2b11cd6fcb35264";
+      sha256 = "13278da244a1cf7342235d75eaca237402432e73835d944dc9d5bdb9c5e967d7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/km/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/km/firefox-96.0b3.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "14fca948f72eedbe8a4aa7081d539957c66fc336cd9c64d0ba85a003156b93ee";
+      sha256 = "de8d8b310cb4b90e40d15e3a991810eee5f7d5418ce1d2b8ae1490c040c9b2f5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/kn/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/kn/firefox-96.0b3.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "c78c4d9790a8f71b85fc53f5856e9b611c4e252207dcce0093c6b2feee23c17b";
+      sha256 = "8f400d8effab470e0823ccfa2fe1ba9f49422faebc576d9775a8194957b4d97a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/ko/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/ko/firefox-96.0b3.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "7f9cd61bce4f20ee219503db674250d3d09b8d4e96d80da8d7c90374a73d8c6e";
+      sha256 = "de78ebc094faedbb79b8b3c050dddd8d89cded9d7f5b8cacf96a8ae0741ed5f0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/lij/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/lij/firefox-96.0b3.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "0b34dea142d2906fad1bf28a86845c170789914b2207a7b77ace49859ec68c03";
+      sha256 = "7b46ed0c449eabbed031a6c944c725e20eff8560adaf579afc386728a6aa078b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/lt/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/lt/firefox-96.0b3.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "c7f254ffbdfac024c186d00a71eae7a4e0620a4e0263f50b9f8f8f95a33242f7";
+      sha256 = "2d51003f43ec3ee6a4891f65d9b1c248bae86da174c997d5cd47b779c403ac3a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/lv/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/lv/firefox-96.0b3.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "f8e7acb4373f82e8d62e62726442ff007c8b463ce07678e0da4bca8387319dd5";
+      sha256 = "18a3afd1e3799ae4af17ca288b3ca2811437d752851e3043b6b2d506db2e1c95";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/mk/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/mk/firefox-96.0b3.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "36d245092a6f3739893dcb2763474c762905eb7233768f2739e9381976c7748a";
+      sha256 = "62acd5a8e0eefed468022331f217cebb7e59e629ca8b26010cdd345fcfd3d50a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/mr/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/mr/firefox-96.0b3.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "f2d0d084482d2b65d4966475e8edac1b1c94c8c2d04cf1bfae58e6dfe5698e8a";
+      sha256 = "4e0ee6d697fafe9b855f3112ce745bab71b53c383a181b94dece0a66589604e7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/ms/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/ms/firefox-96.0b3.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "9e1e964a2f64a6a01fe600091f8d3a45334e7710c936cbd3f78e17c593d3db54";
+      sha256 = "1a6ae8edf5732a766c584bc89b7d51b97ad491abccf59cc649db8f250908ea0e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/my/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/my/firefox-96.0b3.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "d35e42e21e4be92f4921fb886eeb06582b01e142034814624956a07b73c92aa0";
+      sha256 = "f9a53290d295b9be23338bb7b2e6427f75e048f04d0614451a8a23352c286264";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/nb-NO/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/nb-NO/firefox-96.0b3.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "89ae0d9daeae3fe3965084068d23f3769f8f40ae90bc483135c48b48b8f27926";
+      sha256 = "99261f267895a39fd7ddd376c87fe1a0dafd1c18467e5fefe17419c9a1ae058f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/ne-NP/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/ne-NP/firefox-96.0b3.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "39087dc455abdc14bb43694865320888326c1c478ed05de9117157edd241b15d";
+      sha256 = "4c3d5200221d7d7bea5e9263329dc216bf74d9f2c822e1b626f8c051262aafaf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/nl/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/nl/firefox-96.0b3.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "988d58514ec177c031d8df463de1f9251c6ba932123d96c4ab3adc5ecd0c224d";
+      sha256 = "16a4857eda94f8f561fe482f9e21ea53c8a84404d1cf7d3c01ed62a6215aa95f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/nn-NO/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/nn-NO/firefox-96.0b3.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "161ba60c1648e66f89f0af272eb848d2654a8af9e1ef7f06d678ad232b09a24b";
+      sha256 = "12171700aab404bf48914952564a0bf862c816eff294885dd441ca5f68a48bb7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/oc/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/oc/firefox-96.0b3.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "22321b31f4a20a43c838ebff4c9179e1cb73f4333acf458705c15db5f26f772d";
+      sha256 = "636950ca09f5a406581c1605370c85c610a6f53bd2e8adb4987e4ed7dabfed7c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/pa-IN/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/pa-IN/firefox-96.0b3.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "e1fd6a78938021707cbdd966f08de7fee0cd0f96a7030acc7169072e9735e3f1";
+      sha256 = "c7ba5162bbd16ad181d19ea42d34d6182c9972b208c98a009b301bb27c865357";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/pl/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/pl/firefox-96.0b3.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "0684e74c1ef60f6e9db51dbbf0fb7f456636665173406d634fcb474430f16af6";
+      sha256 = "e0cf100f60f73cb96c4ef942240375034c792036608e646a0412fb18179b4316";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/pt-BR/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/pt-BR/firefox-96.0b3.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "27cb20a8511ead70644dac22d552cf8a33716ee55ca4a8e31f145c41fd1f5109";
+      sha256 = "4e2c43ff8dd482691190cdbee40cce73540f066b777e3c345acbb4b1622eb166";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/pt-PT/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/pt-PT/firefox-96.0b3.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "857a616824dd7c1776c181628b732f20111c6de8192f8d772711cbe12bb659b0";
+      sha256 = "de92cff3604a82952e49e04777a098cbe7e0fb991a5253e90c66df68f02a598e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/rm/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/rm/firefox-96.0b3.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "aebcf988963324d57099078474777f8fff23d78bdda0bb8e8a07b78510dc822d";
+      sha256 = "a88e3919ea3c8c29b1050e7dec608e62d986411fd4ae3fa8dd38ba55f9dab1f3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/ro/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/ro/firefox-96.0b3.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "5dad61bf11c5efff6068c2745078474774a859859f373782dacc128892f89556";
+      sha256 = "e8a37f0ed391cd8b7a5bda1b4a492a5fa0201e06521c3c4863df8536c4c2da0a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/ru/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/ru/firefox-96.0b3.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "c99f75d57e2d39cacc7df8a1031b6f25b0e190371e78205da43d39ebf31e5456";
+      sha256 = "284a8064fb0a41aff769af21194fa2359a951dbe2134d6415d40a41d4a5636f0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/sco/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/sco/firefox-96.0b3.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "d653190f119bd11cfb04fc61ead507cd0f1e2a5e1d95eec3f44c3aa15a593dc6";
+      sha256 = "01ac969a91b8d778ed08bb2f58faac842c1c28dda40ce8c0b90b40575658ace9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/si/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/si/firefox-96.0b3.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "d3ed08ab23f62e4430bac90a840c47bcacc88cdb0dc22a3ec6541e93ca4ffdd7";
+      sha256 = "4348f3da5b2b6ac1fb2fe370d2a4c820933c5100baf3c529fcde1814e32f1fc0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/sk/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/sk/firefox-96.0b3.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "48864af2fb4238bddc71cb079c5b8c2d3bac0fd71a086c7cdc6370c686177c58";
+      sha256 = "e55e104417153e939c20be42e6307dc36fec843e9170441a3bd6f7d205111f5e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/sl/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/sl/firefox-96.0b3.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "8b4f326420234eb8972eed66780929db4d37ccd8265ed3dae87e7754f49b6563";
+      sha256 = "73be90dd466c418f0f1e7cd231234823c9aec4b37c73d419c272d5f0c6549408";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/son/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/son/firefox-96.0b3.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "0c62ae0a67d83badddfffb599c7347371cd95e98d25c39d7619ab708a45b48cd";
+      sha256 = "e310eb44e199a44f5c6dc938c5278e0cf5a57b0eca9afe93947caf124499a512";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/sq/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/sq/firefox-96.0b3.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "eb0ed5f8673f04c209c946adf3492d187cdd6e275c6b62aa0e9e2007953da2d2";
+      sha256 = "a878f821fe66613200a69619d26bebeb5abd6e7a512f687dfd939ea7b055117d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/sr/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/sr/firefox-96.0b3.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "ff835d9cb24936714707df0f3424fc0f311f1de25914ec0ae079626e44125c2f";
+      sha256 = "a485ef9d3785f4dc8c9ce88287f597c550a489901b8c48ca9f760d8984c6c385";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/sv-SE/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/sv-SE/firefox-96.0b3.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "8dab744e092bab2d0ec6ee9517d639ac4cd3190a617402602d2124f6077743d6";
+      sha256 = "0ecc83a16278aefd627e50e317ad426d8bfe7b68f4633941e6bdbb20e0f1e043";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/szl/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/szl/firefox-96.0b3.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "d204778205b703e15200acbce9d82bd4e76dc40206328d915fd17915f5a716a4";
+      sha256 = "0de3848f27c6be45f54429cd9679b19a661b79e857eac8c4852b511857a25395";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/ta/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/ta/firefox-96.0b3.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "f23bdc488e2a53871a2f664ea4dac52607476b35b6abff09fc7203c3b806f829";
+      sha256 = "ebff08a86bfdb646c02add5e9226cc3f09e096d684247c1c67b9ca6faa48f33c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/te/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/te/firefox-96.0b3.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "3ea085d2b02aefcdded47157203ffc8e7addb6828ffb241a03e4ec955b646129";
+      sha256 = "8221220edc9041f76a493feb7ac3199d93590c2a4145fc1d7e62e961188b3f3e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/th/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/th/firefox-96.0b3.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "04760547a1e18dec91b2bda9501aae9cd3eac6ff17fd1dd0c31b8dd0491b03c1";
+      sha256 = "6f0b612c589ea43323dc8534111808cc1588dcc8dbda09cd4c8326ee513af2c4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/tl/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/tl/firefox-96.0b3.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "64f7c59b2c5e84e30329ddaac5206f14189b22d35d6214b1cbc13a61db804131";
+      sha256 = "d21cb5dcbb5a6a290d83f96ab8fd171254f54cc8586b0513689d30fa059a7555";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/tr/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/tr/firefox-96.0b3.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "bf06ea01a54208dc724931d16b96d091c107198ea6e5ca6d979f111b9a1fda4d";
+      sha256 = "3cf9572b76b5bc627130e27105ce39bc51e55ba0446b4ea867593d7c36b546dc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/trs/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/trs/firefox-96.0b3.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "789a98876b52043bd924b71d68858ccabf25061ad8ea25151cdc08d773ed88f6";
+      sha256 = "269d9c9b50acc393ca9daf4f19404cf63e2e792028c26c03afb992f67628bd3e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/uk/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/uk/firefox-96.0b3.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "9cf8beab66162b0140cc7ede761331b82effd663c05b36031ff563bd08d951ac";
+      sha256 = "c1d304b0b4a7b5c463c07ccb982b16a0265cb1fc114ade7bc4b39f8e9158f5a3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/ur/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/ur/firefox-96.0b3.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "5b6a8de8051e8083ade61a728dba23e7c2b5484d990a9f7022f0356f0dea992a";
+      sha256 = "17ccb256c21e7f7a0851a980952cd5cb006a9d29176b40f420b0002017748da4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/uz/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/uz/firefox-96.0b3.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "0b1887c1a2f0d4692b39bb1fe2e4454d586476d9f3972903ec9b2fd009557cb9";
+      sha256 = "1ecd6d4a20e74d1b3116602a4661b6ea1d1e70f786c88e1452a61230125d4ca0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/vi/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/vi/firefox-96.0b3.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "df016a17c78cb29ef6f8b6b5f4314e358ba3407beb97997d0e97ae51acc7962d";
+      sha256 = "681857e16b6767b0d66e8d51423b360cfeb8d107839ad52cbeecf1e7003d66ec";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/xh/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/xh/firefox-96.0b3.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "a86a366761b6af5e70fbbbd10e791db65e17d5b27dac27f5783c79421f6dc639";
+      sha256 = "3122fcb6638c00f489c6540c3cca4312dbdc5de5cc16351746e83c68d02a45ac";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/zh-CN/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/zh-CN/firefox-96.0b3.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "66d0221e172b22569c6b3f5bb32d1cffddc9ec70987a464e43392b082bba62ef";
+      sha256 = "5e4be58a4891d7b1363d57fcb9ad67e5d1379401cc3df49a5f9ea4fdf71495fa";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-x86_64/zh-TW/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-x86_64/zh-TW/firefox-96.0b3.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "419161b9f96062de4b2b17c5052030202ed4be2e707f4028b73b656168423921";
+      sha256 = "e904a8e65e8637d01376a08908bba94f437f952eba13a68b81b0a40936044e14";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/ach/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/ach/firefox-96.0b3.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "a2c16ba8478d501abb48ca6129507942a017f322c4d29cace1f662f8d50b351a";
+      sha256 = "f5e383bd0268098f82791079324eb1457298d95431d497adbd6023f12c762932";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/af/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/af/firefox-96.0b3.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "1f34c7409880d2e3f4eaefd62e47751859a5fed0a7f1615f69631edda1494973";
+      sha256 = "ae99c4ccebc0b938ebf2c20758a815fdeebae0b81715db79d8385d6a649bb6c9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/an/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/an/firefox-96.0b3.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "5c7e0997b409029bc3ba64574d3b6f79820cb9cbd21f0d311485150aefdc4ba0";
+      sha256 = "ef7ab3d8b6b51d22f0f30b836024212332aec6989684b9a22a4f045662da6080";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/ar/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/ar/firefox-96.0b3.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "81ff44fe65466070288bd6fcd4b2d4c9969321597ef9e1773702d098d74f33da";
+      sha256 = "b3728cabcbb46393796b5b948daeb5821b70ae29a8571fb5295faa40d9a8e592";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/ast/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/ast/firefox-96.0b3.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "34d2b7eb300e0ffa2d5fbcbe061d536a565867853f88eb3388ea1d32684b32ac";
+      sha256 = "ecfcfa573fe215d94e48933bfb276f6dbd573c92a062f4f3ec1ed83ef0da83a7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/az/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/az/firefox-96.0b3.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "b79807a1500211349630ff2ae997462e382011b731ccfcd9b0ed787520d7b075";
+      sha256 = "37558cf0fdf41c728b2a22fc2b8142af011ef7beeb924e08de2400f29b2dede7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/be/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/be/firefox-96.0b3.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "8029777ac9cd721befa5da4a4fb2af9f4e2d7bd22f30c8506ddc739d8fbf31f4";
+      sha256 = "29a156bac1d7ffe10d05690fa3a82820cf246450ef1a77697e4f7f346c9eda13";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/bg/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/bg/firefox-96.0b3.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "907f5b83e413227e83bfa9ce7caff0248969690a822de170924538a2d4480616";
+      sha256 = "631e34ca2499d6767a1fdc7b944f08841bdcd9e3c248f1e4f0572465797e819c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/bn/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/bn/firefox-96.0b3.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "e0e553ebad27775fd625babe053c9adc5452a8cdf1d495632a9961ac825549f7";
+      sha256 = "3500810a58a0cd5192982fc5536902e377458589faf0e8c978425ac2fffb19ee";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/br/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/br/firefox-96.0b3.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "a3eaea3797b81f305a0a2162a0491f2f7a22d64308e076ec44ab4866e7100778";
+      sha256 = "979342ef754af3751a5466a5d54b40291f87dc8f084173330b2e337aec84c516";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/bs/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/bs/firefox-96.0b3.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "371c7960a78de9fc652ed7d3ff56cbfa7015085e2d430b7cb4d30ecf908fc027";
+      sha256 = "55fe1b0bdac8f8dc37acf3159ccbef78e4054c499ac8df550b215826eeeeec6d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/ca-valencia/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/ca-valencia/firefox-96.0b3.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "2c15a7bcd86c3db9f0fb796eebeb0a984ed9f2689654b8aa22abaaee70e25b40";
+      sha256 = "ff090da1c4a6d6dfb12d1750dfbf1f37fe57e2f5f93250d30851da215f6daefc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/ca/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/ca/firefox-96.0b3.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "d1c667da851018502fb884f9fb4ea16e989155cd179da2771fa94cb70d23b325";
+      sha256 = "67027d0efa86c8fea2d27821a99a30e3878a9c478d9f26af3ecfcbdce336f896";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/cak/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/cak/firefox-96.0b3.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "69f13dcd0cd9a7014e4555f47559a4e5b515d70083abc5331803a6ac58f28b9e";
+      sha256 = "e7c2dd2447f157a2541540ea24d0732dfa0dd84b116824d87d7bae53a572883e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/cs/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/cs/firefox-96.0b3.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "0151d00465cb9d23fa9c43847e09d77d7d4bd1892efdade7811bf1f83391d1b6";
+      sha256 = "bd7dc68d840a6a53a525a8a1229e0abca8aa2af14bee6c5f7198d877f3ecab1c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/cy/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/cy/firefox-96.0b3.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "960b42a14ba87d99549ab66677dab4bce88551fcf44dc3240f29ead31fbff435";
+      sha256 = "4a21599535668ffe96f3adb56801aa3c8b5aef40ce2998fde430e34cbb4898e0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/da/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/da/firefox-96.0b3.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "f866c0217a77b9dd77234cb2b83e63858bb227e7b011dee69afcb21c0dbe0d66";
+      sha256 = "5f47de337347f65ba478c48c373d12befcde1b86b99102feb0c921d149541d2a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/de/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/de/firefox-96.0b3.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "28caa97e671f9165c5b6889a678751c41a83b13ca1d7a9b1b6ee434ba8c10319";
+      sha256 = "4f11bf8857f65091d43835c4c1d16097189e184e72abd2dde6807e8b22370f8e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/dsb/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/dsb/firefox-96.0b3.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "519cd1d26de63628de5edc4800c10981bf516ba81484d2c14d15488daf541988";
+      sha256 = "6b426096f9a652e1eca190320fb485c5573c94d7f7558dc70f58b6c49508e5bb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/el/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/el/firefox-96.0b3.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "7dd982bb79a8693f935c5f98b4aa015aed8034ff2915e8766928a06f6be7a2b5";
+      sha256 = "f374d64f64529238f867b76e7e894065a32b75b2d669787f1f7285f23ffb653a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/en-CA/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/en-CA/firefox-96.0b3.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "0ac683ad5725c5e793c646d7f9723f44de8a7a4b099d60683df59d0143e26e70";
+      sha256 = "0806aa2abdc643eed084e7764acae24ee7da7e01c8482b35de5af0cbd809b9e0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/en-GB/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/en-GB/firefox-96.0b3.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "37aa0a3fbbb99970c3b6ffc8e84707ced9af815cc32c12f07f51ab22e1f00b85";
+      sha256 = "b41a39b046956ba4971c4ef163d9da6f7ea6b70f2dd419fdc278995bdc300723";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/en-US/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/en-US/firefox-96.0b3.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "e33957b8729f4c28665039232ea8ba670dd6c8ccc92cbc18453e123f578f80ea";
+      sha256 = "8869e2fadeeca2c22c7732f22cd9709d8da9b435b6e4f9c9d384f67405f0fc76";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/eo/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/eo/firefox-96.0b3.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "42aed0847ab7de209cd561a43de5dc0f598646c179738ec905ef814e567edc99";
+      sha256 = "3d339e3dcfe1ff4273d0a35f1177f580c8158b6457add582cc23f67c00676e56";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/es-AR/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/es-AR/firefox-96.0b3.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "3101bfd23d31cff57f40e7e2f517ff592bba974aa45f893cc76a2589deecdf16";
+      sha256 = "ed129dc3258a62a6e1f02b881d78b2d6348b95b99c2011005644ba484968e3f9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/es-CL/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/es-CL/firefox-96.0b3.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "05a8f3c9f12208b396ef3a38ba001bd688f98b730d52ce5b2887c47f7a2fddbd";
+      sha256 = "0691ef7be86c09cc92fbebc431668d1eee722ed85179a068ab3c548cb6f50058";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/es-ES/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/es-ES/firefox-96.0b3.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "d6a33146ed8ba2dcde668e56b0d6baf76402e6c55c39fcd18cb6927d4120adf3";
+      sha256 = "86629f77d8092ccc4ddfbbfd2613535e1fb3a76e70c10fab46081a87cecaffd8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/es-MX/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/es-MX/firefox-96.0b3.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "34407e3d05a5fb50dd94559af7381348471fca04b03fd8c3f3aea11c2b7543a9";
+      sha256 = "5225e99833460c3098057602b82be9e0e52f2b00c060c29c1ca7310e2dec8384";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/et/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/et/firefox-96.0b3.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "376e9030777f32785517a4fff01b9c125a92100965fc560627cbd61ef8e9882a";
+      sha256 = "0d97b86b2b6834ae518820e83a0f4af5318f3eb8848ca69ad4e3cf2dbbc56e6c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/eu/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/eu/firefox-96.0b3.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "1b718ceaa8f0c807c2cd8f0fa23c29b5907f5f35d024cb409af537f379a38d38";
+      sha256 = "d44a9db9a6638a6c69c7b4ffba024d5b5028407533eeab387c2c442f73078d47";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/fa/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/fa/firefox-96.0b3.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "d8568027e9bd8ff2366a6289c22cb8f2043ab7aa8ce13f6bf92f5a36ec842a7b";
+      sha256 = "df47ebeaf3e3eccfa2b483e46ffc4f7106299d62337923964249c2a7ee070a4d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/ff/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/ff/firefox-96.0b3.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "6143d1382bf317876b632db2e1c153dbabd9f977952aa5de90f1dbae4ae90d53";
+      sha256 = "4be5b5876f032e09d87c90efb9da8f168f722b46f71adc0ec036c4a1840a2795";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/fi/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/fi/firefox-96.0b3.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "dcc0a0c16a26c86bb09a88b150f897806958dc8479f074b28dd057452923b8e1";
+      sha256 = "8ecb3ec4e9387647d3361345a420574887c74ca8bd38f723bea6d8ba4b2f4c81";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/fr/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/fr/firefox-96.0b3.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "7ae2cd7e392c1c6e47ff0cf0b47797b4a0a7ea7b6554a93462449997ae91272d";
+      sha256 = "15483453905eb6aff243af3c536e6d73a88dcaeee4363e829c30fa3e2e9bcf1b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/fy-NL/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/fy-NL/firefox-96.0b3.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "ffb5531ead8406c5312e6a16b90d3ebcc27495dd37b167cba6186d838a007c78";
+      sha256 = "991445513ebb294c2bc8e5833e7631b791cbcc72ccd501ee883665b3b0b62ba1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/ga-IE/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/ga-IE/firefox-96.0b3.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "12012e40100c80606e076548ad1738f74bcb4cb62b44afa2e89dcce556756a46";
+      sha256 = "036e8d167fc43d940d19ac8b90f4e136f264f16fe7d012fb1827b10dd47d8442";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/gd/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/gd/firefox-96.0b3.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "f0164a64438bc280a726255ed2887baa9df6021e057558deb6873d76c4157d52";
+      sha256 = "056ee174fe2a43aa714abe4e59521d2f040fc326cd9d4d36b8ab2676fefba24f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/gl/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/gl/firefox-96.0b3.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "0118909f19a14f855b747d6f9c0257b61ebb26eec6a50337b96a8ad36ecf3801";
+      sha256 = "6f30edc15658ae9395037751fab17c115391f22d4e2560945cbee436344aae92";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/gn/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/gn/firefox-96.0b3.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "49b80164481a3b9786bf8a2feb4f05205eec94759781ef6db34664144a2fa13d";
+      sha256 = "d3cab8f98f1011b94c8b887db82ee3b64051f03879f83594113a0534fb7a730a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/gu-IN/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/gu-IN/firefox-96.0b3.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "c82736afb3a9394764c10e77df765822c4a63703c4ac10a12a50dfdaa99aceb9";
+      sha256 = "969d9e3ddd308b96fe6475b04e0eaab162aa89f98daa9f921b52a2602e95c93e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/he/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/he/firefox-96.0b3.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "2d96c2d26df3d8c748ca5964f0d64cbe3a19f0c2ce19c20aeed75c4cb8ccf75d";
+      sha256 = "874a5cacf1f6025889a4fc0961b8c26f78a56b403e76af8e84cd6bc54de3455b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/hi-IN/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/hi-IN/firefox-96.0b3.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "e2416cd7591675eed8228f8c7537d351ee98f8e569d21b7c15e1de958d0686eb";
+      sha256 = "4d369daaffdaf1a28d940f98f3f3d4c3936c5ccb3f913c3c1f0233b4ee448da5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/hr/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/hr/firefox-96.0b3.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "c1ed97934c29e95aad7b57ace5eecd5fc25359eda349d08456384135cc5eb1f3";
+      sha256 = "f5138a6569f4c8779c90462b3165fb7bb2351d48e9a81daa88d909e475eef2df";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/hsb/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/hsb/firefox-96.0b3.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "510137ee420ecd1157f6fa91a6433313625bd64c4ebf6b6bdfe20ace8bd8881b";
+      sha256 = "f410a1786eda2f9b7bc27e30c438f4e0a090b436b871c0614f6fd871f4eaa2fd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/hu/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/hu/firefox-96.0b3.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "65fb0b64ffae3627028377507138bfabb9ad74e8c5a828f0cc786ad04ac81046";
+      sha256 = "60aa12adff74ff46ef37141293acc39b4592d61512c9db0a3745a8a41858ce67";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/hy-AM/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/hy-AM/firefox-96.0b3.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "1acd294876af4206160785bc8c9f55faced43a0415ce039b04faa413736fa325";
+      sha256 = "2187efe8640a541ab3b9c11583d09c977cf3af44c280887b03c5f4ed05239439";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/ia/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/ia/firefox-96.0b3.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "097e1b19c26437a24b4ee6d5cb0265617eeddd4b9a8171385d16e8303513759e";
+      sha256 = "1d3a3f28c0a99d56dccd1fc354a56cc1374f4f87a76760b410b616d0128f83fd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/id/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/id/firefox-96.0b3.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "a0759b8827d7e891f32bfd15f3c6db173a6ae1a11f19bc6640643598bd165e20";
+      sha256 = "b2e0853123208160486936e98ba978a7d509d8d4e0500c89bbe522ea69a4ff67";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/is/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/is/firefox-96.0b3.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "48abe4f0ea000ea344c83e4e8791cfe00cc21a958dc27dafbca1ccfafd761671";
+      sha256 = "43e9ca38b6ef601d7834b2b951b4a14394a6442d0da1d5045b83a5ccbf7bad40";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/it/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/it/firefox-96.0b3.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "fb582c7179b5d912188d07fa8e7b5e2adf97122465d31645ec4ff31e6579a441";
+      sha256 = "ef20972394355ce52307056b94af6dea64a3f6b1cf1887b3796505baf4645fde";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/ja/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/ja/firefox-96.0b3.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "83092e4f2a61c9655b67247f3d34669abefa2803adda427658a3b4d5b5f3f1ae";
+      sha256 = "ec106d9e5ebf26c698106c0b751a54b1af77959a39ef47ef124433a3b610f146";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/ka/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/ka/firefox-96.0b3.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "c4d8648f7eaec2268fc94f1a08e3a59f04ae891e0b43dd73ca9a873ef9e87920";
+      sha256 = "19b20479c0df3f63a0d516bfa4521f0c7cb81e7fb9873ad801a6f662bc7558ab";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/kab/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/kab/firefox-96.0b3.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "213115ee45ec7639ff8b9e9d8a7f3638e1434339a564c2514d6a804afa18c32f";
+      sha256 = "200b9ec8da001ef900fa77ba7954ad67f68504e29ddc78a389847f076d9812db";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/kk/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/kk/firefox-96.0b3.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "c2a77e482e8c60abeeb12e06e0c0c4277d8d26ad1414a86d3c6e3df2a58bcd35";
+      sha256 = "8400fb463705221d80015a7b69388478f851231618bd3be0d9fffcc6b35783ec";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/km/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/km/firefox-96.0b3.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "1da5133c8c0eb9ef97092b7c3e2a38dbdbd8026173fcc80e74da20a0c2208ec3";
+      sha256 = "4fee1c00876e71f6d8fe8194ac48dc56bb8ca6da2e5ad41488e1a99e3c65a32c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/kn/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/kn/firefox-96.0b3.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "ed1d785de41ff78d2a3891349c44ff61aa0d8ddc2efb491ca0c2bf2c94b5d8b2";
+      sha256 = "c7aaaffd7539351180240837e1930b8303b1eb9d199a1937940f80041aca1632";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/ko/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/ko/firefox-96.0b3.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "5559ede0cbcba00f9d4dda5a3a5809d83d1484518a7f92c296ac6cb7b6a2e5c8";
+      sha256 = "f54d11032e4b929e0d283223744aec809c46d66a875dfa9e07fc2a9237c5edbc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/lij/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/lij/firefox-96.0b3.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "47658288c6b55b4d64628cd119236f0a3bd6b6673bd1127efa7247e9a86f6ef4";
+      sha256 = "c7e1da38ea4886454f252c656bc1fd9809cbbdbf06b159cc40674e9e03ce0275";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/lt/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/lt/firefox-96.0b3.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "964cc674d2afd867203965210dd77594ac1303d5b1d1b2de3cf7590f44bf9d3c";
+      sha256 = "5177db2a4e0ca4bbdbd9d7e3fe5aa5785f995df15df4ac4213bc22c2f9380a59";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/lv/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/lv/firefox-96.0b3.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "f22df962e2b2c857f6068ea2611260d7a8dff86fc20877e4ce5b2457e7c1f1e6";
+      sha256 = "0e5d27dbb6e1ed3bf87a60bf62bc90beeb1c503fcc545b4a22767fda0e8e695c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/mk/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/mk/firefox-96.0b3.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "9bccdf824261c2241e2c925bad37298eb6311949e568de4c525ce72723e9472a";
+      sha256 = "54250e1742ebd3cd0db36ac68f5790fcb803a4b63d77293905727922379c84f5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/mr/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/mr/firefox-96.0b3.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "91ceb3394fe9d33a81955ccba054163c1012c5219b00a532d3c7e007c0d5aba4";
+      sha256 = "887c2cf008099abfd6cae59203f660e71618ad63d8492f0f1de072debab84450";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/ms/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/ms/firefox-96.0b3.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "17c4dfc95a0413c3d2b599335efdca8685553da02c66347ecf2b6d64ebcc9a36";
+      sha256 = "c34caded0c323906ff15538694b37e3c91a00c731d7f4017434027882f160086";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/my/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/my/firefox-96.0b3.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "b920b16f5d6d480e2ba82cbe266844e4b4d760ed768edd955d8cfe69c194eea5";
+      sha256 = "f66ebec1bc3783cef6c57436a3f9764b52942f2466195fea8e5435275a276411";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/nb-NO/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/nb-NO/firefox-96.0b3.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "97c26af5588cb00b063d145ac9cade31d46c86fef2320f6b7cdc6cb5dcf7dcbf";
+      sha256 = "6ac73b95d650bd7f8454345a041d7f9a294aed2cf249d09ab726eff5c6df0036";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/ne-NP/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/ne-NP/firefox-96.0b3.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "7256e3dcce679ba4422f167def4733e63aad07f49fb2f7d98478f9c04d1eda4e";
+      sha256 = "9f436cf3504f2629cbec87051539e00782c9942aeef4a03fc4fd44000dfd1b93";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/nl/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/nl/firefox-96.0b3.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "073255f663230e17878431ce22bcf6cb79c3782599c8f49027c776dd824c27bb";
+      sha256 = "8759bcafc09fd00beda7f9795b49675d2dcc153d96020198c9c4117c30fe9c0c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/nn-NO/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/nn-NO/firefox-96.0b3.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "01b4f98e2114533f6a80fa458c13f993a470029b797a5e0fcac63ba58063f8cd";
+      sha256 = "2c5fc7af589d06e2bda4de52b6a079b4c8ac9287b71b8d86a6462dd63f64f62c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/oc/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/oc/firefox-96.0b3.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "041259974f4aed0698c30d66aab34b5e7feb6d1d4b5c466038d6773b8d4f6151";
+      sha256 = "0f96f8938af715461ab1267713d57beeafbca389aa291931c1712cfee375dcac";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/pa-IN/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/pa-IN/firefox-96.0b3.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "a275bd1efe636e16573737c18feb830055556783703b1c712149cef2da416129";
+      sha256 = "1a8f36abd3b638cb4aa82e66e4dcbb13a56c0fe967ae3187686217ffac0c37f0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/pl/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/pl/firefox-96.0b3.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "e713eac0580014540d4c522337909fe61da547ab764d47e8b8ec2e22fc2b3d19";
+      sha256 = "01b349d1656b2cc480e22d1a1a4eb376ae3b0be65a4b64d1cfb95e29b8e3a7c0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/pt-BR/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/pt-BR/firefox-96.0b3.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "d1071491df87c5fb15e91764353f6aad183fe7c5f038114ced8f1f77f1f1ebca";
+      sha256 = "4db2f4df874ebd5914ac143c9963e108d45c9822474b43d32b7a417d9a0c14ec";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/pt-PT/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/pt-PT/firefox-96.0b3.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "d86e8c91eae6ef5821b378a7924d46f522f50d972f35642683f1407cbdbd608e";
+      sha256 = "fb4f87a2f1c735fc19da371872990a4dcc76ceee2a0f6776e55b06780795589f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/rm/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/rm/firefox-96.0b3.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "ef71fa9d42c0869d566f47d80992987026926afeb6d37b5e79e7fc1d349ccc18";
+      sha256 = "a9292aa129c8dc538014481865f046b8dbd069138a4ef73743137ad609656174";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/ro/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/ro/firefox-96.0b3.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "a5c5b6343be01f7ab99ce21ef2138128d77fca2e3ea86836c6ea95bf461a972a";
+      sha256 = "4da6f323d2cddfd0a6f85f61c75cae777668cfe4a88a9fae3ed6297702604e35";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/ru/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/ru/firefox-96.0b3.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "62d94da86719653a2143291b9dd201cd1c7ab54379aa64a688dc9264c100ba3b";
+      sha256 = "44eddd02a18b8e419d44bae127a4f37eda740f63fb7524891f3a435a6430f64b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/sco/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/sco/firefox-96.0b3.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "99e15a1dc3f5480ace4e78620162363e32f40e307bd73cd9a186a91344cc06c3";
+      sha256 = "aabcfc84e1a06d901e29b571628905871248a3148fdfa9ebe1b26995db92fb81";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/si/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/si/firefox-96.0b3.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "d8c30f6dc9d44ef986f99fbe0fd4ddbd98685455298e04b91e3001c7bd0eefff";
+      sha256 = "8a8b0fe064719cfb088ac61e412c7b1f2d6d66ea523d7f6742efbb54cf53f0d2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/sk/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/sk/firefox-96.0b3.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "b07cd41d70df6d338ff35f1ed1d398ab43243803a010d50f5ad206ff408374c4";
+      sha256 = "0bba256df30a3deeeaf5edb946fa535b762cdb42232f8e15f3d1ce49743c121f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/sl/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/sl/firefox-96.0b3.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "18653e5212d6b99cb3539d419763af33377b422c0aa239b61f132a0a7d8e3875";
+      sha256 = "5ed15767967d579d6809fdc0fae86f0f42b9f8ec2e024bd40aa151147528ccec";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/son/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/son/firefox-96.0b3.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "e44583fbd4dad99459cb3bc4cb6c9820d6346bc087a892c41eece5a63fc7a717";
+      sha256 = "5e6f78700f74229fb3dfea3b408a5ac78f18892c6ec407bd85017467a5687ba6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/sq/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/sq/firefox-96.0b3.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "118eea3d5ca74a46e9aaedeb05c40e895cbeae902ec6b4e31cd61a6167726610";
+      sha256 = "5eb1de045ee119d67e0251be6223f7efb3fd26d8cebc5f372f4513d0928c8a51";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/sr/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/sr/firefox-96.0b3.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "6154157e166aa7f9466119a34bc62d829c9743f84410443c5c7dd9a9fa57fbb5";
+      sha256 = "78b467f1ceda9ef4d181d5549855241ed37381dc08d4e282bdfdf0db3b0625a3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/sv-SE/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/sv-SE/firefox-96.0b3.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "8b3868825c2aada061ce4d99b41971a5d626e9df5cf34ddf6cf9493f700f5f3b";
+      sha256 = "a708c94b51ee31a40532970d59b2d570c87aedeed24454aace5f6870eaccfa5f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/szl/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/szl/firefox-96.0b3.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "2610600c408da7cc743144ea628057bdc826035472804e3f9d59134ac235c14a";
+      sha256 = "0095fd3dc0eb4eb46c55ae3b2ccc65bea69127aed00d6fac446fb9c9274f4302";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/ta/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/ta/firefox-96.0b3.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "856e537f4bc72e2e0ec8b329db45a69ede9d91b86b70c9413f5bdd6e0e3cd997";
+      sha256 = "c8f052d0275c803da20f62172976b44357861ccd8599d9d70eba9a2c96594824";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/te/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/te/firefox-96.0b3.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "383b6ac9a74295865064d2da74ef2df72f69f0197d935dee942cba9502e183c5";
+      sha256 = "efad15e6aeb3ad1287cc3d0e3d0daa389faa7f348a002cb5c7f52f812eda8c33";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/th/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/th/firefox-96.0b3.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "9939510e49b9f9a0831a87b364a13c34afe9ac77e51c5e99ca46db39d0d398ff";
+      sha256 = "dfff091b8e2f6b19842335da51f4cc7107401268b91c1bee55bb473ab5f245bc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/tl/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/tl/firefox-96.0b3.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "5fffc0f168072b0da9ff7f74742bb6ae0fb7d5f02ec3258eeafcb5971b215366";
+      sha256 = "35f3b8459096105e29d87645ebfba3a93fb23412ac7fcc30357f2ebbce658f2a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/tr/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/tr/firefox-96.0b3.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "61fec1fcc042f9d50d3fa4e4c178493a45ecf42b91df9fe19131e555995c1747";
+      sha256 = "3727440d1c3fac9b5761e3f79e46658dfeb5bee2f3ed17ec78697d869be7a7c0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/trs/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/trs/firefox-96.0b3.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "7058996e6f42de987bfbfd7d8f43ae51693ef985f71cc265d850552b8f61bc52";
+      sha256 = "91808cdc62ff8f8670d3c22acb6c203832471ade8e24fd606a2c00312fc39d7d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/uk/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/uk/firefox-96.0b3.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "f9e4a138049e31321198bf0d01a4a090ce3b0d6542341d6c7260a276a33a9871";
+      sha256 = "947f2cb2572e17d04263e5ebebd897a6900d22dbc85196826e316706a8622aa6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/ur/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/ur/firefox-96.0b3.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "222fb81fc237b70ea79d0defc66dea43fd004c0558db284f7cf450cbbb43afcc";
+      sha256 = "d5baa22518ee5f189f780d159aef432591c7d4855cce7f1dc4c67d48c69d5780";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/uz/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/uz/firefox-96.0b3.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "1cb5f7ee568b85b8151e5119ab163c91f0ba6633551d0683f6cd476b3bc37486";
+      sha256 = "25b19eac0ad6491c7285633ad61dab8f8d2833ba011b7aaa8dd1a2d0eca2b6da";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/vi/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/vi/firefox-96.0b3.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "2e851524f4ea2ec410f9da393e034af1b021fedbe9e8b8103299662329867ca0";
+      sha256 = "ad284426be9590e9a118c5f151c478d15e6d964beb46312fe7172347783e9162";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/xh/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/xh/firefox-96.0b3.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "4f9ee5271308191bbd89b0410a6141ed21eeb590de3a5586e1736419f456caa3";
+      sha256 = "ee90ff4921848363791e0486fc8810d892bf07c448c576bc4c0ea09a6bea8e55";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/zh-CN/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/zh-CN/firefox-96.0b3.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "dedf2b2df257161288dd6fc4385ba56fdb285e532bd16f53294162e4c83b0a98";
+      sha256 = "9cc4ec8d6ac780a0fa8ad01b5b16438a0bcb290da79691e7dbf993033bd919f0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/95.0b3/linux-i686/zh-TW/firefox-95.0b3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/96.0b3/linux-i686/zh-TW/firefox-96.0b3.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "342f39908d268a871133b6e51c4e5d92026f92e7b9fd8602b31a6c75c1566ad4";
+      sha256 = "6018bca3d3963b3b6dbed521ae068d15f659b6779240e8ed1f9c3c66ec75b932";
     }
     ];
 }


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
