### PR TITLE
evolution-data-server: propagate libgdata

### DIFF
--- a/pkgs/applications/networking/calls/default.nix
+++ b/pkgs/applications/networking/calls/default.nix
@@ -73,7 +73,6 @@ stdenv.mkDerivation rec {
     callaudiod
     gtk3
     libpeas
-    libgdata # required by some dependency transitively
     sofia_sip
   ];
 

--- a/pkgs/applications/office/elementary-planner/default.nix
+++ b/pkgs/applications/office/elementary-planner/default.nix
@@ -59,7 +59,6 @@ stdenv.mkDerivation rec {
     pantheon.granite
     sqlite
     webkitgtk
-    libgdata # required by some dependency transitively
     libhandy
     curl
   ];

--- a/pkgs/desktops/gnome/core/evolution-data-server/default.nix
+++ b/pkgs/desktops/gnome/core/evolution-data-server/default.nix
@@ -38,7 +38,15 @@ stdenv.mkDerivation rec {
     libcanberra-gtk3 pcre libphonenumber boost protobuf
   ];
 
-  propagatedBuildInputs = [ libsecret nss nspr libical db libsoup ];
+  propagatedBuildInputs = [
+    db
+    libsecret
+    nss
+    nspr
+    libical
+    libgdata # needed for GObject inspection, https://gitlab.gnome.org/GNOME/evolution-data-server/-/merge_requests/57/diffs
+    libsoup
+  ];
 
   cmakeFlags = [
     "-DENABLE_UOA=OFF"

--- a/pkgs/desktops/gnome/core/gnome-contacts/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-contacts/default.nix
@@ -59,7 +59,6 @@ stdenv.mkDerivation rec {
     evolution-data-server
     gsettings-desktop-schemas
     folks
-    libgdata # required by some dependency transitively
     gnome-desktop
     libhandy
     libxml2

--- a/pkgs/desktops/pantheon/apps/elementary-calendar/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-calendar/default.nix
@@ -64,7 +64,6 @@ stdenv.mkDerivation rec {
     libhandy
     libical
     libnotify
-    libgdata # required by some dependency transitively
   ];
 
   postPatch = ''

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/datetime/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/datetime/default.nix
@@ -57,7 +57,6 @@ stdenv.mkDerivation rec {
     libical
     libsoup
     wingpanel
-    libgdata # required by some dependency transitively
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
Stop program packaging from having to declare transitive dependencies (fixed in this PR). This was observed during a review of https://github.com/NixOS/nixpkgs/pull/136537.

Per https://gitlab.gnome.org/GNOME/evolution-data-server/-/merge_requests/57/diffs, evolution-data-server requires libgdata for gobject introspection.

See also https://github.com/NixOS/nixpkgs/commit/025960d2296456b8a4cc3b2bcd5a6c624c68a54b, which did a similar thing for libsoup.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage). Logs: https://paste.debian.net/1222888/
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
