### PR TITLE
fbgrab: init at 1.5

### DIFF
--- a/pkgs/tools/graphics/fbgrab/default.nix
+++ b/pkgs/tools/graphics/fbgrab/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, fetchFromGitHub, libpng, zlib } :
+
+stdenv.mkDerivation rec {
+  pname = "fbgrab";
+  version = "1.5";
+
+  src = fetchFromGitHub {
+    owner = "GunnarMonell";
+    repo = pname;
+    rev = version;
+    sha256 = "1npn7l8jg0nhjraybjl38v8635zawzmn06ql3hs3vhci1vi1r90r";
+  };
+
+  buildInputs = [
+    libpng
+    zlib
+  ];
+
+  preConfigure = ''
+    substituteInPlace Makefile \
+      --replace "/usr/bin/" "/bin/" \
+      --replace "/usr/share/" "/share/"
+  '';
+
+  makeFlags = [ "DESTDIR=$(out)" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/GunnarMonell/fbgrab";
+    description = "Linux framebuffer screenshot utility";
+    license = licenses.gpl2Only;
+    maintainers = [ maintainers.davidak ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -969,6 +969,8 @@ with pkgs;
 
   cope = callPackage ../tools/misc/cope { };
 
+  fbgrab  = callPackage ../tools/graphics/fbgrab { };
+
   gamemode = callPackage ../tools/games/gamemode {
     libgamemode32 = pkgsi686Linux.gamemode.lib;
   };


### PR DESCRIPTION
###### Motivation for this change

https://twitter.com/JJJollyjim/status/1469605662032154627

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
