### PR TITLE
comma: init at 1.1.0

### DIFF
--- a/pkgs/tools/package-management/comma/default.nix
+++ b/pkgs/tools/package-management/comma/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, stdenv
+, fetchurl
+, fetchFromGitHub
+, linkFarm
+, nix-index
+, fzy
+}:
+
+let
+
+  # nix-index takes a little while to run and the contents don't change
+  # meaningfully very often.
+  indexCache = fetchurl {
+    url = "https://github.com/Mic92/nix-index-database/releases/download/2021-12-12/index-x86_64-linux";
+    sha256 = "sha256-+SoG5Qz2KWA/nIWXE6SLpdi8MDqTs8LY90fGZxGKOiA=";
+  };
+
+  # nix-locate needs the --db argument to be a directory containing a file
+  # named "files".
+  nixIndexDB = linkFarm "nix-index-cache" [
+    { name = "files"; path = indexCache; }
+  ];
+
+in stdenv.mkDerivation rec {
+  pname = "comma";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "nix-community";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-WBIQmwlkb/GMoOq+Dnyrk8YmgiM/wJnc5HYZP8Uw72E=";
+  };
+
+  postPatch = ''
+    substituteInPlace , \
+      --replace '$PREBUILT_NIX_INDEX_DB' "${nixIndexDB}" \
+      --replace nix-locate "${nix-index}/bin/nix-locate" \
+      --replace fzy "${fzy}/bin/fzy"
+  '';
+
+  installPhase = ''
+    install -Dm755 , -t $out/bin
+    ln -s $out/bin/, $out/bin/comma
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/nix-community/comma";
+    description = "Run software without installing it";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Enzime ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2554,6 +2554,8 @@ with pkgs;
 
   cz-cli = callPackage ../applications/version-management/cz-cli {};
 
+  comma = callPackage ../tools/package-management/comma { };
+
   common-licenses = callPackage ../data/misc/common-licenses {};
 
   compactor = callPackage ../applications/networking/compactor { };


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/nix-community/comma/issues/2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
