### PR TITLE
lib/nixos/eval-config.nix: Fix extraArgs

### DIFF
--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -53,12 +53,12 @@ let
   };
 
   withWarnings = x:
-    lib.warnIf (evalConfigArgs?args) "The extraArgs argument to eval-config.nix is deprecated. Please set config._module.args instead."
+    lib.warnIf (evalConfigArgs?extraArgs) "The extraArgs argument to eval-config.nix is deprecated. Please set config._module.args instead."
     lib.warnIf (evalConfigArgs?check) "The check argument to eval-config.nix is deprecated. Please set config._module.check instead."
     x;
 
   legacyModules =
-    lib.optional (evalConfigArgs?args) {
+    lib.optional (evalConfigArgs?extraArgs) {
       config = {
         _module.args = extraArgs;
       };


### PR DESCRIPTION
###### Motivation for this change
Fixes a mistake in https://github.com/NixOS/nixpkgs/pull/148315 that
caused https://github.com/NixOS/nixpkgs/issues/148343#issuecomment-990881216

Tested with this command:
```
nix-instantiate nixos/lib/eval-config.nix --arg modules '[ ({ x, ... }: { environment.etc.x.text = x; fileSystems."/".device = "d"; boot.loader.grub.device = "nodev"; }) ]' --arg extraArgs '{ x = "x"; }' -A config.system.build.toplevel
```

Which previously threw an error:
```
error: attribute 'x' missing, at /home/infinisil/src/nixpkgs/lib/modules.nix:385:28
(use '--show-trace' to show detailed location information)
```

But with this commit works, and gives the intended warning for `extraArgs`:
```
trace: warning: The extraArgs argument to eval-config.nix is deprecated. Please set config._module.args instead.
warning: you did not specify '--add-root'; the result might be removed by the garbage collector
/nix/store/hg5019xr1alcn76dbm38c17ci6x6pz3a-nixos-system-nixos-22.05pre-git.drv
```

Ping @roberth 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
