### PR TITLE
libbass: disable until upstream provides stable urls

### DIFF
--- a/pkgs/development/libraries/audio/libbass/default.nix
+++ b/pkgs/development/libraries/audio/libbass/default.nix
@@ -60,6 +60,8 @@ let
       homepage = "https://www.un4seen.com/";
       license = licenses.unfreeRedistributable;
       platforms = builtins.attrNames bass.so;
+      # until upstream has stable URLs, this package is prone to always being broken
+      broken = true;
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change
cc @Profpatsch , `ultrastar-*` packages are the only consumer of this

Why does this matter to me?

because I keep seeing:
```
error: hash mismatch in fixed-output derivation '/nix/store/zxam85m6y6lnjlibzlvh4nk2ns8v7xlp-bass24-linux.zip.drv':
         specified: sha256-iB5IC09FB8FOqGuIhFCO5iBe3oqD1q2m/kccD13XvtI=
            got:    sha256-d/OHdiqe5Lcto8ZYHCLlBFareut8mnFUVkUwqUaNtlU=
error: hash mismatch in fixed-output derivation '/nix/store/m39s8rmsdkai3g3fjmw7vdan99gnlxbr-bass_fx24-linux.zip.drv':
         specified: sha256-Ni4dhEdd01N0VHtWkEOUUmzE4rL2jVX0xR36eD45D+A=
            got:    sha256-qY64G63lK9zC1Z6NaAPeqX7UBg87mOcJfwXbH5FIHLU=
```

and I first started noticing this at the beginning of ZHF.

"Just update the sha's" isn't good enough, as this is liable to break at any time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
