### PR TITLE
pythonPackages.streamlit: 0.50.2 -> 1.2.0

### DIFF
--- a/pkgs/applications/science/machine-learning/streamlit/default.nix
+++ b/pkgs/applications/science/machine-learning/streamlit/default.nix
@@ -1,23 +1,79 @@
-{   lib, buildPythonApplication, fetchPypi
-  , altair, astor, base58, blinker, boto3, botocore, click, enum-compat
-  , future, pillow, protobuf, requests, toml, tornado_5, tzlocal, validators, watchdog
-  , jinja2, setuptools
+{
+  # Nix
+  lib,
+  buildPythonApplication,
+  fetchPypi,
+
+  # Build inputs
+  altair,
+  astor,
+  base58,
+  blinker,
+  boto3,
+  botocore,
+  click,
+  cachetools,
+  enum-compat,
+  future,
+  GitPython,
+  jinja2,
+  pillow,
+  pyarrow,
+  pydeck,
+  pympler,
+  protobuf,
+  requests,
+  setuptools,
+  toml,
+  tornado,
+  tzlocal,
+  validators,
+  watchdog,
 }:
 
-buildPythonApplication rec {
+let
+  click_7 = click.overridePythonAttrs(old: rec {
+    version = "7.1.2";
+    src = old.src.override {
+      inherit version;
+      sha256 = "d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a";
+    };
+  });
+in buildPythonApplication rec {
   pname = "streamlit";
-  version = "0.50.2";
+  version = "1.2.0";
   format = "wheel"; # the only distribution available
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "1wymv7qckafs0p2jdjlxjaf1xrhm3iyd185jkldanbb0na5n3ndz";
+    sha256 = "1dzb68a8n8wvjppcmqdaqnh925b2dg6rywv51ac9q09zjxb6z11n";
   };
 
   propagatedBuildInputs = [
-    altair astor base58 blinker boto3 botocore click enum-compat
-    future pillow protobuf requests toml tornado_5 tzlocal validators watchdog
-    jinja2 setuptools
+    altair
+    astor
+    base58
+    blinker
+    boto3
+    botocore
+    cachetools
+    click_7
+    enum-compat
+    future
+    GitPython
+    jinja2
+    pillow
+    protobuf
+    pyarrow
+    pydeck
+    pympler
+    requests
+    setuptools
+    toml
+    tornado
+    tzlocal
+    validators
+    watchdog
   ];
 
   postInstall = ''
@@ -30,5 +86,4 @@ buildPythonApplication rec {
     maintainers = with maintainers; [ yrashk ];
     license = licenses.asl20;
   };
-
 }


### PR DESCRIPTION
###### Motivation for this change

Closes #118764.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

CC @yrashk @nphilou @Creator54 #139295