### PR TITLE
aflplusplus: qemu: move to python3

### DIFF
--- a/pkgs/tools/security/aflplusplus/qemu.nix
+++ b/pkgs/tools/security/aflplusplus/qemu.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, aflplusplus, python2, zlib, pkg-config, glib, perl
+{ lib, stdenv, fetchurl, aflplusplus, python3, zlib, pkg-config, glib, perl
 , texinfo, libuuid, flex, bison, pixman, autoconf
 }:
 
@@ -44,7 +44,7 @@ stdenv.mkDerivation {
   '';
 
   nativeBuildInputs = [
-    python2 perl pkg-config flex bison autoconf texinfo
+    python3 perl pkg-config flex bison autoconf texinfo
   ];
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change

QEMU 3.1 already had support for building with python3, so this should
be a change that doesn't have any effect on the produced binaries.

I checked with diffoscope and I don't see anything that has changed, so presumably this is all ok.

Python2 removal tracking issue: https://github.com/NixOS/nixpkgs/issues/148779

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
