### PR TITLE
stdenv: define used hook variables

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -295,6 +295,14 @@ if [ -z "${SHELL:-}" ]; then echo "SHELL not set"; exit 1; fi
 BASH="$SHELL"
 export CONFIG_SHELL="$SHELL"
 
+# those variables are declared here, since where and if they are used varies
+# shellcheck disable=SC2034
+declare -a failureHooks addInputsHooks userHooks unpackCmdHooks fixupOutputHooks
+declare -a preHooks prePatchHooks preUnpackHooks preConfigureHooks preBuildHooks preInstallHooks preInstallCheckHooks preCheckHooks preFixupHooks preDistHooks
+declare -a postHooks postPathHooks postUnpackHooks postConfigureHooks postBuildHooks postInstallHooks postInstallCheckHooks postCheckHooks postFixupHooks postDistHooks
+declare failureHook addInputsHook userHook unpackCmdHook fixupOutputHook
+declare preHook prePatch preUnpack preConfigure preBuild preInstall preInstallCheck preCheck preFixup preDist
+declare postHook postPatch postUnpack postConfigure postBuild postInstall postInstallCheck postCheck postFixup postDist
 
 # Execute the pre-hook.
 if [ -z "${shell:-}" ]; then export shell="$SHELL"; fi
@@ -332,10 +340,6 @@ declare -a pkgHostHookVars=(envHostHostHook envHostTargetHook)
 declare -a pkgTargetHookVars=(envTargetTargetHook)
 
 declare -a pkgHookVarVars=(pkgBuildHookVars pkgHostHookVars pkgTargetHookVars)
-
-# those variables are declared here, since where and if they are used varies
-# shellcheck disable=SC2034
-declare -a preFixupHooks fixupOutputHooks preConfigureHooks postFixupHooks postUnpackHooks unpackCmdHooks
 
 # Add env hooks for all sorts of deps with the specified host offset.
 addEnvHooks() {


### PR DESCRIPTION
###### Motivation for this change

This PR defines in bash the hook variables used throughout nixpkgs.
I've tried to remove the kludge, but bash (even 5.x) doesn't like empty arrays being derefenced in that situation (not really sure why). So I've decided to keep the weird syntax for now.

@andersk always interested in your opinion if you have time.
@SuperSandro2000 you might see something I'm missing. (the particular syntax is there to help readability, so that people can check nothing is missing.)
@andychu This PR aims at defining the remaining potentially undefined variables in stdenv

I'll rebase on staging if this looks good. (sorry for alerting half of the world).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
