### PR TITLE
nheko: add identicons support

### DIFF
--- a/pkgs/by-name/nh/nheko/package.nix
+++ b/pkgs/by-name/nh/nheko/package.nix
@@ -62,6 +62,7 @@ stdenv.mkDerivation rec {
       qt6Packages.qtmultimedia
       qt6Packages.qttools
       qt6Packages.qtwayland
+      qt6Packages.qt-jdenticon
       re2
       spdlog
     ]

--- a/pkgs/development/libraries/qt-jdenticon/default.nix
+++ b/pkgs/development/libraries/qt-jdenticon/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  qmake,
+  qtbase,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qt-jdenticon";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "Nheko-Reborn";
+    repo = "qt-jdenticon";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-Q5M7+XkY+/IS45rcFLYPfbcvQm8LDk4S9gzKigCIM7s=";
+  };
+
+  nativeBuildInputs = [ qmake ];
+  buildInputs = [ qtbase ];
+
+  dontWrapQtApps = true;
+
+  postPatch = ''
+    # Fix plugins dir
+    substituteInPlace QtIdenticon.pro \
+      --replace "\$\$[QT_INSTALL_PLUGINS]" "$out/$qtPluginPrefix"
+  '';
+
+  meta = {
+    description = "Qt plugin for generating highly recognizable identicons";
+    homepage = "https://github.com/Nheko-Reborn/qt-jdenticon";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ unclechu ];
+  };
+})

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -86,6 +86,8 @@ makeScopeWithSplicing' {
 
   qtutilities = callPackage ../development/libraries/qtutilities { };
 
+  qt-jdenticon = callPackage ../development/libraries/qt-jdenticon { };
+
   quazip = callPackage ../development/libraries/quazip { };
 
   qscintilla = callPackage ../development/libraries/qscintilla { };


### PR DESCRIPTION
###### Motivation for this change

Nheko has support for identicons. There is a checkbox in the settings of nheko but it wasn’t clickable because the dependency (“qt-jdenticon” plugin) was missing.

This change adds “qt-jdenticon” as a new package (Qt plugin) and as a dependency for Nheko. This package is maintained by Nheko team.

![2021-12-13 00-59-48](https://user-images.githubusercontent.com/799353/145733431-1af540a5-cb69-476d-a1ee-b1187983abc1.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
