### PR TITLE
[21.05] tsm-client: 8.1.8.0 -> 8.1.13.3 (security update)

### DIFF
--- a/pkgs/tools/backup/tsm-client/default.nix
+++ b/pkgs/tools/backup/tsm-client/default.nix
@@ -4,6 +4,7 @@
 , buildEnv
 , fetchurl
 , makeWrapper
+, openssl
 , procps
 , zlib
 # optional packages that enable certain features
@@ -40,7 +41,7 @@
 # point to this derivations `/dsmi_dir` directory symlink.
 # Other environment variables might be necessary,
 # depending on local configuration or usage; see:
-# https://www.ibm.com/docs/en/spectrum-protect/8.1.8?topic=solaris-set-api-environment-variables
+# https://www.ibm.com/docs/en/spectrum-protect/8.1.13?topic=solaris-set-api-environment-variables
 
 
 # The newest version of TSM client should be discoverable by
@@ -88,10 +89,10 @@ let
 
   unwrapped = stdenv.mkDerivation rec {
     name = "tsm-client-${version}-unwrapped";
-    version = "8.1.8.0";
+    version = "8.1.13.0";
     src = fetchurl {
       url = mkSrcUrl version;
-      sha256 = "0c1d0jm0i7qjd314nhj2vj8fs7sncm1x2n4d6dg4049jniyvjhpk";
+      sha256 = "0fy9c224g6rkrgd6ls01vs30bk9j9mlhf2x6akd11r7h8bib19zn";
     };
     inherit meta;
 
@@ -99,6 +100,7 @@ let
       autoPatchelfHook
     ];
     buildInputs = [
+      openssl
       stdenv.cc.cc
       zlib
     ];

--- a/pkgs/tools/backup/tsm-client/default.nix
+++ b/pkgs/tools/backup/tsm-client/default.nix
@@ -18,7 +18,7 @@
 
 # For an explanation of optional packages
 # (features provided by them, version limits), see
-# https://www-01.ibm.com/support/docview.wss?uid=swg21052223#Version%208.1
+# https://www.ibm.com/support/pages/node/660813#Version%208.1
 
 
 # IBM Tivoli Storage Manager Client uses a system-wide
@@ -40,21 +40,25 @@
 # point to this derivations `/dsmi_dir` directory symlink.
 # Other environment variables might be necessary,
 # depending on local configuration or usage; see:
-# https://www.ibm.com/support/knowledgecenter/en/SSEQVQ_8.1.8/client/c_cfg_sapiunix.html
+# https://www.ibm.com/docs/en/spectrum-protect/8.1.8?topic=solaris-set-api-environment-variables
 
 
-# The newest version of TSM client should be discoverable
-# by going the the `downloadPage` (see `meta` below),
-# there to "Client Latest Downloads",
-# "IBM Spectrum Protect Client Downloads and READMEs",
-# then to "Linux x86_64 Ubuntu client" (as of 2019-07-15).
+# The newest version of TSM client should be discoverable by
+# going to the `downloadPage` (see `meta` below), then
+# * find section "Client Service Release",
+# * pick the latest version and follow the link
+#   "IBM Spectrum Protect Client .. Downloads and READMEs"
+# * in the table at the page's bottom, follow the
+#   "HTTPS" link of the "Linux x86_64 Ubuntu client"
+# * in the directory listing, pick the big `.tar` file
+# (as of 2021-12-13)
 
 
 let
 
   meta = {
-    homepage = "https://www.ibm.com/us-en/marketplace/data-protection-and-recovery";
-    downloadPage = "https://www-01.ibm.com/support/docview.wss?uid=swg21239415";
+    homepage = "https://www.ibm.com/products/data-protection-and-recovery";
+    downloadPage = "https://www.ibm.com/support/pages/ibm-spectrum-protect-downloads-latest-fix-packs-and-interim-fixes";
     platforms = [ "x86_64-linux" ];
     license = lib.licenses.unfree;
     maintainers = [ lib.maintainers.yarny ];
@@ -74,11 +78,19 @@ let
     '';
   };
 
+  mkSrcUrl = version:
+    let
+      major = lib.versions.major version;
+      minor = lib.versions.minor version;
+      patch = lib.versions.patch version;
+    in
+      "https://public.dhe.ibm.com/storage/tivoli-storage-management/maintenance/client/v${major}r${minor}/Linux/LinuxX86_DEB/BA/v${major}${minor}${patch}/${version}-TIV-TSMBAC-LinuxX86_DEB.tar";
+
   unwrapped = stdenv.mkDerivation rec {
     name = "tsm-client-${version}-unwrapped";
     version = "8.1.8.0";
     src = fetchurl {
-      url = "ftp://public.dhe.ibm.com/storage/tivoli-storage-management/maintenance/client/v8r1/Linux/LinuxX86_DEB/BA/v818/${version}-TIV-TSMBAC-LinuxX86_DEB.tar";
+      url = mkSrcUrl version;
       sha256 = "0c1d0jm0i7qjd314nhj2vj8fs7sncm1x2n4d6dg4049jniyvjhpk";
     };
     inherit meta;

--- a/pkgs/tools/backup/tsm-client/default.nix
+++ b/pkgs/tools/backup/tsm-client/default.nix
@@ -97,10 +97,10 @@ let
 
   unwrapped = stdenv.mkDerivation rec {
     name = "tsm-client-${version}-unwrapped";
-    version = "8.1.13.0";
+    version = "8.1.13.1";
     src = fetchurl {
       url = mkSrcUrl version;
-      sha256 = "1p6bw1szsb6kl7nfalsnz0kxcs8dvggh8ad8irj677ljhhryqbm4";
+      sha256 = "00kgfn00b4gmmpxgw7n5kyfh94a9fkmi8bm9pqy9gz8qrp1v9d2r";
     };
     inherit meta;
 

--- a/pkgs/tools/backup/tsm-client/default.nix
+++ b/pkgs/tools/backup/tsm-client/default.nix
@@ -97,10 +97,10 @@ let
 
   unwrapped = stdenv.mkDerivation rec {
     name = "tsm-client-${version}-unwrapped";
-    version = "8.1.13.1";
+    version = "8.1.13.2";
     src = fetchurl {
       url = mkSrcUrl version;
-      sha256 = "00kgfn00b4gmmpxgw7n5kyfh94a9fkmi8bm9pqy9gz8qrp1v9d2r";
+      sha256 = "0cspxr96g93kb8vy6m86ks16sfw1zghkd2fmxk95mwphs762d5xm";
     };
     inherit meta;
 

--- a/pkgs/tools/backup/tsm-client/default.nix
+++ b/pkgs/tools/backup/tsm-client/default.nix
@@ -97,10 +97,10 @@ let
 
   unwrapped = stdenv.mkDerivation rec {
     name = "tsm-client-${version}-unwrapped";
-    version = "8.1.13.2";
+    version = "8.1.13.3";
     src = fetchurl {
       url = mkSrcUrl version;
-      sha256 = "0cspxr96g93kb8vy6m86ks16sfw1zghkd2fmxk95mwphs762d5xm";
+      sha256 = "1dwczf236drdaf4jcfzz5154vdwvxf5zraxhrhiddl6n80hnvbcd";
     };
     inherit meta;
 


### PR DESCRIPTION
###### Motivation for this change

This backports ~~two~~ ~~four~~ five commits from https://github.com/NixOS/nixpkgs/pull/138386, effectively updating `tsm-client` to its latest version.  This appears in order as the update contains security critical fixes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)  (however, tested with current `nixos-21.05` branch)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
