### PR TITLE
Init pypemicro and pyocd-pemicro

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11660,6 +11660,12 @@
     githubId = 3105057;
     name = "Jan Beinke";
   };
+  theotherjimmy = {
+    email = "theotherjimmy@gmail.com";
+    github = "theotherjimmy";
+    name = "Jimmy Brisson";
+    githubId = 685409;
+  };
   therealansh = {
     email = "tyagiansh23@gmail.com";
     github = "therealansh";

--- a/pkgs/development/python-modules/pyocd-pemicro/default.nix
+++ b/pkgs/development/python-modules/pyocd-pemicro/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pypemicro
+, setuptools
+, setuptools-scm
+, setuptools-scm-git-archive
+}:
+buildPythonPackage rec {
+  version = "1.0.6";
+  pname = "pyocd-pemicro";
+  doCheck = false;
+  src = fetchFromGitHub {
+    owner = "pyocd";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-i/uLE+MYGNKa3V3FudMLYMfBK9r41tu5FvzwFoa1Oag=";
+  };
+  buildInputs = [
+    setuptools
+    setuptools-scm
+    setuptools-scm-git-archive
+  ];
+  propagatedBuildInputs = [
+    pypemicro
+  ];
+  meta = {
+    description = "PEMicro probe plugin for pyOCD";
+    longDescription = ''
+      The simple PyOCD debug probe plugin for PEMicro debug probes -
+      Multilink/FX, Cyclone/FX. The purpose of this plugin is keep separately
+      this support because is using PyPemicro package which is designed for
+      Python 3.x without backward compatibility for Python2.x. The PyOCD use
+      this support only with Python 3.x and higher, for Python 2.x the PeMicro
+      won't be supported.
+    '';
+    homepage = "https://github.com/pyocd/pyocd-pemicro";
+    license = [ lib.licenses.bsd3 ];
+    maintainers = [ lib.maintainers.theotherjimmy ];
+  };
+}

--- a/pkgs/development/python-modules/pypemicro/default.nix
+++ b/pkgs/development/python-modules/pypemicro/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi }:
+buildPythonPackage rec {
+  version = "0.1.7";
+  pname = "pypemicro";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-G2RXDhXy7IGcrEMVQrsT14nb2KhC5QQrmF4lhe1iDgU=";
+  };
+  meta = {
+    description = "A Python interface for PEMicro debug probes";
+    longDescription = ''
+      This is simple package that provides Python interface for PEMicro
+      debug probes precompiled libraries. The package provides most of
+      functionality of the PEMicro libraries and their debug probes.
+
+      The package is tested only with Multilink/FX and Cyclone/FX probes
+      on NXP ARM microcontrollers.
+    '';
+    homepage = "https://github.com/nxpmicro/pypemicro";
+    license = [ lib.licenses.bsd3 ];
+    maintainers = [ lib.maintainers.theotherjimmy ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5873,6 +5873,8 @@ in {
 
   pynx584 = callPackage ../development/python-modules/pynx584 { };
 
+  pyocd-pemicro = callPackage ../development/python-modules/pyocd-pemicro { };
+
   pypemicro = callPackage ../development/python-modules/pypemicro { };
 
   pypoint = callPackage ../development/python-modules/pypoint { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5873,6 +5873,8 @@ in {
 
   pynx584 = callPackage ../development/python-modules/pynx584 { };
 
+  pypemicro = callPackage ../development/python-modules/pypemicro { };
+
   pypoint = callPackage ../development/python-modules/pypoint { };
 
   pypoolstation = callPackage ../development/python-modules/pypoolstation { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I would eventually like to contribute pyocd support. This is a step along the way.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) (Note: no packages currently depend on these packages, they're new)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
