### PR TITLE
lib.meta.getLicenseFromSpdxIdOr: init

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -120,7 +120,7 @@ let
     inherit (self.derivations) lazyDerivation optionalDrvAttr;
     inherit (self.meta) addMetaAttrs dontDistribute setName updateName
       appendToName mapDerivationAttrset setPrio lowPrio lowPrioSet hiPrio
-      hiPrioSet getLicenseFromSpdxId getExe getExe';
+      hiPrioSet getLicenseFromSpdxId getLicenseFromSpdxIdOr getExe getExe';
     inherit (self.filesystem) pathType pathIsDirectory pathIsRegularFile
       packagesFromDirectoryRecursive;
     inherit (self.sources) cleanSourceFilter

--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -315,14 +315,56 @@ rec {
     :::
   */
   getLicenseFromSpdxId =
-    let
-      spdxLicenses = lib.mapAttrs (id: ls: assert lib.length ls == 1; builtins.head ls)
-        (lib.groupBy (l: lib.toLower l.spdxId) (lib.filter (l: l ? spdxId) (lib.attrValues lib.licenses)));
-    in licstr:
-      spdxLicenses.${ lib.toLower licstr } or (
+    licstr:
+      getLicenseFromSpdxIdOr licstr (
         lib.warn "getLicenseFromSpdxId: No license matches the given SPDX ID: ${licstr}"
         { shortName = licstr; }
       );
+
+  /**
+    Get the corresponding attribute in lib.licenses from the SPDX ID
+    or fallback to the given default value.
+
+    For SPDX IDs, see https://spdx.org/licenses
+
+    # Inputs
+
+    `licstr`
+    : 1\. SPDX ID string to find a matching license
+
+    `default`
+    : 2\. Fallback value when a match is not found
+
+    # Type
+
+    ```
+    getLicenseFromSpdxIdOr :: str -> Any -> Any
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.meta.getLicenseFromSpdxIdOr` usage example
+
+    ```nix
+    lib.getLicenseFromSpdxIdOr "MIT" null == lib.licenses.mit
+    => true
+    lib.getLicenseFromSpdxId "mIt" null == lib.licenses.mit
+    => true
+    lib.getLicenseFromSpdxIdOr "MY LICENSE" lib.licenses.free == lib.licenses.free
+    => true
+    lib.getLicenseFromSpdxIdOr "MY LICENSE" null
+    => null
+    lib.getLicenseFromSpdxIdOr "MY LICENSE" (builtins.throw "No SPDX ID matches MY LICENSE")
+    => error: No SPDX ID matches MY LICENSE
+    ```
+    :::
+  */
+  getLicenseFromSpdxIdOr =
+    let
+      spdxLicenses = lib.mapAttrs (id: ls: assert lib.length ls == 1; builtins.head ls)
+        (lib.groupBy (l: lib.toLower l.spdxId) (lib.filter (l: l ? spdxId) (lib.attrValues lib.licenses)));
+    in licstr: default:
+      spdxLicenses.${ lib.toLower licstr } or default;
 
   /**
     Get the path to the main program of a package based on meta.mainProgram

--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -287,10 +287,10 @@ rec {
     all (elem: !platformMatch platform elem) (pkg.meta.badPlatforms or []);
 
   /**
-    Get the corresponding attribute in lib.licenses
-    from the SPDX ID.
-    For SPDX IDs, see
-    https://spdx.org/licenses
+    Get the corresponding attribute in lib.licenses from the SPDX ID
+    or warn and fallback to `{ shortName = <license string>; }`.
+
+    For SPDX IDs, see https://spdx.org/licenses
 
     # Type
 

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -58,6 +58,7 @@ let
     genList
     getExe
     getExe'
+    getLicenseFromSpdxIdOr
     groupBy
     groupBy'
     hasAttrByPath
@@ -2305,6 +2306,25 @@ runTests {
 
   testGetExe'FailureSecondArg = testingThrow (
     getExe' { type = "derivation"; } "dir/executable"
+  );
+
+  testGetLicenseFromSpdxIdOrExamples = {
+    expr = [
+      (getLicenseFromSpdxIdOr "MIT" null)
+      (getLicenseFromSpdxIdOr "mIt" null)
+      (getLicenseFromSpdxIdOr "MY LICENSE" lib.licenses.free)
+      (getLicenseFromSpdxIdOr "MY LICENSE" null)
+    ];
+    expected = [
+      lib.licenses.mit
+      lib.licenses.mit
+      lib.licenses.free
+      null
+    ];
+  };
+
+  testGetLicenseFromSpdxIdOrThrow = testingThrow (
+    getLicenseFromSpdxIdOr "MY LICENSE" (throw "No SPDX ID matches MY LICENSE")
   );
 
   testPlatformMatch = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR introduces `lib.meta.getLicenseFromSpdxIdOr`, a variant function of `lib.meta.getLicenseFromSpdxId` that allows the developers to specify the fallback value explicitly when a license with a matching SPDX ID is not found in `lib.licenses`.

Given that the typical use case of this function is to parse configuration files such as `package.json` and `pyproject.toml` during automatic package generation, the warning introduced by `lib.getLicenseFromSpdxId` will block the Release Tests and OfBorg evaluation for a programmatically generated package set.

`lib.getLicenseFromSpdxIdOr` enables developers to control the fallback behavior, leading to a smoother developer and user experience.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
