### PR TITLE
nixos/guix: init at 1.3.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -386,6 +386,7 @@
   ./services/development/bloop.nix
   ./services/development/blackfire.nix
   ./services/development/distccd.nix
+  ./services/development/guix.nix
   ./services/development/hoogle.nix
   ./services/development/jupyter/default.nix
   ./services/development/jupyterhub/default.nix

--- a/nixos/modules/services/development/guix.nix
+++ b/nixos/modules/services/development/guix.nix
@@ -1,0 +1,95 @@
+{config, pkgs, lib, ...}:
+
+with lib;
+
+let
+
+  cfg = config.services.guix;
+
+  buildGuixUser = i:
+    {
+      "guixbuilder${builtins.toString i}" = {
+        group = "guixbuild";
+        extraGroups = ["guixbuild"];
+        home = "/var/empty";
+        shell = pkgs.nologin;
+        description = "Guix build user ${builtins.toString i}";
+        isSystemUser = true;
+      };
+    };
+
+in {
+
+  options.services.guix = {
+    enable = mkEnableOption "GNU Guix package manager";
+    package = mkOption {
+      type = types.package;
+      default = pkgs.guix;
+      defaultText = "pkgs.guix";
+      description = "Package that contains the guix binary and initial store.";
+    };
+  };
+
+  config = mkIf (cfg.enable) {
+
+    users = {
+      extraUsers = lib.fold (a: b: a // b) {} (builtins.map buildGuixUser (lib.range 1 10));
+      extraGroups.guixbuild = {name = "guixbuild";};
+    };
+
+    systemd.services.guix-daemon = {
+      enable = true;
+      description = "Build daemon for GNU Guix";
+      serviceConfig = {
+        ExecStart="/var/guix/profiles/per-user/root/current-guix/bin/guix-daemon --build-users-group=guixbuild";
+        Environment="GUIX_LOCPATH=/var/guix/profiles/per-user/root/guix-profile/lib/locale";
+        RemainAfterExit="yes";
+
+        # See <https://lists.gnu.org/archive/html/guix-devel/2016-04/msg00608.html>.
+        # Some package builds (for example, go@1.8.1) may require even more than
+        # 1024 tasks.
+        TasksMax="8192";
+      };
+      wantedBy = [ "multi-user.target" ];
+    };
+
+    system.activationScripts.guix = ''
+
+      # copy initial /gnu/store
+      if [ ! -d /gnu/store ]
+      then
+        mkdir -p /gnu
+        cp -ra ${cfg.package.store}/gnu/store /gnu/
+      fi
+
+      # copy initial /var/guix content
+      if [ ! -d /var/guix ]
+      then
+        mkdir -p /var
+        cp -ra ${cfg.package.var}/var/guix /var/
+      fi
+
+      # root profile
+      if [ ! -d ~root/.config/guix ]
+      then
+        mkdir -p ~root/.config/guix
+        ln -sf /var/guix/profiles/per-user/root/current-guix \
+          ~root/.config/guix/current
+      fi
+
+      # authorize substitutes
+      GUIX_PROFILE="`echo ~root`/.config/guix/current"; source $GUIX_PROFILE/etc/profile
+      guix archive --authorize < ~root/.config/guix/current/share/guix/ci.guix.info.pub
+    '';
+
+    environment.shellInit = ''
+      # Make the Guix command available to users
+      export PATH="/var/guix/profiles/per-user/root/current-guix/bin:$PATH"
+
+      export GUIX_LOCPATH="$HOME/.guix-profile/lib/locale"
+      export PATH="$HOME/.guix-profile/bin:$PATH"
+      export INFOPATH="$HOME/.guix-profile/share/info:$INFOPATH"
+    '';
+  };
+
+}

--- a/nixos/modules/services/development/guix.nix
+++ b/nixos/modules/services/development/guix.nix
@@ -1,4 +1,4 @@
-{config, pkgs, lib, ...}:
+{ config, pkgs, lib, ... }:
 
 with lib;
 
@@ -10,7 +10,7 @@ let
     {
       "guixbuilder${builtins.toString i}" = {
         group = "guixbuild";
-        extraGroups = ["guixbuild"];
+        extraGroups = [ "guixbuild" ];
         home = "/var/empty";
         shell = pkgs.nologin;
         description = "Guix build user ${builtins.toString i}";
@@ -18,7 +18,8 @@ let
       };
     };
 
-in {
+in
+{
 
   options.services.guix = {
     enable = mkEnableOption "GNU Guix package manager";
@@ -33,22 +34,22 @@ in {
   config = mkIf (cfg.enable) {
 
     users = {
-      extraUsers = lib.fold (a: b: a // b) {} (builtins.map buildGuixUser (lib.range 1 10));
-      extraGroups.guixbuild = {name = "guixbuild";};
+      extraUsers = lib.fold (a: b: a // b) { } (builtins.map buildGuixUser (lib.range 1 10));
+      extraGroups.guixbuild = { name = "guixbuild"; };
     };
 
     systemd.services.guix-daemon = {
       enable = true;
       description = "Build daemon for GNU Guix";
       serviceConfig = {
-        ExecStart="/var/guix/profiles/per-user/root/current-guix/bin/guix-daemon --build-users-group=guixbuild";
-        Environment="GUIX_LOCPATH=/var/guix/profiles/per-user/root/guix-profile/lib/locale";
-        RemainAfterExit="yes";
+        ExecStart = "/var/guix/profiles/per-user/root/current-guix/bin/guix-daemon --build-users-group=guixbuild";
+        Environment = "GUIX_LOCPATH=/var/guix/profiles/per-user/root/guix-profile/lib/locale";
+        RemainAfterExit = "yes";
 
         # See <https://lists.gnu.org/archive/html/guix-devel/2016-04/msg00608.html>.
         # Some package builds (for example, go@1.8.1) may require even more than
         # 1024 tasks.
-        TasksMax="8192";
+        TasksMax = "8192";
       };
       wantedBy = [ "multi-user.target" ];
     };

--- a/pkgs/development/guix/guix.nix
+++ b/pkgs/development/guix/guix.nix
@@ -1,0 +1,42 @@
+{stdenv, fetchurl}:
+stdenv.mkDerivation rec
+  { name = "guix-${version}";
+    version = "1.0.0";
+
+    src = fetchurl {
+      url = "https://ftp.gnu.org/gnu/guix/guix-binary-${version}.${stdenv.targetPlatform.system}.tar.xz";
+      sha256 = {
+        "x86_64-linux" = "11y9nnicd3ah8dhi51mfrjmi8ahxgvx1mhpjvsvdzaz07iq56333";
+        "i686-linux" = "14qkz12nsw0cm673jqx0q6ls4m2bsig022iqr0rblpfrgzx20f0i";
+        "aarch64-linux" = "0qzlpvdkiwz4w08xvwlqdhz35mjfmf1v3q8mv7fy09bk0y3cwzqs";
+        }."${stdenv.targetPlatform.system}";
+    };
+    sourceRoot = ".";
+
+    outputs = [ "out" "store" "var" ];
+    phases = [ "unpackPhase" "installPhase" ];
+
+    installPhase = ''
+      # copy the /gnu/store content
+      mkdir -p $store
+      cp -r gnu $store
+
+      # copy /var content
+      mkdir -p $var
+      cp -r var $var
+
+      # link guix binaries
+      mkdir -p $out/bin
+      ln -s /var/guix/profiles/per-user/root/current-guix/bin/guix $out/bin/guix
+      ln -s /var/guix/profiles/per-user/root/current-guix/bin/guix-daemon $out/bin/guix-daemon
+    '';
+
+    meta = with stdenv.lib; {
+      description = "The GNU Guix package manager";
+      homepage = https://www.gnu.org/software/guix/;
+      license = licenses.gpl3Plus;
+      maintainers = [ maintainers.johnazoidberg ];
+      platforms = [ "aarch64-linux" "i686-linux" "x86_64-linux" ];
+    };
+
+  }

--- a/pkgs/development/guix/guix.nix
+++ b/pkgs/development/guix/guix.nix
@@ -1,15 +1,16 @@
-{ stdenv, fetchurl }:
+{ stdenv, lib, fetchurl }:
+
 stdenv.mkDerivation rec
 {
   name = "guix-${version}";
-  version = "1.0.0";
+  version = "1.3.0";
 
   src = fetchurl {
     url = "https://ftp.gnu.org/gnu/guix/guix-binary-${version}.${stdenv.targetPlatform.system}.tar.xz";
     sha256 = {
-      "x86_64-linux" = "11y9nnicd3ah8dhi51mfrjmi8ahxgvx1mhpjvsvdzaz07iq56333";
-      "i686-linux" = "14qkz12nsw0cm673jqx0q6ls4m2bsig022iqr0rblpfrgzx20f0i";
-      "aarch64-linux" = "0qzlpvdkiwz4w08xvwlqdhz35mjfmf1v3q8mv7fy09bk0y3cwzqs";
+      "x86_64-linux" = "sha256-xffvtIlHVF5J0tr0jQ+DLzXSqNGfZdqvYHlCWsMnwFA=";
+      "i686-linux" = "sha256-QHOK7hFh8LmRFK+EnNBNqfDNwQ0ia0lqRiHov9uyG2Q=";
+      "aarch64-linux" = "sha256-RE9lNs9ZWWNhI6xxjbm4UHFQLkhVVbLYAb8pNpMIEM4=";
     }."${stdenv.targetPlatform.system}";
   };
   sourceRoot = ".";
@@ -32,12 +33,11 @@ stdenv.mkDerivation rec
     ln -s /var/guix/profiles/per-user/root/current-guix/bin/guix-daemon $out/bin/guix-daemon
   '';
 
-  meta = with stdenv.lib; {
+  meta = {
     description = "The GNU Guix package manager";
     homepage = https://www.gnu.org/software/guix/;
-    license = licenses.gpl3Plus;
-    maintainers = [ maintainers.johnazoidberg ];
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ johnazoidberg mohe2015 ];
     platforms = [ "aarch64-linux" "i686-linux" "x86_64-linux" ];
   };
-
 }

--- a/pkgs/development/guix/guix.nix
+++ b/pkgs/development/guix/guix.nix
@@ -1,42 +1,43 @@
-{stdenv, fetchurl}:
+{ stdenv, fetchurl }:
 stdenv.mkDerivation rec
-  { name = "guix-${version}";
-    version = "1.0.0";
+{
+  name = "guix-${version}";
+  version = "1.0.0";
 
-    src = fetchurl {
-      url = "https://ftp.gnu.org/gnu/guix/guix-binary-${version}.${stdenv.targetPlatform.system}.tar.xz";
-      sha256 = {
-        "x86_64-linux" = "11y9nnicd3ah8dhi51mfrjmi8ahxgvx1mhpjvsvdzaz07iq56333";
-        "i686-linux" = "14qkz12nsw0cm673jqx0q6ls4m2bsig022iqr0rblpfrgzx20f0i";
-        "aarch64-linux" = "0qzlpvdkiwz4w08xvwlqdhz35mjfmf1v3q8mv7fy09bk0y3cwzqs";
-        }."${stdenv.targetPlatform.system}";
-    };
-    sourceRoot = ".";
+  src = fetchurl {
+    url = "https://ftp.gnu.org/gnu/guix/guix-binary-${version}.${stdenv.targetPlatform.system}.tar.xz";
+    sha256 = {
+      "x86_64-linux" = "11y9nnicd3ah8dhi51mfrjmi8ahxgvx1mhpjvsvdzaz07iq56333";
+      "i686-linux" = "14qkz12nsw0cm673jqx0q6ls4m2bsig022iqr0rblpfrgzx20f0i";
+      "aarch64-linux" = "0qzlpvdkiwz4w08xvwlqdhz35mjfmf1v3q8mv7fy09bk0y3cwzqs";
+    }."${stdenv.targetPlatform.system}";
+  };
+  sourceRoot = ".";
 
-    outputs = [ "out" "store" "var" ];
-    phases = [ "unpackPhase" "installPhase" ];
+  outputs = [ "out" "store" "var" ];
+  phases = [ "unpackPhase" "installPhase" ];
 
-    installPhase = ''
-      # copy the /gnu/store content
-      mkdir -p $store
-      cp -r gnu $store
+  installPhase = ''
+    # copy the /gnu/store content
+    mkdir -p $store
+    cp -r gnu $store
 
-      # copy /var content
-      mkdir -p $var
-      cp -r var $var
+    # copy /var content
+    mkdir -p $var
+    cp -r var $var
 
-      # link guix binaries
-      mkdir -p $out/bin
-      ln -s /var/guix/profiles/per-user/root/current-guix/bin/guix $out/bin/guix
-      ln -s /var/guix/profiles/per-user/root/current-guix/bin/guix-daemon $out/bin/guix-daemon
-    '';
+    # link guix binaries
+    mkdir -p $out/bin
+    ln -s /var/guix/profiles/per-user/root/current-guix/bin/guix $out/bin/guix
+    ln -s /var/guix/profiles/per-user/root/current-guix/bin/guix-daemon $out/bin/guix-daemon
+  '';
 
-    meta = with stdenv.lib; {
-      description = "The GNU Guix package manager";
-      homepage = https://www.gnu.org/software/guix/;
-      license = licenses.gpl3Plus;
-      maintainers = [ maintainers.johnazoidberg ];
-      platforms = [ "aarch64-linux" "i686-linux" "x86_64-linux" ];
-    };
+  meta = with stdenv.lib; {
+    description = "The GNU Guix package manager";
+    homepage = https://www.gnu.org/software/guix/;
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.johnazoidberg ];
+    platforms = [ "aarch64-linux" "i686-linux" "x86_64-linux" ];
+  };
 
-  }
+}

--- a/pkgs/development/guix/guix.nix
+++ b/pkgs/development/guix/guix.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec
 
   meta = {
     description = "The GNU Guix package manager";
-    homepage = https://www.gnu.org/software/guix/;
+    homepage = "https://www.gnu.org/software/guix/";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ johnazoidberg mohe2015 ];
     platforms = [ "aarch64-linux" "i686-linux" "x86_64-linux" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -509,6 +509,8 @@ with pkgs;
 
   graph-easy = callPackage ../tools/graphics/graph-easy { };
 
+  guix = callPackage ../development/guix/guix.nix { };
+
   packer = callPackage ../development/tools/packer { };
 
   packr = callPackage ../development/libraries/packr { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Successor of https://github.com/NixOS/nixpkgs/pull/56430
Would like to try out Guix a bit.

###### Things done
Commits will be properly rebased later of course.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
