### PR TITLE
nordzy-icon-theme: init at unstable-2021-12-14

### DIFF
--- a/pkgs/data/icons/nordzy-icon-theme/default.nix
+++ b/pkgs/data/icons/nordzy-icon-theme/default.nix
@@ -1,0 +1,52 @@
+{ stdenv
+, fetchFromGitHub
+, lib
+, bash
+, gtk3
+, nordzy-themes ? [ "all" ] # Override this to only install selected themes
+}:
+
+let
+  themes-arg-string = lib.strings.concatMapStrings (theme: "-t ${theme} ") nordzy-themes;
+in
+stdenv.mkDerivation rec {
+  pname = "nordzy-icon-theme";
+  version = "unstable-2021-12-14";
+
+  src = fetchFromGitHub {
+    owner = "alvatip";
+    repo = "Nordzy-icon";
+    rev = "5c247a4f19cf9849615631d1bf77727b945b634e";
+    sha256 = "Jqn5CF80xlYJ7H4qI1VEj91vcKPPoMXP5+sPs0ksiC4=";
+  };
+
+  nativeBuildInputs = [ gtk3 ];
+
+  postPatch = ''
+    substituteInPlace install.sh \
+      --replace /bin/bash ${bash}/bin/bash
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/icons
+    ./install.sh --dest $out/share/icons \
+      -n Nordzy \
+      -t ${themes-arg-string}
+
+    runHook postInstall
+  '';
+
+  dontFixup = true;
+
+  meta = with lib; {
+    description = "A free and open source icon theme using the Nord color palette and based on WhiteSur and Numix Icon Theme";
+    homepage = "https://github.com/alvatip/Nordzy-icon";
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [
+      alexnortung
+    ];
+  };
+}

--- a/pkgs/data/icons/nordzy-icon-theme/default.nix
+++ b/pkgs/data/icons/nordzy-icon-theme/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     description = "A free and open source icon theme using the Nord color palette and based on WhiteSur and Numix Icon Theme";
     homepage = "https://github.com/alvatip/Nordzy-icon";
     license = licenses.gpl3;
-    platforms = platforms.all;
+    platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [
       alexnortung
     ];

--- a/pkgs/data/icons/nordzy-icon-theme/default.nix
+++ b/pkgs/data/icons/nordzy-icon-theme/default.nix
@@ -2,22 +2,19 @@
 , fetchFromGitHub
 , lib
 , gtk3
-, nordzy-theme-name ? "Nordzy"
+, jdupes
 , nordzy-themes ? [ "all" ] # Override this to only install selected themes
 }:
 
-let
-  themes-arg-string = lib.strings.concatMapStrings (theme: "-t ${theme} ") nordzy-themes;
-in
 stdenvNoCC.mkDerivation {
   pname = "nordzy-icon-theme";
-  version = "unstable-2021-12-14";
+  version = "unstable-2022-01-23";
 
   src = fetchFromGitHub {
     owner = "alvatip";
     repo = "Nordzy-icon";
-    rev = "5c247a4f19cf9849615631d1bf77727b945b634e";
-    sha256 = "Jqn5CF80xlYJ7H4qI1VEj91vcKPPoMXP5+sPs0ksiC4=";
+    rev = "10b9ee80ef5c4cac1d1770d89a6d55046521ea36";
+    sha256 = "1b8abhs5gzr2qy407jq818pr67vjky8zn3pa3c8n552ayybblibk";
   };
 
   # In the post patch phase we should first make sure to patch shebangs.
@@ -27,6 +24,7 @@ stdenvNoCC.mkDerivation {
 
   nativeBuildInputs = [
     gtk3
+    jdupes
   ];
 
   dontDropIconThemeCache = true;
@@ -34,10 +32,12 @@ stdenvNoCC.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/share/icons
-    ./install.sh --dest $out/share/icons \
-      -n ${nordzy-theme-name} \
-      ${themes-arg-string}
+    name= ./install.sh --dest $out/share/icons \
+      ${lib.optionalString (nordzy-themes != []) (lib.strings.concatMapStrings (theme: "-t ${theme} ") nordzy-themes)}
+
+    # Replace duplicate files with hardlinks to the first file in each
+    # set of duplicates, reducing the installed size in about 87%
+    jdupes -L -r $out/share
 
     runHook postInstall
   '';
@@ -45,12 +45,10 @@ stdenvNoCC.mkDerivation {
   dontFixup = true;
 
   meta = with lib; {
-    description = "A free and open source icon theme using the Nord color palette and based on WhiteSur and Numix Icon Theme";
+    description = "Icon theme using the Nord color palette, based on WhiteSur and Numix icon themes";
     homepage = "https://github.com/alvatip/Nordzy-icon";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     platforms = platforms.linux;
-    maintainers = with maintainers; [
-      alexnortung
-    ];
+    maintainers = with maintainers; [ alexnortung ];
   };
 }

--- a/pkgs/data/icons/nordzy-icon-theme/default.nix
+++ b/pkgs/data/icons/nordzy-icon-theme/default.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ stdenvNoCC
 , fetchFromGitHub
 , lib
 , bash
@@ -10,7 +10,7 @@
 let
   themes-arg-string = lib.strings.concatMapStrings (theme: "-t ${theme} ") nordzy-themes;
 in
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation {
   pname = "nordzy-icon-theme";
   version = "unstable-2021-12-14";
 
@@ -21,10 +21,12 @@ stdenv.mkDerivation rec {
     sha256 = "Jqn5CF80xlYJ7H4qI1VEj91vcKPPoMXP5+sPs0ksiC4=";
   };
 
-  nativeBuildInputs = [ gtk3 ];
-
+  # In the post patch phase we should fir st make sure to patch shebangs.
+  # We can also remove the gtk-update-icon-cache since the cache will later be built by the system.
   postPatch = ''
     patchShebangs install.sh
+    substituteInPlace install.sh \
+      --replace "gtk-update-icon-cache" "#"
   '';
 
   installPhase = ''
@@ -33,7 +35,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/icons
     ./install.sh --dest $out/share/icons \
       -n ${nordzy-theme-name} \
-      -t ${themes-arg-string}
+      ${themes-arg-string}
 
     runHook postInstall
   '';

--- a/pkgs/data/icons/nordzy-icon-theme/default.nix
+++ b/pkgs/data/icons/nordzy-icon-theme/default.nix
@@ -3,6 +3,7 @@
 , lib
 , bash
 , gtk3
+, nordzy-theme-name ? "Nordzy"
 , nordzy-themes ? [ "all" ] # Override this to only install selected themes
 }:
 
@@ -23,8 +24,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ gtk3 ];
 
   postPatch = ''
-    substituteInPlace install.sh \
-      --replace /bin/bash ${bash}/bin/bash
+    patchShebangs install.sh
   '';
 
   installPhase = ''
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/share/icons
     ./install.sh --dest $out/share/icons \
-      -n Nordzy \
+      -n ${nordzy-theme-name} \
       -t ${themes-arg-string}
 
     runHook postInstall
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     description = "A free and open source icon theme using the Nord color palette and based on WhiteSur and Numix Icon Theme";
     homepage = "https://github.com/alvatip/Nordzy-icon";
     license = licenses.gpl3;
-    platforms = [ "x86_64-linux" ];
+    platforms = platforms.all;
     maintainers = with maintainers; [
       alexnortung
     ];

--- a/pkgs/data/icons/nordzy-icon-theme/default.nix
+++ b/pkgs/data/icons/nordzy-icon-theme/default.nix
@@ -1,7 +1,6 @@
 { stdenvNoCC
 , fetchFromGitHub
 , lib
-, bash
 , gtk3
 , nordzy-theme-name ? "Nordzy"
 , nordzy-themes ? [ "all" ] # Override this to only install selected themes
@@ -21,13 +20,16 @@ stdenvNoCC.mkDerivation {
     sha256 = "Jqn5CF80xlYJ7H4qI1VEj91vcKPPoMXP5+sPs0ksiC4=";
   };
 
-  # In the post patch phase we should fir st make sure to patch shebangs.
-  # We can also remove the gtk-update-icon-cache since the cache will later be built by the system.
+  # In the post patch phase we should first make sure to patch shebangs.
   postPatch = ''
     patchShebangs install.sh
-    substituteInPlace install.sh \
-      --replace "gtk-update-icon-cache" "#"
   '';
+
+  nativeBuildInputs = [
+    gtk3
+  ];
+
+  dontDropIconThemeCache = true;
 
   installPhase = ''
     runHook preInstall
@@ -46,7 +48,7 @@ stdenvNoCC.mkDerivation {
     description = "A free and open source icon theme using the Nord color palette and based on WhiteSur and Numix Icon Theme";
     homepage = "https://github.com/alvatip/Nordzy-icon";
     license = licenses.gpl3;
-    platforms = platforms.all;
+    platforms = platforms.linux;
     maintainers = with maintainers; [
       alexnortung
     ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23546,6 +23546,8 @@ with pkgs;
 
   nordzy-cursor-theme = callPackage ../data/icons/nordzy-cursor-theme { };
 
+  nordzy-icon-theme = callPackage ../data/icons/nordzy-icon-theme { };
+
   inherit (callPackages ../data/fonts/noto-fonts {})
     noto-fonts noto-fonts-cjk noto-fonts-emoji noto-fonts-emoji-blob-bin noto-fonts-extra;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adding icon theme for Nordzy

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
