### PR TITLE
home-assistant: 2021.12.0 -> 2021.12.1

### DIFF
--- a/pkgs/development/python-modules/aiohue/default.nix
+++ b/pkgs/development/python-modules/aiohue/default.nix
@@ -6,11 +6,11 @@
 
 buildPythonPackage rec {
   pname = "aiohue";
-  version = "3.0.2";
+  version = "3.0.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "8aaee7fef3fff4c9271728c645896226f3df1e00bfab8dcea2456edfb3395fd0";
+    sha256 = "sha256-ajDwA8zFBQdFeI3oUBBWQZA13PNust21BWxrsB7PcTQ=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/aiopvapi/default.nix
+++ b/pkgs/development/python-modules/aiopvapi/default.nix
@@ -2,22 +2,35 @@
 , aiohttp
 , async-timeout
 , buildPythonPackage
+, fetchFromGitHub
 , fetchPypi
+, fetchpatch
 , pytestCheckHook
 , pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "aiopvapi";
-  version = "1.6.14";
+  version = "unstable-2021-09-27";
   format = "setuptools";
 
   disabled = pythonOlder "3.5";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "02bl7q166j6rb8av9n1jz11xlwhrzmbkjq70mwr86qaj63pcxrak";
+  src = fetchFromGitHub {
+    owner = "sander76";
+    repo = "aio-powerview-api";
+    rev = "7b362e28a8ec8c9a53905879d8b519e03fd88e13";
+    sha256 = "sha256-7bZLCv9PEJr61vimw39m89w/rha3tQWM8TWMtfd8kjQ=";
   };
+
+  patches = [
+    (fetchpatch {
+      # Drop loop= kwarg from async_timeout and ClientSession calls
+      # https://github.com/sander76/aio-powerview-api/pull/13
+      url = "https://github.com/sander76/aio-powerview-api/commit/7be67268050fbbf7652ce5a020d2ff26f34d0b27.patch";
+      sha256 = "sha256-7QPwrMP1Sbrayg63YZJcRkVDAqcm6hqh0fuJdrUk5WY=";
+    })
+  ];
 
   propagatedBuildInputs = [
     aiohttp

--- a/pkgs/development/python-modules/aiopvapi/default.nix
+++ b/pkgs/development/python-modules/aiopvapi/default.nix
@@ -3,15 +3,13 @@
 , async-timeout
 , buildPythonPackage
 , fetchFromGitHub
-, fetchPypi
-, fetchpatch
 , pytestCheckHook
 , pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "aiopvapi";
-  version = "unstable-2021-09-27";
+  version = "1.6.19";
   format = "setuptools";
 
   disabled = pythonOlder "3.5";
@@ -19,18 +17,10 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "sander76";
     repo = "aio-powerview-api";
-    rev = "7b362e28a8ec8c9a53905879d8b519e03fd88e13";
-    sha256 = "sha256-7bZLCv9PEJr61vimw39m89w/rha3tQWM8TWMtfd8kjQ=";
+    # no tags on git, no sdist on pypi: https://github.com/sander76/aio-powerview-api/issues/12
+    rev = "89711e2a0cb4640eb458767d289dcfa3acafb10f";
+    sha256 = "18gbz9rcf183syvxvvhhl62af3b7463rlqxxs49w4m805hkvirdp";
   };
-
-  patches = [
-    (fetchpatch {
-      # Drop loop= kwarg from async_timeout and ClientSession calls
-      # https://github.com/sander76/aio-powerview-api/pull/13
-      url = "https://github.com/sander76/aio-powerview-api/commit/7be67268050fbbf7652ce5a020d2ff26f34d0b27.patch";
-      sha256 = "sha256-7QPwrMP1Sbrayg63YZJcRkVDAqcm6hqh0fuJdrUk5WY=";
-    })
-  ];
 
   propagatedBuildInputs = [
     aiohttp

--- a/pkgs/development/python-modules/google-nest-sdm/default.nix
+++ b/pkgs/development/python-modules/google-nest-sdm/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "google-nest-sdm";
-  version = "0.4.5";
+  version = "0.4.6";
   format = "setuptools";
 
   disabled = pythonOlder "3.8";
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "allenporter";
     repo = "python-google-nest-sdm";
     rev = version;
-    sha256 = "sha256-R1/PkWyMHrZmLp+6VqAkLVzycdT1uK5SySUqpOolJCY=";
+    sha256 = "sha256-oMYCBmqDTPcGHwP3LFYX3CdbHw2hg41EQQv8iiv+ljE=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2021.12.0";
+  version = "2021.12.1";
   components = {
     "abode" = ps: with ps; [ abodepy ];
     "accuweather" = ps: with ps; [ accuweather ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -252,7 +252,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "2021.12.0";
+  hassVersion = "2021.12.1";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -269,7 +269,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    hash = "sha256:00hi709pb06c4ki0zb42my6g9cifrp2pn04ygrn5i7q7sr6min71";
+    hash = "sha256:11qlalfzykbq5ydn2cagkqcbvdjkmjcdpp6lgiys9lyrw1rxycnb";
   };
 
   # leave this in, so users don't have to constantly update their downstream patch handling

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,11 +4,11 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20211211.0";
+  version = "20211212.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-+rUrNCWf7CBzTPGuK7m88c1ouApelGla/L3SBwxYqdQ=";
+    sha256 = "sha256-cYh8xBUS8rb2koNAq8JwWtrOHSF1jC5v0lq+W1SwiXI=";
   };
 
   # there is nothing to strip in this package


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/home-assistant/core/releases/tag/2021.12.1

Hit a test failure, that I hope is spurious.
> FAILED tests/components/template/test_sensor.py::test_invalid_attribute_template[pyloop-config0-1-sensor]

Also picked an aiopvapi bump from python-unstable/staging-next, to build upon it. Should make the merge cleaner.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
