### PR TITLE
vdrift: ShellCheck output file

### DIFF
--- a/pkgs/games/vdrift/default.nix
+++ b/pkgs/games/vdrift/default.nix
@@ -13,6 +13,7 @@
 , curl
 , gettext
 , writeTextFile
+, shellcheck
 
 , data ? fetchsvn {
     url = "svn://svn.code.sf.net/p/vdrift/code/vdrift-data";
@@ -57,6 +58,7 @@ let
 in writeTextFile {
   name = wrappedName;
   text = ''
+    # shellcheck shell=bash
     export VDRIFT_DATA_DIRECTORY="${data}"
     exec ${bin}/bin/vdrift "$@"
   '';
@@ -64,6 +66,7 @@ in writeTextFile {
   executable = true;
   checkPhase = ''
     ${stdenv.shell} -n $out/bin/vdrift
+    ${shellcheck}/bin/shellcheck "$out/bin/vdrift"
   '';
 } // {
   meta = bin.meta // {


### PR DESCRIPTION
###### Motivation for this change

#133088. This change could also be effected by using pulling the change into `writeShellApplication` and using that instead of `writeText`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@Artturin 