### PR TITLE
fbmark: init at 0.3

### DIFF
--- a/pkgs/tools/misc/fbmark/default.nix
+++ b/pkgs/tools/misc/fbmark/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "fbmark";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "caramelli";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0n2czl2sy1k6r5ri0hp7jgq84xcwrx4x43bqvw1b4na99mqhyahn";
+  };
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    description = "Linux Framebuffer Benchmark";
+    homepage = "https://github.com/caramelli/fbmark";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ davidak ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32406,6 +32406,8 @@ with pkgs;
   fahcontrol = callPackage ../applications/science/misc/foldingathome/control.nix {};
   fahviewer = callPackage ../applications/science/misc/foldingathome/viewer.nix {};
 
+  fbmark = callPackage ../tools/misc/fbmark { };
+
   foma = callPackage ../tools/misc/foma { };
 
   foo2zjs = callPackage ../misc/drivers/foo2zjs {};


### PR DESCRIPTION
###### Motivation for this change

Testing framebuffer.

```
[davidak@gaming:~/code/nixpkgs]$ fb_mandelbrot
Mandelbrot frame buffer test bench
Benchmarking 48 iterations: 6.14 seconds
```

![fb_mandelbrot](https://user-images.githubusercontent.com/91113/145866295-2bc42b5b-9841-4878-b386-3afde561c91a.png)

```
[davidak@gaming:~/code/nixpkgs]$ fb_rectangle
Rectangle frame buffer test bench
Benchmarking 640x360 size: 236.90 MPixels/second
```

![fb_rectangle](https://user-images.githubusercontent.com/91113/145866323-34b805dd-e04e-4b7a-92fe-1d98e2b7e6b8.png)

```
[davidak@gaming:~/code/nixpkgs]$ fb_sierpinski
Sierpinski frame buffer test bench

Benchmarking     1024 iterations:   375.56 Frames/second
Benchmarking     2048 iterations:   390.33 Frames/second
Benchmarking     4096 iterations:   383.14 Frames/second
Benchmarking     8192 iterations:   373.42 Frames/second
Benchmarking    16384 iterations:   352.70 Frames/second
Benchmarking    32768 iterations:   320.82 Frames/second
Benchmarking    65536 iterations:   269.25 Frames/second
Benchmarking   131072 iterations:   204.70 Frames/second
Benchmarking   262144 iterations:   138.63 Frames/second
Benchmarking   524288 iterations:    84.07 Frames/second
Benchmarking  1048576 iterations:    46.97 Frames/second
Benchmarking  2097152 iterations:    25.00 Frames/second
Benchmarking  4194304 iterations:    12.94 Frames/second
Benchmarking  8388608 iterations:     6.57 Frames/second
```

![fb_sierpinski](https://user-images.githubusercontent.com/91113/145866342-8ff257cf-c85f-4280-9ea1-99011e0b7b74.png)

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
