### PR TITLE
whispers: init at 1.5.3

### DIFF
--- a/pkgs/development/python-modules/jproperties/default.nix
+++ b/pkgs/development/python-modules/jproperties/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, six
+, pytest-datadir
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "jproperties";
+  version = "2.1.1";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "Tblue";
+    repo = "python-jproperties";
+    rev = "v${version}";
+    sha256 = "sha256-O+ALeGHMNjW1dc9IRyLzO81k8DW2vbGjuZqXxgrhYjo=";
+  };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    six
+  ];
+
+  checkInputs = [
+    pytest-datadir
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "setuptools_scm ~= 3.3" "setuptools_scm"
+    substituteInPlace pytest.ini \
+      --replace "--cov=jproperties --cov-report=term --cov-report=html --cov-branch" ""
+  '';
+
+  disabledTestPaths = [
+    # TypeError: 'PosixPath' object...
+    "tests/test_simple_utf8.py"
+  ];
+
+  pythonImportsCheck = [
+    "jproperties"
+  ];
+
+  meta = with lib; {
+    description = "Java Property file parser and writer for Python";
+    homepage = "https://github.com/Tblue/python-jproperties";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/luhn/default.nix
+++ b/pkgs/development/python-modules/luhn/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "luhn";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "mmcloughlin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-ZifaCjOVhWdXuzi5n6V+6eVN5vrEHKgUdpSOXoMyR18=";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    "test.py"
+  ];
+
+  pythonImportsCheck = [
+    "luhn"
+  ];
+
+  meta = with lib; {
+    description = "Python module for generate and verify Luhn check digits";
+    homepage = "https://github.com/mmcloughlin/luhn";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/tools/security/whispers/default.nix
+++ b/pkgs/tools/security/whispers/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "whispers";
+  version = "1.5.3";
+
+  src = fetchFromGitHub {
+    owner = "Skyscanner";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-jruUGyoZCyMu015QKtlvfx5WRMfxo/eYUue9wUIWb6o=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    astroid
+    beautifulsoup4
+    jproperties
+    luhn
+    lxml
+    python-Levenshtein
+    pyyaml
+  ];
+
+  checkInputs = with python3.pkgs; [
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace '"pytest-runner"' ""
+  '';
+
+  preCheck = ''
+    # Some tests need the binary available in PATH
+    export PATH=$out/bin:$PATH
+  '';
+
+  pythonImportsCheck = [
+    "whispers"
+  ];
+
+  meta = with lib; {
+    description = "Tool to identify hardcoded secrets in static structured text";
+    homepage = "https://github.com/Skyscanner/whispers";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29151,6 +29151,8 @@ with pkgs;
 
   wafw00f = python3Packages.callPackage ../tools/security/wafw00f { };
 
+  whispers = callPackage ../tools/security/whispers { };
+
   waon = callPackage ../applications/audio/waon { };
 
   w3m = callPackage ../applications/networking/browsers/w3m { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4049,6 +4049,8 @@ in {
     inherit (self) systemd pytest;
   };
 
+  jproperties = callPackage ../development/python-modules/jproperties { };
+
   jpylyzer = callPackage ../development/python-modules/jpylyzer { };
 
   JPype1 = callPackage ../development/python-modules/JPype1 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4609,6 +4609,8 @@ in {
 
   luftdaten = callPackage ../development/python-modules/luftdaten { };
 
+  luhn = callPackage ../development/python-modules/luhn { };
+
   luxor = callPackage ../development/python-modules/luxor { };
 
   luxtronik = callPackage ../development/python-modules/luxtronik { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Tool to identify hardcoded secrets in static structured text

https://github.com/Skyscanner/whispers

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
