### PR TITLE
guile-sdl2: 0.5.0 → 0.7.0

### DIFF
--- a/pkgs/development/guile-modules/guile-sdl2/default.nix
+++ b/pkgs/development/guile-modules/guile-sdl2/default.nix
@@ -12,11 +12,11 @@
 
 stdenv.mkDerivation rec {
   pname = "guile-sdl2";
-  version = "0.5.0";
+  version = "0.7.0";
 
   src = fetchurl {
     url = "https://files.dthompson.us/${pname}/${pname}-${version}.tar.gz";
-    hash = "sha256-lWTLctPUDqvN/Y95oOL7LF3czlLJFQ9d9np9dx4DHYU=";
+    hash = "sha256-h0osCURnYTUQFrKw0i7Jd+QCI8piR1NUE2lbxPv87aQ=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://git.dthompson.us/guile-sdl2.git/log)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
