### PR TITLE
gitlab-runner: 14.5.0 -> 14.5.2

### DIFF
--- a/pkgs/development/tools/continuous-integration/gitlab-runner/0001-gitlab-runner-don-t-checked-for-fixed-runtime.patch
+++ b/pkgs/development/tools/continuous-integration/gitlab-runner/0001-gitlab-runner-don-t-checked-for-fixed-runtime.patch
@@ -1,0 +1,30 @@
+From 13c633bf0075daa6ff973f368a25cf205caa017e Mon Sep 17 00:00:00 2001
+From: Pascal Bach <pascal.bach@nextrem.ch>
+Date: Sat, 11 Dec 2021 10:07:01 +0100
+Subject: [PATCH] gitlab-runner: don't checked for fixed runtime
+
+We already use 1.16.12 which has the proper fix
+---
+ helpers/patches/issue_28732/syscall.go | 7 +------
+ 1 file changed, 1 insertion(+), 6 deletions(-)
+
+diff --git a/helpers/patches/issue_28732/syscall.go b/helpers/patches/issue_28732/syscall.go
+index 580513b57..fa9e4cc85 100644
+--- a/helpers/patches/issue_28732/syscall.go
++++ b/helpers/patches/issue_28732/syscall.go
+@@ -2,11 +2,6 @@
+ 
+ package issue_28732
+ 
+-import (
+-	"syscall"
+-)
+-
+ func AssertFixPresent() {
+-	// Ensure that Issue28732Fix fixed runtime is used
+-	syscall.Issue28732Fix()
++	// Issue already fixed by using go 1.16.12
+ }
+-- 
+2.34.0
+

--- a/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
@@ -1,7 +1,7 @@
 { lib, buildGoPackage, fetchFromGitLab, fetchurl }:
 
 let
-  version = "14.5.0";
+  version = "14.5.2";
 in
 buildGoPackage rec {
   inherit version;
@@ -19,7 +19,7 @@ buildGoPackage rec {
     owner = "gitlab-org";
     repo = "gitlab-runner";
     rev = "v${version}";
-    sha256 = "sha256-BxnIrjiEW61J6hl7mWNXc2Vb4ae1cWqOypTy9Xo7Hkc=";
+    sha256 = "07mr9w1rp3rnrlixmqziin1gw78s3gncg47b4z9h9zzpy3acy3xd";
   };
 
   patches = [ ./fix-shell-path.patch ];

--- a/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
@@ -22,7 +22,10 @@ buildGoPackage rec {
     sha256 = "07mr9w1rp3rnrlixmqziin1gw78s3gncg47b4z9h9zzpy3acy3xd";
   };
 
-  patches = [ ./fix-shell-path.patch ];
+  patches = [
+    ./fix-shell-path.patch
+    ./0001-gitlab-runner-don-t-checked-for-fixed-runtime.patch
+  ];
 
   meta = with lib; {
     description = "GitLab Runner the continuous integration executor of GitLab";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://about.gitlab.com/releases/2021/12/10/security-release-gitlab-runner-14-5-2-released/


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
