### PR TITLE
cryptomator: 1.5.15 -> 1.6.4

### DIFF
--- a/pkgs/development/compilers/zulu/17.nix
+++ b/pkgs/development/compilers/zulu/17.nix
@@ -1,0 +1,120 @@
+{ stdenv
+, lib
+, fetchurl
+, autoPatchelfHook
+, unzip
+, makeWrapper
+, setJavaClassPath
+, zulu
+  # minimum dependencies
+, alsa-lib
+, fontconfig
+, freetype
+, zlib
+, xorg
+  # runtime dependencies
+, cups
+  # runtime dependencies for GTK+ Look and Feel
+, gtkSupport ? stdenv.isLinux
+, cairo
+, glib
+, gtk3
+}:
+
+let
+  version = "17.30.15";
+  openjdk = "17.0.1";
+
+  sha256_linux = "9b8e4d1e47b02b9c2392462ee82988c189357471de3224c37173fa58e2b25112";
+  sha256_darwin = "b30ef16a4384899f5a87e4de7c70f901168efd70bc614e06fc4f78ecfb81af68";
+
+  platform = if stdenv.isDarwin then "macosx" else "linux";
+  hash = if stdenv.isDarwin then sha256_darwin else sha256_linux;
+  extension = if stdenv.isDarwin then "zip" else "tar.gz";
+
+  runtimeDependencies = [
+    cups
+  ] ++ lib.optionals gtkSupport [
+    cairo
+    glib
+    gtk3
+  ];
+  runtimeLibraryPath = lib.makeLibraryPath runtimeDependencies;
+
+in
+stdenv.mkDerivation {
+  inherit version openjdk platform hash extension;
+
+  pname = "zulu";
+
+  src = fetchurl {
+    url = "https://cdn.azul.com/zulu/bin/zulu${version}-ca-jdk${openjdk}-${platform}_x64.${extension}";
+    sha256 = hash;
+  };
+
+  buildInputs = lib.optionals stdenv.isLinux [
+    alsa-lib # libasound.so wanted by lib/libjsound.so
+    fontconfig
+    freetype
+    stdenv.cc.cc # libstdc++.so.6
+    xorg.libX11
+    xorg.libXext
+    xorg.libXi
+    xorg.libXrender
+    xorg.libXtst
+    zlib
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+  ] ++ lib.optionals stdenv.isDarwin [
+    unzip
+  ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r ./* "$out/"
+  '' + lib.optionalString stdenv.isLinux ''
+    # jni.h expects jni_md.h to be in the header search path.
+    ln -s $out/include/linux/*_md.h $out/include/
+  '' + ''
+    mkdir -p $out/nix-support
+    printWords ${setJavaClassPath} > $out/nix-support/propagated-build-inputs
+
+    # Set JAVA_HOME automatically.
+    cat <<EOF >> $out/nix-support/setup-hook
+    if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
+    EOF
+  '' + lib.optionalString stdenv.isLinux ''
+    # We cannot use -exec since wrapProgram is a function but not a command.
+    #
+    # jspawnhelper is executed from JVM, so it doesn't need to wrap it, and it
+    # breaks building OpenJDK (#114495).
+    for bin in $( find "$out" -executable -type f -not -name jspawnhelper ); do
+      wrapProgram "$bin" --prefix LD_LIBRARY_PATH : "${runtimeLibraryPath}"
+    done
+  '';
+
+  preFixup = ''
+    find "$out" -name libfontmanager.so -exec \
+      patchelf --add-needed libfontconfig.so {} \;
+  '';
+
+  passthru = {
+    home = zulu;
+  };
+
+  meta = with lib; {
+    homepage = "https://www.azul.com/products/zulu/";
+    license = licenses.gpl2;
+    description = "Certified builds of OpenJDK";
+    longDescription = ''
+      Certified builds of OpenJDK that can be deployed across multiple
+      operating systems, containers, hypervisors and Cloud platforms.
+    '';
+    maintainers = with maintainers; [ fpletz ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    mainProgram = "java";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13234,6 +13234,7 @@ with pkgs;
 
   zulip-term = callPackage ../applications/networking/instant-messengers/zulip-term { };
 
+  zulu17 = callPackage ../development/compilers/zulu/17.nix { };
   zulu8 = callPackage ../development/compilers/zulu/8.nix { };
   zulu = callPackage ../development/compilers/zulu { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Cryptomator was out of date. It was also broken, and needed fixing (see: https://github.com/NixOS/nixpkgs/issues/150391)

###### Things done

I fixed the bug by changing from OpenJDK to Zulu 17. For this, I also had to make a package for Zulu 17 as it didn't exist yet. So that too is added with this PR.

I was awake a few nights for this peculiarity, I feel I'm experienced enough now to maintain this package so I added myself as maintainer in addition to bachp.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
