### PR TITLE
helvum: 0.3.1 -> 0.3.2

### DIFF
--- a/pkgs/applications/audio/helvum/default.nix
+++ b/pkgs/applications/audio/helvum/default.nix
@@ -1,47 +1,73 @@
 { lib
-, fetchFromGitLab
-, makeDesktopItem
-, copyDesktopItems
-, rustPlatform
-, pkg-config
 , clang
-, libclang
+, desktop-file-utils
+, fetchFromGitLab
+, fetchpatch
 , glib
 , gtk4
+, libclang
+, meson
+, ninja
 , pipewire
+, pkg-config
+, rustPlatform
+, stdenv
 }:
 
-rustPlatform.buildRustPackage rec {
+stdenv.mkDerivation rec {
   pname = "helvum";
-  version = "0.3.1";
+  version = "0.3.2";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "ryuukyu";
     repo = pname;
     rev = version;
-    sha256 = "sha256-f6+6Qicg5J6oWcafG4DF0HovTmF4r6yfw6p/3dJHmB4=";
+    sha256 = "sha256-Kt6gnMRTOVXqjAjEZKlylcGhzl52ZzPNVbJhwzLhzkM=";
   };
 
-  cargoSha256 = "sha256-zGa6nAmOOrpiMr865J06Ez3L6lPL0j18/lW8lw1jPyU=";
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-kxJRY9GSPwnb431iYCfJdGcl5HjpFr2KkWrFDpGajp8=";
+  };
 
-  nativeBuildInputs = [ clang copyDesktopItems pkg-config ];
-  buildInputs = [ glib gtk4 pipewire ];
+  nativeBuildInputs = [
+    clang
+    meson
+    ninja
+    pkg-config
+    rustPlatform.cargoSetupHook
+    rustPlatform.rust.cargo
+    rustPlatform.rust.rustc
+  ];
+
+  buildInputs = [
+    desktop-file-utils
+    glib
+    gtk4
+    pipewire
+  ];
 
   LIBCLANG_PATH = "${libclang.lib}/lib";
 
-  desktopItems = makeDesktopItem {
-    name = "Helvum";
-    exec = pname;
-    desktopName = "Helvum";
-    genericName = "Helvum";
-    categories = "AudioVideo;";
-  };
+  patches = [
+    # enables us to use gtk4-update-icon-cache instead of gtk3 one
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/ryuukyu/helvum/-/merge_requests/24.patch";
+      sha256 = "sha256-WmI6taBL/6t587j06n0mwByQ8x0eUA5ECvGNjg2/vtk=";
+    })
+  ];
+
+  prePatch = ''
+    patchShebangs build-aux/cargo.sh
+  '';
 
   meta = with lib; {
     description = "A GTK patchbay for pipewire";
     homepage = "https://gitlab.freedesktop.org/ryuukyu/helvum";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ fufexan ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/audio/helvum/default.nix
+++ b/pkgs/applications/audio/helvum/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  prePatch = ''
+  postPatch = ''
     patchShebangs build-aux/cargo.sh
   '';
 
@@ -68,6 +68,6 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.freedesktop.org/ryuukyu/helvum";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ fufexan ];
-    platforms = lib.platforms.linux;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Switched to meson build system, which also installs a .desktop file and icons. Took inspiration from #116324 when rewriting the derivation.
Supersedes #150081.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
