### PR TITLE
[WIP] lairucrem: init at 5.4.0

### DIFF
--- a/pkgs/applications/version-management/lairucrem/default.nix
+++ b/pkgs/applications/version-management/lairucrem/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonApplication, fetchFromSourcehut
+, pytest, mock, sh, mercurial
+, urwid, setuptools }:
+
+buildPythonApplication rec {
+  pname = "lairucrem";
+  version = "5.4.0";
+
+  src = fetchFromSourcehut {
+    vc = "hg";
+    owner = "~alainl";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-QW7rKpnXBWmlEEzMJnW19vdhTn5UmC4hDZvIL64kLIQ=";
+  };
+
+  propagatedBuildInputs = [ urwid setuptools ];
+  checkInputs = [ pytest mock sh mercurial ];
+  checkPhase = "py.test --doctest-modules -q";
+
+  meta = with lib; {
+    description = "A simple and powerful text-based interactive user interface for Mercurial";
+    homepage = "https://hg.sr.ht/~alainl/lairucrem";
+    license = licenses.wtfpl;
+    maintainers = with maintainers; [ pacien ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25589,6 +25589,8 @@ with pkgs;
 
   jmusicbot = callPackage ../applications/audio/jmusicbot { };
 
+  lairucrem = python3Packages.callPackage ../applications/version-management/lairucrem { };
+
   libquvi = callPackage ../applications/video/quvi/library.nix { };
 
   librespot = callPackage ../applications/audio/librespot {


### PR DESCRIPTION
###### Motivation for this change

This adds a package for [lairucrem],
"A simple and powerful text-based interactive user interface for Mercurial".

[lairucrem]: https://hg.sr.ht/~alainl/lairucrem


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
