### PR TITLE
sgx-sdk, sgx-psw: 2.14 -> 2.15.1

### DIFF
--- a/pkgs/os-specific/linux/sgx/psw/default.nix
+++ b/pkgs/os-specific/linux/sgx/psw/default.nix
@@ -25,14 +25,14 @@ stdenv.mkDerivation rec {
     let
       ae.prebuilt = fetchurl {
         url = "https://download.01.org/intel-sgx/sgx-linux/${versionTag}/prebuilt_ae_${versionTag}.tar.gz";
-        hash = "sha256-nGKZEpT2Mx0DLgqjv9qbZqBt1pQaSHcnA0K6nHma3sk";
+        hash = "sha256-JriA9UGYFkAPuCtRizk8RMM1YOYGR/eO9ILnx47A40s=";
       };
       dcap = rec {
-        version = "1.11";
+        version = "1.12.1";
         filename = "prebuilt_dcap_${version}.tar.gz";
         prebuilt = fetchurl {
           url = "https://download.01.org/intel-sgx/sgx-dcap/${version}/linux/${filename}";
-          hash = "sha256-ShGScS4yNLki04RNPxxLvqzGmy4U1L0gVETvfAo8w9M=";
+          hash = "sha256-V/XHva9Sq3P36xSW+Sd0G6Dnk4H0ANO1Ns/u+FI1eGI=";
         };
       };
     in

--- a/pkgs/os-specific/linux/sgx/sdk/ipp-crypto.nix
+++ b/pkgs/os-specific/linux/sgx/sdk/ipp-crypto.nix
@@ -2,23 +2,35 @@
 , stdenv
 , fetchFromGitHub
 , cmake
-, python3
 , nasm
+, openssl
+, python3
 , extraCmakeFlags ? [ ]
 }:
 
 stdenv.mkDerivation rec {
   pname = "ipp-crypto";
-  version = "2020_update3";
+  version = "2021.3";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "ipp-crypto";
-    rev = "ipp-crypto_${version}";
-    sha256 = "02vlda6mlhbd12ljzdf65klpx4kmx1ylch9w3yllsiya4hwqzy4b";
+    rev = "ippcp_${version}";
+    hash = "sha256-QEJXvQ//zhQqibFxXwPMdS1MHewgyb24LRmkycVSGrM=";
   };
+
+  # Fix typo: https://github.com/intel/ipp-crypto/pull/33
+  postPatch = ''
+    substituteInPlace sources/cmake/ippcp-gen-config.cmake \
+      --replace 'ippcpo-config.cmake' 'ippcp-config.cmake'
+  '';
 
   cmakeFlags = [ "-DARCH=intel64" ] ++ extraCmakeFlags;
 
-  nativeBuildInputs = [ cmake python3 nasm ];
+  nativeBuildInputs = [
+    cmake
+    nasm
+    openssl
+    python3
+  ];
 }

--- a/pkgs/os-specific/linux/sgx/sdk/samples.nix
+++ b/pkgs/os-specific/linux/sgx/sdk/samples.nix
@@ -12,7 +12,11 @@ let
     buildInputs = [
       sgx-sdk
     ];
-    enableParallelBuilding = true;
+
+    # The samples don't have proper support for parallel building
+    # causing them to fail randomly.
+    enableParallelBuilding = false;
+
     buildFlags = [
       "SGX_MODE=SIM"
     ];
@@ -44,6 +48,7 @@ in
     # Requires interaction
     doInstallCheck = false;
   });
+  protobufSGXDemo = buildSample "ProtobufSGXDemo";
   remoteAttestation = (buildSample "RemoteAttestation").overrideAttrs (oldAttrs: {
     dontFixup = true;
     installCheckPhase = ''
@@ -52,6 +57,7 @@ in
   });
   sampleEnclave = buildSample "SampleEnclave";
   sampleEnclavePCL = buildSample "SampleEnclavePCL";
+  sampleEnclaveGMIPP = buildSample "SampleEnclaveGMIPP";
   sealUnseal = buildSample "SealUnseal";
   switchless = buildSample "Switchless";
 }


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Also add some of the new samples as tests. Disable parallel builds for
the samples as they don't seem to support it (fail randomly).

~**Still a draft. Waiting for #148593.**~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
