### PR TITLE
prometheus-mikrotik-exporter: 2020-02-10 -> 2021-08-10

### DIFF
--- a/pkgs/servers/monitoring/prometheus/mikrotik-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/mikrotik-exporter.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "mikrotik-exporter-unstable";
-  version = "2020-02-10";
+  version = "2021-08-10";
 
   src = fetchFromGitHub {
     owner = "nshttpd";
     repo = "mikrotik-exporter";
-    sha256 = "193zh06rqp9ybsnkxwmv7l4p2h2xisw4f01jjirshsb784j44bh6";
-    rev = "3b33400d24abcfdc07dc31c15ca5ba7b82de444f";
+    sha256 = "1vqn1f159g0l76021gifbxpjf7zjhrj807qqqn51h5413lbi6r66";
+    rev = "4bfa7adfef500ff621a677adfab1f7010af920d1";
   };
 
-  vendorSha256 = "0i5x4d3ra0s41knmybbg8gnjxgraxkid6y3gfkjwa65xcbp7hr7q";
+  vendorSha256 = "0b244z3hly5726vwkr7vhdzzm2fi38cv1qh7nvfp3vpsxnii04md";
 
   doCheck = false;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New Metrics (capsman, conntrack, firmware, lte, netwatch) [3b33400...4bfa7ad](https://github.com/nshttpd/mikrotik-exporter/compare/3b33400d24abcfdc07dc31c15ca5ba7b82de444f...4bfa7adfef500ff621a677adfab1f7010af920d1)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
