### PR TITLE
cudatext: 1.150.0 → 1.152.0

### DIFF
--- a/pkgs/applications/editors/cudatext/default.nix
+++ b/pkgs/applications/editors/cudatext/default.nix
@@ -38,13 +38,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "cudatext";
-  version = "1.150.0";
+  version = "1.152.0";
 
   src = fetchFromGitHub {
     owner = "Alexey-T";
     repo = "CudaText";
     rev = version;
-    sha256 = "sha256-6XG4v2S7InKA6OVrV+q1lT/CzNxmzVQfmAAo2cqbqBY=";
+    sha256 = "sha256-LwPlWfna+/LsQxOBuTFpE7e7Qr5g9NN14rVasMZVImQ=";
   };
 
   postPatch = ''
@@ -98,6 +98,8 @@ stdenv.mkDerivation rec {
       exit 1
     fi
   '') additionalLexers;
+
+  passthru.updateScript = ./update.sh;
 
   meta = with lib; {
     description = "Cross-platform code editor";

--- a/pkgs/applications/editors/cudatext/deps.json
+++ b/pkgs/applications/editors/cudatext/deps.json
@@ -16,8 +16,8 @@
   },
   "ATSynEdit": {
     "owner": "Alexey-T",
-    "rev": "2021.11.25",
-    "sha256": "sha256-CbH0C+UOJ9X2wKG5IEbgitda06lazujYM8l961k7C7g="
+    "rev": "2021.12.12",
+    "sha256": "sha256-glP2Srw3Lw1JNQO+DIwixf4Xdbo5M6pBdYufwGERPW4="
   },
   "ATSynEdit_Cmp": {
     "owner": "Alexey-T",
@@ -26,13 +26,13 @@
   },
   "EControl": {
     "owner": "Alexey-T",
-    "rev": "2021.10.21",
-    "sha256": "sha256-RyRpHihmmr/EeVWk9CR0S3pvKy0FzqLZNGti33+4fkI="
+    "rev": "2021.12.07",
+    "sha256": "sha256-givCklAHao26psWLI2qK246igxcAQEeIYTGH61FX6Xo="
   },
   "ATSynEdit_Ex": {
     "owner": "Alexey-T",
-    "rev": "2021.11.25",
-    "sha256": "sha256-6hk9wNdoz1d3VpuW7yHyIQnnYseEAfgjCNGl6+o0Hjs="
+    "rev": "2021.12.07",
+    "sha256": "sha256-/2Fv/vrpbHSiJro11cjbziUaT4gfwa6y5aQBoYgq3OQ="
   },
   "Python-for-Lazarus": {
     "owner": "Alexey-T",

--- a/pkgs/applications/editors/cudatext/update.sh
+++ b/pkgs/applications/editors/cudatext/update.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnused jq nix-prefetch moreutils
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+version=$(curl -s https://api.github.com/repos/Alexey-T/CudaText/releases/latest | jq -r '.tag_name')
+url="https://github.com/Alexey-T/CudaText/archive/refs/tags/${version}.tar.gz"
+hash=$(nix-prefetch-url --quiet --unpack --type sha256 $url)
+sriHash=$(nix hash to-sri --type sha256 $hash)
+
+sed -i "s#version = \".*\"#version = \"$version\"#" default.nix
+sed -i "s#sha256 = \".*\"#sha256 = \"$sriHash\"#" default.nix
+
+while IFS=$'\t' read repo owner rev; do
+  latest=$(curl -s https://api.github.com/repos/${owner}/${repo}/releases/latest | jq -r '.tag_name')
+  if [ "$latest" != "$rev" ]; then
+    url="https://github.com/${owner}/${repo}/archive/refs/tags/${latest}.tar.gz"
+    hash=$(nix-prefetch-url --quiet --unpack --type sha256 $url)
+    sriHash=$(nix hash to-sri --type sha256 $hash)
+    jq ".${repo}.rev = \"${latest}\" | .${repo}.sha256 = \"${sriHash}\"" deps.json | sponge deps.json
+  fi
+done <<< $(jq -r 'to_entries[]|[.key,.value.owner,.value.rev]|@tsv' deps.json)


### PR DESCRIPTION
###### Motivation for this change
* [Changelog](https://cudatext.github.io/history.txt)
* Add update script

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
