### PR TITLE
[21.11] python3Packages.mahotas: fix freeimage support

### DIFF
--- a/pkgs/development/python-modules/mahotas/default.nix
+++ b/pkgs/development/python-modules/mahotas/default.nix
@@ -1,4 +1,15 @@
-{ buildPythonPackage, fetchFromGitHub, pillow, scipy, numpy, pytestCheckHook, imread, freeimage, lib, stdenv }:
+{ buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, pillow
+, scipy
+, numpy
+, pytestCheckHook
+, imread
+, freeimage
+, lib
+, stdenv
+}:
 
 buildPythonPackage rec {
   pname = "mahotas";
@@ -11,11 +22,22 @@ buildPythonPackage rec {
     sha256 = "029gvy1fb855pvxvy8zwj44k4s7qpqi0161bg5wldfiprrysn1kw";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "fix-freeimage-tests.patch";
+      url = "https://github.com/luispedro/mahotas/commit/08cc4aa0cbd5dbd4c37580d52b822810c03b2c69.patch";
+      sha256 = "0389sz7fyl8h42phw8sn4pxl4wc3brcrj9d05yga21gzil9bfi23";
+      excludes = [ "ChangeLog" ];
+    })
+  ];
+
   propagatedBuildInputs = [ numpy imread pillow scipy freeimage ];
   checkInputs = [ pytestCheckHook ];
 
   postPatch = ''
-    substituteInPlace mahotas/io/freeimage.py --replace "/opt/local/lib" "${freeimage}/lib"
+    substituteInPlace mahotas/io/freeimage.py \
+      --replace "ctypes.util.find_library('freeimage')" 'True' \
+      --replace 'ctypes.CDLL(libname)' 'np.ctypeslib.load_library("libfreeimage", "${freeimage}/lib")'
   '';
 
   # tests must be run in the build directory
@@ -29,6 +51,12 @@ buildPythonPackage rec {
     "test_ellipse_axes"
     "test_normalize"
     "test_haralick3d"
+    "test_uint16"
+  ];
+
+  pythonImportsCheck = [
+    "mahotas"
+    "mahotas.freeimage"
   ];
 
   disabled = stdenv.isi686; # Failing tests


### PR DESCRIPTION
###### Motivation for this change
More or less a backport of #148496 without the bump.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
