### PR TITLE
stdenv: separate assignment and export

### DIFF
--- a/pkgs/build-support/bintools-wrapper/setup-hook.sh
+++ b/pkgs/build-support/bintools-wrapper/setup-hook.sh
@@ -14,7 +14,7 @@ bintoolsWrapper_addLDVars () {
     getHostRoleEnvHook
 
     if [[ -d "$1/lib64" && ! -L "$1/lib64" ]]; then
-        export NIX_LDFLAGS${role_post}+=" -L$1/lib64"
+        exportAppend "NIX_LDFLAGS$role_post" "-L$1/lib64"
     fi
 
     if [[ -d "$1/lib" ]]; then
@@ -24,7 +24,7 @@ bintoolsWrapper_addLDVars () {
         # directories and bloats the size of the environment variable space.
         local -a glob=( $1/lib/lib* )
         if [ "${#glob[*]}" -gt 0 ]; then
-            export NIX_LDFLAGS${role_post}+=" -L$1/lib"
+            exportAppend "NIX_LDFLAGS$role_post" " -L$1/lib"
         fi
     fi
 }

--- a/pkgs/build-support/cc-wrapper/setup-hook.sh
+++ b/pkgs/build-support/cc-wrapper/setup-hook.sh
@@ -69,11 +69,11 @@ ccWrapper_addCVars () {
     getHostRoleEnvHook
 
     if [ -d "$1/include" ]; then
-        export NIX_CFLAGS_COMPILE${role_post}+=" -isystem $1/include"
+        exportAppend "NIX_CFLAGS_COMPILE$role_post" " -isystem $1/include"
     fi
 
     if [ -d "$1/Library/Frameworks" ]; then
-        export NIX_CFLAGS_COMPILE${role_post}+=" -iframework $1/Library/Frameworks"
+        exportAppend "NIX_CFLAGS_COMPILE$role_post" " -iframework $1/Library/Frameworks"
     fi
 }
 

--- a/pkgs/development/libraries/gettext/gettext-setup-hook.sh
+++ b/pkgs/development/libraries/gettext/gettext-setup-hook.sh
@@ -13,5 +13,5 @@ addEnvHooks "$hostOffset" gettextDataDirsHook
 if [ -n "@gettextNeedsLdflags@" -a -z "${dontAddExtraLibs-}" ]; then
     # See pkgs/build-support/setup-hooks/role.bash
     getHostRole
-    export NIX_LDFLAGS${role_post}+=" -lintl"
+    exportAppend "NIX_LDFLAGS$role_post" " -lintl"
 fi

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -249,6 +249,16 @@ printWords() {
     printf '%s ' "$@"
 }
 
+# This function was created to separate the assign and the export step of a dynamic variable
+# abstracted in a function since used in several places
+# Note: $append can't contain " (double quotes)
+exportAppend() {
+    local ref="$1"
+    local append="$2"
+    eval "$ref=\"${!ref:-}$append\""
+    export "$ref"
+}
+
 ######################################################################
 # Initialisation.
 


### PR DESCRIPTION
###### Motivation for this change

The original code does dynamic variable evaluation, assignment and export all in one.
I thought it would be clearer to separate those 3 steps.

The function can be tested with the following script
```
exportAppend() {
    local ref="$1"
    local append="$2"
    eval "$ref=\"${!ref:-}$append\""
    export "$ref"
}

var1="something"
exportAppend "var1" " else"
echo $var1
exportAppend "var2" " else"
echo $var2
```

I'm happy to drop this PR if people disagree with the change. I thought I would propose it.

@andersk if you have an opinion I'm interested (positive or negative, happy to drop this PR).
@andychu 

One thought I had was that append can't contain double quotes. I don't see why that would be the case, but perhaps I should document it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
