### PR TITLE
ocaml: enable parallel building

### DIFF
--- a/pkgs/development/compilers/ocaml/Makefile.nixpkgs
+++ b/pkgs/development/compilers/ocaml/Makefile.nixpkgs
@@ -1,0 +1,16 @@
+# ocaml build system does not allow for parallel building of some
+# top-level targets like 'world', 'bootstrap', 'world.opt' as
+# then spawn '$(MAKE) all' subprocesses that conflict among each
+# other. But we would still like to run each target in parallel
+# individually. This file defines such entry points.
+
+# Re-export all existing phases to make 'make install' work as is.
+include Makefile
+
+nixpkgs_world:
+	$(MAKE) world
+
+nixpkgs_world_bootstrap_world_opt:
+	$(MAKE) world
+	$(MAKE) bootstrap
+	$(MAKE) world.opt

--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -68,7 +68,18 @@ stdenv.mkDerivation (args // {
   # x86_64-unknown-linux-musl-ld: -r and -pie may not be used together
   hardeningDisable = lib.optional (lib.versionAtLeast version "4.09" && stdenv.hostPlatform.isMusl) "pie";
 
-  buildFlags = [ "world" ] ++ optionals useNativeCompilers [ "bootstrap" "world.opt" ];
+  # Older versions have some race:
+  #  cp: cannot stat 'boot/ocamlrun': No such file or directory
+  #  make[2]: *** [Makefile:199: backup] Error 1
+  enableParallelBuilding = lib.versionAtLeast version "4.08";
+
+  # Workaround lack of parallelism support among top-level targets:
+  # we place nixpkgs-specific targets to a separate file and set
+  # sequential order among them as a single rule.
+  makefile = ./Makefile.nixpkgs;
+  buildFlags = if useNativeCompilers
+    then ["nixpkgs_world_bootstrap_world_opt"]
+    else ["nixpkgs_world"];
   buildInputs = optional (!lib.versionAtLeast version "4.07") ncurses
     ++ optionals useX11 [ libX11 xorgproto ];
   propagatedBuildInputs = optional spaceTimeSupport libunwind;


### PR DESCRIPTION
Enable parallel building for ocaml-4.06 and above. tested as:

    $ nix build -f. ocaml-ng.ocamlPackages_{4_{00_1,01_0,02,03,04,05,06,07,08,09,10,11,12,13},latest}.ocaml --keep-going

ocaml build system supports parallel building, but but for multiple
top-level targets at the same time as it usually spawns subprocess
$(MAKE) that occasionally conflict with one another. To work it around
we use tiny Makefile with a single rule that calls top-level targets
sequentially as makefile calls:

    nixpkgs_world_bootstrap_world_opt:
       $(MAKE) world
       $(MAKE) bootstrap
       $(MAKE) world.opt

On a 16-core machine ocaml-4.12 build speeds up from 6m55s to 1m35s.

Releases 4_00_1, 4_01_0, 4_04 and 4_05 still have some race in them.
Thus this change enables parallel builds only for ocaml-4.06 and above.

Ropening of #142723 without the change to ocaml 4.00
all credits goes to @trofi

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
