### PR TITLE
writers.writePython2: remove / writers.writePyPy{2,3}: init

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -83,11 +83,22 @@
           release based on GTK+3 and Python 3.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          The <literal>writers.writePython2</literal> and corresponding
+          <literal>writers.writePython2Bin</literal> convenience
+          functions to create executable Python 2 scripts in the store
+          were removed in preparation of removal of the Python 2
+          interpreter. Scripts have to be converted to Python 3 for use
+          with <literal>writers.writePython3</literal> or
+          <literal>writers.writePyPy2</literal> needs to be used.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-22.05-notable-changes">
     <title>Other Notable Changes</title>
-    <itemizedlist spacing="compact">
+    <itemizedlist>
       <listitem>
         <para>
           The option
@@ -111,6 +122,16 @@
           are only accessible by default to the members of the Unix
           group <literal>redis-${serverName}</literal> through the Unix
           socket <literal>/run/redis-${serverName}/redis.sock</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The
+          <literal>writers.writePyPy2</literal>/<literal>writers.writePyPy3</literal>
+          and corresponding
+          <literal>writers.writePyPy2Bin</literal>/<literal>writers.writePyPy3Bin</literal>
+          convenience functions to create executable Python 2/3 scripts
+          using the PyPy interpreter were added.
         </para>
       </listitem>
     </itemizedlist>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -34,6 +34,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 - `pkgs.claws-mail-gtk2`, representing Claws Mail's older release version three, was removed in order to get rid of Python 2.
   Please switch to `claws-mail`, which is Claws Mail's latest release based on GTK+3 and Python 3.
 
+- The `writers.writePython2` and corrersponding `writers.writePython2Bin` convenience functions to create executable Python 2 scripts in the store were removed in preparation of removal of the Python 2 interpreter.
+
 ## Other Notable Changes {#sec-release-22.05-notable-changes}
 
 - The option [services.redis.servers](#opt-services.redis.servers) was added

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -34,7 +34,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 - `pkgs.claws-mail-gtk2`, representing Claws Mail's older release version three, was removed in order to get rid of Python 2.
   Please switch to `claws-mail`, which is Claws Mail's latest release based on GTK+3 and Python 3.
 
-- The `writers.writePython2` and corrersponding `writers.writePython2Bin` convenience functions to create executable Python 2 scripts in the store were removed in preparation of removal of the Python 2 interpreter.
+- The `writers.writePython2` and corresponding `writers.writePython2Bin` convenience functions to create executable Python 2 scripts in the store were removed in preparation of removal of the Python 2 interpreter.
+  Scripts have to be converted to Python 3 for use with `writers.writePython3` or `writers.writePyPy2` needs to be used.
 
 ## Other Notable Changes {#sec-release-22.05-notable-changes}
 
@@ -53,3 +54,5 @@ In addition to numerous new and upgraded packages, this release has the followin
   are only accessible by default
   to the members of the Unix group `redis-${serverName}`
   through the Unix socket `/run/redis-${serverName}/redis.sock`.
+
+- The `writers.writePyPy2`/`writers.writePyPy3` and corresponding `writers.writePyPy2Bin`/`writers.writePyPy3Bin` convenience functions to create executable Python 2/3 scripts using the PyPy interpreter were added.

--- a/pkgs/build-support/writers/aliases.nix
+++ b/pkgs/build-support/writers/aliases.nix
@@ -1,0 +1,35 @@
+lib: prev:
+
+let
+  # Removing recurseForDerivation prevents derivations of aliased attribute
+  # set to appear while listing all the packages available.
+  removeRecurseForDerivations = alias: with lib;
+    if alias.recurseForDerivations or false then
+      removeAttrs alias ["recurseForDerivations"]
+    else alias;
+
+  # Disabling distribution prevents top-level aliases for non-recursed package
+  # sets from building on Hydra.
+  removeDistribute = alias: with lib;
+    if isDerivation alias then
+      dontDistribute alias
+    else alias;
+
+  # Make sure that we are not shadowing something from
+  # writers.
+  checkInPkgs = n: alias: if builtins.hasAttr n prev
+                          then throw "Alias ${n} is still in writers"
+                          else alias;
+
+  mapAliases = aliases:
+    lib.mapAttrs (n: alias: removeDistribute
+                             (removeRecurseForDerivations
+                              (checkInPkgs n alias)))
+                     aliases;
+
+in
+mapAliases ({
+  /* Cleanup before 22.05, Added 2021-12-11 */
+  writePython2 = "Python 2 is EOL and the use of writers.writePython2 is deprecated.";
+  writePython2Bin = "Python 2 is EOL and the use of writers.writePython2Bin is deprecated.";
+})

--- a/pkgs/build-support/writers/default.nix
+++ b/pkgs/build-support/writers/default.nix
@@ -247,6 +247,24 @@ let
     '');
   } name;
 
+  # writePyPy2 takes a name an attributeset with libraries and some pypy2 sourcecode and
+  # returns an executable
+  #
+  # Example:
+  # writePyPy2 "test_pypy2" { libraries = [ pkgs.pypy2Packages.enum ]; } ''
+  #   from enum import Enum
+  #
+  #   class Test(Enum):
+  #       a = "success"
+  #
+  #   print Test.a
+  # ''
+  writePyPy2 = makePythonWriter pkgs.pypy2 pkgs.pypy2Packages;
+
+  # writePyPy2Bin takes the same arguments as writePyPy2 but outputs a directory (like writeScriptBin)
+  writePyPy2Bin = name:
+    writePyPy2 "/bin/${name}";
+
   # writePython3 takes a name an attributeset with libraries and some python3 sourcecode and
   # returns an executable
   #
@@ -264,6 +282,24 @@ let
   # writePython3Bin takes the same arguments as writePython3 but outputs a directory (like writeScriptBin)
   writePython3Bin = name:
     writePython3 "/bin/${name}";
+
+  # writePyPy3 takes a name an attributeset with libraries and some pypy3 sourcecode and
+  # returns an executable
+  #
+  # Example:
+  # writePyPy3 "test_pypy3" { libraries = [ pkgs.pypy3Packages.pyyaml ]; } ''
+  #   import yaml
+  #
+  #   y = yaml.load("""
+  #     - test: success
+  #   """)
+  #   print(y[0]['test'])
+  # ''
+  writePyPy3 = makePythonWriter pkgs.pypy3 pkgs.pypy3Packages;
+
+  # writePyPy3Bin takes the same arguments as writePyPy3 but outputs a directory (like writeScriptBin)
+  writePyPy3Bin = name:
+    writePyPy3 "/bin/${name}";
 
 };
 in

--- a/pkgs/build-support/writers/default.nix
+++ b/pkgs/build-support/writers/default.nix
@@ -1,7 +1,9 @@
-{ pkgs, buildPackages, lib, stdenv, libiconv, gawk, gnused, gixy }:
+{ pkgs, config, buildPackages, lib, stdenv, libiconv, gawk, gnused, gixy }:
 
-with lib;
-rec {
+let
+  aliases = if (config.allowAliases or true) then (import ./aliases.nix lib) else prev: {};
+
+  writers = with lib; rec {
   # Base implementation for non-compiled executables.
   # Takes an interpreter, for example `${pkgs.bash}/bin/bash`
   #
@@ -245,24 +247,6 @@ rec {
     '');
   } name;
 
-  # writePython2 takes a name an attributeset with libraries and some python2 sourcecode and
-  # returns an executable
-  #
-  # Example:
-  # writePython2 "test_python2" { libraries = [ pkgs.python2Packages.enum ]; } ''
-  #   from enum import Enum
-  #
-  #   class Test(Enum):
-  #       a = "success"
-  #
-  #   print Test.a
-  # ''
-  writePython2 = makePythonWriter pkgs.python2 pkgs.python2Packages;
-
-  # writePython2Bin takes the same arguments as writePython2 but outputs a directory (like writeScriptBin)
-  writePython2Bin = name:
-    writePython2 "/bin/${name}";
-
   # writePython3 takes a name an attributeset with libraries and some python3 sourcecode and
   # returns an executable
   #
@@ -280,4 +264,7 @@ rec {
   # writePython3Bin takes the same arguments as writePython3 but outputs a directory (like writeScriptBin)
   writePython3Bin = name:
     writePython3 "/bin/${name}";
-}
+
+};
+in
+writers // (aliases writers)

--- a/pkgs/build-support/writers/test.nix
+++ b/pkgs/build-support/writers/test.nix
@@ -3,7 +3,6 @@
 , lib
 , nodePackages
 , perlPackages
-, python2Packages
 , python3Packages
 , runCommand
 , writers
@@ -54,17 +53,6 @@ let
       print "success\n" if true;
     '';
 
-    python2 = writePython2Bin "test-writers-python2-bin" { libraries = [ python2Packages.enum ]; } ''
-      from enum import Enum
-
-
-      class Test(Enum):
-          a = "success"
-
-
-      print Test.a
-    '';
-
     python3 = writePython3Bin "test-writers-python3-bin" { libraries = [ python3Packages.pyyaml ]; } ''
       import yaml
 
@@ -111,17 +99,6 @@ let
       print "success\n" if true;
     '';
 
-    python2 = writePython2 "test-writers-python2" { libraries = [ python2Packages.enum ]; } ''
-      from enum import Enum
-
-
-      class Test(Enum):
-          a = "success"
-
-
-      print Test.a
-    '';
-
     python3 = writePython3 "test-writers-python3" { libraries = [ python3Packages.pyyaml ]; } ''
       import yaml
 
@@ -129,10 +106,6 @@ let
         - test: success
       """)
       print(y[0]['test'])
-    '';
-
-    python2NoLibs = writePython2 "test-writers-python2-no-libs" {} ''
-      print("success")
     '';
 
     python3NoLibs = writePython3 "test-writers-python3-no-libs" {} ''

--- a/pkgs/build-support/writers/test.nix
+++ b/pkgs/build-support/writers/test.nix
@@ -3,7 +3,9 @@
 , lib
 , nodePackages
 , perlPackages
+, pypy2Packages
 , python3Packages
+, pypy3Packages
 , runCommand
 , writers
 , writeText
@@ -53,7 +55,27 @@ let
       print "success\n" if true;
     '';
 
+    pypy2 = writePyPy2Bin "test-writers-pypy2-bin" { libraries = [ pypy2Packages.enum ]; } ''
+      from enum import Enum
+
+
+      class Test(Enum):
+          a = "success"
+
+
+      print Test.a
+    '';
+
     python3 = writePython3Bin "test-writers-python3-bin" { libraries = [ python3Packages.pyyaml ]; } ''
+      import yaml
+
+      y = yaml.load("""
+        - test: success
+      """)
+      print(y[0]['test'])
+    '';
+
+    pypy3 = writePyPy3Bin "test-writers-pypy3-bin" { libraries = [ pypy3Packages.pyyaml ]; } ''
       import yaml
 
       y = yaml.load("""
@@ -99,6 +121,17 @@ let
       print "success\n" if true;
     '';
 
+    pypy2 = writePyPy2 "test-writers-pypy2" { libraries = [ pypy2Packages.enum ]; } ''
+      from enum import Enum
+
+
+      class Test(Enum):
+          a = "success"
+
+
+      print Test.a
+    '';
+
     python3 = writePython3 "test-writers-python3" { libraries = [ python3Packages.pyyaml ]; } ''
       import yaml
 
@@ -108,7 +141,24 @@ let
       print(y[0]['test'])
     '';
 
+    pypy3 = writePyPy3 "test-writers-pypy3" { libraries = [ pypy3Packages.pyyaml ]; } ''
+      import yaml
+
+      y = yaml.load("""
+        - test: success
+      """)
+      print(y[0]['test'])
+    '';
+
+    pypy2NoLibs = writePyPy2 "test-writers-pypy2-no-libs" {} ''
+      print("success")
+    '';
+
     python3NoLibs = writePython3 "test-writers-python3-no-libs" {} ''
+      print("success")
+    '';
+
+    pypy3NoLibs = writePyPy3 "test-writers-pypy3-no-libs" {} ''
       print("success")
     '';
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/148779
python2 is EOL and due for removal; functions unused in nixpkgs

a replacement using the PyPy interpreter is added to ease transition
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review pr 150132"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
