### PR TITLE
open-watcom-v2: Update, wrapWatcom: inherit meta

### DIFF
--- a/pkgs/development/compilers/open-watcom/v2.nix
+++ b/pkgs/development/compilers/open-watcom/v2.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, unstableGitUpdater
 
 # Docs cause an immense increase in build time, up to 2 additional hours
 , withDocs ? false
@@ -11,14 +12,14 @@
 
 stdenv.mkDerivation rec {
   pname = "open-watcom-v2";
-  version = "unstable-2021-11-30";
+  version = "unstable-2021-12-10";
   name = "${pname}-unwrapped-${version}";
 
   src = fetchFromGitHub {
     owner = "open-watcom";
     repo = "open-watcom-v2";
-    rev = "982c958eb4840e1c6a98773ba0600f652500f5a7";
-    sha256 = "18dp9nd1gjnpd1870149v67vzxbna25l6zi052z1r51xvaqwc3cx";
+    rev = "ca685c1b780149f7210426f0bb78dd7b67b19e6d";
+    sha256 = "1nmmj94z5hips2426rcdqdcsm8015jjj51rm9fnx81qagdj52j5d";
   };
 
   postPatch = ''
@@ -81,6 +82,10 @@ stdenv.mkDerivation rec {
 
   # Stripping breaks many tools
   dontStrip = true;
+
+  passthru.updateScript = unstableGitUpdater {
+    url = "https://github.com/open-watcom/open-watcom-v2.git";
+  };
 
   meta = with lib; {
     description = "The v2 fork of the Open Watcom suite of compilers and tools";

--- a/pkgs/development/compilers/open-watcom/wrapper.nix
+++ b/pkgs/development/compilers/open-watcom/wrapper.nix
@@ -123,6 +123,8 @@ let
           '';
         };
       };
+
+      inherit (open-watcom) meta;
     };
 in
 lib.makeOverridable wrapper


### PR DESCRIPTION
###### Motivation for this change
- open-watcom-v2: unstable-2021-11-30 -> unstable-2021-12-10, add updateScript
- wrapWatcom: inherit compiler's meta, so the search results on search.nixos.org hopefully look abit nicer:

![Bildschirmfoto von 2021-12-10 14-05-04](https://user-images.githubusercontent.com/23431373/145578853-7ed8cf5a-34ff-4633-885d-951107399693.png)
![Bildschirmfoto von 2021-12-10 14-05-28](https://user-images.githubusercontent.com/23431373/145578851-1938bfc7-6643-4ed3-b03a-b4bd49eaa1c6.png)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
