### PR TITLE
python3Packages.elastic-apm: init at 6.7.2

### DIFF
--- a/pkgs/development/python-modules/ecs-logging/default.nix
+++ b/pkgs/development/python-modules/ecs-logging/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flit-core
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "ecs-logging";
+  version = "1.1.0";
+  format = "flit";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "elastic";
+    repo = "ecs-logging-python";
+    rev = version;
+    sha256 = "sha256-UcQh/+K2d4tiMZaz4IAZ2w/B88vEkHoq2LCPMNZ95Mo=";
+  };
+
+  nativeBuildInputs = [
+    flit-core
+  ];
+
+  # Circular dependency elastic-apm
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "ecs_logging"
+  ];
+
+  meta = with lib; {
+    description = "Logging formatters for the Elastic Common Schema (ECS) in Python";
+    homepage = "https://github.com/elastic/ecs-logging-python";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/elastic-apm/default.nix
+++ b/pkgs/development/python-modules/elastic-apm/default.nix
@@ -1,0 +1,90 @@
+{ lib
+, asynctest
+, aiohttp
+, blinker
+, buildPythonPackage
+, certifi
+, ecs-logging
+, fetchFromGitHub
+, httpx
+, jinja2
+, jsonschema
+, Logbook
+, mock
+, pytest-asyncio
+, pytest-bdd
+, pytest-localserver
+, pytest-mock
+, pytestCheckHook
+, pythonOlder
+, sanic
+, sanic-testing
+, starlette
+, structlog
+, tornado
+, urllib3
+, webob
+}:
+
+buildPythonPackage rec {
+  pname = "elastic-apm";
+  version = "6.7.2";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "elastic";
+    repo = "apm-agent-python";
+    rev = "v${version}";
+    sha256 = "sha256-NyoFJ3HVxE3AdCCZCZrEk4dDiTIv9cGZYPHVre/PMO4=";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    blinker
+    certifi
+    sanic
+    starlette
+    tornado
+    urllib3
+  ];
+
+  checkInputs = [
+    asynctest
+    ecs-logging
+    jinja2
+    jsonschema
+    Logbook
+    mock
+    httpx
+    pytest-asyncio
+    pytest-bdd
+    pytest-mock
+    pytest-localserver
+    sanic-testing
+    pytestCheckHook
+    structlog
+    webob
+  ];
+
+  disabledTests = [
+    "elasticapm_client"
+  ];
+
+  disabledTestPaths = [
+    # Exclude tornado tests
+    "tests/contrib/asyncio/tornado/tornado_tests.py"
+  ];
+
+  pythonImportsCheck = [
+    "elasticapm"
+  ];
+
+  meta = with lib; {
+    description = "Python agent for the Elastic APM";
+    homepage = "https://github.com/elastic/apm-agent-python";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2430,6 +2430,8 @@ in {
 
   ecpy = callPackage ../development/python-modules/ecpy { };
 
+  ecs-logging =  callPackage ../development/python-modules/ecs-logging { };
+
   ed25519 = callPackage ../development/python-modules/ed25519 { };
 
   editables = callPackage ../development/python-modules/editables { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2456,6 +2456,8 @@ in {
 
   elkm1-lib = callPackage ../development/python-modules/elkm1-lib { };
 
+  elastic-apm = callPackage ../development/python-modules/elastic-apm { };
+
   elasticsearch = callPackage ../development/python-modules/elasticsearch { };
 
   elasticsearch-dsl = callPackage ../development/python-modules/elasticsearch-dsl { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python agent for the Elastic APM

https://github.com/elastic/apm-agent-python

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
