### PR TITLE
diffoscope: Fix the OpenPGP test which broke with pgpdump 0.34

### DIFF
--- a/pkgs/tools/misc/diffoscope/fix-tests.patch
+++ b/pkgs/tools/misc/diffoscope/fix-tests.patch
@@ -12,3 +12,22 @@ index 8d201ab..05960aa 100644
      return get_data(diff_file)
  
  
+diff --git a/tests/data/pgp_signed_expected_diff b/tests/data/pgp_signed_expected_diff
+index 7e90e428..9628efa0 100644
+--- a/tests/data/pgp_signed_expected_diff
++++ b/tests/data/pgp_signed_expected_diff
+@@ -5,11 +5,11 @@
+  	Key ID - 0x1E953E27D4311E58
+  	Next packet - other than one pass signature
+  Old: Literal Data Packet(tag 11)(10255 bytes)
+- 	Format - binary
++ 	Packet data format - binary
+ -	Filename - test1.tar
+--	File modified time - Tue Aug 25 11:47:35 UTC 2020
++-	Creation time - Tue Aug 25 11:47:35 UTC 2020
+ +	Filename - test2.tar
+-+	File modified time - Tue Aug 25 11:47:38 UTC 2020
+++	Creation time - Tue Aug 25 11:47:38 UTC 2020
+  	Literal - ...
+  Old: Signature Packet(tag 2)(563 bytes)
+  	Ver 4 - new


### PR DESCRIPTION
This fixes a regression from the last pgpdump update: 816d311bd07
See https://github.com/NixOS/nixpkgs/pull/149700#issuecomment-991592708

Reported-by: Sergei Trofimovich <slyich@gmail.com>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
