### PR TITLE
kube-linter: init at 0.2.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8137,6 +8137,12 @@
     githubId = 4996739;
     name = "Masayuki Takeda";
   };
+  mtesseract = {
+    email = "moritz@stackrox.com";
+    github = "mtesseract";
+    githubId = 11706080;
+    name = "Moritz Clasmeier";
+  };
   MtP = {
     email = "marko.nixos@poikonen.de";
     github = "MtP76";

--- a/pkgs/development/tools/kube-linter/default.nix
+++ b/pkgs/development/tools/kube-linter/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildGoModule, fetchFromGitHub, testVersion, kube-linter }:
+
+buildGoModule rec {
+  pname = "kube-linter";
+  version = "0.2.5";
+
+  src = fetchFromGitHub {
+    owner = "stackrox";
+    repo = pname;
+    rev = "${version}";
+    sha256 = "GUDrUEBorV4/ZqPnfNYcsbW4Zr1LpS3yL+4OgxFbTOk=";
+  };
+
+  vendorSha256 = "xGghTP9thICOGIfc5VPJK06DeXfLiTckwa4nXv83/P8=";
+
+  ldflags = [
+    "-s" "-w" "-X golang.stackrox.io/kube-linter/internal/version.version=${version}"
+  ];
+
+  passthru.tests.version = testVersion {
+    package = kube-linter;
+    command = "kube-linter version";
+  };
+
+  meta = with lib; {
+    description = "A static analysis tool that checks Kubernetes YAML files and Helm charts";
+    homepage = "https://kubelinter.io";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mtesseract ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14820,6 +14820,8 @@ with pkgs;
 
   kubectx = callPackage ../development/tools/kubectx { };
 
+  kube-linter = callPackage ../development/tools/kube-linter { };
+
   kube-prompt = callPackage ../development/tools/kube-prompt { };
 
   kubei = callPackage ../tools/security/kubei { };


### PR DESCRIPTION
###### Motivation for this change

This PR adds the [kube-linter](https://kubelinter.io) tool to the nixpkgs database.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
