### PR TITLE
uclibc-ng: fix cross-compile to mips (for ben-nanonote)

### DIFF
--- a/pkgs/os-specific/linux/uclibc/default.nix
+++ b/pkgs/os-specific/linux/uclibc/default.nix
@@ -39,6 +39,8 @@ let
     UCLIBC_SUSV4_LEGACY y
     UCLIBC_HAS_THREADS_NATIVE y
     KERNEL_HEADERS "${linuxHeaders}/include"
+  '' + lib.optionalString (stdenv.hostPlatform.gcc.float or "" == "soft") ''
+    UCLIBC_HAS_FPU n
   '' + lib.optionalString (stdenv.isAarch32 && stdenv.buildPlatform != stdenv.hostPlatform) ''
     CONFIG_ARM_EABI y
     ARCH_WANTS_BIG_ENDIAN n
@@ -81,7 +83,8 @@ stdenv.mkDerivation {
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   makeFlags = [
-    "ARCH=${stdenv.hostPlatform.parsed.cpu.name}"
+    "ARCH=${stdenv.hostPlatform.linuxArch}"
+    "TARGET_ARCH=${stdenv.hostPlatform.linuxArch}"
     "VERBOSE=1"
   ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
     "CROSS=${stdenv.cc.targetPrefix}"
@@ -93,7 +96,7 @@ stdenv.mkDerivation {
 
   installPhase = ''
     mkdir -p $out
-    make PREFIX=$out VERBOSE=1 install
+    make $makeFlags PREFIX=$out VERBOSE=1 install
     (cd $out/include && ln -s $(ls -d ${linuxHeaders}/include/* | grep -v "scsi$") .)
     # libpthread.so may not exist, so I do || true
     sed -i s@/lib/@$out/lib/@g $out/lib/libc.so $out/lib/libpthread.so || true
@@ -109,6 +112,7 @@ stdenv.mkDerivation {
     description = "A small implementation of the C library";
     maintainers = with maintainers; [ rasendubi ];
     license = licenses.lgpl2;
-    platforms = intersectLists platforms.linux platforms.x86; # fails to build on ARM
+    platforms = platforms.linux;
+    broken = stdenv.hostPlatform.isAarch32 || stdenv.hostPlatform.isAarch64;
   };
 }


### PR DESCRIPTION
Must specify the the TARGET_ARCH (which confusingly is actually
for the host platform, in Nix/autotools terminology) at build and
`make install` time.

Also, auto-disable UCLIBC_HAS_FPU when hostPlatform.gcc.float == "soft".

Clarify platforms = linux and broken = arm to better reflect
the current support situation.

Fixes pkgsCross.ben-nanonote.stdenv

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
