### PR TITLE
purpur: init at 1.17.1r1428

### DIFF
--- a/pkgs/games/purpur/default.nix
+++ b/pkgs/games/purpur/default.nix
@@ -1,0 +1,41 @@
+{ lib, stdenv, fetchurl, nixosTests, jre_headless, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "purpur";
+  version = "1.18.1r1522";
+
+  src = fetchurl {
+    url = "https://api.purpurmc.org/v2/purpur/${builtins.replaceStrings [ "r" ] [ "/" ] version}/download";
+    sha256 = "1060fsfcw6m30d47wla1vsnmc4czyla6m8wf91ws095hbvc22qsm";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  preferLocalBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib/minecraft
+    cp -v $src $out/lib/minecraft/server.jar
+
+    makeWrapper ${jre_headless}/bin/java $out/bin/minecraft-server \
+      --add-flags "-jar $out/lib/minecraft/server.jar nogui"
+  '';
+
+  dontUnpack = true;
+
+  passthru = {
+    tests = { inherit (nixosTests) minecraft-server; };
+  };
+
+  meta = with lib; {
+    description = "A drop-in replacement for Minecraft Paper servers";
+    longDescription = ''
+      Purpur is a drop-in replacement for Minecraft Paper servers designed for configurability, new fun and exciting
+      gameplay features, and performance built on top of Airplane.
+    '';
+    homepage = "https://purpurmc.org/";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jyooru ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27756,6 +27756,8 @@ with pkgs;
 
   purple-facebook = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-facebook { };
 
+  purpur = callPackage ../games/purpur { };
+
   pikopixel = callPackage ../applications/graphics/pikopixel { };
 
   pithos = callPackage ../applications/audio/pithos {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add https://github.com/PurpurMC/Purpur. I use this server, so I packaged it for Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
