### PR TITLE
 nodePackages."@prettier/plugin-xml": init at version 1.1.0 

### DIFF
--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -227,6 +227,7 @@
 , "postcss-cli"
 , "prettier"
 , "prettier-plugin-toml"
+, "@prettier/plugin-xml"
 , "prisma"
 , "@prisma/language-server"
 , "pscid"


### PR DESCRIPTION
###### Motivation for this change
[`@prettier/plugin-xml`](https://github.com/prettier/plugin-xml) is a plugin for [prettier](https://github.com/prettier/prettier) which beautifies XML files.

I followed [the documentation](https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/javascript.section.md) for adding node modules:
1. Added `"@prettier/plugin-xml"` to node-packages.json.
2. Ran generate.sh.

Unfortunately, actually using the plugin with prettier in an actual config is still a bit awkward (example below). Perhaps the next step is to introduce a module for this? This is my first time contributing to Nix, and I'm pretty new to it in general, so I'm not sure. I apologize if I have made any mistakes in this pull request.
```nix
let
  my-prettier = pkgs.nodePackages.prettier.override
    {
      nativeBuildInputs = [ pkgs.makeWrapper ];
      postInstall = ''
        wrapProgram "$out/bin/prettier" \
        --add-flags "--plugin ${my-nixpkgs.nodePackages."@prettier/plugin-xml"}/lib/node_modules/@prettier/plugin-xml"
      '';
    };
in
{
...
}
```

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
