### PR TITLE
python3Packages.weconnect: init at 0.26.0, python3Packages.weconnect-mqtt: init at 0.20.0

### DIFF
--- a/pkgs/development/python-modules/ascii-magic/default.nix
+++ b/pkgs/development/python-modules/ascii-magic/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, colorama
+, fetchPypi
+, pillow
+}:
+
+buildPythonPackage rec {
+  pname = "ascii-magic";
+  version = "1.6";
+
+  src = fetchPypi {
+    pname = "ascii_magic";
+    inherit version;
+    sha256 = "sha256-faVRj3No5z8R4hUaDAYIBKoUniZ7Npt+52U/vXsEalE=";
+  };
+
+  propagatedBuildInputs = [
+    colorama
+    pillow
+  ];
+
+  # Project is not tagging releases and tests are not shipped with PyPI source
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "ascii_magic"
+  ];
+
+  meta = with lib; {
+    description = "Python module to converts pictures into ASCII art";
+    homepage = "https://github.com/LeandroBarone/python-ascii_magic";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/weconnect-mqtt/default.nix
+++ b/pkgs/development/python-modules/weconnect-mqtt/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
+, paho-mqtt
+, weconnect
+}:
+
+buildPythonPackage rec {
+  pname = "weconnect-mqtt";
+  version = "0.20.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "tillsteinbach";
+    repo = "WeConnect-mqtt";
+    rev = "v${version}";
+    sha256 = "sha256-RUOOHVX9IY24ZpDE7nQr//JxtQZgowcT5PrTgzaTK6Q=";
+  };
+
+  propagatedBuildInputs = [
+    paho-mqtt
+    weconnect
+  ];
+
+  postPatch = ''
+    substituteInPlace weconnect_mqtt/__version.py \
+      --replace "develop" "${version}"
+    substituteInPlace pytest.ini \
+      --replace "--cov=weconnect_mqtt --cov-config=.coveragerc --cov-report html" "" \
+      --replace "pytest-cov" ""
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "weconnect_mqtt"
+  ];
+
+  meta = with lib; {
+    description = "Python client that publishes data from Volkswagen WeConnect";
+    homepage = "https://github.com/tillsteinbach/WeConnect-mqtt";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/weconnect/default.nix
+++ b/pkgs/development/python-modules/weconnect/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, ascii-magic
+, buildPythonPackage
+, fetchFromGitHub
+, pillow
+, pytest-httpserver
+, pytestCheckHook
+, pythonOlder
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "weconnect";
+  version = "0.26.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "tillsteinbach";
+    repo = "WeConnect-python";
+    rev = "v${version}";
+    sha256 = "sha256-30guJudGOY8WAYupX89hx6mFwfAPASnKMSa+0kDbtfQ=";
+  };
+
+  propagatedBuildInputs = [
+    ascii-magic
+    pillow
+    requests
+  ];
+
+  checkInputs = [
+    pytest-httpserver
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace weconnect/__version.py \
+      --replace "develop" "${version}"
+    substituteInPlace setup.py \
+      --replace "setup_requires=SETUP_REQUIRED," "setup_requires=[]," \
+      --replace "tests_require=TEST_REQUIRED," "tests_require=[],"
+    substituteInPlace pytest.ini \
+      --replace "--cov=weconnect --cov-config=.coveragerc --cov-report html" "" \
+      --replace "pytest-cov" ""
+  '';
+
+  pythonImportsCheck = [
+    "weconnect"
+  ];
+
+  meta = with lib; {
+    description = "Python client for the Volkswagen WeConnect Services";
+    homepage = "https://github.com/tillsteinbach/WeConnect-python";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10074,6 +10074,8 @@ in {
 
   weconnect = callPackage ../development/python-modules/weconnect { };
 
+  weconnect-mqtt = callPackage ../development/python-modules/weconnect-mqtt { };
+
   werkzeug = callPackage ../development/python-modules/werkzeug { };
 
   werkzeug1 = callPackage ../development/python-modules/werkzeug/1.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -603,6 +603,8 @@ in {
 
   asana = callPackage ../development/python-modules/asana { };
 
+  ascii-magic = callPackage ../development/python-modules/ascii-magic { };
+
   asciimatics = callPackage ../development/python-modules/asciimatics { };
 
   asciitree = callPackage ../development/python-modules/asciitree { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10072,6 +10072,8 @@ in {
 
   webthing = callPackage ../development/python-modules/webthing { };
 
+  weconnect = callPackage ../development/python-modules/weconnect { };
+
   werkzeug = callPackage ../development/python-modules/werkzeug { };
 
   werkzeug1 = callPackage ../development/python-modules/werkzeug/1.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python client for the Volkswagen WeConnect Services

https://github.com/tillsteinbach/WeConnect-python

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
