### PR TITLE
makeBinaryWrapper fixes for Darwin

### DIFF
--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -35,8 +35,6 @@ with pkgs;
 
   macOSSierraShared = callPackage ./macos-sierra-shared {};
 
-  make-binary-wrapper = callPackage ./make-binary-wrapper { inherit makeBinaryWrapper; };
-
   cross = callPackage ./cross {};
 
   php = recurseIntoAttrs (callPackages ./php {});

--- a/pkgs/test/make-binary-wrapper/chdir.c
+++ b/pkgs/test/make-binary-wrapper/chdir.c
@@ -5,7 +5,7 @@
 #define assert_success(e) do { if ((e) < 0) { perror(#e); abort(); } } while (0)
 
 int main(int argc, char **argv) {
-    assert_success(chdir("/tmp/foo"));
+    assert_success(chdir("./tmp/foo"));
     argv[0] = "/send/me/flags";
     return execv("/send/me/flags", argv);
 }

--- a/pkgs/test/make-binary-wrapper/chdir.cmdline
+++ b/pkgs/test/make-binary-wrapper/chdir.cmdline
@@ -1,1 +1,1 @@
-    --chdir /tmp/foo
+    --chdir ./tmp/foo

--- a/pkgs/test/make-binary-wrapper/chdir.env
+++ b/pkgs/test/make-binary-wrapper/chdir.env
@@ -1,2 +1,2 @@
-CWD=/tmp/foo
+CWD=SUBST_CWD/tmp/foo
 SUBST_ARGV0

--- a/pkgs/test/make-binary-wrapper/default.nix
+++ b/pkgs/test/make-binary-wrapper/default.nix
@@ -1,7 +1,7 @@
 { lib, coreutils, python3, gcc, writeText, writeScript, runCommand, makeBinaryWrapper }:
 
 let
-  env = { nativeBuildInputs = [ makeBinaryWrapper ]; };
+  env = { buildInputs = [ makeBinaryWrapper ]; };
   envCheck = runCommand "envcheck" env ''
     ${gcc}/bin/cc -Wall -Werror -Wpedantic -o $out ${./envcheck.c}
   '';

--- a/pkgs/test/make-binary-wrapper/default.nix
+++ b/pkgs/test/make-binary-wrapper/default.nix
@@ -6,7 +6,7 @@ let
     ${gcc}/bin/cc -Wall -Werror -Wpedantic -o $out ${./envcheck.c}
   '';
   makeGoldenTest = testname: runCommand "test-wrapper_${testname}" env ''
-    mkdir -p /tmp/foo
+    mkdir -p ./tmp/foo
 
     params=$(<"${./.}/${testname}.cmdline")
     eval "makeCWrapper /send/me/flags $params" > wrapper.c

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -699,7 +699,7 @@ with pkgs;
       makeSetupHook { deps = [ dieHook ]; } script;
   in
     lib.makeOverridable f {
-      cc = stdenv.cc.cc;
+      cc = stdenv.cc;
       sanitizers = [ "undefined" "address" ];
     };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -696,7 +696,10 @@ with pkgs;
           --replace " @CC@ " " ${cc}/bin/cc ${san} "
       '';
     in
-      makeSetupHook { deps = [ dieHook ]; } script;
+      makeSetupHook {
+        deps = [ dieHook ];
+        substitutions.passthru.tests = callPackage ../test/make-binary-wrapper { inherit makeBinaryWrapper; };
+      } script;
   in
     lib.makeOverridable f {
       cc = stdenv.cc;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -697,8 +697,15 @@ with pkgs;
       '';
     in
       makeSetupHook {
-        deps = [ dieHook ];
-        substitutions.passthru.tests = callPackage ../test/make-binary-wrapper { inherit makeBinaryWrapper; };
+        deps = [ dieHook cc ];
+        substitutions.passthru.tests = callPackage ../test/make-binary-wrapper {
+          makeBinaryWrapper = makeBinaryWrapper.override {
+            sanitizers = (if stdenv.isDarwin && stdenv.isAarch64
+              then [ ]
+              else [ "undefined" "address" ]
+            );
+          };
+        };
       } script;
   in
     lib.makeOverridable f {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -703,7 +703,7 @@ with pkgs;
   in
     lib.makeOverridable f {
       cc = stdenv.cc;
-      sanitizers = [ "undefined" "address" ];
+      sanitizers = [ ];
     };
 
   makeModulesClosure = { kernel, firmware, rootModules, allowMissing ? false }:


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
See discussion on https://github.com/NixOS/nixpkgs/pull/124556

### TODO:
- [x] Switch from stdenv.cc.cc -> stdenv.cc
- [x] Fix chdir test breaking on darwin due to /tmp being a symlink to /private/tmp
- [x] Make sure OfBorg makeBinaryWrapper tests are not skipped
- [x] Use address sanitizer in tests only due to performance impact and compilation problems
- [x] Make sure tests work on aarch64-darwin and macOS 12 (Monterey)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Future work/Next PRs for makeBinaryWrapper
- Add (sound) static analysis of generated C code
- Print usage notes when makeWrapper is called with 0 or 1 argument(s), since it requires at least 2 arguments.
- Add substitute for `--run COMMAND` from makeWrapper
- Start using binary wrapper for interpreters - so that we no longer need to special for darwin case in makeScriptWriter ( https://github.com/NixOS/nixpkgs/pull/93757)