### PR TITLE
hdr-plus: unstable-2020-10-29 -> unstable-2021-12-10

### DIFF
--- a/pkgs/applications/graphics/hdr-plus/default.nix
+++ b/pkgs/applications/graphics/hdr-plus/default.nix
@@ -1,30 +1,18 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch
+{ lib, stdenv, fetchFromGitHub
 , cmake, halide
 , libpng, libjpeg, libtiff, libraw
 }:
 
 stdenv.mkDerivation rec {
-  pname = "hdr-plus-unstable";
-  version = "2020-10-29";
+  pname = "hdr-plus";
+  version = "unstable-2021-12-10";
 
   src = fetchFromGitHub {
     owner = "timothybrooks";
     repo = "hdr-plus";
-    rev = "132bd73ccd4eaef9830124605c93f06a98607cfa";
-    sha256 = "1n49ggrppf336p7n510kapzh376791bysxj3f33m3bdzksq360ps";
+    rev = "0ab70564493bdbcd5aca899b5885505d0c824435";
+    sha256 = "sha256-QV8bGxkwFpbNzJG4kmrWwFQxUo2XzLPnoI1e32UmM6g=";
   };
-
-  patches = [
-    # PR #70, fixes incompatibility with Halide 10.0.0
-    (fetchpatch {
-      url = "https://github.com/timothybrooks/hdr-plus/pull/70/commits/077e1a476279539c72e615210762dca27984c57b.patch";
-      sha256 = "1sg2l1bqs2smpfpy4flwg86fzhcc4yf7zx998v1bfhim43yyrx59";
-    })
-  ];
-
-  postPatch = ''
-    sed -i '2a #include <array>' src/InputSource.h
-  '';
 
   nativeBuildInputs = [ cmake ];
 


### PR DESCRIPTION
#### Motivation for this change

Simplify the derivation by removing patches. The resulting tree is just the same, but now with patches incorporated upstream (timothybrooks/hdr-plus#70 and timothybrooks/hdr-plus#77).

#### Things done

Bump to latest commit.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
