### PR TITLE
pantheon.appcenter: re-add patch for disable packagekit backend

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/pantheon.xml
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.xml
@@ -107,6 +107,12 @@ switchboard-with-plugs.override {
      <para>
       AppCenter has been available since 20.03, but it is of little use. This is because there is no functioning PackageKit backend for Nix 2.0. The Flatpak backend will not work before <link xlink:href="https://github.com/elementary/appcenter/issues/1076">flag for Flatpak-only</link> is provided. See this <link xlink:href="https://github.com/NixOS/nixpkgs/issues/70214">issue</link>.
      </para>
+     <para>
+      To use AppCenter on NixOS, add <literal>pantheon.appcenter</literal> to <xref linkend="opt-environment.systemPackages" />, <link linkend="module-services-flatpak">enable Flatpak support</link> and optionally add the <literal>appcenter</literal> Flatpak remote:
+     </para>
+<screen>
+<prompt>$ </prompt>flatpak remote-add --if-not-exists appcenter https://flatpak.elementary.io/repo.flatpakrepo
+</screen>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/nixos/modules/services/x11/desktop-managers/pantheon.xml
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.xml
@@ -105,7 +105,7 @@ switchboard-with-plugs.override {
     </term>
     <listitem>
      <para>
-      AppCenter has been available since 20.03, but it is of little use. This is because there is no functioning PackageKit backend for Nix 2.0. The Flatpak backend will not work before <link xlink:href="https://github.com/elementary/appcenter/issues/1076">flag for Flatpak-only</link> is provided. See this <link xlink:href="https://github.com/NixOS/nixpkgs/issues/70214">issue</link>.
+      AppCenter has been available since 20.03, but it is of little use. This is because there is no functioning PackageKit backend for Nix 2.0. Starting from 21.11, the Flatpak backend should work so you can install some Flatpak applications using it. See this <link xlink:href="https://github.com/NixOS/nixpkgs/issues/70214">issue</link>.
      </para>
      <para>
       To use AppCenter on NixOS, add <literal>pantheon.appcenter</literal> to <xref linkend="opt-environment.systemPackages" />, <link linkend="module-services-flatpak">enable Flatpak support</link> and optionally add the <literal>appcenter</literal> Flatpak remote:

--- a/pkgs/desktops/pantheon/apps/appcenter/add-packagekit-backend-option.patch
+++ b/pkgs/desktops/pantheon/apps/appcenter/add-packagekit-backend-option.patch
@@ -1,0 +1,240 @@
+From b5d7cb20713eff3b3729e5c5fdd2f15680a29385 Mon Sep 17 00:00:00 2001
+From: Bobby Rong <rjl931189261@126.com>
+Date: Sun, 31 Oct 2021 23:12:46 +0800
+Subject: [PATCH] build: add packagekit_backend option
+
+---
+ .github/workflows/main.yml      |  7 +++++++
+ meson_options.txt               |  1 +
+ src/Application.vala            |  4 ++++
+ src/Core/BackendAggregator.vala |  2 ++
+ src/Core/Package.vala           | 21 +++++++++++++--------
+ src/Core/UpdateManager.vala     |  6 ++++++
+ src/Views/Homepage.vala         |  4 ++++
+ src/meson.build                 | 10 ++++++++--
+ 8 files changed, 45 insertions(+), 10 deletions(-)
+
+diff --git a/.github/workflows/main.yml b/.github/workflows/main.yml
+index daf13654..5dc5a2fb 100644
+--- a/.github/workflows/main.yml
++++ b/.github/workflows/main.yml
+@@ -42,6 +42,13 @@ jobs:
+         meson configure -Dcurated=false -Dpayments=false -Dsharing=false -Dname=Pop\!_Shop build
+         ninja -C build install
+ 
++    - name: Build (NixOS)
++      env:
++        DESTDIR: out
++      run: |
++        meson configure -Dcurated=false -Dpayments=false -Dpackagekit_backend=false build
++        ninja -C build install
++
+   lint:
+ 
+     runs-on: ubuntu-latest
+diff --git a/meson_options.txt b/meson_options.txt
+index 0ae93d07..37a6cd8a 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -4,3 +4,4 @@ option('name', type : 'string', value : 'AppCenter', description : 'The name of
+ option('payments', type : 'boolean', value : true, description : 'Enable payment features and display paid apps')
+ option('sharing', type : 'boolean', value : true, description : 'Display sharing features, i.e. copyable URLs to appcenter.elementary.io')
+ option('hide_upstream_distro_apps', type : 'boolean', value : true, description : 'Used for hiding Ubuntu repo apps on elementary OS')
++option('packagekit_backend', type : 'boolean', value : true, description : 'Enable PackageKit backend')
+diff --git a/src/Application.vala b/src/Application.vala
+index 65fae5aa..7c075076 100644
+--- a/src/Application.vala
++++ b/src/Application.vala
+@@ -167,9 +167,11 @@ public class AppCenter.App : Gtk.Application {
+ 
+         var client = AppCenterCore.Client.get_default ();
+ 
++#if PACKAGEKIT_BACKEND
+         if (fake_update_packages != null) {
+             AppCenterCore.PackageKitBackend.get_default ().fake_packages = fake_update_packages;
+         }
++#endif
+ 
+         if (silent) {
+             NetworkMonitor.get_default ().network_changed.connect ((available) => {
+@@ -183,6 +185,7 @@ public class AppCenter.App : Gtk.Application {
+             return;
+         }
+ 
++#if PACKAGEKIT_BACKEND
+         if (local_path != null) {
+             var file = File.new_for_commandline_arg (local_path);
+ 
+@@ -192,6 +195,7 @@ public class AppCenter.App : Gtk.Application {
+                 warning ("Failed to load local AppStream XML file: %s", e.message);
+             }
+         }
++#endif
+ 
+         if (main_window == null) {
+             main_window = new MainWindow (this);
+diff --git a/src/Core/BackendAggregator.vala b/src/Core/BackendAggregator.vala
+index 539dba98..feb1eaa9 100644
+--- a/src/Core/BackendAggregator.vala
++++ b/src/Core/BackendAggregator.vala
+@@ -26,8 +26,10 @@ public class AppCenterCore.BackendAggregator : Backend, Object {
+ 
+     construct {
+         backends = new Gee.ArrayList<unowned Backend> ();
++#if PACKAGEKIT_BACKEND
+         backends.add (PackageKitBackend.get_default ());
+         backends.add (UbuntuDriversBackend.get_default ());
++#endif
+         backends.add (FlatpakBackend.get_default ());
+ 
+         unowned Gtk.Application app = (Gtk.Application) GLib.Application.get_default ();
+diff --git a/src/Core/Package.vala b/src/Core/Package.vala
+index d6f12f15..8dbd7a22 100644
+--- a/src/Core/Package.vala
++++ b/src/Core/Package.vala
+@@ -328,7 +328,14 @@ public class AppCenterCore.Package : Object {
+     public string origin_description {
+         owned get {
+             unowned string origin = component.get_origin ();
+-            if (backend is PackageKitBackend) {
++            if (backend is FlatpakBackend) {
++                var fp_package = this as FlatpakPackage;
++                if (fp_package != null && fp_package.installation == FlatpakBackend.system_installation) {
++                    return _("%s (system-wide)").printf (origin);
++                }
++                return origin;
++#if PACKAGEKIT_BACKEND
++            } else if (backend is PackageKitBackend) {
+                 if (origin == APPCENTER_PACKAGE_ORIGIN) {
+                     return _("AppCenter");
+                 } else if (origin == ELEMENTARY_STABLE_PACKAGE_ORIGIN) {
+@@ -336,15 +343,9 @@ public class AppCenterCore.Package : Object {
+                 } else if (origin.has_prefix ("ubuntu-")) {
+                     return _("Ubuntu (non-curated)");
+                 }
+-            } else if (backend is FlatpakBackend) {
+-                var fp_package = this as FlatpakPackage;
+-                if (fp_package != null && fp_package.installation == FlatpakBackend.system_installation) {
+-                    return _("%s (system-wide)").printf (origin);
+-                }
+-
+-                return origin;
+             } else if (backend is UbuntuDriversBackend) {
+                 return _("Ubuntu Drivers");
++#endif
+             }
+ 
+             return _("Unknown Origin (non-curated)");
+@@ -434,11 +435,15 @@ public class AppCenterCore.Package : Object {
+         _author_title = null;
+         backend_details = null;
+ 
++#if PACKAGEKIT_BACKEND
+         // The version on a PackageKit package comes from the package not AppStream, so only reset the version
+         // on other backends
+         if (!(backend is PackageKitBackend)) {
+             _latest_version = null;
+         }
++#else
++        _latest_version = null;
++#endif
+ 
+         this.component = component;
+     }
+diff --git a/src/Core/UpdateManager.vala b/src/Core/UpdateManager.vala
+index 9deceaf5..c92c0d37 100644
+--- a/src/Core/UpdateManager.vala
++++ b/src/Core/UpdateManager.vala
+@@ -52,6 +52,7 @@ public class AppCenterCore.UpdateManager : Object {
+             installed_package.update_state ();
+         }
+ 
++#if PACKAGEKIT_BACKEND
+         Pk.Results pk_updates;
+         unowned PackageKitBackend client = PackageKitBackend.get_default ();
+         try {
+@@ -60,10 +61,12 @@ public class AppCenterCore.UpdateManager : Object {
+             warning ("Unable to get updates from PackageKit backend: %s", e.message);
+             return 0;
+         }
++#endif
+ 
+         uint os_count = 0;
+         string os_desc = "";
+ 
++#if PACKAGEKIT_BACKEND
+         var package_array = pk_updates.get_package_array ();
+         debug ("PackageKit backend reports %d updates", package_array.length);
+ 
+@@ -87,6 +90,7 @@ public class AppCenterCore.UpdateManager : Object {
+                 );
+             }
+         });
++#endif
+ 
+         os_updates.component.set_pkgnames ({});
+         os_updates.change_information.clear_update_info ();
+@@ -159,6 +163,7 @@ public class AppCenterCore.UpdateManager : Object {
+             count += 1;
+         }
+ 
++#if PACKAGEKIT_BACKEND
+         pk_updates.get_details_array ().foreach ((pk_detail) => {
+             var pk_package = new Pk.Package ();
+             try {
+@@ -181,6 +186,7 @@ public class AppCenterCore.UpdateManager : Object {
+                 critical (e.message);
+             }
+         });
++#endif
+ 
+         os_updates.update_state ();
+         return count;
+diff --git a/src/Views/Homepage.vala b/src/Views/Homepage.vala
+index 3673903f..2e128e77 100644
+--- a/src/Views/Homepage.vala
++++ b/src/Views/Homepage.vala
+@@ -107,9 +107,13 @@ public class AppCenter.Homepage : AbstractView {
+             column_spacing = 24,
+             orientation = Gtk.Orientation.VERTICAL
+         };
++#if PACKAGEKIT_BACKEND
+         grid.add (banner_revealer);
+         grid.add (recently_updated_revealer);
+         grid.add (categories_label);
++#else
++        category_flow.margin_top = 12;
++#endif
+         grid.add (category_flow);
+ 
+         scrolled_window = new Gtk.ScrolledWindow (null, null) {
+diff --git a/src/meson.build b/src/meson.build
+index 7b319fc6..d1d77931 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -12,10 +12,8 @@ appcenter_files = files(
+     'Core/FlatpakBackend.vala',
+     'Core/Job.vala',
+     'Core/Package.vala',
+-    'Core/PackageKitBackend.vala',
+     'Core/ScreenshotCache.vala',
+     'Core/Task.vala',
+-    'Core/UbuntuDriversBackend.vala',
+     'Core/UpdateManager.vala',
+     'Dialogs/InstallFailDialog.vala',
+     'Dialogs/NonCuratedWarningDialog.vala',
+@@ -76,6 +74,14 @@ if get_option('hide_upstream_distro_apps')
+     args += '--define=HIDE_UPSTREAM_DISTRO_APPS'
+ endif
+ 
++if get_option('packagekit_backend')
++    args += '--define=PACKAGEKIT_BACKEND'
++    appcenter_files += files(
++        'Core/PackageKitBackend.vala',
++        'Core/UbuntuDriversBackend.vala',
++    )
++endif
++
+ executable(
+     meson.project_name(),
+     appcenter_files,

--- a/pkgs/desktops/pantheon/apps/appcenter/default.nix
+++ b/pkgs/desktops/pantheon/apps/appcenter/default.nix
@@ -39,11 +39,12 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-xktIHQHmz5gh72NEz9UQ9fMvBlj1BihWxHgxsHmTIB0=";
   };
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
+  patches = [
+    # Introduces a packagekit_backend meson flag.
+    # Makes appcenter actually work by using only the flatpak backend.
+    # https://github.com/elementary/appcenter/pull/1739
+    ./add-packagekit-backend-option.patch
+  ];
 
   nativeBuildInputs = [
     appstream-glib
@@ -78,12 +79,20 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-Dpayments=false"
     "-Dcurated=false"
+    # This option is introduced in add-packagekit-backend-option.patch
+    "-Dpackagekit_backend=false"
   ];
 
   postPatch = ''
     chmod +x meson/post_install.py
     patchShebangs meson/post_install.py
   '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     homepage = "https://github.com/elementary/appcenter";


### PR DESCRIPTION
###### Motivation for this change

This patch is actually a lot easier to maintain than the legacy one. I have opened upstream PR one month ago but it makes no sense to wait any longer as the app is totally not working specifically on NixOS 🤦

Again closes #70214

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
