### PR TITLE
cdk: enable and fix parallel build

### DIFF
--- a/pkgs/development/libraries/cdk/default.nix
+++ b/pkgs/development/libraries/cdk/default.nix
@@ -16,8 +16,16 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-xBbJh793tPGycD18XkM7qUWMi+Uma/RUy/gBrYfnKTY=";
   };
 
+  patches = [
+    # Proposed upstream as https://lists.gnu.org/archive/html/bug-ncurses/2021-12/msg00004.html
+    ./parallel.patch
+  ];
+
+  enableParallelBuilding = true;
+
   meta = with lib; {
     description = "Curses development kit";
+    homepage = "https://invisible-island.net/cdk/";
     license = licenses.bsdOriginal ;
     maintainers = [ maintainers.raskin ];
     platforms = platforms.linux;

--- a/pkgs/development/libraries/cdk/parallel.patch
+++ b/pkgs/development/libraries/cdk/parallel.patch
@@ -1,0 +1,13 @@
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -296,7 +296,9 @@ LIB_OBJECT	= @LIB_OBJECT@
+ 
+ all sources :: $(AUTO_SRC)
+ 
+-$(OBJECTS) :	include/cdk_config.h
++# make sure we generate all headers before trying
++# to build first source file.
++$(OBJECTS) :	$(MY_HDR)
+ 
+ #
+ # Standard library directive.


### PR DESCRIPTION
Without the change parallel build occasionally fails due to missing
dependency on generated headers:

Fixes the follow build failure on make -j16:

    build flags: -j16 -l16 SHELL=/bin/bash
    bash ./gen-scale.sh DSCALE DScale Double double ./include/gen-scale.h>include/dscale.h
    bash ./gen-scale.sh FSCALE FScale Float float ./include/gen-scale.h>include/fscale.h
    bash ./gen-scale.sh FSLIDER FSlider Float float ./include/gen-slider.h>include/fslider.h
    bash ./gen-scale.sh SCALE Scale Int int ./include/gen-scale.h>include/scale.h
    gcc -g -O2  -DHAVE_CONFIG_H -I./include -I./include -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=500 -D_XOPEN_SOURCE_EXTENDED -c cdkscreen.c
    gcc -g -O2  -DHAVE_CONFIG_H -I./include -I./include -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=500 -D_XOPEN_SOURCE_EXTENDED -c debug.c
    In file included from ./include/cdk_int.h:13,
                     from cdkscreen.c:1:
    ./include/cdk.h:321:10: fatal error: uscale.h: No such file or directory
      321 | #include <uscale.h>
          |          ^~~~~~~~~~
