### PR TITLE
wireplumber: init, add NixOS module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6049,6 +6049,13 @@
     github = "k4leg";
     githubId = 39882583;
   };
+  k900 = {
+    name = "Ilya K.";
+    email = "me@0upti.me";
+    github = "K900";
+    githubId = 386765;
+    matrix = "@k900:0upti.me";
+  };
   kaction = {
     name = "Dmitry Bogatov";
     email = "KAction@disroot.org";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -364,6 +364,7 @@
   ./services/desktops/malcontent.nix
   ./services/desktops/pipewire/pipewire.nix
   ./services/desktops/pipewire/pipewire-media-session.nix
+  ./services/desktops/pipewire/wireplumber.nix
   ./services/desktops/gnome/at-spi2-core.nix
   ./services/desktops/gnome/chrome-gnome-shell.nix
   ./services/desktops/gnome/evolution-data-server.nix

--- a/nixos/modules/services/desktops/pipewire/wireplumber.nix
+++ b/nixos/modules/services/desktops/pipewire/wireplumber.nix
@@ -1,0 +1,41 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.pipewire.wireplumber;
+in
+{
+  meta.maintainers = [ lib.maintainers.k900 ];
+
+  options = {
+    services.pipewire.wireplumber = {
+      enable = lib.mkEnableOption "A modular session / policy manager for PipeWire";
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.wireplumber;
+        defaultText = lib.literalExpression "pkgs.wireplumber";
+        description = ''
+          The wireplumber derivation to use.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !config.services.pipewire.media-session.enable;
+        message = "WirePlumber and pipewire-media-session can't be enabled at the same time.";
+      }
+    ];
+
+    environment.systemPackages = [ cfg.package ];
+    systemd.packages = [ cfg.package ];
+
+    systemd.services.wireplumber.enable = config.services.pipewire.systemWide;
+    systemd.user.services.wireplumber.enable = !config.services.pipewire.systemWide;
+
+    systemd.services.wireplumber.wantedBy = [ "pipewire.service" ];
+    systemd.user.services.wireplumber.wantedBy = [ "pipewire.service" ];
+  };
+}

--- a/pkgs/development/libraries/pipewire/wireplumber.nix
+++ b/pkgs/development/libraries/pipewire/wireplumber.nix
@@ -1,0 +1,82 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, nix-update-script
+, # base build deps
+  meson
+, pkg-config
+, ninja
+, # docs build deps
+  python3
+, doxygen
+, graphviz
+, # GI build deps
+  gobject-introspection
+, # runtime deps
+  glib
+, systemd
+, lua5_4
+, pipewire
+, # options
+  enableDocs ? true
+, enableGI ? stdenv.hostPlatform == stdenv.buildPlatform
+}:
+let
+  mesonEnableFeature = b: if b then "enabled" else "disabled";
+in
+stdenv.mkDerivation rec {
+  pname = "wireplumber";
+  version = "0.4.6";
+
+  outputs = [ "out" "dev" ] ++ lib.optional enableDocs "doc";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "pipewire";
+    repo = "wireplumber";
+    rev = version;
+    sha256 = "sha256-y+Gj9EZn67W3U81zXgp+6JAFxZSZTwwT0TB3Kueb/Tw=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    pkg-config
+    ninja
+  ] ++ lib.optionals enableDocs [
+    graphviz
+  ] ++ lib.optionals enableGI [
+    gobject-introspection
+  ] ++ lib.optionals (enableDocs || enableGI) [
+    doxygen
+    (python3.withPackages (ps: with ps;
+    lib.optionals enableDocs [ sphinx sphinx_rtd_theme breathe ] ++
+      lib.optionals enableGI [ lxml ]
+    ))
+  ];
+
+  buildInputs = [
+    glib
+    systemd
+    lua5_4
+    pipewire
+  ];
+
+  mesonFlags = [
+    "-Dsystem-lua=true"
+    "-Delogind=disabled"
+    "-Ddoc=${mesonEnableFeature enableDocs}"
+    "-Dintrospection=${mesonEnableFeature enableGI}"
+  ];
+
+  passthru.updateScript = nix-update-script {
+    attrPath = pname;
+  };
+
+  meta = with lib; {
+    description = "A modular session / policy manager for PipeWire";
+    homepage = "https://pipewire.org";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ k900 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13777,6 +13777,7 @@ with pkgs;
   pipewire = callPackage ../development/libraries/pipewire {};
   pipewire-media-session = callPackage ../development/libraries/pipewire/media-session.nix {};
   pipewire_0_2 = callPackage ../development/libraries/pipewire/0.2.nix {};
+  wireplumber = callPackage ../development/libraries/pipewire/wireplumber.nix {};
 
   pyradio = callPackage ../applications/audio/pyradio {};
 


### PR DESCRIPTION
###### Motivation for this change
Upstream recommends this over pipewire-media-session: https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/41392eda7fb0e8b27a0167ef04241b18e9c14bf8/NEWS#L295

Depends on https://github.com/NixOS/nixpkgs/pull/153658

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
