### PR TITLE
socat: fix darwin build by adding missing feature check

### DIFF
--- a/pkgs/tools/networking/socat/default.nix
+++ b/pkgs/tools/networking/socat/default.nix
@@ -16,6 +16,13 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-ZpCp+ZkEV7UFCXonK78sv0zDVXYXb3ZkbjUksOkcF2M=";
   };
 
+  patches = [
+    # This adds missing feature checks for TCP_INFO, a Linux feature
+    #
+    # Discussed in https://github.com/Homebrew/homebrew-core/pull/88595
+    ./socat-fix-feature-check-tcpinfo.patch
+  ];
+
   postPatch = ''
     patchShebangs test.sh
     substituteInPlace test.sh \

--- a/pkgs/tools/networking/socat/socat-fix-feature-check-tcpinfo.patch
+++ b/pkgs/tools/networking/socat/socat-fix-feature-check-tcpinfo.patch
@@ -1,0 +1,21 @@
+diff --git a/filan.c b/filan.c
+index 3465f7c..77c22a4 100644
+--- a/filan.c
++++ b/filan.c
+@@ -905,6 +905,7 @@ int tcpan(int fd, FILE *outfile) {
+ #if WITH_TCP
+ 
+ int tcpan2(int fd, FILE *outfile) {
++#ifdef TCP_INFO
+    struct tcp_info tcpinfo;
+    socklen_t tcpinfolen = sizeof(tcpinfo);
+    int result;
+@@ -930,6 +931,8 @@ int tcpan2(int fd, FILE *outfile) {
+    // fprintf(outfile, "%s={%u}\t", "TCPI_", tcpinfo.tcpi_);
+ 
+    return 0;
++#endif
++   return -1;
+ }
+ 
+ #endif /* WITH_TCP */


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Recent changes in the upstream code uses [`TCP_INFO` ](https://man7.org/linux/man-pages/man7/tcp.7.html) without checking if it's available. This PR adds the required check through a patch.

Socat doesn't seem to have an official issue tracker, but the issue seems to be discussed at https://github.com/Homebrew/homebrew-core/pull/88595.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
