### PR TITLE
ben-nanonote: drop

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -85,10 +85,6 @@ rec {
     config = "armv5tel-unknown-linux-gnueabi";
   } // platforms.pogoplug4;
 
-  ben-nanonote = {
-    config = "mipsel-unknown-linux-uclibc";
-  } // platforms.ben_nanonote;
-
   fuloongminipc = {
     config = "mipsel-unknown-linux-gnu";
   } // platforms.fuloong2f_n32;

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -394,16 +394,6 @@ rec {
   ## MIPS
   ##
 
-  ben_nanonote = {
-    linux-kernel = {
-      name = "ben_nanonote";
-    };
-    gcc = {
-      arch = "mips32";
-      float = "soft";
-    };
-  };
-
   fuloong2f_n32 = {
     linux-kernel = {
       name = "fuloong2f_n32";

--- a/pkgs/development/misc/newlib/default.nix
+++ b/pkgs/development/misc/newlib/default.nix
@@ -49,4 +49,9 @@ stdenv.mkDerivation rec {
     incdir = "/${stdenv.targetPlatform.config}/include";
     libdir = "/${stdenv.targetPlatform.config}/lib";
   };
+
+  meta = {
+    description = "C library intended for use on embedded systems";
+    homepage = "https://sourceware.org/newlib/";
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10982,7 +10982,7 @@ with pkgs;
   xbursttools = callPackage ../tools/misc/xburst-tools {
     # It needs a cross compiler for mipsel to build the firmware it will
     # load into the Ben Nanonote
-    gccCross = pkgsCross.ben-nanonote.buildPackages.gccCrossStageStatic;
+    gccCross = pkgsCross.fuloongminipc.buildPackages.gccCrossStageStatic;
     autoconf = buildPackages.autoconf269;
   };
 

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -136,7 +136,6 @@ in
 
   /* Linux on mipsel */
   fuloongminipc = mapTestOnCross lib.systems.examples.fuloongminipc linuxCommon;
-  ben-nanonote = mapTestOnCross lib.systems.examples.ben-nanonote linuxCommon;
 
   /* Javacript */
   ghcjs = mapTestOnCross lib.systems.examples.ghcjs {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This does not evaluate for at least 2 years. The hardware is 12 years
old. MIPS is a dead horse. Let's focus on the important things.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
