### PR TITLE
qt515.qtwebkit: fix build on darwin

### DIFF
--- a/pkgs/development/libraries/qt-5/5.15/qtwebkit-darwin-no-readline.patch
+++ b/pkgs/development/libraries/qt-5/5.15/qtwebkit-darwin-no-readline.patch
@@ -28,18 +28,3 @@ diff --git a/Source/WTF/wtf/Platform.h b/Source/WTF/wtf/Platform.h
  #define HAVE_SYS_TIMEB_H 1
  
  #if !PLATFORM(GTK) && !PLATFORM(QT)
-diff --git a/Source/WTF/wtf/PlatformMac.cmake b/Source/WTF/wtf/PlatformMac.cmake
---- a/Source/WTF/wtf/PlatformMac.cmake
-+++ b/Source/WTF/wtf/PlatformMac.cmake
-@@ -2,11 +2,9 @@ set(WTF_LIBRARY_TYPE SHARED)
- 
- find_library(COCOA_LIBRARY Cocoa)
- find_library(COREFOUNDATION_LIBRARY CoreFoundation)
--find_library(READLINE_LIBRARY Readline)
- list(APPEND WTF_LIBRARIES
-     ${COREFOUNDATION_LIBRARY}
-     ${COCOA_LIBRARY}
--    ${READLINE_LIBRARY}
-     libicucore.dylib
- )
- 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This fixes the build on darwin by correcting the patch which no longer applies.

Essentially, this PR is the same as https://github.com/NixOS/nixpkgs/pull/107898, but for Qt 5.15

(the build failure on aarch64-darwin is unrelated, every Qt5 version is broken there ...)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
