### PR TITLE
uhk-agent: init at 1.15.16

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9383,6 +9383,12 @@
       fingerprint = "2CD2 B030 BD22 32EF DF5A  008A 3618 20A4 5DB4 1E9A";
     }];
   };
+  poelzi = {
+    email = "nix@poelzi.org";
+    github = "poelzi";
+    githubId = 66107;
+    name = "Daniel Poelzleithner";
+  };
   polendri = {
     email = "paul@ijj.li";
     github = "polendri";

--- a/nixos/modules/hardware/uhk.nix
+++ b/nixos/modules/hardware/uhk.nix
@@ -1,0 +1,11 @@
+{ config, lib, pkgs, ... }:
+
+with lib; {
+  options.hardware.uhk.enable = mkEnableOption
+    "Enable support for UHK (Ultimate Hacking Keyboard) keyboards";
+
+  config = mkIf config.hardware.uhk.enable {
+    environment.systemPackages = [ pkgs.uhk-agent ];
+    services.udev.packages = [ pkgs.uhk-udev-rules ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -81,6 +81,7 @@
   ./hardware/sata.nix
   ./hardware/wooting.nix
   ./hardware/uinput.nix
+  ./hardware/uhk.nix
   ./hardware/video/amdgpu-pro.nix
   ./hardware/video/capture/mwprocapture.nix
   ./hardware/video/bumblebee.nix

--- a/pkgs/os-specific/linux/uhk-udev-rules/50-uhk60.rules
+++ b/pkgs/os-specific/linux/uhk-udev-rules/50-uhk60.rules
@@ -1,0 +1,6 @@
+# Ultimate Hacking Keyboard rules
+# These are the udev rules for accessing the USB interfaces of the UHK as non-root users.
+# Copy this file to /etc/udev/rules.d and physically reconnect the UHK afterwards.
+SUBSYSTEM=="input", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="612[0-7]", GROUP="input", MODE="0660"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="612[0-7]", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="612[0-7]", TAG+="uaccess"

--- a/pkgs/os-specific/linux/uhk-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/uhk-udev-rules/default.nix
@@ -1,0 +1,24 @@
+{ lib, stdenv }:
+
+stdenv.mkDerivation rec {
+  pname = "uhk-udev-rules";
+  version = "20210525";
+
+  # Source: https://raw.githubusercontent.com/UltimateHackingKeyboard/agent/master/rules/50-uhk60.rules
+  src = [ ./50-uhk60.rules ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    install -Dpm644 $src $out/lib/udev/rules.d/50-uhk60.rules
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/UltimateHackingKeyboard/agent";
+    description =
+      "udev rules that give users permission to program UHK keyboards";
+    platforms = platforms.linux;
+    license = "unknown";
+    maintainers = with maintainers; [ poelzi ];
+  };
+}

--- a/pkgs/tools/misc/uhk-agent/default.nix
+++ b/pkgs/tools/misc/uhk-agent/default.nix
@@ -1,0 +1,41 @@
+{ appimageTools, lib, fetchurl, makeWrapper, polkit, uhk-udev-rules }:
+
+let
+  pname = "uhk-agent";
+  version = "1.5.16";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url =
+      "https://github.com/UltimateHackingKeyboard/agent/releases/download/v${version}/UHK.Agent-${version}-linux-x86_64.AppImage";
+    name = "${name}.AppImage";
+    sha256 = "sha256-nJxfhmHt2bnu+lQOL7zQPzBe03n6yAVtyG7Y1atOpgg=";
+  };
+
+  appimageContents = appimageTools.extract {
+    name = "${pname}-${version}";
+    inherit src;
+  };
+in appimageTools.wrapType2 {
+  inherit src name;
+
+  extraPkgs = pkgs: with pkgs; [ polkit udev uhk-udev-rules ];
+
+  extraInstallCommands = ''
+    mv $out/bin/${name} $out/bin/${pname}
+
+    install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace 'Exec=AppRun' 'Exec=${pname}'
+    cp -r ${appimageContents}/usr/share/icons $out/share
+  '';
+
+  meta = with lib; {
+    description =
+      "Agent is the configuration application of the Ultimate Hacking Keyboard.";
+    homepage = "https://github.com/UltimateHackingKeyboard/agent";
+    license = licenses.mit;
+    maintainers = [ poelzi ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1015,6 +1015,8 @@ with pkgs;
 
   topicctl = callPackage ../tools/misc/topicctl { };
 
+  uhk-agent = callPackage ../tools/misc/uhk-agent { };
+
   veikk-linux-driver-gui = libsForQt5.callPackage ../tools/misc/veikk-linux-driver-gui { };
 
   ventoy-bin = callPackage ../tools/cd-dvd/ventoy-bin { };
@@ -22931,6 +22933,8 @@ with pkgs;
   udisks_glue = callPackage ../os-specific/linux/udisks-glue { };
 
   ugtrain = callPackage ../tools/misc/ugtrain { };
+
+  uhk-udev-rules = callPackage ../os-specific/linux/uhk-udev-rules { };
 
   untie = callPackage ../os-specific/linux/untie { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add uhk-agent which is used to program the ultimate hacking keyboard. Also add the udev rules to set the permissions on the hidraw device.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
