### PR TITLE
code-browser 8.0

### DIFF
--- a/pkgs/applications/editors/code-browser/default.nix
+++ b/pkgs/applications/editors/code-browser/default.nix
@@ -8,6 +8,8 @@
 , withGtk3 ? false, gtk3
 , mkDerivation ? stdenv.mkDerivation
 }:
+let onlyOneEnabled = xs: 1 == builtins.length (builtins.filter lib.id xs);
+in assert onlyOneEnabled [ withQt withGtk2 withGtk3 ];
 mkDerivation rec {
   pname = "code-browser";
   version = "8.0";

--- a/pkgs/applications/editors/code-browser/default.nix
+++ b/pkgs/applications/editors/code-browser/default.nix
@@ -1,46 +1,55 @@
 { lib, stdenv
 , fetchurl
 , copper
-, ruby
 , python3
-, qtbase
-, gtk3
 , pkg-config
-, withQt ? false
-, withGtk ? false, wrapQtAppsHook ? null
+, withQt ? false, qtbase ? null, wrapQtAppsHook ? null
+, withGtk2 ? false, gtk2
+, withGtk3 ? false, gtk3
+, mkDerivation ? stdenv.mkDerivation
 }:
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "code-browser";
-  version = "7.1.20";
+  version = "8.0";
   src = fetchurl {
     url = "https://tibleiz.net/download/code-browser-${version}-src.tar.gz";
-    sha256 = "1svi0v3h42h2lrb8c7pjvqc8019v1p20ibsnl48pfhl8d96mmdnz";
+    sha256 = "sha256-beCp4lx4MI1+hVgWp2h3piE/zu51zfwQdB5g7ImgmwY=";
   };
   postPatch = ''
     substituteInPlace Makefile --replace "LFLAGS=-no-pie" "LFLAGS=-no-pie -L."
-    substituteInPlace libs/copper-ui/Makefile --replace "moc -o" "${qtbase.dev}/bin/moc -o"
     patchShebangs .
-  '';
+  ''
+  + lib.optionalString withQt ''
+    substituteInPlace libs/copper-ui/Makefile --replace "moc -o" "${qtbase.dev}/bin/moc -o"
+    substituteInPlace libs/copper-ui/Makefile --replace "all: qt gtk gtk2" "all: qt"
+  ''
+  + lib.optionalString withGtk2 ''
+    substituteInPlace libs/copper-ui/Makefile --replace "all: qt gtk gtk2" "all: gtk2"
+  ''
+  + lib.optionalString withGtk3 ''
+    substituteInPlace libs/copper-ui/Makefile --replace "all: qt gtk gtk2" "all: gtk"
+  ''
+  ;
   nativeBuildInputs = [ copper
                         python3
-                        ruby
-                        qtbase
-                        gtk3
                         pkg-config
                       ]
-  ++ lib.optionals withQt [ wrapQtAppsHook ];
+  ++ lib.optionals withGtk2 [ gtk2 ]
+  ++ lib.optionals withGtk3 [ gtk3 ]
+  ++ lib.optionals withQt [ qtbase wrapQtAppsHook ];
   buildInputs = lib.optionals withQt [ qtbase ]
-                ++ lib.optionals withGtk [ gtk3 ];
+                ++ lib.optionals withGtk2 [ gtk2 ]
+                ++ lib.optionals withGtk3 [ gtk3 ];
   makeFlags = [
     "prefix=$(out)"
     "COPPER=${copper}/bin/copper-elf64"
     "with-local-libs"
-    "QINC=${qtbase.dev}/include"
   ]
-  ++ lib.optionals withQt [ "UI=qt" ]
-  ++ lib.optionals withGtk [ "UI=gtk" ];
-
-  dontWrapQtApps = true;
+  ++ lib.optionals withQt [ "QINC=${qtbase.dev}/include"
+                            "UI=qt"
+                          ]
+  ++ lib.optionals withGtk2 [ "UI=gtk2" ]
+  ++ lib.optionals withGtk3 [ "UI=gtk" ];
 
   meta = with lib; {
     description = "Folding text editor, designed to hierarchically structure any kind of text file and especially source code";

--- a/pkgs/development/compilers/copper/default.nix
+++ b/pkgs/development/compilers/copper/default.nix
@@ -4,16 +4,15 @@
 }:
 stdenv.mkDerivation rec {
   pname = "copper";
-  version = "4.4";
+  version = "4.6";
   src = fetchurl {
     url = "https://tibleiz.net/download/copper-${version}-src.tar.gz";
-    sha256 = "1nf0bw143rjhd019yms3k6k531rahl8anidwh6bif0gm7cngfwfw";
+    sha256 = "sha256-tyxAMJp4H50eBz8gjt2O3zj5fq6nOIXKX47wql8aUUg=";
   };
   buildInputs = [
     libffi
   ];
   postPatch = ''
-    substituteInPlace Makefile --replace "-s scripts/" "scripts/"
     patchShebangs .
   '';
   buildPhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4283,11 +4283,9 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };
 
-  code-browser-qt = libsForQt5.callPackage ../applications/editors/code-browser { withQt = true;
-                                                                                };
-  code-browser-gtk = callPackage ../applications/editors/code-browser { withGtk = true;
-                                                                        qtbase = qt5.qtbase;
-                                                                      };
+  code-browser-qt = libsForQt5.callPackage ../applications/editors/code-browser { withQt = true; };
+  code-browser-gtk2 = callPackage ../applications/editors/code-browser { withGtk2 = true; };
+  code-browser-gtk = callPackage ../applications/editors/code-browser { withGtk3 = true; };
 
   c14 = callPackage ../applications/networking/c14 { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to latest version, add a gtk2 version. On top of https://github.com/NixOS/nixpkgs/pull/150419

The gtk3 version doesn't run on wayland, as a workaround you can use:

`env GDK_BACKEND=x11 code-browser`

Closes #150212

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
