### PR TITLE
nixos/podman: refactor tests

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -369,9 +369,7 @@ in
   plikd = handleTest ./plikd.nix {};
   plotinus = handleTest ./plotinus.nix {};
   podgrab = handleTest ./podgrab.nix {};
-  podman = handleTestOn ["x86_64-linux"] ./podman/default.nix {};
-  podman-dnsname = handleTestOn ["x86_64-linux"] ./podman/dnsname.nix {};
-  podman-tls-ghostunnel = handleTestOn ["x86_64-linux"] ./podman/tls-ghostunnel.nix {};
+  podman = handleTestOn ["x86_64-linux"] ./podman/base.nix {};
   pomerium = handleTestOn ["x86_64-linux"] ./pomerium.nix {};
   postfix = handleTest ./postfix.nix {};
   postfix-raise-smtpd-tls-security-level = handleTest ./postfix-raise-smtpd-tls-security-level.nix {};

--- a/nixos/tests/podman/base.nix
+++ b/nixos/tests/podman/base.nix
@@ -1,0 +1,7 @@
+{ system ? builtins.currentSystem, pkgs ? import ../../.. { inherit system; } }:
+
+pkgs.lib.recurseIntoAttrs {
+  default = import ./default.nix { inherit system pkgs; };
+  dnsname = import ./dnsname.nix { inherit system pkgs; };
+  tls-ghostunnel = import ./tls-ghostunnel.nix { inherit system pkgs; };
+}

--- a/pkgs/applications/networking/cluster/dnsname-cni/default.nix
+++ b/pkgs/applications/networking/cluster/dnsname-cni/default.nix
@@ -29,7 +29,7 @@ buildGoModule rec {
   doCheck = false; # NOTE: requires root privileges
 
   passthru.tests = {
-    inherit (nixosTests) podman-dnsname;
+    inherit (nixosTests.podman) dnsname;
   };
 
   meta = with lib; {

--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -77,11 +77,6 @@ buildGoModule rec {
 
   passthru.tests = {
     inherit (nixosTests) podman;
-    # related modules
-    inherit (nixosTests)
-      podman-tls-ghostunnel
-      podman-dnsname
-      ;
   };
 
   meta = with lib; {

--- a/pkgs/tools/networking/ghostunnel/default.nix
+++ b/pkgs/tools/networking/ghostunnel/default.nix
@@ -28,7 +28,7 @@ buildGoModule rec {
 
   passthru.tests = {
     nixos = nixosTests.ghostunnel;
-    podman = nixosTests.podman-tls-ghostunnel;
+    podman = nixosTests.podman.tls-ghostunnel;
   };
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This moves all of the `podman` tests under `nixosTests.podman` so they are all checked by default while still allowing them to be run separately.

If we ever want to make just the main `podman` test a channel blocker we could do this:
```diff
diff --git a/nixos/release-combined.nix b/nixos/release-combined.nix
index ee3f3d19174..4782a24e9f2 100644
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -64,6 +64,7 @@ in rec {
         (onFullSupported "nixos.tests.containers-imperative")
         (onFullSupported "nixos.tests.containers-ip")
         (onSystems ["x86_64-linux"] "nixos.tests.docker")
+        (onSystems ["x86_64-linux"] "nixos.tests.podman.default")
         (onFullSupported "nixos.tests.ecryptfs")
         (onFullSupported "nixos.tests.env")
         (onFullSupported "nixos.tests.firefox-esr")
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


cc @NixOS/podman @roberth 