### PR TITLE
openafs: 1.8.8 → 1.8.8.1

### DIFF
--- a/pkgs/servers/openafs/1.8/default.nix
+++ b/pkgs/servers/openafs/1.8/default.nix
@@ -1,7 +1,23 @@
-{ lib, stdenv, buildPackages, fetchurl, which, autoconf, automake, flex
-, bison , glibc, perl, libkrb5, libxslt, docbook_xsl, file
-, docbook_xml_dtd_43, libtool_2
-, withDevdoc ? false, doxygen, dblatex # Extra developer documentation
+{ lib
+, stdenv
+, buildPackages
+, fetchurl
+, which
+, autoconf
+, automake
+, flex
+, bison
+, glibc
+, perl
+, libkrb5
+, libxslt
+, docbook_xsl
+, file
+, docbook_xml_dtd_43
+, libtool_2
+, withDevdoc ? false
+, doxygen
+, dblatex # Extra developer documentation
 , ncurses # Extra ncurses utilities. Needed for debugging and monitoring.
 , tsmbac ? null # Tivoli Storage Manager Backup Client from IBM
 }:
@@ -10,13 +26,22 @@ with (import ./srcs.nix { inherit fetchurl; });
 let
   inherit (lib) optional optionalString optionals;
 
-in stdenv.mkDerivation {
+in
+stdenv.mkDerivation {
   pname = "openafs";
   inherit version srcs;
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
-  nativeBuildInputs = [ autoconf automake flex libxslt libtool_2 perl
-    which bison ] ++ optionals withDevdoc [ doxygen dblatex ];
+  nativeBuildInputs = [
+    autoconf
+    automake
+    flex
+    libxslt
+    libtool_2
+    perl
+    which
+    bison
+  ] ++ optionals withDevdoc [ doxygen dblatex ];
 
   buildInputs = [ libkrb5 ncurses ];
 

--- a/pkgs/servers/openafs/1.8/module.nix
+++ b/pkgs/servers/openafs/1.8/module.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, which, autoconf, automake, flex, bison
-, kernel, glibc, perl, libtool_2, libkrb5, fetchpatch }:
+, kernel, glibc, perl, libtool_2, libkrb5 }:
 
 with (import ./srcs.nix {
   inherit fetchurl;
@@ -17,23 +17,6 @@ in stdenv.mkDerivation {
     ++ kernel.moduleBuildDependencies;
 
   buildInputs = [ libkrb5 ];
-
-  patches = [
-    # LINUX 5.14: explicitly set set_page_dirty to default
-    ((fetchpatch {
-      url = "https://gerrit.openafs.org/changes/14830/revisions/20b8a37950b3718b85a4a3d21b23469a5176eb6a/patch";
-      sha256 = "1mkfwq0pbwvfjspsy2lxhi0f09hljgc6xyn3y97sai0dyivn05jp";
-    }).overrideAttrs (o: {
-      postFetch = "mv $out p; base64 -d p > $out; " + o.postFetch;
-    }))
-    # Linux 5.15: Convert osi_Msg macro to a function
-    ((fetchpatch {
-      url = "https://gerrit.openafs.org/changes/14831/revisions/6cfa9046229d90c0625687e3fddb7877f21fbcff/patch";
-      sha256 = "18rip9a1krxf47fizf3f12ddq55apzb2w3wjj5qs7n3sh2nwks7g";
-    }).overrideAttrs (o: {
-      postFetch = "mv $out p; base64 -d p > $out; " + o.postFetch;
-    }))
-  ];
 
   hardeningDisable = [ "pic" ];
 

--- a/pkgs/servers/openafs/1.8/module.nix
+++ b/pkgs/servers/openafs/1.8/module.nix
@@ -1,5 +1,17 @@
-{ lib, stdenv, fetchurl, which, autoconf, automake, flex, bison
-, kernel, glibc, perl, libtool_2, libkrb5 }:
+{ lib
+, stdenv
+, fetchurl
+, which
+, autoconf
+, automake
+, flex
+, bison
+, kernel
+, glibc
+, perl
+, libtool_2
+, libkrb5
+}:
 
 with (import ./srcs.nix {
   inherit fetchurl;
@@ -9,7 +21,8 @@ let
   modDestDir = "$out/lib/modules/${kernel.modDirVersion}/extra/openafs";
   kernelBuildDir = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
 
-in stdenv.mkDerivation {
+in
+stdenv.mkDerivation {
   name = "openafs-${version}-${kernel.modDirVersion}";
   inherit version src;
 

--- a/pkgs/servers/openafs/1.8/srcs.nix
+++ b/pkgs/servers/openafs/1.8/srcs.nix
@@ -6,9 +6,11 @@ rec {
     sha256 = "sha256-58S+1wdbzWQC4/DC1bnb52rS7jxf1d3DlzozVsoj70Q=";
   };
 
-  srcs = [ src
+  srcs = [
+    src
     (fetchurl {
       url = "https://www.openafs.org/dl/openafs/${version}/openafs-${version}-doc.tar.bz2";
       sha256 = "sha256-y17O3C4WS+o7SMayydbxw2v96R0GikxiqciF30j+jms=";
-    })];
+    })
+  ];
 }

--- a/pkgs/servers/openafs/1.8/srcs.nix
+++ b/pkgs/servers/openafs/1.8/srcs.nix
@@ -1,14 +1,14 @@
 { fetchurl }:
 rec {
-  version = "1.8.8";
+  version = "1.8.8.1";
   src = fetchurl {
     url = "https://www.openafs.org/dl/openafs/${version}/openafs-${version}-src.tar.bz2";
-    sha256 = "sha256-2qjvhqdyf6z83jvJemrRQxKcHCXuNfM0cIDsfp0oTaA=";
+    sha256 = "sha256-58S+1wdbzWQC4/DC1bnb52rS7jxf1d3DlzozVsoj70Q=";
   };
 
   srcs = [ src
     (fetchurl {
       url = "https://www.openafs.org/dl/openafs/${version}/openafs-${version}-doc.tar.bz2";
-      sha256 = "sha256-3cxODH1KvOTxrGB+acEudxGCX1iBPjZcTfjpfraOm+U=";
+      sha256 = "sha256-y17O3C4WS+o7SMayydbxw2v96R0GikxiqciF30j+jms=";
     })];
 }


### PR DESCRIPTION
###### Motivation for this change

Upgrade OpenAFS to 1.8.8.1, which adds official support for newer Linux kernels through 5.16-rc6.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
