### PR TITLE
haskell.packages.ghcjs.vector: Fix evaluation failure

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghcjs.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs.nix
@@ -101,9 +101,6 @@ self: super:
   # still present here https://github.com/glguy/th-abstraction/issues/53
   th-abstraction = dontCheck super.th-abstraction;
 
-  # https://github.com/haskell/vector/issues/410
-  vector = appendPatch super.vector (../compilers/ghcjs/patches/vector-ghcjs-storable-set.patch);
-
   # Need hedgehog for tests, which fails to compile due to dep on concurrent-output
   zenc = dontCheck super.zenc;
 }


### PR DESCRIPTION
The derivation for the GHCJS `vector` package broke in #142940 due to
introducing the line of code that this change deletes.

The offending line appears to have been unintentionally added and
causes an evaluation failure for two separate reason :

* The argument order is wrong

  The change in #142940 switched the `haskellLib` utilities to flip
  their argument order, but the `appendPatch` in the offending line
  has the original argument order

* The patch file referenced by the offending line does not exist

The correct fix is to delete the line, because the patch is not
necessary.  The default version of the `vector` package is `0.12.3.1`,
which already includes the fix from that patch.