### PR TITLE
nixos: force the user to set system.stateVersion

### DIFF
--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -52,7 +52,7 @@ in
 
     stateVersion = mkOption {
       type = types.str;
-      default = cfg.release;
+      default = throw "system.stateVersion needs to be set. Use the value of the current release.";
       description = ''
         Every once in a while, a new NixOS release may change
         configuration defaults in a way incompatible with stateful

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -26,14 +26,16 @@ let
       };
     };
   allTests =
-    foldAttrs recursiveUpdate {} (map allTestsForSystem supportedSystems);
+    foldAttrs recursiveUpdate { } (map allTestsForSystem supportedSystems);
 
   pkgs = import ./.. { system = "x86_64-linux"; };
 
 
   versionModule =
-    { system.nixos.versionSuffix = versionSuffix;
+    {
+      system.nixos.versionSuffix = versionSuffix;
       system.nixos.revision = nixpkgs.rev or nixpkgs.shortRev;
+      system.stateVersion = mkForce "21.04";
     };
 
   makeModules = module: rest: [ configuration versionModule module rest ];
@@ -92,9 +94,10 @@ let
   buildFromConfig = module: sel: forAllSystems (system: hydraJob (sel (import ./lib/eval-config.nix {
     inherit system;
     modules = makeModules module
-      ({ ... }:
+      ({ config, ... }:
       { fileSystems."/".device  = mkDefault "/dev/sda1";
         boot.loader.grub.device = mkDefault "/dev/sda";
+        system.stateVersion = mkDefault config.system.version;
       });
   }).config));
 


### PR DESCRIPTION
The argument for introducing `system.stateVersion` was that some data
that lives on disk, like the postgres database, would change shape
depending on which release of NixOS the user was using.

If the default is always the current version, it can lead to unwanted
breakages. It's better to fail the evaluation and force the user to set
something.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
