### PR TITLE
[21.11] signald: incorporate log4j update for CVE-2021-44228

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signald/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signald/default.nix
@@ -1,9 +1,15 @@
 { lib, stdenv, fetchurl, fetchFromGitLab, jre_headless, coreutils, gradle_6, git, perl
-, makeWrapper }:
+, makeWrapper, fetchpatch
+}:
 
 let
   pname = "signald";
   version = "0.14.1";
+
+  log4j-update-cve-2021-44228 = fetchpatch {
+    url = "https://gitlab.com/signald/signald/-/commit/7f668062ab9ffa09a49d171e995f57cf0a0803a7.patch";
+    sha256 = "sha256-504je6hKciUGelVCGZjxGjHi1qZQaovagXD5PBQP+mM=";
+  };
 
   src = fetchFromGitLab {
     owner = pname;
@@ -26,6 +32,7 @@ let
   deps = stdenv.mkDerivation {
     name = "${pname}-deps";
     inherit src version postPatch;
+    patches = [ log4j-update-cve-2021-44228 ];
     nativeBuildInputs = [ gradle_6 perl ];
     buildPhase = ''
       export GRADLE_USER_HOME=$(mktemp -d)
@@ -43,15 +50,18 @@ let
     outputHashMode = "recursive";
     # Downloaded jars differ by platform
     outputHash = {
-      x86_64-linux = "/gJFoT+vvdSWr33oI44XiZXlFfyUjtRVB1M6CMzSztM=";
-      aarch64-linux = "v71stMWBbNALasfGAHvsVTBaDOZfpKK3sQrjNJ6FG1A=";
+      x86_64-linux = "sha256-Tn0x5MJJMe04Du+eFGAkdvh/7Sgb7pf2FtBiRyCvjo8=";
+      aarch64-linux = "sha256-T/Cj/QxlW48xW6l+O3K4fFA19fulOB8nk9dRoiP1sys=";
     }.${stdenv.system} or (throw "Unsupported platform");
   };
 
 in stdenv.mkDerivation rec {
   inherit pname src version postPatch;
 
-  patches = [ ./gradle-plugin.patch ];
+  patches = [
+    ./gradle-plugin.patch
+    log4j-update-cve-2021-44228
+  ];
 
   buildPhase = ''
     runHook preBuild


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Equivalent to 79ab6a83828ecee660e362e6c97384ff0489f9b2 on `master`, but
against 0.14.1.

Relevant for #150288


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
