### PR TITLE
ledfx: init at 0.10.7

### DIFF
--- a/pkgs/servers/home-automation/ledfx/default.nix
+++ b/pkgs/servers/home-automation/ledfx/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+let
+  pname = "ledfx";
+  version = "0.10.7";
+in
+python3.pkgs.buildPythonApplication {
+  inherit pname version;
+  format = "setuptools";
+
+  src = python3.pkgs.fetchPypi {
+    inherit pname version;
+    hash = "sha256:1vm4h62m0ha6i256ggzapv87mzps3x7ji4qwz6gjn60byigg8x6k";
+  };
+
+  patches = [
+    ./drop-pyupdater.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "aiohttp~=3.7.4.post0" "aiohttp" \
+      --replace "sacn==1.5.0" "sacn" \
+      --replace "sentry-sdk~=1.1.0" "sentry-sdk" \
+      --replace "zeroconf<=0.28.8||>=0.30.0" "zeroconf" \
+      --replace '"pyupdater>=4.0.0",' ""
+  '';
+
+  propagatedBuildInputs = with python3.pkgs; [
+    aiohttp
+    aiohttp-jinja2
+    aubio
+    cython
+    multidict
+    numpy
+    pyaudio
+    pyserial
+    pyyaml
+    requests
+    sacn
+    sentry-sdk
+    voluptuous
+    zeroconf
+  ];
+
+  # no tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "LedFx instantaneously transforms audio input into a realtime light show";
+    longDescription = ''
+      LedFx is a real-time music visualization program that streams audio reactive effects to networked LED strips. LedFx can control multiple devices and works great with cheap ESP8266/ESP32 nodes, allowing for cost effective synchronized effects across your entire house!
+    '';
+    homepage = "https://ledfx.app";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/servers/home-automation/ledfx/drop-pyupdater.patch
+++ b/pkgs/servers/home-automation/ledfx/drop-pyupdater.patch
@@ -1,0 +1,42 @@
+diff --git a/ledfx/__main__.py b/ledfx/__main__.py
+index 85361d67..4d9d10b9 100644
+--- a/ledfx/__main__.py
++++ b/ledfx/__main__.py
+@@ -23,7 +23,7 @@ import sys
+ import warnings
+ from logging.handlers import RotatingFileHandler
+ 
+-from pyupdater.client import Client
++#from pyupdater.client import Client
+ 
+ import ledfx.config as config_helpers
+ from ledfx.consts import (
+@@ -199,6 +199,8 @@ def installed_via_pip():
+     Returns:
+         boolean
+     """
++    return True
++
+     pip_package_command = subprocess.check_output(
+         [sys.executable, "-m", "pip", "freeze"]
+     )
+@@ -212,6 +214,7 @@ def installed_via_pip():
+ 
+ 
+ def update_ledfx():
++    return
+ 
+     # initialize & refresh in one update, check client
+ 
+diff --git a/setup.py b/setup.py
+index dabea5e0..3546f3c0 100644
+--- a/setup.py
++++ b/setup.py
+@@ -37,7 +37,6 @@ INSTALL_REQUIRES = [
+     "zeroconf<=0.28.8||>=0.30.0",
+     'pywin32>=300; platform_system == "Windows"',
+     "cython>=0.29.21",
+-    "pyupdater>=4.0.0",
+     "sentry-sdk~=1.1.0",
+     "certifi>=2020.12.5",
+     "pyserial>=3.5",

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20952,6 +20952,8 @@ with pkgs;
 
   leafnode = callPackage ../servers/news/leafnode { };
 
+  ledfx = callPackage ../servers/home-automation/ledfx { };
+
   lemmy-server = callPackage ../servers/web-apps/lemmy/server.nix {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Wanted to try this out. Works in combination with e.g. WLED, but eats a whole core on my i7-8550U while trying to drive ~2.1k LEDs with 30fps over WLAN to an ESP32. Not a pleasant experience, but totally not their fault.

The packaging patches out pyupdater, since that won't work on NixOS anyhow.

The packaging relies on the fact that the upstream ships their generated frontend files with their PyPi package, so it can leave out annoying NodeJS packaging efforts.

Dropping this as is for now, so others can find it and try it out. No intention to maintain at this point.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
