### PR TITLE
python3Packages.pytest-randomly: 3.10.1 -> 3.10.3

### DIFF
--- a/pkgs/development/python-modules/pytest-randomly/default.nix
+++ b/pkgs/development/python-modules/pytest-randomly/default.nix
@@ -5,7 +5,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-randomly";
-  version = "3.10.1";
+  version = "3.10.3";
 
   disabled = pythonOlder "3.6";
 
@@ -14,7 +14,7 @@ buildPythonPackage rec {
     repo = pname;
     owner = "pytest-dev";
     rev = version;
-    sha256 = "10z7hsr8yd80sf5113i61p0g1c0nqkx7p4xi19v3d133f6vjbh3k";
+    sha256 = "0xw0xkk568za10y6r31my0qg378njklm5272sfcrvksnj4r2k1in";
   };
 
   propagatedBuildInputs = lib.optionals (pythonOlder "3.10") [
@@ -30,6 +30,8 @@ buildPythonPackage rec {
   ];
   # needs special invocation, copied from tox.ini
   pytestFlagsArray = [ "-p" "no:randomly" ];
+
+  pythonImportsCheck = [ "pytest_randomly" ];
 
   meta = with lib; {
     description = "Pytest plugin to randomly order tests and control random.seed";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


Tested direct reverse dependencies

```
/nix/store/h4rc787qm7aggzl4ilpyrswwl1680r1c-python3.9-fonttools-4.21.1
/nix/store/s3d1dxdhd4xc2pfvin2bzdxx7midbpg9-python3.9-httplib2-0.20.1
/nix/store/n5cj7qqvgab8wvfzn9k606fkq1isgbwx-python3.9-mlrose-1.3.0
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
