### PR TITLE
haskellPackages.Monadoro: remove from broken pkgs

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -3177,7 +3177,6 @@ broken-packages:
   - monad-mersenne-random
   - monad-mock
   - monad-open
-  - Monadoro
   - monad-parallel-progressbar
   - monad-param
   - monad-persist


### PR DESCRIPTION
Package tests are fixed in the recent version (0.2.6.0).

###### Motivation for this change

Monadoro tests that used to fail are fixed in the new version (0.2.6.0).

###### Things done

- [x] Built and ran tests
  - `nix-build --no-out-link -A haskellPackages.Monadoro --arg config '{ allowBroken = true; }'`
- [x] Built on platform x86_64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`.
  - No dependencies needed recompiling in regard to this change.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
  - Result: nothing to be changed
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).