### PR TITLE
netboot: Add `netboot_gnome` and `netboot_plasma5`

### DIFF
--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
@@ -1,56 +1,12 @@
 # This module contains the basic configuration for building a graphical NixOS
 # installation CD.
 
-{ lib, pkgs, ... }:
-
-with lib;
+{ ... }:
 
 {
-  imports = [ ./installation-cd-base.nix ];
+  imports =
+    [ ./installation-cd-base.nix
 
-  # Whitelist wheel users to do anything
-  # This is useful for things like pkexec
-  #
-  # WARNING: this is dangerous for systems
-  # outside the installation-cd and shouldn't
-  # be used anywhere else.
-  security.polkit.extraConfig = ''
-    polkit.addRule(function(action, subject) {
-      if (subject.isInGroup("wheel")) {
-        return polkit.Result.YES;
-      }
-    });
-  '';
-
-  services.xserver.enable = true;
-
-  # Provide networkmanager for easy wireless configuration.
-  networking.networkmanager.enable = true;
-  networking.wireless.enable = mkForce false;
-
-  # KDE complains if power management is disabled (to be precise, if
-  # there is no power management backend such as upower).
-  powerManagement.enable = true;
-
-  # Enable sound in graphical iso's.
-  hardware.pulseaudio.enable = true;
-
-  environment.systemPackages = [
-    # Include gparted for partitioning disks.
-    pkgs.gparted
-
-    # Include some editors.
-    pkgs.vim
-    pkgs.bvi # binary editor
-    pkgs.joe
-
-    # Include some version control tools.
-    pkgs.git
-
-    # Firefox for reading the manual.
-    pkgs.firefox
-
-    pkgs.glxinfo
-  ];
-
+      ../../profiles/graphical-base.nix
+    ];
 }

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-gnome.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-gnome.nix
@@ -1,38 +1,13 @@
 # This module defines a NixOS installation CD that contains GNOME.
 
-{ lib, ... }:
-
-with lib;
+{ ... }:
 
 {
-  imports = [ ./installation-cd-graphical-base.nix ];
+  imports =
+    [ ./installation-cd-graphical-base.nix
+
+      ../../profiles/graphical-gnome.nix
+    ];
 
   isoImage.edition = "gnome";
-
-  services.xserver.desktopManager.gnome = {
-    # Add firefox to favorite-apps
-    favoriteAppsOverride = ''
-      [org.gnome.shell]
-      favorite-apps=[ 'firefox.desktop', 'org.gnome.Geary.desktop', 'org.gnome.Calendar.desktop', 'org.gnome.Music.desktop', 'org.gnome.Photos.desktop', 'org.gnome.Nautilus.desktop' ]
-    '';
-    enable = true;
-  };
-
-  services.xserver.displayManager = {
-    gdm = {
-      enable = true;
-      # autoSuspend makes the machine automatically suspend after inactivity.
-      # It's possible someone could/try to ssh'd into the machine and obviously
-      # have issues because it's inactive.
-      # See:
-      # * https://github.com/NixOS/nixpkgs/pull/63790
-      # * https://gitlab.gnome.org/GNOME/gnome-control-center/issues/22
-      autoSuspend = false;
-    };
-    autoLogin = {
-      enable = true;
-      user = "nixos";
-    };
-  };
-
 }

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-plasma5.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-plasma5.nix
@@ -1,50 +1,14 @@
 # This module defines a NixOS installation CD that contains X11 and
 # Plasma 5.
 
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ ... }:
 
 {
-  imports = [ ./installation-cd-graphical-base.nix ];
+  imports =
+    [ ./installation-cd-graphical-base.nix
+
+      ../../profiles/graphical-plasma5.nix
+    ];
 
   isoImage.edition = "plasma5";
-
-  services.xserver = {
-    desktopManager.plasma5 = {
-      enable = true;
-    };
-
-    # Automatically login as nixos.
-    displayManager = {
-      sddm.enable = true;
-      autoLogin = {
-        enable = true;
-        user = "nixos";
-      };
-    };
-  };
-
-  environment.systemPackages = with pkgs; [
-    # Graphical text editor
-    kate
-  ];
-
-  system.activationScripts.installerDesktop = let
-
-    # Comes from documentation.nix when xserver and nixos.enable are true.
-    manualDesktopFile = "/run/current-system/sw/share/applications/nixos-manual.desktop";
-
-    homeDir = "/home/nixos/";
-    desktopDir = homeDir + "Desktop/";
-
-  in ''
-    mkdir -p ${desktopDir}
-    chown nixos ${homeDir} ${desktopDir}
-
-    ln -sfT ${manualDesktopFile} ${desktopDir + "nixos-manual.desktop"}
-    ln -sfT ${pkgs.gparted}/share/applications/gparted.desktop ${desktopDir + "gparted.desktop"}
-    ln -sfT ${pkgs.konsole}/share/applications/org.kde.konsole.desktop ${desktopDir + "org.kde.konsole.desktop"}
-  '';
-
 }

--- a/nixos/modules/installer/netboot/netboot-graphical-gnome.nix
+++ b/nixos/modules/installer/netboot/netboot-graphical-gnome.nix
@@ -1,0 +1,12 @@
+# This module defines a netboot environment that contains GNOME.
+
+{ ... }:
+
+{
+  imports =
+    [ ./netboot-base.nix
+
+      ../../profiles/graphical-base.nix
+      ../../profiles/graphical-gnome.nix
+    ];
+}

--- a/nixos/modules/installer/netboot/netboot-graphical-plasma5.nix
+++ b/nixos/modules/installer/netboot/netboot-graphical-plasma5.nix
@@ -1,0 +1,12 @@
+# This module defines a netboot environment that contains Plasma 5.
+
+{ ... }:
+
+{
+  imports =
+    [ ./netboot-base.nix
+
+      ../../profiles/graphical-base.nix
+      ../../profiles/graphical-plasma5.nix
+    ];
+}

--- a/nixos/modules/profiles/graphical-base.nix
+++ b/nixos/modules/profiles/graphical-base.nix
@@ -1,0 +1,48 @@
+{ lib, pkgs, ... }:
+
+{
+  # Whitelist wheel users to do anything
+  # This is useful for things like pkexec
+  #
+  # WARNING: this is dangerous for systems
+  # outside the installation-cd and shouldn't
+  # be used anywhere else.
+  security.polkit.extraConfig = ''
+    polkit.addRule(function(action, subject) {
+      if (subject.isInGroup("wheel")) {
+        return polkit.Result.YES;
+      }
+    });
+  '';
+
+  services.xserver.enable = true;
+
+  # Provide networkmanager for easy wireless configuration.
+  networking.networkmanager.enable = true;
+  networking.wireless.enable = lib.mkForce false;
+
+  # KDE complains if power management is disabled (to be precise, if
+  # there is no power management backend such as upower).
+  powerManagement.enable = true;
+
+  # Enable sound in graphical iso's.
+  hardware.pulseaudio.enable = true;
+
+  environment.systemPackages = [
+    # Include gparted for partitioning disks.
+    pkgs.gparted
+
+    # Include some editors.
+    pkgs.vim
+    pkgs.bvi # binary editor
+    pkgs.joe
+
+    # Include some version control tools.
+    pkgs.git
+
+    # Firefox for reading the manual.
+    pkgs.firefox
+
+    pkgs.glxinfo
+  ];
+}

--- a/nixos/modules/profiles/graphical-gnome.nix
+++ b/nixos/modules/profiles/graphical-gnome.nix
@@ -1,0 +1,29 @@
+{ ... }:
+
+{
+  services.xserver.desktopManager.gnome = {
+    # Add firefox to favorite-apps
+    favoriteAppsOverride = ''
+      [org.gnome.shell]
+      favorite-apps=[ 'firefox.desktop', 'org.gnome.Geary.desktop', 'org.gnome.Calendar.desktop', 'org.gnome.Music.desktop', 'org.gnome.Photos.desktop', 'org.gnome.Nautilus.desktop' ]
+    '';
+    enable = true;
+  };
+
+  services.xserver.displayManager = {
+    gdm = {
+      enable = true;
+      # autoSuspend makes the machine automatically suspend after inactivity.
+      # It's possible someone could/try to ssh'd into the machine and obviously
+      # have issues because it's inactive.
+      # See:
+      # * https://github.com/NixOS/nixpkgs/pull/63790
+      # * https://gitlab.gnome.org/GNOME/gnome-control-center/issues/22
+      autoSuspend = false;
+    };
+    autoLogin = {
+      enable = true;
+      user = "nixos";
+    };
+  };
+}

--- a/nixos/modules/profiles/graphical-plasma5.nix
+++ b/nixos/modules/profiles/graphical-plasma5.nix
@@ -1,0 +1,40 @@
+{ pkgs, ... }:
+
+{
+  services.xserver = {
+    desktopManager.plasma5 = {
+      enable = true;
+    };
+
+    # Automatically login as nixos.
+    displayManager = {
+      sddm.enable = true;
+      autoLogin = {
+        enable = true;
+        user = "nixos";
+      };
+    };
+  };
+
+  environment.systemPackages = with pkgs; [
+    # Graphical text editor
+    kate
+  ];
+
+  system.activationScripts.installerDesktop = let
+
+    # Comes from documentation.nix when xserver and nixos.enable are true.
+    manualDesktopFile = "/run/current-system/sw/share/applications/nixos-manual.desktop";
+
+    homeDir = "/home/nixos/";
+    desktopDir = homeDir + "Desktop/";
+
+  in ''
+    mkdir -p ${desktopDir}
+    chown nixos ${homeDir} ${desktopDir}
+
+    ln -sfT ${manualDesktopFile} ${desktopDir + "nixos-manual.desktop"}
+    ln -sfT ${pkgs.gparted}/share/applications/gparted.desktop ${desktopDir + "gparted.desktop"}
+    ln -sfT ${pkgs.konsole}/share/applications/org.kde.konsole.desktop ${desktopDir + "org.kde.konsole.desktop"}
+  '';
+}

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -143,6 +143,16 @@ in rec {
     inherit system;
   });
 
+  netboot_plasma5 = forMatchingSystems supportedSystems (system: makeNetboot {
+    module = ./modules/installer/netboot/netboot-graphical-plasma5.nix;
+    inherit system;
+  });
+
+  netboot_gnome = forMatchingSystems supportedSystems (system: makeNetboot {
+    module = ./modules/installer/netboot/netboot-graphical-gnome.nix;
+    inherit system;
+  });
+
   iso_minimal = forAllSystems (system: makeIso {
     module = ./modules/installer/cd-dvd/installation-cd-minimal.nix;
     type = "minimal";


### PR DESCRIPTION
###### Motivation for this change

Adds `netboot_gnome` and `netboot_plasma5` for those who want to netboot with a graphical interface.

Moved most of the code from `installer/cd-dvd/installation-cd-graphical-*.nix` to `profiles/graphical-*.nix` so that it can be reused between the `netboot` and the `installation-cd`

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
