### PR TITLE
inql: init at 4.0.5

### DIFF
--- a/pkgs/development/python-modules/spur/default.nix
+++ b/pkgs/development/python-modules/spur/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, paramiko
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "spur";
+  version = "0.3.22";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.4";
+
+  src = fetchFromGitHub {
+    owner = "mwilliamson";
+    repo = "spur.py";
+    rev = version;
+    sha256 = "sha256-YlwezAE7V4ykFsp+bJ2nYRp6HG4I9Bk7Lhq6f1Inn0s=";
+  };
+
+  propagatedBuildInputs = [
+    paramiko
+  ];
+
+  # Tests require a running SSH server
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "spur"
+  ];
+
+  meta = with lib; {
+    description = "Python module to run commands and manipulate files locally or over SSH";
+    homepage = "https://github.com/mwilliamson/spur.py";
+    license = with licenses; [ bsd2 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/stickytape/default.nix
+++ b/pkgs/development/python-modules/stickytape/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, nose
+, pytestCheckHook
+, pythonOlder
+, spur
+}:
+
+buildPythonPackage rec {
+  pname = "stickytape";
+  version = "0.2.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.4";
+
+  src = fetchFromGitHub {
+    owner = "mwilliamson";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-KOZN9oxPb91l8QVU07I49UMNXqox8j+oekA1fMtj6l8=";
+  };
+
+  # Tests have additional requirements
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "stickytape"
+  ];
+
+  meta = with lib; {
+    description = "Python module to convert Python packages into a single script";
+    homepage = "https://github.com/mwilliamson/stickytape";
+    license = with licenses; [ bsd2 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/tools/security/inql/default.nix
+++ b/pkgs/tools/security/inql/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "inql";
+  version = "4.0.5";
+
+  src = fetchFromGitHub {
+    owner = "doyensec";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-0LPJMCg7F9kcPcq4jkADdCPNLfRThXu8QHy4qOn7+QU=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    stickytape
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "inql"
+  ];
+
+  meta = with lib; {
+    description = "Security testing tool for GraphQL";
+    homepage = "https://github.com/doyensec/inql";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6536,6 +6536,8 @@ with pkgs;
 
   input-utils = callPackage ../os-specific/linux/input-utils { };
 
+  inql = callPackage ../tools/security/inql { };
+
   intecture-agent = callPackage ../tools/admin/intecture/agent.nix { };
 
   intecture-auth = callPackage ../tools/admin/intecture/auth.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9137,6 +9137,8 @@ in {
 
   stevedore = callPackage ../development/python-modules/stevedore { };
 
+  stickytape = callPackage ../development/python-modules/stickytape { };
+
   stm32loader = callPackage ../development/python-modules/stm32loader { };
 
   stone = callPackage ../development/python-modules/stone { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9041,6 +9041,8 @@ in {
 
   spotipy = callPackage ../development/python-modules/spotipy { };
 
+  spur = callPackage ../development/python-modules/spur { };
+
   spyder = callPackage ../development/python-modules/spyder { };
 
   spyder-kernels = callPackage ../development/python-modules/spyder-kernels { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Security testing tool for GraphQL

https://github.com/doyensec/inql

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
