### PR TITLE
fbcat: small refactor, fix fbgrab dependencies

### DIFF
--- a/pkgs/tools/misc/fbcat/default.nix
+++ b/pkgs/tools/misc/fbcat/default.nix
@@ -1,4 +1,8 @@
-{ lib, stdenv, fetchFromGitHub } :
+{ lib
+, stdenv
+, fetchFromGitHub
+, netpbm
+}:
 
 stdenv.mkDerivation rec {
   pname = "fbcat";
@@ -11,16 +15,15 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-ORzcd8XGy2BfwuPK5UX+K5Z+FYkb+tdg/gHl3zHjvbk=";
   };
 
-  # hardcoded because makefile target "install" depends on libxslt dependencies from network
-  # that are just too hard to monkeypatch here
-  # so this is the simple fix.
-  installPhase = ''
-    mkdir -p $out
-    install -d $out/bin
-    install -m755 fbcat $out/bin/
-    install -m755 fbgrab $out/bin/
-    install -d $out/share/man/man1
+  postPatch = ''
+    substituteInPlace fbgrab \
+      --replace 'pnmtopng' '${netpbm}/bin/pnmtopng' \
+      --replace 'fbcat' "$out/bin/fbcat"
   '';
+
+  installFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
 
   meta = with lib; {
     homepage = "http://jwilk.net/software/fbcat";


### PR DESCRIPTION
###### Motivation for this change
Closes #150505

@davidak could you test this? Can't access anything other than my graphical session rn.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
