### PR TITLE
libsidplayfp: fix tests on x86_64-darwin

### DIFF
--- a/pkgs/development/libraries/libsidplayfp/default.nix
+++ b/pkgs/development/libraries/libsidplayfp/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , autoreconfHook
 , pkg-config
@@ -25,6 +26,15 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
     sha256 = "sha256-Cu5mZzsqAO4X4Y8QAn851zIFPVPwxj5pB+jvA62L108=";
   };
+
+  patches = [
+    # Fixes test failure on x86_64-darwin
+    # Drop when fix for https://github.com/libsidplayfp/libsidplayfp/issues/39 in a release (>2.3.1)
+    (fetchpatch {
+      url = "https://github.com/libsidplayfp/libsidplayfp/commit/337020a91caa0113de4f4374e0dc770e4056d2c7.patch";
+      sha256 = "0sd7bqic8k945f05d8sk9mshf5d90ykd7f5p6m0n6v3jjhpwmqlq";
+    })
+  ];
 
   postPatch = ''
     patchShebangs .


### PR DESCRIPTION
###### Motivation for this change
As noted in https://github.com/NixOS/nixpkgs/pull/149644#pullrequestreview-827074081, one of the tests fails on x86_64-darwin but not on aarch64-darwin or any other platform. Reported & fixed upstream, pulling in the commit as a patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
