### PR TITLE
monero-{cli,gui}: 0.17.2.3 -> 0.17.3.0

### DIFF
--- a/pkgs/applications/blockchains/monero-cli/default.nix
+++ b/pkgs/applications/blockchains/monero-cli/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "monero-cli";
-  version = "0.17.2.3";
+  version = "0.17.3.0";
 
   src = fetchFromGitHub {
     owner = "monero-project";
     repo = "monero";
     rev = "v${version}";
-    sha256 = "0nax991fshfh51grhh2ryfrwwws35k16gzl1l3niva28zff2xmq6";
+    sha256 = "1spsf7m3x4psp9s7mivr6x4886jnbq4i8ll2dl8bv5bsdhcd3pjm";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/blockchains/monero-cli/use-system-libraries.patch
+++ b/pkgs/applications/blockchains/monero-cli/use-system-libraries.patch
@@ -1,14 +1,17 @@
 diff --git a/external/CMakeLists.txt b/external/CMakeLists.txt
-index a8916a7d0..39ec7747b 100644
+index 5b7f69a56..5536debe8 100644
 --- a/external/CMakeLists.txt
 +++ b/external/CMakeLists.txt
-@@ -37,34 +37,16 @@
+@@ -36,22 +36,9 @@
+ # others.
  
  find_package(Miniupnpc REQUIRED)
- 
+-
 -message(STATUS "Using in-tree miniupnpc")
+-set(UPNPC_NO_INSTALL TRUE CACHE BOOL "Disable miniupnp installation" FORCE)
 -add_subdirectory(miniupnp/miniupnpc)
 -set_property(TARGET libminiupnpc-static PROPERTY FOLDER "external")
+-set_property(TARGET libminiupnpc-static PROPERTY POSITION_INDEPENDENT_CODE ON)
 -if(MSVC)
 -  set_property(TARGET libminiupnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -wd4244 -wd4267")
 -elseif(NOT MSVC)
@@ -25,36 +28,16 @@ index a8916a7d0..39ec7747b 100644
  
  find_package(Unbound)
  
- if(NOT UNBOUND_INCLUDE_DIR OR STATIC)
--  # NOTE: If STATIC is true, CMAKE_FIND_LIBRARY_SUFFIXES has been reordered.
--  # unbound has config tests which used OpenSSL libraries, so -ldl may need to
--  # be set in this case.
--  # The unbound CMakeLists.txt can set it, since it's also needed for the
--  # static OpenSSL libraries set up there after with target_link_libraries.
--  add_subdirectory(unbound)
--
--  set(UNBOUND_STATIC true PARENT_SCOPE)
--  set(UNBOUND_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/unbound/libunbound" PARENT_SCOPE)
--  set(UNBOUND_LIBRARY "unbound" PARENT_SCOPE)
--  set(UNBOUND_LIBRARY_DIRS "${LIBEVENT2_LIBDIR}" PARENT_SCOPE)
-+  set(UNBOUND_STATIC false PARENT_SCOPE)
-+  set(UPNP_INCLUDE ${MINIUPNP_INCLUDE_DIR} PARENT_SCOPE)
-+  set(UPNP_LIBRARIES ${MINIUPNP_LIBRARY} PARENT_SCOPE)
- else()
-   message(STATUS "Found libunbound include (unbound.h) in ${UNBOUND_INCLUDE_DIR}")
-   if(UNBOUND_LIBRARIES)
-@@ -81,4 +63,5 @@ endif()
+@@ -69,4 +56,3 @@ endif()
  add_subdirectory(db_drivers)
  add_subdirectory(easylogging++)
  add_subdirectory(qrcodegen)
 -add_subdirectory(randomx EXCLUDE_FROM_ALL)
-+
-+find_library(RANDOMX_LIBRARIES NAMES RandomX)
 diff --git a/src/p2p/net_node.inl b/src/p2p/net_node.inl
-index 175741146..088b582f7 100644
+index d4b39869c..13071d898 100644
 --- a/src/p2p/net_node.inl
 +++ b/src/p2p/net_node.inl
-@@ -60,9 +60,9 @@
+@@ -61,9 +61,9 @@
  #include "cryptonote_core/cryptonote_core.h"
  #include "net/parse.h"
  

--- a/pkgs/applications/blockchains/monero-gui/default.nix
+++ b/pkgs/applications/blockchains/monero-gui/default.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "monero-gui";
-  version = "0.17.2.3";
+  version = "0.17.3.0";
 
   src = fetchFromGitHub {
     owner  = "monero-project";
     repo   = "monero-gui";
     rev    = "v${version}";
-    sha256 = "1d8y5yqyw0db2jdv9mwkczwm2qcwhzyslvq994yq5rvs4vkd8xjg";
+    sha256 = "0rc1p0k16icgfhc7yvkvb8p6570zz0cvigs648l05fcm3mf787rp";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Version bump

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested connecting to a remote node with monero-gui.
- [x] Tested compilation of all packages that depend on this change
- [x] Tested basic functionality of all binary files
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
