### PR TITLE
colima: init at 0.2.2

### DIFF
--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+, lima
+, makeWrapper
+}:
+
+buildGoModule rec {
+  pname = "colima";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "abiosoft";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-vWNkYsT2XF+oMOQ3pb1+/a207js8B+EmVanRQrYE/2A=";
+  };
+
+  nativeBuildInputs = [ installShellFiles makeWrapper ];
+
+  vendorSha256 = "sha256-F1ym88JrJWzsBg89Y1ufH4oefIRBwTGOw72BrjtpvBw=";
+
+  postInstall = ''
+    wrapProgram $out/bin/colima \
+      --prefix PATH : ${lib.makeBinPath [ lima ]}
+
+    installShellCompletion --cmd colima \
+      --bash <($out/bin/colima completion bash) \
+      --fish <($out/bin/colima completion fish) \
+      --zsh <($out/bin/colima completion zsh)
+  '';
+
+  meta = with lib; {
+    description = "Container runtimes on MacOS with minimal setup";
+    homepage = "https://github.com/abiosoft/colima";
+    license = licenses.mit;
+    platforms = platforms.darwin;
+    maintainers = with maintainers; [ aaschmid ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32475,6 +32475,8 @@ with pkgs;
 
   idsk = callPackage ../tools/filesystems/idsk { };
 
+  colima = callPackage ../applications/virtualization/colima {};
+
   lima = callPackage ../applications/virtualization/lima {};
 
   logtop = callPackage ../tools/misc/logtop { };


### PR DESCRIPTION
###### Motivation for this change

`colima` is a very easy usable replacement for Docker Desktop on MacOS.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
