### PR TITLE
llvmPackages_5.compiler-rt: fix build against gcc-12

### DIFF
--- a/pkgs/development/compilers/llvm/5/compiler-rt/compiler-rt-5-cstddef.patch
+++ b/pkgs/development/compilers/llvm/5/compiler-rt/compiler-rt-5-cstddef.patch
@@ -1,0 +1,10 @@
+--- a/lib/xray/xray_buffer_queue.h
++++ b/lib/xray/xray_buffer_queue.h
+@@ -17,6 +17,7 @@
+ 
+ #include "sanitizer_common/sanitizer_atomic.h"
+ #include "sanitizer_common/sanitizer_mutex.h"
++#include <cstddef>
+ #include <deque>
+ #include <unordered_set>
+ #include <utility>

--- a/pkgs/development/compilers/llvm/5/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/5/compiler-rt/default.nix
@@ -58,6 +58,7 @@ stdenv.mkDerivation {
 
     ./sys-ustat.patch
     ../../common/compiler-rt/libsanitizer-no-cyclades-9.patch
+    ./compiler-rt-5-cstddef.patch
   ] ++ lib.optional stdenv.hostPlatform.isAarch32 ./armv7l.patch;
 
   # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks


### PR DESCRIPTION
    [ 11%] Building CXX object lib/xray/CMakeFiles/clang_rt.xray-x86_64.dir/xray_buffer_queue.cc.o
    In file included from lib/xray/xray_buffer_queue.cc:15:
    lib/xray/xray_buffer_queue.h:35:5: error: 'size_t' does not name a type
       35 |     size_t Size = 0;
          |     ^~~~~~
    lib/xray/xray_buffer_queue.h:23:1: note: 'size_t' is defined in header '<cstddef>';
      did you forget to '#include <cstddef>'?
       22 | #include <utility>
      +++ |+#include <cstddef>
       23 |
