### PR TITLE
javaPackages.openjdk17: Fix download URL

### DIFF
--- a/pkgs/development/compilers/openjdk/darwin/17.nix
+++ b/pkgs/development/compilers/openjdk/darwin/17.nix
@@ -12,7 +12,7 @@ let
 
     aarch64-darwin = {
       arch = "aarch64";
-      zuluVersion = "17.30.19";
+      zuluVersion = "17.30.15";
       jdkVersion = "17.0.1";
       sha256 = "sha256-zhBCXOnO/fsj6+q+vAlEz7QVMRFKLVvYnjwZzFz6mRM=";
     };


### PR DESCRIPTION
The current build attempts to fetch
https://cdn.azul.com/zulu/bin/zulu17.30.19-ca-jdk17.0.1-macosx_aarch64.tar.gz
on aarch64-darwin, and that URL does not exist.

Changing the Zulu version to 17.30.19 to 17.30.15 fixes the URL, and
the hash requires no changes, indicating that the hash must have
originally been computed for version 17.30.15 anyway.