### PR TITLE
signald: incorporate log4j update for CVE-2021-44228

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signald/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signald/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchurl, fetchFromGitLab, jdk17_headless, coreutils, gradle_6, git, perl
-, makeWrapper }:
+, makeWrapper, fetchpatch
+}:
 
 let
   pname = "signald";
@@ -12,6 +13,11 @@ let
     sha256 = "ftK+oeqzJ+TxrlvqivFkAi5RCcyJ5Y0oQAJuo0YheBg=";
   };
 
+  log4j-update-cve-2021-44228 = fetchpatch {
+    url = "https://gitlab.com/signald/signald/-/commit/7f668062ab9ffa09a49d171e995f57cf0a0803a7.patch";
+    sha256 = "sha256-504je6hKciUGelVCGZjxGjHi1qZQaovagXD5PBQP+mM=";
+  };
+
   buildConfigJar = fetchurl {
     url = "https://dl.bintray.com/mfuerstenau/maven/gradle/plugin/de/fuerstenau/BuildConfigPlugin/1.1.8/BuildConfigPlugin-1.1.8.jar";
     sha256 = "0y1f42y7ilm3ykgnm6s3ks54d71n8lsy5649xgd9ahv28lj05x9f";
@@ -21,6 +27,7 @@ let
   deps = stdenv.mkDerivation {
     pname = "${pname}-deps";
     inherit src version;
+    patches = [ log4j-update-cve-2021-44228 ];
     nativeBuildInputs = [ gradle_6 perl ];
     buildPhase = ''
       export GRADLE_USER_HOME=$(mktemp -d)
@@ -38,15 +45,18 @@ let
     outputHashMode = "recursive";
     # Downloaded jars differ by platform
     outputHash = {
-      x86_64-linux = "gEaOOsELhfKC1cFV8tqRHbBUI6+M/cDOaqN8FQ1J/TE=";
-      aarch64-linux = "UhnQ+Ge48/NdTqUWIxd0VNadHFvQ9awBTtn65Nz3+UM=";
+      x86_64-linux = "sha256-e2Tehtznc+VsvQzD3lQ50Lg7ipQc7P3ekOnb8XLORO8=";
+      aarch64-linux = "sha256-P48s3vG5vUNxCCga5FhzpODhlvvc+F2ZZGX/G0FVGWc=";
     }.${stdenv.system} or (throw "Unsupported platform");
   };
 
 in stdenv.mkDerivation rec {
   inherit pname src version;
 
-  patches = [ ./gradle-plugin.patch ];
+  patches = [
+    ./gradle-plugin.patch
+    log4j-update-cve-2021-44228
+  ];
 
   postPatch = ''
     sed -i 's|BuildConfig.jar|${buildConfigJar}|' build.gradle


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Currently, the log4j update needed to mitigate CVE-2021-44228[1] is not
yet part of a release, so we apply the commit[2] as patch for now.

Relevant for #150288

[1] https://nvd.nist.gov/vuln/detail/CVE-2021-44228
[2] https://gitlab.com/signald/signald/-/commit/7f668062ab9ffa09a49d171e995f57cf0a0803a7

__Note:__ we'll need to backport this to 21.05 and 21.11. Since we don't have 0.15.0 there, this can't be applied as -is, I'll take care of it as soon as this is merged.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
