### PR TITLE
[21.11] ocamlPackages.jsonrpc: 1.8.3 → 1.9

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
@@ -1,4 +1,4 @@
-{ buildDunePackage, jsonrpc, lsp, re, makeWrapper, dot-merlin-reader }:
+{ lib, buildDunePackage, jsonrpc, lsp, re, makeWrapper, dot-merlin-reader, spawn }:
 
 buildDunePackage {
   pname = "ocaml-lsp-server";
@@ -7,7 +7,8 @@ buildDunePackage {
 
   inherit (lsp) preBuild;
 
-  buildInputs = lsp.buildInputs ++ [ lsp re ];
+  buildInputs = lsp.buildInputs ++ [ lsp re ]
+  ++ lib.optional (lib.versionAtLeast jsonrpc.version "1.9") spawn;
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
@@ -10,7 +10,11 @@
 }:
 
 let params =
-  if lib.versionAtLeast ocaml.version "4.12"
+  if lib.versionAtLeast ocaml.version "4.13"
+  then {
+    version = "1.9.1";
+    sha256 = "sha256:1vnwdpjppihprc8q2i5zcqq7vp67255jclg90ldfvwafgljxn76g";
+  } else if lib.versionAtLeast ocaml.version "4.12"
   then {
     version = "1.8.3";
     sha256 = "sha256-WO9ap78XZxJCi04LEBX+r21nfL2UdPiCLRMrJSI7FOk=";
@@ -29,7 +33,7 @@ buildDunePackage rec {
   };
 
   useDune2 = true;
-  minimumOCamlVersion = "4.06";
+  minimalOCamlVersion = "4.06";
 
   buildInputs =
     if lib.versionAtLeast version "1.7.0" then


### PR DESCRIPTION
(cherry picked from commit 8f7e8ee23d9e24806faf07078b2702dc19cb9b53)
edited to not upgrade ocaml-lsp to 1.9 on ocaml < 4.12

###### Motivation for this change


partial backport of #149397

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
