### PR TITLE
kde-gear: 21.08.3 -> 21.12.0

### DIFF
--- a/pkgs/applications/kde/akonadi/default.nix
+++ b/pkgs/applications/kde/akonadi/default.nix
@@ -36,4 +36,11 @@ mkDerivation {
     ''-DNIX_OUT=\"${placeholder "out"}\"''
     ''-I${lib.getDev kio}/include/KF5''  # Fixes: kio_version.h: No such file or directory
   ];
+
+  # compatibility symlinks for kmymoney, can probably be removed in next kde bump
+  postInstall = ''
+    ln -s $dev/include/KF5/AkonadiCore/Akonadi/Collection $dev/include/KF5/AkonadiCore/Collection
+    ln -s $dev/include/KF5/AkonadiCore/Akonadi/ItemFetchScope $dev/include/KF5/AkonadiCore/ItemFetchScope
+    ln -s $dev/include/KF5/AkonadiCore/Akonadi/RecursiveItemFetchJob $dev/include/KF5/AkonadiCore/RecursiveItemFetchJob
+  '';
 }

--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/release-service/21.08.3/src -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/release-service/21.12.0/src -A '*.tar.xz' )

--- a/pkgs/applications/kde/kitinerary.nix
+++ b/pkgs/applications/kde/kitinerary.nix
@@ -1,6 +1,5 @@
-{
-  mkDerivation, lib, extra-cmake-modules
-, qtbase, qtdeclarative, ki18n, kmime, kpkpass
+{ mkDerivation, lib, extra-cmake-modules
+, qtdeclarative, ki18n, kmime, kpkpass
 , poppler, kcontacts, kcalendarcore
 , shared-mime-info
 }:
@@ -16,8 +15,13 @@ mkDerivation {
     shared-mime-info # for update-mime-database
   ];
   buildInputs = [
-    qtbase qtdeclarative ki18n kmime kpkpass poppler
+    qtdeclarative kmime kpkpass poppler
     kcontacts kcalendarcore
   ];
+
+  CXXFLAGS = [
+    "-I${lib.getDev ki18n}/include/KF5"  # Fixes: ki18n_version.h: No such file or directory
+  ];
+
   outputs = [ "out" "dev" ];
 }

--- a/pkgs/applications/kde/krfb.nix
+++ b/pkgs/applications/kde/krfb.nix
@@ -1,10 +1,9 @@
-{
-  mkDerivation, lib,
-  extra-cmake-modules, kdoctools,
-  kconfig, kcoreaddons, kcrash, kdbusaddons, kdnssd, knotifications, kwallet,
-  kwidgetsaddons, kwindowsystem, kxmlgui,
-  libvncserver, libXtst, libXdamage,
-  qtx11extras
+{ mkDerivation, lib
+, extra-cmake-modules, kdoctools
+, kconfig, kcoreaddons, kcrash, kdbusaddons, kdnssd, knotifications, kwallet
+, kwidgetsaddons, kwindowsystem, kxmlgui, kwayland
+, libvncserver, libXtst, libXdamage
+, qtx11extras
 }:
 
 mkDerivation {
@@ -19,7 +18,7 @@ mkDerivation {
   buildInputs = [
     libvncserver libXtst libXdamage
     kconfig kcoreaddons kcrash kdbusaddons knotifications kwallet kwidgetsaddons
-    kwindowsystem kxmlgui
+    kwindowsystem kxmlgui kwayland
     qtx11extras
   ];
   propagatedBuildInputs = [ kdnssd ];

--- a/pkgs/applications/kde/picmi.nix
+++ b/pkgs/applications/kde/picmi.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, lib
+{ mkDerivation, lib, fetchpatch
 , libkdegames, extra-cmake-modules
 , kdeclarative, knewstuff
 }:
@@ -15,6 +15,17 @@ mkDerivation {
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
   };
+
+  patches = [
+    # fix compile error due to usage of deprecated things
+    # probably can be removed with the next kde bump
+    (fetchpatch {
+      url = "https://invent.kde.org/games/picmi/-/commit/99639fb499fe35eb463621efca1c0e4ff2a52bad.patch";
+      revert = true;
+      sha256 = "sha256-rRhTvUB1Hpc3bLv9b5yIf/G7uJy2/OgBfXToZwV4jrg=";
+    })
+  ];
+
   nativeBuildInputs = [
     extra-cmake-modules
   ];

--- a/pkgs/applications/kde/srcs.nix
+++ b/pkgs/applications/kde/srcs.nix
@@ -4,1811 +4,1843 @@
 
 {
   akonadi = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/akonadi-21.08.3.tar.xz";
-      sha256 = "1yqlgzni7kj0n7k2wvi65wfz4il75j7qvmrdjw3a0ld6115j2vqs";
-      name = "akonadi-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/akonadi-21.12.0.tar.xz";
+      sha256 = "1wxqkhqlvjidr7j5g4hcqykvys27snc2cp2k077dixdnp4v71gr3";
+      name = "akonadi-21.12.0.tar.xz";
     };
   };
   akonadi-calendar = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/akonadi-calendar-21.08.3.tar.xz";
-      sha256 = "17pl7viz89zn43iyp6hk9q2dix1mzfxmxf08jk5wcciphabyj2sc";
-      name = "akonadi-calendar-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/akonadi-calendar-21.12.0.tar.xz";
+      sha256 = "0jkzq071f2w3ysra87clxa63ykg8ywr92mqc57fxzc9hydkg0pbs";
+      name = "akonadi-calendar-21.12.0.tar.xz";
     };
   };
   akonadi-calendar-tools = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/akonadi-calendar-tools-21.08.3.tar.xz";
-      sha256 = "0wc3yfb8riijmmwqbny7vpfav24w8id4s2ysbcljrvypv420ii2g";
-      name = "akonadi-calendar-tools-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/akonadi-calendar-tools-21.12.0.tar.xz";
+      sha256 = "0nxcgv1vwr60706sd3hipmxx22nf3sxxif8li2r0pqnfqf542hcy";
+      name = "akonadi-calendar-tools-21.12.0.tar.xz";
     };
   };
   akonadi-contacts = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/akonadi-contacts-21.08.3.tar.xz";
-      sha256 = "1i5mwjf8vp40mmdfkafhhbcmvdd2sihd6aa4z1wnhnbg59cjvp8i";
-      name = "akonadi-contacts-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/akonadi-contacts-21.12.0.tar.xz";
+      sha256 = "0al4v2yv9hf1lidk135m45ckr0hgvvlb0px9wqa2zqkrykpm0qz4";
+      name = "akonadi-contacts-21.12.0.tar.xz";
     };
   };
   akonadi-import-wizard = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/akonadi-import-wizard-21.08.3.tar.xz";
-      sha256 = "1splq2fgifk4mh00j4dd1lmgyc4bvz8sbsw0fznmafg76k1fvama";
-      name = "akonadi-import-wizard-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/akonadi-import-wizard-21.12.0.tar.xz";
+      sha256 = "0lrvmkaphrk4sad83nc2pm3qy5q7jgp13dqh5mvqk2sb3mlpv5xi";
+      name = "akonadi-import-wizard-21.12.0.tar.xz";
     };
   };
   akonadi-mime = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/akonadi-mime-21.08.3.tar.xz";
-      sha256 = "19dbgl9940wwsiyhysh1lm5ks9xb6a5m53p9qmdr5siid9karq64";
-      name = "akonadi-mime-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/akonadi-mime-21.12.0.tar.xz";
+      sha256 = "07rmlsgrghy38j8nahpml5yp5zaxdwjjk77ydp2nn10fprr6ssyq";
+      name = "akonadi-mime-21.12.0.tar.xz";
     };
   };
   akonadi-notes = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/akonadi-notes-21.08.3.tar.xz";
-      sha256 = "0g1kdhj4qjl29x70dl4fl30f4r67s6ldpmqrf0xnj7zwz008r0fn";
-      name = "akonadi-notes-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/akonadi-notes-21.12.0.tar.xz";
+      sha256 = "0p1gn9rl5hyh14kx7p461l9a2va4kc44a1xr2xlk392bpyi7zn22";
+      name = "akonadi-notes-21.12.0.tar.xz";
     };
   };
   akonadi-search = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/akonadi-search-21.08.3.tar.xz";
-      sha256 = "1fvfd1410zy9dbcjl21463wj91s5vly00l53ixaizylnjbj67lm0";
-      name = "akonadi-search-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/akonadi-search-21.12.0.tar.xz";
+      sha256 = "07fazr0hq9ndpvgjvrh606qbkgk429ikmk62bp8lz161n6hxw19k";
+      name = "akonadi-search-21.12.0.tar.xz";
     };
   };
   akonadiconsole = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/akonadiconsole-21.08.3.tar.xz";
-      sha256 = "1id1l6ifc1b8qsx16badhww33idk7c8qnn4lh3bg6mg1whmvy4k2";
-      name = "akonadiconsole-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/akonadiconsole-21.12.0.tar.xz";
+      sha256 = "0ld1z3vidpqhrj2hmbhsiwmfn10za0jvfkg79vbdv8x0gmbyjynd";
+      name = "akonadiconsole-21.12.0.tar.xz";
     };
   };
   akregator = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/akregator-21.08.3.tar.xz";
-      sha256 = "1jb2vd43pn7i1b7ylhm74q0jkk3hwbjxh6nc2hqpl9c0ic20arf2";
-      name = "akregator-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/akregator-21.12.0.tar.xz";
+      sha256 = "0w51ndga17v7xj98r9i944v42py2qqrsg2p7q69r2ip9k73m56cv";
+      name = "akregator-21.12.0.tar.xz";
     };
   };
   analitza = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/analitza-21.08.3.tar.xz";
-      sha256 = "04g1l9q80j5rigz0667js35zjm3as0dpfkjhcm997bna1yb0d92z";
-      name = "analitza-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/analitza-21.12.0.tar.xz";
+      sha256 = "0nr84vr20aq3v3k28vx3xk4la8ff1hw7nm930vvjw8vkhpdkm03m";
+      name = "analitza-21.12.0.tar.xz";
     };
   };
   ark = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/ark-21.08.3.tar.xz";
-      sha256 = "1wrxv8csj1irrwcddkjgbcivpxi2v3nj06lvayzr32b29i85h637";
-      name = "ark-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/ark-21.12.0.tar.xz";
+      sha256 = "1krhxhhab4m0z4ni8dbgraymbawc85rf3b3q8zcm799zk4hphr6x";
+      name = "ark-21.12.0.tar.xz";
     };
   };
   artikulate = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/artikulate-21.08.3.tar.xz";
-      sha256 = "14g5wcw1bxxmbc9vvy07zbk2ma2cj1zbb5fdcwdf4ybaal9r43jq";
-      name = "artikulate-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/artikulate-21.12.0.tar.xz";
+      sha256 = "13jvbgvqrcrhvcnb2j3dh9r7m50b2m0nf9479ayqkp2cirm77k61";
+      name = "artikulate-21.12.0.tar.xz";
     };
   };
   audiocd-kio = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/audiocd-kio-21.08.3.tar.xz";
-      sha256 = "0fp29igj87pff8jya230j67vcz9pv7g27g4dv2pl3r6gm2kv8c9i";
-      name = "audiocd-kio-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/audiocd-kio-21.12.0.tar.xz";
+      sha256 = "12nxyy16pc4a8kwag39bmyl055f1izfsrwiblm1l5567m0v93vd1";
+      name = "audiocd-kio-21.12.0.tar.xz";
     };
   };
   baloo-widgets = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/baloo-widgets-21.08.3.tar.xz";
-      sha256 = "1pjlw22ivqhpd6bf50d8s9jaq6h2k0l2szwnh841qq7bwwkp9kcb";
-      name = "baloo-widgets-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/baloo-widgets-21.12.0.tar.xz";
+      sha256 = "19f9as73cim6f3h5qcirr88h0cmi3w0r3gcy5hdc6ghyx37wj87p";
+      name = "baloo-widgets-21.12.0.tar.xz";
     };
   };
   blinken = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/blinken-21.08.3.tar.xz";
-      sha256 = "03s3pv61jhkx3lm5rik25fglhda9l4w43blpwh78rbdk3c3s3ijg";
-      name = "blinken-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/blinken-21.12.0.tar.xz";
+      sha256 = "01542z383xkhjznmf220qvgbg902ky5jdpj1p8shbzaij5yxv847";
+      name = "blinken-21.12.0.tar.xz";
     };
   };
   bomber = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/bomber-21.08.3.tar.xz";
-      sha256 = "0h5iwpmpw8xnqh6xcm4zqqcp1ia5wir0ghwsbcgrz9ka59dfdh4z";
-      name = "bomber-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/bomber-21.12.0.tar.xz";
+      sha256 = "1iwk0b5fnv328bjd7mxhs46rmbkrchpdxk7q8mmysn8z6vyscisc";
+      name = "bomber-21.12.0.tar.xz";
     };
   };
   bovo = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/bovo-21.08.3.tar.xz";
-      sha256 = "0p5pi6rnnmikhg72gagld67r022bq3nsrhls0gglx14zfj6pgln3";
-      name = "bovo-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/bovo-21.12.0.tar.xz";
+      sha256 = "0nfzqmqfb6kwprhv4dbp3lpv8hf51rw12ib21hpx9s1jknqs6179";
+      name = "bovo-21.12.0.tar.xz";
     };
   };
   calendarsupport = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/calendarsupport-21.08.3.tar.xz";
-      sha256 = "1kial8x8sw0039n2s3nl9i0wadf8xda1bv2g9kws0kp29k58lyfy";
-      name = "calendarsupport-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/calendarsupport-21.12.0.tar.xz";
+      sha256 = "1a3rxy5g2illphi61x90b6sijkiqyfw458br5cbxj7c1q98y2p1l";
+      name = "calendarsupport-21.12.0.tar.xz";
     };
   };
   cantor = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/cantor-21.08.3.tar.xz";
-      sha256 = "1l3z0aikrfjdpcfq6apmwla9k7dqymvysi275kpx0dqi5sfgi9lb";
-      name = "cantor-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/cantor-21.12.0.tar.xz";
+      sha256 = "04413152yhg1s6iyp3a8ihjs41ni3wbv7kgqx9sz0zmn7vyfl859";
+      name = "cantor-21.12.0.tar.xz";
     };
   };
   cervisia = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/cervisia-21.08.3.tar.xz";
-      sha256 = "0a7g3g849vf0c0222944iwqhymnxcn9qj0v85m2b0bfxgdf0fgk7";
-      name = "cervisia-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/cervisia-21.12.0.tar.xz";
+      sha256 = "17b116y4bvs2d40m2m7xbwjsnf2wffv921lw5f6nwgmxqfdinacp";
+      name = "cervisia-21.12.0.tar.xz";
     };
   };
   dolphin = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/dolphin-21.08.3.tar.xz";
-      sha256 = "19yrgfliqabmymrh3sx2i5129rcc14nxb86f21wd616b3pcby5rv";
-      name = "dolphin-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/dolphin-21.12.0.tar.xz";
+      sha256 = "0s96ggzkwjs8pyad4mp8x2z2hiajxwpb2fzwsjzzkicjwa7c03z7";
+      name = "dolphin-21.12.0.tar.xz";
     };
   };
   dolphin-plugins = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/dolphin-plugins-21.08.3.tar.xz";
-      sha256 = "098i2zydzi95i860pk6p0g0wx1bryyxanawhcis5d5h3xra66s0p";
-      name = "dolphin-plugins-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/dolphin-plugins-21.12.0.tar.xz";
+      sha256 = "150kfhm3qh6x4qq3b5s5fbm7q9z7i9asmnmwqfppcqz3fjc5pg7j";
+      name = "dolphin-plugins-21.12.0.tar.xz";
     };
   };
   dragon = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/dragon-21.08.3.tar.xz";
-      sha256 = "0zfh5kmw2mvnwpcbh9i6xzzdigkglr6y0y7acw2dw6bi2cqx5cc7";
-      name = "dragon-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/dragon-21.12.0.tar.xz";
+      sha256 = "147m5rki2s8xc9i09fan37c16yicbkwz1v95li2ihjah43kgq78h";
+      name = "dragon-21.12.0.tar.xz";
     };
   };
   elisa = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/elisa-21.08.3.tar.xz";
-      sha256 = "0w3sk52ghkka305hagld5ia6z6czavbqgc0abqdz442bgnk1f1vb";
-      name = "elisa-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/elisa-21.12.0.tar.xz";
+      sha256 = "0rs81kbgsd7412sz7h6xax1c83n9lp21k062m2h50ccf4lzx7fyw";
+      name = "elisa-21.12.0.tar.xz";
     };
   };
   eventviews = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/eventviews-21.08.3.tar.xz";
-      sha256 = "08bcw79iag71yiaf7ck27b2ja4pg18ah04rxa1c6g5fr9x6kkk46";
-      name = "eventviews-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/eventviews-21.12.0.tar.xz";
+      sha256 = "1667ck9na8ajqaagxks7rlrwb6w04mxdci7mc5ash8l57icdgp6y";
+      name = "eventviews-21.12.0.tar.xz";
     };
   };
   ffmpegthumbs = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/ffmpegthumbs-21.08.3.tar.xz";
-      sha256 = "10l9592f2l63rfak3f0knvzapsaa8nyx3dl82n724359qj43m530";
-      name = "ffmpegthumbs-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/ffmpegthumbs-21.12.0.tar.xz";
+      sha256 = "14mimxgml627lkq7gw24j62hs5iglvbwnlbv879p7zlsg46fjg1b";
+      name = "ffmpegthumbs-21.12.0.tar.xz";
     };
   };
   filelight = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/filelight-21.08.3.tar.xz";
-      sha256 = "0j5106x93ljkcxk90cs1yvd9dw3pnr007cd4plsw5z7kgmch3zww";
-      name = "filelight-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/filelight-21.12.0.tar.xz";
+      sha256 = "1w3n550smqnq1vwsizrcry3rnpk8f3xmiabdzkx9bggrk5p07jnj";
+      name = "filelight-21.12.0.tar.xz";
     };
   };
   granatier = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/granatier-21.08.3.tar.xz";
-      sha256 = "1igia7fxll361np76763nw915d90f5hklgqii9iyld8si99amy4y";
-      name = "granatier-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/granatier-21.12.0.tar.xz";
+      sha256 = "19r5lilgjapz7bdam55cxs3z40rclczmzklp5ns348f2rqh36chg";
+      name = "granatier-21.12.0.tar.xz";
     };
   };
   grantlee-editor = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/grantlee-editor-21.08.3.tar.xz";
-      sha256 = "04yry04cdysh4a1y6nznxmfw2pww956xan0dnf77yjzssri9p2fq";
-      name = "grantlee-editor-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/grantlee-editor-21.12.0.tar.xz";
+      sha256 = "1lyv3c6801pv3mgxn8i9k6g319ggxg0mxk85nzq1w74m56ywkx12";
+      name = "grantlee-editor-21.12.0.tar.xz";
     };
   };
   grantleetheme = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/grantleetheme-21.08.3.tar.xz";
-      sha256 = "11c72jp9ywpmsc3d92cj2c9xvwmqbilsfddmlxlwnpnp2rf8q933";
-      name = "grantleetheme-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/grantleetheme-21.12.0.tar.xz";
+      sha256 = "1agkqrr29ib314x48jl4yfybnq10nk45976g7yjlfp6r8qib4pal";
+      name = "grantleetheme-21.12.0.tar.xz";
     };
   };
   gwenview = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/gwenview-21.08.3.tar.xz";
-      sha256 = "06hg20sygi6xfbifgi1d6s5zba5qqpm949xa7gyxi1vsq0kbvrq4";
-      name = "gwenview-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/gwenview-21.12.0.tar.xz";
+      sha256 = "1y484f7fvnj217qrdfva0k3359n7mz4pvxw54xar2xa9z18iqw8g";
+      name = "gwenview-21.12.0.tar.xz";
     };
   };
   incidenceeditor = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/incidenceeditor-21.08.3.tar.xz";
-      sha256 = "0p45x5qkzbfklxk22kzp9zlvl8ggdjgniq889q8hzb1s89ia1cck";
-      name = "incidenceeditor-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/incidenceeditor-21.12.0.tar.xz";
+      sha256 = "1rrda32h004gfqvvxh74wlr9ym3zbgf6a7nd2ldmn7z852z7gpsp";
+      name = "incidenceeditor-21.12.0.tar.xz";
     };
   };
   itinerary = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/itinerary-21.08.3.tar.xz";
-      sha256 = "0w7kb4wvy1sfhlkikvq1ajckizf7k2bzy2wcjdz5is69rrd5cab5";
-      name = "itinerary-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/itinerary-21.12.0.tar.xz";
+      sha256 = "1dwpaznzklxbyaj6fvgm416vbz5fyw78c5bx10z9ygmj88jv6dls";
+      name = "itinerary-21.12.0.tar.xz";
     };
   };
   juk = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/juk-21.08.3.tar.xz";
-      sha256 = "19g1dpvrssip8vysds3j4wa599ivapznz10p0p1254gkjyxdxdm3";
-      name = "juk-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/juk-21.12.0.tar.xz";
+      sha256 = "0gsdiysld5mk2k2c34d883hlgcn3ad2qkvbf4ba6iikn2kbsdhw2";
+      name = "juk-21.12.0.tar.xz";
     };
   };
   k3b = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/k3b-21.08.3.tar.xz";
-      sha256 = "1k5xn33sggx3a7lns8y64sa3schqvg476q81rig9mylh68x8rr5y";
-      name = "k3b-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/k3b-21.12.0.tar.xz";
+      sha256 = "1g6slra4bwbsr282p7xzbldq4j366x03fv99icfj9xj5kargp3jq";
+      name = "k3b-21.12.0.tar.xz";
     };
   };
   kaccounts-integration = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kaccounts-integration-21.08.3.tar.xz";
-      sha256 = "0hyaygrsdp6s96s4wa9z5l1w5w5hxwbw432zs6a2fkgq5dpa3wn4";
-      name = "kaccounts-integration-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kaccounts-integration-21.12.0.tar.xz";
+      sha256 = "0dlan1gjzci3f3xfr3gr6wb4k7qvdm3r91ihxza9bravn2pkf4n7";
+      name = "kaccounts-integration-21.12.0.tar.xz";
     };
   };
   kaccounts-providers = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kaccounts-providers-21.08.3.tar.xz";
-      sha256 = "0chajl87w3gp1a8l7h6bxf93js6jxdkx90ir82glgh45p5qhdhcr";
-      name = "kaccounts-providers-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kaccounts-providers-21.12.0.tar.xz";
+      sha256 = "0y3hirzs0q1pkrfi3k41lyxbylc0zahaky9zar5262w36wcc28ai";
+      name = "kaccounts-providers-21.12.0.tar.xz";
     };
   };
   kaddressbook = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kaddressbook-21.08.3.tar.xz";
-      sha256 = "1c16pcbjd5w04xbkjalvf697nqi751f4g8ldaing3k2rmdvhsqwg";
-      name = "kaddressbook-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kaddressbook-21.12.0.tar.xz";
+      sha256 = "126sf8agg2j8dkq4vbpd28bkg2smmkb0q3ynmxz2llifrzfxz1is";
+      name = "kaddressbook-21.12.0.tar.xz";
     };
   };
   kajongg = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kajongg-21.08.3.tar.xz";
-      sha256 = "15i5vdcwm7a5amrxxbi0f4c3ls7ly1ccg88hff2wc960wwc6nvqb";
-      name = "kajongg-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kajongg-21.12.0.tar.xz";
+      sha256 = "15fj2bmkwz9la4d44w5qpk9fwzb8y77gvybv5rqxpmaknzan2b76";
+      name = "kajongg-21.12.0.tar.xz";
     };
   };
   kalarm = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kalarm-21.08.3.tar.xz";
-      sha256 = "0zcmaf4x9jvpyri1kirnm2rij3886z9k1vx6wxxxmx6sbllpb669";
-      name = "kalarm-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kalarm-21.12.0.tar.xz";
+      sha256 = "0hl1xk6zch2ji4lgh74qpd0j8i00y0vmw6xfmhpzkri6hk3shgrm";
+      name = "kalarm-21.12.0.tar.xz";
     };
   };
   kalarmcal = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kalarmcal-21.08.3.tar.xz";
-      sha256 = "03zmw8pxhfmrm7xl5h2k42xyqwn4cllhrp43sv7pjbym9ya41wyk";
-      name = "kalarmcal-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kalarmcal-21.12.0.tar.xz";
+      sha256 = "0rk078dnr7a3x73n7sfd06p7mr2r84hbv8lvknimfdy3i2c63hhx";
+      name = "kalarmcal-21.12.0.tar.xz";
     };
   };
   kalgebra = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kalgebra-21.08.3.tar.xz";
-      sha256 = "0w2n3nyds9069c4cj1ap2b14w8nw5dc3yb62j5y6yj9qz9ip7cdk";
-      name = "kalgebra-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kalgebra-21.12.0.tar.xz";
+      sha256 = "0qibj81w8l0g144yplhy7wmh3zwws865xhih4vp6n3apa8h3a5bk";
+      name = "kalgebra-21.12.0.tar.xz";
     };
   };
   kalzium = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kalzium-21.08.3.tar.xz";
-      sha256 = "0x7dn0f2bwzplzxal2wvnc3qh2qs522626ksp6ajgf16jwf7d4kl";
-      name = "kalzium-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kalzium-21.12.0.tar.xz";
+      sha256 = "04inkz95qm3s6yh6j4aaa2vja0zkls7f9i3y5zykx665jr90bl87";
+      name = "kalzium-21.12.0.tar.xz";
     };
   };
   kamera = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kamera-21.08.3.tar.xz";
-      sha256 = "1yv87rmb8k6yh5150915fsnh8rdj1d4k8zpc8k54hxa9gjw5wqm7";
-      name = "kamera-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kamera-21.12.0.tar.xz";
+      sha256 = "1vhc5b0ry1344dh4swfbw4r9in08i297p1x0nfv28v989bf15axn";
+      name = "kamera-21.12.0.tar.xz";
     };
   };
   kamoso = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kamoso-21.08.3.tar.xz";
-      sha256 = "1k2kis36a6dlsnh85qc01yd6qnz8kwrv4hvzpkpqvvp3m4ik17wx";
-      name = "kamoso-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kamoso-21.12.0.tar.xz";
+      sha256 = "0fixk5zc647r56z1vigaj5m0xkp7n56lmda248zh54x0n5prhd8d";
+      name = "kamoso-21.12.0.tar.xz";
     };
   };
   kanagram = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kanagram-21.08.3.tar.xz";
-      sha256 = "1rxirjrw6dj23awv6gbypv0jlwfdh4baz86l32rx8pnmd9icg7s3";
-      name = "kanagram-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kanagram-21.12.0.tar.xz";
+      sha256 = "0j7agapb1byd28fn49c3j02gl108n8skk95spyi998rnm9zm2wc6";
+      name = "kanagram-21.12.0.tar.xz";
     };
   };
   kapman = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kapman-21.08.3.tar.xz";
-      sha256 = "0v8ay2s868l7dxasq0rhy065rp9sfb4fzldcqs46lxy7jmk3ws93";
-      name = "kapman-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kapman-21.12.0.tar.xz";
+      sha256 = "11vnm8ajrckg0ix5xc7mpbwqisbsqy3wivf9y18m5qkz5bvis4g4";
+      name = "kapman-21.12.0.tar.xz";
     };
   };
   kapptemplate = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kapptemplate-21.08.3.tar.xz";
-      sha256 = "02dp4qwrv3gylri936c82imh4lv1a3vfzlphmwadyhiy7j9ic5fa";
-      name = "kapptemplate-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kapptemplate-21.12.0.tar.xz";
+      sha256 = "022rrgb8bak62q253x14gk5grsimwhilwkb4rlm2scq84m4lwil7";
+      name = "kapptemplate-21.12.0.tar.xz";
     };
   };
   kate = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kate-21.08.3.tar.xz";
-      sha256 = "1gdz0wxkh34a2zi9vks9qw70g7dvkbvrbp6y68rjg7720sdb0gp2";
-      name = "kate-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kate-21.12.0.tar.xz";
+      sha256 = "0yvg2j4ijx3zq0v0djidjp5w3lj8j7qpfh9ax2ym7a3qf1y2w4ml";
+      name = "kate-21.12.0.tar.xz";
     };
   };
   katomic = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/katomic-21.08.3.tar.xz";
-      sha256 = "1sgrpqbv4zz22qijm00lzv1cv4rwjh7bbf4gz9xmnfmhyw0n88i1";
-      name = "katomic-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/katomic-21.12.0.tar.xz";
+      sha256 = "1k8aivpn9fmzwn5nzcbn2zym7m65xganxx43drk8mhx5m2lgvs0c";
+      name = "katomic-21.12.0.tar.xz";
     };
   };
   kbackup = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kbackup-21.08.3.tar.xz";
-      sha256 = "1cjb2invbc60i2lahn01kd28q3wb6s35grwglgmx2cgqqkmgl42s";
-      name = "kbackup-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kbackup-21.12.0.tar.xz";
+      sha256 = "1ki86g18mc7m9cywjpjcx1i83b5ff9dbjx7qa5fqmy5n16b85l5m";
+      name = "kbackup-21.12.0.tar.xz";
     };
   };
   kblackbox = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kblackbox-21.08.3.tar.xz";
-      sha256 = "1i4c5v5w42akf4b44sqrl9x4rhqgyjljr7k5i440ahch9qkf93pj";
-      name = "kblackbox-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kblackbox-21.12.0.tar.xz";
+      sha256 = "09lafayr6fl50dm272qph0j0qvznqsg7jkfmkq06wwm2sxxlabc9";
+      name = "kblackbox-21.12.0.tar.xz";
     };
   };
   kblocks = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kblocks-21.08.3.tar.xz";
-      sha256 = "0326fxv1nvh37h8xhvv5x4fy3l4gbrzmwsgcwslma1hakys9dhrs";
-      name = "kblocks-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kblocks-21.12.0.tar.xz";
+      sha256 = "0lc4wmgb07x87y4hyaajqkd3sw5afk1yby46wywak3m8v8scyvwg";
+      name = "kblocks-21.12.0.tar.xz";
     };
   };
   kbounce = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kbounce-21.08.3.tar.xz";
-      sha256 = "00d9m7c564qrifpaldvjk6ahclrjk1aawhypjj9sls2sisx2mip4";
-      name = "kbounce-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kbounce-21.12.0.tar.xz";
+      sha256 = "1qb3n03cl1qbnrbm2cqk20zxkpilddr8j67ca22mipp0md67c0fv";
+      name = "kbounce-21.12.0.tar.xz";
     };
   };
   kbreakout = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kbreakout-21.08.3.tar.xz";
-      sha256 = "1h3s4cr4bxi24j55anks946h7iba2wda5kbglsyfqw1ifrsq13vz";
-      name = "kbreakout-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kbreakout-21.12.0.tar.xz";
+      sha256 = "12zd36zv7qbdavism2kzbmx78vx66laykhkskaz66z1qxw1wls6y";
+      name = "kbreakout-21.12.0.tar.xz";
     };
   };
   kbruch = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kbruch-21.08.3.tar.xz";
-      sha256 = "15bfqxz4j5f5ix55fsk780p7ddrzqzmk55gmbjy796sgh8b71wcr";
-      name = "kbruch-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kbruch-21.12.0.tar.xz";
+      sha256 = "1xk8g3zp8qpqz893nnj50h1ypqzbalj57x6m4g7xy77dmwdjqgnd";
+      name = "kbruch-21.12.0.tar.xz";
     };
   };
   kcachegrind = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kcachegrind-21.08.3.tar.xz";
-      sha256 = "188m15y7sj17jyr9963gblgkknhgf32331kvzz4cwqzk14b9krr2";
-      name = "kcachegrind-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kcachegrind-21.12.0.tar.xz";
+      sha256 = "1k5fgqyd76679ay53dlksp46a0f54qyk9av5z0bq4l2ldna5k2ly";
+      name = "kcachegrind-21.12.0.tar.xz";
     };
   };
   kcalc = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kcalc-21.08.3.tar.xz";
-      sha256 = "1d7716law49cwmis4w9ij1xmi4g2wrv4mnc78xcms8kmgba5gs7v";
-      name = "kcalc-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kcalc-21.12.0.tar.xz";
+      sha256 = "1ih0xmldzm39li93xiprr4wm6xqwwkqc15bnmvy846p0b1kqg2s5";
+      name = "kcalc-21.12.0.tar.xz";
     };
   };
   kcalutils = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kcalutils-21.08.3.tar.xz";
-      sha256 = "0l209pyi866mf1pr4rkq7g3pgjvyss5sqhpy9vb2b2w66w3f66ri";
-      name = "kcalutils-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kcalutils-21.12.0.tar.xz";
+      sha256 = "09i4kbfgwpzw55rdlvl0hi1bvra0796b2d18n97lf2idafiz6bny";
+      name = "kcalutils-21.12.0.tar.xz";
     };
   };
   kcharselect = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kcharselect-21.08.3.tar.xz";
-      sha256 = "0fk06whwi4h43sw3adcs4b2s9ycwjamzrwr23m33c31mlpcb3i8z";
-      name = "kcharselect-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kcharselect-21.12.0.tar.xz";
+      sha256 = "1nbys46mbrsb1j5migpap5x11hz54vmfwxcrgcrr5l74g2gr33ks";
+      name = "kcharselect-21.12.0.tar.xz";
     };
   };
   kcolorchooser = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kcolorchooser-21.08.3.tar.xz";
-      sha256 = "07fvl4rfzhgz4kh9dhqkq6kf4913jv9cw9abfdb7k3pbr0r26qgz";
-      name = "kcolorchooser-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kcolorchooser-21.12.0.tar.xz";
+      sha256 = "0dy6p6yg1rki3bnhvskphha3v72lbw70h4x9aazkiczfyb19iyjk";
+      name = "kcolorchooser-21.12.0.tar.xz";
     };
   };
   kcron = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kcron-21.08.3.tar.xz";
-      sha256 = "1374agj9qc5ifm0yckq8m94gq7sjd42n4wwb59p756736asan8k5";
-      name = "kcron-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kcron-21.12.0.tar.xz";
+      sha256 = "1j5jcfamb3srxfli7wd32j194f51y5x60p21hkgprwmj7k8l7nia";
+      name = "kcron-21.12.0.tar.xz";
     };
   };
   kde-dev-scripts = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kde-dev-scripts-21.08.3.tar.xz";
-      sha256 = "152n6iir4xzx1a5d5bi4lb42rgl222pi6jz0hfkchk7swfgpvdfs";
-      name = "kde-dev-scripts-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kde-dev-scripts-21.12.0.tar.xz";
+      sha256 = "0b8xnkk0xmkw7jjhi9ilvgsn41p1f5ni6008nl1vf2ys76iv8ccq";
+      name = "kde-dev-scripts-21.12.0.tar.xz";
     };
   };
   kde-dev-utils = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kde-dev-utils-21.08.3.tar.xz";
-      sha256 = "1xs4fybbqlxji2py06hxabsisfb3bkvbfb3vy9lyj2k5vnnmpkf8";
-      name = "kde-dev-utils-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kde-dev-utils-21.12.0.tar.xz";
+      sha256 = "1jfdadirgpw4cd7apvzxk5ql0hljyqqmpzak0v395q6nhyflpa54";
+      name = "kde-dev-utils-21.12.0.tar.xz";
     };
   };
   kdebugsettings = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kdebugsettings-21.08.3.tar.xz";
-      sha256 = "1d47igv0xg1hlxzyfg10h5g7s79yq44d3ixpr82risyrslbwvll4";
-      name = "kdebugsettings-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kdebugsettings-21.12.0.tar.xz";
+      sha256 = "0jasjhhfyaakgawzhw7dqbxhc7pzfrcbpghg03pw0ld54ma69s0f";
+      name = "kdebugsettings-21.12.0.tar.xz";
     };
   };
   kdeconnect-kde = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kdeconnect-kde-21.08.3.tar.xz";
-      sha256 = "1gfsbg6rwqv3cpfxcayn3q9i99mnhjz666p9x9ih205idlrn6iij";
-      name = "kdeconnect-kde-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kdeconnect-kde-21.12.0.tar.xz";
+      sha256 = "0jlx6rlg2sspfxq9fsl1416b7229vbx0fydy0a4vdj7nrq1iv7ji";
+      name = "kdeconnect-kde-21.12.0.tar.xz";
     };
   };
   kdeedu-data = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kdeedu-data-21.08.3.tar.xz";
-      sha256 = "15qqcl6gws6ddyv373dfql3wj2fryvr5b6d66q4l1xwc1mg6wnqs";
-      name = "kdeedu-data-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kdeedu-data-21.12.0.tar.xz";
+      sha256 = "11wqcli3dvalkpvbzx271nmxmv825crd5bn03gl9606366q94vin";
+      name = "kdeedu-data-21.12.0.tar.xz";
     };
   };
   kdegraphics-mobipocket = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kdegraphics-mobipocket-21.08.3.tar.xz";
-      sha256 = "1bli0ld2mymgppjsjjvkyk7ldpz787p30d7lf6lpafrf64di2bhm";
-      name = "kdegraphics-mobipocket-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kdegraphics-mobipocket-21.12.0.tar.xz";
+      sha256 = "04rcjlhmqhgaclg0hv5mjjaq5r5nx2pi7ngj5rvh1c14001ip8y2";
+      name = "kdegraphics-mobipocket-21.12.0.tar.xz";
     };
   };
   kdegraphics-thumbnailers = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kdegraphics-thumbnailers-21.08.3.tar.xz";
-      sha256 = "1hbjmkjymb3pi1lz43bl5clgdyy6kr928q7fniwiwmak3k1xrng5";
-      name = "kdegraphics-thumbnailers-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kdegraphics-thumbnailers-21.12.0.tar.xz";
+      sha256 = "0zli49aa2zljly10fzhzj60mjjdikfn6fsxspgx48y0vfcqb1p3h";
+      name = "kdegraphics-thumbnailers-21.12.0.tar.xz";
     };
   };
   kdenetwork-filesharing = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kdenetwork-filesharing-21.08.3.tar.xz";
-      sha256 = "19c3my0i9xb3salf7sk870nhv797wkk83dyrczw672skwl8xcnd9";
-      name = "kdenetwork-filesharing-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kdenetwork-filesharing-21.12.0.tar.xz";
+      sha256 = "15svxqkynw9k6zzdjx9b8bwwy5v76lngw9hvygrfjhif8nr2np6m";
+      name = "kdenetwork-filesharing-21.12.0.tar.xz";
     };
   };
   kdenlive = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kdenlive-21.08.3.tar.xz";
-      sha256 = "00ss9i9gw112vc3bjayp193qnfd3dq47bij9mv429azl20ff0y0c";
-      name = "kdenlive-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kdenlive-21.12.0.tar.xz";
+      sha256 = "083lswdllznyj33qzfbzvy7lp73fwbrhn8xvp33x36nqb3h2w7g1";
+      name = "kdenlive-21.12.0.tar.xz";
     };
   };
   kdepim-addons = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kdepim-addons-21.08.3.tar.xz";
-      sha256 = "1ham9yzmj89lp3zwxwpyh0qy7fxrlhgmhphn9crrkx9gsy77ddsf";
-      name = "kdepim-addons-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kdepim-addons-21.12.0.tar.xz";
+      sha256 = "00xn3l54n9c1znp2k5bll04rqsqazr24mx1hg0vk3gqi6fnff2ph";
+      name = "kdepim-addons-21.12.0.tar.xz";
     };
   };
   kdepim-runtime = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kdepim-runtime-21.08.3.tar.xz";
-      sha256 = "1d2208pwalc6mjfnn4gfq2f2fqgxp9w3g8igx6r6l9qsgybh1msx";
-      name = "kdepim-runtime-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kdepim-runtime-21.12.0.tar.xz";
+      sha256 = "1mmp8wlhm6avwkzs81vfvqidxxagv14ll10bg4pyy2mafnm0q31a";
+      name = "kdepim-runtime-21.12.0.tar.xz";
     };
   };
   kdesdk-kioslaves = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kdesdk-kioslaves-21.08.3.tar.xz";
-      sha256 = "0frw2zxwckmqmffxn5gszdxz61zc0k8xpbhbiyfxsqprh3ck4a2y";
-      name = "kdesdk-kioslaves-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kdesdk-kioslaves-21.12.0.tar.xz";
+      sha256 = "1zj1xz6b0hrjvslw00vs3rgcnrhcm50as7d481zgky385j3c5i8r";
+      name = "kdesdk-kioslaves-21.12.0.tar.xz";
     };
   };
   kdesdk-thumbnailers = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kdesdk-thumbnailers-21.08.3.tar.xz";
-      sha256 = "06s7i85g5gpknxlrq59i5w8czpaz5wl1b8kfx9flzx0x6ibm5s9q";
-      name = "kdesdk-thumbnailers-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kdesdk-thumbnailers-21.12.0.tar.xz";
+      sha256 = "1m471h9c8lsd5jchmdjynjwj85i163qq0m6jxcl9pppsn3hvb6a3";
+      name = "kdesdk-thumbnailers-21.12.0.tar.xz";
+    };
+  };
+  kdev-php = {
+    version = "21.12.0";
+    src = fetchurl {
+      url = "${mirror}/stable/release-service/21.12.0/src/kdev-php-21.12.0.tar.xz";
+      sha256 = "02s116xbdhpvk14y8rgb6icmccy77d0mwrriqv2fxwgl2d26g57z";
+      name = "kdev-php-21.12.0.tar.xz";
+    };
+  };
+  kdev-python = {
+    version = "21.12.0";
+    src = fetchurl {
+      url = "${mirror}/stable/release-service/21.12.0/src/kdev-python-21.12.0.tar.xz";
+      sha256 = "02nfdvbwj4arkx4z5i148n7mxfb4r2f605wjhc2iddkvdmpbgpcx";
+      name = "kdev-python-21.12.0.tar.xz";
+    };
+  };
+  kdevelop = {
+    version = "21.12.0";
+    src = fetchurl {
+      url = "${mirror}/stable/release-service/21.12.0/src/kdevelop-21.12.0.tar.xz";
+      sha256 = "17v1347ljvr6wif1lihv6vbd5h2n6pi1nb5v43lin5s165d7scv4";
+      name = "kdevelop-21.12.0.tar.xz";
     };
   };
   kdf = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kdf-21.08.3.tar.xz";
-      sha256 = "061xclwkhmc9m8f113hlb46dwk5zvqlmgahz13yfbvyrpj810a7k";
-      name = "kdf-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kdf-21.12.0.tar.xz";
+      sha256 = "1q5w741kvyy7bkbm4xiif7ac1cyc02v8wrwr7h10fvcvbvyca50a";
+      name = "kdf-21.12.0.tar.xz";
     };
   };
   kdialog = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kdialog-21.08.3.tar.xz";
-      sha256 = "1ibqz8s8p90rxy843f1wn3jnyzrm54srhfpr4ix48amf86afj2gp";
-      name = "kdialog-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kdialog-21.12.0.tar.xz";
+      sha256 = "1klz70xw43rb89mi1dql0rmjpnzz4hp5dmdwybbby8zd7vkwkp07";
+      name = "kdialog-21.12.0.tar.xz";
     };
   };
   kdiamond = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kdiamond-21.08.3.tar.xz";
-      sha256 = "1vkflwvi1wa2kd6hq647g9skxg6c7jdk9hakzfphlq2jw6daml94";
-      name = "kdiamond-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kdiamond-21.12.0.tar.xz";
+      sha256 = "003qaf5nyv098f6ap86gjiqmr3a84vqjxjn40jd2g09vsn717xpf";
+      name = "kdiamond-21.12.0.tar.xz";
     };
   };
   keditbookmarks = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/keditbookmarks-21.08.3.tar.xz";
-      sha256 = "0v9grm385zyxpsqjp287cz8lvrvfzkk7b4blvdr1hi66sng7nr2n";
-      name = "keditbookmarks-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/keditbookmarks-21.12.0.tar.xz";
+      sha256 = "1pglks8hh1h7lhgzqai4jahy5zgw7j5si4ijbnk02s8zi1prjn21";
+      name = "keditbookmarks-21.12.0.tar.xz";
     };
   };
   kfind = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kfind-21.08.3.tar.xz";
-      sha256 = "04qdxqa8gfipjm5akplxrjbnlaky2djkx8nkvcqzqfhvw5i9rxqp";
-      name = "kfind-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kfind-21.12.0.tar.xz";
+      sha256 = "1a5p8673c544w1587pp49ra8xwj80hg8v6vgxh88xs5fjdxwzgf5";
+      name = "kfind-21.12.0.tar.xz";
     };
   };
   kfloppy = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kfloppy-21.08.3.tar.xz";
-      sha256 = "14l53a0mrzhnfrhalr71fv0j0ksz6c1zqj8j33nayhqz386yrccx";
-      name = "kfloppy-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kfloppy-21.12.0.tar.xz";
+      sha256 = "1sk7gaywq90nc54n18vfls5lc6pb780ggljdgn1mr9qyz98brf4v";
+      name = "kfloppy-21.12.0.tar.xz";
     };
   };
   kfourinline = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kfourinline-21.08.3.tar.xz";
-      sha256 = "0w2zdl0yfhwdwbnlqd4l9pdx7q9mr0xq7kw49h9wiajy1zmh8vls";
-      name = "kfourinline-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kfourinline-21.12.0.tar.xz";
+      sha256 = "18nl5gik49gmamdfv21ihg2fvsbx8fviwqzvfqpqjwmf7hmdn854";
+      name = "kfourinline-21.12.0.tar.xz";
     };
   };
   kgeography = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kgeography-21.08.3.tar.xz";
-      sha256 = "03wchz3bd4vlijywp9r2xilmhw4gc3ka54ilf2w60baazslhlnr3";
-      name = "kgeography-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kgeography-21.12.0.tar.xz";
+      sha256 = "0dqv45aaqdw9sf7knrsm1r8bj3vf14vvra41gsi19g6ksv245xzq";
+      name = "kgeography-21.12.0.tar.xz";
     };
   };
   kget = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kget-21.08.3.tar.xz";
-      sha256 = "0zpzh7bf65kz469viff794zdwc54aq84ndafx6g07nhqs3jhnmjp";
-      name = "kget-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kget-21.12.0.tar.xz";
+      sha256 = "0dd57942mv0rlgsdr2hm75x4g1hbkjnzy11fkczhdb2hy49ylmaz";
+      name = "kget-21.12.0.tar.xz";
     };
   };
   kgoldrunner = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kgoldrunner-21.08.3.tar.xz";
-      sha256 = "0c566c83a7kdc4kvzn37q4kdmr373hfrjgmq7mvn9bji5gcaqzch";
-      name = "kgoldrunner-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kgoldrunner-21.12.0.tar.xz";
+      sha256 = "1y5119jxg1fx0wpi9b50gc9h1im1ixzyzhsjcrp0rzqqcdyajm17";
+      name = "kgoldrunner-21.12.0.tar.xz";
     };
   };
   kgpg = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kgpg-21.08.3.tar.xz";
-      sha256 = "0q8da9mzqxg0xmclcpgjh8c744l1sm180ga6hxbasan47wwq67as";
-      name = "kgpg-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kgpg-21.12.0.tar.xz";
+      sha256 = "0i6iqnjplms1rv2f8h3p4z56z20apyw45hmp1mf45pgadwjvs59v";
+      name = "kgpg-21.12.0.tar.xz";
     };
   };
   khangman = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/khangman-21.08.3.tar.xz";
-      sha256 = "1iq4njq0fa7all8zm2q585i1grmv2nfb5qnpr8xpyn13np39q8sr";
-      name = "khangman-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/khangman-21.12.0.tar.xz";
+      sha256 = "1jvw3d743s41b1kq9vpa8l3063br4asbc9spffqlrx09d748w14n";
+      name = "khangman-21.12.0.tar.xz";
     };
   };
   khelpcenter = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/khelpcenter-21.08.3.tar.xz";
-      sha256 = "1pn5822yxqw62hynkf05a33gzs9xvrwwrxam024g6gs0y0v5nsfp";
-      name = "khelpcenter-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/khelpcenter-21.12.0.tar.xz";
+      sha256 = "0mashc7kkmq2hnsbc8cdb3jh5l3q3rynqxvdl2hqwgla83pnfs5c";
+      name = "khelpcenter-21.12.0.tar.xz";
     };
   };
   kidentitymanagement = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kidentitymanagement-21.08.3.tar.xz";
-      sha256 = "00fhw2c7jmv0xqyd1jlrlkahszw163a7cbljn83msws8m5mrnlcb";
-      name = "kidentitymanagement-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kidentitymanagement-21.12.0.tar.xz";
+      sha256 = "0gjdhxqzshc82hkhsmypyq9sgrnppq6r33zcz31c1d1g0bgklrgw";
+      name = "kidentitymanagement-21.12.0.tar.xz";
     };
   };
   kig = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kig-21.08.3.tar.xz";
-      sha256 = "1l4zap7lm1pigyldbqy20jaqysid0r4a6y71qalxk3f565jsqfx5";
-      name = "kig-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kig-21.12.0.tar.xz";
+      sha256 = "00i7ng9csgf6h2db2g6vxnhipqhhhbrnvw4zx6qz7y4f6ik3qxlc";
+      name = "kig-21.12.0.tar.xz";
     };
   };
   kigo = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kigo-21.08.3.tar.xz";
-      sha256 = "1cdrmlwpzbkz1mi2f72z9dh1pvkdkjn885zqqybhqbqicn3w3qch";
-      name = "kigo-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kigo-21.12.0.tar.xz";
+      sha256 = "1r90hxxzd36aphjhkn46q965wmsghqraiwq68x14w1kzgwkh5a7x";
+      name = "kigo-21.12.0.tar.xz";
     };
   };
   killbots = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/killbots-21.08.3.tar.xz";
-      sha256 = "1mwa46r7yvxhavprc6yjh773gjhz5ks0znsvpzambn6hk23r11p8";
-      name = "killbots-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/killbots-21.12.0.tar.xz";
+      sha256 = "19dr1n4hzhzqnhfc1sbgyimb3dr0gnfch031f1wgybg94avdk7yx";
+      name = "killbots-21.12.0.tar.xz";
     };
   };
   kimagemapeditor = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kimagemapeditor-21.08.3.tar.xz";
-      sha256 = "0vzy028cgq0ai4f9rgkc32w09yz5836y280nck2wxk2dajjc5k6x";
-      name = "kimagemapeditor-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kimagemapeditor-21.12.0.tar.xz";
+      sha256 = "0f07k4fwbp7nniky88s5h3p96g60m6zh1shkhndiv1zpznlgiaba";
+      name = "kimagemapeditor-21.12.0.tar.xz";
     };
   };
   kimap = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kimap-21.08.3.tar.xz";
-      sha256 = "11xwkgxm0ghbpcy6bmvkw1hlsfkdrlyyfbblv5m4s881ky7h4aim";
-      name = "kimap-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kimap-21.12.0.tar.xz";
+      sha256 = "0fasq0lk6w477bqg1mfpslxpclwd5jrgayfxi6qxh8pfi486c8fd";
+      name = "kimap-21.12.0.tar.xz";
     };
   };
   kio-extras = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kio-extras-21.08.3.tar.xz";
-      sha256 = "0lx0b9q68mfb96jfwsf0awcx9wn47nmnqqnk57wrbx8zx880q0j2";
-      name = "kio-extras-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kio-extras-21.12.0.tar.xz";
+      sha256 = "15lws6d794rqyxnyp812f58agd1ydgg7vka6gc2d92ks3m438qi4";
+      name = "kio-extras-21.12.0.tar.xz";
     };
   };
   kio-gdrive = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kio-gdrive-21.08.3.tar.xz";
-      sha256 = "1h781cksqq5qana80rlc0x3cfz5prl1g3il4282vf2yqihl3zgrd";
-      name = "kio-gdrive-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kio-gdrive-21.12.0.tar.xz";
+      sha256 = "0ysd1368gal4fc92jilvshj4mxr7babsqmlhx0623q2jm20f5hxj";
+      name = "kio-gdrive-21.12.0.tar.xz";
     };
   };
   kipi-plugins = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kipi-plugins-21.08.3.tar.xz";
-      sha256 = "1vscmljcadz11m4jsbkkx5f8ywbyvmfxnw1g7x5ks8d8hqsrcgd0";
-      name = "kipi-plugins-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kipi-plugins-21.12.0.tar.xz";
+      sha256 = "04abfilhlrh9lf1ayg4pc87qc5i6adxwmw1gyq9yjjg5zg7vksz9";
+      name = "kipi-plugins-21.12.0.tar.xz";
     };
   };
   kirigami-gallery = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kirigami-gallery-21.08.3.tar.xz";
-      sha256 = "0d2psfq5q7zjmd4k1jz0fgwi3gnhi78jn10hrwvc7f8fb6pw4rzc";
-      name = "kirigami-gallery-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kirigami-gallery-21.12.0.tar.xz";
+      sha256 = "1c2dyncjm6nsv4zra3h6pks808xbvgma4g7hjqlivb35snf32ky7";
+      name = "kirigami-gallery-21.12.0.tar.xz";
     };
   };
   kiriki = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kiriki-21.08.3.tar.xz";
-      sha256 = "19qvbxc0dpjq0vb5kh3qsrkv1793bz5ii958a4yqfmmc8xb26v2x";
-      name = "kiriki-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kiriki-21.12.0.tar.xz";
+      sha256 = "1a82091b66rxbfbaqls52q34gxg1jvxkjcangwgs6rq8gk624siq";
+      name = "kiriki-21.12.0.tar.xz";
     };
   };
   kiten = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kiten-21.08.3.tar.xz";
-      sha256 = "0ly44w9y4ha5nw6lqpm5gavxc3ywqc4wh04nl7wpg0m2rm624mci";
-      name = "kiten-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kiten-21.12.0.tar.xz";
+      sha256 = "1c5dh2xip3g7144rbrzaxi15lgw6x1c12aa40svjm29c7xayhac4";
+      name = "kiten-21.12.0.tar.xz";
     };
   };
   kitinerary = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kitinerary-21.08.3.tar.xz";
-      sha256 = "066rq42g5l1rmzf5c7xg21p35ln60ir92d0sp2wg9s5li0l0azbf";
-      name = "kitinerary-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kitinerary-21.12.0.tar.xz";
+      sha256 = "0dzgvijgm7f5zywpalpf9rj47jfi6dzd7j7qnq5k9sdbm9q9bw9k";
+      name = "kitinerary-21.12.0.tar.xz";
     };
   };
   kjumpingcube = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kjumpingcube-21.08.3.tar.xz";
-      sha256 = "0iya370m6n9g6m6rzfkdsb9ypwdd0ksfddiy2g0yvjf1xdxr7im9";
-      name = "kjumpingcube-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kjumpingcube-21.12.0.tar.xz";
+      sha256 = "1y0q6hzjqwaky3vjnx9wrb7glx29ffgv22d5kplgsdzg6pfz890m";
+      name = "kjumpingcube-21.12.0.tar.xz";
     };
   };
   kldap = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kldap-21.08.3.tar.xz";
-      sha256 = "1jb1k5xpicsmazc6c57z203w75h8klja7jp7p8934nvj9dgqqcd1";
-      name = "kldap-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kldap-21.12.0.tar.xz";
+      sha256 = "0q6p7r6h4xad341whg0njgq0cm9z76csdphdpg2adiqbdvgyly3g";
+      name = "kldap-21.12.0.tar.xz";
     };
   };
   kleopatra = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kleopatra-21.08.3.tar.xz";
-      sha256 = "1gpn0kpxrw4jn214k5swg2frkfgp9clr99n45z3mzjdccl8zfsbi";
-      name = "kleopatra-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kleopatra-21.12.0.tar.xz";
+      sha256 = "0q8qn4zxaphlakd2biv19fma7p4zxpc7qliz4n0yxmnkj8mhr2l7";
+      name = "kleopatra-21.12.0.tar.xz";
     };
   };
   klettres = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/klettres-21.08.3.tar.xz";
-      sha256 = "0w4fynbvnvlizz0qjkn2qcnn3xs1b0jjfmy9a01wff93a4nw2cj8";
-      name = "klettres-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/klettres-21.12.0.tar.xz";
+      sha256 = "0wz894rcgpcag23k37w7h4ddaniismvaw7ymfdwz2gzfki7mj8w7";
+      name = "klettres-21.12.0.tar.xz";
     };
   };
   klickety = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/klickety-21.08.3.tar.xz";
-      sha256 = "00dl0c6si302mprdwdngxa4361qmr27ii5kvk38vrdlq0cynzgzv";
-      name = "klickety-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/klickety-21.12.0.tar.xz";
+      sha256 = "1z0z4hb52ahzar7v5y2ap722dbz1mgil33iv6jcny1zazh7ddr5i";
+      name = "klickety-21.12.0.tar.xz";
     };
   };
   klines = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/klines-21.08.3.tar.xz";
-      sha256 = "0n3mdnwlyl0q09bz7dkb3796ki3l181085rb2r1k2mjnjwmn8zya";
-      name = "klines-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/klines-21.12.0.tar.xz";
+      sha256 = "1hjyq1n2bmdgm7v3kqw405gxvnsrf1x0i7278lz2w10x8ab6yzsk";
+      name = "klines-21.12.0.tar.xz";
     };
   };
   kmag = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kmag-21.08.3.tar.xz";
-      sha256 = "09jvp1hhdam31qwljzpflcnm1mczsai6xlxlks6q0qi2n52cxkhb";
-      name = "kmag-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kmag-21.12.0.tar.xz";
+      sha256 = "099mzwlgkc8zjp6nkakp73968kjimbb49wsg1ah9qmmairc0amdf";
+      name = "kmag-21.12.0.tar.xz";
     };
   };
   kmahjongg = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kmahjongg-21.08.3.tar.xz";
-      sha256 = "0afjg3svj1sg47xrz3fgvgkd74lvl71sy26br7jjyxjbq1ag9sin";
-      name = "kmahjongg-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kmahjongg-21.12.0.tar.xz";
+      sha256 = "0givhpisv19il3g4if14b4a8dkmspf90bw5h3ys0ybwnk7nyqj77";
+      name = "kmahjongg-21.12.0.tar.xz";
     };
   };
   kmail = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kmail-21.08.3.tar.xz";
-      sha256 = "02kina7xn10f963xb7jgzrf15z6akzgl8ba4c9a7yb46ra4w2707";
-      name = "kmail-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kmail-21.12.0.tar.xz";
+      sha256 = "11la8c8l6b612qwhqiiahi1nd249lsk9k9s9lihm7sjcqzhii070";
+      name = "kmail-21.12.0.tar.xz";
     };
   };
   kmail-account-wizard = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kmail-account-wizard-21.08.3.tar.xz";
-      sha256 = "1wfzbkipdhmbsj1q5c79ssij1sz57mapg1kkypw10p0nlriklz89";
-      name = "kmail-account-wizard-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kmail-account-wizard-21.12.0.tar.xz";
+      sha256 = "08bl6v4fs955yk3hb0a3csb644r2qpy687nakv8msqkjkm8bkjvj";
+      name = "kmail-account-wizard-21.12.0.tar.xz";
     };
   };
   kmailtransport = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kmailtransport-21.08.3.tar.xz";
-      sha256 = "0xn4imfb4085wx5czxb3yiigslwfxwdi2dmgv7ng01wbphpg0chw";
-      name = "kmailtransport-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kmailtransport-21.12.0.tar.xz";
+      sha256 = "161z6bd4j87c4qksgf5hnsfhip614j0lkvb11dlgnjfn99jfl8gh";
+      name = "kmailtransport-21.12.0.tar.xz";
     };
   };
   kmbox = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kmbox-21.08.3.tar.xz";
-      sha256 = "19dkc5l5h5x4h5nq924clc06vz5abll2ki70pc6r9py33rfjs11j";
-      name = "kmbox-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kmbox-21.12.0.tar.xz";
+      sha256 = "1052hpr6qgqdzhy7ja2bnfqzfd2mj402vbz46rsc1zghzx5vx7qk";
+      name = "kmbox-21.12.0.tar.xz";
     };
   };
   kmime = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kmime-21.08.3.tar.xz";
-      sha256 = "1bmgnsslhfzyix85c5p3mym6r9f2sjw5ajd5kzw9yxzyvzyc7kv6";
-      name = "kmime-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kmime-21.12.0.tar.xz";
+      sha256 = "0n6qya2j5aa8vv6iqn5rxb5jdd3zyk7p5qwp8yza5fjzvb4mrfvm";
+      name = "kmime-21.12.0.tar.xz";
     };
   };
   kmines = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kmines-21.08.3.tar.xz";
-      sha256 = "0x2ligjxam6aaxpzl1zj5circ0ssn9ycafl3ydvhk9pz9j3c9cx1";
-      name = "kmines-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kmines-21.12.0.tar.xz";
+      sha256 = "0jp4d6lfy07iv8ancbd22m8kmy9dx1ip8kl97zsjydzy5jz3ys7z";
+      name = "kmines-21.12.0.tar.xz";
     };
   };
   kmix = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kmix-21.08.3.tar.xz";
-      sha256 = "0smfvkw8svg4fd3sf3f3l5my516jjh2n203kffkg6nr2pgscfw58";
-      name = "kmix-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kmix-21.12.0.tar.xz";
+      sha256 = "02wrbh4g0xic3q7f9x51nb094xgfvsjp19dfx0phq33mcc6257b0";
+      name = "kmix-21.12.0.tar.xz";
     };
   };
   kmousetool = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kmousetool-21.08.3.tar.xz";
-      sha256 = "0fyhni1m96xh7ir7zhggszfvn7rsf5dp8l065pzvla73w7l6iqwy";
-      name = "kmousetool-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kmousetool-21.12.0.tar.xz";
+      sha256 = "0xrrhycdmjc2izrgmlr2c6nb2fd6ilhbgzsq816g5rnn85n2yd66";
+      name = "kmousetool-21.12.0.tar.xz";
     };
   };
   kmouth = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kmouth-21.08.3.tar.xz";
-      sha256 = "0d30r0kyq260pmbk4n9ild0zibwf1sdqwpszvi2j8y5v3gn2bg69";
-      name = "kmouth-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kmouth-21.12.0.tar.xz";
+      sha256 = "15g8b7xjca9klvjlfnpp61n3i4dpr77c7cx3vpm7lhm672vnb6am";
+      name = "kmouth-21.12.0.tar.xz";
     };
   };
   kmplot = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kmplot-21.08.3.tar.xz";
-      sha256 = "0az7krs0m7xly9v2aclfh4schw9hj99qmv6qmqwa1qvdhhhxd52p";
-      name = "kmplot-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kmplot-21.12.0.tar.xz";
+      sha256 = "0jhq983b4sfx57ld7b05z6i81bqbink5v5fcym56l8c7clm7jbwn";
+      name = "kmplot-21.12.0.tar.xz";
     };
   };
   knavalbattle = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/knavalbattle-21.08.3.tar.xz";
-      sha256 = "0ydbkfi1n1j9fv0rjxpvh6nsjp20zwmb5ii47pv77z6a3rk5sqf4";
-      name = "knavalbattle-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/knavalbattle-21.12.0.tar.xz";
+      sha256 = "1rh8v5m05zpvra955y3hgrral5dn0ac0vdgsbs881nj2g2md66gr";
+      name = "knavalbattle-21.12.0.tar.xz";
     };
   };
   knetwalk = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/knetwalk-21.08.3.tar.xz";
-      sha256 = "0nplhxvqiw9ap12hxyk1z247f31jqwg59d5q75jiqi1xr1gf27n2";
-      name = "knetwalk-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/knetwalk-21.12.0.tar.xz";
+      sha256 = "0akkc92s44ddak7k2arrh986pzfan3k9ccxb1b91qv2cr3ma004c";
+      name = "knetwalk-21.12.0.tar.xz";
     };
   };
   knights = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/knights-21.08.3.tar.xz";
-      sha256 = "0ajnn8jaa1h97k89qj5c7i51c2wr3zgbsiiz9bxhhmb6gwrwjqpi";
-      name = "knights-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/knights-21.12.0.tar.xz";
+      sha256 = "179c17zs4nvhwmbi04fshcww4s2lg9nzlx7f2zmg3cnbw905h939";
+      name = "knights-21.12.0.tar.xz";
     };
   };
   knotes = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/knotes-21.08.3.tar.xz";
-      sha256 = "0v5kg8gi2wmz4dhwg6pmq5pd6kh91ha9hg64z21p38b3nc4z07l4";
-      name = "knotes-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/knotes-21.12.0.tar.xz";
+      sha256 = "0qdwfnbp79jh6anvk6laj02zikvwjj1xh33phmbja2g69x9igsxg";
+      name = "knotes-21.12.0.tar.xz";
     };
   };
   kolf = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kolf-21.08.3.tar.xz";
-      sha256 = "1mz30vzdcsa9nhwqmcr6kxwvi9843b876kzpmqrlrxc19ixqbyq4";
-      name = "kolf-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kolf-21.12.0.tar.xz";
+      sha256 = "10qknxia43dh6cxarwdfgfm8qricydginxmv1y9an6v8p1mafpvm";
+      name = "kolf-21.12.0.tar.xz";
     };
   };
   kollision = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kollision-21.08.3.tar.xz";
-      sha256 = "1m46xrik0ppp6nhrsx264zzy0fdvryamcj0w5m6bm0hnyj75c4rk";
-      name = "kollision-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kollision-21.12.0.tar.xz";
+      sha256 = "0bji11sqnz3bkaa85kap2lz3sksy68gbg6062rn6nvwgwvq80fsw";
+      name = "kollision-21.12.0.tar.xz";
     };
   };
   kolourpaint = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kolourpaint-21.08.3.tar.xz";
-      sha256 = "11ciijpr8aa8nd3zgxrikdnx1gk1w78h1v1nhgqn399lxn3vkchi";
-      name = "kolourpaint-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kolourpaint-21.12.0.tar.xz";
+      sha256 = "167b9zishg4z51i2hcdq0ig9wasmmqsgr0hmj6xh8vs7bi6hdfam";
+      name = "kolourpaint-21.12.0.tar.xz";
     };
   };
   kompare = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kompare-21.08.3.tar.xz";
-      sha256 = "1988y00mb5wz9c6h4kchkyda4vas44bhiqd1zc4i0fkyl5wi5vp0";
-      name = "kompare-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kompare-21.12.0.tar.xz";
+      sha256 = "05g9i6nh7bgdxbf1i6w1g5rjbwblgj83xd7vx2l8381db2f0p6ks";
+      name = "kompare-21.12.0.tar.xz";
     };
   };
   konqueror = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/konqueror-21.08.3.tar.xz";
-      sha256 = "1ls9avkwcf7c9qnmxasbi933sjw9q3hnjyys5zf69v7p5hqvg0dz";
-      name = "konqueror-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/konqueror-21.12.0.tar.xz";
+      sha256 = "1cy0n04nnrfwms0clj5p7q6m3aayijg5nkr3n9rgbhaia050sdk7";
+      name = "konqueror-21.12.0.tar.xz";
     };
   };
   konquest = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/konquest-21.08.3.tar.xz";
-      sha256 = "0vsvzz47yn5wyl8zjnbfs1g97466l5ldxcc7mpg1q4y28fxb4jiv";
-      name = "konquest-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/konquest-21.12.0.tar.xz";
+      sha256 = "0wyzgs89xii7pcgkq6x99dfajbwhjma6va4lp58pfrrg7ysisdxw";
+      name = "konquest-21.12.0.tar.xz";
     };
   };
   konsole = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/konsole-21.08.3.tar.xz";
-      sha256 = "1w802g95s8hrlpkilxs2mh7fsg7xq3x9vzw48766kpl9ri3ppx91";
-      name = "konsole-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/konsole-21.12.0.tar.xz";
+      sha256 = "0wvgwcpp8wg6c08s95nc09ypm915741118ggy88ilz3vxf3rjlpk";
+      name = "konsole-21.12.0.tar.xz";
     };
   };
   kontact = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kontact-21.08.3.tar.xz";
-      sha256 = "0rwi34avk98m0jjbaij895ganfcz5c8l926nr399j5qnv9r6j82l";
-      name = "kontact-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kontact-21.12.0.tar.xz";
+      sha256 = "17jrj21jbxp121jmkvdzw05fbkjb6035pz38d982bkwpgc4sv5j9";
+      name = "kontact-21.12.0.tar.xz";
     };
   };
   kontactinterface = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kontactinterface-21.08.3.tar.xz";
-      sha256 = "1284f6cndf3l4il4mw1qrqvf9jmww6nmhh6fx7asw7mfc32r5zaj";
-      name = "kontactinterface-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kontactinterface-21.12.0.tar.xz";
+      sha256 = "01wz9ifmf6d8m0ggmbqyphnm05hi07zgqypy0safy9kvn3m4jj3v";
+      name = "kontactinterface-21.12.0.tar.xz";
     };
   };
   kontrast = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kontrast-21.08.3.tar.xz";
-      sha256 = "1yy4gfckabb175apvm7fcj77nxdc2fdszz1f1zrikrss20r7dc79";
-      name = "kontrast-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kontrast-21.12.0.tar.xz";
+      sha256 = "1dv79n5792pd4fs9f8i7528zy8a7xyaygyzhf3311v9dbi14arg8";
+      name = "kontrast-21.12.0.tar.xz";
     };
   };
   konversation = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/konversation-21.08.3.tar.xz";
-      sha256 = "0wfjhp6scrq9a5llr5f9fcz2k7b5jnid8m8hrp520ai4wg4ll7zv";
-      name = "konversation-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/konversation-21.12.0.tar.xz";
+      sha256 = "1lmfmw9nizp4y35w216ykxp9yz2bbds9hyw8bzy51qjk0k8lw3jl";
+      name = "konversation-21.12.0.tar.xz";
     };
   };
   kopeninghours = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kopeninghours-21.08.3.tar.xz";
-      sha256 = "090rp2qpsbsyqm4nipq398c3pkr0rx46rwmr4393wffzmnbiwcb9";
-      name = "kopeninghours-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kopeninghours-21.12.0.tar.xz";
+      sha256 = "1p0ql8amxaf7j36y5qajy341aa90lb9q5667jw1zbvfc7kf3myq7";
+      name = "kopeninghours-21.12.0.tar.xz";
     };
   };
   kopete = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kopete-21.08.3.tar.xz";
-      sha256 = "105zwy4k7idkdmjjx754x7acszd4yw3y3r7lrf61f44wsm9dv2wr";
-      name = "kopete-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kopete-21.12.0.tar.xz";
+      sha256 = "0m47h44b4xxva5qg6iw09a52ildfgwgz8c7z3wjc09r88akiarsy";
+      name = "kopete-21.12.0.tar.xz";
     };
   };
   korganizer = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/korganizer-21.08.3.tar.xz";
-      sha256 = "00r7abidj71yqgx4g0kd09dfnq0ilqh3kyzq47ms912gp1dkr5b9";
-      name = "korganizer-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/korganizer-21.12.0.tar.xz";
+      sha256 = "1qfc43llhw9941k9lh9g03bal4hzp80m5yapklcnd6smq2z0kk98";
+      name = "korganizer-21.12.0.tar.xz";
     };
   };
   kosmindoormap = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kosmindoormap-21.08.3.tar.xz";
-      sha256 = "15qq6w14yxfprzzj3267z15zkalsb8y0igq772hwyz4v7f6xhydp";
-      name = "kosmindoormap-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kosmindoormap-21.12.0.tar.xz";
+      sha256 = "1li3jz8b6kqxwivdmcfjgyxc4kvldi6i8n7ik4kllvljv67zqch3";
+      name = "kosmindoormap-21.12.0.tar.xz";
     };
   };
   kpat = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kpat-21.08.3.tar.xz";
-      sha256 = "0s8k8q12hvciz2c38gn5w7miz0i97pqn4jrs69sm294nw7wh1xi4";
-      name = "kpat-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kpat-21.12.0.tar.xz";
+      sha256 = "032advwlagv52nkfd2dv6ri6hq3i8wdmffcgcb2879fvdix6jkz2";
+      name = "kpat-21.12.0.tar.xz";
     };
   };
   kpimtextedit = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kpimtextedit-21.08.3.tar.xz";
-      sha256 = "18bjvhlvjn5a1gnzw478l15mgda4c7qba0qqk9rrbh2ryr1ksf7h";
-      name = "kpimtextedit-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kpimtextedit-21.12.0.tar.xz";
+      sha256 = "17yhh63cjpjdxynqflb33cdkfy047zq7d4f1xjx3kczcm5is2ms1";
+      name = "kpimtextedit-21.12.0.tar.xz";
     };
   };
   kpkpass = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kpkpass-21.08.3.tar.xz";
-      sha256 = "0l6n358gng24fqhwjmfpxfmmcw8x80di120k72zahiqplk2arcf5";
-      name = "kpkpass-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kpkpass-21.12.0.tar.xz";
+      sha256 = "02kpwyh169swlvf0dn0n64xn4r3hbzjj6ls2jncnjwlzyrpa56xn";
+      name = "kpkpass-21.12.0.tar.xz";
     };
   };
   kpmcore = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kpmcore-21.08.3.tar.xz";
-      sha256 = "0y9bpw71dn9c39rjsl44az3y2bdczrj833dvwmrwaz6jbnhxl1kj";
-      name = "kpmcore-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kpmcore-21.12.0.tar.xz";
+      sha256 = "0czjkxv8mzf3j7kjrzncb81binvscf2vmzjv19aiaa8nq9gx9i55";
+      name = "kpmcore-21.12.0.tar.xz";
     };
   };
   kpublictransport = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kpublictransport-21.08.3.tar.xz";
-      sha256 = "06jbc0qgi5dgx9jwhdnimw1k480whbqw5x75jrx9bspv5y5br16j";
-      name = "kpublictransport-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kpublictransport-21.12.0.tar.xz";
+      sha256 = "1dzr6b404bg8f2zzphy75pr265kqpyv5bivia9p779s27vc4456a";
+      name = "kpublictransport-21.12.0.tar.xz";
     };
   };
   kqtquickcharts = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kqtquickcharts-21.08.3.tar.xz";
-      sha256 = "0kyznsq7bjzj5c091kpgn443zvkn3qbmn2b0sppj78a7b8ica5ca";
-      name = "kqtquickcharts-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kqtquickcharts-21.12.0.tar.xz";
+      sha256 = "0bnwzpawb7160vi2n10nihgb5r5dqsc5fdzwxyympl37r4l9jxin";
+      name = "kqtquickcharts-21.12.0.tar.xz";
     };
   };
   krdc = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/krdc-21.08.3.tar.xz";
-      sha256 = "0jcbbq9vd4f1kp76fanwnp6q4hq10w3z7ygrb8makpa0daa96vx4";
-      name = "krdc-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/krdc-21.12.0.tar.xz";
+      sha256 = "0v59fdf5nkgbd27nkgpynqvj0ga8a36ii2h8x3kz47rrw9xvr961";
+      name = "krdc-21.12.0.tar.xz";
     };
   };
   kreversi = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kreversi-21.08.3.tar.xz";
-      sha256 = "1ifcckbf9lr4pr9n2ggqjvv6xz747k9hk7m43y5ij0bixi6cq474";
-      name = "kreversi-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kreversi-21.12.0.tar.xz";
+      sha256 = "1s2gh544l1knwg2yl3wm3mkq1d229kp0hb376pi0lzg94cvwhwzw";
+      name = "kreversi-21.12.0.tar.xz";
     };
   };
   krfb = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/krfb-21.08.3.tar.xz";
-      sha256 = "17q0hpwqbwqg4xbq5lmk5g1fl5jplzpx1acyhcbx7il0j06cfcn4";
-      name = "krfb-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/krfb-21.12.0.tar.xz";
+      sha256 = "11vlzk0kimqnqlxcwam1j8hkd7r20lvclaflv0fr8wv5jgy5jikd";
+      name = "krfb-21.12.0.tar.xz";
     };
   };
   kross-interpreters = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kross-interpreters-21.08.3.tar.xz";
-      sha256 = "0z9lmazpw5389sgvhsjsm1219ys3fybr7hg95nrz8a334vw39nqv";
-      name = "kross-interpreters-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kross-interpreters-21.12.0.tar.xz";
+      sha256 = "1p836hhvz37gk84n2z12j49y206q525agvm1gpbf8zvizjiii12g";
+      name = "kross-interpreters-21.12.0.tar.xz";
     };
   };
   kruler = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kruler-21.08.3.tar.xz";
-      sha256 = "0rjxy4ipxxk91wlzhrw9mg5avz18l4p01in29l1ccfz278b97lqm";
-      name = "kruler-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kruler-21.12.0.tar.xz";
+      sha256 = "1ki5g7hzpxzv9fqk6xv368rzsj1pbbgnf7nfsksla0xjb7ixm4mi";
+      name = "kruler-21.12.0.tar.xz";
     };
   };
   kshisen = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kshisen-21.08.3.tar.xz";
-      sha256 = "1fnd2qck51gxnw6ncq52rd1q08abh70azs0apjnh9qk0dyjk91wh";
-      name = "kshisen-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kshisen-21.12.0.tar.xz";
+      sha256 = "1l37an6blv1a9ka8hq3nhf83nbb15mzqqgyza3g80cfziafdiy73";
+      name = "kshisen-21.12.0.tar.xz";
     };
   };
   ksirk = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/ksirk-21.08.3.tar.xz";
-      sha256 = "03v8sghnipkpca3c71s3008m3psawinj90a7637r19h7gyvlyws7";
-      name = "ksirk-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/ksirk-21.12.0.tar.xz";
+      sha256 = "01amnrk3apxk8i081pr2rpnra5akl751j3x9y61qh248jvh856px";
+      name = "ksirk-21.12.0.tar.xz";
     };
   };
   ksmtp = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/ksmtp-21.08.3.tar.xz";
-      sha256 = "0diz01z8gczkwy8c8gvjd583w02vma7kpngzg1ax0wx640vbjq50";
-      name = "ksmtp-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/ksmtp-21.12.0.tar.xz";
+      sha256 = "0p85a8svywbli6579zm931lk1nq199lfad7vf23q5qjmlg2hmnic";
+      name = "ksmtp-21.12.0.tar.xz";
     };
   };
   ksnakeduel = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/ksnakeduel-21.08.3.tar.xz";
-      sha256 = "0gmcn31dg3isv5dxv01rg8w6cbfdhwsz5rpp98lrr0qx4abphva7";
-      name = "ksnakeduel-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/ksnakeduel-21.12.0.tar.xz";
+      sha256 = "0gry8fl74wfs5l2qdhs9qg03l174fw207c24v9fiyhr1hjg18f9w";
+      name = "ksnakeduel-21.12.0.tar.xz";
     };
   };
   kspaceduel = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kspaceduel-21.08.3.tar.xz";
-      sha256 = "0099rc25zvbl2zg1gpmxdhnphl32bd0cxlgikyfvanigq3mx8zkd";
-      name = "kspaceduel-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kspaceduel-21.12.0.tar.xz";
+      sha256 = "1fvw18n8bq18k5n0g4a3p5b15aiwbgbwb67bz0i8p30pr969lsks";
+      name = "kspaceduel-21.12.0.tar.xz";
     };
   };
   ksquares = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/ksquares-21.08.3.tar.xz";
-      sha256 = "1mgs9yapz8fm2nmv0zg2x9qfd0ijj518s43dqmss41zrjr0g3mv2";
-      name = "ksquares-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/ksquares-21.12.0.tar.xz";
+      sha256 = "16kmw5c8gnfdlssh97z3g24snh7gg1hr9nb1ynszwpazvbrga7mm";
+      name = "ksquares-21.12.0.tar.xz";
     };
   };
   ksudoku = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/ksudoku-21.08.3.tar.xz";
-      sha256 = "09s91xvkbybhwdkf80d7kvjj2jvii938vf650fqicypki2vf0zyx";
-      name = "ksudoku-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/ksudoku-21.12.0.tar.xz";
+      sha256 = "1rymwcs0klzg6nb9jjckdcw70pv4w8x9scvlvbdyy8n54yflzrw6";
+      name = "ksudoku-21.12.0.tar.xz";
     };
   };
   ksystemlog = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/ksystemlog-21.08.3.tar.xz";
-      sha256 = "1m20nvvvfbgzd3aay7hsb5pm1bgjngc36ixqs0hrklhrcmwjq9g6";
-      name = "ksystemlog-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/ksystemlog-21.12.0.tar.xz";
+      sha256 = "01mqbk6gzfv1mc1b3g75ia5cb3szx02vbxykjq80icmz4x96nl2g";
+      name = "ksystemlog-21.12.0.tar.xz";
     };
   };
   kteatime = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kteatime-21.08.3.tar.xz";
-      sha256 = "175vmcbhhlan6smhagli0jpa3ik0y0wwiijigfk2srm8cyk29ymn";
-      name = "kteatime-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kteatime-21.12.0.tar.xz";
+      sha256 = "0ywr3cyijzv20qjdiyq5v4wkxhk9a7z38dv450w63v19b309gb28";
+      name = "kteatime-21.12.0.tar.xz";
     };
   };
   ktimer = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/ktimer-21.08.3.tar.xz";
-      sha256 = "1nr116cxw81c2bh32l2xrzmrglk36qkzycbfcffxnm7ka4flwzbm";
-      name = "ktimer-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/ktimer-21.12.0.tar.xz";
+      sha256 = "0qb9vlr5mvf0dnwdbz375wn8nrqvawlvsbf01g8ad43x67q7yqi7";
+      name = "ktimer-21.12.0.tar.xz";
     };
   };
   ktnef = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/ktnef-21.08.3.tar.xz";
-      sha256 = "0vfsy894hs3538ssbqky6nfnjzhyn8yjlmvh0mb6gg69952gcvqa";
-      name = "ktnef-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/ktnef-21.12.0.tar.xz";
+      sha256 = "03b5zjmfl6gmsc9pg6a8ig15gqvh2l6513yaix7ib4qxm1dmdrh8";
+      name = "ktnef-21.12.0.tar.xz";
     };
   };
   ktorrent = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/ktorrent-21.08.3.tar.xz";
-      sha256 = "0y1vpfc8xsm98lrf119r5clmb6xwq2a8adb347ksyvvr4l7rdkwm";
-      name = "ktorrent-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/ktorrent-21.12.0.tar.xz";
+      sha256 = "1jn029494vl2aj9y0c2bgpzkk1f07if904f27j83jv28fv5ynl24";
+      name = "ktorrent-21.12.0.tar.xz";
     };
   };
   ktouch = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/ktouch-21.08.3.tar.xz";
-      sha256 = "0i0ph52k2zw6q37qam2s09msxsdxr5v8qiqwxirjab8ad7g9z0gf";
-      name = "ktouch-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/ktouch-21.12.0.tar.xz";
+      sha256 = "09ayp6infp1xhh411mrqsfj31n89gyq191rgjcwajn97190kd3ch";
+      name = "ktouch-21.12.0.tar.xz";
     };
   };
   ktp-accounts-kcm = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/ktp-accounts-kcm-21.08.3.tar.xz";
-      sha256 = "1ymq8cnvvw62xd4va969imm2g62fw7fhbs8rw3wqrc2lal9d5l1g";
-      name = "ktp-accounts-kcm-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/ktp-accounts-kcm-21.12.0.tar.xz";
+      sha256 = "1vhygwh5lx1pxc1qxskc4v87fqhrwnk53a0k1xz5nymighcyxdvy";
+      name = "ktp-accounts-kcm-21.12.0.tar.xz";
     };
   };
   ktp-approver = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/ktp-approver-21.08.3.tar.xz";
-      sha256 = "0z9kw2gamgdz425aw6li6nvv1g0b1ffil0rmjh0b0z89bbpbc6jx";
-      name = "ktp-approver-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/ktp-approver-21.12.0.tar.xz";
+      sha256 = "1qsfcfym7pbihyb82sh12ziibf9hp73qwhy0hr81h2z5ijg05a7r";
+      name = "ktp-approver-21.12.0.tar.xz";
     };
   };
   ktp-auth-handler = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/ktp-auth-handler-21.08.3.tar.xz";
-      sha256 = "1z89ycwpq46w82hylwq1sizd7a563g5a22jdc1chhhlwp9dqmdc2";
-      name = "ktp-auth-handler-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/ktp-auth-handler-21.12.0.tar.xz";
+      sha256 = "0m3lwqlykx3dqd77hww7x9rmnwdwxbyl279h6mdjjr0bgnf1ypm1";
+      name = "ktp-auth-handler-21.12.0.tar.xz";
     };
   };
   ktp-call-ui = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/ktp-call-ui-21.08.3.tar.xz";
-      sha256 = "1nr064h0f4rqjka030xflhrmq0l8g87fwyi853plk7y0473fy6h2";
-      name = "ktp-call-ui-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/ktp-call-ui-21.12.0.tar.xz";
+      sha256 = "0z6v68xlg89i29zr9ldg5hlqzykwrsw1yvmi5q25rhaamqbcbhy8";
+      name = "ktp-call-ui-21.12.0.tar.xz";
     };
   };
   ktp-common-internals = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/ktp-common-internals-21.08.3.tar.xz";
-      sha256 = "0ndfdggs4j2jc93pf998r0fyj7fjnc2pz98acc1l6laq8d8aawd2";
-      name = "ktp-common-internals-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/ktp-common-internals-21.12.0.tar.xz";
+      sha256 = "1wah79byc6f5w8c0xa0z7iwjbg628m1v18nfqqs2d6mdb0wlclz4";
+      name = "ktp-common-internals-21.12.0.tar.xz";
     };
   };
   ktp-contact-list = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/ktp-contact-list-21.08.3.tar.xz";
-      sha256 = "0pdl3w1vj6f4nms4cs91yagfyf5ssqms0bzmcnjf53pcpyf8rhjs";
-      name = "ktp-contact-list-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/ktp-contact-list-21.12.0.tar.xz";
+      sha256 = "0r654q55x27m6cd9jsxgf574wd4r4b8wajj30h6mah317kpfnxg4";
+      name = "ktp-contact-list-21.12.0.tar.xz";
     };
   };
   ktp-contact-runner = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/ktp-contact-runner-21.08.3.tar.xz";
-      sha256 = "0zjw9f66rn5nc37q3q54qy8m09qlama949ksfrvyyh3qhsxp17pm";
-      name = "ktp-contact-runner-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/ktp-contact-runner-21.12.0.tar.xz";
+      sha256 = "1kbwf4pikgiym58g8hksai011braa32r1n6s20dnj2r637fywprd";
+      name = "ktp-contact-runner-21.12.0.tar.xz";
     };
   };
   ktp-desktop-applets = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/ktp-desktop-applets-21.08.3.tar.xz";
-      sha256 = "1wlls0rhynfq9cfn48g31avviy067r409c5pcvasfwgzcv5hjan5";
-      name = "ktp-desktop-applets-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/ktp-desktop-applets-21.12.0.tar.xz";
+      sha256 = "007wa3mas3cdh2cxw5k1rwhc9bdr96jk3lb0ka82viqz0fiyxlcv";
+      name = "ktp-desktop-applets-21.12.0.tar.xz";
     };
   };
   ktp-filetransfer-handler = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/ktp-filetransfer-handler-21.08.3.tar.xz";
-      sha256 = "1vnwgcmn3j18spcn2dl468n2y073mk9nsc3557hid5mmg7byp8ng";
-      name = "ktp-filetransfer-handler-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/ktp-filetransfer-handler-21.12.0.tar.xz";
+      sha256 = "19pb90zihhrsqb0nkdwan1w7mb4w65apm9ghsp9zb0j6d7sjj1yx";
+      name = "ktp-filetransfer-handler-21.12.0.tar.xz";
     };
   };
   ktp-kded-module = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/ktp-kded-module-21.08.3.tar.xz";
-      sha256 = "0mgw2w812306w04w1xgv9ngd31zj0m4v9hv3cyyk2dz1hi97g9hz";
-      name = "ktp-kded-module-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/ktp-kded-module-21.12.0.tar.xz";
+      sha256 = "18n4b3a6fyf3vwyw8pp6ilj34gbcd1s778m4b03xnm5110nrkplv";
+      name = "ktp-kded-module-21.12.0.tar.xz";
     };
   };
   ktp-send-file = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/ktp-send-file-21.08.3.tar.xz";
-      sha256 = "1c0yrir3z6p6ravizaqhdgjiwcj2cyzd61n4zcx2mrr4mfq7wr4l";
-      name = "ktp-send-file-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/ktp-send-file-21.12.0.tar.xz";
+      sha256 = "1a33cbgczivqlxksjq4a0z0qc5nml8mlkip7g9cx40vly495cj8d";
+      name = "ktp-send-file-21.12.0.tar.xz";
     };
   };
   ktp-text-ui = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/ktp-text-ui-21.08.3.tar.xz";
-      sha256 = "0xk9lcdp99rd1n6gg9a4ix5bdfk229y1ddf115ldjsk30ksfv0r0";
-      name = "ktp-text-ui-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/ktp-text-ui-21.12.0.tar.xz";
+      sha256 = "1xi4nkvcp13yzf2hdpk77icmvxsf8598njlkq72x5dw9hx6hzxfd";
+      name = "ktp-text-ui-21.12.0.tar.xz";
     };
   };
   ktuberling = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/ktuberling-21.08.3.tar.xz";
-      sha256 = "1i0ykflfr2q3043z5j5h1m093n103la8zbax7cacid109d0kca5g";
-      name = "ktuberling-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/ktuberling-21.12.0.tar.xz";
+      sha256 = "0n2hlj7v225c58j6xkqkcvk3a246l4wcmqp9fhqlanmagsn2vq2l";
+      name = "ktuberling-21.12.0.tar.xz";
     };
   };
   kturtle = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kturtle-21.08.3.tar.xz";
-      sha256 = "1fw7hgx0zxsl1l9ymjhf3k3w5999ijj8vdagnyiz01y2i2hlnvhc";
-      name = "kturtle-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kturtle-21.12.0.tar.xz";
+      sha256 = "1macqjp0b5iqvpi83d95rzzzyvmcxzfiw99g042hga48na3zz50p";
+      name = "kturtle-21.12.0.tar.xz";
     };
   };
   kubrick = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kubrick-21.08.3.tar.xz";
-      sha256 = "1fq2icsfbd6k4gm9w25aml2rigzami934vvkvb30222vbhs86qr4";
-      name = "kubrick-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kubrick-21.12.0.tar.xz";
+      sha256 = "1v9x3zf80y0aj7nhwi8r14mcxb67fav6ww7cnw6m7czyxwrpmx82";
+      name = "kubrick-21.12.0.tar.xz";
     };
   };
   kwalletmanager = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kwalletmanager-21.08.3.tar.xz";
-      sha256 = "0cbq0md317fipd4lfqvcgan1jm5n0zyilzbrkjymbnl7cy276ajq";
-      name = "kwalletmanager-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kwalletmanager-21.12.0.tar.xz";
+      sha256 = "0n8m46kvax12ji1nd3c42yqa6cznx374yzr569ilm523m1lp74hy";
+      name = "kwalletmanager-21.12.0.tar.xz";
     };
   };
   kwave = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kwave-21.08.3.tar.xz";
-      sha256 = "08qs33mi047jcqaavglgxk3i6gq4h73aygn6gj8xpcpqhq82kjl5";
-      name = "kwave-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kwave-21.12.0.tar.xz";
+      sha256 = "1cgp55c75v200b7l5q8jhvirf1pkfllgk7c2fzv7axzyg4vr2d4v";
+      name = "kwave-21.12.0.tar.xz";
     };
   };
   kwordquiz = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/kwordquiz-21.08.3.tar.xz";
-      sha256 = "066v2w8i2fvrrqb1aakscwcd6rchlm4m5pwsql0s6k59mn7wab6b";
-      name = "kwordquiz-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/kwordquiz-21.12.0.tar.xz";
+      sha256 = "0ycsy753msm50x5p938lw3mp8cxcdcbvq85f8az9f8x3y7qmnxlm";
+      name = "kwordquiz-21.12.0.tar.xz";
     };
   };
   libgravatar = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/libgravatar-21.08.3.tar.xz";
-      sha256 = "0ni2lgrfpx8vx9mmm43gsn1kw4jj8j52yq4ylfam89q6mhpxcnix";
-      name = "libgravatar-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/libgravatar-21.12.0.tar.xz";
+      sha256 = "1c27azlwp0yfsf4nv33n2nsrb7w9m2shqp9pv09i8hqfv7prm5sq";
+      name = "libgravatar-21.12.0.tar.xz";
     };
   };
   libkcddb = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/libkcddb-21.08.3.tar.xz";
-      sha256 = "00wivb6viw5w1ylcsx3m9ps7j00z7fzjh2s7nap95xnprraihcmv";
-      name = "libkcddb-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/libkcddb-21.12.0.tar.xz";
+      sha256 = "0qipr0399hw5vdlgyw6kp4msi4jlk4z4m8rhgsihp6qdmszhav6d";
+      name = "libkcddb-21.12.0.tar.xz";
     };
   };
   libkcompactdisc = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/libkcompactdisc-21.08.3.tar.xz";
-      sha256 = "1rsmibz9mamqvhppnxwn2db6jmsipvjx2kj8ikpsp9bx8h421n2g";
-      name = "libkcompactdisc-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/libkcompactdisc-21.12.0.tar.xz";
+      sha256 = "03qb8w03qhh5b9y0cm8jx8amfiv7j2ijjjd8wqxih66rda8sj11m";
+      name = "libkcompactdisc-21.12.0.tar.xz";
     };
   };
   libkdcraw = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/libkdcraw-21.08.3.tar.xz";
-      sha256 = "0gm8nfc6ayg1ipba4yvhy5nzfrpdwx6l434bg9y7yqvbm3lm1g86";
-      name = "libkdcraw-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/libkdcraw-21.12.0.tar.xz";
+      sha256 = "0czwigf1w1k9643flfh4ri1xlbn9k9gkfma3x1qkqa14g4dpm2if";
+      name = "libkdcraw-21.12.0.tar.xz";
     };
   };
   libkdegames = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/libkdegames-21.08.3.tar.xz";
-      sha256 = "0ysc5g6ap207c5yq3ryiaxmvkrh6wzqzdgccdffs0lncd24g641a";
-      name = "libkdegames-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/libkdegames-21.12.0.tar.xz";
+      sha256 = "09llvfssc2msidjlh3mf188ayfv0vm0c5bicnxd3m2lfwr7mw6w2";
+      name = "libkdegames-21.12.0.tar.xz";
     };
   };
   libkdepim = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/libkdepim-21.08.3.tar.xz";
-      sha256 = "1776fjzd88kj2crr8lcrwxmkvjsxxyll2gy21wlbmqy4h04bi130";
-      name = "libkdepim-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/libkdepim-21.12.0.tar.xz";
+      sha256 = "1kd67k7n4rkdblfzx8xl671dyjhxrzrw1cfi13s83538sa0hfcyi";
+      name = "libkdepim-21.12.0.tar.xz";
     };
   };
   libkeduvocdocument = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/libkeduvocdocument-21.08.3.tar.xz";
-      sha256 = "1qyi5y5v1zp3qid58sdfpcp83rkmz2s1hsvir4f9j5ngir0czcq1";
-      name = "libkeduvocdocument-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/libkeduvocdocument-21.12.0.tar.xz";
+      sha256 = "1gyv8524xvlgx7h0sh79aziwj9169f8wm0d309839hacwxmz7llb";
+      name = "libkeduvocdocument-21.12.0.tar.xz";
     };
   };
   libkexiv2 = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/libkexiv2-21.08.3.tar.xz";
-      sha256 = "15d8d3mzp0yhj6lm5799mfncqkxnw0cvfxcgpkz0lf9askv2cq8n";
-      name = "libkexiv2-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/libkexiv2-21.12.0.tar.xz";
+      sha256 = "1mpy194pfgxdbhyb8h30f04r8pv90896ppdnyaypsa5dvc0ajr4h";
+      name = "libkexiv2-21.12.0.tar.xz";
     };
   };
   libkgapi = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/libkgapi-21.08.3.tar.xz";
-      sha256 = "101yb495k5bxq402qdvyqd0sdhzc5z3r8szymfmrlilgk35wy9rs";
-      name = "libkgapi-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/libkgapi-21.12.0.tar.xz";
+      sha256 = "11f5kn6hc3whhpppgh78m7a47sdhxi13498p447cbnpfgwzjgxw9";
+      name = "libkgapi-21.12.0.tar.xz";
     };
   };
   libkipi = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/libkipi-21.08.3.tar.xz";
-      sha256 = "12qjvd7ynab33qid2d4j06z8fbfziaxdlrpq0h3ywd2drks0ykvf";
-      name = "libkipi-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/libkipi-21.12.0.tar.xz";
+      sha256 = "1pkf14y97xwl4r9fjv4b8czb0ygwlqn37616gwmvd5zr8c0kkmpc";
+      name = "libkipi-21.12.0.tar.xz";
     };
   };
   libkleo = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/libkleo-21.08.3.tar.xz";
-      sha256 = "0ivyqmc1hv1cljbpxr5xrzyf9z96dbaa48ak54cxxpanphpialrl";
-      name = "libkleo-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/libkleo-21.12.0.tar.xz";
+      sha256 = "1mm5ypnq2847fijp986j9si504mfszlvap1zlama2mkcgfiyjbap";
+      name = "libkleo-21.12.0.tar.xz";
     };
   };
   libkmahjongg = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/libkmahjongg-21.08.3.tar.xz";
-      sha256 = "0rh61491dl90rrlmqmqjdj7vlrjhayhkk5i50zb6jfvrysq9axkc";
-      name = "libkmahjongg-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/libkmahjongg-21.12.0.tar.xz";
+      sha256 = "03v2jszin48mbxd7h8gh76az4j5ns3g9cy832rii6dbwwilakgad";
+      name = "libkmahjongg-21.12.0.tar.xz";
     };
   };
   libkomparediff2 = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/libkomparediff2-21.08.3.tar.xz";
-      sha256 = "0a3980kiigc5kqkyxf4glcxvgr3f4rnc43gcx9vj9mk2qhfcsiqy";
-      name = "libkomparediff2-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/libkomparediff2-21.12.0.tar.xz";
+      sha256 = "1kbj86s7lf3bvjihgmhgrh08b2dcivs5h1amx3lc5qw7nvfqa38d";
+      name = "libkomparediff2-21.12.0.tar.xz";
     };
   };
   libksane = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/libksane-21.08.3.tar.xz";
-      sha256 = "086zrddpammihia888nrx2p18if1fyzvhs3igkxq9q2p551vk9fy";
-      name = "libksane-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/libksane-21.12.0.tar.xz";
+      sha256 = "0r8npxzi8dij4lvi27ycnz51y9cax5agsjcf2rg1zafg4gq3zgcl";
+      name = "libksane-21.12.0.tar.xz";
     };
   };
   libksieve = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/libksieve-21.08.3.tar.xz";
-      sha256 = "1snli2yvq2n567vgi1xs6iiqgn4zp31cid17aqpxllyw8a3xa0l7";
-      name = "libksieve-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/libksieve-21.12.0.tar.xz";
+      sha256 = "0wda6waxqhsffhn7akxbmklq7i6rp57kj13ghm3lyfwccsxf38z0";
+      name = "libksieve-21.12.0.tar.xz";
     };
   };
   libktorrent = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/libktorrent-21.08.3.tar.xz";
-      sha256 = "1zjnnxhd0mv9if61rr28h35wban7sif61dmgc3wsixp4dz1xfrm6";
-      name = "libktorrent-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/libktorrent-21.12.0.tar.xz";
+      sha256 = "0lzb3vnw500bqll7nvz5r5cwbh2fh11c1a845rarnsyrfsvbdh2y";
+      name = "libktorrent-21.12.0.tar.xz";
     };
   };
   lokalize = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/lokalize-21.08.3.tar.xz";
-      sha256 = "0m084mayd9b0iwm4j5cckw22ix1mc4zcwxjfk0cdapm3g2ls1rzd";
-      name = "lokalize-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/lokalize-21.12.0.tar.xz";
+      sha256 = "11rw0g63zcdlqs5649yn1rx327l19ia0pf3yag2g42r5ssdv4znf";
+      name = "lokalize-21.12.0.tar.xz";
     };
   };
   lskat = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/lskat-21.08.3.tar.xz";
-      sha256 = "09l209fz82ibsxzg2f53lhbcsaq6zpwllpyklj2988xzn7h49cqg";
-      name = "lskat-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/lskat-21.12.0.tar.xz";
+      sha256 = "0glg9ql6kldy0cyypsn7z01dv7l5i3h26l8b7andzp8i5345p9yp";
+      name = "lskat-21.12.0.tar.xz";
     };
   };
   mailcommon = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/mailcommon-21.08.3.tar.xz";
-      sha256 = "0vpbp88pl462d1j9f3ww22zybrmz92zx3b5cj4gsl7gmb7ijwb19";
-      name = "mailcommon-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/mailcommon-21.12.0.tar.xz";
+      sha256 = "16i0vzg94ni5hr8ax1r8cc1vfb9s8q47fbk65r7z4svqqwvxhpvw";
+      name = "mailcommon-21.12.0.tar.xz";
     };
   };
   mailimporter = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/mailimporter-21.08.3.tar.xz";
-      sha256 = "00vm445i5c7vjfmbfgzdj3xildqbnlzpi5i16w4c47wyg5kvpj2c";
-      name = "mailimporter-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/mailimporter-21.12.0.tar.xz";
+      sha256 = "0ns2cwq32aymljn9mbkcr5ac8qgkbblcc75b5dbm42cvyjb3a8iz";
+      name = "mailimporter-21.12.0.tar.xz";
     };
   };
   marble = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/marble-21.08.3.tar.xz";
-      sha256 = "0bapnmm2x0ihms5gd12brqb2yx7g5h4c8ky70l1czd4a8d95ha0a";
-      name = "marble-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/marble-21.12.0.tar.xz";
+      sha256 = "1c01v6k8l04vlnm9pslfpmmk2jb3h0wk29n9zcgjigc00klfjrmw";
+      name = "marble-21.12.0.tar.xz";
     };
   };
   markdownpart = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/markdownpart-21.08.3.tar.xz";
-      sha256 = "1cqkwvs1ssg203fkaiibcmqjm2viaq3iq880cjlkx9irh0bv9q9h";
-      name = "markdownpart-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/markdownpart-21.12.0.tar.xz";
+      sha256 = "1ndnr2hlp1njwxf2pcjws3vxl3s3x1qfxhv014msnhll6k1l3lyz";
+      name = "markdownpart-21.12.0.tar.xz";
     };
   };
   mbox-importer = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/mbox-importer-21.08.3.tar.xz";
-      sha256 = "19i5a1rax3xfkcz0hv0vqq9iavggqrliwpqsqnx6zvwjzgjrvsif";
-      name = "mbox-importer-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/mbox-importer-21.12.0.tar.xz";
+      sha256 = "0r9z09yaifj45q1igyh890kzpdazy72rc6q78lisgnslllc22fv1";
+      name = "mbox-importer-21.12.0.tar.xz";
     };
   };
   messagelib = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/messagelib-21.08.3.tar.xz";
-      sha256 = "0q9mligkkvbwb92ghv5g66rkn0vpbw2xfbgsdnn4jajjxsixipg7";
-      name = "messagelib-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/messagelib-21.12.0.tar.xz";
+      sha256 = "1r2p4inav6shbjlnfkxnkpsak58cflzj0ra2c2930gszhyfyc6b1";
+      name = "messagelib-21.12.0.tar.xz";
     };
   };
   minuet = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/minuet-21.08.3.tar.xz";
-      sha256 = "1g2chj23dw9p2lgf094mn9cd26wnhwgslwdwzwax2a23p42j7kb8";
-      name = "minuet-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/minuet-21.12.0.tar.xz";
+      sha256 = "0rglwxfbmh4hl9kf8h8krx42jamzv9i6k5i99gwlaz63rsylh4w6";
+      name = "minuet-21.12.0.tar.xz";
     };
   };
   okular = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/okular-21.08.3.tar.xz";
-      sha256 = "00ghh7z39904d5x5sa39adkavkhl09hzib6fpwjn14f6sz925f9r";
-      name = "okular-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/okular-21.12.0.tar.xz";
+      sha256 = "08vybplc0bhf9bh9jbwddh9x98f3jdrha2wd1yp53nbcz3jqgm68";
+      name = "okular-21.12.0.tar.xz";
     };
   };
   palapeli = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/palapeli-21.08.3.tar.xz";
-      sha256 = "084nvavgzkmrv77rsg2zf2vykfjwwsvn2i2y24jsh63hs7i5xqhb";
-      name = "palapeli-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/palapeli-21.12.0.tar.xz";
+      sha256 = "1sypyhidjn2cv1nly54r85a4v331z0mazg19bby1lfn5rn2sg34r";
+      name = "palapeli-21.12.0.tar.xz";
     };
   };
   parley = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/parley-21.08.3.tar.xz";
-      sha256 = "0wyv5qx4g0941kg870qb9rc9npdw39ggvndjk7ywaad9nkvdj73g";
-      name = "parley-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/parley-21.12.0.tar.xz";
+      sha256 = "0y5lby0jqlsj7cf62hwka1l449na7f1nazq63a6vxng9wf22fl4x";
+      name = "parley-21.12.0.tar.xz";
     };
   };
   partitionmanager = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/partitionmanager-21.08.3.tar.xz";
-      sha256 = "0im782ggbnkyzcczxx3mv5qi4nlqmcyhwkbf0mzh8cz56qkfvzhr";
-      name = "partitionmanager-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/partitionmanager-21.12.0.tar.xz";
+      sha256 = "0g17y1c4fj6c9hr1xac3qp4yllrr666nh3mxhlgl9qkxa9lyh7jp";
+      name = "partitionmanager-21.12.0.tar.xz";
     };
   };
   picmi = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/picmi-21.08.3.tar.xz";
-      sha256 = "0h208sy2r2jzy7a6rmla349d8lydvfvdb2vahdfxrqql0m15s07s";
-      name = "picmi-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/picmi-21.12.0.tar.xz";
+      sha256 = "1l91i7mmj60zawkpv2s14l8qajk84gcyxm8x4zzlx7pf9pizbyps";
+      name = "picmi-21.12.0.tar.xz";
     };
   };
   pim-data-exporter = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/pim-data-exporter-21.08.3.tar.xz";
-      sha256 = "0l6gkwh6pxp6px50n8i0374by3n7nv0gjkb2qy0s4hsvfz8nwlwk";
-      name = "pim-data-exporter-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/pim-data-exporter-21.12.0.tar.xz";
+      sha256 = "19qssd032x4ma12i8hmd42s7904n8x5z8dydwccc32ma29s5hw0p";
+      name = "pim-data-exporter-21.12.0.tar.xz";
     };
   };
   pim-sieve-editor = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/pim-sieve-editor-21.08.3.tar.xz";
-      sha256 = "1z01c0wsxzl69kr0cxfq23l56dgi0xfjak5qbpfd9p4b2kr095s7";
-      name = "pim-sieve-editor-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/pim-sieve-editor-21.12.0.tar.xz";
+      sha256 = "1fpkf5lksy8irzs3bfv1b6g53hs2s575pi02rnps33cpr6lxn8q7";
+      name = "pim-sieve-editor-21.12.0.tar.xz";
     };
   };
   pimcommon = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/pimcommon-21.08.3.tar.xz";
-      sha256 = "1hj49spfjwqrwh7h86kw7ydcx13rknagj54mhcn60kawz639533l";
-      name = "pimcommon-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/pimcommon-21.12.0.tar.xz";
+      sha256 = "02xpw6n1k030hqivqw10xvq6s279712wyy58snn3x2i2a1bzyjaq";
+      name = "pimcommon-21.12.0.tar.xz";
     };
   };
   poxml = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/poxml-21.08.3.tar.xz";
-      sha256 = "0yrn2dbdhm3ap55w401ma8z64b7pgs57lzgakzkdpcf69bww9xkw";
-      name = "poxml-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/poxml-21.12.0.tar.xz";
+      sha256 = "0hvwhg4z5f6m9vr0hpvvnpyxhy6zp8yprbh3qkw1216nfpfaw0md";
+      name = "poxml-21.12.0.tar.xz";
     };
   };
   print-manager = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/print-manager-21.08.3.tar.xz";
-      sha256 = "0dmd1wp6c5f58fssnyc977d29gqcr6pmzplvq5pj97xq0i8fq15z";
-      name = "print-manager-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/print-manager-21.12.0.tar.xz";
+      sha256 = "10glinq92m08kwsgk9hijangz7grbj7l2vd7p3rxivrbk8q6jms5";
+      name = "print-manager-21.12.0.tar.xz";
     };
   };
   rocs = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/rocs-21.08.3.tar.xz";
-      sha256 = "0mdn58wbv5rhljp7ai0282h5z5j7m9yly6q9s6c8vm5kaxhbwg58";
-      name = "rocs-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/rocs-21.12.0.tar.xz";
+      sha256 = "1h94da4qqs1qcnc5rz4lk5vwfwwhpb8ww7bpj40fg0fpdd3w5anw";
+      name = "rocs-21.12.0.tar.xz";
     };
   };
   signon-kwallet-extension = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/signon-kwallet-extension-21.08.3.tar.xz";
-      sha256 = "1m3wyyndlwk4snjzz45j377hz5plx01bl69y39aw1y53rsx0baln";
-      name = "signon-kwallet-extension-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/signon-kwallet-extension-21.12.0.tar.xz";
+      sha256 = "0a8amssfwxsb9acjaw7lw1m812yma1lw2c21x5if35ivgwagnjdx";
+      name = "signon-kwallet-extension-21.12.0.tar.xz";
     };
   };
   skanlite = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/skanlite-21.08.3.tar.xz";
-      sha256 = "1llvq89vdsypbak8lmhnyfr61s72c4lra1yypxmgw0hwqvwqzyjk";
-      name = "skanlite-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/skanlite-21.12.0.tar.xz";
+      sha256 = "0q1sqf2h9y4q0bmy88pnmm0dxlnbwpq7h7plkv9hbkka8k6yk9w1";
+      name = "skanlite-21.12.0.tar.xz";
     };
   };
   spectacle = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/spectacle-21.08.3.tar.xz";
-      sha256 = "0l1p565y2d04fw9mz1ns11bwc9z5apkjd4llgdihz4qwq5j0ri5y";
-      name = "spectacle-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/spectacle-21.12.0.tar.xz";
+      sha256 = "0s196rjphwhsafwqb3vdl3flxkan6a2y9250v2v9m5dkphll13sn";
+      name = "spectacle-21.12.0.tar.xz";
     };
   };
   step = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/step-21.08.3.tar.xz";
-      sha256 = "1pznz6hxj1h0vcsidsyjm9zgzx4pla47yckykc3mxb9biraalhi5";
-      name = "step-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/step-21.12.0.tar.xz";
+      sha256 = "0cjqxyazlrq88nhfz7ha4p9lc06iimpjc439w37qq3030kx3257r";
+      name = "step-21.12.0.tar.xz";
     };
   };
   svgpart = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/svgpart-21.08.3.tar.xz";
-      sha256 = "1zpzmhgvxlyalq4nn446k7plz5fw2pl4r7zv7q3hjrzla1wgcqx8";
-      name = "svgpart-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/svgpart-21.12.0.tar.xz";
+      sha256 = "1qqvkrw3frncs9jni99w0vrsjrzjw9wgdg35qzp2svfaxmyczin1";
+      name = "svgpart-21.12.0.tar.xz";
     };
   };
   sweeper = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/sweeper-21.08.3.tar.xz";
-      sha256 = "0sa8dfx26m9ry3pvqryx41w51l76r8l2xh16b783ixqln7x08z5j";
-      name = "sweeper-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/sweeper-21.12.0.tar.xz";
+      sha256 = "17rkp2dwnyyh4ywx7xhnswvbh3mwgnd6y9ylrw37q5r3m35ym89i";
+      name = "sweeper-21.12.0.tar.xz";
     };
   };
   umbrello = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/umbrello-21.08.3.tar.xz";
-      sha256 = "025qds7nahm6kpi94j4blk8xpv6vh2alrbgwby20vvn3h678z26x";
-      name = "umbrello-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/umbrello-21.12.0.tar.xz";
+      sha256 = "0s6ld4da8hj48xqzk5fwrw23wmyh05d8540m2w1pzp4wiba7d32f";
+      name = "umbrello-21.12.0.tar.xz";
     };
   };
   yakuake = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/yakuake-21.08.3.tar.xz";
-      sha256 = "1za4vhnr495dadrarqqanavmyn1mmzm3y8jx05cpbjyqmlm353dk";
-      name = "yakuake-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/yakuake-21.12.0.tar.xz";
+      sha256 = "1wrmzjn317fdv3lp8sgdhzvgxf6n0pdnsbhidh5qw33fr53n8zc1";
+      name = "yakuake-21.12.0.tar.xz";
+    };
+  };
+  zanshin = {
+    version = "21.12.0";
+    src = fetchurl {
+      url = "${mirror}/stable/release-service/21.12.0/src/zanshin-21.12.0.tar.xz";
+      sha256 = "07bs2zh12jbwjxrjq2qz6fmfq0vpr5qiz024gqxvxaxvskpbiicp";
+      name = "zanshin-21.12.0.tar.xz";
     };
   };
   zeroconf-ioslave = {
-    version = "21.08.3";
+    version = "21.12.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.3/src/zeroconf-ioslave-21.08.3.tar.xz";
-      sha256 = "1dkig267znwyw03fq6mpdb5g1xnkhr0brnvxskjm44a4d5ipbv2g";
-      name = "zeroconf-ioslave-21.08.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.0/src/zeroconf-ioslave-21.12.0.tar.xz";
+      sha256 = "1s1vrfifz11z4bqrz8860rkd5fxa1qqvaxaka67gs2yrb788m0ii";
+      name = "zeroconf-ioslave-21.12.0.tar.xz";
     };
   };
 }

--- a/pkgs/applications/office/zanshin/default.nix
+++ b/pkgs/applications/office/zanshin/default.nix
@@ -1,55 +1,31 @@
 { mkDerivation
 , lib
 , fetchurl
-, fetchpatch
 , extra-cmake-modules
-, qtbase
 , boost
 , akonadi-calendar
-, akonadi-notes
-, akonadi-search
-, kidentitymanagement
 , kontactinterface
-, kldap
 , krunner
-, kwallet
-, kcalendarcore
 }:
 
 mkDerivation rec {
   pname = "zanshin";
-  version = "0.5.71";
+  version = "21.12.0";
 
   src = fetchurl {
-    url = "mirror://kde/stable/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "0b316ddcd46sawva84x5d8nsp19v66gbm83djrra7fv3k8nkv4xh";
+    url = "mirror://kde/stable/release-service/${version}/src/zanshin-${version}.tar.xz";
+    sha256 = "sha256-l8W47tS7q747fkSAH3HJdwPsqjMfCyxzl3xJEeAXeh0=";
   };
-
-  patches = [
-    # Build with kontactinterface >= 5.14.42.
-    # Remove after next release.
-    (fetchpatch {
-      url = "https://invent.kde.org/pim/zanshin/-/commit/4850c08998b33b37af99c3312d193b063b3e8174.diff";
-      sha256 = "sha256:0lh0a035alhmws3zyfnkb814drq5cqxvzpwl4g1g5d435gy8k4ps";
-    })
-  ];
 
   nativeBuildInputs = [
     extra-cmake-modules
   ];
 
   buildInputs = [
-    qtbase
     boost
     akonadi-calendar
-    akonadi-notes
-    akonadi-search
-    kidentitymanagement
     kontactinterface
-    kldap
     krunner
-    kwallet
-    kcalendarcore
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
Update KDE Gear (aka KDE Applications) to 21.12.0
Just a version bump, everything (I tested) working fine locally.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
