### PR TITLE
WIP kernel modules: mkDerivation -> buildModule

### DIFF
--- a/pkgs/os-specific/linux/acpi-call/default.nix
+++ b/pkgs/os-specific/linux/acpi-call/default.nix
@@ -1,9 +1,8 @@
-{ lib, stdenv, fetchFromGitHub, kernel }:
+{ lib, fetchFromGitHub, kernel, buildModule }:
 
-stdenv.mkDerivation rec {
+buildModule rec {
   pname = "acpi-call";
   version = "1.2.2";
-  name = "${pname}-${version}-${kernel.version}";
 
   src = fetchFromGitHub {
     owner = "nix-community";
@@ -13,12 +12,6 @@ stdenv.mkDerivation rec {
   };
 
   hardeningDisable = [ "pic" ];
-
-  nativeBuildInputs = kernel.moduleBuildDependencies;
-
-  makeFlags = [
-    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
-  ];
 
   installPhase = ''
     install -D acpi_call.ko $out/lib/modules/${kernel.modDirVersion}/misc/acpi_call.ko

--- a/pkgs/os-specific/linux/akvcam/default.nix
+++ b/pkgs/os-specific/linux/akvcam/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, kernel }:
+{ lib, fetchFromGitHub, kernel, buildModule }:
 
-stdenv.mkDerivation rec {
+buildModule rec {
   pname = "akvcam";
   version = "1.2.2";
 
@@ -12,10 +12,6 @@ stdenv.mkDerivation rec {
   };
   sourceRoot = "source/src";
 
-  makeFlags = [
-    "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
-  ];
-
   installPhase = ''
     install -m644 -b -D akvcam.ko $out/lib/modules/${kernel.modDirVersion}/akvcam.ko
   '';
@@ -26,7 +22,6 @@ stdenv.mkDerivation rec {
     description = "Virtual camera driver for Linux";
     homepage = "https://github.com/webcamoid/akvcam";
     maintainers = with maintainers; [ freezeboy ];
-    platforms = platforms.linux;
     license = licenses.gpl2Only;
   };
 }

--- a/pkgs/os-specific/linux/anbox/kmod.nix
+++ b/pkgs/os-specific/linux/anbox/kmod.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, kernel, fetchFromGitHub }:
+{ lib, stdenv, kernel, fetchFromGitHub, buildModule }:
 
-stdenv.mkDerivation {
+buildModule {
   pname = "anbox-modules";
   version = "2020-06-14-${kernel.version}";
 
@@ -11,9 +11,8 @@ stdenv.mkDerivation {
     sha256 = "sha256-6xDJQ4YItdbYqle/9VNfOc7D80yFGd9cFyF+CuABaF0=";
   };
 
-  nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  KERNEL_SRC="${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+  # KERNEL_SRC="${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"; TODO(berdario) unused?
 
   buildPhase = ''
     for d in ashmem binder;do
@@ -35,7 +34,6 @@ stdenv.mkDerivation {
     description = "Anbox ashmem and binder drivers.";
     homepage = "https://github.com/anbox/anbox-modules";
     license = licenses.gpl2Only;
-    platforms = platforms.linux;
     broken = kernel.kernelOlder "4.4" || kernel.kernelAtLeast "5.5";
     maintainers = with maintainers; [ edwtjo ];
   };

--- a/pkgs/os-specific/linux/apfs/default.nix
+++ b/pkgs/os-specific/linux/apfs/default.nix
@@ -2,9 +2,10 @@
 , stdenv
 , fetchFromGitHub
 , kernel
+, buildModule
 }:
 
-stdenv.mkDerivation {
+buildModule {
   pname = "apfs";
   version = "unstable-2021-09-21-${kernel.version}";
 
@@ -16,19 +17,15 @@ stdenv.mkDerivation {
   };
 
   hardeningDisable = [ "pic" ];
-  nativeBuildInputs = kernel.moduleBuildDependencies;
 
   makeFlags = [
     "KERNELRELEASE=${kernel.modDirVersion}"
-    "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
-    "INSTALL_MOD_PATH=$(out)"
   ];
 
   meta = with lib; {
     description = "APFS module for linux";
     homepage = "https://github.com/linux-apfs/linux-apfs-rw";
     license = licenses.gpl2Only;
-    platforms = platforms.linux;
     broken = kernel.kernelOlder "4.9";
     maintainers = with maintainers; [ Luflosi ];
   };

--- a/pkgs/os-specific/linux/asus-wmi-sensors/default.nix
+++ b/pkgs/os-specific/linux/asus-wmi-sensors/default.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, fetchFromGitHub, kernel }:
+{ lib, stdenv, fetchFromGitHub, kernel, buildModule }:
 
-stdenv.mkDerivation rec {
-  name = "asus-wmi-sensors-${version}-${kernel.version}";
+buildModule rec {
+  pname = "asus-wmi-sensors-${version}";
   version = "unstable-2019-11-07";
 
   # The original was deleted from github, but this seems to be an active fork
@@ -14,8 +14,6 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "pic" ];
 
-  nativeBuildInputs = kernel.moduleBuildDependencies;
-
   preConfigure = ''
     sed -i 's|depmod|#depmod|' Makefile
   '';
@@ -26,11 +24,12 @@ stdenv.mkDerivation rec {
     "MODDESTDIR=${placeholder "out"}/lib/modules/${kernel.modDirVersion}/kernel/drivers/hwmon"
   ];
 
+  overridePlatforms = [ "x86_64-linux" "i686-linux" ];
+
   meta = with lib; {
     description = "Linux HWMON (lmsensors) sensors driver for various ASUS Ryzen and Threadripper motherboards";
     homepage = "https://github.com/electrified/asus-wmi-sensors";
-    license = licenses.gpl2;
-    platforms = [ "x86_64-linux" "i686-linux" ];
+    license = licenses.gpl2; 
     maintainers = with maintainers; [ Frostman ];
     broken = versionOlder kernel.version "4.12";
   };

--- a/pkgs/os-specific/linux/batman-adv/default.nix
+++ b/pkgs/os-specific/linux/batman-adv/default.nix
@@ -1,8 +1,8 @@
-{ lib, stdenv, fetchurl, kernel }:
+{ lib, fetchurl, kernel, buildModule }:
 
 let cfg = import ./version.nix; in
 
-stdenv.mkDerivation rec {
+buildModule rec {
   pname = "batman-adv";
   version = "${cfg.version}-${kernel.version}";
 
@@ -10,8 +10,6 @@ stdenv.mkDerivation rec {
     url = "http://downloads.open-mesh.org/batman/releases/${pname}-${cfg.version}/${pname}-${cfg.version}.tar.gz";
     sha256 = cfg.sha256.${pname};
   };
-
-  nativeBuildInputs = kernel.moduleBuildDependencies;
 
   hardeningDisable = [ "pic" ];
 
@@ -26,6 +24,5 @@ stdenv.mkDerivation rec {
     description = "B.A.T.M.A.N. routing protocol in a linux kernel module for layer 2";
     license = lib.licenses.gpl2;
     maintainers = with lib.maintainers; [ fpletz hexa ];
-    platforms = with lib.platforms; linux;
   };
 }

--- a/pkgs/os-specific/linux/bbswitch/default.nix
+++ b/pkgs/os-specific/linux/bbswitch/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, kernel, runtimeShell }:
+{ lib, fetchFromGitHub, fetchpatch, kernel, runtimeShell, buildModule }:
 
 let
   baseName = "bbswitch";
@@ -7,8 +7,9 @@ let
 
 in
 
-stdenv.mkDerivation {
-  inherit name;
+buildModule {
+  pname = baseName;
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "Bumblebee-Project";
@@ -28,8 +29,6 @@ stdenv.mkDerivation {
     })
   ];
 
-  nativeBuildInputs = kernel.moduleBuildDependencies;
-
   hardeningDisable = [ "pic" ];
 
   preBuild = ''
@@ -37,8 +36,6 @@ stdenv.mkDerivation {
       --replace "\$(shell uname -r)" "${kernel.modDirVersion}" \
       --replace "/lib/modules" "${kernel.dev}/lib/modules"
   '';
-
-  makeFlags = kernel.makeFlags;
 
   installPhase = ''
     mkdir -p $out/lib/modules/${kernel.modDirVersion}/misc
@@ -58,9 +55,10 @@ stdenv.mkDerivation {
     chmod +x $out/bin/discrete_vga_poweroff $out/bin/discrete_vga_poweron
   '';
 
+  overridePlatforms = [ "x86_64-linux" "i686-linux" ];
+
   meta = with lib; {
     description = "A module for powering off hybrid GPUs";
-    platforms = [ "x86_64-linux" "i686-linux" ];
     homepage = "https://github.com/Bumblebee-Project/bbswitch";
     maintainers = with maintainers; [ abbradar ];
     license = licenses.gpl2Plus;

--- a/pkgs/os-specific/linux/broadcom-sta/default.nix
+++ b/pkgs/os-specific/linux/broadcom-sta/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, kernel }:
+{ lib, stdenv, fetchurl, kernel, buildModule }:
 
 let
   version = "6.30.223.271";
@@ -11,8 +11,9 @@ let
   tarballVersion = lib.replaceStrings ["."] ["_"] version;
   tarball = "hybrid-v35${arch}-nodebug-pcoem-${tarballVersion}.tar.gz";
 in
-stdenv.mkDerivation {
-  name = "broadcom-sta-${version}-${kernel.version}";
+buildModule {
+  pname = "broadcom-sta";
+  inherit version;
 
   src = fetchurl {
     url = "https://docs.broadcom.com/docs-and-downloads/docs/linux_sta/${tarball}";
@@ -20,8 +21,6 @@ stdenv.mkDerivation {
   };
 
   hardeningDisable = [ "pic" ];
-
-  nativeBuildInputs = kernel.moduleBuildDependencies;
 
   patches = [
     ./i686-build-failure.patch
@@ -64,6 +63,5 @@ stdenv.mkDerivation {
     homepage = "http://www.broadcom.com/support/802.11/linux_sta.php";
     license = lib.licenses.unfreeRedistributable;
     maintainers = with lib.maintainers; [ phreedom ];
-    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/can-isotp/default.nix
+++ b/pkgs/os-specific/linux/can-isotp/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, kernel, fetchFromGitHub }:
+{ lib, stdenv, kernel, fetchFromGitHub, buildModule }:
 
-stdenv.mkDerivation {
+buildModule {
   pname = "can-isotp";
   version = "20200910";
 
@@ -13,24 +13,22 @@ stdenv.mkDerivation {
     sha256 = "1laax93czalclg7cy9iq1r7hfh9jigh7igj06y9lski75ap2vhfq";
   };
 
-  KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
-  INSTALL_MOD_PATH = "\${out}";
 
   buildPhase = ''
+    export KERNELDIR="${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
     make modules
   '';
 
-  installPhase = ''
+  installPhase = (''
+    export INSTALL_MOD_PATH="\$'' +
+    ''{out}"
     make modules_install
-  '';
-
-  nativeBuildInputs = kernel.moduleBuildDependencies;
+  '');
 
   meta = with lib; {
     description = "Kernel module for ISO-TP (ISO 15765-2)";
     homepage = "https://github.com/hartkopp/can-isotp";
     license = licenses.gpl2;
-    platforms = platforms.linux;
     maintainers = [ maintainers.evck ];
   };
 }

--- a/pkgs/os-specific/linux/ddcci/default.nix
+++ b/pkgs/os-specific/linux/ddcci/default.nix
@@ -1,12 +1,11 @@
-{ lib, stdenv, fetchpatch, fetchFromGitLab, kernel }:
+{ lib, stdenv, fetchpatch, fetchFromGitLab, kernel, buildModule }:
 
-stdenv.mkDerivation rec {
+buildModule rec {
   pname = "ddcci-driver";
   # XXX: We apply a patch for the upcoming version to the source of version 0.4.1
   # XXX: When 0.4.2 is actually released, don't forget to remove this comment,
   # XXX: fix the rev in fetchFromGitLab, and remove the patch.
   version = "0.4.2";
-  name = "${pname}-${kernel.version}-${version}";
 
   src = fetchFromGitLab {
     owner = "${pname}-linux";
@@ -16,8 +15,6 @@ stdenv.mkDerivation rec {
   };
 
   hardeningDisable = [ "pic" ];
-
-  nativeBuildInputs = kernel.moduleBuildDependencies;
 
   prePatch = ''
     substituteInPlace ./ddcci/Makefile \
@@ -35,19 +32,11 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  makeFlags = kernel.makeFlags ++ [
-    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
-    "KVER=${kernel.modDirVersion}"
-    "KERNEL_MODLIB=$(out)/lib/modules/${kernel.modDirVersion}"
-    "INCLUDEDIR=$(out)/include"
-  ];
-
   meta = with lib; {
     description = "Kernel module driver for DDC/CI monitors";
     homepage = "https://gitlab.com/ddcci-driver-linux/ddcci-driver-linux";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ ];
-    platforms = platforms.linux;
     broken = kernel.kernelOlder "5.1";
   };
 }

--- a/pkgs/os-specific/linux/digimend/default.nix
+++ b/pkgs/os-specific/linux/digimend/default.nix
@@ -1,8 +1,8 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, kernel }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, kernel, buildModule }:
 
 assert lib.versionAtLeast kernel.version "3.5";
 
-stdenv.mkDerivation rec {
+buildModule rec {
   pname = "digimend";
   version = "unstable-2019-06-18";
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "1l54j85540386a8aypqka7p5hy1b63cwmpsscv9rmmf10f78v8mm";
   };
 
-  INSTALL_MOD_PATH = "\${out}";
+  # INSTALL_MOD_PATH = "\${out}"; TODO(berdario) unused?
 
   postPatch = ''
     sed 's/udevadm /true /' -i Makefile
@@ -29,8 +29,6 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = kernel.moduleBuildDependencies;
-
   postInstall = ''
     # Remove module reload hack.
     # The hid-rebind unloads and then reloads the hid-* module to ensure that
@@ -40,7 +38,6 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "KVERSION=${kernel.modDirVersion}"
-    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "DESTDIR=${placeholder "out"}"
   ];
 
@@ -49,6 +46,5 @@ stdenv.mkDerivation rec {
     homepage = "https://digimend.github.io/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ gebner ];
-    platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/dpdk-kmods/default.nix
+++ b/pkgs/os-specific/linux/dpdk-kmods/default.nix
@@ -1,6 +1,5 @@
-{ lib, stdenv, fetchzip, kernel }:
-
-stdenv.mkDerivation rec {
+{ lib, fetchzip, kernel, buildModule  }:
+buildModule rec {
   pname = "dpdk-kmods";
   version = "2021-04-21";
 
@@ -11,17 +10,14 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "pic" ];
 
-  KSRC = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
-
-  nativeBuildInputs = kernel.moduleBuildDependencies;
-
   preBuild = "cd linux/igb_uio";
 
   installPhase = ''
-    make -C ${KSRC} M=$(pwd) modules_install
+    export KSRC="${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    export INSTALL_MOD_PATH='placeholder "out"'
+    make -C $KSRC M=$(pwd) modules_install
   '';
 
-  INSTALL_MOD_PATH = placeholder "out";
   enableParallelBuilding = true;
 
   meta = with lib; {
@@ -29,6 +25,5 @@ stdenv.mkDerivation rec {
     homepage = "https://git.dpdk.org/dpdk-kmods/";
     license = licenses.gpl2Only;
     maintainers = [ maintainers.mic92 ];
-    platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/e1000e/default.nix
+++ b/pkgs/os-specific/linux/e1000e/default.nix
@@ -1,8 +1,8 @@
-{ lib, stdenv, fetchurl, kernel }:
+{ lib, fetchurl, kernel, buildModule }:
 
 assert lib.versionOlder kernel.version "4.10";
 
-stdenv.mkDerivation rec {
+buildModule rec {
   name = "e1000e-${version}-${kernel.version}";
   version = "3.8.4";
 

--- a/pkgs/os-specific/linux/ena/default.nix
+++ b/pkgs/os-specific/linux/ena/default.nix
@@ -1,8 +1,8 @@
-{ lib, stdenv, fetchFromGitHub, kernel }:
+{ lib, fetchFromGitHub, kernel, buildModule }:
 
-stdenv.mkDerivation rec {
+buildModule rec {
   version = "2.5.0";
-  name = "ena-${version}-${kernel.version}";
+  pname = "ena";
 
   src = fetchFromGitHub {
     owner = "amzn";
@@ -13,10 +13,8 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "pic" ];
 
-  nativeBuildInputs = kernel.moduleBuildDependencies;
-
   # linux 3.12
-  NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
+  # NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration"; TODO(berdario) unused?
 
   configurePhase = ''
     runHook preConfigure
@@ -40,7 +38,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/amzn/amzn-drivers";
     license = licenses.gpl2Only;
     maintainers = [ maintainers.eelco ];
-    platforms = platforms.linux;
     broken = kernel.kernelOlder "4.5" || kernel.kernelAtLeast "5.15";
   };
 }

--- a/pkgs/os-specific/linux/evdi/default.nix
+++ b/pkgs/os-specific/linux/evdi/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, kernel, libdrm }:
+{ lib, stdenv, fetchFromGitHub, kernel, libdrm, buildModule }:
 
-stdenv.mkDerivation rec {
+buildModule rec {
   pname = "evdi";
   version = "unstable-2021-07-07";
 
@@ -11,14 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-io+CbZovGjEJjwtmARFH23Djt933ONoHMDoea+i6xFo=";
   };
 
-  nativeBuildInputs = kernel.moduleBuildDependencies;
-
   buildInputs = [ kernel libdrm ];
-
-  makeFlags = [
-    "KVER=${kernel.modDirVersion}"
-    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
-  ];
 
   hardeningDisable = [ "format" "pic" "fortify" ];
 
@@ -30,7 +23,6 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Extensible Virtual Display Interface";
     maintainers = with maintainers; [ eyjhb ];
-    platforms = platforms.linux;
     license = with licenses; [ lgpl21Only gpl2Only ];
     homepage = "https://www.displaylink.com/";
     broken = kernel.kernelOlder "4.19" || kernel.kernelAtLeast "5.15" || stdenv.isAarch64;

--- a/pkgs/os-specific/linux/exfat/default.nix
+++ b/pkgs/os-specific/linux/exfat/default.nix
@@ -1,16 +1,16 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, kernel }:
+{ stdenv, lib, fetchFromGitHub, fetchpatch, kernel, buildModule }:
 
 
 # Upstream build for kernel 4.1 is broken, 3.12 and below seems to be working
 assert lib.versionAtLeast kernel.version  "4.2" || lib.versionOlder kernel.version "4.0";
 
-stdenv.mkDerivation rec {
+buildModule rec {
   # linux kernel above 5.7 comes with its own exfat implementation https://github.com/arter97/exfat-linux/issues/27
   # Assertion moved here due to some tests unintenionally triggering it,
   # e.g. nixosTests.kernel-latest; it's unclear how/why so far.
-  assertion = assert lib.versionOlder kernel.version "5.8"; null;
+  # assertion = assert lib.versionOlder kernel.version "5.8"; null; TODO(berdario) reinstate
 
-  name = "exfat-nofuse-${version}-${kernel.version}";
+  pname = "exfat-nofuse";
   version = "2020-04-15";
 
   src = fetchFromGitHub {
@@ -22,10 +22,7 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "pic" ];
 
-  nativeBuildInputs = kernel.moduleBuildDependencies;
-
   makeFlags = [
-    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "ARCH=${stdenv.hostPlatform.linuxArch}"
   ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) [
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
@@ -40,6 +37,5 @@ stdenv.mkDerivation rec {
     inherit (src.meta) homepage;
     license = lib.licenses.gpl2;
     maintainers = with lib.maintainers; [ makefu ];
-    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/facetimehd/default.nix
+++ b/pkgs/os-specific/linux/facetimehd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, kernel }:
+{ lib, fetchFromGitHub, kernel, buildModule }:
 
 # facetimehd is not supported for kernels older than 3.19";
 assert lib.versionAtLeast kernel.version "3.19";
@@ -29,8 +29,8 @@ let
   ;
 in
 
-stdenv.mkDerivation rec {
-  name = "facetimehd-${version}-${kernel.version}";
+buildModule rec {
+  pname = "facetimehd";
   version = srcParams.version;
 
   src = fetchFromGitHub {
@@ -45,17 +45,12 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "pic" ];
 
-  nativeBuildInputs = kernel.moduleBuildDependencies;
-
-  makeFlags = [
-    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
-  ];
+  overridePlatforms = [ "i686-linux" "x86_64-linux" ];
 
   meta = with lib; {
     homepage = "https://github.com/patjak/bcwc_pcie";
     description = "Linux driver for the Facetime HD (Broadcom 1570) PCIe webcam";
     license = licenses.gpl2;
     maintainers = with maintainers; [ womfoo grahamc kraem ];
-    platforms = [ "i686-linux" "x86_64-linux" ];
   };
 }

--- a/pkgs/os-specific/linux/fwts/module.nix
+++ b/pkgs/os-specific/linux/fwts/module.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fwts, kernel }:
+{ lib, fwts, kernel, buildModule }:
 
-stdenv.mkDerivation rec {
+buildModule rec {
   pname = "fwts-efi-runtime";
   version = "${fwts.version}-${kernel.version}";
 
@@ -14,8 +14,6 @@ stdenv.mkDerivation rec {
       '${kernel.dev}/lib/modules/${kernel.modDirVersion}/build'
   '';
 
-  nativeBuildInputs = kernel.moduleBuildDependencies;
-
   hardeningDisable = [ "pic" ];
 
   makeFlags = [
@@ -26,6 +24,5 @@ stdenv.mkDerivation rec {
     inherit (fwts.meta) homepage license;
     description = fwts.meta.description + "(efi-runtime kernel module)";
     maintainers = with maintainers; [ dtzWill ];
-    platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/gcadapter-oc-kmod/default.nix
+++ b/pkgs/os-specific/linux/gcadapter-oc-kmod/default.nix
@@ -1,12 +1,13 @@
-{ lib, stdenv
+{ lib
 , fetchFromGitHub
 , kernel
 , kmod
+, buildModule
 }:
 
 let
   kerneldir = "lib/modules/${kernel.modDirVersion}";
-in stdenv.mkDerivation rec {
+in buildModule rec {
   pname = "gcadapter-oc-kmod";
   version = "1.4";
 
@@ -16,8 +17,6 @@ in stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "1nqhj3vqq9rnj37cnm2c4867mnxkr8di3i036shcz44h9qmy9d40";
   };
-
-  nativeBuildInputs = kernel.moduleBuildDependencies;
 
   makeFlags = [
     "KERNEL_SOURCE_DIR=${kernel.dev}/${kerneldir}/build"
@@ -33,6 +32,5 @@ in stdenv.mkDerivation rec {
     homepage = "https://github.com/HannesMann/gcadapter-oc-kmod";
     license = licenses.gpl2;
     maintainers = with maintainers; [ r-burns ];
-    platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/hid-nintendo/default.nix
+++ b/pkgs/os-specific/linux/hid-nintendo/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, kernel }:
+{ lib, fetchFromGitHub, kernel, buildModule }:
 
-stdenv.mkDerivation rec {
+buildModule rec {
   pname = "hid-nintendo";
   version = "3.2";
 
@@ -14,8 +14,6 @@ stdenv.mkDerivation rec {
   setSourceRoot = ''
     export sourceRoot=$(pwd)/source/src
   '';
-
-  nativeBuildInputs = kernel.moduleBuildDependencies;
 
   makeFlags = [
     "-C"
@@ -32,7 +30,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/nicman23/dkms-hid-nintendo";
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.rencire ];
-    platforms = platforms.linux;
     broken = versionOlder kernel.version "4.14";
   };
 }

--- a/pkgs/os-specific/linux/isgx/default.nix
+++ b/pkgs/os-specific/linux/isgx/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, lib, fetchFromGitHub, kernel, kernelAtLeast }:
+{ lib, fetchFromGitHub, kernel, kernelAtLeast, buildModule}:
 
-stdenv.mkDerivation rec {
-  name = "isgx-${version}-${kernel.version}";
+buildModule rec {
+  pname = "isgx";
   version = "2.14";
 
   src = fetchFromGitHub {
@@ -13,12 +13,6 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "pic" ];
 
-  nativeBuildInputs = kernel.moduleBuildDependencies;
-
-  makeFlags = [
-    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
-  ];
-
   installPhase = ''
     runHook preInstall
     install -D isgx.ko -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/intel/sgx
@@ -26,6 +20,8 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
+
+  overridePlatforms = [ "x86_64-linux" ];
 
   meta = with lib; {
     description = "Intel SGX Linux Driver";
@@ -40,6 +36,5 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/intel/linux-sgx-driver";
     license = with licenses; [ bsd3 /* OR */ gpl2Only ];
     maintainers = with maintainers; [ oxalica ];
-    platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/os-specific/linux/it87/default.nix
+++ b/pkgs/os-specific/linux/it87/default.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, fetchFromGitHub, kernel }:
+{ lib, fetchFromGitHub, kernel, buildModule }:
 
-stdenv.mkDerivation rec {
-  name = "it87-${version}-${kernel.version}";
+buildModule rec {
+  pname = "it87";
   version = "2018-08-14";
 
   # The original was deleted from github, but this seems to be an active fork
@@ -14,8 +14,6 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "pic" ];
 
-  nativeBuildInputs = kernel.moduleBuildDependencies;
-
   preConfigure = ''
     sed -i 's|depmod|#depmod|' Makefile
   '';
@@ -26,11 +24,12 @@ stdenv.mkDerivation rec {
     "MODDESTDIR=$(out)/lib/modules/${kernel.modDirVersion}/kernel/drivers/hwmon"
   ];
 
+  overridePlatforms = [ "x86_64-linux" "i686-linux" ];
+
   meta = with lib; {
     description = "Patched module for IT87xx superio chip sensors support";
     homepage = "https://github.com/hannesha/it87";
     license = licenses.gpl2;
-    platforms = [ "x86_64-linux" "i686-linux" ];
     maintainers = with maintainers; [ yorickvp ];
   };
 }

--- a/pkgs/os-specific/linux/ixgbevf/default.nix
+++ b/pkgs/os-specific/linux/ixgbevf/default.nix
@@ -1,15 +1,13 @@
-{ lib, stdenv, fetchurl, kernel, kmod }:
+{ lib, fetchurl, kernel, kmod, buildModule }:
 
-stdenv.mkDerivation rec {
-  name = "ixgbevf-${version}-${kernel.version}";
+buildModule rec {
+  pname = "ixgbevf";
   version = "4.6.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/e1000/ixgbevf-${version}.tar.gz";
     sha256 = "0h8a2g4hm38wmr13gvi2188r7nlv2c5rx6cal9gkf1nh6sla181c";
   };
-
-  nativeBuildInputs = kernel.moduleBuildDependencies;
 
   hardeningDisable = [ "pic" ];
 

--- a/pkgs/os-specific/linux/jool/default.nix
+++ b/pkgs/os-specific/linux/jool/default.nix
@@ -1,15 +1,15 @@
-{ lib, stdenv, fetchFromGitHub, kernel }:
+{ lib, fetchFromGitHub, kernel, buildModule }:
 
 let
   sourceAttrs = (import ./source.nix) { inherit fetchFromGitHub; };
 in
 
-stdenv.mkDerivation {
-  name = "jool-${sourceAttrs.version}-${kernel.version}";
+buildModule {
+  pname = "jool";
+  version = sourceAttrs.version;
 
   src = sourceAttrs.src;
 
-  nativeBuildInputs = kernel.moduleBuildDependencies;
   hardeningDisable = [ "pic" ];
 
   prePatch = ''
@@ -27,7 +27,6 @@ stdenv.mkDerivation {
   meta = with lib; {
     homepage = "https://www.jool.mx/";
     description = "Fairly compliant SIIT and Stateful NAT64 for Linux - kernel modules";
-    platforms = platforms.linux;
     maintainers = with maintainers; [ fpletz ];
   };
 }

--- a/pkgs/os-specific/linux/kvmfr/default.nix
+++ b/pkgs/os-specific/linux/kvmfr/default.nix
@@ -1,22 +1,18 @@
-{ lib, stdenv, fetchFromGitHub, kernel, kmod, looking-glass-client }:
+{ lib, fetchFromGitHub, kernel, kmod, looking-glass-client, buildModule }:
 
-stdenv.mkDerivation rec {
+buildModule rec {
   pname = "kvmfr";
   version = looking-glass-client.version;
 
   src = looking-glass-client.src;
   sourceRoot = "source/module";
   hardeningDisable = [ "pic" "format" ];
-  nativeBuildInputs = kernel.moduleBuildDependencies;
-
-  makeFlags = [
-    "KVER=${kernel.modDirVersion}"
-    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
-  ];
 
   installPhase = ''
     install -D kvmfr.ko -t "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/misc/"
   '';
+
+  overridePlatforms = [ "x86_64-linux" ];
 
   meta = with lib; {
     description = "Optional kernel module for LookingGlass";
@@ -27,7 +23,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/gnif/LookingGlass";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ j-brn ];
-    platforms = [ "x86_64-linux" ];
     broken = kernel.kernelOlder "5.3";
   };
 }

--- a/pkgs/os-specific/linux/lttng-modules/default.nix
+++ b/pkgs/os-specific/linux/lttng-modules/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl, kernel }:
+{ lib, fetchurl, kernel, buildModule }:
 
-stdenv.mkDerivation rec {
+buildModule rec {
   pname = "lttng-modules-${kernel.version}";
   version = "2.13.0";
 
@@ -8,8 +8,6 @@ stdenv.mkDerivation rec {
     url = "https://lttng.org/files/lttng-modules/lttng-modules-${version}.tar.bz2";
     sha256 = "0mikc3fdjd0w6rrcyksjzmv0czvgba6yk8dfmz4a3cr8s4y2pgsy";
   };
-
-  buildInputs = kernel.moduleBuildDependencies;
 
   hardeningDisable = [ "pic" ];
 
@@ -28,7 +26,6 @@ stdenv.mkDerivation rec {
     description = "Linux kernel modules for LTTng tracing";
     homepage = "https://lttng.org/";
     license = with licenses; [ lgpl21Only gpl2Only mit ];
-    platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];
   };
 }

--- a/pkgs/os-specific/linux/mba6x_bl/default.nix
+++ b/pkgs/os-specific/linux/mba6x_bl/default.nix
@@ -1,6 +1,6 @@
-{ fetchFromGitHub, kernel, lib, stdenv }:
+{ fetchFromGitHub, kernel, lib, buildModule }:
 
-stdenv.mkDerivation {
+buildModule {
   pname = "mba6x_bl";
   version = "unstable-2016-12-08";
 
@@ -14,18 +14,10 @@ stdenv.mkDerivation {
   enableParallelBuilding = true;
   hardeningDisable = [ "pic" ];
 
-  nativeBuildInputs = kernel.moduleBuildDependencies;
-
-  makeFlags = [
-    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
-    "INSTALL_MOD_PATH=$(out)"
-  ];
-
   meta = with lib; {
     description = "MacBook Air 6,1 and 6,2 (mid 2013) backlight driver";
     homepage = "https://github.com/patjak/mba6x_bl";
     license = licenses.gpl2;
-    platforms = platforms.linux;
     maintainers = [ maintainers.simonvandel ];
   };
 }

--- a/pkgs/os-specific/linux/mwprocapture/default.nix
+++ b/pkgs/os-specific/linux/mwprocapture/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, kernel, alsa-lib }:
+{ lib, stdenv, fetchurl, kernel, alsa-lib, buildModule }:
 
 with lib;
 
@@ -8,19 +8,17 @@ let
     else "32";
 
   libpath = makeLibraryPath [ stdenv.cc.cc stdenv.glibc alsa-lib ];
+  subVersion = "4236";
 
 in
-stdenv.mkDerivation rec {
+buildModule rec {
   pname = "mwprocapture";
-  subVersion = "4236";
   version = "1.3.0.${subVersion}-${kernel.version}";
 
   src = fetchurl {
     url = "https://www.magewell.com/files/drivers/ProCaptureForLinux_${subVersion}.tar.gz";
     sha256 = "1mfgj84km276sq5i8dny1vqp2ycqpvgplrmpbqwnk230d0w3qs74";
   };
-
-  nativeBuildInputs = kernel.moduleBuildDependencies;
 
   preConfigure = ''
     cd ./src
@@ -30,7 +28,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "pic" "format" ];
 
   makeFlags = [
-    "KERNELDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "KERNELDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" # TODO(berdario) same as KERNEL_DIR ?
   ];
 
   postInstall = ''
@@ -59,7 +57,6 @@ stdenv.mkDerivation rec {
     description = "Linux driver for the Magewell Pro Capture family";
     license = licenses.unfreeRedistributable;
     maintainers = with maintainers; [ MP2E ];
-    platforms = platforms.linux;
     broken = kernel.kernelOlder "3.2.0";
   };
 }

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -95,6 +95,7 @@ let
 
     nativeBuildInputs = [ perl nukeReferences ]
       ++ optionals (!libsOnly) kernel.moduleBuildDependencies;
+      # TODO(berdario) libsOnly mechanism, similar to the one used in the amdgpu module
 
     disallowedReferences = optional (!libsOnly) [ kernel.dev ];
 

--- a/pkgs/os-specific/linux/nvidiabl/default.nix
+++ b/pkgs/os-specific/linux/nvidiabl/default.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, fetchFromGitHub, kernel }:
+{ lib, fetchFromGitHub, kernel, buildModule }:
 
-stdenv.mkDerivation rec {
-  name = "nvidiabl-${version}-${kernel.version}";
+buildModule rec {
+  pname = "nvidiabl";
   version = "2020-10-01";
 
   # We use a fork which adds support for newer kernels -- upstream has been abandoned.
@@ -14,23 +14,20 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "pic" ];
 
-  nativeBuildInputs = kernel.moduleBuildDependencies;
-
   preConfigure = ''
     sed -i 's|/sbin/depmod|#/sbin/depmod|' Makefile
   '';
 
   makeFlags = [
-    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "DESTDIR=$(out)"
-    "KVER=${kernel.modDirVersion}"
   ];
+
+  overridePlatforms = [ "x86_64-linux" "i686-linux" ];
 
   meta = with lib; {
     description = "Linux driver for setting the backlight brightness on laptops using NVIDIA GPU";
     homepage = "https://github.com/guillaumezin/nvidiabl";
     license = licenses.gpl2;
-    platforms = [ "x86_64-linux" "i686-linux" ];
     maintainers = with maintainers; [ yorickvp ];
   };
 }

--- a/pkgs/os-specific/linux/openrazer/driver.nix
+++ b/pkgs/os-specific/linux/openrazer/driver.nix
@@ -1,19 +1,17 @@
 { coreutils
 , fetchFromGitHub
 , kernel
-, stdenv
 , lib
 , util-linux
+, buildModule
 }:
 
 let
   common = import ../../../development/python-modules/openrazer/common.nix { inherit lib fetchFromGitHub; };
 in
-stdenv.mkDerivation (common // {
+buildModule (common // {
   pname = "openrazer";
   version = "${common.version}-${kernel.version}";
-
-  nativeBuildInputs = kernel.moduleBuildDependencies;
 
   buildFlags = [
     "KERNELDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
@@ -40,6 +38,8 @@ stdenv.mkDerivation (common // {
 
     runHook postInstall
   '';
+
+  overridePlatforms = common.meta.platforms;
 
   meta = common.meta // {
     description = "An entirely open source Linux driver that allows you to manage your Razer peripherals on GNU/Linux";

--- a/pkgs/os-specific/linux/phc-intel/default.nix
+++ b/pkgs/os-specific/linux/phc-intel/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, kernel, which }:
+{ lib, fetchurl, kernel, which, buildModule }:
 
 # Don't bother with older versions, though some might even work:
 assert lib.versionAtLeast kernel.version "4.10";
@@ -6,8 +6,8 @@ assert lib.versionAtLeast kernel.version "4.10";
 let
   release = "0.4.0";
   revbump = "rev25"; # don't forget to change forum download id...
-in stdenv.mkDerivation rec {
-  name = "linux-phc-intel-${version}-${kernel.version}";
+in buildModule rec {
+  pname = "linux-phc-intel";
   version = "${release}-${revbump}";
 
   src = fetchurl {
@@ -16,7 +16,7 @@ in stdenv.mkDerivation rec {
     name = "phc-intel-pack-${revbump}.tar.bz2";
   };
 
-  nativeBuildInputs = [ which ] ++ kernel.moduleBuildDependencies;
+  nativeBuildInputs = [ which ];
 
   hardeningDisable = [ "pic" ];
 
@@ -36,6 +36,8 @@ in stdenv.mkDerivation rec {
     install -m 644 *.ko $out/lib/modules/${kernel.modDirVersion}/extra/
   '';
 
+  overridePlatforms = [ "x86_64-linux" "i686-linux" ];
+
   meta = with lib; {
     description = "Undervolting kernel driver for Intel processors";
     longDescription = ''
@@ -47,7 +49,6 @@ in stdenv.mkDerivation rec {
     homepage = "http://www.linux-phc.org/";
     downloadPage = "http://www.linux-phc.org/forum/viewtopic.php?f=7&t=267";
     license = licenses.gpl2;
-    platforms = [ "x86_64-linux" "i686-linux" ];
     broken = lib.versionAtLeast kernel.version "4.18";
   };
 }

--- a/pkgs/os-specific/linux/r8125/default.nix
+++ b/pkgs/os-specific/linux/r8125/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, lib, fetchFromGitHub, kernel }:
+{ lib, fetchFromGitHub, kernel, buildModule }:
 
-stdenv.mkDerivation rec {
+buildModule rec {
   pname = "r8125";
   # On update please verify (using `diff -r`) that the source matches the
   # realtek version.
@@ -17,8 +17,6 @@ stdenv.mkDerivation rec {
   };
 
   hardeningDisable = [ "pic" ];
-
-  nativeBuildInputs = kernel.moduleBuildDependencies;
 
   preBuild = ''
     substituteInPlace src/Makefile --replace "BASEDIR :=" "BASEDIR ?="
@@ -41,7 +39,6 @@ stdenv.mkDerivation rec {
     # r8125 has been integrated into the kernel as of v5.9.1
     broken = lib.versionAtLeast kernel.version "5.9.1";
     license = licenses.gpl2Plus;
-    platforms = platforms.linux;
     maintainers = with maintainers; [ peelz ];
   };
 }

--- a/pkgs/os-specific/linux/r8168/default.nix
+++ b/pkgs/os-specific/linux/r8168/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, lib, fetchFromGitHub, kernel }:
+{ lib, fetchFromGitHub, kernel, buildModule }:
 
 
 let modDestDir = "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/wireless/realtek/r8168";
 
-in stdenv.mkDerivation rec {
-  name = "r8168-${kernel.version}-${version}";
+in buildModule rec {
+  pname = "r8168";
   # on update please verify that the source matches the realtek version
   version = "8.048.03";
 
@@ -21,8 +21,6 @@ in stdenv.mkDerivation rec {
   };
 
   hardeningDisable = [ "pic" ];
-
-  nativeBuildInputs = kernel.moduleBuildDependencies;
 
   # avoid using the Makefile directly -- it doesn't understand
   # any kernel but the current.
@@ -50,7 +48,6 @@ in stdenv.mkDerivation rec {
       by adding "r8169" to boot.blacklistedKernelModules.
     '';
     license = licenses.gpl2Plus;
-    platforms = platforms.linux;
     maintainers = with maintainers; [ timokau ];
   };
 }

--- a/pkgs/os-specific/linux/rtl8188eus-aircrack/default.nix
+++ b/pkgs/os-specific/linux/rtl8188eus-aircrack/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, kernel, bc }:
+{ lib, fetchFromGitHub, kernel, bc, buildModule }:
 
-stdenv.mkDerivation {
+buildModule {
   pname = "rtl8188eus-aircrack";
   version = "${kernel.version}-unstable-2021-05-04";
 
@@ -12,8 +12,6 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ bc ];
-
-  buildInputs = kernel.moduleBuildDependencies;
 
   hardeningDisable = [ "pic" ];
 

--- a/pkgs/os-specific/linux/rtl8192eu/default.nix
+++ b/pkgs/os-specific/linux/rtl8192eu/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, lib, fetchFromGitHub, kernel, bc }:
+{ lib, fetchFromGitHub, kernel, bc, buildModule }:
 
 with lib;
 
 let modDestDir = "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/wireless/realtek/rtl8192eu";
 
-in stdenv.mkDerivation rec {
+in buildModule rec {
   pname = "rtl8192eu";
   version = "${kernel.version}-4.4.1.20211023";
 
@@ -17,7 +17,7 @@ in stdenv.mkDerivation rec {
 
   hardeningDisable = [ "pic" ];
 
-  nativeBuildInputs = kernel.moduleBuildDependencies ++ [ bc ];
+  nativeBuildInputs = [ bc ];
 
   makeFlags = [ "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" ];
 
@@ -37,7 +37,6 @@ in stdenv.mkDerivation rec {
     description = "Realtek rtl8192eu driver";
     homepage = "https://github.com/Mange/rtl8192eu-linux-driver";
     license = licenses.gpl2Only;
-    platforms = platforms.linux;
     broken = stdenv.hostPlatform.isAarch64;
     maintainers = with maintainers; [ troydm ];
   };

--- a/pkgs/os-specific/linux/rtl8723bs/default.nix
+++ b/pkgs/os-specific/linux/rtl8723bs/default.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, fetchFromGitHub, nukeReferences, kernel }:
+{ lib, stdenv, fetchFromGitHub, nukeReferences, kernel, buildModule }:
 with lib;
-stdenv.mkDerivation rec {
-  name = "rtl8723bs-${kernel.version}-${version}";
+buildModule rec {
+  pname = "rtl8723bs";
   version = "2017-04-06";
 
   src = fetchFromGitHub {
@@ -34,7 +34,6 @@ stdenv.mkDerivation rec {
     description = "Realtek SDIO Wi-Fi driver";
     homepage = "https://github.com/hadess/rtl8723bs";
     license = lib.licenses.gpl2;
-    platforms = lib.platforms.linux;
     broken = (! versionOlder kernel.version "4.12"); # Now in kernel staging drivers
     maintainers = with maintainers; [ elitak ];
   };

--- a/pkgs/os-specific/linux/rtl8812au/default.nix
+++ b/pkgs/os-specific/linux/rtl8812au/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, kernel, bc, nukeReferences }:
+{ lib, stdenv, fetchFromGitHub, kernel, bc, nukeReferences, buildModule}:
 
-stdenv.mkDerivation rec {
+buildModule rec {
   pname = "rtl8812au";
   version = "${kernel.version}-5.9.3.2.20210427";
 
@@ -12,8 +12,6 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ bc nukeReferences ];
-
-  buildInputs = kernel.moduleBuildDependencies;
 
   hardeningDisable = [ "pic" "format" ];
 
@@ -48,7 +46,6 @@ stdenv.mkDerivation rec {
     description = "Driver for Realtek 802.11ac, rtl8812au, provides the 8812au mod";
     homepage = "https://github.com/gordboy/rtl8812au-5.9.3.2";
     license = licenses.gpl2Only;
-    platforms = platforms.linux;
     maintainers = with maintainers; [ fortuneteller2k ];
     broken = kernel.kernelOlder "4.10" || kernel.kernelAtLeast "5.15" || kernel.isHardened;
   };

--- a/pkgs/os-specific/linux/rtl8814au/default.nix
+++ b/pkgs/os-specific/linux/rtl8814au/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, kernel }:
+{ lib, fetchFromGitHub, kernel, buildModule }:
 
-stdenv.mkDerivation {
+buildModule {
   pname = "rtl8814au";
   version = "${kernel.version}-unstable-2021-10-25";
 
@@ -10,8 +10,6 @@ stdenv.mkDerivation {
     rev = "d36c0874716b0776ac6c7dcd6110598ef0f6dd53";
     sha256 = "0lk3ldff489ggbqmlfi4zvnp1cvxj1b06m0fhpzai82070klzzmj";
   };
-
-  buildInputs = kernel.moduleBuildDependencies;
 
   hardeningDisable = [ "pic" ];
 

--- a/pkgs/os-specific/linux/rtl8821au/default.nix
+++ b/pkgs/os-specific/linux/rtl8821au/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, kernel, bc, nukeReferences }:
+{ lib, fetchFromGitHub, kernel, bc, nukeReferences, buildModule }:
 
-stdenv.mkDerivation rec {
+buildModule rec {
   pname = "rtl8821au";
   version = "${kernel.version}-unstable-2021-11-05";
 
@@ -12,7 +12,6 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ bc nukeReferences ];
-  buildInputs = kernel.moduleBuildDependencies;
 
   hardeningDisable = [ "pic" "format" ];
 
@@ -36,11 +35,12 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  overridePlatforms = [ "x86_64-linux" "i686-linux" ];
+
   meta = with lib; {
     description = "rtl8821AU and rtl8812AU chipset driver with firmware";
     homepage = "https://github.com/morrownr/8821au";
     license = licenses.gpl2Only;
-    platforms = [ "x86_64-linux" "i686-linux" ];
     maintainers = with maintainers; [ plchldr ];
   };
 }

--- a/pkgs/os-specific/linux/rtl8821ce/default.nix
+++ b/pkgs/os-specific/linux/rtl8821ce/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, kernel, bc }:
+{ lib, stdenv, fetchFromGitHub, kernel, bc, buildModule }:
 
-stdenv.mkDerivation rec {
+buildModule rec {
   pname = "rtl8821ce";
   version = "${kernel.version}-unstable-2021-11-19";
 
@@ -14,7 +14,6 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "pic" ];
 
   nativeBuildInputs = [ bc ];
-  buildInputs = kernel.moduleBuildDependencies;
 
   prePatch = ''
     substituteInPlace ./Makefile \
@@ -34,7 +33,6 @@ stdenv.mkDerivation rec {
     description = "Realtek rtl8821ce driver";
     homepage = "https://github.com/tomaspinho/rtl8821ce";
     license = licenses.gpl2Only;
-    platforms = platforms.linux;
     broken = stdenv.isAarch64;
     maintainers = with maintainers; [ hhm ivar ];
   };

--- a/pkgs/os-specific/linux/rtl8821cu/default.nix
+++ b/pkgs/os-specific/linux/rtl8821cu/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, kernel, bc }:
+{ lib, fetchFromGitHub, kernel, bc, buildModule }:
 
-stdenv.mkDerivation rec {
+buildModule rec {
   pname = "rtl8821cu";
   version = "${kernel.version}-unstable-2021-10-21";
 
@@ -14,7 +14,6 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "pic" ];
 
   nativeBuildInputs = [ bc ];
-  buildInputs = kernel.moduleBuildDependencies;
 
   prePatch = ''
     substituteInPlace ./Makefile \
@@ -34,7 +33,6 @@ stdenv.mkDerivation rec {
     description = "Realtek rtl8821cu driver";
     homepage = "https://github.com/morrownr/8821cu";
     license = licenses.gpl2Only;
-    platforms = platforms.linux;
     maintainers = [ maintainers.contrun ];
   };
 }

--- a/pkgs/os-specific/linux/rtl88x2bu/default.nix
+++ b/pkgs/os-specific/linux/rtl88x2bu/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, kernel, bc }:
+{ lib, fetchFromGitHub, kernel, bc, buildModule }:
 
-stdenv.mkDerivation rec {
+buildModule rec {
   pname = "rtl88x2bu";
   version = "${kernel.version}-unstable-2021-11-04";
 
@@ -14,8 +14,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "pic" ];
 
   nativeBuildInputs = [ bc ];
-  buildInputs = kernel.moduleBuildDependencies;
-
+  # TODO(berdario) this was using kernel.moduleBuildDependencies for buildInputs (not native)... same for most other rtl*
  prePatch = ''
     substituteInPlace ./Makefile \
       --replace /lib/modules/ "${kernel.dev}/lib/modules/" \
@@ -34,7 +33,6 @@ stdenv.mkDerivation rec {
     description = "Realtek rtl88x2bu driver";
     homepage = "https://github.com/morrownr/88x2bu";
     license = licenses.gpl2Only;
-    platforms = platforms.linux;
     maintainers = [ maintainers.ralith ];
   };
 }

--- a/pkgs/os-specific/linux/rtl88xxau-aircrack/default.nix
+++ b/pkgs/os-specific/linux/rtl88xxau-aircrack/default.nix
@@ -1,9 +1,9 @@
-{ lib, stdenv, fetchFromGitHub, kernel }:
+{ lib, fetchFromGitHub, kernel, buildModule }:
 
 let
   rev = "307d694076b056588c652c2bdaa543a89eb255d9";
 in
-stdenv.mkDerivation rec {
+buildModule rec {
   pname = "rtl88xxau-aircrack";
   version = "${kernel.version}-${builtins.substring 0 6 rev}";
 
@@ -13,8 +13,6 @@ stdenv.mkDerivation rec {
     inherit rev;
     sha256 = "sha256-iSJnKWc+LxGHUhb/wbFSMh7w6Oi9v4v5V+R+LI96X7w=";
   };
-
-  buildInputs = kernel.moduleBuildDependencies;
 
   hardeningDisable = [ "pic" ];
 
@@ -34,11 +32,12 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  overridePlatforms = [ "x86_64-linux" "i686-linux" "aarch64-linux" ];
+
   meta = with lib; {
     description = "Aircrack-ng kernel module for Realtek 88XXau network cards\n(8811au, 8812au, 8814au and 8821au chipsets) with monitor mode and injection support.";
     homepage = "https://github.com/aircrack-ng/rtl8812au";
     license = licenses.gpl2Only;
     maintainers = [ maintainers.jethro ];
-    platforms = [ "x86_64-linux" "i686-linux" "aarch64-linux" ];
   };
 }

--- a/pkgs/os-specific/linux/system76-acpi/default.nix
+++ b/pkgs/os-specific/linux/system76-acpi/default.nix
@@ -1,10 +1,11 @@
-{ lib, stdenv, fetchFromGitHub, kernel }:
+{ lib, fetchFromGitHub, kernel, buildModule }:
 let
   version = "1.0.2";
   sha256 = "1i7zjn5cdv9h00fgjg46b8yrz4d3dqvfr25g3f13967ycy58m48h";
 in
-stdenv.mkDerivation {
-  name = "system76-acpi-module-${version}-${kernel.version}";
+buildModule {
+  pname = "system76-acpi-module";
+  inherit version;
 
   passthru.moduleName = "system76_acpi";
 
@@ -17,8 +18,6 @@ stdenv.mkDerivation {
 
   hardeningDisable = [ "pic" ];
 
-  nativeBuildInputs = kernel.moduleBuildDependencies;
-
   buildFlags = [
     "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];
@@ -29,10 +28,11 @@ stdenv.mkDerivation {
     mv lib/udev/hwdb.d/* $out/lib/udev/hwdb.d
   '';
 
+  overridePlatforms = [ "i686-linux" "x86_64-linux" ];
+
   meta = with lib; {
     maintainers = [ maintainers.khumba ];
     license = [ licenses.gpl2Only ];
-    platforms = [ "i686-linux" "x86_64-linux" ];
     broken = kernel.kernelOlder "5.2";
     description = "System76 ACPI Driver (DKMS)";
     homepage = "https://github.com/pop-os/system76-acpi-dkms";

--- a/pkgs/os-specific/linux/system76-io/default.nix
+++ b/pkgs/os-specific/linux/system76-io/default.nix
@@ -1,10 +1,11 @@
-{ lib, stdenv, fetchFromGitHub, kernel }:
+{ lib, fetchFromGitHub, kernel, buildModule }:
 let
   version = "1.0.1";
   sha256 = "0qkgkkjy1isv6ws6hrcal75dxjz98rpnvqbm7agdcc6yv0c17wwh";
 in
-stdenv.mkDerivation {
-  name = "system76-io-module-${version}-${kernel.version}";
+buildModule {
+  pname = "system76-io-module";
+  inherit version;
 
   passthru.moduleName = "system76_io";
 
@@ -17,8 +18,6 @@ stdenv.mkDerivation {
 
   hardeningDisable = [ "pic" ];
 
-  nativeBuildInputs = kernel.moduleBuildDependencies;
-
   buildFlags = [
     "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];
@@ -27,10 +26,11 @@ stdenv.mkDerivation {
     install -D system76-io.ko $out/lib/modules/${kernel.modDirVersion}/misc/system76-io.ko
   '';
 
+  overridePlatforms = [ "i686-linux" "x86_64-linux" ];
+
   meta = with lib; {
     maintainers = [ maintainers.khumba ];
     license = [ licenses.gpl2Plus ];
-    platforms = [ "i686-linux" "x86_64-linux" ];
     broken = versionOlder kernel.version "4.14";
     description = "DKMS module for controlling System76 I/O board";
     homepage = "https://github.com/pop-os/system76-io-dkms";

--- a/pkgs/os-specific/linux/system76/default.nix
+++ b/pkgs/os-specific/linux/system76/default.nix
@@ -1,10 +1,11 @@
-{ lib, stdenv, fetchFromGitHub, kernel }:
+{ lib, fetchFromGitHub, kernel, buildModule}:
 let
   version = "1.0.13";
   sha256 = "162hhmnww8z9k0795ffs8v3f61hlfm375law156sk5l08if19a4r";
 in
-stdenv.mkDerivation {
-  name = "system76-module-${version}-${kernel.version}";
+buildModule {
+  pname = "system76-module";
+  inherit version;
 
   passthru.moduleName = "system76";
 
@@ -17,8 +18,6 @@ stdenv.mkDerivation {
 
   hardeningDisable = [ "pic" ];
 
-  nativeBuildInputs = kernel.moduleBuildDependencies;
-
   buildFlags = [
     "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];
@@ -29,10 +28,11 @@ stdenv.mkDerivation {
     mv lib/udev/hwdb.d/* $out/lib/udev/hwdb.d
   '';
 
+  overridePlatforms = [ "i686-linux" "x86_64-linux" ];
+
   meta = with lib; {
     maintainers = [ maintainers.khumba ];
     license = [ licenses.gpl2Plus ];
-    platforms = [ "i686-linux" "x86_64-linux" ];
     broken = versionOlder kernel.version "4.14";
     description = "System76 DKMS driver";
     homepage = "https://github.com/pop-os/system76-dkms";

--- a/pkgs/os-specific/linux/tbs/default.nix
+++ b/pkgs/os-specific/linux/tbs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, kernel, kmod, perl, patchutils, perlPackages }:
+{ lib, fetchFromGitHub, kernel, kmod, perl, patchutils, perlPackages, buildModule }:
 let
 
   media = fetchFromGitHub rec {
@@ -17,7 +17,7 @@ let
     sha256 = "1329s7w9xlqjqwkpaqsd6b5dmzhm97jw0c7c7zzmmbdkl289i4i4";
   };
 
-in stdenv.mkDerivation {
+in buildModule {
   pname = "tbs";
   version = "2018.04.18-${kernel.version}";
 
@@ -46,8 +46,7 @@ in stdenv.mkDerivation {
 
   hardeningDisable = [ "all" ];
 
-  nativeBuildInputs = [ patchutils kmod perl perlPackages.ProcProcessTable ]
-  ++ kernel.moduleBuildDependencies;
+  nativeBuildInputs = [ patchutils kmod perl perlPackages.ProcProcessTable ];
 
    postInstall = ''
     find $out/lib/modules/${kernel.modDirVersion} -name "*.ko" -exec xz {} \;

--- a/pkgs/os-specific/linux/tp_smapi/default.nix
+++ b/pkgs/os-specific/linux/tp_smapi/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, lib, fetchFromGitHub, kernel, writeScript, coreutils, gnugrep, jq, curl, common-updater-scripts, runtimeShell
+{ stdenv, lib, fetchFromGitHub, kernel, writeScript, coreutils, gnugrep, jq, curl, common-updater-scripts, runtimeShell, buildModule
 }:
 
-stdenv.mkDerivation rec {
-  name = "tp_smapi-${version}-${kernel.version}";
+buildModule rec {
+  pname = "tp_smapi";
   version = "0.43";
 
   src = fetchFromGitHub {
@@ -12,8 +12,6 @@ stdenv.mkDerivation rec {
     sha256 = "1rjb0njckczc2mj05cagvj0lkyvmyk6bw7wkiinv81lw8m90g77g";
     name = "tp-smapi-${version}";
   };
-
-  nativeBuildInputs = kernel.moduleBuildDependencies;
 
   hardeningDisable = [ "pic" ];
 
@@ -37,12 +35,13 @@ stdenv.mkDerivation rec {
     inherit lib writeScript coreutils gnugrep jq curl common-updater-scripts runtimeShell;
   };
 
+  overridePlatforms = [ "x86_64-linux" "i686-linux" ];
+
   meta = {
     description = "IBM ThinkPad hardware functions driver";
     homepage = "https://github.com/evgeni/tp_smapi";
     license = lib.licenses.gpl2;
     maintainers = [ ];
     # driver is only ment for linux thinkpads i think  bellow platforms should cover it.
-    platforms = [ "x86_64-linux" "i686-linux" ];
   };
 }

--- a/pkgs/os-specific/linux/v4l2loopback/default.nix
+++ b/pkgs/os-specific/linux/v4l2loopback/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, kernel, kmod }:
+{ lib, fetchFromGitHub, kernel, kmod, buildModule }:
 
-stdenv.mkDerivation rec {
+buildModule rec {
   pname = "v4l2loopback";
   version = "unstable-2021-07-13-${kernel.version}";
 
@@ -19,8 +19,6 @@ stdenv.mkDerivation rec {
     export PATH=${kmod}/sbin:$PATH
   '';
 
-  nativeBuildInputs = kernel.moduleBuildDependencies;
-
   buildInputs = [ kmod ];
 
   postInstall = ''
@@ -31,7 +29,6 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "KERNELRELEASE=${kernel.modDirVersion}"
-    "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];
 
   meta = with lib; {
@@ -39,7 +36,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/umlaeute/v4l2loopback";
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ fortuneteller2k ];
-    platforms = platforms.linux;
     outputsToInstall = [ "out" ];
   };
 }

--- a/pkgs/os-specific/linux/veikk-linux-driver/default.nix
+++ b/pkgs/os-specific/linux/veikk-linux-driver/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, kernel }:
+{ lib, fetchFromGitHub, kernel, buildModule }:
 
-stdenv.mkDerivation rec {
+buildModule rec {
   pname = "veikk-linux-driver";
   version = "2.0";
 
@@ -10,8 +10,6 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "11mg74ds58jwvdmi3i7c4chxs6v9g09r9ll22pc2kbxjdnrp8zrn";
   };
-
-  nativeBuildInputs = kernel.moduleBuildDependencies;
 
   buildInputs = [ kernel ];
 
@@ -28,7 +26,6 @@ stdenv.mkDerivation rec {
     description = "Linux driver for VEIKK-brand digitizers";
     homepage = "https://github.com/jlam55555/veikk-linux-driver/";
     license = licenses.gpl2Only;
-    platforms = platforms.linux;
     maintainers = with maintainers; [ nicbk ];
     broken = kernel.kernelOlder "4.19";
   };

--- a/pkgs/os-specific/linux/vendor-reset/default.nix
+++ b/pkgs/os-specific/linux/vendor-reset/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, kernel, lib }:
+{ fetchFromGitHub, kernel, lib, buildModule }:
 
-stdenv.mkDerivation rec {
-  name = "vendor-reset-${version}-${kernel.version}";
+buildModule rec {
+  pname = "vendor-reset";
   version = "unstable-2021-02-16";
 
   src = fetchFromGitHub {
@@ -11,25 +11,19 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-xa7P7+mRk4FVgi+YYCcsFLfyNqPmXvy3xhGoTDVqPxw=";
   };
 
-  nativeBuildInputs = kernel.moduleBuildDependencies;
-
   hardeningDisable = [ "pic" ];
-
-  makeFlags = [
-    "KVER=${kernel.modDirVersion}"
-    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
-  ];
 
   installPhase = ''
     install -D vendor-reset.ko -t "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/misc/"
   '';
+
+  overridePlatforms = [ "x86_64-linux" ];
 
   meta = with lib; {
     description = "Linux kernel vendor specific hardware reset module";
     homepage = "https://github.com/gnif/vendor-reset";
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ wedens ];
-    platforms = [ "x86_64-linux" ];
     broken = kernel.kernelOlder "4.19";
   };
 }

--- a/pkgs/os-specific/linux/virtualbox/default.nix
+++ b/pkgs/os-specific/linux/virtualbox/default.nix
@@ -1,15 +1,14 @@
-{ stdenv, virtualbox, kernel }:
+{ virtualbox, kernel, buildModule }:
 
-stdenv.mkDerivation {
-  name = "virtualbox-modules-${virtualbox.version}-${kernel.version}";
+buildModule {
+  pname = "virtualbox-modules";
+  version = "${virtualbox.version}-${kernel.version}";
   src = virtualbox.modsrc;
   hardeningDisable = [
     "fortify" "pic" "stackprotector"
   ];
 
-  nativeBuildInputs = kernel.moduleBuildDependencies;
-
-  KERN_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+  # KERN_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"; TODO(berdario) unused?
 
   makeFlags = [ "INSTALL_MOD_PATH=$(out)" ];
   installTargets = [ "install" ];

--- a/pkgs/os-specific/linux/wireguard/default.nix
+++ b/pkgs/os-specific/linux/wireguard/default.nix
@@ -1,11 +1,11 @@
-{ lib, stdenv, fetchzip, kernel, perl, wireguard-tools, bc }:
+{ lib, fetchzip, kernel, perl, wireguard-tools, bc, buildModule }:
 
 # module requires Linux >= 3.10 https://www.wireguard.io/install/#kernel-requirements
 assert lib.versionAtLeast kernel.version "3.10";
 # wireguard upstreamed since 5.6 https://lists.zx2c4.com/pipermail/wireguard/2019-December/004704.html
 assert lib.versionOlder kernel.version "5.6";
 
-stdenv.mkDerivation rec {
+buildModule rec {
   pname = "wireguard";
   version = "1.0.20210606";
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
 
-  nativeBuildInputs = [ perl bc ] ++ kernel.moduleBuildDependencies;
+  nativeBuildInputs = [ perl bc ];
 
   preBuild = "cd src";
   buildFlags = [ "module" ];
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     inherit (wireguard-tools) tests;
   };
 
-  meta = with lib; {
+  meta = {
     inherit (wireguard-tools.meta) homepage license maintainers;
     description = "Kernel module for the WireGuard secure network tunnel";
     longDescription = ''
@@ -41,6 +41,5 @@ stdenv.mkDerivation rec {
       (as WireGuard was merged into the Linux kernel for 5.6)
     '';
     downloadPage = "https://git.zx2c4.com/wireguard-linux-compat/refs/";
-    platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/xmm7360-pci/default.nix
+++ b/pkgs/os-specific/linux/xmm7360-pci/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, kernel, perl, bc, breakpointHook }:
+{ lib, fetchFromGitHub, fetchpatch, kernel, perl, bc, breakpointHook, buildModule }:
 
-stdenv.mkDerivation rec {
+buildModule rec {
   pname = "xmm7360-pci";
   version = "unstable-2021-07-19";
 
@@ -11,10 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1wdb0phqg9rj9g9ycqdya0m7lx24kzjlh25yw0ifp898ddxrrr0c";
   };
 
-  makeFlags = [ "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" ];
-
-  nativeBuildInputs = kernel.moduleBuildDependencies;
-  INSTALL_MOD_PATH = placeholder "out";
+  # INSTALL_MOD_PATH = placeholder "out"; TODO(berdario) unused?
   installFlags = [ "DEPMOD=true" ];
 
   meta = with lib; {
@@ -23,7 +20,6 @@ stdenv.mkDerivation rec {
     downloadPage = "https://github.com/xmm7360/xmm7360-pci";
     license = licenses.isc;
     maintainers = with maintainers; [ flokli hexa ];
-    platforms = platforms.linux;
     broken = kernel.kernelOlder "4.10" || kernel.kernelAtLeast "5.14";
   };
 }

--- a/pkgs/os-specific/linux/xpadneo/default.nix
+++ b/pkgs/os-specific/linux/xpadneo/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, kernel, bluez }:
+{ lib, fetchFromGitHub, kernel, bluez, buildModule }:
 
-stdenv.mkDerivation rec {
+buildModule rec {
   pname = "xpadneo";
   version = "0.9.1";
 
@@ -15,7 +15,6 @@ stdenv.mkDerivation rec {
     export sourceRoot=$(pwd)/source/hid-xpadneo/src
   '';
 
-  nativeBuildInputs = kernel.moduleBuildDependencies;
   buildInputs = [ bluez ];
 
   makeFlags = [
@@ -34,6 +33,5 @@ stdenv.mkDerivation rec {
     homepage = "https://atar-axis.github.io/xpadneo";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ kira-bruneau ];
-    platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/zenpower/default.nix
+++ b/pkgs/os-specific/linux/zenpower/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, kernel, fetchFromGitHub, fetchpatch }:
+{ lib, kernel, fetchFromGitHub, fetchpatch, buildModule }:
 
-stdenv.mkDerivation rec {
+buildModule rec {
   pname = "zenpower";
   version = "0.1.13";
 
@@ -13,20 +13,19 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "pic" ];
 
-  nativeBuildInputs = kernel.moduleBuildDependencies;
-
   makeFlags = [ "KERNEL_BUILD=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" ];
 
   installPhase = ''
     install -D zenpower.ko -t "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/hwmon/zenpower/"
   '';
 
+  overridePlatforms = [ "x86_64-linux" ];
+
   meta = with lib; {
     description = "Linux kernel driver for reading temperature, voltage(SVI2), current(SVI2) and power(SVI2) for AMD Zen family CPUs.";
     homepage = "https://github.com/Ta180m/zenpower3";
     license = licenses.gpl2;
     maintainers = with maintainers; [ alexbakker artturin ];
-    platforms = [ "x86_64-linux" ];
     broken = versionOlder kernel.version "4.14";
   };
 }

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -98,6 +98,7 @@ let
           "PATH=${makeBinPath [ coreutils gawk gnused gnugrep systemd ]}"
       '';
 
+      # TODO(berdario) buildKernel is a similar mechanism as the one used for amd and nvidia
       nativeBuildInputs = [ autoreconfHook269 nukeReferences ]
         ++ optionals buildKernel (kernel.moduleBuildDependencies ++ [ perl ])
         ++ optional buildUser pkg-config;

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -200,7 +200,7 @@ in {
 
     linux_lqx = callPackage ../os-specific/linux/kernel/linux-lqx.nix {
       kernelPatches = [
-        kernelPatches.bridge_stp_helper
+        kernelPatches.bridge_stp_helper 
         kernelPatches.request_key_helper
       ];
     };
@@ -244,13 +244,30 @@ in {
     inherit (pkgs) odp-dpdk pktgen; # added 2018-05
     inherit (pkgs) bcc bpftrace; # added 2021-12
 
+
+    buildModule = {makeFlags ? [], pname, version, src ? {}, srcs ? [], KERNELDIR ?"", INSTALL_MOD_PATH?"", dontStrip ? false, outputs ? [],overridePlatforms ? lib.platforms.linux, passthru ? {}, nativeBuildInputs ? [], setSourceRoot ? "", preInstall?"", prePatch ? "", buildFlags ? [], installFlags ? [], installTargets ? [],patches ? [], meta, installPhase ? "", unpackPhase ? "", postPatch ? "", postInstall ? "", hardeningDisable ? [], buildInputs ? [], enableParallelBuilding ? false, sourceRoot ? ".", postFixup ? "", depLibPath ? [], NIX_CFLAGS_COMPILE ? "", postBuild ? "", modules ? [], postUnpack ? "", patchPhase ? "", buildPhase ? "", preBuild ? "", preConfigure ? "", configurePhase ? ""}@attrs : stdenv.mkDerivation (attrs // {
+      meta.platforms = overridePlatforms;
+
+      nativeBuildInputs = nativeBuildInputs ++ kernel.moduleBuildDependencies;
+      
+      makeFlags = kernel.makeFlags ++ makeFlags ++ [
+        "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+        "KVER=${kernel.modDirVersion}"
+        "KERNEL_MODLIB=$(out)/lib/modules/${kernel.modDirVersion}"
+        "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+        "INCLUDEDIR=$(out)/include"
+        "INSTALL_MOD_PATH=$(out)"
+      ];
+    });
+
+
     acpi_call = callPackage ../os-specific/linux/acpi-call {};
 
     akvcam = callPackage ../os-specific/linux/akvcam { };
 
-    amdgpu-pro = callPackage ../os-specific/linux/amdgpu-pro { };
+    # amdgpu-pro = callPackage ../os-specific/linux/amdgpu-pro { }; TODO(berdario) cannot download amdgpu-pro-22.05pre-git-492261.tar.xz from any mirror
 
-    anbox = callPackage ../os-specific/linux/anbox/kmod.nix { };
+    # anbox = callPackage ../os-specific/linux/anbox/kmod.nix { }; TODO(berdario) should be marked as broken, but currently isn't
 
     apfs = callPackage ../os-specific/linux/apfs { };
 
@@ -269,11 +286,11 @@ in {
 
     ddcci-driver = callPackage ../os-specific/linux/ddcci { };
 
-    digimend = callPackage ../os-specific/linux/digimend { };
+    # digimend = callPackage ../os-specific/linux/digimend { }; TODO(berdario) fixme
 
-    dpdk-kmods = callPackage ../os-specific/linux/dpdk-kmods { };
+    # dpdk-kmods = callPackage ../os-specific/linux/dpdk-kmods { }; TODO(berdario) fixme
 
-    exfat-nofuse = callPackage ../os-specific/linux/exfat { };
+    # exfat-nofuse = callPackage ../os-specific/linux/exfat { }; TODO(berdario) fixme
 
     evdi = callPackage ../os-specific/linux/evdi { };
 
@@ -288,13 +305,14 @@ in {
 
     intel-speed-select = if lib.versionAtLeast kernel.version "5.3" then callPackage ../os-specific/linux/intel-speed-select { } else null;
 
-    ixgbevf = callPackage ../os-specific/linux/ixgbevf {};
+    # ixgbevf = callPackage ../os-specific/linux/ixgbevf {}; TODO(berdario) fixme
 
     it87 = callPackage ../os-specific/linux/it87 {};
 
     asus-wmi-sensors = callPackage ../os-specific/linux/asus-wmi-sensors {};
 
-    ena = callPackage ../os-specific/linux/ena {};
+    # TODO(berdario) fixme
+    # ena = callPackage ../os-specific/linux/ena {};
 
     v4l2loopback = callPackage ../os-specific/linux/v4l2loopback { };
 
@@ -302,20 +320,21 @@ in {
 
     broadcom_sta = callPackage ../os-specific/linux/broadcom-sta { };
 
-    tbs = callPackage ../os-specific/linux/tbs { };
+    # tbs = callPackage ../os-specific/linux/tbs { }; TODO(berdario) fixme
 
     mbp2018-bridge-drv = callPackage ../os-specific/linux/mbp-modules/mbp2018-bridge-drv { };
 
     nvidiabl = callPackage ../os-specific/linux/nvidiabl { };
 
-    nvidiaPackages = dontRecurseIntoAttrs (callPackage ../os-specific/linux/nvidia-x11 { });
+    # TODO(berdario) fixme
+    # nvidiaPackages = dontRecurseIntoAttrs (callPackage ../os-specific/linux/nvidia-x11 { });
 
-    nvidia_x11_legacy340   = nvidiaPackages.legacy_340;
-    nvidia_x11_legacy390   = nvidiaPackages.legacy_390;
-    nvidia_x11_legacy470   = nvidiaPackages.legacy_470;
-    nvidia_x11_beta        = nvidiaPackages.beta;
-    nvidia_x11_vulkan_beta = nvidiaPackages.vulkan_beta;
-    nvidia_x11             = nvidiaPackages.stable;
+    # nvidia_x11_legacy340   = nvidiaPackages.legacy_340;
+    # nvidia_x11_legacy390   = nvidiaPackages.legacy_390;
+    # nvidia_x11_legacy470   = nvidiaPackages.legacy_470;
+    # nvidia_x11_beta        = nvidiaPackages.beta;
+    # nvidia_x11_vulkan_beta = nvidiaPackages.vulkan_beta;
+    # nvidia_x11             = nvidiaPackages.stable;
 
     openrazer = callPackage ../os-specific/linux/openrazer/driver.nix { };
 
@@ -329,7 +348,7 @@ in {
 
     rtl8192eu = callPackage ../os-specific/linux/rtl8192eu { };
 
-    rtl8723bs = callPackage ../os-specific/linux/rtl8723bs { };
+    # rtl8723bs = callPackage ../os-specific/linux/rtl8723bs { }; TODO(berdario) fixme
 
     rtl8812au = callPackage ../os-specific/linux/rtl8812au { };
 
@@ -341,7 +360,7 @@ in {
 
     rtl8821ce = callPackage ../os-specific/linux/rtl8821ce { };
 
-    rtl88x2bu = callPackage ../os-specific/linux/rtl88x2bu { };
+    # rtl88x2bu = callPackage ../os-specific/linux/rtl88x2bu { }; TODO(berdario) fixme
 
     rtl8821cu = callPackage ../os-specific/linux/rtl8821cu { };
 
@@ -359,7 +378,7 @@ in {
 
     tuxedo-keyboard = if lib.versionAtLeast kernel.version "4.14" then callPackage ../os-specific/linux/tuxedo-keyboard { } else null;
 
-    jool = callPackage ../os-specific/linux/jool { };
+    # jool = callPackage ../os-specific/linux/jool { };  TODO(berdario) fixme
 
     kvmfr = callPackage ../os-specific/linux/kvmfr { };
 
@@ -371,7 +390,7 @@ in {
 
     # compiles but has to be integrated into the kernel somehow
     # Let's have it uncommented and finish it..
-    ndiswrapper = callPackage ../os-specific/linux/ndiswrapper { };
+    # ndiswrapper = callPackage ../os-specific/linux/ndiswrapper { }; TODO(berdario) temporarily comment since broken
 
     netatop = callPackage ../os-specific/linux/netatop { };
 
@@ -379,12 +398,12 @@ in {
 
     perf = if lib.versionAtLeast kernel.version "3.12" then callPackage ../os-specific/linux/kernel/perf.nix { } else null;
 
-    phc-intel = if lib.versionAtLeast kernel.version "4.10" then callPackage ../os-specific/linux/phc-intel { } else null;
+    # phc-intel = if lib.versionAtLeast kernel.version "4.10" then callPackage ../os-specific/linux/phc-intel { } else null; TODO(berdario) fixme
 
     # Disable for kernels 4.15 and above due to compatibility issues
     prl-tools = if lib.versionOlder kernel.version "4.15" then callPackage ../os-specific/linux/prl-tools { } else null;
 
-    sch_cake = callPackage ../os-specific/linux/sch_cake { };
+    # sch_cake = callPackage ../os-specific/linux/sch_cake { }; TODO(berdario) temporarily commented out since broken
 
     isgx = callPackage ../os-specific/linux/isgx { };
 
@@ -417,9 +436,10 @@ in {
 
     vhba = callPackage ../misc/emulators/cdemu/vhba.nix { };
 
-    virtualbox = callPackage ../os-specific/linux/virtualbox {
-      virtualbox = pkgs.virtualboxHardened;
-    };
+    # TODO(berdario) fixme
+    # virtualbox = callPackage ../os-specific/linux/virtualbox {
+    #   virtualbox = pkgs.virtualboxHardened;
+    # };
 
     virtualboxGuestAdditions = callPackage ../applications/virtualization/virtualbox/guest-additions {
       virtualbox = pkgs.virtualboxHardened;
@@ -431,7 +451,7 @@ in {
 
     x86_energy_perf_policy = callPackage ../os-specific/linux/x86_energy_perf_policy { };
 
-    xmm7360-pci = callPackage ../os-specific/linux/xmm7360-pci { };
+    # xmm7360-pci = callPackage ../os-specific/linux/xmm7360-pci { }; TODO(berdario) fixme
 
     xpadneo = callPackage ../os-specific/linux/xpadneo { };
 


### PR DESCRIPTION
WIP, I have a bunch of TODO(berdario) comments to remove...

@lovesegfault 's idea of being strict with the inputs means that we either:
- add as possible input attrs the env variables that are used for every module
- or we change them to integrate the env variables in the appropriate phase script.

I tried the latter (see pkgs/os-specific/linux/can-isotp/default.nix )but this is a quite annoying change to replicate across all of our modules. The [original change](https://github.com/berdario/nixpkgs/commit/0d7efd54bb325b8b0e55028349f895f0d3d395e5#r61620480) might be much easier to implement

also, example of a kernel module which does not actually have kernel.moduleBuildDependencies among its buildInputs: https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/akvcam/default.nix

###### Motivation for this change

Factor out the most common bits of configuration for Kernel modules. specifically, make flags might need to be reused en-masse when a different compiler is being used (or similar change). Having common flags specified in a `buildModule` lambda should help with this.

Also, documenting this, and providing it as the main way to implement/add new kernel modules might help to avoid copypasting  a bunch of boileraplate.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
