### PR TITLE
python3Packages.ircrobots: 0.3.8 -> 0.4.6

### DIFF
--- a/pkgs/development/python-modules/asyncio-rlock/default.nix
+++ b/pkgs/development/python-modules/asyncio-rlock/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "asyncio-rlock";
+  version = "0.1.0";
+
+  src = fetchPypi {
+    pname = "asyncio_rlock";
+    inherit version;
+    sha256 = "7e29824331619873e10d5d99dcc46d7b8f196c4a11b203f4eeccc0c091039d43";
+  };
+
+  # no tests on PyPI, no tags on GitLab
+  doCheck = false;
+
+  pythonImportsCheck = [ "asyncio_rlock" ];
+
+  meta = with lib; {
+    description = "Rlock like in threading module but for asyncio";
+    homepage = "https://gitlab.com/heckad/asyncio_rlock";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/ircrobots/default.nix
+++ b/pkgs/development/python-modules/ircrobots/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , pythonOlder
 , anyio
+, asyncio-rlock
 , asyncio-throttle
 , dataclasses
 , ircstates
@@ -13,23 +14,26 @@
 
 buildPythonPackage rec {
   pname = "ircrobots";
-  version = "0.3.8";
+  version = "0.4.6";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "jesopo";
     repo = pname;
     rev = "v${version}";
-    sha256 = "06q86dqllxvi3nssfplmjk9yxaybighwh87lrxfpfhl8yy4z68jz";
+    sha256 = "sha256-+BrS1+ZkgwT/qvqD0PwRZi2LF+31biS738SzKH1dy7w=";
   };
 
   postPatch = ''
     # too specific pins https://github.com/jesopo/ircrobots/issues/3
     sed -iE 's/anyio.*/anyio/' requirements.txt
+    sed -iE 's/ircstates.*/ircstates/' requirements.txt
+    sed -iE 's/async_timeout.*/async_timeout/' requirements.txt
   '';
 
   propagatedBuildInputs = [
     anyio
+    asyncio-rlock
     asyncio-throttle
     ircstates
     async_stagger

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -671,6 +671,8 @@ in {
 
   asyncio-nats-client = callPackage ../development/python-modules/asyncio-nats-client { };
 
+  asyncio-rlock = callPackage ../development/python-modules/asyncio-rlock { };
+
   asyncmy = callPackage ../development/python-modules/asyncmy { };
 
   asyncio-throttle = callPackage ../development/python-modules/asyncio-throttle { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/145602#issuecomment-992952375

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @trofi 