### PR TITLE
[staging-next] python2Packages.pyjwt: init at 1.7.1

### DIFF
--- a/pkgs/development/python-modules/pyjwt/1.nix
+++ b/pkgs/development/python-modules/pyjwt/1.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, cryptography
+, ecdsa
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pyjwt";
+  version = "1.7.1";
+
+  src = fetchPypi {
+    pname = "PyJWT";
+    inherit version;
+    sha256 = "8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cbaa20e96";
+  };
+
+  postPatch = ''
+    sed -i '/^addopts/d' setup.cfg
+  '';
+
+  propagatedBuildInputs = [
+    cryptography
+    ecdsa
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    "test_ec_verify_should_return_false_if_signature_invalid"
+  ];
+
+  pythonImportsCheck = [ "jwt" ];
+
+  meta = with lib; {
+    description = "JSON Web Token implementation in Python";
+    homepage = "https://github.com/jpadilla/pyjwt";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -457,6 +457,8 @@ with self; with super; {
 
   pyhamcrest = callPackage ../development/python-modules/pyhamcrest/1.nix { };
 
+  pyjwt = callPackage ../development/python-modules/pyjwt/1.nix { };
+
   pykickstart = callPackage ../development/python-modules/pykickstart { };
 
   pylibacl = callPackage ../development/python-modules/pylibacl/0.5.nix { };


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
needed for NixOps


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
