### PR TITLE
team-list: add bazel team

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -32,6 +32,13 @@ with lib.maintainers; {
   bazel = {
     members = [
       mboes
+      marsam
+      uri-canva
+      cbley
+      olebedev
+      groodt
+      aherrmann
+      ylecornec
     ];
     scope = "Bazel build tool & related tools https://bazel.build/";
   };

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -29,6 +29,13 @@ with lib.maintainers; {
     scope = "Maintain ACME-related packages and modules.";
   };
 
+  bazel = {
+    members = [
+      mboes
+    ];
+    scope = "Bazel build tool & related tools https://bazel.build/";
+  };
+
   beam = {
     members = [
       ankhers

--- a/pkgs/development/tools/build-managers/bazel/README.md
+++ b/pkgs/development/tools/build-managers/bazel/README.md
@@ -1,0 +1,7 @@
+# The Bazel build tool
+
+https://bazel.build/
+
+The bazel tool requires regular maintenance, especially under darwin, so we created a maintainers team.
+
+Please ping @NixOS/bazel in your github PR/issue to increase your chance of a quick turnaround, thanks!

--- a/pkgs/development/tools/build-managers/bazel/bazel-remote/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel-remote/default.nix
@@ -22,7 +22,7 @@ buildGoModule rec {
     homepage = "https://github.com/buchgr/bazel-remote";
     description = "A remote HTTP/1.1 cache for Bazel";
     license = licenses.asl20;
-    maintainers = [ maintainers.uri-canva ];
+    maintainers = lib.teams.bazel.members;
     platforms = platforms.darwin ++ platforms.linux;
   };
 }

--- a/pkgs/development/tools/build-managers/bazel/bazel_0_29/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_0_29/default.nix
@@ -149,7 +149,7 @@ stdenv'.mkDerivation rec {
     homepage = "https://github.com/bazelbuild/bazel/";
     description = "Build tool that builds code quickly and reliably";
     license = licenses.asl20;
-    maintainers = [ maintainers.mboes ];
+    maintainers = lib.teams.bazel.members;
     inherit platforms;
   };
 

--- a/pkgs/development/tools/build-managers/bazel/bazel_1/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_1/default.nix
@@ -150,7 +150,7 @@ stdenv'.mkDerivation rec {
     homepage = "https://github.com/bazelbuild/bazel/";
     description = "Build tool that builds code quickly and reliably";
     license = licenses.asl20;
-    maintainers = [ maintainers.mboes ];
+    maintainers = lib.teams.bazel.members;
     inherit platforms;
   };
 

--- a/pkgs/development/tools/build-managers/bazel/bazel_3/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_3/default.nix
@@ -164,7 +164,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/bazelbuild/bazel/";
     description = "Build tool that builds code quickly and reliably";
     license = licenses.asl20;
-    maintainers = [ maintainers.mboes ];
+    maintainers = lib.teams.bazel.members;
     inherit platforms;
   };
 

--- a/pkgs/development/tools/build-managers/bazel/bazel_4/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_4/default.nix
@@ -177,7 +177,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/bazelbuild/bazel/";
     description = "Build tool that builds code quickly and reliably";
     license = licenses.asl20;
-    maintainers = [ maintainers.mboes ];
+    maintainers = lib.teams.bazel.members;
     inherit platforms;
   };
 

--- a/pkgs/development/tools/build-managers/bazel/buildtools/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/buildtools/default.nix
@@ -27,6 +27,8 @@ buildGoModule rec {
     description = "Tools for working with Google's bazel buildtool. Includes buildifier, buildozer, and unused_deps";
     homepage = "https://github.com/bazelbuild/buildtools";
     license = licenses.asl20;
-    maintainers = with maintainers; [ elasticdog uri-canva marsam ];
+    maintainers = with maintainers;
+      [ elasticdog uri-canva marsam ]
+      ++ lib.teams.bazel.members;
   };
 }


### PR DESCRIPTION
(refactor)

We are going to set up a maintenance team for bazel & tools.

@kalbasit @avdv @ethercrow @uri-canva I invited you to the @NixOS/bazel group, if you want to join the maintenance team, this will give people the ability to ping the whole team. I am unable to add non-members of Nixos though.

This PR sets up a team within nixpkgs, so that the maintainer field in all bazel packages can mention that team (plus some extra maintainers via list concatenation). I only added @mboes to that list for now, since he is in the current maintainer lists.

I would add a bunch more people, please can you comment with `ok` if you want to be in the maintainer list, then I’d add you in this PR (you can always add or remove yourself later ofc).

- [x] @marsam 
- [ ] @kalbasit 
- [x] @uri-canva 
- [x] @mboes 
- [x] @avdv 
- [ ] @ethercrow 
- [x] @ylecornec