### PR TITLE
nixos/zfs: new option unsafeDisableVersionCheck

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -87,7 +87,7 @@
   </section>
   <section xml:id="sec-release-22.05-notable-changes">
     <title>Other Notable Changes</title>
-    <itemizedlist spacing="compact">
+    <itemizedlist>
       <listitem>
         <para>
           The option
@@ -111,6 +111,16 @@
           are only accessible by default to the members of the Unix
           group <literal>redis-${serverName}</literal> through the Unix
           socket <literal>/run/redis-${serverName}/redis.sock</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          There is a new option
+          <literal>boot.zfs.unsafeDisableVersionCheck</literal> for
+          people living on the bleeding edge, which allows compiling the
+          ZFS kernel module against kernel versions that are not
+          officially supported upstream. To prevent people from
+          accidentally using it, a big fat warning was added.
         </para>
       </listitem>
     </itemizedlist>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -51,3 +51,8 @@ In addition to numerous new and upgraded packages, this release has the followin
   are only accessible by default
   to the members of the Unix group `redis-${serverName}`
   through the Unix socket `/run/redis-${serverName}/redis.sock`.
+
+- There is a new option `boot.zfs.unsafeDisableVersionCheck` for people living
+  on the bleeding edge, which allows compiling the ZFS kernel module against
+  kernel versions that are not officially supported upstream. To prevent people
+  from accidentally using it, a big fat warning was added.

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -43,6 +43,9 @@ in
           kernelPatches = (originalArgs.kernelPatches or []) ++ kernelPatches;
           features = lib.recursiveUpdate super.kernel.features features;
         });
+      } // optionalAttrs config.boot.zfs.unsafeDisableVersionCheck {
+        zfs = super.zfs.overrideAttrs (_: { meta.broken = false; });
+        zfsUnstable = super.zfsUnstable.overrideAttrs (_: { meta.broken = false; });
       });
       # We don't want to evaluate all of linuxPackages for the manual
       # - some of it might not even evaluate correctly.

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -115,6 +115,21 @@ in
         description = "True if ZFS filesystem support is enabled";
       };
 
+      unsafeDisableVersionCheck = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          This will disable the kernel version compatibility check of the ZFS
+          kernel module that is normally in place. Hence this allows the user to
+          compile (or at least attempt to compile) the ZFS kernel module against
+          kernel versions that are not officially supported by upstream.
+
+          <emphasis>Caution</emphasis>: You are entering UNSUPPORTED
+          territory. Here be dragons, pool corruption and data loss! You have
+          been warned.
+        '';
+      };
+
       enableUnstable = mkOption {
         type = types.bool;
         default = false;
@@ -397,6 +412,10 @@ in
           assertion = !cfgZfs.forceImportAll || cfgZfs.forceImportRoot;
           message = "If you enable boot.zfs.forceImportAll, you must also enable boot.zfs.forceImportRoot";
         }
+      ];
+
+      warnings = mkIf cfgZfs.unsafeDisableVersionCheck [
+        "You have disabled the ZFS kernel module version check. This can lead to pool corruption or data loss."
       ];
 
       boot = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ZFS upstream is quite slow with marking the stable kernel as supported. This results in NixOS being in some sort of limbo every once in a while where the latest stable kernel is not yet supported by ZFS but the last stable kernel before that is already EOL'd, so a downgrade to the LTS kernel would be necessary for ZFS to work.

For these people (or anyone else who wants to live on the bleeding edge) this PR introduces a new option to simply disable the version check and attempt to compile the ZFS kernel module anyway. Since this is not explicitly supported by upstream the option carries `unsafe` in its name and a scary warning is printed when the option is enabled.

https://github.com/NixOS/nixpkgs/issues/150517

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
