### PR TITLE
python3Packages.msoffcrypto-tool: init at 4.12.0, python3Packages.oletools: init at 0.60

### DIFF
--- a/pkgs/development/python-modules/msoffcrypto-tool/default.nix
+++ b/pkgs/development/python-modules/msoffcrypto-tool/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, olefile
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, cryptography
+, pytestCheckHook
+, pythonOlder
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "msoffcrypto-tool";
+  version = "4.12.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "nolze";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-EBEwldh2Ct/4oxnAF1hWeW/uRrVsCYEi0cJaZubofFk=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    cryptography
+    olefile
+    setuptools
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Test fails with AssertionError
+    "test_cli"
+  ];
+
+  pythonImportsCheck = [
+    "msoffcrypto"
+  ];
+
+  meta = with lib; {
+    description = "Python tool and library for decrypting MS Office files with passwords or other keys";
+    homepage = "https://github.com/nolze/msoffcrypto-tool";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/oletools/default.nix
+++ b/pkgs/development/python-modules/oletools/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, buildPythonPackage
+, colorclass
+, easygui
+, fetchFromGitHub
+, msoffcrypto-tool
+, olefile
+, pcodedmp
+, pyparsing
+, pytestCheckHook
+, pythonOlder
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "oletools";
+  version = "0.60";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "decalage2";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-gatUVkf8iT1OGnahX1BzQLDypCqhS1EvkAgUHJ6myA4=";
+  };
+
+  propagatedBuildInputs = [
+    colorclass
+    easygui
+    msoffcrypto-tool
+    olefile
+    pcodedmp
+    pyparsing
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Test fails with AssertionError: Tuples differ: ('MS Word 2007+...
+    "test_all"
+  ];
+
+  pythonImportsCheck = [
+    "oletools"
+  ];
+
+  meta = with lib; {
+    description = "Python tool to analyze MS OLE2 files and MS Office documents";
+    homepage = "https://github.com/decalage2/oletools";
+    license = with licenses; [ bsd2 /* and */ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pcodedmp/default.nix
+++ b/pkgs/development/python-modules/pcodedmp/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pcodedmp";
+  version = "1.2.6";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "bontchev";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-SYOFGMvrzxDPMACaCvqwU28Mh9LEuvFBGvAph4X+geo=";
+  };
+
+  postPatch = ''
+    # Circular dependency
+    substituteInPlace setup.py \
+      --replace "'oletools>=0.54'," ""
+  '';
+
+  # Module doesn't have tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "pcodedmp"
+  ];
+
+  meta = with lib; {
+    description = "Python VBA p-code disassembler";
+    homepage = "https://github.com/bontchev/pcodedmp";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -373,6 +373,8 @@ with pkgs;
 
   onesixtyone = callPackage ../tools/security/onesixtyone {};
 
+  oletools = with python3.pkgs; toPythonApplication oletools;
+
   creddump = callPackage ../tools/security/creddump {};
 
   credential-detector = callPackage ../tools/security/credential-detector { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18768,6 +18768,8 @@ with pkgs;
 
   msgpack = callPackage ../development/libraries/msgpack { };
 
+  msoffcrypto-tool = with python3.pkgs; toPythonApplication msoffcrypto-tool;
+
   msilbc = callPackage ../development/libraries/msilbc { };
 
   mp4v2 = callPackage ../development/libraries/mp4v2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5411,6 +5411,8 @@ in {
 
   olefile = callPackage ../development/python-modules/olefile { };
 
+  oletools = callPackage ../development/python-modules/oletools { };
+
   omegaconf = callPackage ../development/python-modules/omegaconf { };
 
   omnilogic = callPackage ../development/python-modules/omnilogic { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5030,6 +5030,8 @@ in {
 
   msldap = callPackage ../development/python-modules/msldap { };
 
+  msoffcrypto-tool = callPackage ../development/python-modules/msoffcrypto-tool { };
+
   mss = callPackage ../development/python-modules/mss { };
 
   msrestazure = callPackage ../development/python-modules/msrestazure { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5696,6 +5696,8 @@ in {
 
   pc-ble-driver-py = toPythonModule (callPackage ../development/python-modules/pc-ble-driver-py { });
 
+  pcodedmp = callPackage ../development/python-modules/pcodedmp { };
+
   pcpp = callPackage ../development/python-modules/pcpp { };
 
   pdf2image = callPackage ../development/python-modules/pdf2image { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python tool and library for decrypting MS Office files with passwords or other keys

https://github.com/nolze/msoffcrypto-tool

and

Python tool to analyze MS OLE2 files and MS Office documents

https://github.com/decalage2/oletools

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
