### PR TITLE
[21.11] gnomeExtensions.freon: 44 -> 45, patch binary paths

### DIFF
--- a/pkgs/desktops/gnome/extensions/freon/default.nix
+++ b/pkgs/desktops/gnome/extensions/freon/default.nix
@@ -1,8 +1,20 @@
-{ lib, stdenv, fetchFromGitHub, glib }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, glib
+, substituteAll
+, hddtemp
+, liquidctl
+, lm_sensors
+, netcat-gnu
+, nvme-cli
+, procps
+, smartmontools
+}:
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-freon";
-  version = "44";
+  version = "45";
 
   passthru = {
     extensionUuid = "freon@UshakovVasilii_Github.yahoo.com";
@@ -13,10 +25,19 @@ stdenv.mkDerivation rec {
     owner = "UshakovVasilii";
     repo = "gnome-shell-extension-freon";
     rev = "EGO-${version}";
-    sha256 = "sha256-4DYAIC9N5id3vQe0WaOFP+MymsrPK18hbYqO4DjG+2U=";
+    sha256 = "sha256-tPb7SzHSwvz7VV+kZTmcw1eAdtL1J7FJ3BOtg4Us8jc=";
   };
 
   nativeBuildInputs = [ glib ];
+
+  patches = [
+    (substituteAll {
+      src = ./fix_paths.patch;
+      inherit hddtemp liquidctl lm_sensors procps smartmontools;
+      netcat = netcat-gnu;
+      nvmecli = nvme-cli;
+    })
+  ];
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/desktops/gnome/extensions/freon/fix_paths.patch
+++ b/pkgs/desktops/gnome/extensions/freon/fix_paths.patch
@@ -1,0 +1,85 @@
+diff --git a/freon@UshakovVasilii_Github.yahoo.com/hddtempUtil.js b/freon@UshakovVasilii_Github.yahoo.com/hddtempUtil.js
+index e5d1d6d..856654b 100644
+--- a/freon@UshakovVasilii_Github.yahoo.com/hddtempUtil.js
++++ b/freon@UshakovVasilii_Github.yahoo.com/hddtempUtil.js
+@@ -7,7 +7,7 @@ var HddtempUtil = class extends CommandLineUtil.CommandLineUtil {
+ 
+     constructor() {
+         super();
+-        let hddtempArgv = GLib.find_program_in_path('hddtemp');
++        let hddtempArgv = GLib.find_program_in_path('@hddtemp@/bin/hddtemp');
+         if(hddtempArgv) {
+             // check if this user can run hddtemp directly.
+             if(!GLib.spawn_command_line_sync(hddtempArgv)[3]){
+@@ -19,8 +19,8 @@ var HddtempUtil = class extends CommandLineUtil.CommandLineUtil {
+         // doesn't seem to be the case… is it running as a daemon?
+         // Check first for systemd
+         let systemctl = GLib.find_program_in_path('systemctl');
+-        let pidof = GLib.find_program_in_path('pidof');
+-        let nc = GLib.find_program_in_path('nc');
++        let pidof = GLib.find_program_in_path('@procps@/bin/pidof');
++        let nc = GLib.find_program_in_path('@netcat@/bin/nc');
+         let pid = undefined;
+ 
+         if(systemctl) {
+@@ -35,7 +35,7 @@ var HddtempUtil = class extends CommandLineUtil.CommandLineUtil {
+ 
+         // systemd isn't used on this system, try sysvinit instead
+         if(!pid && pidof) {
+-            let output = GLib.spawn_command_line_sync("pidof hddtemp")[1].toString().trim();
++            let output = GLib.spawn_command_line_sync("@procps@/bin/pidof hddtemp")[1].toString().trim();
+             if(output.length)
+                 pid = Number(output.trim());
+         }
+diff --git a/freon@UshakovVasilii_Github.yahoo.com/liquidctlUtil.js b/freon@UshakovVasilii_Github.yahoo.com/liquidctlUtil.js
+index 766bf62..7cd4e94 100644
+--- a/freon@UshakovVasilii_Github.yahoo.com/liquidctlUtil.js
++++ b/freon@UshakovVasilii_Github.yahoo.com/liquidctlUtil.js
+@@ -8,7 +8,7 @@ const commandLineUtil = Me.imports.commandLineUtil;
+ var LiquidctlUtil = class extends commandLineUtil.CommandLineUtil {
+     constructor() {
+         super();
+-        const path = GLib.find_program_in_path('liquidctl');
++        const path = GLib.find_program_in_path('@liquidctl@/bin/liquidctl');
+         this._argv = path ? [path, 'status', '--json'] : null;
+     }
+ 
+diff --git a/freon@UshakovVasilii_Github.yahoo.com/nvmecliUtil.js b/freon@UshakovVasilii_Github.yahoo.com/nvmecliUtil.js
+index ae2ea93..2349b9e 100644
+--- a/freon@UshakovVasilii_Github.yahoo.com/nvmecliUtil.js
++++ b/freon@UshakovVasilii_Github.yahoo.com/nvmecliUtil.js
+@@ -3,7 +3,7 @@ const GLib = imports.gi.GLib;
+ const Me = imports.misc.extensionUtils.getCurrentExtension();
+ 
+ function getNvmeData (argv){
+-    const nvme = GLib.find_program_in_path('nvme')
++    const nvme = GLib.find_program_in_path('@nvmecli@/bin/nvme')
+     return JSON.parse(GLib.spawn_command_line_sync(`${nvme} ${argv} -o json`)[1].toString())
+ }
+ 
+diff --git a/freon@UshakovVasilii_Github.yahoo.com/sensorsUtil.js b/freon@UshakovVasilii_Github.yahoo.com/sensorsUtil.js
+index 62fa580..c017748 100644
+--- a/freon@UshakovVasilii_Github.yahoo.com/sensorsUtil.js
++++ b/freon@UshakovVasilii_Github.yahoo.com/sensorsUtil.js
+@@ -7,7 +7,7 @@ var SensorsUtil = class extends CommandLineUtil.CommandLineUtil {
+ 
+     constructor() {
+         super();
+-        let path = GLib.find_program_in_path('sensors');
++        let path = GLib.find_program_in_path('@lm_sensors@/bin/sensors');
+         // -A: Do not show adapter -j: JSON output
+         this._argv = path ? [path, '-A', '-j'] : null;
+     }
+diff --git a/freon@UshakovVasilii_Github.yahoo.com/smartctlUtil.js b/freon@UshakovVasilii_Github.yahoo.com/smartctlUtil.js
+index 03d469b..6057a3b 100644
+--- a/freon@UshakovVasilii_Github.yahoo.com/smartctlUtil.js
++++ b/freon@UshakovVasilii_Github.yahoo.com/smartctlUtil.js
+@@ -3,7 +3,7 @@ const GLib = imports.gi.GLib;
+ const Me = imports.misc.extensionUtils.getCurrentExtension();
+ const ByteArray = imports.byteArray;
+ function getSmartData (argv){
+-    const smartctl = GLib.find_program_in_path('smartctl')
++    const smartctl = GLib.find_program_in_path('@smartmontools@/bin/smartctl')
+     return JSON.parse(ByteArray.toString( GLib.spawn_command_line_sync(`${smartctl} ${argv} -j`)[1] ))
+ }
+ 


### PR DESCRIPTION
(cherry picked from commit 702dfffa0684795284a3195fa438bc36015c3bbc)

###### Motivation for this change

Reason for backport: adds compatibility w/ GNOME 41 (default in 21.11) and lessens the reliance on globally installed packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
