### PR TITLE
Update elisp packages

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/bqn-mode/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/bqn-mode/default.nix
@@ -5,7 +5,7 @@
 
 trivialBuild {
   pname = "bqn-mode";
-  version = "0.pre+unstable=2021-12-04";
+  version = "0.pre+date=2021-12-03";
 
   src = fetchFromGitHub {
     owner = "museoa";

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -3727,21 +3727,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    shell-command-plus = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
-      elpaBuild {
-        pname = "shell-command-plus";
-        ename = "shell-command+";
-        version = "2.3.2";
-        src = fetchurl {
-          url = "https://elpa.gnu.org/packages/shell-command+-2.3.2.tar";
-          sha256 = "03hmk4gr9kjy3238n0ys9na00py035j9s0y8d87c45f5af6c6g2c";
-        };
-        packageRequires = [ emacs ];
-        meta = {
-          homepage = "https://elpa.gnu.org/packages/shell-command+.html";
-          license = lib.licenses.free;
-        };
-      }) {};
     shen-mode = callPackage ({ elpaBuild, fetchurl, lib }:
       elpaBuild {
         pname = "shen-mode";

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -39,10 +39,10 @@
       elpaBuild {
         pname = "ada-mode";
         ename = "ada-mode";
-        version = "7.1.8";
+        version = "7.2.0";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/ada-mode-7.1.8.tar";
-          sha256 = "0gggzjj58bxp7n4xdvhqwaxk6z79bbiqs59cc36mxk4gqyzf41xh";
+          url = "https://elpa.gnu.org/packages/ada-mode-7.2.0.tar";
+          sha256 = "00mrcn98bah9cld78qz75mmmk1yrs9k4dbzf6r1x07pngz70fxm2";
         };
         packageRequires = [ emacs uniquify-files wisi ];
         meta = {
@@ -448,10 +448,10 @@
       elpaBuild {
         pname = "capf-autosuggest";
         ename = "capf-autosuggest";
-        version = "0.2";
+        version = "0.3";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/capf-autosuggest-0.2.tar";
-          sha256 = "0a3bkf3c1gwv9m4rq9kvgw48y5av4arnymnm64yija55ygrnm88b";
+          url = "https://elpa.gnu.org/packages/capf-autosuggest-0.3.tar";
+          sha256 = "05abnvg84248pbqr2hdkyxr1q1qlgsf4nji23nw41bfly795ikpm";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -681,10 +681,10 @@
       elpaBuild {
         pname = "consult";
         ename = "consult";
-        version = "0.12";
+        version = "0.13";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/consult-0.12.tar";
-          sha256 = "0xcr7jki9m30hppy24z74nrw7xv5nahm1yrjilcck32mxfkrc69x";
+          url = "https://elpa.gnu.org/packages/consult-0.13.tar";
+          sha256 = "08hwvyj9sif9r92nhd09prwlryyqgnifjfqj51xgx98m0rg7ks3p";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -711,10 +711,10 @@
       elpaBuild {
         pname = "corfu";
         ename = "corfu";
-        version = "0.13";
+        version = "0.16";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/corfu-0.13.tar";
-          sha256 = "0psvkxr7fjqq7gkqdzl0ma367zjlxgixk563vpv9hmwfwymddyyb";
+          url = "https://elpa.gnu.org/packages/corfu-0.16.tar";
+          sha256 = "04xgq5rkz8a0lykcyjsxq76yapbzz8vfw8gxqvdx0y58bhcw82y6";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -726,10 +726,10 @@
       elpaBuild {
         pname = "coterm";
         ename = "coterm";
-        version = "1.2";
+        version = "1.3";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/coterm-1.2.tar";
-          sha256 = "0jl48bi4a4fkk7p2nj2bx0b658wrjw0cvab5ds6rid44irc8b1mn";
+          url = "https://elpa.gnu.org/packages/coterm-1.3.tar";
+          sha256 = "078rrc776mdzb4nczp1h8p0pymzds76kz3g2h78ri95k3wpy5ksj";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -801,10 +801,10 @@
       elpaBuild {
         pname = "csharp-mode";
         ename = "csharp-mode";
-        version = "1.0.2";
+        version = "1.1.1";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/csharp-mode-1.0.2.tar";
-          sha256 = "1xddnd6g6qz3xnzl6dmd38qvzvm32acdyhmm27hfdpqcbg6isfad";
+          url = "https://elpa.gnu.org/packages/csharp-mode-1.1.1.tar";
+          sha256 = "096aj4np1ii60h1kxbff5lkfznd0l0x551x103m5i1ks82kxlv1l";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -816,10 +816,10 @@
       elpaBuild {
         pname = "csv-mode";
         ename = "csv-mode";
-        version = "1.16";
+        version = "1.17";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/csv-mode-1.16.tar";
-          sha256 = "1i43b2p31xhrf97xbdi35y550ysp69fasa5gcrhg6iyxw176807p";
+          url = "https://elpa.gnu.org/packages/csv-mode-1.17.tar";
+          sha256 = "16kv3n70pl4h3jfmmqy9bzflsm4nv7cwvrj7g4mgy8yb76nbyka2";
         };
         packageRequires = [ cl-lib emacs ];
         meta = {
@@ -1176,10 +1176,10 @@
       elpaBuild {
         pname = "eev";
         ename = "eev";
-        version = "20211101";
+        version = "20211205";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/eev-20211101.tar";
-          sha256 = "0sxbf116msfv6ly1dqga2sz2zpqr78nzp3v44qy7rps2887incmr";
+          url = "https://elpa.gnu.org/packages/eev-20211205.tar";
+          sha256 = "0qicm3ym9n6iamlj0xyzn8729gfwjp5lwq6lj8r3ydgs4ggsr4jy";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -1279,10 +1279,10 @@
       elpaBuild {
         pname = "elisp-benchmarks";
         ename = "elisp-benchmarks";
-        version = "1.12";
+        version = "1.13";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/elisp-benchmarks-1.12.tar";
-          sha256 = "0jzpzif4vrjg5hl0hxg4aqvi6nv56cxa1w0amnkgcz4hsscxkvwm";
+          url = "https://elpa.gnu.org/packages/elisp-benchmarks-1.13.tar";
+          sha256 = "13gvljqj7k8qpyn9fcwa6gl3kqakiy5rqx5s3afdc2y356a06wr6";
         };
         packageRequires = [];
         meta = {
@@ -1474,10 +1474,10 @@
       elpaBuild {
         pname = "exwm";
         ename = "exwm";
-        version = "0.25";
+        version = "0.26";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/exwm-0.25.tar";
-          sha256 = "0imd4v9ccvpsskmfnycz5fgabsvdjp1msg5v8rc7x0v26r3kr4x7";
+          url = "https://elpa.gnu.org/packages/exwm-0.26.tar";
+          sha256 = "03pg0r8a5vb1wc5grmjgzql74p47fniv47x39gdll5s3cq0haf6q";
         };
         packageRequires = [ xelb ];
         meta = {
@@ -2078,10 +2078,10 @@
       elpaBuild {
         pname = "javaimp";
         ename = "javaimp";
-        version = "0.7.1";
+        version = "0.8";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/javaimp-0.7.1.tar";
-          sha256 = "0i93akp9jhlpgbm454wkjhir8cbzhfjb97cxxlk8n4pgzbh481l3";
+          url = "https://elpa.gnu.org/packages/javaimp-0.8.tar";
+          sha256 = "1i6k0yz6r7v774qgnkzinia783fwx73y3brxr31sbip3b5dbpmsn";
         };
         packageRequires = [];
         meta = {
@@ -2161,6 +2161,21 @@
         packageRequires = [];
         meta = {
           homepage = "https://elpa.gnu.org/packages/jumpc.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    kind-icon = callPackage ({ elpaBuild, emacs, fetchurl, lib, svg-lib }:
+      elpaBuild {
+        pname = "kind-icon";
+        ename = "kind-icon";
+        version = "0.1.3";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/kind-icon-0.1.3.tar";
+          sha256 = "0iqbjlqna5n8dx78350macs129wnri7kgmxk2qf3w9bj6qp760sn";
+        };
+        packageRequires = [ emacs svg-lib ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/kind-icon.html";
           license = lib.licenses.free;
         };
       }) {};
@@ -2348,10 +2363,10 @@
       elpaBuild {
         pname = "marginalia";
         ename = "marginalia";
-        version = "0.9";
+        version = "0.10";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/marginalia-0.9.tar";
-          sha256 = "0jnw9ys7p2rhi7sx2wxi3xs95ryg9vr34xb2jdfiz0p1xv04a300";
+          url = "https://elpa.gnu.org/packages/marginalia-0.10.tar";
+          sha256 = "0sw4kfqda3z9bph4vgzqvg045li64ww2gdc2cgddi2m5p7anq20g";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2386,6 +2401,21 @@
         packageRequires = [];
         meta = {
           homepage = "https://elpa.gnu.org/packages/math-symbol-lists.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    mct = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "mct";
+        ename = "mct";
+        version = "0.3.0";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/mct-0.3.0.tar";
+          sha256 = "07wywk5zadcinjpx9hvag8ndzb426lq5jlg42rqdgrv92ka7n16b";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/mct.html";
           license = lib.licenses.free;
         };
       }) {};
@@ -2517,10 +2547,10 @@
       elpaBuild {
         pname = "modus-themes";
         ename = "modus-themes";
-        version = "1.6.0";
+        version = "1.7.0";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/modus-themes-1.6.0.tar";
-          sha256 = "03ahavpvd57z7cw1n46k6lq5335p1ld7kkjcylyx5fvq1rc1jw44";
+          url = "https://elpa.gnu.org/packages/modus-themes-1.7.0.tar";
+          sha256 = "1ncpgya5lbwr5z7gbq59prfqqnjxhqgaylcjr23mwrhbvvfrj5ff";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2661,10 +2691,10 @@
       elpaBuild {
         pname = "nano-agenda";
         ename = "nano-agenda";
-        version = "0.1";
+        version = "0.2.1";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/nano-agenda-0.1.tar";
-          sha256 = "1bylgd4ly6dybpg66ndgsmgs5w0y5ymfq3s2pbwjnl46fnrmggz0";
+          url = "https://elpa.gnu.org/packages/nano-agenda-0.2.1.tar";
+          sha256 = "0j29fwc273mjdlj83h1a46sb7z3j066qqnp2i78kn2pmgjg27szb";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2860,10 +2890,10 @@
       elpaBuild {
         pname = "org";
         ename = "org";
-        version = "9.5";
+        version = "9.5.1";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/org-9.5.tar";
-          sha256 = "16cflg5nms5nb8w86nvwkg49zkl0rvdhigkf4xpvbs0v7zb5y3ky";
+          url = "https://elpa.gnu.org/packages/org-9.5.1.tar";
+          sha256 = "033q5rpk8kfp43qymll339dybk4ig3gc6jz7av6zwjjcz2iawpj1";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2898,6 +2928,21 @@
         packageRequires = [ boxy emacs org ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/org-real.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    org-transclusion = callPackage ({ elpaBuild, emacs, fetchurl, lib, org }:
+      elpaBuild {
+        pname = "org-transclusion";
+        ename = "org-transclusion";
+        version = "1.0.1";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/org-transclusion-1.0.1.tar";
+          sha256 = "1mn66a82nk3daf2vjw6pg9zgff48inik04ffizgm6cdlgn6ymrcs";
+        };
+        packageRequires = [ emacs org ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/org-transclusion.html";
           license = lib.licenses.free;
         };
       }) {};
@@ -3006,6 +3051,21 @@
           license = lib.licenses.free;
         };
       }) {};
+    parser-generator = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "parser-generator";
+        ename = "parser-generator";
+        version = "0.1.3";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/parser-generator-0.1.3.tar";
+          sha256 = "13ssmdlni9ma6iafr4zwa2jlmq6rdlaafkdpli1a4jrk6ri6w996";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/parser-generator.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     path-iterator = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
       elpaBuild {
         pname = "path-iterator";
@@ -3055,10 +3115,10 @@
       elpaBuild {
         pname = "phps-mode";
         ename = "phps-mode";
-        version = "0.4.12";
+        version = "0.4.13";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/phps-mode-0.4.12.tar";
-          sha256 = "0xkzx5narbry0kbamzxv1hjgsal98cj9rp3ck25xg2ywb6nspwcw";
+          url = "https://elpa.gnu.org/packages/phps-mode-0.4.13.tar";
+          sha256 = "03j5ck0pk88kdl7br1rkdqmnjd8418y9w9m27gk63hqbi3p8diy6";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3100,10 +3160,10 @@
       elpaBuild {
         pname = "posframe";
         ename = "posframe";
-        version = "1.1.0";
+        version = "1.1.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/posframe-1.1.0.tar";
-          sha256 = "0ddm149dz71nksbpz7rwa8cax1nisf6wklv5iq4zrcbf5ghpagkg";
+          url = "https://elpa.gnu.org/packages/posframe-1.1.2.tar";
+          sha256 = "0vrv46v7qwmax5m1i6b7lwdh789dfr18ggxjl4bk05qn7waway6j";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3160,10 +3220,10 @@
       elpaBuild {
         pname = "pyim";
         ename = "pyim";
-        version = "3.9.4";
+        version = "3.9.5";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/pyim-3.9.4.tar";
-          sha256 = "0ggnl2jidcklyhqd5av5kk1f855gsq29wq2nhvp1yjzn35hz6xij";
+          url = "https://elpa.gnu.org/packages/pyim-3.9.5.tar";
+          sha256 = "1dj46yprbl3l6n83aj0hsnd0rwjcp4ypyg2nhwig39wxirwlf9an";
         };
         packageRequires = [ async emacs xr ];
         meta = {
@@ -3440,10 +3500,10 @@
       elpaBuild {
         pname = "rec-mode";
         ename = "rec-mode";
-        version = "1.8.1";
+        version = "1.8.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/rec-mode-1.8.1.tar";
-          sha256 = "0injk27l38d0sl9nzjz2bkd0qgccxyf31i42mwmivv86kv0kyxyb";
+          url = "https://elpa.gnu.org/packages/rec-mode-1.8.2.tar";
+          sha256 = "06mjj1la2v8zdhsflj3mwcp7qnkj7gxzm8wbk2pli1h8vnq2zvd0";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3533,7 +3593,7 @@
         version = "2.4";
         src = fetchurl {
           url = "https://elpa.gnu.org/packages/rt-liberation-2.4.tar";
-          sha256 = "1yqcrgfn9lbv26729x5d9qx4zyp1k05r4f63ikrnk8lhqpjs5i00";
+          sha256 = "1qfd0dy4n04gf3vx0pbwfgmp4wm2a64sh3m6mlfhinqgmasajh6r";
         };
         packageRequires = [];
         meta = {
@@ -3626,10 +3686,10 @@
       elpaBuild {
         pname = "setup";
         ename = "setup";
-        version = "1.1.0";
+        version = "1.2.0";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/setup-1.1.0.tar";
-          sha256 = "1xbh4fix6n47avv57gz48zf4ad1l6mfj30qr5lwvk6pz5gpnjg7i";
+          url = "https://elpa.gnu.org/packages/setup-1.2.0.tar";
+          sha256 = "1fyzkm42gsvsjpk3vahfb7asfldarixm0wsw3g66q3ad0r7cbjnz";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3649,6 +3709,21 @@
         packageRequires = [];
         meta = {
           homepage = "https://elpa.gnu.org/packages/shelisp.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    shell-command-plus = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "shell-command-plus";
+        ename = "shell-command+";
+        version = "2.3.2";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/shell-command+-2.3.2.tar";
+          sha256 = "03hmk4gr9kjy3238n0ys9na00py035j9s0y8d87c45f5af6c6g2c";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/shell-command+.html";
           license = lib.licenses.free;
         };
       }) {};
@@ -3868,8 +3943,8 @@
         ename = "sql-beeline";
         version = "0.1";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/sql-beeline-0.1.el";
-          sha256 = "0z2wdvvq1zdw90253s5i57lx8b59rjf7g7isns4yz29lwav04j3r";
+          url = "https://elpa.gnu.org/packages/sql-beeline-0.1.tar";
+          sha256 = "0yvj96aljmyiz8y6xjpypqjfrl1jdcrcc4jx4kbgl6mkv4z2aq1g";
         };
         packageRequires = [];
         meta = {
@@ -4095,10 +4170,10 @@
       elpaBuild {
         pname = "tramp";
         ename = "tramp";
-        version = "2.5.1.4";
+        version = "2.5.1.5";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/tramp-2.5.1.4.tar";
-          sha256 = "0mk9r9hj43klah7mwldg4bw7fxcqvrbwv1gj6g90zdfsflqy7nh9";
+          url = "https://elpa.gnu.org/packages/tramp-2.5.1.5.tar";
+          sha256 = "1g3xf97q5h6sr67w9bphcbbqx9jz2lbl8lij5rz1r0zbsnlcv7n8";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -4188,7 +4263,7 @@
         version = "0.2";
         src = fetchurl {
           url = "https://elpa.gnu.org/packages/uni-confusables-0.2.tar";
-          sha256 = "1lak9sr0h7hmc4qb7lzjqc1f88vjzbk8n76sspplfrizs3avg5ps";
+          sha256 = "1an2l7f8lqhp3hq511a371isv1q00nx431g2a7266pp6pn2sndj1";
         };
         packageRequires = [];
         meta = {
@@ -4203,7 +4278,7 @@
         version = "1.0.3";
         src = fetchurl {
           url = "https://elpa.gnu.org/packages/uniquify-files-1.0.3.tar";
-          sha256 = "04yfys615ncz3jyh3hx5sg6x6szx028223184zv52skb4j99vkwq";
+          sha256 = "1i7svplkw9wxiypw52chdry7f5gf992fb4yg8s7jy77v521fd2af";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -4376,10 +4451,10 @@
       elpaBuild {
         pname = "vertico";
         ename = "vertico";
-        version = "0.14";
+        version = "0.17";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/vertico-0.14.tar";
-          sha256 = "1lvfvrmfi6f1jcf356rj1zl2bcbqxas7wi3yb93mxpn37l22l8mi";
+          url = "https://elpa.gnu.org/packages/vertico-0.17.tar";
+          sha256 = "1zhrkdhnc32wsc5f958hwa7mgf2vcjh3x6ng1cpndds5yllxb7s9";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -4396,10 +4471,10 @@
       elpaBuild {
         pname = "vertico-posframe";
         ename = "vertico-posframe";
-        version = "0.3.10";
+        version = "0.4.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/vertico-posframe-0.3.10.tar";
-          sha256 = "1bksipfi92adlmnk2rdw33c2g6qhw8hplcg67xhc299svqlkd0j2";
+          url = "https://elpa.gnu.org/packages/vertico-posframe-0.4.2.tar";
+          sha256 = "1kajkjnjlisws2zdahy3bym942f3zvf05qhbmw9i2lv54jiy07pz";
         };
         packageRequires = [ emacs posframe vertico ];
         meta = {
@@ -4474,10 +4549,10 @@
       elpaBuild {
         pname = "wcheck-mode";
         ename = "wcheck-mode";
-        version = "2020.10.4";
+        version = "2021";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/wcheck-mode-2020.10.4.el";
-          sha256 = "0pi6gvyw80phmx0qzc5wdk5czv4m9cq1hs3l4s7r8rr91g2cqi3m";
+          url = "https://elpa.gnu.org/packages/wcheck-mode-2021.tar";
+          sha256 = "0qcj0af0570cssy9b7f74v9pv0pssm6ysnl1lyh8wwvl4yf0zx61";
         };
         packageRequires = [];
         meta = {
@@ -4594,10 +4669,10 @@
       elpaBuild {
         pname = "wisi";
         ename = "wisi";
-        version = "3.1.5";
+        version = "3.1.7";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/wisi-3.1.5.tar";
-          sha256 = "07jc8x6xdhpjv9hlghmvk7ga4gwww33nj5pizlx5scvpp0qvikpy";
+          url = "https://elpa.gnu.org/packages/wisi-3.1.7.tar";
+          sha256 = "1xraks3n97axc978qlgcwr4f7ib3lyr4bvb5lq5z099hd2g01qch";
         };
         packageRequires = [ emacs seq ];
         meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
@@ -297,10 +297,10 @@
       elpaBuild {
         pname = "geiser";
         ename = "geiser";
-        version = "0.18";
+        version = "0.19";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/geiser-0.18.tar";
-          sha256 = "131j4f82hl4pqj07qsl1f2dz4105v5fyll3bc97ggayzvrdiy58i";
+          url = "https://elpa.nongnu.org/nongnu/geiser-0.19.tar";
+          sha256 = "13w6gx6y8ilppcpfib5293600n0xy4xc4xa6idpmbcfd2pkmnw1x";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -327,10 +327,10 @@
       elpaBuild {
         pname = "geiser-chibi";
         ename = "geiser-chibi";
-        version = "0.16";
+        version = "0.17";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/geiser-chibi-0.16.tar";
-          sha256 = "0j9dgg2q01ya6yawpfc15ywrfykd5gzbh118k1x4mghfkfnqn1zi";
+          url = "https://elpa.nongnu.org/nongnu/geiser-chibi-0.17.tar";
+          sha256 = "1mpbkv48y1ij762f61hp1zjg3lx8k5b9bbsm5lfb7xzvmk5k3zf0";
         };
         packageRequires = [ emacs geiser ];
         meta = {
@@ -342,10 +342,10 @@
       elpaBuild {
         pname = "geiser-chicken";
         ename = "geiser-chicken";
-        version = "0.16";
+        version = "0.17";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/geiser-chicken-0.16.tar";
-          sha256 = "1zmb8c86akrd5f1v59s4xkbpgsqbdcbc6d5f9h6kxa55ylc4dn6a";
+          url = "https://elpa.nongnu.org/nongnu/geiser-chicken-0.17.tar";
+          sha256 = "13jhh0083fjx4xq0k31vw5v3ffbmn3jkb2608bimm9xlw6acgn4s";
         };
         packageRequires = [ emacs geiser ];
         meta = {
@@ -357,10 +357,10 @@
       elpaBuild {
         pname = "geiser-gambit";
         ename = "geiser-gambit";
-        version = "0.16";
+        version = "0.17";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/geiser-gambit-0.16.tar";
-          sha256 = "0bc38qlqj7a3cnrcnqrb6m3jvjh2ia5iby9i50vcn0jbs52rfsnz";
+          url = "https://elpa.nongnu.org/nongnu/geiser-gambit-0.17.tar";
+          sha256 = "12r9h1dl0y9j421v0idvr9ljj93962xfrs0nff5lmx5z1cayq456";
         };
         packageRequires = [ emacs geiser ];
         meta = {
@@ -387,10 +387,10 @@
       elpaBuild {
         pname = "geiser-guile";
         ename = "geiser-guile";
-        version = "0.18";
+        version = "0.19";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/geiser-guile-0.18.tar";
-          sha256 = "1jnqra7gysscn0gb1ap56rbjlrnhsmma7q4yfiy3zxsz8m69xhqf";
+          url = "https://elpa.nongnu.org/nongnu/geiser-guile-0.19.tar";
+          sha256 = "1rjml11gkl80x4hmh84m84r4qb3kxi36d7mwm25n791v5fs1cl32";
         };
         packageRequires = [ emacs geiser ];
         meta = {
@@ -417,10 +417,10 @@
       elpaBuild {
         pname = "geiser-mit";
         ename = "geiser-mit";
-        version = "0.13";
+        version = "0.15";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/geiser-mit-0.13.tar";
-          sha256 = "1y2cgrcvdp358x7lpcz8x8nw5g1y4h03d9gbkbd6k85643cwrkbi";
+          url = "https://elpa.nongnu.org/nongnu/geiser-mit-0.15.tar";
+          sha256 = "11agp5k79g0w5596x98kbwijvqnb1hwrbqx680mh1svd1l8374q0";
         };
         packageRequires = [ emacs geiser ];
         meta = {
@@ -447,10 +447,10 @@
       elpaBuild {
         pname = "geiser-stklos";
         ename = "geiser-stklos";
-        version = "1.3";
+        version = "1.4";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/geiser-stklos-1.3.tar";
-          sha256 = "1wkhnkdhdrhrh0vipgnlmyimi859za6jhf2ldpwfmk8r2aj8ywan";
+          url = "https://elpa.nongnu.org/nongnu/geiser-stklos-1.4.tar";
+          sha256 = "18z34x4xmn58080r2ar6wd07kap7f367my2q5ph6cdf0gs6nz4sv";
         };
         packageRequires = [ emacs geiser ];
         meta = {
@@ -881,6 +881,26 @@
           license = lib.licenses.free;
         };
       }) {};
+    pdf-tools = callPackage ({ elpaBuild
+                             , emacs
+                             , fetchurl
+                             , let-alist
+                             , lib
+                             , tablist }:
+      elpaBuild {
+        pname = "pdf-tools";
+        ename = "pdf-tools";
+        version = "1.0";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/pdf-tools-1.0.tar";
+          sha256 = "0cjr7y2ikf2al43wrzlqdpbksj0ww6m0nvmlz97slx8nk94k2qyf";
+        };
+        packageRequires = [ emacs let-alist tablist ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/pdf-tools.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     php-mode = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
       elpaBuild {
         pname = "php-mode";
@@ -975,10 +995,10 @@
       elpaBuild {
         pname = "rust-mode";
         ename = "rust-mode";
-        version = "1.0.1";
+        version = "1.0.2";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/rust-mode-1.0.1.tar";
-          sha256 = "1rybjnaycvjgqp8g8lkjzgvnwd4565cbx88qlnxfrlqd5161r1k3";
+          url = "https://elpa.nongnu.org/nongnu/rust-mode-1.0.2.tar";
+          sha256 = "08zkq5md20ppqlvd5xxsbzargs6ffzmjr1b1pq9i937l3n9d4swl";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -1095,6 +1115,21 @@
           license = lib.licenses.free;
         };
       }) {};
+    subed = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "subed";
+        ename = "subed";
+        version = "0.0.2";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/subed-0.0.2.tar";
+          sha256 = "1q9sb8kn1g5hvmm5zl4hm90fvf5kb82da69y24x7yzgs6axy0dga";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/subed.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     swift-mode = callPackage ({ elpaBuild, emacs, fetchurl, lib, seq }:
       elpaBuild {
         pname = "swift-mode";
@@ -1122,6 +1157,21 @@
         packageRequires = [ emacs ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/systemd.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    tablist = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "tablist";
+        ename = "tablist";
+        version = "1.0";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/tablist-1.0.tar";
+          sha256 = "1r37vk31ddiahhd11ric00py9ay9flgmsv368j47pl9653g9i6d9";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/tablist.html";
           license = lib.licenses.free;
         };
       }) {};
@@ -1182,6 +1232,26 @@
         packageRequires = [ emacs ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/web-mode.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    webpaste = callPackage ({ cl-lib ? null
+                            , elpaBuild
+                            , emacs
+                            , fetchurl
+                            , lib
+                            , request }:
+      elpaBuild {
+        pname = "webpaste";
+        ename = "webpaste";
+        version = "3.2.2";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/webpaste-3.2.2.tar";
+          sha256 = "0vviv062v46mlssz8627623g1b2nq4n4x3yiv8c882gvgvfvi2bi";
+        };
+        packageRequires = [ cl-lib emacs request ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/webpaste.html";
           license = lib.licenses.free;
         };
       }) {};

--- a/pkgs/applications/editors/emacs/elisp-packages/org-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/org-generated.nix
@@ -4,10 +4,10 @@
       elpaBuild {
         pname = "org";
         ename = "org";
-        version = "20210920";
+        version = "20210929";
         src = fetchurl {
-          url = "https://orgmode.org/elpa/org-20210920.tar";
-          sha256 = "01b44npf0rxq7c4ddygc3n3cv3h7afs41az0nfs67a5x7ag6c1jj";
+          url = "https://orgmode.org/elpa/org-20210929.tar";
+          sha256 = "1fxhxjy48jxvs16x7270c4qj6n4lm952sn7q369c88gbf2jqxis4";
         };
         packageRequires = [];
         meta = {
@@ -19,10 +19,10 @@
       elpaBuild {
         pname = "org-plus-contrib";
         ename = "org-plus-contrib";
-        version = "20210920";
+        version = "20210929";
         src = fetchurl {
-          url = "https://orgmode.org/elpa/org-plus-contrib-20210920.tar";
-          sha256 = "1m376fnm8hrm83hgx4b0y21lzdrbxjp83bv45plvrjky44qfdwfn";
+          url = "https://orgmode.org/elpa/org-plus-contrib-20210929.tar";
+          sha256 = "0bn80kji2h423d39c0am2r3p2hwvdxs9rm31xa4810dff27ihxb1";
         };
         packageRequires = [];
         meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -213,11 +213,11 @@
   "repo": "ymarco/auto-activating-snippets",
   "unstable": {
    "version": [
-    20211103,
-    1551
+    20211208,
+    2116
    ],
-   "commit": "b868ef7065039899628a2846dd1274233e07a310",
-   "sha256": "1a8rr7ni9x4n21lysfhczf0j0nqi9xd17s39lfpxmpp10s36mrxf"
+   "commit": "b1a436922ba06ab9e1a5cc222f1a4f25a7697231",
+   "sha256": "0alscwf2937ak2pzgl9jih7s9dya7kibl59qik4fy6xbq5h52v77"
   },
   "stable": {
    "version": [
@@ -1044,8 +1044,8 @@
     "auto-complete",
     "yasnippet"
    ],
-   "commit": "933805013e026991d29a7abfb425075d104aa1cf",
-   "sha256": "0qzb6wlh2hf0kp9n74m2q6hrf4rar62dfxfh8yj1rjx2brpi1qdq"
+   "commit": "fc834dcc193e7168ffa0b3ae81ab3eefa4fd3c59",
+   "sha256": "08hnw5dbcs4ww2ir7ilnfc6r0b123alh4l8i1mzvng0h3mvmlhgq"
   },
   "stable": {
    "version": [
@@ -1070,8 +1070,8 @@
   "repo": "xcwen/ac-php",
   "unstable": {
    "version": [
-    20210909,
-    918
+    20211204,
+    733
    ],
    "deps": [
     "dash",
@@ -1081,8 +1081,8 @@
     "s",
     "xcscope"
    ],
-   "commit": "933805013e026991d29a7abfb425075d104aa1cf",
-   "sha256": "0qzb6wlh2hf0kp9n74m2q6hrf4rar62dfxfh8yj1rjx2brpi1qdq"
+   "commit": "fc834dcc193e7168ffa0b3ae81ab3eefa4fd3c59",
+   "sha256": "08hnw5dbcs4ww2ir7ilnfc6r0b123alh4l8i1mzvng0h3mvmlhgq"
   },
   "stable": {
    "version": [
@@ -1855,19 +1855,19 @@
   "repo": "Sauermann/emacs-aes",
   "unstable": {
    "version": [
-    20171029,
-    623
+    20211204,
+    2348
    ],
-   "commit": "b7d5da89c3443292e4f0b1c9d254d459933cf5af",
-   "sha256": "0nz1lf77qr3vm90rm02d4inw8glav722rxsiqds76m4xsjrq02m7"
+   "commit": "c9cd12d6c1dbc18603eb4703276132cea59d5c78",
+   "sha256": "1k5qq187xz5dbbgsrjsk3ff0dz5v328cn9iwn5rvn8a34akyal81"
   },
   "stable": {
    "version": [
-    0,
-    9
+    1,
+    0
    ],
-   "commit": "b7d5da89c3443292e4f0b1c9d254d459933cf5af",
-   "sha256": "0nz1lf77qr3vm90rm02d4inw8glav722rxsiqds76m4xsjrq02m7"
+   "commit": "b834673297a3468eeebb1b72d7c4736ffe6094ce",
+   "sha256": "0qpkzqb34qfmiyq8bpqa8jjdhl8wg4894d0qj18bnxkcilqg9kg8"
   }
  },
  {
@@ -1884,8 +1884,8 @@
    "deps": [
     "consult"
    ],
-   "commit": "0ee5e2374339c1a57d36c06818247afeecadc2c5",
-   "sha256": "0r9ziscf2f4plp740ggd2vh73cgax31xsvzmc1f5w9cy88i9f8nn"
+   "commit": "8bf8b0a365e7a4c0a7088ca47553d437de19f45a",
+   "sha256": "021wbixfgb4lzj4kq4d0hi12smzmh2j5pjh0n2xa70jidsclnfcg"
   },
   "stable": {
    "version": [
@@ -2878,8 +2878,8 @@
   "repo": "pythonic-emacs/anaconda-mode",
   "unstable": {
    "version": [
-    20210714,
-    1738
+    20211122,
+    817
    ],
    "deps": [
     "dash",
@@ -2887,14 +2887,14 @@
     "pythonic",
     "s"
    ],
-   "commit": "0546c093071417e4f30f505d9de09da883109cbf",
-   "sha256": "0mqkpgrl524j6h5037ymvfxx9zvz4gxz11kds0vqlqlrpm0vp0xc"
+   "commit": "cbea0fb3182321d34ff93981c5a59f8dd72d82a5",
+   "sha256": "0ajmqa60avwmlx9c63rirfb5mjqhbcxf2x15mnxr6a1rlzcylxg6"
   },
   "stable": {
    "version": [
     0,
     1,
-    14
+    15
    ],
    "deps": [
     "dash",
@@ -2902,8 +2902,8 @@
     "pythonic",
     "s"
    ],
-   "commit": "80afec20f91f13614647b192522fff460505db6f",
-   "sha256": "04f6kw4rd8k6waiyfbk7x8qdrqm411mdsdzjh2w9rvmv7y36ckh8"
+   "commit": "cbea0fb3182321d34ff93981c5a59f8dd72d82a5",
+   "sha256": "0ajmqa60avwmlx9c63rirfb5mjqhbcxf2x15mnxr6a1rlzcylxg6"
   }
  },
  {
@@ -2967,8 +2967,8 @@
     20211030,
     1358
    ],
-   "commit": "9f814c5e8bcabb5f65563b057ae9ad8458b90408",
-   "sha256": "0jy2pxcsj06klrc02q9nsm626nj229zg5y9gn7xyixszjjbvmlyj"
+   "commit": "db79f86842c10874ce18c1a1e4496e9d0e28bed9",
+   "sha256": "0aysq514abw75kxl3chq189xkd57mmyrv1j6rq41chndp94nl37r"
   }
  },
  {
@@ -3249,17 +3249,18 @@
     20200914,
     644
    ],
-   "commit": "6cb77e1a216098d6a4e273f6750dbf4445953272",
-   "sha256": "1rj04f9q7fn88ifznqqi3p7anv0m827mz2w2bwb4s09kdn03nf6p"
+   "commit": "756ac774b5191b252bf993b67c7ccd5648cbbb65",
+   "sha256": "174vd5dw7wz2kf08mcaakr0r0qx64bigkdhr9zg7c68xj0w0kasn"
   },
   "stable": {
    "version": [
     2,
     6,
-    2
+    2,
+    1
    ],
-   "commit": "246a229faea2ef2fa53caf491ff8a2d72dd7510c",
-   "sha256": "1ccmryw6vs8d87d5zmjl0kr2kvyd1zxl73344fa7yzqgg2kw1da6"
+   "commit": "59c7944b1a2e8015e473eb1932353818614a1e5b",
+   "sha256": "0p6jh8hyyf7xg0sni2rchck2fd1wyr5v106dfxxm09krxxawh0nh"
   }
  },
  {
@@ -3383,20 +3384,20 @@
   "repo": "zellio/ansible-vault-mode",
   "unstable": {
    "version": [
-    20211027,
-    1528
+    20211119,
+    1500
    ],
-   "commit": "5deca2fdb640fa70e614e66ee37e1d6739d39ba4",
-   "sha256": "169vfz5xz58f9avb74vzpdk1k0wj4ylc26c15ggl0y19acqx4hdw"
+   "commit": "8da2ad658dbe94c71aad1c75d6fd22888338030c",
+   "sha256": "1382ks8nakanv864flk070haibk7841ygb3nm262i7414zqsyfrk"
   },
   "stable": {
    "version": [
     0,
     5,
-    1
+    2
    ],
-   "commit": "4fc188a9817cb4c7e0f19b6f1ae720c902f7ebe9",
-   "sha256": "169vfz5xz58f9avb74vzpdk1k0wj4ylc26c15ggl0y19acqx4hdw"
+   "commit": "9b3d82ee49d484a494f2d88927b37fcd6245d51e",
+   "sha256": "1382ks8nakanv864flk070haibk7841ygb3nm262i7414zqsyfrk"
   }
  },
  {
@@ -3601,11 +3602,11 @@
   "repo": "raxod502/apheleia",
   "unstable": {
    "version": [
-    20211116,
-    132
+    20211121,
+    1845
    ],
-   "commit": "8e0605cc29732ec889b7318dd57921bf3f5ba06c",
-   "sha256": "1ffhnpz2zv4s4wl4a31c9xz9srx6h50q0ya7lacmj15vw9ffwd4z"
+   "commit": "2cf903e9a2faa3b50c97896b59361960472330f9",
+   "sha256": "04wgv5mhh9r2814k0332c8dxn89hyxh06vls2g89zzqmy5nm6gi5"
   },
   "stable": {
    "version": [
@@ -4197,6 +4198,21 @@
   }
  },
  {
+  "ename": "async-backup",
+  "commit": "79cfb4a1c6b89cc5d93020089804b5e6ae711387",
+  "sha256": "0w56q76x2b31adhjjsqm38jfgxi2305s9lxvwbq8w13693i5fv8a",
+  "fetcher": "git",
+  "url": "https://tildegit.org/contrapunctus/async-backup.git",
+  "unstable": {
+   "version": [
+    20211128,
+    1603
+   ],
+   "commit": "ba927feec1b568eb2b0a647b3eb7adf2d4a061e8",
+   "sha256": "0y88wj7p4amsqbj19rxxvhpffw43yganp1cxmzrmhbi5v66jikpr"
+  }
+ },
+ {
   "ename": "atcoder-tools",
   "commit": "314396ec5a51460ad679ee9fcf3aa3970cd44229",
   "sha256": "1rlsqqc7p351yyzmad4dvxrp5aj2788sg04019ybk83kacy0y5hf",
@@ -4700,15 +4716,15 @@
   "repo": "auto-complete/auto-complete",
   "unstable": {
    "version": [
-    20201213,
-    1255
+    20211210,
+    1808
    ],
    "deps": [
     "cl-lib",
     "popup"
    ],
-   "commit": "aafd3f566a8002a1e9b3e197721a2660c0a835ff",
-   "sha256": "0ipa5kaprisrmyyqlgzi5giq0449hjflfm81i9a5vy82ikz5lsxg"
+   "commit": "027dd93ffdd6219c9229fbb98d0ee25496dec1ee",
+   "sha256": "013g2dkyhvvx44l9q8lphv1011ilanyikhs7jf6qxp5v2plp4i6q"
   },
   "stable": {
    "version": [
@@ -5017,8 +5033,8 @@
     20211101,
     1155
    ],
-   "commit": "2a19931b275dc3c70c4bb16a3c60046800ba631a",
-   "sha256": "00f0n6pz0qi2fandcgj8skgj169bwxrda62vkrf0frwpavwpmkml"
+   "commit": "a1c67bf557277934f6dae9f2de6624d949ef2c8a",
+   "sha256": "0z5afn48w3p3i98zn81422khbl0k460spgqj60b9s7sqccbssg57"
   }
  },
  {
@@ -5029,14 +5045,14 @@
   "repo": "elp-revive/auto-highlight-symbol",
   "unstable": {
    "version": [
-    20211116,
-    1242
+    20211125,
+    747
    ],
    "deps": [
     "ht"
    ],
-   "commit": "0a16afcb10d8b3cf0e21002a6dff74f3b417c7c5",
-   "sha256": "13z0p702qxnz2xfrdw3himzgkwl3sqhcskqw8awmz67fqglw71zf"
+   "commit": "40efce76ee0dff920f2ba2315e568e75e5218830",
+   "sha256": "0nisaafqlns76wqvd4ys68h5ys4vcrzwy7lxrb4nvlhvq840g9f6"
   },
   "stable": {
    "version": [
@@ -5598,8 +5614,8 @@
     "avy",
     "embark"
    ],
-   "commit": "edfd0a842a75ad25115f95f56b0c8a9351d3e248",
-   "sha256": "1mq84aiak2fwxbxacf9wzk223dri6z918vqdgs3vy0amvn1ys2ji"
+   "commit": "54e5efae17a5c2898faabeaca9564a4d5f05761f",
+   "sha256": "0vpjszfqvkjzkjpma47rdyjzgkqdfg7palyzlii62wsrh04frg4l"
   },
   "stable": {
    "version": [
@@ -5809,11 +5825,11 @@
   "url": "https://bitbucket.org/pdo/axiom-environment",
   "unstable": {
    "version": [
-    20211116,
-    2200
+    20211120,
+    1646
    ],
-   "commit": "3266c5b2e4865337da86043b53a4e6609dbc8308",
-   "sha256": "11k53vvw5df66f54mh3zkghspmi7zsgls3mlkfvl19hz2z1pyhwq"
+   "commit": "e60de5ed107ffeb530a56d24d04f38988124d12b",
+   "sha256": "0p8kbxfcrx1ib8g17g6h2i2ygy35qq992n3s2xa6ysij7wrfn4hd"
   }
  },
  {
@@ -6062,11 +6078,14 @@
   "repo": "LiShiZhensPi/baidu-translate",
   "unstable": {
    "version": [
-    20190817,
-    1318
+    20211130,
+    1235
    ],
-   "commit": "b04a74d09ff5e3fbefd1b39b2abe79a9e272321a",
-   "sha256": "0qja8xw2sk2wn7w6qa5zj2i0j5c8a7cnldrag99ip2b5m02f1z4l"
+   "deps": [
+    "unicode-escape"
+   ],
+   "commit": "16101d5e6ce19bbcc8badf4422a95db457160999",
+   "sha256": "0799gc0nhqmgz691sn2zam3bfyraq9ljr4da1481nawwkwyzad1v"
   }
  },
  {
@@ -6378,11 +6397,11 @@
   "repo": "bazelbuild/emacs-bazel-mode",
   "unstable": {
    "version": [
-    20211031,
-    1941
+    20211130,
+    1645
    ],
-   "commit": "cdb2643dba39fe2bd64ba3b190b94d1ef1d83b18",
-   "sha256": "0ln06dprnivx9zxm6n23ppyx7x4kbn0f85pxwvkq32aq7wnqz82m"
+   "commit": "03fa200475e830b9df98c716bec26d7fb07ddda2",
+   "sha256": "16gx2qc4q14kmqkfxncxg6c2qz5si3wdql1iwkv782b335j0gkab"
   }
  },
  {
@@ -6786,11 +6805,11 @@
   "url": "https://git.sr.ht/~technomancy/better-defaults",
   "unstable": {
    "version": [
-    20210222,
-    1928
+    20211212,
+    1841
    ],
-   "commit": "4c5409406ee35c5ba46880c6cfe98df4b14dc631",
-   "sha256": "0agj1zyspm3bqj7apfjwhllnmydyj00x2iv7nvy03szpnwvm11fq"
+   "commit": "5383a9b2560adc4f7ebbdf148d87b19bf7cf8cc4",
+   "sha256": "1h1nfmpa4prfhi4j7l46q99y315ds6kl3qnxjgkdnw57nxqbwfl5"
   },
   "stable": {
    "version": [
@@ -7517,26 +7536,26 @@
   "repo": "Artawower/blamer.el",
   "unstable": {
    "version": [
-    20211114,
-    2013
+    20211206,
+    2137
    ],
    "deps": [
     "a"
    ],
-   "commit": "8855eeb6ef6aa323361498714d06365e0db83488",
-   "sha256": "04wy05pa9xzvrk33xnfvfk8hy127q7nlgn9kbcd4mm7ql4ywf8gp"
+   "commit": "d452006a31895a79216bf35a64482631a83cfc2d",
+   "sha256": "0gi0q60q9r5nx5wzavxywajmh9gw4nl20msgh9k9k9ilj4jy3a1b"
   },
   "stable": {
    "version": [
     0,
     3,
-    2
+    6
    ],
    "deps": [
     "a"
    ],
-   "commit": "8855eeb6ef6aa323361498714d06365e0db83488",
-   "sha256": "04wy05pa9xzvrk33xnfvfk8hy127q7nlgn9kbcd4mm7ql4ywf8gp"
+   "commit": "d452006a31895a79216bf35a64482631a83cfc2d",
+   "sha256": "0gi0q60q9r5nx5wzavxywajmh9gw4nl20msgh9k9k9ilj4jy3a1b"
   }
  },
  {
@@ -7598,11 +7617,11 @@
   "repo": "Sodaware/blitzmax-mode",
   "unstable": {
    "version": [
-    20200415,
-    1529
+    20211128,
+    2028
    ],
-   "commit": "5f67bb3c8e4baf1f6881cc998f9f031641a7b08a",
-   "sha256": "1hcx6b3ka0n6sbi9p0z2wqlsxk5d2pvkjawpcyh40b5f1r6dpfmc"
+   "commit": "c9651fa69116b5821cd34fb34eabc3e12ce238e2",
+   "sha256": "1h88nhqja5gzfrnbdxymnggvg3xd5yl305l4j80x3am3pyyfp909"
   },
   "stable": {
    "version": [
@@ -7945,8 +7964,8 @@
     20211019,
     511
    ],
-   "commit": "06e41de8ed7050e70627203c93b6132fec7e88d8",
-   "sha256": "07nvbp3b8bf2n5gaiz0fvr2himg624i80im4pzjx81k5fpb16sl7"
+   "commit": "59078eaa37ec168c37d52798c9f1020741271a64",
+   "sha256": "01yklj4nkpz5x45szs9b0d77xdn05rkwgl3dwjyr2j3134828mk6"
   },
   "stable": {
    "version": [
@@ -7989,16 +8008,16 @@
   "repo": "jyp/boon",
   "unstable": {
    "version": [
-    20210921,
-    1154
+    20211125,
+    2054
    ],
    "deps": [
     "dash",
     "expand-region",
     "multiple-cursors"
    ],
-   "commit": "ee88a9bbb3d39e2fa216984b6349a122a80e3c99",
-   "sha256": "0y28i8zqy6i93bajqldfwqwvlln75s81aadqq04sy6krc5nlfldy"
+   "commit": "12d6838c90058fea768cb55a0018807db804b11b",
+   "sha256": "1hcm9a09sy038kn1ij50q24w73485q55gypzx1yypz3wp5a2s8yd"
   },
   "stable": {
    "version": [
@@ -8029,8 +8048,8 @@
     "epkg",
     "magit"
    ],
-   "commit": "2ffcfd4481710e5b6d45a07a99da2561fe1c9d3e",
-   "sha256": "1nfrvln6s09krabzgsw1hqxs5rp95137dcaqk0pfj9y320awa1gb"
+   "commit": "bcae8f00dc60eca1a7cdd837e9be3b0fc942097d",
+   "sha256": "1agdddpjfxqrpiz7b9xnffw0bmb09a2mglcjb3xmhgn7zv309m3h"
   },
   "stable": {
    "version": [
@@ -8364,21 +8383,6 @@
   }
  },
  {
-  "ename": "brutal-theme",
-  "commit": "e415b9a4d269cfee5ee2b0e58acb18804c2a8cb7",
-  "sha256": "1xjj2ssw3lbx21w6g4m6vqc471v8jgmgk0zw1z1hkmygg0xipgl3",
-  "fetcher": "github",
-  "repo": "topikettunen/brutal-emacs",
-  "unstable": {
-   "version": [
-    20211112,
-    1713
-   ],
-   "commit": "f9bba56199e861bc405703286ac3378bda496898",
-   "sha256": "12j7ad1fs93a9d5s9ki99321lbky1kpsz0b84xj0yld08zvhwixb"
-  }
- },
- {
   "ename": "brutalist-theme",
   "commit": "ec889956a5685c3a60003ad2bfa04b03b57aa8e8",
   "sha256": "0dg0432r3cpjgdlpz583vky4hj5vld9d25dvaj6nxlir2ph9g9hn",
@@ -8574,27 +8578,27 @@
   "repo": "plandes/buffer-manage",
   "unstable": {
    "version": [
-    20210914,
-    1251
+    20211122,
+    1957
    ],
    "deps": [
     "choice-program",
     "dash"
    ],
-   "commit": "b903e97e47b463e08468011dc74689d61b2e52ce",
-   "sha256": "0fd1zzhvp2a7dvzm5vcywxx3iigcdz8vp7fw505mwc7hhbxv3gv0"
+   "commit": "819bbfd9ae2f028361f484bc3b60d751623a2df5",
+   "sha256": "0g79xcq0jf8p1cpsz3fifjpyaidkr0b2zm8sf11n8li4hfqmr10d"
   },
   "stable": {
    "version": [
     1,
-    0
+    1
    ],
    "deps": [
     "choice-program",
     "dash"
    ],
-   "commit": "b903e97e47b463e08468011dc74689d61b2e52ce",
-   "sha256": "0fd1zzhvp2a7dvzm5vcywxx3iigcdz8vp7fw505mwc7hhbxv3gv0"
+   "commit": "819bbfd9ae2f028361f484bc3b60d751623a2df5",
+   "sha256": "0g79xcq0jf8p1cpsz3fifjpyaidkr0b2zm8sf11n8li4hfqmr10d"
   }
  },
  {
@@ -9140,8 +9144,8 @@
     20210105,
     2255
    ],
-   "commit": "1de6be465cfe2c3f00183de9351bd838690c9f81",
-   "sha256": "1w02p4bfkyga6sign4flq2kw0hawyvnv63410pyh8nm7acp311gg"
+   "commit": "108d2298cc34d906b196178ad955e3dc139e1779",
+   "sha256": "1vwg82haclgwgjaq0r84gj416ribv7qn1lz8ixf05xhqsvq7ja87"
   },
   "stable": {
    "version": [
@@ -9780,16 +9784,16 @@
   "repo": "kisaragi-hiu/cangjie.el",
   "unstable": {
    "version": [
-    20200808,
-    828
+    20211201,
+    2307
    ],
    "deps": [
     "dash",
     "f",
     "s"
    ],
-   "commit": "0cbf706890df06b9e0d541692c579ed213da8252",
-   "sha256": "0a3mwgbza09rfiswmk4kh699mqc5746k16jc6rgy9q24jbjgradf"
+   "commit": "87408d79b73a69194842a8848de6d7708e98c3a4",
+   "sha256": "1pafp5sqr1zb0fkci6i542s683vx4x14955rv51311s2y8xzgyqf"
   },
   "stable": {
    "version": [
@@ -9807,6 +9811,29 @@
   }
  },
  {
+  "ename": "cape",
+  "commit": "2fb82d0719f9aee8c82722e81b107ef269afd6d4",
+  "sha256": "1bfml43m6xmcpvad1nc5bhwsrpnwszlyz97d82fl4m9033p6a0nc",
+  "fetcher": "github",
+  "repo": "minad/cape",
+  "unstable": {
+   "version": [
+    20211213,
+    1130
+   ],
+   "commit": "700c9d7bc221e04e259947f8fb7a908bf1909bc0",
+   "sha256": "1z2qddbirvzz017wflvc3wl5mnc7l8p8j8sc1wn7v0k8c0vdcw63"
+  },
+  "stable": {
+   "version": [
+    0,
+    3
+   ],
+   "commit": "edb2be3b71ce29ba3dbbafcafbd4e02e5a2e0ba3",
+   "sha256": "162jx3d50yxqsh5dgwvhzf6mgfgpb6lk5dwqg7j6s92alh5ardvb"
+  }
+ },
+ {
   "ename": "capnp-mode",
   "commit": "7981e5108f449a52631699439724712cba1d2a40",
   "sha256": "04idy13yzb5khzycsh394j8m4cchvnl7j75cw7ms1kdxzx6w2k4b",
@@ -9817,8 +9844,8 @@
     20210707,
     2310
    ],
-   "commit": "5ecc98425417732e7124460c7d938c0994958c1f",
-   "sha256": "10g0jap8rq0bbxqq61vvn2zklmhz94d883mr18gq1f926l3ni9z2"
+   "commit": "2ed8664a08e2c92f0af39e213c20b13d15c03346",
+   "sha256": "1rp0fx1d8mafk08smxmkdgx2gwxkvn44hyw2rxn4ax72lli61j2g"
   },
   "stable": {
    "version": [
@@ -10251,8 +10278,8 @@
     20210804,
     452
    ],
-   "commit": "f215b70c5cb02bbc43f5a7d5c8e5e3460ff82428",
-   "sha256": "0gf4xjzf3afcg88cvjmxq87pqci8s8y2av4phbh3bgd00myjmhfw"
+   "commit": "8e963c68531f75e459e8ebe7a34fd3ba9d3729a0",
+   "sha256": "1x5zg7qj4npi1y4030iakwy1mvfa04r79ijc3bwlsc74351wf27z"
   },
   "stable": {
    "version": [
@@ -10371,15 +10398,15 @@
   "repo": "ema2159/centaur-tabs",
   "unstable": {
    "version": [
-    20210507,
-    1633
+    20211130,
+    637
    ],
    "deps": [
     "cl-lib",
     "powerline"
    ],
-   "commit": "8b4249c40581368faf7bb8e06f86b9eee199c3c6",
-   "sha256": "185q3iplgycmq6zyyjn3aqq1gylvbb7r8zd1q9km2xl1fzg94jxi"
+   "commit": "5860a5c40c2318797f1274ea4c6907ae77ea1ec9",
+   "sha256": "10xw1cz9b6fvkn4rjsds1m2xrz9hf22k9bbdy089v49nwla5xiyk"
   },
   "stable": {
    "version": [
@@ -10506,17 +10533,17 @@
     20171115,
     2108
    ],
-   "commit": "be17316bf94dcfd0e725383041f5f059d85d8846",
-   "sha256": "0jf9ss3nj1v5qn02g9vhcsxp4rdrhx9s5ajd9md641av9p8c6rkm"
+   "commit": "945aee7d4538e71a990dbb42ce99bf3f74e17b40",
+   "sha256": "0g1ak590qjfqd0nyj9spf10jbyb9f8mxrhjm6cq9p3hlzcbjl11c"
   },
   "stable": {
    "version": [
     3,
-    18,
+    19,
     0
    ],
-   "commit": "b2e902351f51f30b46836494ae9cc1b38b3c6cf5",
-   "sha256": "1lm791bv829p4yjy95lw673g1l9cihg0akan6qxyjg7x219l7dgy"
+   "commit": "945aee7d4538e71a990dbb42ce99bf3f74e17b40",
+   "sha256": "0g1ak590qjfqd0nyj9spf10jbyb9f8mxrhjm6cq9p3hlzcbjl11c"
   }
  },
  {
@@ -11153,16 +11180,16 @@
   "url": "https://tildegit.org/contrapunctus/chronometrist.git",
   "unstable": {
    "version": [
-    20210905,
-    1942
+    20211206,
+    928
    ],
    "deps": [
     "dash",
     "seq",
     "ts"
    ],
-   "commit": "d673f00e5a43f8ac276b89c85622dcdf4cbd8148",
-   "sha256": "0cppwh15wb4kkhmqpi5cndvvyqlb6jjfj634cxlhkkvwbr0rmnjv"
+   "commit": "7ca6413907ac57e09010265257c48b5500fe09f8",
+   "sha256": "06lsaw2z7q131dfgfcmm0dgiimjd6psxlk1biyzrahgs992gm7d2"
   },
   "stable": {
    "version": [
@@ -11219,14 +11246,14 @@
   "url": "https://tildegit.org/contrapunctus/chronometrist.git",
   "unstable": {
    "version": [
-    20210904,
-    1359
+    20211118,
+    1235
    ],
    "deps": [
     "chronometrist"
    ],
-   "commit": "d673f00e5a43f8ac276b89c85622dcdf4cbd8148",
-   "sha256": "0cppwh15wb4kkhmqpi5cndvvyqlb6jjfj634cxlhkkvwbr0rmnjv"
+   "commit": "7ca6413907ac57e09010265257c48b5500fe09f8",
+   "sha256": "06lsaw2z7q131dfgfcmm0dgiimjd6psxlk1biyzrahgs992gm7d2"
   },
   "stable": {
    "version": [
@@ -11297,8 +11324,8 @@
   "repo": "clojure-emacs/cider",
   "unstable": {
    "version": [
-    20211108,
-    621
+    20211209,
+    1217
    ],
    "deps": [
     "clojure-mode",
@@ -11309,8 +11336,8 @@
     "sesman",
     "spinner"
    ],
-   "commit": "a30d2e5ee2052dbc06e24c2494747ebd60f0cd03",
-   "sha256": "1dsx3f752hkj18b2bwyjnl37xfb4cqhh8mxl5gjp5dc9nk6i2ccv"
+   "commit": "e7387f07b1398021cfce09aaf29bdc572f925154",
+   "sha256": "16pdq27c269bch1hmrc4j8xmxkiz6n26mapvgzks65156qrv9gfm"
   },
   "stable": {
    "version": [
@@ -11450,6 +11477,36 @@
   }
  },
  {
+  "ename": "cilk-mode",
+  "commit": "2bd58dbb29a3e1c03804d91cdfed3e0dd4a4a2a2",
+  "sha256": "1g1jskhczzqiklkx402lfg0nn2rclxc1m7ic08rrjfbvqxv5m3rc",
+  "fetcher": "github",
+  "repo": "ailiop/cilk-mode",
+  "unstable": {
+   "version": [
+    20211207,
+    1656
+   ],
+   "deps": [
+    "flycheck"
+   ],
+   "commit": "51eb3088337674389275b9352a1b16dce2d917db",
+   "sha256": "0mbfk0r14n7kx5m49b0j50m2kzg042nzrk2y91y7pj8sc7vh1lm6"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    1
+   ],
+   "deps": [
+    "flycheck"
+   ],
+   "commit": "51eb3088337674389275b9352a1b16dce2d917db",
+   "sha256": "0mbfk0r14n7kx5m49b0j50m2kzg042nzrk2y91y7pj8sc7vh1lm6"
+  }
+ },
+ {
   "ename": "cinspect",
   "commit": "1e5b5bdbfeb59ed8e98e50d0cc773d78c72d1699",
   "sha256": "0djh61mrfgcm3767ll1l5apw6646j4fdcaripksrmvn5aqfn8rjj",
@@ -11579,28 +11636,30 @@
   "repo": "bdarcus/citar",
   "unstable": {
    "version": [
-    20211117,
-    312
+    20211212,
+    2349
+   ],
+   "deps": [
+    "citeproc",
+    "org",
+    "parsebib",
+    "s"
+   ],
+   "commit": "51b30f2e4091a41243ae62cfbac53e7a579f3168",
+   "sha256": "1gym9nsqpxhmjx03j2hc4vsx6y20w2ara6nwhgyf6723dkjdg47m"
+  },
+  "stable": {
+   "version": [
+    0,
+    9
    ],
    "deps": [
     "org",
     "parsebib",
     "s"
    ],
-   "commit": "26c83fb42e0daece49cc98bebca0e81ea7c0232b",
-   "sha256": "0ch6wja4s6mdcfhxkdjfx82k519wq41v4rirsggczpkrzx7j5ql3"
-  },
-  "stable": {
-   "version": [
-    0,
-    8
-   ],
-   "deps": [
-    "bibtex-completion",
-    "parsebib"
-   ],
-   "commit": "2dcf0c450a80609294edcb89d55f352e763d0570",
-   "sha256": "1jrfcfr976c9nb2vpfrh6yhck5gm34wcjzbk0m6gq2xg3qfv2g6p"
+   "commit": "348ffb9853e04fbe3e0cbc25185236ecf65ccb35",
+   "sha256": "15jhpl2j4rm97cvvqzlfzxarvxvcsg64raz068psrsd2y7y2zh4c"
   }
  },
  {
@@ -11611,8 +11670,8 @@
   "repo": "andras-simonyi/citeproc-el",
   "unstable": {
    "version": [
-    20211111,
-    1008
+    20211213,
+    1446
    ],
    "deps": [
     "dash",
@@ -11623,8 +11682,8 @@
     "s",
     "string-inflection"
    ],
-   "commit": "2857f9bb819d0d0a6e6ed91cc38b165e506bfc2e",
-   "sha256": "11qm0mg0spwmqrl8d4pwjp0byn5b2askjcbs1yl1rpmlki97hb6m"
+   "commit": "538fed794c29acf81efee8a2674268bd3d7cc471",
+   "sha256": "0z6i352f7gjxml7cl2yi35phw0dqw5kb14bsrhk4rh0vs065g7vg"
   },
   "stable": {
    "version": [
@@ -11690,11 +11749,11 @@
   "repo": "universal-ctags/citre",
   "unstable": {
    "version": [
-    20211010,
-    1654
+    20211204,
+    1356
    ],
-   "commit": "047aece5a6d8e1ed267e542c53f5f013293fce21",
-   "sha256": "09szz5m8gw3j86c3pd449wghrff1zbs1nxypbxxagry59kvsdxkf"
+   "commit": "b9e274b180fcda981eec35dae0355d9d1305ad42",
+   "sha256": "1nxqcr560ahsfx1ffc97zz80cm173q9hjdv1nhnz31cdcyjrb35s"
   },
   "stable": {
    "version": [
@@ -11759,20 +11818,20 @@
   "url": "https://git.sr.ht/~pkal/clang-capf",
   "unstable": {
    "version": [
-    20210707,
-    1127
+    20211204,
+    1351
    ],
-   "commit": "258863d5cd77d2c9d07cc5dfa41b20db22a178f7",
-   "sha256": "1zg192hy2mf6r6fiy2ahkprxjnb79lh9n6wv6nvxqnc5cq0969i4"
+   "commit": "147be0e908f09ab2346443d48457f9624a404019",
+   "sha256": "1qwlafw28axrnhk9zrhpgww22964j9s0ys43dndmmh16ykyzaxgc"
   },
   "stable": {
    "version": [
     1,
     2,
-    1
+    3
    ],
-   "commit": "e422f339395aac6d023954880d19bc76a0d1072d",
-   "sha256": "1gdd674m1vbl8acwsgx6qfmx1gr7h8a6yadzp1jjaandpmc9jlrf"
+   "commit": "147be0e908f09ab2346443d48457f9624a404019",
+   "sha256": "1qwlafw28axrnhk9zrhpgww22964j9s0ys43dndmmh16ykyzaxgc"
   }
  },
  {
@@ -12057,8 +12116,8 @@
     "seq",
     "yasnippet"
    ],
-   "commit": "af1bde5cb0ca5679927f70eb21e7a95a33791e51",
-   "sha256": "1a962xav2pzbdx2zfaf53hqj8a5nz1im1773b7b1d9s7vp4lc991"
+   "commit": "363b95c5d2855abc93ac011e9adc778cf7a773e5",
+   "sha256": "1fm01ns63l1yrrya37aby4sx91kcnm56ba1bm3y7r8ilm4zcz40x"
   },
   "stable": {
    "version": [
@@ -12305,11 +12364,11 @@
   "repo": "clojure-emacs/clojure-mode",
   "unstable": {
    "version": [
-    20211114,
-    757
+    20211119,
+    1904
    ],
-   "commit": "08986ac32972830bb191496ea680fba1d6cd5fe2",
-   "sha256": "1y6zr7ijpyl1kf15108b5mkicf76ha2v8wq8lsk02xglgmjb7f5l"
+   "commit": "7d3c0c16e4aa14a051b393c249f0f4d307a2c74d",
+   "sha256": "1b3442z4awk3h1ns0fn0mif8vzlrdqzq1gbj9k848df5qz2qgvcv"
   },
   "stable": {
    "version": [
@@ -12335,8 +12394,8 @@
    "deps": [
     "clojure-mode"
    ],
-   "commit": "08986ac32972830bb191496ea680fba1d6cd5fe2",
-   "sha256": "1y6zr7ijpyl1kf15108b5mkicf76ha2v8wq8lsk02xglgmjb7f5l"
+   "commit": "7d3c0c16e4aa14a051b393c249f0f4d307a2c74d",
+   "sha256": "1b3442z4awk3h1ns0fn0mif8vzlrdqzq1gbj9k848df5qz2qgvcv"
   },
   "stable": {
    "version": [
@@ -12638,19 +12697,17 @@
     20210104,
     1831
    ],
-   "commit": "d2e10c4d8dd7dc32ae775a6382c5277308639271",
-   "sha256": "1jcw34vbfhs6mv4a9sl9gnqyf3g4fsnrcpdzkyx872c6awdg36dl"
+   "commit": "cd6b08440752f335f01c3419417dc817d20423ec",
+   "sha256": "1np0hnx9c7prc40abwy43m2ycvayxjdibcgrw68a4c4bx0hljw6z"
   },
   "stable": {
    "version": [
     3,
     22,
-    0,
-    -1,
-    3
+    1
    ],
-   "commit": "fed67fa40d7b6e34ee7c8565694bd54af61aed73",
-   "sha256": "0ddnqjbkmj40119w071vhchprcljdm1k9n3aps5vsa6srdpxa0dh"
+   "commit": "aa6a33fe54918967f6ffcad30773e01664e8a2b2",
+   "sha256": "1b5afd4ryqmkdkwpr1xb6g31d8xlkbjg9ql191rvnp5rsmb9a75w"
   }
  },
  {
@@ -12718,11 +12775,11 @@
   "repo": "tumashu/cnfonts",
   "unstable": {
    "version": [
-    20211112,
-    808
+    20211208,
+    2153
    ],
-   "commit": "4dad44ed3619c40ba406bcf45d37fdec3ce0db8e",
-   "sha256": "037k5d4ikb3bqa1gqipzkx92ml8fajgalz0r375y7hlvasr2zvzx"
+   "commit": "2f14a3c169896f5bfe92a0bf7a76d5ebf480eb6a",
+   "sha256": "0p7x3rlfg4q61xbd5mvwyr6lxjfr0m24nhj2l24z5r4qfldzsknf"
   },
   "stable": {
    "version": [
@@ -12825,6 +12882,52 @@
    ],
    "commit": "32d59c5c845d6dbdda18f9bd1c03a58d55417fc5",
    "sha256": "1n00bb39jgx02zdgla85zx0a338xir0zh0af6xca14kg5bx07vsv"
+  }
+ },
+ {
+  "ename": "code-review",
+  "commit": "35fb4e48e1ea127fc64734dceb29fa00f08005a3",
+  "sha256": "0pvd1g3485m2qjq93w5qd0rras7rznmk1yk8mfa90pk2y8p7gmrd",
+  "fetcher": "github",
+  "repo": "wandersoncferreira/code-review",
+  "unstable": {
+   "version": [
+    20211212,
+    1051
+   ],
+   "deps": [
+    "a",
+    "closql",
+    "deferred",
+    "emojify",
+    "forge",
+    "ghub",
+    "magit",
+    "markdown-mode",
+    "uuidgen"
+   ],
+   "commit": "a440c3429c158a88af6517bbcd0efb1a2956bf12",
+   "sha256": "0mabb6z0hp34w93az3x2hzkrlwi2mv885m5j4xy1rz5k9vc31ssq"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    4
+   ],
+   "deps": [
+    "a",
+    "closql",
+    "deferred",
+    "emojify",
+    "forge",
+    "ghub",
+    "magit",
+    "markdown-mode",
+    "uuidgen"
+   ],
+   "commit": "36f62479c263a3b1832d89e1eb0576e958d477f1",
+   "sha256": "1gsmrczhj1vjs6v5anxc9kbv22dmq37a3l16xnb1p76zyk3p7cmm"
   }
  },
  {
@@ -13591,11 +13694,11 @@
   "repo": "company-mode/company-mode",
   "unstable": {
    "version": [
-    20211112,
-    2354
+    20211201,
+    2335
    ],
-   "commit": "eb9be0bff7c323c720198dcd539ee05fa2485cd3",
-   "sha256": "09xzxyk81rwpgc05g8w0nl36lax6x6z94hrnjivn72c7zdwq58i2"
+   "commit": "8b58e5895c2eaf8686de0e25c807b00fdb205c7a",
+   "sha256": "1rc4hcg3bgqmllgb4xfylpkmg2wkx5qk7nagwdhx6klq87jbxdz9"
   },
   "stable": {
    "version": [
@@ -13733,8 +13836,8 @@
     "axiom-environment",
     "company"
    ],
-   "commit": "3266c5b2e4865337da86043b53a4e6609dbc8308",
-   "sha256": "11k53vvw5df66f54mh3zkghspmi7zsgls3mlkfvl19hz2z1pyhwq"
+   "commit": "e60de5ed107ffeb530a56d24d04f38988124d12b",
+   "sha256": "0p8kbxfcrx1ib8g17g6h2i2ygy35qq992n3s2xa6ysij7wrfn4hd"
   }
  },
  {
@@ -13873,26 +13976,26 @@
   "repo": "redguardtoo/company-ctags",
   "unstable": {
    "version": [
-    20210723,
-    1322
+    20211211,
+    338
    ],
    "deps": [
     "company"
    ],
-   "commit": "ff813c58e930d01fb55ee2f57fe810896a12c51b",
-   "sha256": "0v5a7aaqj1p2c6ci34v31r4jb1wd29rff7n779n3klaqjbkg3b6h"
+   "commit": "313508ba5d4f1e4b5d5d554faaa74076201c3248",
+   "sha256": "0hf7lq6rcs6xhmgpc8bwk115rykyfvakcjqpanlsh5m3fdswjq03"
   },
   "stable": {
    "version": [
     0,
     0,
-    6
+    7
    ],
    "deps": [
     "company"
    ],
-   "commit": "cf7bfdbfedc8ca4ee134c8d66e70eb6035185174",
-   "sha256": "0ysf3gd3fk74j203y2zg3rq41jx42wgk1y1fn2g5giawazi7ym2x"
+   "commit": "313508ba5d4f1e4b5d5d554faaa74076201c3248",
+   "sha256": "0hf7lq6rcs6xhmgpc8bwk115rykyfvakcjqpanlsh5m3fdswjq03"
   }
  },
  {
@@ -14394,8 +14497,8 @@
     "lean-mode",
     "s"
    ],
-   "commit": "bf32bb97930ed67c5cbe0fe3d4a69dedcf68be44",
-   "sha256": "1bkv5zs38ijawvavbba0fdf2flb6fiwici3qi99ws8wvwhnbkws2"
+   "commit": "4a90f2ae6e33c162a3dd6f624fb080c2ed8e8494",
+   "sha256": "1zikz4qaxabs3j86gljpp2qbhbzxsjzz544k9vsngibd468dszlv"
   }
  },
  {
@@ -14685,16 +14788,16 @@
   "repo": "xcwen/ac-php",
   "unstable": {
    "version": [
-    20201009,
-    1025
+    20211204,
+    558
    ],
    "deps": [
     "ac-php-core",
     "cl-lib",
     "company"
    ],
-   "commit": "933805013e026991d29a7abfb425075d104aa1cf",
-   "sha256": "0qzb6wlh2hf0kp9n74m2q6hrf4rar62dfxfh8yj1rjx2brpi1qdq"
+   "commit": "fc834dcc193e7168ffa0b3ae81ab3eefa4fd3c59",
+   "sha256": "08hnw5dbcs4ww2ir7ilnfc6r0b123alh4l8i1mzvng0h3mvmlhgq"
   },
   "stable": {
    "version": [
@@ -15182,15 +15285,15 @@
   "repo": "stan-dev/stan-mode",
   "unstable": {
    "version": [
-    20210130,
-    1325
+    20211129,
+    2051
    ],
    "deps": [
     "company",
     "stan-mode"
    ],
-   "commit": "9bb858b9f1314dcf1a5df23e39f9af522098276b",
-   "sha256": "031418nkp9qwlxda8i3ankp3lq94sv8a8ijwrbcwb4w3ssr9j3ds"
+   "commit": "150bbbe5fd3ad2b5a3dbfba9d291e66eeea1a581",
+   "sha256": "06y4gvw8g4mjyiv77rznivqphh9sayjmi9aqr9nhxlf6i19a6hqh"
   },
   "stable": {
    "version": [
@@ -15656,8 +15759,8 @@
   "repo": "necaris/conda.el",
   "unstable": {
    "version": [
-    20210818,
-    103
+    20211123,
+    357
    ],
    "deps": [
     "dash",
@@ -15665,8 +15768,8 @@
     "pythonic",
     "s"
    ],
-   "commit": "4de6eccda5ffa1a15c6f2695d93234047a127d88",
-   "sha256": "1mk8511zx429970k5l4mqjazr883mnz63hzk9h9jb17fvhv38d3i"
+   "commit": "7a34e06931515d46f9e22154762e06e66cfbc81c",
+   "sha256": "0n1w3gx7xv84nc5hz8w1ab2ml45g64jx05cwrflf5kqmx496phms"
   },
   "stable": {
    "version": [
@@ -15820,11 +15923,11 @@
   "repo": "minad/consult",
   "unstable": {
    "version": [
-    20211117,
-    855
+    20211213,
+    1713
    ],
-   "commit": "69bc425c59414ece0a49dfa8e3f2d9759a13748c",
-   "sha256": "066a3gf1hgzc4n7r06m1x3kyp98sabs8kf25dhlg9wgl2l6gccf0"
+   "commit": "cc8eff9578f5d089735e8b7dd7a08732890ed648",
+   "sha256": "17rq9l54hvchbr8z0cr8zd1w3j7sf1ykgxgclwrprrq74qs5dmps"
   },
   "stable": {
    "version": [
@@ -15920,8 +16023,8 @@
     "consult",
     "flycheck"
    ],
-   "commit": "92b259e6a8ebe6439f67d3d7ffa44b7e64b76478",
-   "sha256": "15lihfdjdp5ynmq0g8wkq8dhb2jdlvfcqbb2ap588igi5vax3glz"
+   "commit": "0ad7e8ff15683a4d64b79c29b3fcf847edfe244b",
+   "sha256": "09h9p7axy4gavzz2fn847hx2xvfxlnz4x9lpvp9arivjzn0yqrzi"
   },
   "stable": {
    "version": [
@@ -16009,27 +16112,27 @@
   "url": "https://codeberg.org/jao/consult-notmuch.git",
   "unstable": {
    "version": [
-    20211114,
-    557
+    20211210,
+    338
    ],
    "deps": [
     "consult",
     "notmuch"
    ],
-   "commit": "5e62b4da80c5361a656f459fc2fd3ec65d5d9bf1",
-   "sha256": "1krap35x6r3gfh0hk9vq7z471m21j2dyljaf5ppx85yhfanhpxp2"
+   "commit": "2fd4befde0a2664b862a0e0c4ed3ccaedfc19c00",
+   "sha256": "1snl2qi9d7mhycz3aspqh24rgd57xnykj4378whryq0590i7ca82"
   },
   "stable": {
    "version": [
     0,
-    5
+    6
    ],
    "deps": [
     "consult",
     "notmuch"
    ],
-   "commit": "f978408fb4f7bae1b2d2913d71d7a816c18b78b6",
-   "sha256": "04ha4mysxvfz6yzbkgrl1mcwic1lwr1xx6gdy5rl6hn1wwnwam4p"
+   "commit": "a5509cfd0c9f69327ab63fd18e548b7f39be16c8",
+   "sha256": "07qbm5p4cfrrwyp8a5sw0wkdhnqbappz4xjlnjil2krhj9g39q78"
   }
  },
  {
@@ -16107,15 +16210,15 @@
   "repo": "mohkale/consult-yasnippet",
   "unstable": {
    "version": [
-    20211002,
-    1849
+    20211122,
+    810
    ],
    "deps": [
     "consult",
     "yasnippet"
    ],
-   "commit": "5a053c0867a80832de04ef58a084b231aced78cf",
-   "sha256": "12xdk8z0nzb1in2zgqvlqk8dwqlg3y7jg9c26lgg174qi5h995r5"
+   "commit": "9f38ad510328e708370a3a6b41cf40e8bd031b04",
+   "sha256": "019m29j9xf49shd3qnkvxx8bb20d7xavq1y5a07k5vn9lahmzhj2"
   }
  },
  {
@@ -16215,14 +16318,14 @@
   "repo": "liuyinz/emacs-conventional-changelog",
   "unstable": {
    "version": [
-    20211103,
-    1242
+    20211212,
+    1158
    ],
    "deps": [
     "transient"
    ],
-   "commit": "9db9dcfdff2ff8cf6a88e938646cb26ce0f61774",
-   "sha256": "1qm6v88mz6bxz0yg2yw5xfiz5jjnz3i9vwaa3irnywzs6prw7pa4"
+   "commit": "40c2ee58364422b776e81dc153918205bfbeda86",
+   "sha256": "1zxs0sgrdhzlfixahss4m3a7jx2qdkaccqkg9jbyf4vsdm17im48"
   },
   "stable": {
    "version": [
@@ -16681,14 +16784,14 @@
   "repo": "redguardtoo/counsel-etags",
   "unstable": {
    "version": [
-    20211010,
-    1332
+    20211210,
+    1127
    ],
    "deps": [
     "counsel"
    ],
-   "commit": "98860e5981b07952b5c15361cdb996741e5842c5",
-   "sha256": "056zqa9rq32vrmqq7i1yi37l5ypjdk2dgcd0yl9wlcl339cdzwsq"
+   "commit": "bafd22a20c3328b0cf81aa9c35bfa37a095cf9c3",
+   "sha256": "1p651ykxbakzhwlrxcz4v62kj4f78l83f67qcghi58sq9cvwg1gi"
   },
   "stable": {
    "version": [
@@ -17075,16 +17178,16 @@
   "repo": "AdamNiederer/cov",
   "unstable": {
    "version": [
-    20211026,
-    308
+    20211203,
+    416
    ],
    "deps": [
     "elquery",
     "f",
     "s"
    ],
-   "commit": "58cf3d5fd2d71084083a293b0fc7ce947aadaf26",
-   "sha256": "0lbsc5dz810gcvpapqa0x9b0wpd9fb1sb4qj32ypfbc3ywklzd38"
+   "commit": "6c951cca9867e26df316ca5dc313ceabd22070a5",
+   "sha256": "16xf7hfyq39wc363g6lqmdcl0vidk4i9wycdws17954w9gzhahq6"
   }
  },
  {
@@ -17656,20 +17759,20 @@
   "repo": "emacs-csharp/csharp-mode",
   "unstable": {
    "version": [
-    20211115,
-    2134
+    20211124,
+    1105
    ],
-   "commit": "515b866704252fc862144d9ff677fba75488e445",
-   "sha256": "0xadchhbfikw2vac6kqkmdjjixhybxqqf99cpl089cga9sjc7i5p"
+   "commit": "856ecbc0a78ae3bdc2db2ae4d16be43e2d9d9c5e",
+   "sha256": "18s3vj4hkxdmzbch4zh943p4fbm721kmh91vdkc2fjgpilr2imk3"
   },
   "stable": {
    "version": [
     1,
     1,
-    0
+    1
    ],
-   "commit": "515b866704252fc862144d9ff677fba75488e445",
-   "sha256": "0xadchhbfikw2vac6kqkmdjjixhybxqqf99cpl089cga9sjc7i5p"
+   "commit": "9917e1b97d6a374c8043124817142ea3419a649b",
+   "sha256": "0wfd4jdjsq8qp6pavf25y87dxvlnsqapfi4c4m3xj24baalr2dpq"
   }
  },
  {
@@ -18352,17 +18455,17 @@
     20211111,
     1407
    ],
-   "commit": "2b1e743b9c736ec41e92b197eb709db0427558b4",
-   "sha256": "0x6nbir7pk8w4265qywqxjdvrrkyvkp8z066z29zljwcry1wk1ml"
+   "commit": "b2fac63f4a653bfd32eb4bba20bfb30b2ebad190",
+   "sha256": "1h20vkj3m2igb2ny7nrjphg1k0r2jqz7ijj859gb85avrv9mffdh"
   },
   "stable": {
    "version": [
     0,
     29,
-    24
+    25
    ],
-   "commit": "3a34c5fb48ee86be9d0a819fee1ff3cb3efd1a1e",
-   "sha256": "0jsbmgqxhyjsrjc2h6lw4yqjjqaiqmgz4yjg580j76q8zk9vkjyb"
+   "commit": "4c4585ce459e258b70dbff6765e841685d4e19fd",
+   "sha256": "0fg0fwklvsjdnkga314rw3v6ywq51r4fdha5yzdhgz51bnilymd5"
   }
  },
  {
@@ -18450,11 +18553,11 @@
   "repo": "cbowdon/daemons.el",
   "unstable": {
    "version": [
-    20210728,
-    1514
+    20211204,
+    1202
    ],
-   "commit": "cbab674d995022c1c223bfccf13d8009c7c4e2ba",
-   "sha256": "0h08k9g746j1kg4138am3v7lv9w6fg7yrz2hzm7x737qmg852chn"
+   "commit": "cf0ab15a26490ca82aaf6c258f1fc7da195e4fdd",
+   "sha256": "1icd6l8cpiqiyg1489dnwsqdxq3l62j7iib0c2a54wr83l7zyp7w"
   },
   "stable": {
    "version": [
@@ -18560,8 +18663,8 @@
   "repo": "emacs-lsp/dap-mode",
   "unstable": {
    "version": [
-    20211110,
-    1129
+    20211117,
+    1555
    ],
    "deps": [
     "bui",
@@ -18573,8 +18676,8 @@
     "posframe",
     "s"
    ],
-   "commit": "c19da4d347114d19fd9cd77af3650bcec7d81b15",
-   "sha256": "1pmzrb9c8z3jhwfjygdlkarc9ssaldvqx4vi48j6yg8av99p5z03"
+   "commit": "76cad34de8984f57c2b1e374e9c985cc7ec8dad0",
+   "sha256": "0q37nnxvb362pni0nralb6cpw7vvaj0kw63y8zpip8szwj9yqrki"
   },
   "stable": {
    "version": [
@@ -19311,16 +19414,16 @@
   "repo": "Wilfred/deadgrep",
   "unstable": {
    "version": [
-    20211107,
-    445
+    20211201,
+    1747
    ],
    "deps": [
     "dash",
     "s",
     "spinner"
    ],
-   "commit": "97663c41624526c4ceaf82fb6a0137ab2081affe",
-   "sha256": "1rkskf8byl5fnnlahvppawfjj7zc41sag4gwxdb2r3j77g5d5ahq"
+   "commit": "7f1a537783bdad65246cb7a510aa0ae539bdd526",
+   "sha256": "045j8jl4cdwp45qxsxlzykqh5iz3z7njl3qb9fdz9bspa659db4r"
   },
   "stable": {
    "version": [
@@ -19412,19 +19515,19 @@
   "repo": "lifelike/decide-mode",
   "unstable": {
    "version": [
-    20190201,
-    2137
+    20211127,
+    2248
    ],
-   "commit": "4bfcc826dd5b1c30caec455d8baa4f363159eac6",
-   "sha256": "07rwflgqlsgqrw2v7rbshrbcr1qkgsx59y904jspvj310s8bsczg"
+   "commit": "668fa559b95b50f140e73f26a21fad559c1ffa77",
+   "sha256": "1wbiy8lda6p888qf4ak8j02cp42h25y17xnz5bq5p032xgq731n0"
   },
   "stable": {
    "version": [
     0,
-    7
+    8
    ],
-   "commit": "90133687118c236142b8110571c463304b3192f9",
-   "sha256": "04yakjnh9c165ssmcwkkm03lnlhgfx5bnk0v3cm73kmwdmfd2q7s"
+   "commit": "668fa559b95b50f140e73f26a21fad559c1ffa77",
+   "sha256": "1wbiy8lda6p888qf4ak8j02cp42h25y17xnz5bq5p032xgq731n0"
   }
  },
  {
@@ -19968,11 +20071,11 @@
   "repo": "blahgeek/emacs-devdocs-browser",
   "unstable": {
    "version": [
-    20210815,
-    1600
+    20211212,
+    1544
    ],
-   "commit": "4d81e4db165671ba3e7326dec72f950b26df4dde",
-   "sha256": "0jfrsqvlfv1xh8ss0c9pk4b5dffrxq8i3vp08ckigbdbk31fsvmx"
+   "commit": "2d265d48d40156d4a2dd2b6b433c8d969e037c5a",
+   "sha256": "1y6akvcky85z45d9s7ll8i1v2xz4a1xy0pfg7c1qi0xs5d3xw4i1"
   }
  },
  {
@@ -20395,27 +20498,27 @@
   "repo": "DaniruKun/dilbert-el",
   "unstable": {
    "version": [
-    20211114,
-    1009
+    20211118,
+    1512
    ],
    "deps": [
     "dash",
     "enlive"
    ],
-   "commit": "bd8c11ccc512ca60906a8b0e4bca2081ba4aab7b",
-   "sha256": "110ynzqsnkv6sdnbk475h6qyrvj4w1dk577hpr1p7pk7bif4waxd"
+   "commit": "3e9a39717490be4d5c14211a47fcd8588ef668af",
+   "sha256": "0hjscamqn70b0npj69ajycd0kld98bqkcjfnsgrmk97w367719lp"
   },
   "stable": {
    "version": [
     0,
-    1
+    2
    ],
    "deps": [
     "dash",
     "enlive"
    ],
-   "commit": "e660def51721f80b7d21eeab60e9a719be5106f7",
-   "sha256": "0gim8imb9cw16sr76hydjp1rjw2cczslnh4h2gvq3jsmpk2hdvma"
+   "commit": "4d0ac315d1bf2d7965ea6a4d32a572a73315caf0",
+   "sha256": "1kvvkq050z5dhlyjcdg3b9563pgy6aphf5xmh9ph26w6a29r7i7q"
   }
  },
  {
@@ -20550,11 +20653,11 @@
   "repo": "gonewest818/dimmer.el",
   "unstable": {
    "version": [
-    20210109,
-    1932
+    20211123,
+    1536
    ],
-   "commit": "8559fb73a2c96755cb30f560be82191164014b43",
-   "sha256": "0jb5ki27yvzli3yybglhcnkhzpjxv15zy646yaafszq232j1ylnk"
+   "commit": "2f915b100044e09dd647b22085e1696249c4b115",
+   "sha256": "00y6645zjary1sz7517qy5pjwfm5ipsc46sypmdygin65hbbc8wg"
   },
   "stable": {
    "version": [
@@ -20969,11 +21072,11 @@
   "repo": "thomp/dired-launch",
   "unstable": {
    "version": [
-    20210818,
-    2257
+    20211205,
+    712
    ],
-   "commit": "d54f661c8b3477f342c6c3b3c6c9a500cde595a9",
-   "sha256": "1p7pvl8fp043cv9b0gzbrilnk0k54s7jana39xyvb1zrch99zx2s"
+   "commit": "b4a5341e22efed3c1a261b9b5098d7c429d655d1",
+   "sha256": "1i0lc6sq87yyg1xzj2qqk3rld9j0mvbl7vhlpdpk75g7nlfi2w8w"
   }
  },
  {
@@ -21565,6 +21668,24 @@
   }
  },
  {
+  "ename": "dirvish",
+  "commit": "7361fcfc439b061eb365cb4113a05b6f3de8efb6",
+  "sha256": "1l2a6d68vdsdgjsh0kl02hnxsf14k6p981w8cy9vzzz5nfw7cjwx",
+  "fetcher": "github",
+  "repo": "alexluigit/dirvish",
+  "unstable": {
+   "version": [
+    20211213,
+    610
+   ],
+   "deps": [
+    "posframe"
+   ],
+   "commit": "e92752e7ebbe527b00a104d56c68607e917eae9e",
+   "sha256": "1fvqwmibhqdl76z2rrvmjqfqj89mz67358yp0fybcpxaqmfg4nka"
+  }
+ },
+ {
   "ename": "disable-mouse",
   "commit": "dbbc396373212fdf731e135cde391f27708ff015",
   "sha256": "0c0ps39s6wg3grspvgck0cwxnas73nfaahfa87l0mmgsrsvas5m7",
@@ -21862,14 +21983,14 @@
   "repo": "unhammer/dix",
   "unstable": {
    "version": [
-    20211117,
-    954
+    20211124,
+    1227
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "9ad8b231812af17c2f7655057a8e0dece96a7d7f",
-   "sha256": "1l3js4rqwqjlk5b13fsr3nk6n3yzlnscya4jsc1j8dr19i5nbxcf"
+   "commit": "80d5ea3bceff75b842065e2f99657f3f70c7e604",
+   "sha256": "0l7ls9967km1vsmhqqrmbyykc6hx21frz5pjr8znasz5yhflbzwg"
   },
   "stable": {
    "version": [
@@ -21899,8 +22020,8 @@
     "dix",
     "evil"
    ],
-   "commit": "9ad8b231812af17c2f7655057a8e0dece96a7d7f",
-   "sha256": "1l3js4rqwqjlk5b13fsr3nk6n3yzlnscya4jsc1j8dr19i5nbxcf"
+   "commit": "80d5ea3bceff75b842065e2f99657f3f70c7e604",
+   "sha256": "0l7ls9967km1vsmhqqrmbyykc6hx21frz5pjr8znasz5yhflbzwg"
   },
   "stable": {
    "version": [
@@ -22178,6 +22299,21 @@
    ],
    "commit": "7a48393fcf0015eed2368fcb89b3091c9d029dc4",
    "sha256": "05p1mllp7vgk69078gn6hc0vx5hfqz6k81i4ghkfkxr5fdm5fdk5"
+  }
+ },
+ {
+  "ename": "doc-show-inline",
+  "commit": "4439485b5c582bc6a72789d07ca3b033c6195f3a",
+  "sha256": "1j1bwm5hfzcq683rl8k9362vlzxnddcqhmxsinwq2c9c7md8hfrv",
+  "fetcher": "gitlab",
+  "repo": "ideasman42/emacs-doc-show-inline",
+  "unstable": {
+   "version": [
+    20211210,
+    102
+   ],
+   "commit": "3a4eee3ef3fb3b50252418308f1b45e22a67bc8e",
+   "sha256": "1ihp3hva01zs5gwmjzsr62rbd5gmd7k23sjxg887vq04qmwcqcb5"
   }
  },
  {
@@ -22598,16 +22734,16 @@
   "repo": "seagle0128/doom-modeline",
   "unstable": {
    "version": [
-    20211111,
-    834
+    20211128,
+    1709
    ],
    "deps": [
     "all-the-icons",
     "dash",
     "shrink-path"
    ],
-   "commit": "36fed6d1a1614f72d425073d7c9e1529f622fe7a",
-   "sha256": "0g56jvpsz8mdjpg7rifn89p7k2iw4rl1rvj8xv5323x9hl6772dx"
+   "commit": "69ede7d719764f26671897c5020f295e5eb1e6c8",
+   "sha256": "1czl20z1sc2cfgdwhl8hly1mcbdyx41zr2swrwmzl6w3xai9lsa5"
   },
   "stable": {
    "version": [
@@ -22651,14 +22787,14 @@
   "repo": "hlissner/emacs-doom-themes",
   "unstable": {
    "version": [
-    20211114,
-    1641
+    20211212,
+    2109
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "96edc0ceb864b7d72218e58c8e9272cd96e5712c",
-   "sha256": "0qkpwlg5h3ysmf6aywz49a9gkl4xszxzdkcfpqc3n0i2bvcmf6vk"
+   "commit": "7d1a56623c08da769fd424e901916e9c3d8fdb25",
+   "sha256": "1ifwb8mw0jcif3plj6wz9ak2ankpvxfqndv6qlcr6yij7xvi9qnk"
   },
   "stable": {
    "version": [
@@ -22902,11 +23038,11 @@
   "repo": "dracula/emacs",
   "unstable": {
    "version": [
-    20211108,
-    749
+    20211206,
+    1333
    ],
-   "commit": "8c38b293af039041e8914894d86122403eec5bcf",
-   "sha256": "15h2zkrhlhhc7qkyydpbm2xdgbx3vwy1jj78rq3vycwb37v52kci"
+   "commit": "049257458288cbc2d94737e30bc0005601c9727c",
+   "sha256": "0nry6fjjlwm0n8rqwk0g6jbjzqf97hzicaq1mf438f06f7h6h2mr"
   },
   "stable": {
    "version": [
@@ -23180,11 +23316,11 @@
   "repo": "jscheid/dtrt-indent",
   "unstable": {
    "version": [
-    20210423,
-    745
+    20211121,
+    2114
    ],
-   "commit": "9714f2c5f1c9b7c21e732df8c15a870a88caba84",
-   "sha256": "1aygba84si1g8kx12hscwa6m3c3946r0vbk93p9izib9fkbgngw6"
+   "commit": "1986ad4e60f2e21f69d77ef9fb14da80a6157866",
+   "sha256": "0gn18mwz9jfb5pmsx83rhjf5vb2krv1vzsfp4nwk2bvmmv56jls7"
   },
   "stable": {
    "version": [
@@ -23203,11 +23339,11 @@
   "repo": "bgamari/dts-mode",
   "unstable": {
    "version": [
-    20161103,
-    1223
+    20211202,
+    18
    ],
-   "commit": "9ee0854446dcc6c53d2b8d2941051768dba50344",
-   "sha256": "1k8lljdbc90nd29xrhdrsscxavzdq532wq2mg7ljc94krj7538b1"
+   "commit": "32517e7eeeccc785b7c669fd5e93c5df45597ef1",
+   "sha256": "03h5qmxyxvcw92j7rhzr1l3qmspfsnbf2cn68v7r5qk7hzrixmpr"
   }
  },
  {
@@ -23314,8 +23450,8 @@
     20210909,
     1010
    ],
-   "commit": "05653b996b18032a4e80ab71827e7a15601a69d6",
-   "sha256": "1l2803hd9gr5mjzpfz21fgwcyy55zj0rdafwdmy1hcdy9g1d3cg8"
+   "commit": "f9dfb2ff556ff4d32def138dbb53b54a6187b046",
+   "sha256": "0q347dm67xds8kz9f4r7br5iszd65xbgicn75qpn2mzyidlhdqbc"
   },
   "stable": {
    "version": [
@@ -23832,11 +23968,11 @@
   "repo": "redguardtoo/eacl",
   "unstable": {
    "version": [
-    20210801,
-    843
+    20211205,
+    122
    ],
-   "commit": "e7e4be6d2590a9e433817f6ce7420d44f0095235",
-   "sha256": "14sy7abn8aq5daw7jzfjf21zrcxqni7arzgsr0ns5vr8yjc4m7y0"
+   "commit": "e68203765549c85050c26a4d37b12528c96b912a",
+   "sha256": "1hs0xjpqn1zl5pr7zc9akwr9kin7s6yjnhi7vav2x5gsgr5xdm8h"
   },
   "stable": {
    "version": [
@@ -23934,26 +24070,26 @@
   "repo": "masasam/emacs-easy-jekyll",
   "unstable": {
    "version": [
-    20201205,
-    1918
+    20211209,
+    1521
    ],
    "deps": [
     "request"
    ],
-   "commit": "b79176c6c4a8d5914e2c6e2bb53f61633ff5e023",
-   "sha256": "18ywyq9k05a16b6k1492czp19gya1y5ngqmzfqgbzdm1xl9icxxz"
+   "commit": "07e54052a141b32edb55f0a12b03248b0d5b1325",
+   "sha256": "1vfk49b0pi0wwjl64x4jbw7drhvmwblmkhskin3zmyr073a91k2r"
   },
   "stable": {
    "version": [
     2,
-    4,
+    5,
     30
    ],
    "deps": [
     "request"
    ],
-   "commit": "b79176c6c4a8d5914e2c6e2bb53f61633ff5e023",
-   "sha256": "18ywyq9k05a16b6k1492czp19gya1y5ngqmzfqgbzdm1xl9icxxz"
+   "commit": "a680696a46d3d1aaa589ee443f816808f4e12b64",
+   "sha256": "1css68pfl88ygxgdibyzcb5mwx3xp1s900w91jmqnj0hf2w5zsks"
   }
  },
  {
@@ -24080,25 +24216,25 @@
   "repo": "joostkremers/ebib",
   "unstable": {
    "version": [
-    20211112,
-    2206
+    20211212,
+    2107
    ],
    "deps": [
     "parsebib"
    ],
-   "commit": "b2f9c0a354044449a49501cc405cdb090e19dda0",
-   "sha256": "0f56rmpwj71lgqyb5gx9mnb2gz9s7bnmf7fyiwc0f541jrrgcfcl"
+   "commit": "37b9c4ec7a57ffdda53f3345cc99cf6819e94863",
+   "sha256": "1mk487k20baqjx2ysd763nrj14b2ialddpp5rvscbyiw5mll598s"
   },
   "stable": {
    "version": [
     2,
-    33
+    34
    ],
    "deps": [
     "parsebib"
    ],
-   "commit": "84c7234c4901207fa0520af96922c2b8e407ff4c",
-   "sha256": "18gvmymkpzws8s4zjcm1kijyr55dgfcq201z3w1jzhkhcs01bfsc"
+   "commit": "5d4012c1f1d47d2ab03e2280ad2b600ff40ce545",
+   "sha256": "0al846i1dn5wrx3r0ak63m80g9j9xk2q5cpcpk63lq0l0gfdff2m"
   }
  },
  {
@@ -24461,11 +24597,11 @@
   "repo": "Fanael/edit-indirect",
   "unstable": {
    "version": [
-    20200805,
-    1840
+    20211201,
+    1541
    ],
-   "commit": "bdc8f542fe8430ba55f9a24a7910639d4c434422",
-   "sha256": "189nvmlkki1jfszm9i0crbb1p4nzgmbly0wpvpg0i8vmw7vrpl40"
+   "commit": "7fffd87ac3b027d10a26e8492629da01a4cd7633",
+   "sha256": "18pbxl68bw33kr9vb1f7d9gra4wlndykv6vn7mj2h7d92p9pjcig"
   },
   "stable": {
    "version": [
@@ -24725,8 +24861,8 @@
  },
  {
   "ename": "edts",
-  "commit": "92b0d3a2af833e0f11e6a935d54eba5e3879d690",
-  "sha256": "1363k9fh1z7r6hxccsqx2a1d688kldr4h6vp91hwph7ihk4868il",
+  "commit": "2932e874ab3adbb022fa4793ea18376c34c9405e",
+  "sha256": "1gas7y5f94y1b5z9dgl8wpv1q8sf5341hlynmvpskmg0g1y1yy4s",
   "fetcher": "github",
   "repo": "sebastiw/edts",
   "unstable": {
@@ -24788,19 +24924,19 @@
   "repo": "suntsov/efar",
   "unstable": {
    "version": [
-    20211019,
-    1512
+    20211122,
+    1943
    ],
-   "commit": "ff82fa01dd350d662cdef1fbf3db57425abc3649",
-   "sha256": "0zavb6xwdnysbbfs6k0cs9xdqaw87kmp97wrdsf1d8k5xam6l36v"
+   "commit": "49dc9b89a8b9bf2523c202ac8830d1245768f3f4",
+   "sha256": "18pxs3mml90hd97fdhpgxyww4vjcj7jjiz0xzlzj0fd83pxxjr3n"
   },
   "stable": {
    "version": [
     1,
-    23
+    29
    ],
-   "commit": "a9ff16e8994f525086e72d1e6a827e5fe90d1326",
-   "sha256": "0wv351ajzdy1srsbfmg33az2fdns96zc1jxygxfyzja0y2r9q065"
+   "commit": "ee10a6770b0523f25152fbe8fc3409fdb5f70544",
+   "sha256": "0lisiyg7ngvf6jg3715ds9v5557kmsdjgii3fk9vdnpxvn18xrw7"
   }
  },
  {
@@ -25009,6 +25145,25 @@
   }
  },
  {
+  "ename": "eglot-java",
+  "commit": "e75a21c91d8aa1a07ba274b56fe8cf96119f22a4",
+  "sha256": "189kf8dmhwwia89dkzmdhclcywi026hn5rgz4r2lggyjwyviibnv",
+  "fetcher": "github",
+  "repo": "yveszoundi/eglot-java",
+  "unstable": {
+   "version": [
+    20211213,
+    1014
+   ],
+   "deps": [
+    "eglot",
+    "jsonrpc"
+   ],
+   "commit": "66b9615ab021d26d92de34e5131cee44f8e58886",
+   "sha256": "0lfifd43fz09avwgy6gs7j06s2xxlll6vkrbfbb9gl4r6q17786y"
+  }
+ },
+ {
   "ename": "eglot-jl",
   "commit": "5f04bf5d68dc12aa3f3fd66591d45cc894e59df6",
   "sha256": "0ffbxzhx1fqgqlfk8gqdgyfsc98rqw7mbrdd99qx9gds1pzzx4r8",
@@ -25016,28 +25171,28 @@
   "repo": "non-Jedi/eglot-jl",
   "unstable": {
    "version": [
-    20210415,
-    1207
+    20211208,
+    359
    ],
    "deps": [
     "eglot",
     "julia-mode"
    ],
-   "commit": "49f170e01c5a107c2cb662c00544d827eaa2c4d8",
-   "sha256": "1bmp517zfsspxlj0k67q15ladiphjha45zgnq3djs631mvr9bfaw"
+   "commit": "2e35cf9768d97a0429a72deddbe30d6d7722d454",
+   "sha256": "15d4pym6dv08jp6iki00xpf1i4vc92yd2rcjv21k64h6fc862gps"
   },
   "stable": {
    "version": [
     2,
     1,
-    1
+    2
    ],
    "deps": [
     "eglot",
     "julia-mode"
    ],
-   "commit": "49f170e01c5a107c2cb662c00544d827eaa2c4d8",
-   "sha256": "1bmp517zfsspxlj0k67q15ladiphjha45zgnq3djs631mvr9bfaw"
+   "commit": "2e35cf9768d97a0429a72deddbe30d6d7722d454",
+   "sha256": "15d4pym6dv08jp6iki00xpf1i4vc92yd2rcjv21k64h6fc862gps"
   }
  },
  {
@@ -25070,11 +25225,11 @@
   "url": "https://forge.chapril.org/hjuvi/eide.git",
   "unstable": {
    "version": [
-    20211027,
-    617
+    20211210,
+    2050
    ],
-   "commit": "5bb04501a7f5bb3f5be33b8b96742f1ac9839a8d",
-   "sha256": "0w3xc2yhdrhcb5fjy1h877y14k1iidcqc548qnxjyzal8l0z5nw1"
+   "commit": "3a36db2bf007cc5afeead407492add1e2d2a51c7",
+   "sha256": "0gsai42nv3cgpa1lz11pbrcms9rlbpb1a30vwx1syqyi22rkcdns"
   },
   "stable": {
    "version": [
@@ -25178,8 +25333,8 @@
   "repo": "kostafey/ejc-sql",
   "unstable": {
    "version": [
-    20201129,
-    2043
+    20211119,
+    1910
    ],
    "deps": [
     "clomacs",
@@ -25187,8 +25342,8 @@
     "direx",
     "spinner"
    ],
-   "commit": "c24519e5b7fc1051257b0ec67fc6dec84d6b996e",
-   "sha256": "1qsps36cxvd8vpssr7xjydgmgq8zslck0j77920xm27wvfyrj2a2"
+   "commit": "b8d534cec8f75dc95961dca72e39a096c5eea980",
+   "sha256": "0xl6mb1s70ljb5wkd41qrjvr0gdnds4yli2y3mmrcvry0cp3kp0f"
   },
   "stable": {
    "version": [
@@ -25384,11 +25539,11 @@
   "repo": "raxod502/el-patch",
   "unstable": {
    "version": [
-    20210411,
-    1954
+    20211121,
+    1808
    ],
-   "commit": "14c35cee52b415fe9892440014c4b8dc045103df",
-   "sha256": "1v4wbfrr09n08lf8l72jmmg2ckhybagcyvk9jrsfarl0d9mxgd7v"
+   "commit": "93c414f9a93035a8467aff53b43eded2edfb4a3e",
+   "sha256": "13v59nx2a6iwbvr8pk2ka47vwgpw5rmcfil9k4vjdmf892hnxr76"
   },
   "stable": {
    "version": [
@@ -25398,6 +25553,102 @@
    ],
    "commit": "ff1951d776f80d2fd4a0cd9a0c930182fbb57b3c",
    "sha256": "1f783xapqa6zigg0gqayxsf8lfkldng8r4ns9x04rqg9vmhkxmk0"
+  }
+ },
+ {
+  "ename": "el-secretario",
+  "commit": "be7e856c1d1f14de6636a7c9b6818faca72e66c8",
+  "sha256": "10z41n06szwkfhy54w56581y86hg5zh8yn3k21j7bmgnmwliyzw8",
+  "fetcher": "git",
+  "url": "https://git.sr.ht/~zetagon/el-secretario",
+  "unstable": {
+   "version": [
+    20211208,
+    1038
+   ],
+   "deps": [
+    "hercules",
+    "org-ql"
+   ],
+   "commit": "915b98b901b3ea50416461dea624537ae8796847",
+   "sha256": "0bnkacmznbyj0q26br3vdvg43jmsczsksv61mp864q7l77vixgg4"
+  }
+ },
+ {
+  "ename": "el-secretario-elfeed",
+  "commit": "a4acda1c2e5b717e6678b88be4bb9b326f70cfe7",
+  "sha256": "1v42p3ryiwq1vv87cdss3czmccn825zqnn1yyrj7cbkpwi31qxyv",
+  "fetcher": "git",
+  "url": "https://git.sr.ht/~zetagon/el-secretario",
+  "unstable": {
+   "version": [
+    20211205,
+    1916
+   ],
+   "deps": [
+    "el-secretario",
+    "elfeed"
+   ],
+   "commit": "915b98b901b3ea50416461dea624537ae8796847",
+   "sha256": "0bnkacmznbyj0q26br3vdvg43jmsczsksv61mp864q7l77vixgg4"
+  }
+ },
+ {
+  "ename": "el-secretario-mu4e",
+  "commit": "a4acda1c2e5b717e6678b88be4bb9b326f70cfe7",
+  "sha256": "053nwvna3v57lbj6lqqijgyk81yxhk73pjjyhp9k9k7lbj7pmdpi",
+  "fetcher": "git",
+  "url": "https://git.sr.ht/~zetagon/el-secretario",
+  "unstable": {
+   "version": [
+    20211205,
+    1916
+   ],
+   "deps": [
+    "el-secretario",
+    "org-ql"
+   ],
+   "commit": "915b98b901b3ea50416461dea624537ae8796847",
+   "sha256": "0bnkacmznbyj0q26br3vdvg43jmsczsksv61mp864q7l77vixgg4"
+  }
+ },
+ {
+  "ename": "el-secretario-notmuch",
+  "commit": "a4acda1c2e5b717e6678b88be4bb9b326f70cfe7",
+  "sha256": "0cqia5445pyssgb4vadnc2mbjz6bb2gbgmizlg3mk3vli18nr58p",
+  "fetcher": "git",
+  "url": "https://git.sr.ht/~zetagon/el-secretario",
+  "unstable": {
+   "version": [
+    20211205,
+    1916
+   ],
+   "deps": [
+    "el-secretario",
+    "notmuch"
+   ],
+   "commit": "915b98b901b3ea50416461dea624537ae8796847",
+   "sha256": "0bnkacmznbyj0q26br3vdvg43jmsczsksv61mp864q7l77vixgg4"
+  }
+ },
+ {
+  "ename": "el-secretario-org",
+  "commit": "a4acda1c2e5b717e6678b88be4bb9b326f70cfe7",
+  "sha256": "059kd0svm0i1h7vapfc9ymggf5m6pdgs6sbbqxmzknx60xcz1g16",
+  "fetcher": "git",
+  "url": "https://git.sr.ht/~zetagon/el-secretario",
+  "unstable": {
+   "version": [
+    20211212,
+    1409
+   ],
+   "deps": [
+    "dash",
+    "el-secretario",
+    "org-ql"
+   ],
+   "commit": "915b98b901b3ea50416461dea624537ae8796847",
+   "sha256": "0bnkacmznbyj0q26br3vdvg43jmsczsksv61mp864q7l77vixgg4"
   }
  },
  {
@@ -25620,19 +25871,20 @@
   "repo": "doublep/eldev",
   "unstable": {
    "version": [
-    20211113,
-    1804
+    20211213,
+    1900
    ],
-   "commit": "70aa39c6c6ed696b7f1505c1c9bf4b2556179a27",
-   "sha256": "01y3jyjisxngaj0wyib5s37839m7q4azkchaa381mwx0l5nv5k5d"
+   "commit": "182170f076ccd90f601df8af5e8dcf75c5703743",
+   "sha256": "16wlgxldarj5ky1cyzs2lfry8hr2hfchfx1rgb9jal0bk7jxp5bi"
   },
   "stable": {
    "version": [
     0,
-    10
+    10,
+    3
    ],
-   "commit": "012f5ae33166987b4a541b0df2d39e3770ade228",
-   "sha256": "1y1gc37vn8k1yhp6b069sg8hdh1bn22icdqn4b28c2k5iiw9g7gi"
+   "commit": "f111d19cda305e5e8fcb70a5675b87173041cb68",
+   "sha256": "1y8vz5grmlhln37lf93a3gxwh46ar0v3jj2dcvzkb36lqf1snq73"
   }
  },
  {
@@ -25724,14 +25976,14 @@
   "repo": "stan-dev/stan-mode",
   "unstable": {
    "version": [
-    20210130,
-    1325
+    20211129,
+    2051
    ],
    "deps": [
     "stan-mode"
    ],
-   "commit": "9bb858b9f1314dcf1a5df23e39f9af522098276b",
-   "sha256": "031418nkp9qwlxda8i3ankp3lq94sv8a8ijwrbcwb4w3ssr9j3ds"
+   "commit": "150bbbe5fd3ad2b5a3dbfba9d291e66eeea1a581",
+   "sha256": "06y4gvw8g4mjyiv77rznivqphh9sayjmi9aqr9nhxlf6i19a6hqh"
   },
   "stable": {
    "version": [
@@ -26089,26 +26341,26 @@
   "repo": "sp1ff/elfeed-score",
   "unstable": {
    "version": [
-    20211008,
-    2330
+    20211123,
+    1505
    ],
    "deps": [
     "elfeed"
    ],
-   "commit": "973b337d7104a7adb519b7b74a91fc21f8757731",
-   "sha256": "16a0whgx47irgp3p17xwdwfiaylrv85f26dynh5ba2sy7l0d0irq"
+   "commit": "dc9901aabf6f6659beef1c876bd3c9cc4c7d17b6",
+   "sha256": "10wsjq2zd6kz9182gnkjzlzywx16j29dgm1gzwynr79xmvgs4r2b"
   },
   "stable": {
    "version": [
     1,
-    1,
-    0
+    2,
+    1
    ],
    "deps": [
     "elfeed"
    ],
-   "commit": "d97c813d472b68c977569b14761c242cb33345e1",
-   "sha256": "1drgv16555cyn7w6g44z23yhi1i0cy1b9h1ri3lz6h814px0wj0z"
+   "commit": "dc9901aabf6f6659beef1c876bd3c9cc4c7d17b6",
+   "sha256": "10wsjq2zd6kz9182gnkjzlzywx16j29dgm1gzwynr79xmvgs4r2b"
   }
  },
  {
@@ -26766,20 +27018,20 @@
   "repo": "dochang/elpa-clone",
   "unstable": {
    "version": [
-    20210916,
-    655
+    20211205,
+    1237
    ],
-   "commit": "2549b14e8688e9ee866e0ec9f1b6d9cbc97f462c",
-   "sha256": "1rjc64j7a786xna8xcfp1kxvx1y0jfqxajicbbyvcnhd17g6a7z9"
+   "commit": "03d8e2af55dfb34ab9da1f9385079a995383b2ea",
+   "sha256": "19rlqr4w9hkxxwwyfz02vvs96dx92c1gxy5cn1m1v2a5sdfdz1yq"
   },
   "stable": {
    "version": [
     0,
-    1,
-    1
+    2,
+    0
    ],
-   "commit": "2549b14e8688e9ee866e0ec9f1b6d9cbc97f462c",
-   "sha256": "1rjc64j7a786xna8xcfp1kxvx1y0jfqxajicbbyvcnhd17g6a7z9"
+   "commit": "03d8e2af55dfb34ab9da1f9385079a995383b2ea",
+   "sha256": "19rlqr4w9hkxxwwyfz02vvs96dx92c1gxy5cn1m1v2a5sdfdz1yq"
   }
  },
  {
@@ -26811,8 +27063,8 @@
     20210614,
     302
    ],
-   "commit": "18209f7f4602e48204992e38c5d265eb1a68320a",
-   "sha256": "0507bydbplh515jm1y8w9fpv3mljxkj797ssackadx484n3v0yvv"
+   "commit": "a3e5b974ca9a7004ed6cf72f9d831ba525432c67",
+   "sha256": "19hmvrck77pxxm2pq6a6hfdk2azl6nlhffwyzymr80rqcpx0hysx"
   },
   "stable": {
    "version": [
@@ -26835,8 +27087,8 @@
     20211008,
     1217
    ],
-   "commit": "81e107a26924747c10c671882032d341ca6d77c4",
-   "sha256": "1psvfqk71bi9p5mq99r2ihpk4h80sb7p8398fg2zb33a3j3g52b7"
+   "commit": "79336f8191caa394710722799e6b764493e80a52",
+   "sha256": "16cnk4zp67ld0xaa70qbnsq168xpck0drn3f8jndqgs93nag0r1r"
   },
   "stable": {
    "version": [
@@ -26871,8 +27123,8 @@
   "repo": "jorgenschaefer/elpy",
   "unstable": {
    "version": [
-    20210630,
-    2317
+    20211211,
+    2248
    ],
    "deps": [
     "company",
@@ -26881,8 +27133,8 @@
     "s",
     "yasnippet"
    ],
-   "commit": "8d0de310d41ebf06b22321a8534546447456870c",
-   "sha256": "0hg6yk0wkfh2rwcc4h0bb6m2p3dg62ja22mjpa94khq52lv1piwf"
+   "commit": "9e4382fe99fa922a23a25320bad5df268026e78c",
+   "sha256": "0dlii04byyqr48mnvs3wh8np2zx5r30rhhpbind0z64ahq10a1zh"
   },
   "stable": {
    "version": [
@@ -26946,8 +27198,8 @@
   "repo": "emacs-elsa/Elsa",
   "unstable": {
    "version": [
-    20211101,
-    1023
+    20211129,
+    38
    ],
    "deps": [
     "cl-lib",
@@ -26955,8 +27207,8 @@
     "f",
     "trinary"
    ],
-   "commit": "22bb5bd15e3f4fc2a9f10b998626fec18fd3a1a0",
-   "sha256": "1cccxhni2xk5zc0rf807himgdh8aj0m247q0y1xngc9amjms9hqj"
+   "commit": "5b8848fd7d87ee4927adda12a6cf5ed2a7e0c186",
+   "sha256": "08h86wpgr71xbxpqgbv2jikyzfh1fm33kfb6nxir001inzj0h7aq"
   }
  },
  {
@@ -27539,11 +27791,11 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20211116,
-    2111
+    20211213,
+    1517
    ],
-   "commit": "edfd0a842a75ad25115f95f56b0c8a9351d3e248",
-   "sha256": "1mq84aiak2fwxbxacf9wzk223dri6z918vqdgs3vy0amvn1ys2ji"
+   "commit": "54e5efae17a5c2898faabeaca9564a4d5f05761f",
+   "sha256": "0vpjszfqvkjzkjpma47rdyjzgkqdfg7palyzlii62wsrh04frg4l"
   },
   "stable": {
    "version": [
@@ -27562,15 +27814,15 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20211116,
-    2111
+    20211213,
+    1625
    ],
    "deps": [
     "consult",
     "embark"
    ],
-   "commit": "edfd0a842a75ad25115f95f56b0c8a9351d3e248",
-   "sha256": "1mq84aiak2fwxbxacf9wzk223dri6z918vqdgs3vy0amvn1ys2ji"
+   "commit": "54e5efae17a5c2898faabeaca9564a4d5f05761f",
+   "sha256": "0vpjszfqvkjzkjpma47rdyjzgkqdfg7palyzlii62wsrh04frg4l"
   },
   "stable": {
    "version": [
@@ -27737,16 +27989,16 @@
   "url": "https://git.savannah.gnu.org/git/emms.git",
   "unstable": {
    "version": [
-    20211101,
-    1746
+    20211211,
+    232
    ],
    "deps": [
     "cl-lib",
     "nadvice",
     "seq"
    ],
-   "commit": "777c904c9d6c8dfff3ed21c5e4a24a6432f8ee52",
-   "sha256": "0kg312x6ka4nxpbwsfyhg8n4a2yqi0wcfxgbj17sfcs9d3ssijs8"
+   "commit": "32ff8a70ca9726dd0e3b8ad68430bc6fd66bf387",
+   "sha256": "127xvjsqqk1a5m5qf06ksr3y378fm5h2vyckvm38y3mgrx1kvxx0"
   },
   "stable": {
    "version": [
@@ -28134,8 +28386,8 @@
   "repo": "Wilfred/emacs-refactor",
   "unstable": {
    "version": [
-    20210301,
-    213
+    20211211,
+    500
    ],
    "deps": [
     "cl-lib",
@@ -28148,8 +28400,8 @@
     "projectile",
     "s"
    ],
-   "commit": "648c2e87516fac37b84fd9bc34a6362d2a9001e2",
-   "sha256": "1crgj5skqckvw1l445ywkdq23bqkj6b6yf5y3pcyay1aasvjbhmb"
+   "commit": "64b7fb7b8dea85865db01e471414c1b2a636d5d3",
+   "sha256": "1bi5x7iald8q4p1fjgfikizxx4aryc4q8rjpmbkg247vrsxd7ljx"
   },
   "stable": {
    "version": [
@@ -28488,14 +28740,14 @@
   "repo": "emacscollective/epkg",
   "unstable": {
    "version": [
-    20211017,
-    2000
+    20211119,
+    21
    ],
    "deps": [
     "closql"
    ],
-   "commit": "8fa633c278241df577200c6c94102a0fa07bf8a5",
-   "sha256": "0h3f3xa5chm3vcahk97fx87l468d33myvpyd9blq26a7js568y7q"
+   "commit": "eac43b29286e05192cbeada4cad09774493e0ab7",
+   "sha256": "0j9kp7ar6zccqhaihqphfxxkrvw63ipayy3dp876l9cr1ywxnv8f"
   },
   "stable": {
    "version": [
@@ -29142,17 +29394,18 @@
     20200914,
     644
    ],
-   "commit": "6cb77e1a216098d6a4e273f6750dbf4445953272",
-   "sha256": "1rj04f9q7fn88ifznqqi3p7anv0m827mz2w2bwb4s09kdn03nf6p"
+   "commit": "756ac774b5191b252bf993b67c7ccd5648cbbb65",
+   "sha256": "174vd5dw7wz2kf08mcaakr0r0qx64bigkdhr9zg7c68xj0w0kasn"
   },
   "stable": {
    "version": [
     2,
     6,
-    2
+    2,
+    1
    ],
-   "commit": "246a229faea2ef2fa53caf491ff8a2d72dd7510c",
-   "sha256": "1ccmryw6vs8d87d5zmjl0kr2kvyd1zxl73344fa7yzqgg2kw1da6"
+   "commit": "59c7944b1a2e8015e473eb1932353818614a1e5b",
+   "sha256": "0p6jh8hyyf7xg0sni2rchck2fd1wyr5v106dfxxm09krxxawh0nh"
   }
  },
  {
@@ -29163,20 +29416,20 @@
   "repo": "erlang/otp",
   "unstable": {
    "version": [
-    20211112,
-    1232
+    20211213,
+    1046
    ],
-   "commit": "abe8285f0b4c594d610f72df6890f6851b89f248",
-   "sha256": "1fw0chd6qmv1m06762l3lhbmd23l34g0dyvri7ql3bam0z9jjakq"
+   "commit": "9b07aedd669c2cb1e12e8a9b4f06210d0892041e",
+   "sha256": "0jnxrj17s37mgjmv6smjpfd4qzlql6his4k5f6xpmxabv7kx6lgf"
   },
   "stable": {
    "version": [
     24,
     1,
-    5
+    7
    ],
-   "commit": "9e23eca89170fcdf22441ed65f05ef891096f318",
-   "sha256": "1gd5nac4d56wp5qqkaicdcjf3n63wbbqg4m08s26gxfbjqkfh8ri"
+   "commit": "5d0fa9d31812947479eb29f797990da6655d4fa2",
+   "sha256": "1d86yczbb2dndkjcbzc6lcq8aq6gdibh6pkxrg76n07xr5adk2j7"
   }
  },
  {
@@ -29698,15 +29951,15 @@
   "repo": "Phundrak/eshell-info-banner.el",
   "unstable": {
    "version": [
-    20211115,
-    914
+    20211119,
+    1806
    ],
    "deps": [
     "f",
     "s"
    ],
-   "commit": "312f1e3da3f42a82b99228491427a429ee379648",
-   "sha256": "07xwph4mnmyd80apn6r1m8alxh2vy1d0y1jacb0ghqjbs01qg47q"
+   "commit": "9b75d1945170fdf89ad24db8d150bfb6e08ea56a",
+   "sha256": "0ysj2hdnsf6j7ywz140k94q2sqhh567ipf2ccd5qrj90n6f5crrp"
   }
  },
  {
@@ -29943,10 +30196,10 @@
  },
  {
   "ename": "espotify",
-  "commit": "fb515b013942cf5ef4590e7cbc17f11f10c7692f",
-  "sha256": "05kl2l272gafzp4c79f9fg63xc0rc9r5cjz32v7dhd2m0dv257vc",
+  "commit": "76e7a6c9e67bcea5b681dacf6725f7e313f0c1a8",
+  "sha256": "0fxqc20rcvk632jhlyn9692km7bh3njhp423q9s00wk2hwv2gwas",
   "fetcher": "git",
-  "url": "https://codeberg.org/jao/espotify",
+  "url": "https://codeberg.org/jao/espotify.git",
   "unstable": {
    "version": [
     20211114,
@@ -30065,11 +30318,11 @@
   "repo": "emacs-ess/ESS",
   "unstable": {
    "version": [
-    20211113,
-    1429
+    20211204,
+    958
    ],
-   "commit": "aaa82f24c9f44fd7e39b7d918a7819eefbbb40a7",
-   "sha256": "0hxa8mm2i8xr98yw9b93m8fv3xmfb3kmydgkzai0svpi6wwn9kw2"
+   "commit": "5e6bfa14a328095833a038275105f3aa31715a17",
+   "sha256": "0djlhrjrrkwnlw77aip4bj7jx3fg2cfzbap4z09vhnf77asrz6j2"
   },
   "stable": {
    "version": [
@@ -30125,14 +30378,14 @@
   "repo": "ShuguangSun/ess-r-insert-obj",
   "unstable": {
    "version": [
-    20200916,
-    843
+    20211209,
+    812
    ],
    "deps": [
     "ess"
    ],
-   "commit": "f6731eb26dc0fc5b7ca1fa881a5f9100f8fcf494",
-   "sha256": "0pvjk5a5v03qnasqsja30bywb4c481x9agf1rfcwbqsva7p97wiy"
+   "commit": "dd367cb918c90ec6d3824da869f7a75bb1ca49b6",
+   "sha256": "17vrs3wz3gpjvnq8i5gz14jnsds8s359ynx73wwh0ydcrx79f9dh"
   },
   "stable": {
    "version": [
@@ -30233,15 +30486,15 @@
   "repo": "ShuguangSun/ess-view-data",
   "unstable": {
    "version": [
-    20211103,
-    1525
+    20211206,
+    916
    ],
    "deps": [
     "csv-mode",
     "ess"
    ],
-   "commit": "060ea424d7781d652ae385a48384848b6ded0105",
-   "sha256": "1nwdf2i47j1m1vhy8ng02xbrmr15gm97fmnd5z4yb29gj2kb69fv"
+   "commit": "05888711212f9a9d72ecd48904de0c66adf6575a",
+   "sha256": "1nm1vzjby8ind8pvqzyy5yjcf0la72azjf55pwr46rzrjgia0s1a"
   },
   "stable": {
    "version": [
@@ -30295,15 +30548,15 @@
   "repo": "tali713/esxml",
   "unstable": {
    "version": [
-    20210722,
-    1345
+    20211122,
+    1657
    ],
    "deps": [
     "cl-lib",
     "kv"
    ],
-   "commit": "701ccc285f3748d94c12f85636fecaa88858c178",
-   "sha256": "1ig5i3h5ldsdmxas4nvxrdbdmawgpa10kwq3mmzczp5qwp5a3vq8"
+   "commit": "f88a323bd15ad7bd94eda684e1a36525ba81a089",
+   "sha256": "1sx8mjk0pfbl664brfwmswn6q1z0iyz23d1457z1imh98b1g91xy"
   },
   "stable": {
    "version": [
@@ -30471,8 +30724,8 @@
   "repo": "zzkt/ethermacs",
   "unstable": {
    "version": [
-    20210401,
-    1213
+    20211128,
+    106
    ],
    "deps": [
     "0xc",
@@ -30481,8 +30734,8 @@
     "request",
     "websocket"
    ],
-   "commit": "fc7de212b34c34d93f5f0f19af846924404e38ae",
-   "sha256": "0a8d66na4c02mdvkcbldac44hhzsv18imz04yqqp8qn4cdamfi4g"
+   "commit": "1fae6a03084e0794e09ac036838b53aaae1dbd63",
+   "sha256": "0aqws67s6c0m6sgqh9i17lpky6wbdyl3fnd3jrk6rwaiyckb1nrc"
   }
  },
  {
@@ -30660,15 +30913,15 @@
   "repo": "emacs-evil/evil",
   "unstable": {
    "version": [
-    20211116,
-    2102
+    20211211,
+    1737
    ],
    "deps": [
     "cl-lib",
     "goto-chg"
    ],
-   "commit": "c28e42126c4ae349e2d77c80b38feb68bc1b5b78",
-   "sha256": "00z3gmcn12nb32nczplxb68kfmmdrv0fg6f376ip6iwygjgn4cqc"
+   "commit": "b00018bf550fbbe1b55165579e6ede973d70f53b",
+   "sha256": "1qw33vhiiia14rzwzmvsp2w4vyrf1z6v3b8vgkcmlxyhns22g26f"
   },
   "stable": {
    "version": [
@@ -30812,15 +31065,15 @@
   "repo": "wbolster/emacs-evil-colemak-basics",
   "unstable": {
    "version": [
-    20211022,
-    1248
+    20211125,
+    2021
    ],
    "deps": [
     "evil",
     "evil-snipe"
    ],
-   "commit": "f9fbb49c48b3347d97fd2e19d7499bfee0ac5ad9",
-   "sha256": "0w40qfwjjmvzkxi8p09s9g266ggvxcw7jhg7j70fz24hq6plmc2r"
+   "commit": "ddea4486de929c399745713a6e616df50b22dedd",
+   "sha256": "1ld9iv6ysk28ps6gx6jgrqyazyqk1xd17a4fhf94m2hy7jzakwaj"
   },
   "stable": {
    "version": [
@@ -30862,15 +31115,15 @@
   "repo": "emacs-evil/evil-collection",
   "unstable": {
    "version": [
-    20211114,
-    702
+    20211208,
+    2219
    ],
    "deps": [
     "annalist",
     "evil"
    ],
-   "commit": "652d74acfb5789eacef36660c4ffc68905c8d741",
-   "sha256": "0pqm6pp6h8v5jy36cgm70kkjjgj38xdyq0irhnyqmaf5hdvrbvkh"
+   "commit": "1b9d5c5d939b6eae13b6e545e53faee958af460a",
+   "sha256": "03i3lv9h61jnnzfjasxszwrkcf0bkkyq65lh22852n35yg7ylxyc"
   },
   "stable": {
    "version": [
@@ -31434,8 +31687,8 @@
    "deps": [
     "evil"
    ],
-   "commit": "9b228b097a863e9deef8033b11747597e055674b",
-   "sha256": "0cxv1bmbnir59k778dip5mkjyqhbh10pk9b4ayvwpgiz25dlp4ss"
+   "commit": "f9faa0b9bf36888d83143db226938344dfc1801f",
+   "sha256": "03jrkzjamh8xxs3h8ga7i3jrv3rhcq0mwysrirqqvxz283hwk9mv"
   },
   "stable": {
    "version": [
@@ -31529,30 +31782,30 @@
   "repo": "hlissner/evil-multiedit",
   "unstable": {
    "version": [
-    20211114,
-    1644
+    20211121,
+    1650
    ],
    "deps": [
     "cl-lib",
     "evil",
     "iedit"
    ],
-   "commit": "e17078ff801c3cfc125bbe432a5fa24bd2958b67",
-   "sha256": "0x4fdjfvpx2nbca7jr1y0gjipg4rwf6cjmzf91j46vzslcvhqv4n"
+   "commit": "23b53bc8743fb82a8854ba907b1d277374c93a79",
+   "sha256": "08ycwss58zh2zikk79jfj074q78yjcd7vbjgv5ssqvws09x5rgfq"
   },
   "stable": {
    "version": [
     1,
-    3,
-    9
+    4,
+    3
    ],
    "deps": [
     "cl-lib",
     "evil",
     "iedit"
    ],
-   "commit": "cb35914ffabb4f65d22ab2f812ff6e7622cc5c26",
-   "sha256": "19h3kqylqzbjv4297wkzzxdmn9yxbg6z4ga4ssrqri90xs7m3rw3"
+   "commit": "23b53bc8743fb82a8854ba907b1d277374c93a79",
+   "sha256": "08ycwss58zh2zikk79jfj074q78yjcd7vbjgv5ssqvws09x5rgfq"
   }
  },
  {
@@ -31660,14 +31913,14 @@
   "repo": "Somelauw/evil-org-mode",
   "unstable": {
    "version": [
-    20211112,
-    108
+    20211117,
+    2046
    ],
    "deps": [
     "evil"
    ],
-   "commit": "c3ec94bc2fb79127826ea85509247f082bc394aa",
-   "sha256": "15fvw5zq97q18nr5vshkf4qp9di0sb8fklyhgwmhyh254zfdlghf"
+   "commit": "26ad08b5f629370f57690315102140878891ef61",
+   "sha256": "0i36pc7kb5ysk8hm1ll6dq5y6xpl19nm3ap64gzi3b3p94wn6jl0"
   },
   "stable": {
    "version": [
@@ -32188,8 +32441,8 @@
    "deps": [
     "evil"
    ],
-   "commit": "c28e42126c4ae349e2d77c80b38feb68bc1b5b78",
-   "sha256": "00z3gmcn12nb32nczplxb68kfmmdrv0fg6f376ip6iwygjgn4cqc"
+   "commit": "b00018bf550fbbe1b55165579e6ede973d70f53b",
+   "sha256": "1qw33vhiiia14rzwzmvsp2w4vyrf1z6v3b8vgkcmlxyhns22g26f"
   },
   "stable": {
    "version": [
@@ -32212,15 +32465,15 @@
   "repo": "iyefrat/evil-tex",
   "unstable": {
    "version": [
-    20210731,
-    927
+    20211208,
+    1631
    ],
    "deps": [
     "auctex",
     "evil"
    ],
-   "commit": "aa0ddf8e768a24cda6d50d07f04c8e7813a2dccd",
-   "sha256": "1n4xg1c2ia1k6vf3rybzx6afsdq47i8jf57x94fkwfm9wvnf9g4r"
+   "commit": "a4b8a4769efb4cf38d91f51145b275f64bdd832e",
+   "sha256": "00mrxmf6s3fss6jb0aic09vk2sk6zpy367nzy8i4r4s7zlnv4wsh"
   },
   "stable": {
    "version": [
@@ -32391,15 +32644,15 @@
   "repo": "meain/evil-textobj-tree-sitter",
   "unstable": {
    "version": [
-    20211105,
-    1632
+    20211210,
+    1354
    ],
    "deps": [
     "evil",
     "tree-sitter"
    ],
-   "commit": "b35565ab6c8e380227048256885bb7aa7e7fd72c",
-   "sha256": "17rbxqvrq9c8j34mycbjkzrd6cjpamldj6h8k1hyzm2ld97w6gqm"
+   "commit": "31b6b20f5dae9edd2f733b347b4f7a0d0a5cb962",
+   "sha256": "108gp9iq7mrmdim0xm845g90f8n9kws4d70ad2gjwl9dcamgjxnz"
   }
  },
  {
@@ -32428,8 +32681,8 @@
   "repo": "ethan-leba/tree-edit",
   "unstable": {
    "version": [
-    20211114,
-    2308
+    20211211,
+    2301
    ],
    "deps": [
     "avy",
@@ -32438,8 +32691,8 @@
     "tree-edit",
     "tree-sitter"
    ],
-   "commit": "6fd445dbeb158d05d785965077cc594aeeb73a61",
-   "sha256": "0h1zjdqxynxxlqdc9yxhmkjwarx4vn9anasv9i68fcmmnq7c0aw9"
+   "commit": "1a670b73cd990af3b08633b01f84b57edaeb92ba",
+   "sha256": "1sr8h96rzghxbs42rzv0c2abhrydjsxf98hijnffa7yqd8gffjdr"
   }
  },
  {
@@ -32962,6 +33215,24 @@
   }
  },
  {
+  "ename": "expenses",
+  "commit": "e29983247bddb6cec49deaa9245ccdd582a39c95",
+  "sha256": "0izyrmgh6viv3a0lnx6dcdx48d7j5plyp0bc1vffwh17b6ry91r7",
+  "fetcher": "github",
+  "repo": "md-arif-shaikh/expenses",
+  "unstable": {
+   "version": [
+    20211213,
+    438
+   ],
+   "deps": [
+    "dash"
+   ],
+   "commit": "df8faaf5c6741dc3387707567940021274c93c5b",
+   "sha256": "017c8vgqn08qn2l3mkinn80922g1rcg7pj8lx9dqylh5nylrp0gn"
+  }
+ },
+ {
   "ename": "express",
   "commit": "9a97f5f81af13c49f5bea31455d7da0bf2c12e4f",
   "sha256": "0lhisy4ds96bwpc7k8w9ws1zi1qh0d36nhxsp36bqzfi09ig0nb9",
@@ -33091,15 +33362,16 @@
   "repo": "ananthakumaran/exunit.el",
   "unstable": {
    "version": [
-    20210222,
-    1453
+    20211209,
+    1012
    ],
    "deps": [
     "f",
-    "s"
+    "s",
+    "transient"
    ],
-   "commit": "5bb115f3270cfe29d36286da889f0ee5bba03cfd",
-   "sha256": "0xz7vnj2wjzih0rm1bsf1ynjy46wmm0aifa9g8362d8570anmkj5"
+   "commit": "0715c2dc2dca0b56c61330eda0690f90cca5f98b",
+   "sha256": "1x42m95gv0gxhqpyd65n5fzgwczsfdjyghp4qrhj6gi1afr7jjhh"
   }
  },
  {
@@ -33532,19 +33804,19 @@
   "repo": "WJCFerguson/emacs-faff-theme",
   "unstable": {
    "version": [
-    20211013,
-    1554
+    20211124,
+    1842
    ],
-   "commit": "3c13ae4d694025207ba7eb43f174f90bb49395d4",
-   "sha256": "1iv9i1j39wj29y86z49yyw1a22wgyafdybjizmji60hi7x4r66az"
+   "commit": "c090f3d3a8a2ddedeffc1f5b5147cb7633dae79e",
+   "sha256": "1kiaqascf4lh1kpvp79yynjyncakq31xgx0h2bfinji8i7y32pg1"
   },
   "stable": {
    "version": [
-    2,
-    21
+    3,
+    0
    ],
-   "commit": "3c13ae4d694025207ba7eb43f174f90bb49395d4",
-   "sha256": "1iv9i1j39wj29y86z49yyw1a22wgyafdybjizmji60hi7x4r66az"
+   "commit": "c090f3d3a8a2ddedeffc1f5b5147cb7633dae79e",
+   "sha256": "1kiaqascf4lh1kpvp79yynjyncakq31xgx0h2bfinji8i7y32pg1"
   }
  },
  {
@@ -33663,14 +33935,14 @@
   "repo": "condy0919/fanyi.el",
   "unstable": {
    "version": [
-    20211030,
-    1408
+    20211211,
+    201
    ],
    "deps": [
     "s"
    ],
-   "commit": "2e37cc1d19f0f6f710932610639e4fd206884770",
-   "sha256": "0j0mqlx5xv1m1ik61q82lj6y030226k7isswd5plbq2v5z1d8b76"
+   "commit": "c328cdd1c5a0e734937125771279838e401fc5a8",
+   "sha256": "0kz6mv7awammgsi68vg6addkqry86sd3l8qrk3djwb77kw6rpvn6"
   }
  },
  {
@@ -33849,8 +34121,8 @@
   "repo": "jumper047/fb2-reader",
   "unstable": {
    "version": [
-    20211116,
-    2053
+    20211205,
+    58
    ],
    "deps": [
     "async",
@@ -33859,8 +34131,8 @@
     "s",
     "visual-fill-column"
    ],
-   "commit": "b93dfcacbe3ea1147642ee4e1dab2e2c36c4f6a3",
-   "sha256": "1c5i2w59kgs1pbhyxa0m0bny50kra2xlziydzpvryyddix94k4ld"
+   "commit": "4e2e20ea6ac7fe4063ad3ecabebf8864b1d48e4f",
+   "sha256": "09b0nkfyrsyinpjbjspr7zd07i77w8m8ic2i8h7fbc84ki2xl2g1"
   }
  },
  {
@@ -34032,20 +34304,20 @@
   "repo": "technomancy/fennel-mode",
   "unstable": {
    "version": [
-    20211110,
-    1728
+    20211126,
+    1803
    ],
-   "commit": "2900e3c2d5554b115a0a3b181e74a27c76489f4d",
-   "sha256": "14in4r89aqx6gq8qlia2bgprr73ldj7nlyvz61np2zqn7kfw1nfq"
+   "commit": "a622c110a2ae6ababfaab0506647a7fbc81e623a",
+   "sha256": "1bfd983zdhq097bb101k8p7x4jkmkgaxfj7s7aiyf4s3zq84v6xy"
   },
   "stable": {
    "version": [
     0,
     4,
-    0
+    1
    ],
-   "commit": "815f4c9433fa389bf10ddcf1da6f280e512912ff",
-   "sha256": "0v9a6psnlbh9cyibp95k2frix29ma6b69cgivmh8z4nrp0ycywc7"
+   "commit": "54ed0792d0ac43a2d5db39741cf070c627368419",
+   "sha256": "1bfd983zdhq097bb101k8p7x4jkmkgaxfj7s7aiyf4s3zq84v6xy"
   }
  },
  {
@@ -34182,15 +34454,15 @@
   "repo": "knpatel401/filetree",
   "unstable": {
    "version": [
-    20211115,
-    506
+    20211128,
+    205
    ],
    "deps": [
     "dash",
     "helm"
    ],
-   "commit": "4f97329cdc628d2b9424114a981d046daab50d61",
-   "sha256": "06hdllrg2xca7qq6m6f4xnjlb06ljn6lk7zypviy20qv7vmxa87s"
+   "commit": "03a58d6de1e76c3a88f50cc3e8735b8b1c09650a",
+   "sha256": "1zm7zlzzxddpbaz9mzg2r7za2p573b3v1kzdywh47hcsa7b1sxss"
   }
  },
  {
@@ -34495,8 +34767,8 @@
   "repo": "LaurenceWarne/finito.el",
   "unstable": {
    "version": [
-    20211107,
-    1925
+    20211130,
+    1023
    ],
    "deps": [
     "async",
@@ -34507,8 +34779,8 @@
     "s",
     "transient"
    ],
-   "commit": "f1b280cfbcbbb0729a83d763f08e25ccdb4c399d",
-   "sha256": "0x8aysl2s0ixl72qbz924b59advxp3f6ifmwf41rn11rnqjdmlr0"
+   "commit": "b547ff8b81aa956d582c1c8edbf4c52ba017265d",
+   "sha256": "000szg9gg0ma61s0kx7ab1gnywbbi6w43csrprjyrhbgldb2bwbk"
   },
   "stable": {
    "version": [
@@ -35031,27 +35303,27 @@
   "repo": "plandes/flex-compile",
   "unstable": {
    "version": [
-    20210914,
-    1255
+    20211203,
+    849
    ],
    "deps": [
     "buffer-manage",
     "dash"
    ],
-   "commit": "64f61ba1c113be38e4eae2a1fcee5596223c5d85",
-   "sha256": "143fzny0l5d8vci43nsgaq2a4ns1qmz01bd35c0s66gl62f02w74"
+   "commit": "7d0421805e4a287358a5c188ff868bd93be2192a",
+   "sha256": "0hv9lp4ybcl7vn27cx3iq64rk0fydinq6sgyslhc2616kll6fdb7"
   },
   "stable": {
    "version": [
     0,
-    9
+    10
    ],
    "deps": [
     "buffer-manage",
     "dash"
    ],
-   "commit": "64f61ba1c113be38e4eae2a1fcee5596223c5d85",
-   "sha256": "143fzny0l5d8vci43nsgaq2a4ns1qmz01bd35c0s66gl62f02w74"
+   "commit": "7d0421805e4a287358a5c188ff868bd93be2192a",
+   "sha256": "0hv9lp4ybcl7vn27cx3iq64rk0fydinq6sgyslhc2616kll6fdb7"
   }
  },
  {
@@ -35478,8 +35750,8 @@
    "deps": [
     "flycheck"
    ],
-   "commit": "3abe1a6184fefea3e427141131fba40afae3d356",
-   "sha256": "1g600caz7v7qm6fj67x0s064f4n5fr57bnd0m3sc43gn24rpjjdv"
+   "commit": "576e7f3e96ef8757a45106346a5f45831a8fee13",
+   "sha256": "1680qkn6n145ib0q039081k9iwgl81i81d1wmy1myifq8h9pgjzc"
   }
  },
  {
@@ -36809,21 +37081,20 @@
    "deps": [
     "flycheck"
    ],
-   "commit": "b6d0b1515418e5821241ac04143a12997c3bb240",
-   "sha256": "1klwi2ssjnjc5cirq201wl643w8cb32r42nmjhvxv4dgad14i659"
+   "commit": "457860482eb1b63aafe8930a08ecfa0ca5073ab1",
+   "sha256": "071h40lh4l47x0b9sfwllxvaqnp1sxidy4c73icf83wikw8h81jr"
   },
   "stable": {
    "version": [
     0,
-    2,
+    3,
     0
    ],
    "deps": [
-    "flycheck",
-    "s"
+    "flycheck"
    ],
-   "commit": "5608a330e09222d05bf0354f1847f537168e22dd",
-   "sha256": "0v6gqhgwn2x6qd34380y5n1ql08anv02bs6qk7glq6a0ha8xkzfa"
+   "commit": "b6d0b1515418e5821241ac04143a12997c3bb240",
+   "sha256": "1klwi2ssjnjc5cirq201wl643w8cb32r42nmjhvxv4dgad14i659"
   }
  },
  {
@@ -37023,8 +37294,8 @@
    "deps": [
     "flycheck"
    ],
-   "commit": "5a441a31e58de17da94f933277150be39198d98c",
-   "sha256": "05j5bngvf3vpabjv7gcm5qar73mr1dyba7z9g1x4i385dgm97f6z"
+   "commit": "0a86156fad0d6f02e8e6b4c5594f7173c96d6481",
+   "sha256": "122j1imz755lhfhlnzl4gggghbvpqyq6r6iix3qq60kzb3hpq1b2"
   },
   "stable": {
    "version": [
@@ -37445,14 +37716,14 @@
   "repo": "msherry/flycheck-pycheckers",
   "unstable": {
    "version": [
-    20210414,
-    2023
+    20211122,
+    235
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "771fb9a66223287fcd4998b5f6d32d8c602bd91c",
-   "sha256": "1p4fys8hb89dfqqrzrwqdglxxm50g4x5na2hgzvkq1n0ss617rdj"
+   "commit": "56965c0ef5d45bcef90093360718c6967ce4ef39",
+   "sha256": "0dfsqgvmnikza9g3wjq1sclflr640wkh37b3lm9g7r74wrrk8waz"
   },
   "stable": {
    "version": [
@@ -37626,15 +37897,15 @@
   "repo": "stan-dev/stan-mode",
   "unstable": {
    "version": [
-    20210130,
-    1325
+    20211129,
+    2051
    ],
    "deps": [
     "flycheck",
     "stan-mode"
    ],
-   "commit": "9bb858b9f1314dcf1a5df23e39f9af522098276b",
-   "sha256": "031418nkp9qwlxda8i3ankp3lq94sv8a8ijwrbcwb4w3ssr9j3ds"
+   "commit": "150bbbe5fd3ad2b5a3dbfba9d291e66eeea1a581",
+   "sha256": "06y4gvw8g4mjyiv77rznivqphh9sayjmi9aqr9nhxlf6i19a6hqh"
   },
   "stable": {
    "version": [
@@ -38022,8 +38293,8 @@
     20210411,
     2342
    ],
-   "commit": "3abe1a6184fefea3e427141131fba40afae3d356",
-   "sha256": "1g600caz7v7qm6fj67x0s064f4n5fr57bnd0m3sc43gn24rpjjdv"
+   "commit": "576e7f3e96ef8757a45106346a5f45831a8fee13",
+   "sha256": "1680qkn6n145ib0q039081k9iwgl81i81d1wmy1myifq8h9pgjzc"
   }
  },
  {
@@ -38537,14 +38808,11 @@
   "stable": {
    "version": [
     0,
-    0,
+    1,
     3
    ],
-   "deps": [
-    "flymake-quickdef"
-   ],
-   "commit": "72052b5ba827faf357608cf720a70221192a8282",
-   "sha256": "0h8dqk35r10pxx2w4swb3kij4y2vi17j9wfk978x8lf0wd3h3hsy"
+   "commit": "784e57f36812a37e323409b90b935ef3c6920a22",
+   "sha256": "1vcl1q07faqqmrryyia36hbgf78g3cs51pbi0bx41yzz779ribvk"
   }
  },
  {
@@ -39058,6 +39326,21 @@
    ],
    "commit": "24cb5b744a1796e554e6dbfc6eeb237d06a00b10",
    "sha256": "0mdam39a85csi9b90wak9j3zkd25lj6x54affwkg3fym8yphmplm"
+  }
+ },
+ {
+  "ename": "flymake-yamllint",
+  "commit": "b8420c724747b635fb7cc208561e03ebca463c90",
+  "sha256": "1mkmwdv53hz4xzmb6kl74wll74zfs8wm4v5bjnp1caf8c6flvzja",
+  "fetcher": "github",
+  "repo": "shaohme/flymake-yamllint",
+  "unstable": {
+   "version": [
+    20211206,
+    907
+   ],
+   "commit": "34fb579087a1d97cabd001dbf3f44ea48914bcde",
+   "sha256": "1x6npp5prgcl0ahcv7x3gvv0g52fjrkgapa1sp2c62l6is5zig3h"
   }
  },
  {
@@ -39620,16 +39903,17 @@
   "repo": "jollm/fontsloth",
   "unstable": {
    "version": [
-    20211102,
-    511
+    20211118,
+    2018
    ],
    "deps": [
     "f",
     "logito",
-    "pcache"
+    "pcache",
+    "stream"
    ],
-   "commit": "e43c7ed8302841aefe45f2e6bf35f84d854868f5",
-   "sha256": "1r3rn65gmnj964wisjagknz46kqhnpma5byw7gyzl69s8gfaifg0"
+   "commit": "5572a44e14d6c00a628f58cc695c735ef64e0ebd",
+   "sha256": "17q9fqbzzdvl8isj498cjr75bk94n2jp514fsdmlw44s0xnfdk4y"
   },
   "stable": {
    "version": [
@@ -39735,8 +40019,8 @@
   "repo": "magit/forge",
   "unstable": {
    "version": [
-    20211111,
-    2038
+    20211211,
+    15
    ],
    "deps": [
     "closql",
@@ -39749,8 +40033,8 @@
     "transient",
     "yaml"
    ],
-   "commit": "41efa674cff0b447efbc103494fd61ec9b9156ae",
-   "sha256": "0baaq8bf07aq80ll1q86q9dzzgkpn6j5jl1c1dssc04awg69kjsb"
+   "commit": "402773ef7e83ddfab64bfee23daea2776d50dbc1",
+   "sha256": "1n8x0bx3av935ky56rzy38d0ry73g57nsax26z3scc4na4h46yip"
   },
   "stable": {
    "version": [
@@ -39805,15 +40089,15 @@
   "repo": "lassik/emacs-format-all-the-code",
   "unstable": {
    "version": [
-    20211017,
-    1857
+    20211119,
+    1042
    ],
    "deps": [
     "inheritenv",
     "language-id"
    ],
-   "commit": "4851bab1659d519b4eaf8a16bfb76a4242d4dde2",
-   "sha256": "02363agwy1mn30q0z4p2ilf2ahb4ry13jv1cfwy318w1d6wgg6b2"
+   "commit": "6200b91d9151b3177a676d30edd948266292bcc1",
+   "sha256": "1d3mqajajr1jqkv4rnc3iwfdpipv9lk14hw4g7y8sli17l286k16"
   },
   "stable": {
    "version": [
@@ -39950,26 +40234,26 @@
   "repo": "rnkn/fountain-mode",
   "unstable": {
    "version": [
-    20211105,
-    1510
+    20211202,
+    1215
    ],
    "deps": [
     "seq"
    ],
-   "commit": "e3e4509e95019b5a56fb6596cafad0a78ebf2c79",
-   "sha256": "199carn2y5kxqsmxwrjcgvq4ih5xk74k09akb7milnxhys0zhnlk"
+   "commit": "3090858848a596ffa88a3b3616e31f70826c8fad",
+   "sha256": "0qvw6s4g2lbxd0w1hja5rzns2h8i40igq137603q1pp6ysmdmqsy"
   },
   "stable": {
    "version": [
     3,
-    5,
-    3
+    6,
+    0
    ],
    "deps": [
     "seq"
    ],
-   "commit": "16bc2a6a817b53ed3306a3ff3cebd271e7bf8746",
-   "sha256": "13k84dzjar67fa1ixicl6h8gxzblszd0ik8vi11bvipysgp3j3ws"
+   "commit": "205d7caeb65766e7787d827a80cca893747a09cc",
+   "sha256": "14cb4r23pn98sxzh0qwjwpvm7k7q9hhpks8avydccwssm69x1s1w"
   }
  },
  {
@@ -40465,8 +40749,8 @@
     "tide",
     "web-mode"
    ],
-   "commit": "f11fea0cf3b92eddf1d083e0ce1abfc396f06631",
-   "sha256": "0gqlb541pka3bqpl9kn672az203yirjnqq4s4ac32i1ai83w5821"
+   "commit": "315d23d23b32f413ea5a4dcc6f4e270b7bef7b67",
+   "sha256": "08bhsad0fmlydl47iaqj10j1r815qiy3jnm29sk5v5xjzrpby65k"
   }
  },
  {
@@ -40573,8 +40857,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "8515fe960b5b0bfce158ad91e9141f07a2c5fcc4",
-   "sha256": "19ch4ndc0pcw6ggv49wpdkq42pw7m86g973g7qrv4mgf95aprbi0"
+   "commit": "ce86de6c23826a318be6dab8c6105542d76d52eb",
+   "sha256": "11h92862sy6s0g830w88j8z0kfi2rdfhwrzwzy8bvapl8b8xw8xm"
   },
   "stable": {
    "version": [
@@ -40727,14 +41011,14 @@
   "repo": "diku-dk/futhark-mode",
   "unstable": {
    "version": [
-    20210803,
-    1401
+    20211212,
+    2032
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "17f048c76bd1dc7f5893b04a14db2b850471f399",
-   "sha256": "0a8gdr0qh985jai75zqb81yjws6lxlfm811wxk939fsglafbxmxx"
+   "commit": "4c340703cb749298dd472cd981df182335e3b4af",
+   "sha256": "1bkckcz2z9hnay3c85yai34hll1fwi4569hvhnpikhabk048k2mq"
   }
  },
  {
@@ -40840,11 +41124,11 @@
   "repo": "tarsius/fwb-cmds",
   "unstable": {
    "version": [
-    20211011,
-    1610
+    20211118,
+    2244
    ],
-   "commit": "9418ad51eaf7c6fd973d7f068ca67de66f3635ee",
-   "sha256": "1rsifl61qdrzmhd6r0d9if5a7a1pwjp3z7aq9rwrkrz6k37mnd0a"
+   "commit": "69409a996ec589ea27df8fa92899900afe8d1011",
+   "sha256": "0xam1zyk6mgk3jvwjcamcmrk5gvxipjfczax7vv37vzzh2wvlqhx"
   },
   "stable": {
    "version": [
@@ -41173,19 +41457,19 @@
   "repo": "emacs-geiser/geiser",
   "unstable": {
    "version": [
-    20211003,
-    2152
+    20211205,
+    2014
    ],
-   "commit": "d5cdad7f3eb44cec434610846cf78f2ad272089b",
-   "sha256": "1dd1jqfnwghqhsm2r5akqq1s4d621rd5rh93rxdqix2xg0nr9yp6"
+   "commit": "365764db5e3e07042f83d120595421770db771b2",
+   "sha256": "1ixkhkq01v8vhm9drih7hisxppjhgml1xfppb120njs12wqkfrl7"
   },
   "stable": {
    "version": [
     0,
-    18
+    19
    ],
-   "commit": "d5cdad7f3eb44cec434610846cf78f2ad272089b",
-   "sha256": "1dd1jqfnwghqhsm2r5akqq1s4d621rd5rh93rxdqix2xg0nr9yp6"
+   "commit": "5be7153e650a9817d30cb480439e3f56ce7422e7",
+   "sha256": "1ixkhkq01v8vhm9drih7hisxppjhgml1xfppb120njs12wqkfrl7"
   }
  },
  {
@@ -41196,14 +41480,14 @@
   "repo": "emacs-geiser/chez",
   "unstable": {
    "version": [
-    20210421,
-    120
+    20211120,
+    250
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "03da1c17253856d8713bc5a25140cb5002c9c188",
-   "sha256": "0cc1z5z5cpvxa5f3n8kvms0wxlybzcg4l1bh3rwv1l1sb0lk1xzx"
+   "commit": "ab2dde7a345c1c135ec0ed8fcd49eff1114951bd",
+   "sha256": "0cwm3xpn4bwgvmcmi06ijydp038054nch2hnjv1lprmnk1jg6d8p"
   },
   "stable": {
    "version": [
@@ -41225,25 +41509,25 @@
   "repo": "emacs-geiser/chibi",
   "unstable": {
    "version": [
-    20210421,
-    123
+    20211204,
+    1938
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "6f59291d8d1dc92ffd3f53f919d8cab4bf50b7d3",
-   "sha256": "0r92iay5cw7jqyd8cy2mm02y0sl89flp4asbz6ca9l818micphfn"
+   "commit": "5a6a5a580ea45cd4974df21629a8d50cbe3d6e99",
+   "sha256": "071m2cvwanra9rd8vmybw8xd4k9a23x02cyy12f7qyjy5fp9s968"
   },
   "stable": {
    "version": [
     0,
-    16
+    17
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "6f59291d8d1dc92ffd3f53f919d8cab4bf50b7d3",
-   "sha256": "0r92iay5cw7jqyd8cy2mm02y0sl89flp4asbz6ca9l818micphfn"
+   "commit": "5a6a5a580ea45cd4974df21629a8d50cbe3d6e99",
+   "sha256": "071m2cvwanra9rd8vmybw8xd4k9a23x02cyy12f7qyjy5fp9s968"
   }
  },
  {
@@ -41254,25 +41538,25 @@
   "repo": "emacs-geiser/chicken",
   "unstable": {
    "version": [
-    20210421,
-    127
+    20211204,
+    2049
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "ceab39c89607f55cba88e5606ba5eb37c7df5260",
-   "sha256": "0klssx0vhj48868p36nkn22qh2k4188gpvi3c2pjk9lb7d5356xj"
+   "commit": "79a9ac78f4df7c9ec1f918313c543c116dbb8b70",
+   "sha256": "19j4ar7900yp2q4i4kdwqj1g0fjywflk6jr2x5n2y3zn7pj7z9nz"
   },
   "stable": {
    "version": [
     0,
-    16
+    17
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "ceab39c89607f55cba88e5606ba5eb37c7df5260",
-   "sha256": "0klssx0vhj48868p36nkn22qh2k4188gpvi3c2pjk9lb7d5356xj"
+   "commit": "79a9ac78f4df7c9ec1f918313c543c116dbb8b70",
+   "sha256": "19j4ar7900yp2q4i4kdwqj1g0fjywflk6jr2x5n2y3zn7pj7z9nz"
   }
  },
  {
@@ -41283,25 +41567,25 @@
   "repo": "emacs-geiser/gambit",
   "unstable": {
    "version": [
-    20210421,
-    124
+    20211204,
+    1940
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "3294c944d1c3b79db44ed14b133129fec454bd60",
-   "sha256": "1vwr0iv7pznr7n6j76i90n306mhq5pxdj8b2f7l5mb32m442w2w9"
+   "commit": "faff8bac11621228640a3107622fe23df4bb6e2c",
+   "sha256": "1v736wh19yma3vjpgb2s1n77rrl5i3n8x451kq3cadsch0wid31d"
   },
   "stable": {
    "version": [
     0,
-    16
+    17
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "3294c944d1c3b79db44ed14b133129fec454bd60",
-   "sha256": "1vwr0iv7pznr7n6j76i90n306mhq5pxdj8b2f7l5mb32m442w2w9"
+   "commit": "faff8bac11621228640a3107622fe23df4bb6e2c",
+   "sha256": "1v736wh19yma3vjpgb2s1n77rrl5i3n8x451kq3cadsch0wid31d"
   }
  },
  {
@@ -41338,25 +41622,25 @@
   "repo": "emacs-geiser/guile",
   "unstable": {
    "version": [
-    20211029,
-    1512
+    20211204,
+    2047
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "1c5affdf1354220b49ab08b5a7665ebf61080863",
-   "sha256": "0gndf0w8dbv54bzc04svp2ck8wypa7i3b8kpixf6rkg91l79xpci"
+   "commit": "961bb01d1930d1edef07cdb3f91fe140f9617caf",
+   "sha256": "177n5z301j82cy47bx39r1h1zkrvicr28a52j7579b26ww639bvd"
   },
   "stable": {
    "version": [
     0,
-    18
+    19
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "1c5affdf1354220b49ab08b5a7665ebf61080863",
-   "sha256": "0gndf0w8dbv54bzc04svp2ck8wypa7i3b8kpixf6rkg91l79xpci"
+   "commit": "adf31d3a36bf9be4b92d5c8854b4a055b1ef6f1f",
+   "sha256": "177n5z301j82cy47bx39r1h1zkrvicr28a52j7579b26ww639bvd"
   }
  },
  {
@@ -41396,25 +41680,25 @@
   "repo": "emacs-geiser/mit",
   "unstable": {
    "version": [
-    20210405,
-    1920
+    20211204,
+    1935
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "d17394f577aaa2854a74a1a0039cb8f73378b400",
-   "sha256": "0w80ifs5d49ss81j34lnq91x2sbkc44i2xswkcwx23rh62p4jvyc"
+   "commit": "4e90e9ae815e89f3540fb9644e6016c663ef5765",
+   "sha256": "1j06y77nq6q33fhvf4kq0md4xmcrvimiycjgv35cpkxvkcprfafa"
   },
   "stable": {
    "version": [
     0,
-    14
+    15
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "d17394f577aaa2854a74a1a0039cb8f73378b400",
-   "sha256": "0w80ifs5d49ss81j34lnq91x2sbkc44i2xswkcwx23rh62p4jvyc"
+   "commit": "4e90e9ae815e89f3540fb9644e6016c663ef5765",
+   "sha256": "1j06y77nq6q33fhvf4kq0md4xmcrvimiycjgv35cpkxvkcprfafa"
   }
  },
  {
@@ -41454,14 +41738,14 @@
   "repo": "emacs-geiser/stklos",
   "unstable": {
    "version": [
-    20210626,
-    1440
+    20211117,
+    2114
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "be482a03225720d7adb003c28e4515f6252e7ce2",
-   "sha256": "1dyzpr9i5pxi2p2hg3ndryh7x4y0r9bra88pd1l904vdfsxdxv5z"
+   "commit": "9db60a7e751c97e30dd528e2a96ff19575b618d2",
+   "sha256": "0a7zv54l8hwwnympw7qhdm2mh6ijbcflxq87niljgbk0163h6y1w"
   },
   "stable": {
    "version": [
@@ -41526,14 +41810,14 @@
   "repo": "noctuid/general.el",
   "unstable": {
    "version": [
-    20211008,
-    1651
+    20211203,
+    120
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "26f1d4c4e258c40e6b70ce831a04800c914f29b3",
-   "sha256": "16rjsmmhjjx4mch1aygrxqj3pr5c4xxqzf21qvr6s4c9yk6ayx1f"
+   "commit": "9651024e7f40a8ac5c3f31f8675d3ebe2b667344",
+   "sha256": "01zfd8akm048gh4kbb6a4zxhd8gbambyi2sji47f022f9skmn3ys"
   }
  },
  {
@@ -41666,8 +41950,8 @@
   "repo": "thisch/gerrit.el",
   "unstable": {
    "version": [
-    20211005,
-    605
+    20211210,
+    1616
    ],
    "deps": [
     "dash",
@@ -41675,8 +41959,8 @@
     "magit",
     "s"
    ],
-   "commit": "3de210e2bcf9a7ce9a2a448cd910ffe477de8432",
-   "sha256": "1aaaff18crz86f1mpjkwc6vfjdayjnv4imqrl8qnqfccbmkb5z4w"
+   "commit": "b2e4ef23c2dd66d10526b58defcaea7beac7442f",
+   "sha256": "0spmljgh82nssv5d7bsywhlgpr4n4xz9vi1ar9kaba2981q3xd2p"
   }
  },
  {
@@ -41828,6 +42112,38 @@
   }
  },
  {
+  "ename": "gh-notify",
+  "commit": "98d33fe63e0263f029921b606edd1d4fb83f7a09",
+  "sha256": "1qm3d7hbg8vccv6pg6w9x0zgrl90wbkl2kgswyqzphk076xjbhli",
+  "fetcher": "github",
+  "repo": "anticomputer/gh-notify",
+  "unstable": {
+   "version": [
+    20211126,
+    638
+   ],
+   "deps": [
+    "forge",
+    "magit"
+   ],
+   "commit": "aa4d8bc0c56366d437e7c126e7eedc5938109342",
+   "sha256": "1sva7322x9cmz1z45ipsgcp3cx8ih999w911q6x23ba50ckyg569"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "deps": [
+    "forge",
+    "magit"
+   ],
+   "commit": "8937f64092ea3b7e2cea2d61c12fde8e0f5e7917",
+   "sha256": "1amqyv0xdvl1ghy2pv2kvp2lc2q250p71mq3qdf50v87png57d9p"
+  }
+ },
+ {
   "ename": "ghc-imported-from",
   "commit": "855ea20024b606314f8590129259747cac0bcc97",
   "sha256": "063kbymk4r1yrg5ks660d2byrnia6gs6nimjzrvqfi2ib1psc7jc",
@@ -41934,15 +42250,15 @@
   "repo": "magit/ghub",
   "unstable": {
    "version": [
-    20211106,
-    2042
+    20211205,
+    17
    ],
    "deps": [
     "let-alist",
     "treepy"
    ],
-   "commit": "4d6a4b2bc1d88b993c09c1cb47b575a08eb264ea",
-   "sha256": "1sdwpn917p92bh8cljl70zzxrwdy368p0w1ynsfp4x9xdkgc068f"
+   "commit": "a32d5f8725607684b091a537375ded61bc2cb818",
+   "sha256": "0q68wv2d8msqygigrgaq2v3nm3a0ymabnxzp4a7mai0brhdb35hj"
   },
   "stable": {
    "version": [
@@ -42300,16 +42616,16 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20211010,
-    1635
+    20211204,
+    2135
    ],
    "deps": [
     "dash",
     "transient",
     "with-editor"
    ],
-   "commit": "9413847c1a085899d8de6f8d978bd7265f65e5d8",
-   "sha256": "0b39813iyxgq0ai6hz4hpf9f4wix1lhcp6z5p1cm6y6hd8dyg486"
+   "commit": "1eb183e7672bf25fa77ea06d97b3d9c502a698ae",
+   "sha256": "08ci7w0pzbzs02fd8zklvhixkj8ab9vvc41w39mcik8qhr1fz5j4"
   },
   "stable": {
    "version": [
@@ -42593,11 +42909,11 @@
   "repo": "sshaw/git-link",
   "unstable": {
    "version": [
-    20211024,
-    1538
+    20211208,
+    312
    ],
-   "commit": "b2d803ad8764b896f5dd7f7e139ceb4903f7d8b6",
-   "sha256": "0gsa2qqxmynj10mpb3mm7xgsbk8fx7f4scwaxwl8l7dw3cmk9rmv"
+   "commit": "09961648e654ba0f7239eedf5cbaea0f0cc0ccf1",
+   "sha256": "0zwbcp2881n92nd0y40sw6id6qbidprzr0bsh9vn64gmvch6jlnd"
   },
   "stable": {
    "version": [
@@ -42893,6 +43209,21 @@
    ],
    "commit": "ab048cf49d9ebda73acae803bc44e731e629d540",
    "sha256": "18c169nxvdl7iv18pyqx690ldg6pkc8njaxdg1cww6ykqzqnfxh7"
+  }
+ },
+ {
+  "ename": "github-dark-vscode-theme",
+  "commit": "a81f7dcb441c13e0bd8d5c5901f135d7f26a2bd9",
+  "sha256": "19c56h6v2lsgj7agmmks56z9iflp6mnm0qnrv6h0il75bpah8j2z",
+  "fetcher": "github",
+  "repo": "justintime50/github-dark-vscode-emacs-theme",
+  "unstable": {
+   "version": [
+    20211122,
+    1800
+   ],
+   "commit": "092324ecb9c0909da2ba2751cb21a994b4e09536",
+   "sha256": "1zr116c9zphm5kgacqxmll7gzd1h5583xy0asg46dzyn4gn0bmhv"
   }
  },
  {
@@ -43436,16 +43767,16 @@
   "url": "https://git.launchpad.net/global-tags.el",
   "unstable": {
    "version": [
-    20210707,
-    1954
+    20211120,
+    347
    ],
    "deps": [
     "async",
     "ht",
     "project"
    ],
-   "commit": "06db25d91cc8bfb5e24e02adc04de1226c7e742d",
-   "sha256": "1q30cbqq0h1gfwlcbnx9s930li7w7a0y8sx2ivbvvyyc2j5gsk4j"
+   "commit": "aaa37da4c538f35a90149ef4ad3d8b0922af54ab",
+   "sha256": "0d1xil1cw0jrk4ciifph2qdhk0qb1h906zgryy74yaj3gd2dx7ak"
   },
   "stable": {
    "version": [
@@ -43551,6 +43882,21 @@
    ],
    "commit": "25d20f9d24594e85cb6f80d35d7c73b7e82cbc71",
    "sha256": "0x0a94bfkk72kqyr5m6arx450qsg1axmp5r0c4r9m84z8j08r4v1"
+  }
+ },
+ {
+  "ename": "gmsh-mode",
+  "commit": "08bc6d7ee700580101da8ab0a09f101c69093fab",
+  "sha256": "0wn0vylalp77sq98irm7skih5ibv95y6nds8w8aiwxrl63lpj2p8",
+  "fetcher": "gitlab",
+  "repo": "matsievskiysv/gmsh-mode",
+  "unstable": {
+   "version": [
+    20211204,
+    826
+   ],
+   "commit": "2b7c573f378f7e9210400115d4d9dfd879f8a4ad",
+   "sha256": "0yipszmblbz2zz784ys78zqzcm44blnvlm79gch2prl56gi0hl3r"
   }
  },
  {
@@ -44541,11 +44887,11 @@
   "repo": "lorniu/go-translate",
   "unstable": {
    "version": [
-    20211025,
-    443
+    20211127,
+    1059
    ],
-   "commit": "8de1c3b660602b6739444ceed3e48214c417fe38",
-   "sha256": "0b8jbcs848ck0zbl6rmyyac3mbhx58zq04l7wvi7paficg9lphj9"
+   "commit": "6aec3af53e69dcacfaa6186660cd4174170ca1c4",
+   "sha256": "0hgr6w7vfa0g385l1b00ngnrp3vjhgg6w2978q3f778vjsz9ipb5"
   },
   "stable": {
    "version": [
@@ -44630,8 +44976,8 @@
     20211031,
     1513
    ],
-   "commit": "36139cb1898c763be08167c74b5c5d05efada9e5",
-   "sha256": "06r5zpp4k4flv9slkpgxfy9m9c7b5kyix2si30bdka3fq4c1jwl5"
+   "commit": "3e48a56356991b3ff5228eced19b07862835cdcd",
+   "sha256": "0mkbra0a14rxh0716m6zxlkx05rhq1fn6n3yry29wwiabxa3w8ab"
   },
   "stable": {
    "version": [
@@ -44814,8 +45160,8 @@
     20180130,
     1736
    ],
-   "commit": "9806df89a3bc110cb9cabc41287bf942710599a3",
-   "sha256": "10l80l8aq30c4pgf930wj9dgfbhxp9jx81f4jnl2gq8z9bd7qwp6"
+   "commit": "842b872ac4da18dda02b797976ea12fd7d84768f",
+   "sha256": "09bxbm59fbqjqcmsmnqg74yzzmi92h9b2z4r62x5hpz625045mhg"
   }
  },
  {
@@ -45156,14 +45502,14 @@
     "magit-popup",
     "s"
    ],
-   "commit": "7f4153164fcd6588e2245ca3f5b4aee7737f4367",
-   "sha256": "1wrmw1y6qp3s36s30v4dncn68mf5biykpwpf5sk3h7sh0ifgk8yv"
+   "commit": "f032fbe4a8627ef85a39f590a6bdeffcdc48daa6",
+   "sha256": "0jlpl0wsypsi1iv092jlcx5807nn26mav2xynm207q042cwi1w8s"
   },
   "stable": {
    "version": [
     0,
     27,
-    1
+    2
    ],
    "deps": [
     "dash",
@@ -45171,8 +45517,8 @@
     "magit-popup",
     "s"
    ],
-   "commit": "6209be5b5c0bd5d81078fdc82eb4001f202f90e7",
-   "sha256": "15w2jbpilhk88rhsanq1hw19qvs66bcrv21v8hkmzsd1579p2qhy"
+   "commit": "f04d77d687dcd5f2dbc546a92ab46a14b5c00d84",
+   "sha256": "1ig7ss0i4r7nsj1qffanlky17lka7328zx6386li0jikfz34jffv"
   }
  },
  {
@@ -45517,8 +45863,8 @@
     20180912,
     31
    ],
-   "commit": "e2b309689f4faf9225f290080f836e988c5a576d",
-   "sha256": "1hqvsr2s2lbdssbx3v8nqxdhhdvydx6hpbhh4rlnfcadhhs0f6nr"
+   "commit": "5ca5f50b5e6f3883f1138453a356d59a1c002120",
+   "sha256": "0wh0f49574zdv0r7zdhckv4jr3ggwzlgyxda0y0hxw8vabzvavw6"
   },
   "stable": {
    "version": [
@@ -45570,11 +45916,11 @@
   "repo": "davazp/graphql-mode",
   "unstable": {
    "version": [
-    20210912,
-    1544
+    20211127,
+    1023
    ],
-   "commit": "80e9ac8020f7a4a8a963136698eb97a9fca28f7d",
-   "sha256": "1m4glbijclbhhzq8apvfyslfv1lgn3hy3wcfiynrpkxnxszygnyx"
+   "commit": "9740e4027bd9313697d5cac5caaa5b15626ab1da",
+   "sha256": "0rsa38fiiwzvxln4g5xvrsggm9mslw58iw3cx5c07y6kasfqfibb"
   }
  },
  {
@@ -45801,11 +46147,11 @@
   "repo": "seagle0128/grip-mode",
   "unstable": {
    "version": [
-    20210818,
-    623
+    20211203,
+    254
    ],
-   "commit": "1c82e27beec629514a8039e22f4f7c649e77ee2b",
-   "sha256": "1hgwqk991cnvslqgmvpwgxavm6nhvgn2cig3r8jpwvmfyjlcbyql"
+   "commit": "5be9942e8f76ebc8b55bcc1a29fb01277cb43743",
+   "sha256": "1a4hq8n7v1310v4fr04fpbx22rfb3dbiini091fk7kcpj21f5x5b"
   },
   "stable": {
    "version": [
@@ -45938,20 +46284,20 @@
   "repo": "ROCKTAKEY/grugru",
   "unstable": {
    "version": [
-    20211116,
-    850
+    20211119,
+    815
    ],
-   "commit": "7b63aa731bf7df528bb7d680ca3efe42ab4ead38",
-   "sha256": "0l60w8r5586af740vkcr11xj8ganws0hgbv4n7rn11mksr5idzwz"
+   "commit": "1b3b807e84cb250f0cc70876a438fed3b27eb756",
+   "sha256": "1p99lrq6p6xyn9lc2zmf68ns70kayhri1xls0h1h6ibxsqzvxyac"
   },
   "stable": {
    "version": [
     1,
-    21,
+    22,
     0
    ],
-   "commit": "1225a06dcb10c600ab9c44fd3d7df25bcd74d704",
-   "sha256": "0b5dgy3la3jzfxvj4fsdjphqvymvs6zx8dsibvld5ydkj3cx4pfw"
+   "commit": "2c743b7a981daf86cdfa3deab88a6c68a8d4e5a2",
+   "sha256": "01gw37yxj5sylhz0mxfbdaklalgw40b11gplyxsf5h7528la923f"
   }
  },
  {
@@ -46970,8 +47316,8 @@
     20211017,
     1730
    ],
-   "commit": "4b73d61f4ef1c73733f7201fbf0b49ba9e3395b6",
-   "sha256": "12a5hgaf2z6prqx45n6y0xyknz2sivpzwxjnzbsdx9sw6rniqm57"
+   "commit": "d708937592f9e2d28ae5622086b9c24d60cd8ac2",
+   "sha256": "0dyg2l96wgyl2l8iqvzqvh2rmxyqn8bgiss5r93f9c3daam7jyca"
   },
   "stable": {
    "version": [
@@ -47200,30 +47546,30 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20211116,
-    1616
+    20211208,
+    606
    ],
    "deps": [
     "async",
     "helm-core",
     "popup"
    ],
-   "commit": "ab2592262f4f62498f3261993eb249bb4c60c8ba",
-   "sha256": "0d5accmbidapgxj9fbrn5cdcfy3i0993sxrafnj2x8cb8px1lrg4"
+   "commit": "a246a9b278fb973d38d13ade7417f55e0a57eae4",
+   "sha256": "1z38jyfw8id62508rxfrkxd2ln70s6sc0cyvngn8zq94z47aqyjx"
   },
   "stable": {
    "version": [
     3,
     8,
-    1
+    2
    ],
    "deps": [
     "async",
     "helm-core",
     "popup"
    ],
-   "commit": "52dcf9e27c1a10be058efa0cf790510bbfeb89e7",
-   "sha256": "1yfr2vz1kd21rvnxi8xzv67gs5r599fhjmw8qphsmpv5afscfl7k"
+   "commit": "94cf15d64bd1dbc7dc3194ab323e0f0ef263ea77",
+   "sha256": "1xkxlbjpqhfhakmfi664cq7i5968941vpngq94napmhbgqydp4qn"
   }
  },
  {
@@ -48108,26 +48454,26 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20211114,
-    1507
+    20211202,
+    1641
    ],
    "deps": [
     "async"
    ],
-   "commit": "ab2592262f4f62498f3261993eb249bb4c60c8ba",
-   "sha256": "0d5accmbidapgxj9fbrn5cdcfy3i0993sxrafnj2x8cb8px1lrg4"
+   "commit": "a246a9b278fb973d38d13ade7417f55e0a57eae4",
+   "sha256": "1z38jyfw8id62508rxfrkxd2ln70s6sc0cyvngn8zq94z47aqyjx"
   },
   "stable": {
    "version": [
     3,
     8,
-    1
+    2
    ],
    "deps": [
     "async"
    ],
-   "commit": "52dcf9e27c1a10be058efa0cf790510bbfeb89e7",
-   "sha256": "1yfr2vz1kd21rvnxi8xzv67gs5r599fhjmw8qphsmpv5afscfl7k"
+   "commit": "94cf15d64bd1dbc7dc3194ab323e0f0ef263ea77",
+   "sha256": "1xkxlbjpqhfhakmfi664cq7i5968941vpngq94napmhbgqydp4qn"
   }
  },
  {
@@ -49670,8 +50016,8 @@
     "helm",
     "lean-mode"
    ],
-   "commit": "bf32bb97930ed67c5cbe0fe3d4a69dedcf68be44",
-   "sha256": "1bkv5zs38ijawvavbba0fdf2flb6fiwici3qi99ws8wvwhnbkws2"
+   "commit": "4a90f2ae6e33c162a3dd6f624fb080c2ed8e8494",
+   "sha256": "1zikz4qaxabs3j86gljpp2qbhbzxsjzz544k9vsngibd468dszlv"
   }
  },
  {
@@ -51933,8 +52279,8 @@
   "repo": "Wilfred/helpful",
   "unstable": {
    "version": [
-    20211021,
-    625
+    20211211,
+    703
    ],
    "deps": [
     "dash",
@@ -51942,8 +52288,8 @@
     "f",
     "s"
    ],
-   "commit": "8df39c15d290cd499ef261de868191d3fc84f75a",
-   "sha256": "0wnbzwlsbigxc9bncy8lf8i5kcjg7qrb6l93k0fsyj8y0qibaja3"
+   "commit": "2afbde902742b1aa64daa31a635ba564f14b35ae",
+   "sha256": "0qwsifzsjw95l83m7z07fr9h1sqbhggwmcps1qgbddpan2a8ab8a"
   },
   "stable": {
    "version": [
@@ -53478,15 +53824,15 @@
   "repo": "plexus/html-to-hiccup",
   "unstable": {
    "version": [
-    20190909,
-    1549
+    20211129,
+    944
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "50a52e2b0d13d865187acdf775b8203d5003f2f1",
-   "sha256": "1qi092mw2n08v6yr0j6hlpx0pnlcnhxjqbsrlw9pn4yin6zk91yp"
+   "commit": "97ecc8cce11f577ad4406da0367aa5eeec1bd8c6",
+   "sha256": "0i96m9wpgwlxp8b6lw7a8lsjbxb7q9m12p8yra33q7q3ilav4g8p"
   }
  },
  {
@@ -53713,30 +54059,30 @@
   "repo": "rkaercher/hugsql-ghosts",
   "unstable": {
    "version": [
-    20180425,
-    1129
+    20211124,
+    1646
    ],
    "deps": [
     "cider",
     "dash",
     "s"
    ],
-   "commit": "f3ebc60c66204ad39058cb84eb4bd5facce091df",
-   "sha256": "0pcr39x8yxl5aa0sz20gw20ixz5imw5m19bzhzbzyn7slr65hlqn"
+   "commit": "7cd242cc2e70ac48959c42be725c81d7fe00b314",
+   "sha256": "1jn8958jabn8zxq11rs9b0r3ga3vznjd9qn40ka8n54rp4hnj1l9"
   },
   "stable": {
    "version": [
     0,
     1,
-    3
+    4
    ],
    "deps": [
     "cider",
     "dash",
     "s"
    ],
-   "commit": "f3ebc60c66204ad39058cb84eb4bd5facce091df",
-   "sha256": "0pcr39x8yxl5aa0sz20gw20ixz5imw5m19bzhzbzyn7slr65hlqn"
+   "commit": "f9ab314b6a10140041233e65a23e924dcab9a7a3",
+   "sha256": "0y5gmv84i0fasmj53wmfhgw6p14r4byg95hfbywccc85f6q2x5vj"
   }
  },
  {
@@ -53747,19 +54093,19 @@
   "repo": "humanoid-colors/emacs-humanoid-themes",
   "unstable": {
    "version": [
-    20210819,
-    811
+    20211206,
+    1411
    ],
-   "commit": "3a157bab0493fe0654de0324ec59eef9b3d15202",
-   "sha256": "0jm81nax0r4h82gd7pbvxpf2nb7ynmxq099103y0s5xhy1cx6v8l"
+   "commit": "8ad6d9ae8e6c2cd7e282922416a596bbb20438c8",
+   "sha256": "0y1kazfhjsyghqm1ddd2dbk1jipwn0l1n15mcm4d7038dd3x6d99"
   },
   "stable": {
    "version": [
     0,
-    2
+    3
    ],
-   "commit": "d140638360a3eb1bf8f17877bd888f898df63ec0",
-   "sha256": "1lybjbbcjsry20p6jzmkg2h7am7hcgfhjkdmby9pk4whnhk9l4lh"
+   "commit": "33c7f8dd55e30c255c2535647fee4126268f8dd8",
+   "sha256": "1wpvk3w4aj8x91xjyplg864j9c4kz43r3831kadcnkp0d1p3k9hm"
   }
  },
  {
@@ -54047,8 +54393,8 @@
    "deps": [
     "request"
    ],
-   "commit": "39fd7daf1efd761336616c870cc5b8871422d95e",
-   "sha256": "18b9n5w36zdsaxc63nhsry2i1s28a4y21sc6cj7rawvd8zyxargv"
+   "commit": "992f53ae2bd572b89bc642ca70b8bdaa5eb2553f",
+   "sha256": "0z00w8ssr1syh5fphk7y7910l66vlcyj2lc76jhs1g7pxs6q5hh9"
   }
  },
  {
@@ -55328,11 +55674,11 @@
   "repo": "petergardfjall/emacs-immaterial-theme",
   "unstable": {
    "version": [
-    20211006,
-    1048
+    20211208,
+    729
    ],
-   "commit": "ae9980927026324ff656721eef2e0f415cf3dfb4",
-   "sha256": "198xii7cdscd521bbz371465pks072zi3cdgqrgcq6860falyfxf"
+   "commit": "1c576624758429118794db9407c9627dfff7c975",
+   "sha256": "0a704nk7ly4wy5nmgqkdrg3lp3lpyk701myp9b72dn6diiv9r4nd"
   },
   "stable": {
    "version": [
@@ -55533,6 +55879,30 @@
    ],
    "commit": "c0360a8146ca65565a7fa66c6d72986edd916dd5",
    "sha256": "0s6hp62kmhvmgj3m5jr3cfqc8yv3p8jfxk0piq8xbf2chr1hp6l5"
+  }
+ },
+ {
+  "ename": "impostman",
+  "commit": "b98f232e6a4b0dd90b0aae1065b441d14c3a10df",
+  "sha256": "1xm4ik32fs2si0gbg1b6l5j8387724w0w6gkji0db2lwd0xvgvck",
+  "fetcher": "github",
+  "repo": "flashcode/impostman",
+  "unstable": {
+   "version": [
+    20211212,
+    851
+   ],
+   "commit": "130ef8218c9e2a776130ab95b6cd199955328913",
+   "sha256": "0w9x6iq7cmzd3vqrjh7l8b457fcphpl8z1xk4dcc3lj113nczyig"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    0
+   ],
+   "commit": "fe8646959223a8b4dbd733aa66cf1a675332d9cf",
+   "sha256": "1zwqibsdbgviv9j1zxs9j330qi357xc0i9bhh87xl4w7hd751xg9"
   }
  },
  {
@@ -55812,20 +56182,20 @@
   "repo": "J3RN/inf-elixir",
   "unstable": {
    "version": [
-    20210731,
-    2030
+    20211202,
+    210
    ],
-   "commit": "404f88530975e3540f357f6a4f96c864bd19065b",
-   "sha256": "14hz77f4sjq0pjr22fp77sk5kh6074qs493aiwc900b1apzh47jk"
+   "commit": "acb948ca41a862c8c9b3f61ad576dec2c30d0052",
+   "sha256": "1rlc2sf8r1vzs13fa2kab93m2xr883ckywx1h1an2b4si73y5ddc"
   },
   "stable": {
    "version": [
     2,
     1,
-    0
+    2
    ],
-   "commit": "9c21ae6d7a1313c856fd508880ee121fbea99f4d",
-   "sha256": "0w6fj1sh1pdsrk5sis2zkbdz0ixbpndaizvlqv2riw3sgpnc41f3"
+   "commit": "acb948ca41a862c8c9b3f61ad576dec2c30d0052",
+   "sha256": "1rlc2sf8r1vzs13fa2kab93m2xr883ckywx1h1an2b4si73y5ddc"
   }
  },
  {
@@ -56203,11 +56573,11 @@
   "repo": "ideasman42/emacs-inkpot-theme",
   "unstable": {
    "version": [
-    20211101,
-    558
+    20211130,
+    214
    ],
-   "commit": "1ca71416869e7515a9c2587b35f21a11921686f3",
-   "sha256": "0pl2hpcy9165np17gwa9qhqxb43kwm0z746pxcga7rfg6apy6krc"
+   "commit": "9afc537af6e56dda5a3ef60792f15ed391ba3b8b",
+   "sha256": "0mffhf0zzvlrc0kcvfj91p4q7wx9v4ih1v1spjad40h5790gn9an"
   }
  },
  {
@@ -56716,8 +57086,8 @@
     "cl-lib",
     "json"
    ],
-   "commit": "b9c64abf81e73860e39ecd82dfa00cca90b53d99",
-   "sha256": "1ilvfqn7hzrjjy2zrv08dbdnmgksdgsmrdcvx05s8704430ag0pb"
+   "commit": "5063d6b16d5d0a444bbc7599caabfdc6b512f70c",
+   "sha256": "1c5xqpr7czncj16rfl8gaa01nczkg3x1n8jh18nd2201xrc4v8z4"
   },
   "stable": {
    "version": [
@@ -56954,19 +57324,19 @@
   "repo": "doublep/iter2",
   "unstable": {
    "version": [
-    20200517,
-    1623
+    20211119,
+    1718
    ],
-   "commit": "987045585d60700b4b9e617313c1a73618a144c9",
-   "sha256": "0gaq3z2v1q4r9mkyq71dzmqakhi0p8g7ph4z0n3a11rvyc3z9ykx"
+   "commit": "077684feec98ce6d5e283a13f056c083986628a2",
+   "sha256": "12flc98nv353cqr9qbkasgdmiyf9c3iw4apzh899xw857j1h5qdr"
   },
   "stable": {
    "version": [
     1,
-    0
+    1
    ],
-   "commit": "987045585d60700b4b9e617313c1a73618a144c9",
-   "sha256": "0gaq3z2v1q4r9mkyq71dzmqakhi0p8g7ph4z0n3a11rvyc3z9ykx"
+   "commit": "077684feec98ce6d5e283a13f056c083986628a2",
+   "sha256": "12flc98nv353cqr9qbkasgdmiyf9c3iw4apzh899xw857j1h5qdr"
   }
  },
  {
@@ -57785,10 +58155,10 @@
  },
  {
   "ename": "ivy-spotify",
-  "commit": "380125490f47bd150218280c2e16c01be9054a60",
-  "sha256": "1mrwwlx3nwvvbwlbp4diz7ylsxl76dp51pfgsb2xay2yq0ia34w8",
+  "commit": "76e7a6c9e67bcea5b681dacf6725f7e313f0c1a8",
+  "sha256": "1qvdrm890n6pyf23swq0af2pjkpzpf9nglzq1vkrmssp2rl3x3wc",
   "fetcher": "git",
-  "url": "https://codeberg.org/jao/espotify",
+  "url": "https://codeberg.org/jao/espotify.git",
   "unstable": {
    "version": [
     20210329,
@@ -59150,14 +59520,14 @@
   "repo": "mooz/js2-mode",
   "unstable": {
    "version": [
-    20211105,
-    1214
+    20211201,
+    1250
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "d2636f95ebe4d423dc9b4311aff248c7688271c5",
-   "sha256": "1p293jhzsqzn4kljz1nl87jg1aq35jzqzs31ryfi8dn8iicwyd85"
+   "commit": "d18730505e4ab57ec2b036980a62f6c6a60381e9",
+   "sha256": "1q26y3fmxlz2hmxdlkh5qpv20c49nv9vd0dmcmzzimr6c8y5yscq"
   },
   "stable": {
    "version": [
@@ -59372,26 +59742,26 @@
   "repo": "taku0/json-par",
   "unstable": {
    "version": [
-    20211106,
-    535
+    20211122,
+    942
    ],
    "deps": [
     "json-mode"
    ],
-   "commit": "45902f2f36d4a90662caaaca6612b762ccb5b34e",
-   "sha256": "1p46pylidl035bhxv73867iw206ddriziplcv347rqj39drknlix"
+   "commit": "2bc383c4f88a111202b4d00303f3345b32e4b8e9",
+   "sha256": "1k1jv0m6mj772dkjzsy86k528lqljqmffcpz9l2lzrm6q1bqnw43"
   },
   "stable": {
    "version": [
     2,
-    0,
-    1
+    1,
+    0
    ],
    "deps": [
     "json-mode"
    ],
-   "commit": "85a5288bea5c579b2bfdd7be16bdfc18a58b3a26",
-   "sha256": "0fbrgxd2n45smq7im6qas6nnzrxv3397rxp1snx7pk58vz4v980h"
+   "commit": "2bc383c4f88a111202b4d00303f3345b32e4b8e9",
+   "sha256": "1k1jv0m6mj772dkjzsy86k528lqljqmffcpz9l2lzrm6q1bqnw43"
   }
  },
  {
@@ -59699,8 +60069,8 @@
   "repo": "gcv/julia-snail",
   "unstable": {
    "version": [
-    20211110,
-    1407
+    20211213,
+    1514
    ],
    "deps": [
     "dash",
@@ -59709,8 +60079,8 @@
     "spinner",
     "vterm"
    ],
-   "commit": "55458e9c8fbeebb33ffeb291d40c529f2b006c8d",
-   "sha256": "0b9khsza4zfxdi03i5gx6s1g0f27qg71vmj4f4gcqkgdhfxxy4yb"
+   "commit": "465f95a54a82a40ee047085115b10ab3e7c2daa9",
+   "sha256": "0vspf2imgvcjyavzj3ljsi7xrhk97is05l1c4d2bypnsq35x3549"
   },
   "stable": {
    "version": [
@@ -59890,8 +60260,8 @@
   "repo": "nnicandro/emacs-jupyter",
   "unstable": {
    "version": [
-    20211116,
-    150
+    20211130,
+    1647
    ],
    "deps": [
     "cl-lib",
@@ -59899,8 +60269,8 @@
     "websocket",
     "zmq"
    ],
-   "commit": "f178c1c7b8d9a0c0b77e38dc03524db3d2c8288a",
-   "sha256": "1vmg6bq8w9aw5r9plnvslvhq1ykj5m5srz67qn9jbn54lx7qq08p"
+   "commit": "df343af5e9187a400a9291fa6a2b0c69f3ad0425",
+   "sha256": "0sa8mi5gmb0n1ylgh1vz72nfgrjxny770l5z3xyxl0myw668vmcf"
   },
   "stable": {
    "version": [
@@ -60015,14 +60385,14 @@
   "repo": "TxGVNN/emacs-k8s-mode",
   "unstable": {
    "version": [
-    20210618,
-    1540
+    20211121,
+    518
    ],
    "deps": [
     "yaml-mode"
    ],
-   "commit": "430e9d698f1411efe3f8f2bb4c8f8857e0321a8d",
-   "sha256": "0rpgsfxvbic7ni82cpqi7wya73ajbd2jfbjskklzlmhwn1j26a9v"
+   "commit": "083bcffbfeeaf5e79015a012b4dbf2f283a493ab",
+   "sha256": "14zrrfkpnh821hpa1d8bpcvmzc654ibjd0sf78v5jckjswh3vqfl"
   },
   "stable": {
    "version": [
@@ -60174,8 +60544,8 @@
     "multiple-cursors",
     "ryo-modal"
    ],
-   "commit": "c39f278811945dbf0958ca8cf81d7b03c39efbcf",
-   "sha256": "0ajh4nk8brwi41rsbd9dn5gbf7i2mkaxm3aal09r2wgmgxigsiqp"
+   "commit": "d81bd00323ba10343a28bc855ee5ddbd09b7d2a5",
+   "sha256": "187dnrjp9khs1l17afwiw8dhk3znvirwzpllpv63fvzvc6gsi2hg"
   }
  },
  {
@@ -60742,14 +61112,14 @@
   "repo": "tarsius/keymap-utils",
   "unstable": {
    "version": [
-    20211027,
-    1933
+    20211128,
+    1356
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "20e5ab2a8bfdf9b44c813c6abd96b478f822ddef",
-   "sha256": "1acflsq0yh3sj607g2yasdbwacyzdh27hmgplybxc3zg464gldj1"
+   "commit": "2f247333435b8b036547658caf04228831f613d2",
+   "sha256": "1iykzph614sjdpxgfx5y55bgzv9m7j9g6b4n1d8icj7r1620yr5w"
   },
   "stable": {
    "version": [
@@ -61136,8 +61506,8 @@
     20210318,
     2106
    ],
-   "commit": "74057b9fcf7cbe3ec2f17c86e7a3da93b40e372b",
-   "sha256": "18n1xpcs8z7pmc2k35c343qsjai0rgyc1jgsc35j9z2xqzq6mpji"
+   "commit": "c27fb3187b527deea585c72bad000b44af520bce",
+   "sha256": "0p91qz7xqbril7yhmxdf1dciy8f8mf5vw4z2xbm1j8al2d3jimyz"
   },
   "stable": {
    "version": [
@@ -61436,8 +61806,8 @@
   "repo": "abrochard/kubel",
   "unstable": {
    "version": [
-    20211001,
-    1327
+    20211129,
+    2118
    ],
    "deps": [
     "dash",
@@ -61445,8 +61815,8 @@
     "transient",
     "yaml-mode"
    ],
-   "commit": "8cf9a8db6af7e604e963d180274af17755562239",
-   "sha256": "1s6lbqrfkdl2kwshrjwjfxwxl4jmchb3y2y8cjpjjp4f65r4p7m6"
+   "commit": "f75a78f785ef1782a32f4464a89fd4c33bf368ca",
+   "sha256": "0as26hsvkkjzls68wf6f1wwcrpnhj31g13cykclgq3jdwcah6xsp"
   },
   "stable": {
    "version": [
@@ -61478,8 +61848,8 @@
     "evil",
     "kubel"
    ],
-   "commit": "8cf9a8db6af7e604e963d180274af17755562239",
-   "sha256": "1s6lbqrfkdl2kwshrjwjfxwxl4jmchb3y2y8cjpjjp4f65r4p7m6"
+   "commit": "f75a78f785ef1782a32f4464a89fd4c33bf368ca",
+   "sha256": "0as26hsvkkjzls68wf6f1wwcrpnhj31g13cykclgq3jdwcah6xsp"
   },
   "stable": {
    "version": [
@@ -61502,8 +61872,8 @@
   "repo": "kubernetes-el/kubernetes-el",
   "unstable": {
    "version": [
-    20211114,
-    420
+    20211211,
+    727
    ],
    "deps": [
     "dash",
@@ -61512,8 +61882,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "4b740d88c6dcb091d701f74ddcf53e3732999ac9",
-   "sha256": "1l5rbgagdi6gfp8prj01pcgh4k3k90aijrrq5b8nkqppxiq85kh7"
+   "commit": "73361de919cff8d773f347868850f6c694d942e7",
+   "sha256": "17imkanh7ay88s1ppzsdr7hf91rgqimx9v6p69srmqq5bpnwpnmy"
   },
   "stable": {
    "version": [
@@ -61547,8 +61917,8 @@
     "evil",
     "kubernetes"
    ],
-   "commit": "4b740d88c6dcb091d701f74ddcf53e3732999ac9",
-   "sha256": "1l5rbgagdi6gfp8prj01pcgh4k3k90aijrrq5b8nkqppxiq85kh7"
+   "commit": "73361de919cff8d773f347868850f6c694d942e7",
+   "sha256": "17imkanh7ay88s1ppzsdr7hf91rgqimx9v6p69srmqq5bpnwpnmy"
   },
   "stable": {
    "version": [
@@ -61668,26 +62038,26 @@
   "url": "https://git.sr.ht/~tarsius/l",
   "unstable": {
    "version": [
-    20210705,
-    2113
+    20211118,
+    1837
    ],
    "deps": [
     "seq"
    ],
-   "commit": "02b1afad2c5649221abada2d938ef3736e020a96",
-   "sha256": "0idzyx6pxn8s78my9b4qjxz6561w6bzjvbp3yv267piyjgvwnzpc"
+   "commit": "5e2c05478868e9e5fac909ac1bee535ffc5c6695",
+   "sha256": "11fmcqn9xpq8hqwf914yd715xrbfyymki95iq5y3r4x42gl30q7s"
   },
   "stable": {
    "version": [
     0,
-    2,
+    3,
     0
    ],
    "deps": [
     "seq"
    ],
-   "commit": "02b1afad2c5649221abada2d938ef3736e020a96",
-   "sha256": "0idzyx6pxn8s78my9b4qjxz6561w6bzjvbp3yv267piyjgvwnzpc"
+   "commit": "5e2c05478868e9e5fac909ac1bee535ffc5c6695",
+   "sha256": "11fmcqn9xpq8hqwf914yd715xrbfyymki95iq5y3r4x42gl30q7s"
   }
  },
  {
@@ -61698,16 +62068,16 @@
   "repo": "tecosaur/LaTeX-auto-activating-snippets",
   "unstable": {
    "version": [
-    20211103,
-    1633
+    20211208,
+    1617
    ],
    "deps": [
     "aas",
     "auctex",
     "yasnippet"
    ],
-   "commit": "397bde14a67e91cb95ca6b2d5a5d5025cae243c3",
-   "sha256": "1kjda08zpzwvmk17f4654zvxildg1dyfxm10n6py0mfc0ldp8rf3"
+   "commit": "fa32c7affc1d232e5ab63b7c7a8a29461a465536",
+   "sha256": "1y4lp5y55r43kjw47wjxdx0i8cd8id8sd7s8cac01c5n9hcsjyiz"
   },
   "stable": {
    "version": [
@@ -61823,16 +62193,30 @@
   "repo": "Deducteam/lambdapi",
   "unstable": {
    "version": [
-    20211116,
-    1414
+    20211207,
+    1509
    ],
    "deps": [
     "eglot",
     "highlight",
     "math-symbol-lists"
    ],
-   "commit": "dcb95cd0605cad14fe491903b40a13fad61e382d",
-   "sha256": "0lw9rydgfr6rf5579ac1jvz0449m52swhp0ad16wlxlrfi0k4iiw"
+   "commit": "19bd984c9695a7cc4f6b66916b89818082c7da27",
+   "sha256": "0cnv4wwimpz7b17vm2j6602ly2jf4drsa220wj60qqqympcq6nil"
+  },
+  "stable": {
+   "version": [
+    2,
+    0,
+    0
+   ],
+   "deps": [
+    "eglot",
+    "highlight",
+    "math-symbol-lists"
+   ],
+   "commit": "96b01a11aa31c38e194bd1910c61ccfd0cea7b61",
+   "sha256": "1pjvyhnq86pkl6lgany25ybyl5b3x3v4p1m7kk631zqrqzk481ms"
   }
  },
  {
@@ -62342,8 +62726,8 @@
     20211115,
     1551
    ],
-   "commit": "7d8f768db5077bdb9f595cbf841018fc600ecf77",
-   "sha256": "15f0q4dlybqb3k17sgaj9vp42mgvrh72mqzs5sh49lxi000bdhkh"
+   "commit": "0a698d240e49ebfbe57f7637ba104498478052ee",
+   "sha256": "004nbm2l9pwhzyd8y12hr24brni6m3k3hxj35kd93dn2zw1wvy0h"
   },
   "stable": {
    "version": [
@@ -62493,8 +62877,8 @@
   "repo": "leanprover/lean-mode",
   "unstable": {
    "version": [
-    20210502,
-    2049
+    20211203,
+    1418
    ],
    "deps": [
     "dash",
@@ -62502,8 +62886,8 @@
     "flycheck",
     "s"
    ],
-   "commit": "bf32bb97930ed67c5cbe0fe3d4a69dedcf68be44",
-   "sha256": "1bkv5zs38ijawvavbba0fdf2flb6fiwici3qi99ws8wvwhnbkws2"
+   "commit": "4a90f2ae6e33c162a3dd6f624fb080c2ed8e8494",
+   "sha256": "1zikz4qaxabs3j86gljpp2qbhbzxsjzz544k9vsngibd468dszlv"
   }
  },
  {
@@ -62760,11 +63144,11 @@
   "repo": "mtenders/emacs-leo",
   "unstable": {
    "version": [
-    20210922,
-    1138
+    20211119,
+    1636
    ],
-   "commit": "2ab30fe567412b4f4e69bc8014b8886d19b30f30",
-   "sha256": "1sjgp0yfa3ynrksrf33gc4qrhj7819lih2ax0sq83vd4gn2m6lcn"
+   "commit": "41db8f64a0b4d335196f8d1c319518a68ccb2e50",
+   "sha256": "1a4nfw617m6zr17xhhpa8ll2hjfl83gpf59d39an47rn7k8cpqay"
   }
  },
  {
@@ -63008,11 +63392,11 @@
   "repo": "merrickluo/liberime",
   "unstable": {
    "version": [
-    20210906,
-    626
+    20211203,
+    244
    ],
-   "commit": "8291e22cd0990a99cb2f88ca67a9065a157f39af",
-   "sha256": "1zr34fsh4l4apdm1jpd9c8863wji5f0g8nwvzgf7bfi6q58bcwzn"
+   "commit": "79b709debe036f98d74ac129934e59c4d08c1dd5",
+   "sha256": "1z1z8x65z4wp9gkbasljxc9bwigi2db95sy31m6k9120k74gkzsk"
   },
   "stable": {
    "version": [
@@ -63190,20 +63574,20 @@
   "repo": "ligolang/ligo",
   "unstable": {
    "version": [
-    20211116,
-    1344
+    20211119,
+    1813
    ],
-   "commit": "f5d298df9bb9acf9a1fc734c75a8f033f3eae3e5",
-   "sha256": "1lg6r78f7c4d4dzkpv3260p9j32f7rc51v4c5bajkblq379yn98r"
+   "commit": "a8bb654339da8d192dbbdb30dbcef86e8e2dd749",
+   "sha256": "08050ri7acngvhizrjgqgvjsyh4jwjn3gzknpji7qs161gzvi74r"
   },
   "stable": {
    "version": [
     0,
-    29,
+    31,
     0
    ],
-   "commit": "e1bcb971b9f964bc927c9d12fcf377a1878c459f",
-   "sha256": "1lg6r78f7c4d4dzkpv3260p9j32f7rc51v4c5bajkblq379yn98r"
+   "commit": "921934a9f54f9e10f7723bf5b61c1c79bbcc3a6e",
+   "sha256": "08050ri7acngvhizrjgqgvjsyh4jwjn3gzknpji7qs161gzvi74r"
   }
  },
  {
@@ -63250,8 +63634,8 @@
     20180219,
     1024
    ],
-   "commit": "7f51793fa6c037a90a90e47b433cc8a773a3b552",
-   "sha256": "0wd493d678587zc10y6hjlmjiacmj3xzw20zzfnvg2qr5nlqpl2g"
+   "commit": "7f5f8d232a647e3966f84aaf35aca7cfb1ea15ca",
+   "sha256": "1bbqlgl955y24jsggzc763dagsv7vnlzcav98f15j9gh54p6h8ws"
   },
   "stable": {
    "version": [
@@ -63355,14 +63739,14 @@
   "repo": "noctuid/link-hint.el",
   "unstable": {
    "version": [
-    20211008,
-    1652
+    20211128,
+    1600
    ],
    "deps": [
     "avy"
    ],
-   "commit": "83cd0489b16f013647d0507ef20905a0a91db433",
-   "sha256": "0kwaia6i0asr7yqcw1anzq6lf93357cc1fphkvp0llbmxizmkzb3"
+   "commit": "3be270f3a732dc4acae6a20ff449eef0c4f9a966",
+   "sha256": "14f0x319mqbk7vyh5nm9gijy59m45j342fl8fxgvkr7ajn4rg7aw"
   }
  },
  {
@@ -63740,20 +64124,20 @@
   "repo": "publicimageltd/lister",
   "unstable": {
    "version": [
-    20211106,
-    2151
+    20211124,
+    1844
    ],
-   "commit": "5ae4f8bcfad02eee81a18c15c921637bb4269c13",
-   "sha256": "04lxz74v8axkn0ahgaan0bxkxyxcfp7ny2kxx9sxm0yg77c26gzl"
+   "commit": "aaaf67a3ace078d317295fd500dae40ecf547392",
+   "sha256": "0lvsx60gwx8510nyjas4wskns65mbjwxbqpzjwh2v991pbi695kk"
   },
   "stable": {
    "version": [
     0,
     9,
-    3
+    4
    ],
-   "commit": "f9271f641f82cca9cdf8dd5737dc6dcf77aa5a1d",
-   "sha256": "1mmph8q1ff3bvsfggff74k7zadn020imyj63p1g1swp5a3bs6yyq"
+   "commit": "35d485f53907d75e5135b177a2e1ab4de2a20a48",
+   "sha256": "1w9kay6mx58g82gs90i0df10p2hxc3nv748nah53wbp2s2lwchgp"
   }
  },
  {
@@ -64028,20 +64412,20 @@
   "repo": "donkirkby/live-py-plugin",
   "unstable": {
    "version": [
-    20211112,
-    1745
+    20211204,
+    2255
    ],
-   "commit": "61e043c705dc8804ee7c6f78ed3f374b325d5917",
-   "sha256": "0hj36x4aall7phvd9mi58scmzr42xc0zzs8jh16nq3i2xd8p0rqd"
+   "commit": "82a34879d4a607fe9f09376d20222ff3c77ef809",
+   "sha256": "01zhzbsdgrsflqpg68qcairg5478n51khp3241x1ga7ga8dyfqz8"
   },
   "stable": {
    "version": [
     4,
     5,
-    0
+    1
    ],
-   "commit": "660dd193cdb51979145a548f495ab02917bc4613",
-   "sha256": "10qcggakqv4fm96mjz72x7rrvgphizdnd4n03gm3hhvc2yw3qma9"
+   "commit": "82a34879d4a607fe9f09376d20222ff3c77ef809",
+   "sha256": "01zhzbsdgrsflqpg68qcairg5478n51khp3241x1ga7ga8dyfqz8"
   }
  },
  {
@@ -64142,26 +64526,26 @@
   "url": "https://git.sr.ht/~tarsius/llama",
   "unstable": {
    "version": [
-    20210525,
-    2005
+    20211118,
+    1847
    ],
    "deps": [
     "seq"
    ],
-   "commit": "2694b2aeb1c87bb2ad8b0f611ca438c30f5eaeae",
-   "sha256": "1xihy4xnvxvwwzy50z7msm9fkplsyy2kvi6zzlpgs8bad6aamg5f"
+   "commit": "22278a95474ccd665f84c16aa8760534ced9b150",
+   "sha256": "1f5hnimnz9vjwnqk0m07g6rrhnxbv84mdybxiblzqgbgrh7x0cx3"
   },
   "stable": {
    "version": [
     0,
-    1,
-    1
+    2,
+    0
    ],
    "deps": [
     "seq"
    ],
-   "commit": "2694b2aeb1c87bb2ad8b0f611ca438c30f5eaeae",
-   "sha256": "1xihy4xnvxvwwzy50z7msm9fkplsyy2kvi6zzlpgs8bad6aamg5f"
+   "commit": "22278a95474ccd665f84c16aa8760534ced9b150",
+   "sha256": "1f5hnimnz9vjwnqk0m07g6rrhnxbv84mdybxiblzqgbgrh7x0cx3"
   }
  },
  {
@@ -64638,11 +65022,11 @@
   "repo": "0x60df/loophole",
   "unstable": {
    "version": [
-    20210825,
-    1323
+    20211212,
+    1302
    ],
-   "commit": "71f0b40cdcffdbae84214d3d82c0a8aae154a69f",
-   "sha256": "19s5617vx5xm932anyplwcjld0p589lplkvsi4p2g69ximjlmih1"
+   "commit": "384ad0ac69483595332cc011f30b7d74065cdef9",
+   "sha256": "0xrqhmry5y61sbbda83jhmbvvz0z9bbv3wbv9068sdihqfik3fq2"
   },
   "stable": {
    "version": [
@@ -64662,15 +65046,15 @@
   "repo": "okamsn/loopy",
   "unstable": {
    "version": [
-    20211101,
-    2351
+    20211124,
+    307
    ],
    "deps": [
     "map",
     "seq"
    ],
-   "commit": "d95cf6dea7addd020d1ccacc25527f181b3eaa63",
-   "sha256": "1jxmnfyxak6c11glsx0j912bhv4y4ly0zbyjl37dfn78vb3yr7y5"
+   "commit": "6a078102467527aff5bf7d6341cc279b53657984",
+   "sha256": "0ksdgml2nz0jmrkjv939mm7kk8b0xf6d2b2h53y0crlxhi4s8823"
   },
   "stable": {
    "version": [
@@ -64701,8 +65085,8 @@
     "dash",
     "loopy"
    ],
-   "commit": "d95cf6dea7addd020d1ccacc25527f181b3eaa63",
-   "sha256": "1jxmnfyxak6c11glsx0j912bhv4y4ly0zbyjl37dfn78vb3yr7y5"
+   "commit": "6a078102467527aff5bf7d6341cc279b53657984",
+   "sha256": "0ksdgml2nz0jmrkjv939mm7kk8b0xf6d2b2h53y0crlxhi4s8823"
   },
   "stable": {
    "version": [
@@ -64782,8 +65166,8 @@
   "repo": "emacs-lsp/lsp-dart",
   "unstable": {
    "version": [
-    20211113,
-    1440
+    20211119,
+    1320
    ],
    "deps": [
     "dap-mode",
@@ -64793,8 +65177,8 @@
     "lsp-mode",
     "lsp-treemacs"
    ],
-   "commit": "9c3ba0a27e8ad3b7fa16c553d8a1815db82b8638",
-   "sha256": "13f6a9fkhasdzh4y5rix8j151csj1x6y2qlld6lvbxgpln19zwz2"
+   "commit": "7afe141fe2a60265049a846abd254b5ff4169c10",
+   "sha256": "0wrcrqvlyp6gpanp5r67qyrn3q8n2pk1w8qwrkxh6kr466cd2lxp"
   },
   "stable": {
    "version": [
@@ -64822,15 +65206,18 @@
   "repo": "emacs-lsp/lsp-docker",
   "unstable": {
    "version": [
-    20210529,
-    621
+    20211203,
+    1659
    ],
    "deps": [
     "dash",
-    "lsp-mode"
+    "f",
+    "ht",
+    "lsp-mode",
+    "yaml"
    ],
-   "commit": "7039afe9507467e0b1c1fba485f26a7892463bc5",
-   "sha256": "1f0k76ic6cv6kdszy38jfi5wbv1i9qqp3gnn63j4p0f0xj0ppsgw"
+   "commit": "c2da2a65cb11e92d23c480dcc12387aa53997181",
+   "sha256": "067bc37v14mvrmayah95qkcmi8gh3fdhdh8493wabm47kgszsfh4"
   }
  },
  {
@@ -64873,8 +65260,8 @@
   "repo": "emacs-grammarly/lsp-grammarly",
   "unstable": {
    "version": [
-    20210715,
-    918
+    20211120,
+    1840
    ],
    "deps": [
     "grammarly",
@@ -64883,8 +65270,8 @@
     "request",
     "s"
    ],
-   "commit": "0a8d9468aeb414bc698566534389031837ba354d",
-   "sha256": "17vgbqyij0q0yms5sxk9f66cxzczfpxf8wykmsgpc7xac1igf7pm"
+   "commit": "02c1d83c6e7ef703ce7426f8eff2c3fc7733cf72",
+   "sha256": "06qrd42hnz0cg28wkxcwb2mi0xpsgdy0yb8x9x7k23hzwdv6wrr6"
   },
   "stable": {
    "version": [
@@ -64911,15 +65298,15 @@
   "repo": "emacs-lsp/lsp-haskell",
   "unstable": {
    "version": [
-    20210813,
-    1040
+    20211213,
+    1950
    ],
    "deps": [
     "haskell-mode",
     "lsp-mode"
    ],
-   "commit": "4e62cf897dd9e9fcef25c6e8e483490a07a5d439",
-   "sha256": "027j70422h4r82hnqkamxl84n0844hlf0fvh3h3ah7f751hynylb"
+   "commit": "401724f9b934894c5f010d6db47bb2aa3ef6b36a",
+   "sha256": "0iga29q2yw16bx6fsrbdkvwyizz2c6ymi1783y3masyw8bg38jwq"
   }
  },
  {
@@ -64981,8 +65368,8 @@
   "repo": "emacs-lsp/lsp-java",
   "unstable": {
    "version": [
-    20211114,
-    1305
+    20211124,
+    605
    ],
    "deps": [
     "dap-mode",
@@ -64994,8 +65381,8 @@
     "request",
     "treemacs"
    ],
-   "commit": "3246272b43659ce3020e6f47cd3eea17432b389a",
-   "sha256": "0kz2bhnijar7dkyqydfq66xp8isf90paaqy0kwzjrb9ss0bglsba"
+   "commit": "ce03cb6574566e334c3ce5735458cc3ec1989486",
+   "sha256": "0z18b7xn9rgrs8w485bzw93g1nimfp0616d9xlrj0wc4k1i8vyd4"
   },
   "stable": {
    "version": [
@@ -65214,8 +65601,8 @@
   "repo": "emacs-lsp/lsp-mode",
   "unstable": {
    "version": [
-    20211115,
-    807
+    20211212,
+    1601
    ],
    "deps": [
     "dash",
@@ -65225,8 +65612,8 @@
     "markdown-mode",
     "spinner"
    ],
-   "commit": "a7effcc79114e91e74f06ef3a7e078bafba05c2a",
-   "sha256": "09kjprvbdcv6h27fi24bfg0yl37djmfkic3a3ymfzl2r52gfkchv"
+   "commit": "41173dca4d6a7fa381ba6dc154e7149cb113f7e1",
+   "sha256": "0sc6a0cw2497gq6d8dybi0mwma5cslkxnwhiwrbgl3jymmflajwb"
   },
   "stable": {
    "version": [
@@ -65393,14 +65780,14 @@
   "repo": "emacs-lsp/lsp-python-ms",
   "unstable": {
    "version": [
-    20210513,
-    1019
+    20211204,
+    1209
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "4061bc25aaddacb2fb848df08dd8bbbc12975814",
-   "sha256": "1ds19l8gvilc6bkqh7s1b5f1v4p79xkdjrq3kln0zawqsszr2crs"
+   "commit": "abf4d89ecf2fa0871130df5fce6065b7cf0a2721",
+   "sha256": "1cad09y36bf97mhgg7xncf4m856ys8n7zlbsgag5h5rja1ha71nl"
   },
   "stable": {
    "version": [
@@ -65494,14 +65881,14 @@
   "repo": "merrickluo/lsp-tailwindcss",
   "unstable": {
    "version": [
-    20211117,
-    321
+    20211211,
+    248
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "bee8bf1f6707362ace02563b4dfc481e7452f936",
-   "sha256": "0rvwp8859p0byypy83mw42akjvv54ifx0gd3f4vb9vvp879rmsfi"
+   "commit": "629ece1acc3280ee506660170cdee77446ba8c18",
+   "sha256": "0wlh68qxk811p8vs6vvjlxz48gb0vx00r4a0i5m74f6n5h41pzvh"
   },
   "stable": {
    "version": [
@@ -65523,8 +65910,8 @@
   "repo": "emacs-lsp/lsp-treemacs",
   "unstable": {
    "version": [
-    20210923,
-    2112
+    20211129,
+    955
    ],
    "deps": [
     "dash",
@@ -65533,8 +65920,8 @@
     "lsp-mode",
     "treemacs"
    ],
-   "commit": "7bf3d52bccb4a5fdce4fdde9ff61bc75161b97af",
-   "sha256": "0vbwam492y858cq1mrka9bn2i695c6rxvap8z92diklmaawdkg4p"
+   "commit": "c40a381730251039d33400cc14539c1e0729385f",
+   "sha256": "1nx5ffgy3yzyynz3ll82flxwci4zrmg608iyk8bqzgfpmdlb4ass"
   },
   "stable": {
    "version": [
@@ -65560,16 +65947,16 @@
   "repo": "emacs-lsp/lsp-ui",
   "unstable": {
    "version": [
-    20211101,
-    131
+    20211206,
+    1840
    ],
    "deps": [
     "dash",
     "lsp-mode",
     "markdown-mode"
    ],
-   "commit": "dd4c181a22d19a28236c442cf6c9cd4bbd6d85f8",
-   "sha256": "1awvnv29ca3whfg48icwqhgdfijrags61cmq9dn6mn0w849b6k4m"
+   "commit": "98d0ad00b8bf1d3a7cea490002169f2286d7208c",
+   "sha256": "1s9h593f0hjb8h4ciimvr78k19cp18h3hdwsadmjafshfdq54szw"
   },
   "stable": {
    "version": [
@@ -66080,8 +66467,8 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20211115,
-    1701
+    20211207,
+    2244
    ],
    "deps": [
     "dash",
@@ -66090,8 +66477,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "9413847c1a085899d8de6f8d978bd7265f65e5d8",
-   "sha256": "0b39813iyxgq0ai6hz4hpf9f4wix1lhcp6z5p1cm6y6hd8dyg486"
+   "commit": "1eb183e7672bf25fa77ea06d97b3d9c502a698ae",
+   "sha256": "08ci7w0pzbzs02fd8zklvhixkj8ab9vvc41w39mcik8qhr1fz5j4"
   },
   "stable": {
    "version": [
@@ -66176,8 +66563,8 @@
    "deps": [
     "magit"
    ],
-   "commit": "3debd2bdf20b78e108d309be606db01bb2cb4810",
-   "sha256": "0pmggb980an5nxjq5jkxfvib9akqyd4k9j80ljpbayhiypda93a2"
+   "commit": "5b60f0c88c33b8dbf73a41b388f55bf8e73e1d8d",
+   "sha256": "03i4rjwdqw2hf6nl5vwgh5zm235svrrnrj0wq82yk25f58dgskb6"
   }
  },
  {
@@ -66456,8 +66843,8 @@
     "libgit",
     "magit"
    ],
-   "commit": "9413847c1a085899d8de6f8d978bd7265f65e5d8",
-   "sha256": "0b39813iyxgq0ai6hz4hpf9f4wix1lhcp6z5p1cm6y6hd8dyg486"
+   "commit": "1eb183e7672bf25fa77ea06d97b3d9c502a698ae",
+   "sha256": "08ci7w0pzbzs02fd8zklvhixkj8ab9vvc41w39mcik8qhr1fz5j4"
   },
   "stable": {
    "version": [
@@ -66624,8 +67011,8 @@
    "deps": [
     "dash"
    ],
-   "commit": "9413847c1a085899d8de6f8d978bd7265f65e5d8",
-   "sha256": "0b39813iyxgq0ai6hz4hpf9f4wix1lhcp6z5p1cm6y6hd8dyg486"
+   "commit": "1eb183e7672bf25fa77ea06d97b3d9c502a698ae",
+   "sha256": "08ci7w0pzbzs02fd8zklvhixkj8ab9vvc41w39mcik8qhr1fz5j4"
   },
   "stable": {
    "version": [
@@ -67072,8 +67459,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "a61781e69d3b451551e269446e1c5f624ab81137",
-   "sha256": "1rr7vpm3xxzcaam3m8xni3ajy8ycyljix07n2jzczayri9sd8csy"
+   "commit": "c0b6bd5956744dd64052e54574e35d39f7c9d75b",
+   "sha256": "19hm9riqinbw1ria63290c5d6hszkbjrzvgsjr74pw5d7gzw4vwv"
   },
   "stable": {
    "version": [
@@ -67420,11 +67807,11 @@
   "repo": "minad/marginalia",
   "unstable": {
    "version": [
-    20211114,
-    1401
+    20211203,
+    2231
    ],
-   "commit": "8b24ffc91222f8a61f8f2aa3c3662198c7d74de9",
-   "sha256": "0kpa0h53jk01x786s8lw7ibcrb78h9ndah9i7lvr6jx0r6v30vkq"
+   "commit": "2fb2787bc302a5533e09bc558c76eb914e98543b",
+   "sha256": "1ypr2chn5fi2ycpz4dawczcjmyll5a71mfjsx8fqbms73izd5392"
   },
   "stable": {
    "version": [
@@ -67940,11 +68327,11 @@
   "url": "https://git.code.sf.net/p/matlab-emacs/src",
   "unstable": {
    "version": [
-    20210726,
-    858
+    20211122,
+    833
    ],
-   "commit": "c25894b91225ccdf0044f04020adf97cb41e73e4",
-   "sha256": "0kns1f5kg4z5wqi26mql4ja2lm1rm8zji4sjiqqlbrnk800iic55"
+   "commit": "c945bf50251150e0d4ad7ee751c7e9615cb4b3e8",
+   "sha256": "0f0h73n5zg766aqhd8w0s2lbg71av4nyswzbcxprah7l57yr6kzi"
   }
  },
  {
@@ -68055,20 +68442,20 @@
   "repo": "dochang/mb-url",
   "unstable": {
    "version": [
-    20211029,
-    2220
+    20211205,
+    1100
    ],
-   "commit": "670d31edc0938c49c77d80543c6b2a955edadf85",
-   "sha256": "0sdiwgkhqnxq3pva9cyvcjyc69qvpxc91785p1z3rgvb9z3bshjj"
+   "commit": "ca0a3878763180fe2d775feae88b87d21dd8dcb8",
+   "sha256": "101fynqcw8hnhrgkxb3wdh9a2iqp35q1rh7hijnzz5xpxds2sj96"
   },
   "stable": {
    "version": [
     0,
-    8,
+    9,
     0
    ],
-   "commit": "670d31edc0938c49c77d80543c6b2a955edadf85",
-   "sha256": "0sdiwgkhqnxq3pva9cyvcjyc69qvpxc91785p1z3rgvb9z3bshjj"
+   "commit": "ca0a3878763180fe2d775feae88b87d21dd8dcb8",
+   "sha256": "101fynqcw8hnhrgkxb3wdh9a2iqp35q1rh7hijnzz5xpxds2sj96"
   }
  },
  {
@@ -68456,16 +68843,25 @@
   "repo": "meow-edit/meow",
   "unstable": {
    "version": [
-    20211116,
-    1952
+    20211213,
+    1752
+   ],
+   "commit": "c111e74296579614847bff9df8f7a1c7e1d6ff45",
+   "sha256": "0pfx5sr6vdghappgl37a3wcd34fnds6kc75qkwwqagvxyfkiaa90"
+  },
+  "stable": {
+   "version": [
+    1,
+    1,
+    1
    ],
    "deps": [
     "cl-lib",
     "dash",
     "s"
    ],
-   "commit": "f1c81c35141e6c669a36b5ebcc04ead8cf7d7364",
-   "sha256": "1353qfvind0xwdl7ig2hb36236bdfv242kij5lwy7z6kqg1d6z0s"
+   "commit": "94fe6e5cf8450a243917e6f6ff9f9c358d19ddb1",
+   "sha256": "1jwzhwvv422i5y1mxjgb305szblqgvdzad1rzrn52xmlx0x5j9lc"
   }
  },
  {
@@ -68479,19 +68875,18 @@
     20210720,
     950
    ],
-   "commit": "a5c440c12758a7dd7d698b843e05aa4eb6d4e721",
-   "sha256": "1czqd9g6f346a96klrsb31xscy23r2ix6xfx9ks6h0fkxyw7prqa"
+   "commit": "d136be61cdd2d25c2b69abb88c005f497775c431",
+   "sha256": "0kqbmysshhr4h6gmgi4brd5kya2p5cqkv672v1hiyxzlnnq9f927"
   },
   "stable": {
    "version": [
     4,
-    3,
-    1,
+    4,
     -4,
-    412
+    413
    ],
-   "commit": "ba8ec63cf40b8999238c4639d111ca3bdb1e34cf",
-   "sha256": "1icd08irnj927d9hs5bzqjfdgc789829xy7032hs946ng44xkcg3"
+   "commit": "7607238326a9352cbee9ecf612669e28ae9fa36e",
+   "sha256": "0wijg1vh2q6yr46vkv34vvksligd0ajl4hv7m6qbz3ywqr8akg23"
   }
  },
  {
@@ -68509,23 +68904,22 @@
     "auto-complete",
     "merlin"
    ],
-   "commit": "a5c440c12758a7dd7d698b843e05aa4eb6d4e721",
-   "sha256": "1czqd9g6f346a96klrsb31xscy23r2ix6xfx9ks6h0fkxyw7prqa"
+   "commit": "d136be61cdd2d25c2b69abb88c005f497775c431",
+   "sha256": "0kqbmysshhr4h6gmgi4brd5kya2p5cqkv672v1hiyxzlnnq9f927"
   },
   "stable": {
    "version": [
     4,
-    3,
-    1,
+    4,
     -4,
-    412
+    413
    ],
    "deps": [
     "auto-complete",
     "merlin"
    ],
-   "commit": "ba8ec63cf40b8999238c4639d111ca3bdb1e34cf",
-   "sha256": "1icd08irnj927d9hs5bzqjfdgc789829xy7032hs946ng44xkcg3"
+   "commit": "7607238326a9352cbee9ecf612669e28ae9fa36e",
+   "sha256": "0wijg1vh2q6yr46vkv34vvksligd0ajl4hv7m6qbz3ywqr8akg23"
   }
  },
  {
@@ -68543,23 +68937,22 @@
     "company",
     "merlin"
    ],
-   "commit": "a5c440c12758a7dd7d698b843e05aa4eb6d4e721",
-   "sha256": "1czqd9g6f346a96klrsb31xscy23r2ix6xfx9ks6h0fkxyw7prqa"
+   "commit": "d136be61cdd2d25c2b69abb88c005f497775c431",
+   "sha256": "0kqbmysshhr4h6gmgi4brd5kya2p5cqkv672v1hiyxzlnnq9f927"
   },
   "stable": {
    "version": [
     4,
-    3,
-    1,
+    4,
     -4,
-    412
+    413
    ],
    "deps": [
     "company",
     "merlin"
    ],
-   "commit": "ba8ec63cf40b8999238c4639d111ca3bdb1e34cf",
-   "sha256": "1icd08irnj927d9hs5bzqjfdgc789829xy7032hs946ng44xkcg3"
+   "commit": "7607238326a9352cbee9ecf612669e28ae9fa36e",
+   "sha256": "0wijg1vh2q6yr46vkv34vvksligd0ajl4hv7m6qbz3ywqr8akg23"
   }
  },
  {
@@ -68606,23 +68999,22 @@
     "iedit",
     "merlin"
    ],
-   "commit": "a5c440c12758a7dd7d698b843e05aa4eb6d4e721",
-   "sha256": "1czqd9g6f346a96klrsb31xscy23r2ix6xfx9ks6h0fkxyw7prqa"
+   "commit": "d136be61cdd2d25c2b69abb88c005f497775c431",
+   "sha256": "0kqbmysshhr4h6gmgi4brd5kya2p5cqkv672v1hiyxzlnnq9f927"
   },
   "stable": {
    "version": [
     4,
-    3,
-    1,
+    4,
     -4,
-    412
+    413
    ],
    "deps": [
     "iedit",
     "merlin"
    ],
-   "commit": "ba8ec63cf40b8999238c4639d111ca3bdb1e34cf",
-   "sha256": "1icd08irnj927d9hs5bzqjfdgc789829xy7032hs946ng44xkcg3"
+   "commit": "7607238326a9352cbee9ecf612669e28ae9fa36e",
+   "sha256": "0wijg1vh2q6yr46vkv34vvksligd0ajl4hv7m6qbz3ywqr8akg23"
   }
  },
  {
@@ -69198,14 +69590,14 @@
   "repo": "kiennq/emacs-mini-modeline",
   "unstable": {
    "version": [
-    20210725,
-    900
+    20211130,
+    604
    ],
    "deps": [
     "dash"
    ],
-   "commit": "fb2fc8661b4a32a40b3f5777ae1d69654c263ff0",
-   "sha256": "1bv06p6m5xygqcpwxngds2hral58h23jvp3di5dq3ac2hkf2m92l"
+   "commit": "434b98b22c69c8b3b08e9c267c935591c49a8301",
+   "sha256": "063bpi3gxzi6kkc3mb9h4m8lvbsvfw47z559960h912h2l3z6vhq"
   },
   "stable": {
    "version": [
@@ -70028,20 +70420,20 @@
   "repo": "protesilaos/modus-themes",
   "unstable": {
    "version": [
-    20211114,
-    1209
+    20211213,
+    700
    ],
-   "commit": "a70c6d0f752859c6de2c175dd9b71a66bf28ed97",
-   "sha256": "05l919641qn2dm6b328i6ymb2xgc42jbvpdvnwypi9brydnz7zm9"
+   "commit": "8f9491d0e2b915dda99224bdbf5b0c063ea537a5",
+   "sha256": "05s7y80020ff8qf9vlql1i1y21g0il80lwijd49n77byawa27cby"
   },
   "stable": {
    "version": [
     1,
-    6,
+    7,
     0
    ],
-   "commit": "8dbfe43fe52a9420a23d29e8ca631c2b7f52d966",
-   "sha256": "12f0bki57cncfzyi8cv8fkvxhh8khlxd890x0glb5ny9w1hd6s11"
+   "commit": "6f69627703caffbd62ba1a89d4a337fc29773ab4",
+   "sha256": "05s7y80020ff8qf9vlql1i1y21g0il80lwijd49n77byawa27cby"
   }
  },
  {
@@ -70375,11 +70767,11 @@
   "repo": "tarsius/moody",
   "unstable": {
    "version": [
-    20211031,
-    1815
+    20211130,
+    1719
    ],
-   "commit": "5ce7cc070ff5a295b1cc4b15b94698447f9596ae",
-   "sha256": "0yrxdxd3iv6vmym8fwp1d1r3bliid5my3a9720pdbhd887i6m4bx"
+   "commit": "60d49cb8ead8fc24b7034fff4de3c4ad959398b6",
+   "sha256": "0lqqxxhrfr9bad6i9xas0b8fcgqwfgvgh6zfla63j5mm4x4azj7x"
   },
   "stable": {
    "version": [
@@ -70663,8 +71055,8 @@
     20210306,
     1053
    ],
-   "commit": "3dc692847d53e209ef9010791c3ab5ac06fd979b",
-   "sha256": "0pcf2vnq38jdnsg8vz92pqsx7qd0r9x8jv5kfqk9br153vsh6xgd"
+   "commit": "01306d0c67c5faa203994bab281c515b9d1248fa",
+   "sha256": "109p65vwii1ppvpnvmgpzn0k0iraby23da1xsb2frad6lc3clz65"
   },
   "stable": {
    "version": [
@@ -70881,16 +71273,16 @@
   "repo": "kljohann/mpv.el",
   "unstable": {
    "version": [
-    20210207,
-    1140
+    20211121,
+    1801
    ],
    "deps": [
     "cl-lib",
     "json",
     "org"
    ],
-   "commit": "2d24187f7bdb0495c90d5109a730742e735636ba",
-   "sha256": "1siwl0pjmklpzywn5jmq7jgnsynpa6qafm6mqg9h8gxxbswd5xbi"
+   "commit": "b026ae5bb6139b8bbbc572d24974dcd295c1465c",
+   "sha256": "1knipmddx8nrd762v7lsnjjqacfrj53ya28yji8k2929k9s3rq83"
   },
   "stable": {
    "version": [
@@ -71350,8 +71742,8 @@
    "deps": [
     "dash"
    ],
-   "commit": "360e44b200d07da379c906856d37613d0f06a9ae",
-   "sha256": "0z2b26qr712j4745wlnqisc53fhh2gh088j6024b00n006fr1lzq"
+   "commit": "5e1e63b6ae4bd94aab5902b14b2bf4238e502cfb",
+   "sha256": "0f27qvf8qh5arzzk9a847qdi87ybkzjl6pgmb9sagrzhybpx8diy"
   }
  },
  {
@@ -72872,8 +73264,8 @@
     20170612,
     437
    ],
-   "commit": "a2bab83c2eb233d57d76b236e7c141c2ccc97005",
-   "sha256": "17dh5pr3gh6adrbqx588gimxbb2fr7iv2qrxv6r48w2727l344xs"
+   "commit": "6e9d96f58eddd69f62f7fd443d9b9753e16e0e96",
+   "sha256": "188m43zv5hidm5xfykfxhrk0nl9i6kcgpqqqnshhiv82c55g46w4"
   },
   "stable": {
    "version": [
@@ -73038,11 +73430,20 @@
   "repo": "m-cat/nimbus-theme",
   "unstable": {
    "version": [
-    20211115,
-    430
+    20211209,
+    1529
    ],
-   "commit": "fe8ebe24cecb0181f49446de0a0faf3cd7630747",
-   "sha256": "1c7y0b880572sxjqqsqf521yhb1jfhl4i7sm4nfysa85bnn6k5n2"
+   "commit": "5ae0bee99d005e62c3b18e793a81405a1a3ca0e5",
+   "sha256": "15fhim7cj7inc2kyl0xgv18a8p4lygnpkxgbq34nl567y9374vs4"
+  },
+  "stable": {
+   "version": [
+    1,
+    1,
+    0
+   ],
+   "commit": "5ae0bee99d005e62c3b18e793a81405a1a3ca0e5",
+   "sha256": "15fhim7cj7inc2kyl0xgv18a8p4lygnpkxgbq34nl567y9374vs4"
   }
  },
  {
@@ -73155,14 +73556,14 @@
   "repo": "NixOS/nix-mode",
   "unstable": {
    "version": [
-    20211109,
-    1805
+    20211120,
+    1627
    ],
    "deps": [
     "magit-section"
    ],
-   "commit": "e7bf2e4cc49e7a12265714dfaf5e286bfbc1e87f",
-   "sha256": "0ym70i1jndm12av9jzq5qq3vr2d5cjh5q95vq22whiah0svbbpxy"
+   "commit": "3d04d92d9c3896d07bc9fed7e4f40032025fbe7b",
+   "sha256": "0rzgnr18gk37y8i4d7rgwjhrxwby0zpkam8k7rf4jq35jjhqr5a4"
   },
   "stable": {
    "version": [
@@ -73771,20 +74172,20 @@
   "url": "https://git.notmuchmail.org/git/notmuch",
   "unstable": {
    "version": [
-    20211030,
-    1819
+    20211212,
+    1414
    ],
-   "commit": "fc3c79dd37d4bae938a5d0a1d7773bea48dd09b4",
-   "sha256": "02bv1fvbww9gk3phpd7ifzxfzjxm17k7ssd3ddizr6yvmkpsz7h0"
+   "commit": "ed03babd053d679a85ea3baa1632d8ae1dff31b6",
+   "sha256": "1hchhwy2kv90014f52zpf2a8qycknplhb9lrpf71aci8f58ndnv0"
   },
   "stable": {
    "version": [
     0,
     34,
-    1
+    2
    ],
-   "commit": "6858c365956ba26b42721093707e5a57ca8a6b93",
-   "sha256": "1bzcnly2xhyfw35k277i8qmw2gdy35jvkriwcyv9y3g7aicbqcc7"
+   "commit": "a254a15861d3510adbe2897fed100a3c77642165",
+   "sha256": "1sn6qb2d7rr7jnlr3vyfcvlzzi7b1l1p0mi2s7nghv8x59b5dqp4"
   }
  },
  {
@@ -73944,15 +74345,15 @@
   "url": "https://depp.brause.cc/nov.el.git",
   "unstable": {
    "version": [
-    20210323,
-    1105
+    20211130,
+    1805
    ],
    "deps": [
     "dash",
     "esxml"
    ],
-   "commit": "b3c7cc28e95fe25ce7b443e5f49e2e45360944a3",
-   "sha256": "0va9xjrq30cv5kb59a4rq5mcm83ggnv774r8spmskff3hj8012wf"
+   "commit": "436f5ec473b69a9d3b6cb6405508e3564f61cd4b",
+   "sha256": "020akj3vi0m63kmda4i6rm9ax7s6di28v5s2cmjkggb4al0n0n6m"
   },
   "stable": {
    "version": [
@@ -74547,8 +74948,8 @@
    "deps": [
     "axiom-environment"
    ],
-   "commit": "3266c5b2e4865337da86043b53a4e6609dbc8308",
-   "sha256": "11k53vvw5df66f54mh3zkghspmi7zsgls3mlkfvl19hz2z1pyhwq"
+   "commit": "e60de5ed107ffeb530a56d24d04f38988124d12b",
+   "sha256": "0p8kbxfcrx1ib8g17g6h2i2ygy35qq992n3s2xa6ysij7wrfn4hd"
   }
  },
  {
@@ -75707,17 +76108,17 @@
     20210923,
     1348
    ],
-   "commit": "f2f50d6fb0371b85bde2eda15c440b68d46059ac",
-   "sha256": "01ac3k1kq6hy2n332775jlh2rg1pmqs8gvkx4qskxmpga87753m7"
+   "commit": "51cd55ad0aa6c6ccbea7fe3041de0931c0292be5",
+   "sha256": "1kga1izbp301rv8y2kdcwc2jrvy4bplaglsbspqm64yz6jcj570l"
   },
   "stable": {
    "version": [
     0,
-    19,
-    0
+    20,
+    1
    ],
-   "commit": "ba67af28ddca8718ef8816b2b0dc1e5b2f5e9591",
-   "sha256": "0dp4pkznz9yvqx9gxwbid1z2b8ajkr8i27zay9ghx69624hz3i4z"
+   "commit": "74668925ca977e252acb084bd139b3077cf95b58",
+   "sha256": "1q78gxsz763d6vbi1lyfmn7733l10qhq80bchdli9zw7sggs7nq1"
   }
  },
  {
@@ -75901,26 +76302,26 @@
   "repo": "oer/oer-reveal",
   "unstable": {
    "version": [
-    20211029,
-    611
+    20211213,
+    1012
    ],
    "deps": [
     "org-re-reveal"
    ],
-   "commit": "44eb766df39b722a26cabebec44bb359bcca1e49",
-   "sha256": "12mdp7pxb4nga1pp17d3kawb55kjdnjc1fg8lavyq4ydznyzn225"
+   "commit": "2ac8f82f3816995a50e47f0f9247b806346d30f6",
+   "sha256": "1kfrnmsjgnn6q5k297q7ka7zqkni33dxsc6dnv5raizlhcxif0qv"
   },
   "stable": {
    "version": [
     4,
-    0,
-    0
+    1,
+    1
    ],
    "deps": [
     "org-re-reveal"
    ],
-   "commit": "c26ddb39288b60ba96f970fa20ef810aa4d0f418",
-   "sha256": "12mdp7pxb4nga1pp17d3kawb55kjdnjc1fg8lavyq4ydznyzn225"
+   "commit": "ef77f31fb99babe7918356897ecc18651a9d30bc",
+   "sha256": "1kfrnmsjgnn6q5k297q7ka7zqkni33dxsc6dnv5raizlhcxif0qv"
   }
  },
  {
@@ -76648,11 +77049,11 @@
   "repo": "oantolin/orderless",
   "unstable": {
    "version": [
-    20210912,
-    1932
+    20211130,
+    102
    ],
-   "commit": "62f71c34baca0b7d0adeab4a1c07d85ffcee80d9",
-   "sha256": "1spab90q4illpsajw0hcfz8s76c1gp8qpmc6zmv14slg1i9m5yri"
+   "commit": "1ccf74ffdbb0dd34caa63022e92f947c09c49c86",
+   "sha256": "16vhmm9an2n5wlj7bvz2rx2qassk5b3d6la90kfm7lnqwch4a7mn"
   },
   "stable": {
    "version": [
@@ -76844,14 +77245,14 @@
   "repo": "awth13/org-appear",
   "unstable": {
    "version": [
-    20210822,
-    39
+    20211202,
+    604
    ],
    "deps": [
     "org"
    ],
-   "commit": "a1aa8496f2fd61305e43e03e6eeee2ff92aa9e24",
-   "sha256": "0sfz8rpvc9hidjj81wlc48vi7ii90mssgvfnp2z215phv67npbzp"
+   "commit": "a4d10fc346ba14f487eb7aa95761b9295089ba55",
+   "sha256": "1jl767qqmnhwbjnivc332yvpjifs95qnf08n088fazg6vax70zhq"
   },
   "stable": {
    "version": [
@@ -76924,14 +77325,14 @@
   "stable": {
    "version": [
     0,
-    2,
-    13
+    3,
+    0
    ],
    "deps": [
     "async"
    ],
-   "commit": "ea2ca74a68eb44d935b7240ffc8f19c8a4db334a",
-   "sha256": "0wskvkwrw0vgknq895by10bcwglaikgkrs1z54f6wyfyksa801ja"
+   "commit": "ad3c332f062b5830e88b2ab13287a096ae434657",
+   "sha256": "05yrw59zrzxj1p8n65sk6mvy7jzik812mp9i2nsimwhlhn3si1pj"
   }
  },
  {
@@ -77480,15 +77881,15 @@
   "repo": "vapniks/org-dotemacs",
   "unstable": {
    "version": [
-    20190903,
-    2024
+    20211126,
+    2038
    ],
    "deps": [
     "cl-lib",
     "org"
    ],
-   "commit": "ee59739c2d59151fe7d7d3034e87c7691120a5be",
-   "sha256": "17xrjhfjahryawrmkd2p0yi7pfxfvgdfhh4n18jdmfkrr6gllavg"
+   "commit": "598759f4a139f94da62836e8f8064da6377536b2",
+   "sha256": "1vikwxwmbkzpg000jv59h3ia3aap3ac3pqc6wia2ni5nw4gfbxcp"
   }
  },
  {
@@ -77970,8 +78371,8 @@
   "repo": "Trevoke/org-gtd.el",
   "unstable": {
    "version": [
-    20211006,
-    1657
+    20211124,
+    2203
    ],
    "deps": [
     "f",
@@ -77979,8 +78380,8 @@
     "org-agenda-property",
     "org-edna"
    ],
-   "commit": "42e75bad36b8a9cadf7ba3cee94c66801e195120",
-   "sha256": "1j2phw903bg7wpymqyrz6yv262s5yjn9dpw6bs9yvy6d9cd3ip64"
+   "commit": "ca5b19dcfd3af5c5222654b2c12ce7bd6f3667c7",
+   "sha256": "1laxw7ixcvdh4cgx5z669wvmwn5x9qqq0gyvl3rj79nrdv755wwr"
   },
   "stable": {
    "version": [
@@ -78327,14 +78728,14 @@
   "repo": "stardiviner/org-link-beautify",
   "unstable": {
    "version": [
-    20211022,
-    114
+    20211209,
+    448
    ],
    "deps": [
     "all-the-icons"
    ],
-   "commit": "7a9a5910cf7037c044af9b3be1b8c2f42488b1c1",
-   "sha256": "0db4p9kjz6fh0ignprkb25bshwa349ns4xzc98v21b9zcbs46wz5"
+   "commit": "29a44cff345928d8ded7ff814edcbf5a3ea0550e",
+   "sha256": "0cgf6bb3b0s378w48sdma0lyasdj93ngfvrdlnnjggk5hlcr98sx"
   }
  },
  {
@@ -78456,11 +78857,11 @@
   "repo": "org-mime/org-mime",
   "unstable": {
    "version": [
-    20210901,
-    244
+    20211130,
+    716
    ],
-   "commit": "23cc52bb539c898de228fc438cd24ed10213bea3",
-   "sha256": "1g32chan6rhlp3kvzd2lvf104i3p37q1sm0d89pq6sya0ia2as1n"
+   "commit": "3b119a22be0ee22d16773e4d9a26478d3c8bf2df",
+   "sha256": "1khvfw2vqakvnai0i5wzr6mlxr01ijbcjm655xv17yp95d878bqw"
   },
   "stable": {
    "version": [
@@ -78499,16 +78900,16 @@
   "repo": "ndwarshuis/org-ml",
   "unstable": {
    "version": [
-    20210911,
-    2131
+    20211213,
+    105
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "5d61f456b0a639e178d6ae4f210e28be5621a620",
-   "sha256": "1ca6wgjwslv3582fmsxna81mgryziw9v9zh1836sbp3yszqddday"
+   "commit": "4fdf359fb716bf9b606650ac119ba10021f94f26",
+   "sha256": "0chnvs577wvddmcx37gij1zw95hii1lmdycr7w2wp5ig2dyz67ns"
   },
   "stable": {
    "version": [
@@ -79073,14 +79474,14 @@
   "repo": "jakebox/org-preview-html",
   "unstable": {
    "version": [
-    20210911,
-    1528
+    20211126,
+    2350
    ],
    "deps": [
     "org"
    ],
-   "commit": "5f7345e75d0fe71afb19fd30c841dff5bdd6d1ab",
-   "sha256": "13i6yqhizh86608hwlkc4ipsaxx44y79v40kpn007h8p1wl1ba7a"
+   "commit": "14e39aec6e29dc15ff40b219b2b7284a9ec0af36",
+   "sha256": "0qza6ylknsd0d87dhwxk5hyqzs5107n2s8y189nr23lnyvpggn49"
   }
  },
  {
@@ -79300,15 +79701,15 @@
   "repo": "oer/org-re-reveal",
   "unstable": {
    "version": [
-    20211025,
-    1153
+    20211119,
+    624
    ],
    "deps": [
     "htmlize",
     "org"
    ],
-   "commit": "ee0417aac3969ec2d776eba1ddc6434d4c61a10d",
-   "sha256": "0j7394zcbzqfk33g2xdyb3fmw3brxy8v66vvf1j9nqlskfddh7bn"
+   "commit": "55fca47c740c50fe04cbf2b8ae90e02174626c0c",
+   "sha256": "01h1vdg96ml8zxfi78j178w4m33n2rmwgcl6k2cisymcfijcp2c5"
   },
   "stable": {
    "version": [
@@ -79476,8 +79877,8 @@
   "repo": "jkitchin/org-ref",
   "unstable": {
    "version": [
-    20211110,
-    1229
+    20211209,
+    2052
    ],
    "deps": [
     "avy",
@@ -79490,8 +79891,8 @@
     "parsebib",
     "s"
    ],
-   "commit": "c87b4155cd2f60ca3a9bed2e6e366c1fa47aec33",
-   "sha256": "1idshb4g1d7ghdwwfyglvqqdjbdi3lrigkgq2rsbhrv7lpxcb8vn"
+   "commit": "12e5f9e89b92e731d5c199ff46f4f887ace9b791",
+   "sha256": "1h8sjcylqklssc5pw723cbl2paha47s3gcgqsn2ak9wzd0zkwads"
   },
   "stable": {
    "version": [
@@ -79524,15 +79925,15 @@
   "repo": "alezost/org-ref-prettify.el",
   "unstable": {
    "version": [
-    20211111,
-    742
+    20211204,
+    825
    ],
    "deps": [
     "bibtex-completion",
     "org-ref"
    ],
-   "commit": "0cecd7b2611bd9d282876ab46d490ce3e635ba86",
-   "sha256": "0jhspfp2mm69q7p1n986pal88ywm5zm9a6f2q073slnpiv4qwvz2"
+   "commit": "bffbc409d277e78ffc4005834d5cbaee19b89bbb",
+   "sha256": "0dd1avxivc1n73l0jz96mh9jhh1cg4c9icai4ypa38p4sb4czmvh"
   }
  },
  {
@@ -79638,8 +80039,8 @@
   "repo": "org-roam/org-roam",
   "unstable": {
    "version": [
-    20211114,
-    913
+    20211213,
+    944
    ],
    "deps": [
     "dash",
@@ -79649,8 +80050,8 @@
     "magit-section",
     "org"
    ],
-   "commit": "d93423d4e11da95bcf177b2bc3c74cb1d1acf807",
-   "sha256": "1az6i7031ff63gxz3wfdg00w1b57r10j12a6s5w3vgchsz896skm"
+   "commit": "7068d63e966c0ca8d098ac4f7a90434f4c9b6822",
+   "sha256": "0yb2n4jvfpnbcvik8v2kfklgl4pbsxbkahl98m9bn56vgian9m2b"
   },
   "stable": {
    "version": [
@@ -79678,30 +80079,30 @@
   "repo": "org-roam/org-roam-bibtex",
   "unstable": {
    "version": [
-    20211117,
-    1225
+    20211203,
+    1348
    ],
    "deps": [
     "bibtex-completion",
     "org-ref",
     "org-roam"
    ],
-   "commit": "f399b85f5c38bd52f6eb41da18fccfb971a04fe1",
-   "sha256": "1da5yv204qvnw5rrczyi5k2982a03l9lygkqh4nbpknm8i7nhrbv"
+   "commit": "196e5815dd13b014804122c4e32ee5f16f0ad66b",
+   "sha256": "1d09y923d9n5v7m201myba85m4064s2hdy3pgzssy70mjncg3m1g"
   },
   "stable": {
    "version": [
     0,
     6,
-    0
+    1
    ],
    "deps": [
     "bibtex-completion",
     "org-ref",
     "org-roam"
    ],
-   "commit": "eea7469fc32eddc9d74621b7ecc1f36832b7efd3",
-   "sha256": "04vc2w7x2lyamp0qa1y274smsf9x2qxr1igrpz9f4y5ha5332px5"
+   "commit": "196e5815dd13b014804122c4e32ee5f16f0ad66b",
+   "sha256": "1d09y923d9n5v7m201myba85m4064s2hdy3pgzssy70mjncg3m1g"
   }
  },
  {
@@ -79730,16 +80131,16 @@
   "repo": "org-roam/org-roam-ui",
   "unstable": {
    "version": [
-    20211117,
-    1208
+    20211209,
+    1418
    ],
    "deps": [
     "org-roam",
     "simple-httpd",
     "websocket"
    ],
-   "commit": "2b167cd03f29714267057e4c0b437a4d6a01b299",
-   "sha256": "0k6i69afzswqvg4zl6b4m5gl7rrrr15yli2kn0g8nlfg0z2ay6dm"
+   "commit": "9ed0c5705a302a91fab2b8bcc777a12dcf9b3682",
+   "sha256": "1am11vnzklv0cbivsw5r8x8fx457166mvfgyv7cdhrz88s8iqm23"
   }
  },
  {
@@ -80058,11 +80459,11 @@
   "repo": "bastibe/org-static-blog",
   "unstable": {
    "version": [
-    20210616,
-    809
+    20211201,
+    1221
    ],
-   "commit": "4738a7bdb24cb4e1d1d5effc23f953e4c76e7713",
-   "sha256": "0kpa1rnpxfar8xkah29f9h6q26fgdxcb8gimsfqvrj145vama7pr"
+   "commit": "cb1fa87896c5cc31430f2d375737144bb1982a76",
+   "sha256": "0q8vznz2q54qkvkspjamlphsgk95pjvlf89fc5m3v5pr92qhvzbk"
   },
   "stable": {
    "version": [
@@ -80283,15 +80684,15 @@
   "repo": "stardiviner/org-tag-beautify",
   "unstable": {
    "version": [
-    20210904,
-    1643
+    20211209,
+    447
    ],
    "deps": [
     "all-the-icons",
     "org-pretty-tags"
    ],
-   "commit": "bdf438847e05f1f9c08c69e93c3d5e717b589074",
-   "sha256": "09k7zmdcyy5mymij4a2wq6s6r60njkxrmiybbwvln322wl0ldgsh"
+   "commit": "7ba298dba1da0cb0d5cee3f366a88f17e778a20f",
+   "sha256": "0bkaj43d1pnna2yicj6584acx173irqdbnhn7mg5hr223qzks42z"
   }
  },
  {
@@ -80531,11 +80932,11 @@
   "repo": "takaxp/org-tree-slide",
   "unstable": {
    "version": [
-    20211009,
-    1707
+    20211213,
+    1254
    ],
-   "commit": "27f8bb6a9676e1c0b500e75799e3b5c37a9156af",
-   "sha256": "0751qlg8xxwx7mldgdry1gfrarvhzg2smjzxd3382i6j63mpala9"
+   "commit": "917612a0d1593de533b7bf0a2792d7e37bb2ca3d",
+   "sha256": "0kqq47f5fgjx1dp72c3qy3lbqb088qh0b5shn5xrqrq84xzilipy"
   },
   "stable": {
    "version": [
@@ -81262,19 +81663,19 @@
   "repo": "tgbugs/orgstrap",
   "unstable": {
    "version": [
-    20210926,
-    2314
+    20211126,
+    2201
    ],
-   "commit": "b99455846908d007cf50ca1ef7093554dc3121a0",
-   "sha256": "1z4hva6dzqrkkabv1apqhic3d2r21dsf9m60blmbnhx6hbc5vgv3"
+   "commit": "bc981b957967be8d872c08be9ba7f2dbde5caf1d",
+   "sha256": "1gn9bs5fxrshyyi7wqm30p2d4izjdrspvh5cx8fs803mxl593wim"
   },
   "stable": {
    "version": [
     1,
-    3
+    4
    ],
-   "commit": "b99455846908d007cf50ca1ef7093554dc3121a0",
-   "sha256": "1z4hva6dzqrkkabv1apqhic3d2r21dsf9m60blmbnhx6hbc5vgv3"
+   "commit": "dbcc35f0dc854dfd4412ca4aa9c5894a2ccb0321",
+   "sha256": "0611zcfkp4min1ixal93qfvbm03w56ydb9hl086vss36ramdiyng"
   }
  },
  {
@@ -81285,11 +81686,11 @@
   "repo": "tbanel/orgaggregate",
   "unstable": {
    "version": [
-    20210925,
-    1850
+    20211203,
+    1717
    ],
-   "commit": "3ddf2fc2262ec7d1ae62aff251a70dcb26dd5f04",
-   "sha256": "09lj6kw1fz1hmrr703rx46d3zsp1kpdzavc3nv1q8x7ii9q0w9bw"
+   "commit": "bbffe6ac2ec3f0ec8c84d628f105072f64f5a00e",
+   "sha256": "1ybva6qxdpnawhv53rqkbs14yrcsgqr0s8xmz1d135pcf31fbsrr"
   }
  },
  {
@@ -81315,14 +81716,14 @@
   "repo": "tbanel/orgtbljoin",
   "unstable": {
    "version": [
-    20210828,
-    715
+    20211202,
+    1204
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "f09ba7fd304b36773a337323a0749cc681ce5049",
-   "sha256": "0li0zks7n8kj30z2a71xyaa6qpp5kgrrikrz1562cymp5r3ddbxv"
+   "commit": "e6a6d1265e1aa93a5b5228ebd3c40fc37fe4496a",
+   "sha256": "1cmwiph9a93zhi8wkz8ps8gcwhyz7k7cj468cnp5ar9ib3ybladp"
   }
  },
  {
@@ -81565,11 +81966,11 @@
   "repo": "raghavgautam/osx-lib",
   "unstable": {
    "version": [
-    20211113,
-    1849
+    20211206,
+    619
    ],
-   "commit": "06744dae53b4ade99b0cd733823e1c8f6b0aa2c4",
-   "sha256": "0rfb9nh5xvfqpnk8k0hxaiv7ywzzzn8dpx3gxx6d2jn25glwp8ql"
+   "commit": "7afdb57edd5725e8a66f841a90fa571a4cbb81e7",
+   "sha256": "02gpfzlbgwxlf7iy7qjzkpkqxhdr81nj06cg6g4mvg0ggvkgyz1s"
   }
  },
  {
@@ -82231,14 +82632,14 @@
   "repo": "kaushalmodi/ox-hugo",
   "unstable": {
    "version": [
-    20211024,
-    1851
+    20211203,
+    1553
    ],
    "deps": [
     "org"
    ],
-   "commit": "3442d8cf1f60f28cf28daaca06f524dd660681f8",
-   "sha256": "123zg67bribf86i98rzvha1fyh72a12bkjrcgn06vph5vm5m08q1"
+   "commit": "88e60681901573797ce53c91ad8fa0936f6e4ee2",
+   "sha256": "0z2ln4iml780xk7qq996aihd7954jx2cpc6f7ayhhx9190dh6lcz"
   },
   "stable": {
    "version": [
@@ -82495,16 +82896,16 @@
   "repo": "emacsorphanage/ox-pandoc",
   "unstable": {
    "version": [
-    20211009,
-    1414
+    20211127,
+    1430
    ],
    "deps": [
     "dash",
     "ht",
     "org"
    ],
-   "commit": "e76324ecf1b9be6353bf22ff5e13652ea2714674",
-   "sha256": "1x1klhj4570mzcnrdlj56qs9hi41nvdmghgj6ddwg6n0lm2kglys"
+   "commit": "eda1f21fd519427c070d165f8a663db07b87ac29",
+   "sha256": "1d8ymkxgfz5z3nrxaad90q4xdc8vj0vqyv9rwv2fhyx9gl72xhg9"
   },
   "stable": {
    "version": [
@@ -82590,14 +82991,14 @@
   "repo": "yjwen/org-reveal",
   "unstable": {
    "version": [
-    20211114,
-    1307
+    20211128,
+    1509
    ],
    "deps": [
     "org"
    ],
-   "commit": "2adca68b2be22bcc05d5136b571472667ffab4fd",
-   "sha256": "1x0ksafnq2fsqg7vls2qdhnk189bfk3184303whircbs0rgiz6md"
+   "commit": "59adea80013e962811b204403cc500a4d28b85a0",
+   "sha256": "133vzdhyzg5w5fqrams9n88adr8klpgb53g2ig2rvir3sckp449v"
   }
  },
  {
@@ -82651,8 +83052,8 @@
     "org",
     "ox-gfm"
    ],
-   "commit": "89cedb9da6ea08b78bc1fe77d6a39aa078172c1e",
-   "sha256": "0a97la3hwkb792a26c6byavwzg8gca6s0ccajd7pi9p430ys1i9y"
+   "commit": "bd797dcc58851d5051dc3516c317706967a44721",
+   "sha256": "1kh2v08fqmsmfj44ik8pljs3fz47fg9zf6q4mr99c0m5ccj5ck7w"
   }
  },
  {
@@ -83006,8 +83407,8 @@
     20210124,
     640
    ],
-   "commit": "06fbc904e09d3349b669c2624a587fee5accf5ef",
-   "sha256": "0mmziyswrfj1a43cy6qn1d8b1a302z4w3xk4z5yi5frdr22j684c"
+   "commit": "079da78f3be8364e964f5861a5f433ad61b6f654",
+   "sha256": "0xxs4iaqxgdgqklrcjj2ydnr9p0l5277xi8gkbar06j65k1l28pj"
   },
   "stable": {
    "version": [
@@ -83027,14 +83428,14 @@
   "repo": "melpa/package-build",
   "unstable": {
    "version": [
-    20210724,
-    1143
+    20211213,
+    1428
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "01246e739da2eded6e007631861cada633302faa",
-   "sha256": "03w5yaivh2zc8c42zrfqmrlcc8lkmg3jjxa7sf223bwq1v9xypdj"
+   "commit": "da9fcbb6bf020922987914a96f1d12012c914d4c",
+   "sha256": "033137h1wwg37c45mmxzyz9ixx6sm90pin131nb6pi5z8jr80hw0"
   },
   "stable": {
    "version": [
@@ -83071,15 +83472,15 @@
   "repo": "purcell/package-lint",
   "unstable": {
    "version": [
-    20211107,
-    1614
+    20211122,
+    1152
    ],
    "deps": [
     "cl-lib",
     "let-alist"
    ],
-   "commit": "786d8b5f382ee5f254a783378e904305cc41367f",
-   "sha256": "19mrzb2ligkz8gyihlrqvb3wbzmsqkpn58kfcnx6dldvk4s2ykdn"
+   "commit": "b5f5554ec38ec2a4d5ef49a0ad9f57f6825d9af9",
+   "sha256": "1ic1a0j8gj930ssc623vi55jflyfw52gb9zkf3yg51w43cw4isfn"
   },
   "stable": {
    "version": [
@@ -83108,8 +83509,8 @@
    "deps": [
     "package-lint"
    ],
-   "commit": "786d8b5f382ee5f254a783378e904305cc41367f",
-   "sha256": "19mrzb2ligkz8gyihlrqvb3wbzmsqkpn58kfcnx6dldvk4s2ykdn"
+   "commit": "b5f5554ec38ec2a4d5ef49a0ad9f57f6825d9af9",
+   "sha256": "1ic1a0j8gj930ssc623vi55jflyfw52gb9zkf3yg51w43cw4isfn"
   },
   "stable": {
    "version": [
@@ -83496,15 +83897,15 @@
   "repo": "joostkremers/pandoc-mode",
   "unstable": {
    "version": [
-    20210910,
-    2043
+    20211208,
+    2229
    ],
    "deps": [
     "dash",
     "hydra"
    ],
-   "commit": "bf01a14e99304653ae722226ea064c7d4b641774",
-   "sha256": "0g64fbcbw8pfq92drgixgplrljw954y9fyp9gjbmc5rq2dhpck4l"
+   "commit": "c1429887287b7ee9601196e26f97c908b6e4f5c0",
+   "sha256": "1zw92bkp5mjzc78vrvsaj3ycqn0j5mqzxxxv2nkb891spgandpvy"
   },
   "stable": {
    "version": [
@@ -83875,20 +84276,19 @@
   "repo": "joostkremers/parsebib",
   "unstable": {
    "version": [
-    20210809,
-    2049
+    20211208,
+    2335
    ],
-   "commit": "8d7cf64badde2b14baac277cac85e83777da9409",
-   "sha256": "1hd6izpb4irinjmfy7zxy8fqnr1fm4iw2sipvl9261nm68dzha6z"
+   "commit": "3d46fb939371664682c711750367de088aa66f92",
+   "sha256": "08vrkadjxaw1w1bx8dg12kxxkvgl65p0d7gkpfhwpvv35k0d9z3y"
   },
   "stable": {
    "version": [
     3,
-    0,
     1
    ],
-   "commit": "8d7cf64badde2b14baac277cac85e83777da9409",
-   "sha256": "1hd6izpb4irinjmfy7zxy8fqnr1fm4iw2sipvl9261nm68dzha6z"
+   "commit": "3d46fb939371664682c711750367de088aa66f92",
+   "sha256": "08vrkadjxaw1w1bx8dg12kxxkvgl65p0d7gkpfhwpvv35k0d9z3y"
   }
  },
  {
@@ -85052,14 +85452,14 @@
   "repo": "nex3/perspective-el",
   "unstable": {
    "version": [
-    20211103,
-    522
+    20211213,
+    435
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "54dc30840c8019f387ccdb84bbab06ca2cf8f296",
-   "sha256": "1d2jmxfb6a93d9h4m7w482f3dbhhn2s6wiynzwxjl8af1l19f5aa"
+   "commit": "d8211a80fbc2cc0d9e163ef6a3e1d0a693b4e00e",
+   "sha256": "1p7il5s5r582w7if3v3cwkvdb6myszkf2fr2f3sw0x70x644bq2z"
   },
   "stable": {
    "version": [
@@ -86128,15 +86528,15 @@
   "repo": "arifer612/pippel",
   "unstable": {
    "version": [
-    20210614,
-    1655
+    20211205,
+    1711
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "2480fd376b8f69691b45b0141fca0d900a5ac64a",
-   "sha256": "190cd66bhvlmyxki7hl43s0h4rvflw9r36xm4ky3c1mhbkrfsz1p"
+   "commit": "5493309f17e7d30254e3832162f73b486079d12d",
+   "sha256": "1agnag5n516966np9027zjvpyr27nrawh1l0l6hmy6hy8hb1jwpq"
   }
  },
  {
@@ -87343,11 +87743,11 @@
   "repo": "polymode/polymode",
   "unstable": {
    "version": [
-    20210907,
-    807
+    20211124,
+    913
    ],
-   "commit": "54888d6c15249503e1a66da7bd7761a9eda9b075",
-   "sha256": "0zxhxsil1p0nf4n75saz33d00xl7d4g528n7qj9xx84gq92g4fnb"
+   "commit": "47a7b6541a1e1cea9c22052fa202b7fdb715f03b",
+   "sha256": "02znv2pg07wn13jxgfbik306y3haafapjfib9pnl96aqbv264kp3"
   },
   "stable": {
    "version": [
@@ -87395,30 +87795,30 @@
   "repo": "SqrtMinusOne/pomm.el",
   "unstable": {
    "version": [
-    20211110,
-    1040
+    20211125,
+    1806
    ],
    "deps": [
     "alert",
     "seq",
     "transient"
    ],
-   "commit": "62832704ba72613af8dbe0a6bf6d4daa89a21e12",
-   "sha256": "06if507c163fia28zzax735r7mwlpa5vi0mmgddyn3vxsirnh4qw"
+   "commit": "2b58c3cad0106299d98e4a12de4f78dbd96fe67b",
+   "sha256": "1i3rimbyw7bkjdifwmzhf56alkhhhvblkjrxpgbnjmbg26xd6zdd"
   },
   "stable": {
    "version": [
     0,
     1,
-    2
+    3
    ],
    "deps": [
     "alert",
     "seq",
     "transient"
    ],
-   "commit": "62832704ba72613af8dbe0a6bf6d4daa89a21e12",
-   "sha256": "06if507c163fia28zzax735r7mwlpa5vi0mmgddyn3vxsirnh4qw"
+   "commit": "2b58c3cad0106299d98e4a12de4f78dbd96fe67b",
+   "sha256": "1i3rimbyw7bkjdifwmzhf56alkhhhvblkjrxpgbnjmbg26xd6zdd"
   }
  },
  {
@@ -87848,11 +88248,11 @@
   "repo": "tumashu/posframe",
   "unstable": {
    "version": [
-    20211110,
-    40
+    20211126,
+    944
    ],
-   "commit": "66b16a20a7b43f19c27487c475799200ad81b3bd",
-   "sha256": "06n9zwbz6hk3k49hw9xjnizaadvgl2s5aqmaaijzfxxm0h0gqh43"
+   "commit": "3b1dc400d286b0a4bd42e518bf3e7eedb49fd1e6",
+   "sha256": "0z05wfw1rv0jiqwyybvs4g4br5mb7xw1r2s1cdvirzi5z8ikh658"
   },
   "stable": {
    "version": [
@@ -88014,16 +88414,15 @@
   "repo": "SavchenkoValeriy/emacs-powerthesaurus",
   "unstable": {
    "version": [
-    20200720,
-    1546
+    20211127,
+    1502
    ],
    "deps": [
-    "jeison",
     "request",
     "s"
    ],
-   "commit": "93036d3b111925ebc34f747ff846cb0b8669b92e",
-   "sha256": "0l45n12b8jny7g4bfdn3sc7lp9kyxd7pyisr0r9svr9sls7cybv4"
+   "commit": "02c9d11a3f407023aa7c7b080bb9f8a5f5e7cd7a",
+   "sha256": "134m24v9xxnnsr180sx9li938jn5lx7kny2095fpl90qgpn3jd5q"
   }
  },
  {
@@ -88083,6 +88482,27 @@
    ],
    "commit": "6aabd694bcc66775c6a4328fa653a83e39791252",
    "sha256": "043wsaibkz82ckxdw4r25nfb8pql3ba9jcyd3vg92lvjdzblm05l"
+  }
+ },
+ {
+  "ename": "pr-review",
+  "commit": "538860d95a05005e7c2e77f186348d464fb653ac",
+  "sha256": "0yw3hlzajncb1zvkp0xdl0srkn20rkcgj4ib76yhlhphn6vc0nlv",
+  "fetcher": "github",
+  "repo": "blahgeek/emacs-pr-review",
+  "unstable": {
+   "version": [
+    20211128,
+    755
+   ],
+   "deps": [
+    "ghub",
+    "magit",
+    "magit-section",
+    "markdown-mode"
+   ],
+   "commit": "f1e1bc2a5ad2092afdba8568d554f35ebc98bec7",
+   "sha256": "07f98c2d9wszlxj6gvrnnb60krbgf55wahg1d16p2mwqczgdl7cp"
   }
  },
  {
@@ -88269,8 +88689,8 @@
     "jsonrpc",
     "s"
    ],
-   "commit": "b766824d60e95720e28917b648e4957d7923370b",
-   "sha256": "0rq75pzbklgk0bq6ah7xrsb2czq1vryfvavvi81iqpp89nik2nrh"
+   "commit": "e1925aa3419b1b4d5670040fcc8543382489507f",
+   "sha256": "0vnwncr3vvckg7mk9z5zfr2pphzid5lbv32jah1ii2cmjcksdhwg"
   }
  },
  {
@@ -88814,11 +89234,11 @@
   "repo": "bbatsov/projectile",
   "unstable": {
    "version": [
-    20211116,
-    700
+    20211206,
+    1920
    ],
-   "commit": "31069dc31469e0d5cddb53126a2993432a22399b",
-   "sha256": "1l86gm0kkszkyi4srknc7vjn589x2pkqdcralw44zwhppx7fcy35"
+   "commit": "2bb7ec28b1275bbce7cac743ee9e7b2cf41c5bbd",
+   "sha256": "1m1d5p87k09wxs2pbia37s9c4ik60vj094xnkxnr3vwyvs5d0a17"
   },
   "stable": {
    "version": [
@@ -89220,11 +89640,11 @@
   "repo": "ProofGeneral/PG",
   "unstable": {
    "version": [
-    20211109,
-    1442
+    20211125,
+    1509
    ],
-   "commit": "2145c23f44a0951a14240d3b85a1a3d08aade9bb",
-   "sha256": "0pilv79a9mqgv2j7915b2lbl3ir1hhaj7xjysliwn6h7rb4b1csg"
+   "commit": "1b1083e86e0cddc20ff2f1a6b25c7a7eee2edf02",
+   "sha256": "1pnysczhscapgwmvf6ix7f31lf3hnh8h977bfll1m7jlxl9b9c0j"
   },
   "stable": {
    "version": [
@@ -89327,8 +89747,8 @@
     20211013,
     1726
    ],
-   "commit": "edc8a3182811cc39272549ff894793e1fff4aaab",
-   "sha256": "08yfcnra0c9jx3fkicxl558vzll7cnx5qn847lxqsjv4f1ms37m1"
+   "commit": "29b3d01572d50c0e5bc0ab2eea32f9779c7576f4",
+   "sha256": "041m090j0pc3svfvybfg8lcip9hzgfvwklf82ynkv2hsddfn9q1b"
   },
   "stable": {
    "version": [
@@ -89739,11 +90159,11 @@
   "repo": "AmaiKinono/puni",
   "unstable": {
    "version": [
-    20211011,
-    1529
+    20211204,
+    1256
    ],
-   "commit": "825952d0a4a1d5eebf849280ffd4e1e44e1a847c",
-   "sha256": "1w3iz542v83n6vc4j0nhqmkp21h0m42rqgp6648jlx7q0n4qmdz6"
+   "commit": "e147a72f3c6b7bb40ef7fa37d12ea54afa09cd7e",
+   "sha256": "06lkpzz6ri092awgba575vq4qy3ym4qbk6hrwfpvmy81n26v7wsw"
   }
  },
  {
@@ -90104,11 +90524,11 @@
   "repo": "statmobile/pydoc",
   "unstable": {
    "version": [
-    20201030,
-    1530
+    20211119,
+    2211
    ],
-   "commit": "4459aa1c2cc7648cb1b9c9fcf470d8809a9bc7b3",
-   "sha256": "01b0gmnvsssh1vmjq79qh8fy2nv6iryw72zd9lp8qnwd9sr42rqp"
+   "commit": "3aaffe41e1c5a9d53fbc1de02686c386fd002890",
+   "sha256": "1z6p1glspxr5vl9igzhginaws65iqs9h2ymi21f62x7ydm54i96y"
   },
   "stable": {
    "version": [
@@ -90233,15 +90653,15 @@
   "repo": "tumashu/pyim",
   "unstable": {
    "version": [
-    20211117,
-    158
+    20211213,
+    1253
    ],
    "deps": [
     "async",
     "xr"
    ],
-   "commit": "a66e999435d9697a0d732576addf3c182fd363f7",
-   "sha256": "06pfpi2z48jhqanwlnq5d55xsnpmqhhrk64x15x7h01haf0wqy64"
+   "commit": "02c50045cb14ab253d8d8435e83e7f10b0bbc130",
+   "sha256": "1gydldssvg368nqpk9xy9snzhp3rb33nlygnwmh9ah4yaq412lh3"
   },
   "stable": {
    "version": [
@@ -90418,17 +90838,17 @@
     20210411,
     1931
    ],
-   "commit": "b91cc8dbb47ce622b73c766b3a53da270bdb24e9",
-   "sha256": "0w7bc2lcrr4axs9s8mgymjy8gwdafc3dl4fl9amaqfbph0xm0arl"
+   "commit": "35254c29eb3a0f1c7847cfcb3451501a4180373d",
+   "sha256": "1cqslii8dyvrc934v5ydhdmrhq2bj2ravrpj7d3ag38gq4lskwlx"
   },
   "stable": {
    "version": [
     2,
-    11,
-    1
+    12,
+    2
    ],
-   "commit": "d98e6e8adcdc5ebcd9c863f630e748cdba639b0a",
-   "sha256": "08kc9139v1sd0vhna0rqikyds0xq8hxv0j9707n2i1nbv2z6xhsv"
+   "commit": "eec287fae66f8fc514d5daa9caee46fd0e0cb6d9",
+   "sha256": "0spmy7j1vvh55shzgma80q61y0d1cj45dcgslb4g5w3y602miq5i"
   }
  },
  {
@@ -90554,8 +90974,8 @@
     "dash",
     "reformatter"
    ],
-   "commit": "6b6ab71d2762b6da703f8d1d3d964b712a98939e",
-   "sha256": "1cmzc0fa3jj7ajxbqhbsc8jx47k6g223sfd42c4lrqdnmh95760m"
+   "commit": "01f1f4269136cfb36938567854383628730faaab",
+   "sha256": "1a8dfz5riw2vlbi9mgb768gb29s5fnbfzas4fw8v1a4cxgwx6b0w"
   },
   "stable": {
    "version": [
@@ -90669,19 +91089,19 @@
   "repo": "macurovc/insert-docstring",
   "unstable": {
    "version": [
-    20211101,
-    1653
+    20211127,
+    1232
    ],
-   "commit": "4d729f5b574ffa3fce41ccbeee7b8bdb9d005174",
-   "sha256": "0gn12bm3w7819j67bnh1m3jkqqb37pdmkagbcwqp4mc74zbpf01m"
+   "commit": "cd6419b74c99c06d5c48c1b289572acce1fd193b",
+   "sha256": "1kr7jgiq1zbhq8j4fbhqd5skprna2jkffrqbabjlri69vl5spl80"
   },
   "stable": {
    "version": [
     2,
-    0
+    2
    ],
-   "commit": "4d729f5b574ffa3fce41ccbeee7b8bdb9d005174",
-   "sha256": "0gn12bm3w7819j67bnh1m3jkqqb37pdmkagbcwqp4mc74zbpf01m"
+   "commit": "cd6419b74c99c06d5c48c1b289572acce1fd193b",
+   "sha256": "1kr7jgiq1zbhq8j4fbhqd5skprna2jkffrqbabjlri69vl5spl80"
   }
  },
  {
@@ -90715,6 +91135,30 @@
   }
  },
  {
+  "ename": "python-mls",
+  "commit": "8b295cbb87ae6feaae445e036a225be7d4176943",
+  "sha256": "0hy5934p6rm5rj0cab2bf03h1lirfn3dh1jhbx0xn8si6y9r1b95",
+  "fetcher": "github",
+  "repo": "jdtsmith/python-mls",
+  "unstable": {
+   "version": [
+    20211211,
+    1934
+   ],
+   "commit": "6987b9fa0f664a1ede7e6a24684ed328eb412d5c",
+   "sha256": "176g9vg3xs8sys0kk3lfx3qq7p6q65d7f7d014pb8fwsi5nvhl47"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "commit": "152c4355ca315b1e5861496d5abed9365d856e57",
+   "sha256": "1d2ymwfdsdqii0drpypbl4mla2mq4a8avch4j4zj7g9h8z7h6wq5"
+  }
+ },
+ {
   "ename": "python-mode",
   "commit": "82861e1ab114451af5e1106d53195afd3605448a",
   "sha256": "1m7c6c97xpr5mrbyzhcl2cy7ykdz5yjj90mrakd4lknnsbcq205k",
@@ -90722,11 +91166,11 @@
   "repo": "python-mode-devs/python-mode",
   "unstable": {
    "version": [
-    20211013,
-    1620
+    20211117,
+    1920
    ],
-   "commit": "e92d0e800b494c1dfcca109154a6b7eb6fad0e4e",
-   "sha256": "1lxi1iwckpfk6966sgcdj3sz9bcbylsm3nqv9wbbzkqbjlyd28y4"
+   "commit": "220379ffcd7961f290d7a4d9f67da136fffb25a6",
+   "sha256": "1h2hplhsqlh6vhdbjc93mf6hkvix8c5s49gbl48v3hr34pj6992r"
   },
   "stable": {
    "version": [
@@ -90899,11 +91343,11 @@
   "repo": "psaris/q-mode",
   "unstable": {
    "version": [
-    20211001,
-    1144
+    20211126,
+    1944
    ],
-   "commit": "c7f6ccb936b673032ae557636177befe5f33a3db",
-   "sha256": "1xi7npwpji0c7jvwnkf056ff3jik7j01fb5mcdn0gwkigqhj1g02"
+   "commit": "43e509ed323c105f9b312813a1ae953d1a2efe3e",
+   "sha256": "1b6prwdy3dnkdsxy1lwws1jmq5r80g729z18np8ylp9j3pzz0nrh"
   }
  },
  {
@@ -91365,11 +91809,11 @@
   "repo": "greghendershott/racket-mode",
   "unstable": {
    "version": [
-    20211114,
-    1656
+    20211130,
+    1748
    ],
-   "commit": "6f94ac6e67c3ee00454e8b7e6d96ab5e9614cdb8",
-   "sha256": "01d2jkg32c7gsh39gil0kjh615fw125dl4nqilfcg23zfc8wlaf2"
+   "commit": "ef54a42ddd32f8827eef430f0410e392f9cb1726",
+   "sha256": "1x81l60k4qb2ffb85sqjr704dyh8dy28wq4rc8d5vc9qpmm1z3kf"
   }
  },
  {
@@ -91600,8 +92044,8 @@
     20210927,
     1227
    ],
-   "commit": "4ee9045eeb90f7831d7c0ee2e4adfcd957f712be",
-   "sha256": "0z8yclpb67x0k7x4ai13wvpc6w6s9z6kkib6a1lm4jpp4gyyraqw"
+   "commit": "977b14a7c1295ebf2aad2f807d3f8e7c27aeb47f",
+   "sha256": "14r1m1iw123y623dxcbjmzn8dpmixc3l7s5svxxs0msxnh5b4fcy"
   },
   "stable": {
    "version": [
@@ -91965,11 +92409,11 @@
   "repo": "simenheg/rdf-prefix",
   "unstable": {
    "version": [
-    20200216,
-    914
+    20211209,
+    1952
    ],
-   "commit": "825af2c584fbad9e67c2c08e29040776fa647fe0",
-   "sha256": "0ky81w36dn6c69x4v4b46j8ixqqws9dc8adi4q19149xkiijx1kl"
+   "commit": "fa4b64bc3e0c1d5b8eed20df8d2daf0dffff2332",
+   "sha256": "0xvq6m8a824ykwfbcb2bkmsg0p9148c4by2hpjly18l8rdi6810d"
   },
   "stable": {
    "version": [
@@ -92678,8 +93122,8 @@
     20211017,
     1727
    ],
-   "commit": "5d98022dee5a5ba3343f1c26e28febc2f095912c",
-   "sha256": "1ksd8p98z5w7kaahwalsmxdb9zvyb1kcr32mcsjqbnxxzagld880"
+   "commit": "bf3aa89893c10a01d5605b8d19b3583cd432cb27",
+   "sha256": "1fg2m1n61sy6iqv5m299rbwdrdkphpd68jq6l1npnlszwa3814ka"
   },
   "stable": {
    "version": [
@@ -92852,8 +93296,8 @@
     20181121,
     21
    ],
-   "commit": "50689559ff970e33013b8cf8a3bbc8be18ec4e09",
-   "sha256": "0v1xc27hfa223bganb7gksv6cc2v95bdfms7riv75sf30v3vh59s"
+   "commit": "49783bd5d83c1d1989838b5ecf4a240bcc994243",
+   "sha256": "163kj0hmvn7vgd86q0dhz3zimkiqabzylyvchnzaqc2y1mp4qhfk"
   }
  },
  {
@@ -94020,8 +94464,8 @@
   "repo": "DogLooksGood/emacs-rime",
   "unstable": {
    "version": [
-    20211014,
-    548
+    20211210,
+    1806
    ],
    "deps": [
     "cl-lib",
@@ -94029,8 +94473,8 @@
     "popup",
     "posframe"
    ],
-   "commit": "b296856c21d32e700005110328fb6a1d48dcbf8d",
-   "sha256": "1x3v18hwxj56zhn4437nklyni4d3chk84c82a8y1z1flcayjipvy"
+   "commit": "5c2ade217134f6f20cd405447af20825e5b44513",
+   "sha256": "1yp92sfirvcz3s2q8j8g6qlcmb7pn30m9ww4nc332m1axah7l05n"
   },
   "stable": {
    "version": [
@@ -94235,14 +94679,14 @@
   "repo": "dgutov/robe",
   "unstable": {
    "version": [
-    20210906,
-    2250
+    20211208,
+    205
    ],
    "deps": [
     "inf-ruby"
    ],
-   "commit": "fd972e912d0c6c310acb2d057da1be1149937d0e",
-   "sha256": "015mciv5d9dap7h0gnjm93fr4jx46dsm1rkp84x8kflmw747g1yk"
+   "commit": "11207bd549a5a78e3a4d70265c3715990dcdab71",
+   "sha256": "0hcyvvv4y78fmwprlxgmpzb81lzip9y1hjskmv8x7l0q1a6a3dsz"
   },
   "stable": {
    "version": [
@@ -94267,6 +94711,15 @@
    "version": [
     20210425,
     1925
+   ],
+   "commit": "e7e9c4d4750d048ad771fa735621ad813fa9c128",
+   "sha256": "127lydk66n90ih39q8gxzb44rss2xllb7bn3ygxrf5m5vvl9w5rj"
+  },
+  "stable": {
+   "version": [
+    0,
+    6,
+    1
    ],
    "commit": "e7e9c4d4750d048ad771fa735621ad813fa9c128",
    "sha256": "127lydk66n90ih39q8gxzb44rss2xllb7bn3ygxrf5m5vvl9w5rj"
@@ -94795,6 +95248,25 @@
   }
  },
  {
+  "ename": "ruby-json-to-hash",
+  "commit": "d4947ac9778d016442e88f324ce61578da301887",
+  "sha256": "0m71v6w3v4qrjivlj980anknz6frpmmv9r5avyzk7kayrri45fy9",
+  "fetcher": "github",
+  "repo": "otavioschwanck/ruby-json-to-hash.el",
+  "unstable": {
+   "version": [
+    20211108,
+    351
+   ],
+   "deps": [
+    "smartparens",
+    "string-inflection"
+   ],
+   "commit": "383b22bb2e007289ac0dba146787d02ff99d4415",
+   "sha256": "1vpjcmsl8nph6sb01ppfim1kbzrdf0z8pxggyv709ayfsavrq19q"
+  }
+ },
+ {
   "ename": "ruby-refactor",
   "commit": "8d223ef5b9e51265c510f1cf7888b621e47bfdcf",
   "sha256": "0nwinnnhy72h1ihjlnjl8k8z3yf4nl2z7hfv085gwiacr6nn2rby",
@@ -94885,6 +95357,30 @@
    ],
    "commit": "4e7413fafd0320f30190ae9835ab021cf7a9ebdc",
    "sha256": "10gwr479q4kd6ndp9r2nzj7rzap21q3f0l3icrviah9l5xzdx2x0"
+  }
+ },
+ {
+  "ename": "ruled-switch-buffer",
+  "commit": "f6ca552d7d29e4ca493b0dd63a007112e8ccb631",
+  "sha256": "1f8l0n4b3gf18jjllbqabzwybwx53x4k6g9dvg795x6ypikdr3cw",
+  "fetcher": "github",
+  "repo": "kzkn/ruled-switch-buffer",
+  "unstable": {
+   "version": [
+    20211205,
+    635
+   ],
+   "commit": "4ae1a722750f7ecb4db93c062ffdbe353e706bf0",
+   "sha256": "0qb69avm7f32y6dlcdsrc2vbj2lki3n732zpfxyr97cgf8vka7xm"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "commit": "99b53f7679e3eb868e4b4585085bbed102e5fce7",
+   "sha256": "0n16al1nx7r98wbwgrq89yfs581wp6nbbhkns1z5qlqmc21brcqr"
   }
  },
  {
@@ -95016,11 +95512,11 @@
   "repo": "rust-lang/rust-mode",
   "unstable": {
    "version": [
-    20211116,
-    2008
+    20211127,
+    1713
    ],
-   "commit": "aadd1dd8f0780692aea1637569aeadfa8f78fd5a",
-   "sha256": "18qqwm05rhbw6bbkg6iifh2xhjww1psah32d7dzjjyc42kswj2ab"
+   "commit": "3f67a880dc8b31b330cf59aee875d9dc96e7c475",
+   "sha256": "0qvsmm9dgxclg0h2d60bh87msbn4cq9l2dq7vipzzibn999yxj4l"
   },
   "stable": {
    "version": [
@@ -95063,8 +95559,8 @@
   "repo": "brotzeit/rustic",
   "unstable": {
    "version": [
-    20211112,
-    1404
+    20211211,
+    2202
    ],
    "deps": [
     "dash",
@@ -95078,13 +95574,13 @@
     "spinner",
     "xterm-color"
    ],
-   "commit": "28b9b6a69ba67e9715b7feb6b3ed56e00ac08acb",
-   "sha256": "0q2695hwrjw3jzy4wg96ma5z8f7ijw08ssvmkbcn57a77wh1xk6v"
+   "commit": "e0285bd19b8f970902042701d28234ebfe160337",
+   "sha256": "1wx6mc1wyzs1d2md8rwsnbkh41ibpbsc1f1ri9diac975gp98w0s"
   },
   "stable": {
    "version": [
     2,
-    1
+    2
    ],
    "deps": [
     "dash",
@@ -95098,8 +95594,8 @@
     "spinner",
     "xterm-color"
    ],
-   "commit": "814775bc7c0ca2cf9041b6d012bf656df7eb554b",
-   "sha256": "0nklqpd24s83ng34xrm4rp80sbylajikj6svz1c6j721pz9crxg9"
+   "commit": "a91b3d99c294a367dc14b9a62a9ca8b462eb7f84",
+   "sha256": "0i72r0kb6f96py3vbprcingik9sy5bndnd19hb9x3yzv1f7r0zfp"
   }
  },
  {
@@ -95561,11 +96057,11 @@
   "repo": "hvesalai/emacs-sbt-mode",
   "unstable": {
    "version": [
-    20210416,
-    1845
+    20211203,
+    1148
    ],
-   "commit": "e29464a82bf706ef921f4e0052ce04fc74c34c84",
-   "sha256": "1r6n1hcpcy6icy8qs98gafqavmwx4z6v4rnknvrfnnynmrv2ajvr"
+   "commit": "9fe1e8807c22cc1dc56a6233e000969518907f4d",
+   "sha256": "1mii46nr4ykkwnbpvsdp46j6n7k38h0jbm49vbm0w7n1az09yg1a"
   },
   "stable": {
    "version": [
@@ -95588,8 +96084,8 @@
     20200830,
     301
    ],
-   "commit": "fc669b449c836d66dc9d542dad766e568952c986",
-   "sha256": "1i9aak2k8zzj2i1wj7xhi750rn8c4wsmcp95w3zabprwxwr790hh"
+   "commit": "b5aba496f270736fd91e0b1591bae872ee39fc62",
+   "sha256": "0rr3rbwybly26n16xmf3wagj2bdda27fj2ybf82nxfyknqskrp1n"
   }
  },
  {
@@ -95600,14 +96096,14 @@
   "repo": "zk-phi/scad-preview",
   "unstable": {
    "version": [
-    20210306,
-    426
+    20211212,
+    1128
    ],
    "deps": [
     "scad-mode"
    ],
-   "commit": "8b2e7feb722ab2bde1ce050fe040f72ae0b05cad",
-   "sha256": "13hsd3sh1azcrbdbjnr1z5q0n5xw3ifzhvsnfqbqdz2pkpr5mfig"
+   "commit": "c5449b26c63f3e0a695905a7e4e84f8d844f761b",
+   "sha256": "1syz8cjyw4rjv1hbvs42r7n56jzjz5c71s21kmm8rp7hlbz71jhr"
   }
  },
  {
@@ -95972,11 +96468,11 @@
   "repo": "ideasman42/emacs-scroll-on-drag",
   "unstable": {
    "version": [
-    20211104,
-    259
+    20211127,
+    1220
    ],
-   "commit": "8962f5f8a79c9178a577732ddfbb333a101bc7fc",
-   "sha256": "157affz6jsar9gnj5nj8ks8zl3dyrwzq4j1g0njvcs4vpz5zf4p9"
+   "commit": "97741be699f08952c79a630869f5772918b378aa",
+   "sha256": "01y34ghp02znckafq51cvzahlbqbnpxdwpdrcgg1insq3qv658wb"
   }
  },
  {
@@ -96631,8 +97127,8 @@
     "dash",
     "edit-indirect"
    ],
-   "commit": "0a2dc1a22955fdd065f04dfdd5242f1b61b4a303",
-   "sha256": "1j1yd9d5hb5ryv0yx02lga0drgyfhkqwli5zrkrhili8h43g522d"
+   "commit": "59c4e3718943dbe8d14bdbba5de24fe2c80f0b56",
+   "sha256": "06wx9nz688x15rz1mcl3jcbaa3pn6xls7my2srn5id1rdbwyl52x"
   },
   "stable": {
    "version": [
@@ -96987,14 +97483,14 @@
   "url": "https://depp.brause.cc/shackle.git",
   "unstable": {
    "version": [
-    20210508,
-    1637
+    20211118,
+    1129
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "4ef05b117c87e1f0d97e0ee74fd2f0bfd07a49b1",
-   "sha256": "12x2b133a7npl2bibgsi5rr73cg77g1dljdwg4l49ipp7g4dsmcb"
+   "commit": "f1467db75a8fa5d51c676181fb308ccbf7b05e6f",
+   "sha256": "00dsk1v7rqj6rbm3lbvgv7dib8wqding5122ln1rrgddqyrrb2fs"
   },
   "stable": {
    "version": [
@@ -97303,20 +97799,20 @@
   "repo": "redguardtoo/shellcop",
   "unstable": {
    "version": [
-    20210622,
-    721
+    20211118,
+    1229
    ],
-   "commit": "7c025b10173ef380ea539dbbdcd7d60977119e24",
-   "sha256": "1rjiyz3sx387b8559k01j6149jw729zlk5s3ah2jaxj6p9cag418"
+   "commit": "8213452241244b797f84e936e6ccd18b6dec3de5",
+   "sha256": "01kvxvwq1v87125arv7lpmlcbjf84pqcyyxm3lfhvzka25d5ibga"
   },
   "stable": {
    "version": [
     0,
     0,
-    6
+    7
    ],
-   "commit": "7c025b10173ef380ea539dbbdcd7d60977119e24",
-   "sha256": "1rjiyz3sx387b8559k01j6149jw729zlk5s3ah2jaxj6p9cag418"
+   "commit": "8213452241244b797f84e936e6ccd18b6dec3de5",
+   "sha256": "01kvxvwq1v87125arv7lpmlcbjf84pqcyyxm3lfhvzka25d5ibga"
   }
  },
  {
@@ -97359,11 +97855,11 @@
   "repo": "Overdr0ne/shelldon",
   "unstable": {
    "version": [
-    20211024,
-    2053
+    20211118,
+    1811
    ],
-   "commit": "232a52eb5d7a9c3ca9f5983140578ddd86ba33a1",
-   "sha256": "0cz6d2msa3dxabbrd9vsm49s4g4f1a1cqi2bmzi96l327kbkzbqy"
+   "commit": "df8ab901c7f47c760879e5ccc26ee0b5195946c2",
+   "sha256": "1xkv0c2hzjccn73wl8x789cqwckbvkwgp80x8fagwswvg6ngzdcx"
   }
  },
  {
@@ -97518,8 +98014,8 @@
     20211029,
     150
    ],
-   "commit": "cb3b873063304ce5e1a5fd386c5f8c933964cd55",
-   "sha256": "19ly819cg5nnjcsr3aqk21hriyv2v8v64xfmyvk1j5p668y6mqkm"
+   "commit": "6112c6a9e13c00c2c7aecd96820a46b4800d4cda",
+   "sha256": "18c1rbcpxv289fbzl66lvyd41l1jhkia7296sksaqsgv9n79c2w6"
   }
  },
  {
@@ -98325,6 +98821,21 @@
   }
  },
  {
+  "ename": "siri-shortcuts",
+  "commit": "f3a67195c63059fbc2d2714b540505bb9cde49d1",
+  "sha256": "04fnzv6sq5mbj5difddbchvp7sgz48qrhs5izhl5w1si5q2ds5ri",
+  "fetcher": "github",
+  "repo": "DaniruKun/siri-shortcuts.el",
+  "unstable": {
+   "version": [
+    20211212,
+    1258
+   ],
+   "commit": "13d030d0f2bdfd1c1543e0a120c6dc321f068365",
+   "sha256": "09vwxpmzam3vmc5akcz9mdq1j6q0lhp9qghs36ivvb3az6kxc6hq"
+  }
+ },
+ {
   "ename": "sis",
   "commit": "bea2374d589869dde682db96c35c530a051de3a9",
   "sha256": "0zkfpmnnj30l36mcv90x90vs31x8q2rrs2ixy5w8lc96vn1dgavf",
@@ -98388,11 +98899,11 @@
   "repo": "dawranliou/sketch-themes",
   "unstable": {
    "version": [
-    20211022,
-    1915
+    20211209,
+    1708
    ],
-   "commit": "8083d2b3e7834c7e4531a6a7882ffa4058aee4c3",
-   "sha256": "0axdrscidpxr4zj88xj53zjfhd5jxbmsg4la4kwsk4krkywp6fm1"
+   "commit": "f0425fb8d2c78a414c653d7bd1b3bf4d282afa1a",
+   "sha256": "0vfq8yhskprhj80wag7r82vzlgf8avj1v612yxi510c2wjrnygzq"
   },
   "stable": {
    "version": [
@@ -98534,8 +99045,8 @@
   "repo": "yuya373/emacs-slack",
   "unstable": {
    "version": [
-    20210712,
-    628
+    20211129,
+    310
    ],
    "deps": [
     "alert",
@@ -98545,8 +99056,8 @@
     "request",
     "websocket"
    ],
-   "commit": "ae1d742a0193fba38698931055708a28cc382bcf",
-   "sha256": "0292z0pzvwg85pr1g3xsglp9rkna6k7b0frbm5r43yr91sr0vv3f"
+   "commit": "ff46d88726482211e3ac3d0b9c95dd4fdffe11c2",
+   "sha256": "15g4dmy4iqqpk8ivhkpsngzllbw0nc5d2sc9j36sdnhwkajzhidj"
   }
  },
  {
@@ -98847,11 +99358,11 @@
   "repo": "joaotavora/sly",
   "unstable": {
    "version": [
-    20211114,
-    1021
+    20211121,
+    1002
    ],
-   "commit": "8b1b968651c6d1a8699d16c3a03d0d1e83ecca3d",
-   "sha256": "10yx6mhfdd79nl3qz5bj275i400hnnr5r951h84xif0hclhr1bxn"
+   "commit": "0470c0281498b9de072fcbf3718fc66720eeb3d0",
+   "sha256": "1ws2a9azmdkkg47xnd4jggna45nf0bh54gyp0799b44c4bgjp029"
   },
   "stable": {
    "version": [
@@ -98957,14 +99468,14 @@
   "repo": "joaotavora/sly-quicklisp",
   "unstable": {
    "version": [
-    20200707,
-    1635
+    20211206,
+    948
    ],
    "deps": [
     "sly"
    ],
-   "commit": "4707b62803d7a29f172e9c5ff993b91187a9aaf3",
-   "sha256": "1i4fqgd42khl85d4fifgfz2z6njpb8bxdry4chmgl8wfhh0mydza"
+   "commit": "34c73d43dd9066262387c626c17a9b486db07b2d",
+   "sha256": "13qjscsgbpzb7bvpybglx46p3nvzdv10v3king9za54qig4gi0v0"
   }
  },
  {
@@ -99024,11 +99535,11 @@
   "repo": "zenitani/elisp",
   "unstable": {
    "version": [
-    20201029,
-    1600
+    20211127,
+    1702
    ],
-   "commit": "2edfcf2004ce927f11ca9cb43e2e4b93f43524a9",
-   "sha256": "17bf25jyqryz6i8viljqcv9fszfllfzwrgps4685xm0gjxxys62q"
+   "commit": "df771e8cf0f7d5ed455c74bf7d9c1e366f47922f",
+   "sha256": "1kglk255ifnwkv3skdks78rq53f5qb0h5qb6yv7cmzp2aprs5p0l"
   }
  },
  {
@@ -99970,14 +100481,14 @@
   "repo": "md-arif-shaikh/soccer",
   "unstable": {
    "version": [
-    20211023,
-    827
+    20211207,
+    1623
    ],
    "deps": [
     "dash"
    ],
-   "commit": "d59b7196a62edb0e72eef52772eec42cab8baa45",
-   "sha256": "1hdp7lcr7pdary7qssf2na6a3n0ycijbx3z0ggk37gxzvz59jiv4"
+   "commit": "b5ba10fe43e43fa40617e2936572add10c72b865",
+   "sha256": "09kkbk5rsjdkajqmq8xkgl4xd9b3c96bp823zfal18jq5jcf2x8j"
   },
   "stable": {
    "version": [
@@ -100081,26 +100592,26 @@
   "repo": "hlissner/emacs-solaire-mode",
   "unstable": {
    "version": [
-    20211114,
-    1644
+    20211213,
+    102
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "87c2efd11b4b71e000d8a464eb694852e22aa0e7",
-   "sha256": "058cflb2199yb2qpzhf5hckz4cknsxqpglmz4nvnfv6k2xbnijpb"
+   "commit": "8af65fbdc50b25ed3214da949b8a484527c7cc14",
+   "sha256": "1lkm09wznal0grpz61ikc77mjrri1x1bi79qwyf1cah9s0wv3isq"
   },
   "stable": {
    "version": [
     2,
     0,
-    3
+    4
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "46408f4a105e216c3c2d88659b8b28601d37d80e",
-   "sha256": "0wq5ckwx3wv4c4l8f9hz3ak6v5wy4lg5yh8xlsgn1h1x6yf8afpp"
+   "commit": "8af65fbdc50b25ed3214da949b8a484527c7cc14",
+   "sha256": "1lkm09wznal0grpz61ikc77mjrri1x1bi79qwyf1cah9s0wv3isq"
   }
  },
  {
@@ -100602,8 +101113,8 @@
   "repo": "TheBB/spaceline",
   "unstable": {
    "version": [
-    20201016,
-    1043
+    20211120,
+    1636
    ],
    "deps": [
     "cl-lib",
@@ -100611,8 +101122,8 @@
     "powerline",
     "s"
    ],
-   "commit": "50cc5b26d823bbfd347becd7da03cd29c2a2a0dc",
-   "sha256": "0yyq8jppsa95m78fr7kfixl20qi8zpgkla64sv1a0v8x42nws02p"
+   "commit": "9a81afa52738544ad5e8b71308a37422ca7e25ba",
+   "sha256": "0m4542wba9zi18qv8lzhgz8f9dbf01l3dca7vv7i0wmnjsg9bsj9"
   },
   "stable": {
    "version": [
@@ -100792,11 +101303,11 @@
   "repo": "condy0919/spdx.el",
   "unstable": {
    "version": [
-    20211003,
-    611
+    20211202,
+    1925
    ],
-   "commit": "67e276ad37a0cf3754798b436e54792816a6d3f2",
-   "sha256": "02vflf5j1g4f81xywfr9vi5bb3raxpp1az650qin90g8irkjhy4z"
+   "commit": "4d1ce0ca8a4c84667301b3e347fe594989c25e60",
+   "sha256": "0fmaxsx6yn3j9i4k6kzap0s2fc5899j623sz9v71g5pjg4pfwmyy"
   }
  },
  {
@@ -100923,11 +101434,11 @@
   "repo": "ideasman42/emacs-spell-fu",
   "unstable": {
    "version": [
-    20211108,
-    203
+    20211121,
+    701
    ],
-   "commit": "570ccd84edddb60e6fc0f6bde5a9fb9b07ed2aa0",
-   "sha256": "0n9b3b8lgr9g4xc5md11agbpr1b7ahpdxphnwy473vw1fzgnj1fl"
+   "commit": "b2da2874f3227c0a969be80946e0c4ea455e8458",
+   "sha256": "1rbczz0i2jddh96ln65kf1gji7rg28lr1kh03p4py46vn6bm9xpd"
   }
  },
  {
@@ -101708,11 +102219,11 @@
   "repo": "stan-dev/stan-mode",
   "unstable": {
    "version": [
-    20210130,
-    1325
+    20211129,
+    2051
    ],
-   "commit": "9bb858b9f1314dcf1a5df23e39f9af522098276b",
-   "sha256": "031418nkp9qwlxda8i3ankp3lq94sv8a8ijwrbcwb4w3ssr9j3ds"
+   "commit": "150bbbe5fd3ad2b5a3dbfba9d291e66eeea1a581",
+   "sha256": "06y4gvw8g4mjyiv77rznivqphh9sayjmi9aqr9nhxlf6i19a6hqh"
   },
   "stable": {
    "version": [
@@ -101732,15 +102243,15 @@
   "repo": "stan-dev/stan-mode",
   "unstable": {
    "version": [
-    20210130,
-    1325
+    20211129,
+    2051
    ],
    "deps": [
     "stan-mode",
     "yasnippet"
    ],
-   "commit": "9bb858b9f1314dcf1a5df23e39f9af522098276b",
-   "sha256": "031418nkp9qwlxda8i3ankp3lq94sv8a8ijwrbcwb4w3ssr9j3ds"
+   "commit": "150bbbe5fd3ad2b5a3dbfba9d291e66eeea1a581",
+   "sha256": "06y4gvw8g4mjyiv77rznivqphh9sayjmi9aqr9nhxlf6i19a6hqh"
   },
   "stable": {
    "version": [
@@ -101943,8 +102454,8 @@
     20200606,
     1308
    ],
-   "commit": "d5bef96e847b50bd436725fa3b102f0c41b56bae",
-   "sha256": "1x2fyh6xyd1xzyhk1pk5x23j3if11rm8zpl75izkc3y6vw37haa3"
+   "commit": "759a38bd8418116e8cdca41a8aacd7ae13ede93e",
+   "sha256": "0xyddk3mj36mknnadjyi9fdpv24zqfzz8bvfn4dlf2qknlb8b9l5"
   },
   "stable": {
    "version": [
@@ -102454,26 +102965,26 @@
   "url": "https://git.sr.ht/~amk/subsonic.el",
   "unstable": {
    "version": [
-    20211016,
-    940
+    20211201,
+    939
    ],
    "deps": [
     "transient"
    ],
-   "commit": "a070cff3f802796dd0dbab4b2ebfbb9f05c36b0b",
-   "sha256": "12j0czk3hgpkm7sxpabwii67q2gfj97f51akhnysdzrm82yb4p60"
+   "commit": "ee2b1f20521e647472be7553242eb2253809e1d1",
+   "sha256": "1j8q47vvvsdfb9hg2r72dgmg2a886aa15yrvi6ahp7g5z4jmp19k"
   },
   "stable": {
    "version": [
     0,
-    2,
+    3,
     0
    ],
    "deps": [
     "transient"
    ],
-   "commit": "5740a2b96c827c499f3ac506f98ec5f9ed31ea37",
-   "sha256": "0qr96a86zj6kipix6p831hj0nkcyj3kvaggyy2zsmvhx7wjavadf"
+   "commit": "ee2b1f20521e647472be7553242eb2253809e1d1",
+   "sha256": "1j8q47vvvsdfb9hg2r72dgmg2a886aa15yrvi6ahp7g5z4jmp19k"
   }
  },
  {
@@ -103448,8 +103959,8 @@
     "seq",
     "undo-tree"
    ],
-   "commit": "ce33a7858481da2a1a07558b0932b19328d3449b",
-   "sha256": "017a6bmacfcwqy7x89pzpgkqpipl8i5hbp429cqpw7xdhjwgc2in"
+   "commit": "c042fffef1d575eb356bf585ec78f1606d3349ad",
+   "sha256": "00f9ky5nkivh2b90swgl3aq4xhwvva97xxyr2pdlnmf8v9jlk1p0"
   },
   "stable": {
    "version": [
@@ -104124,8 +104635,8 @@
     20210415,
     1322
    ],
-   "commit": "5eacb6c1c879038c4448c10b3df9a73d95a48fc3",
-   "sha256": "0k7y7lxdgj73mmrs228l7m9b9fdzjjw8knqzwhkvqb5bb93ii6fm"
+   "commit": "d13f93a8e11aa9f3b8544e51028b012c33d5c97d",
+   "sha256": "1c3cqvsq96vx8f5aa0iyv6kr5309xp0f1b1w579s6p30nhirw4my"
   },
   "stable": {
    "version": [
@@ -104312,15 +104823,15 @@
   "repo": "zevlg/telega.el",
   "unstable": {
    "version": [
-    20211116,
-    1246
+    20211213,
+    2017
    ],
    "deps": [
     "rainbow-identifiers",
     "visual-fill-column"
    ],
-   "commit": "9bc087dab6d2503da41881132664f5c0c979f4b6",
-   "sha256": "1s3p9ndwiv08wh30i9rgdm2lz3a4xj9in2y4rrhywq4gnd5zbz7d"
+   "commit": "737399c5050b68cea618e01136c463107c6125a1",
+   "sha256": "0has60kmjy6ysax6xdn22likvi9qygz3znz24v8mfwzxasil5nhw"
   },
   "stable": {
    "version": [
@@ -104400,11 +104911,11 @@
   "repo": "lassik/emacs-teletext",
   "unstable": {
    "version": [
-    20211016,
-    2156
+    20211203,
+    1111
    ],
-   "commit": "e6e4ad4231f916d69f34a389f0b4cede6e04c951",
-   "sha256": "06iv3y6ij484n2gx46yby0whb8q99h7gb40rwialravgbpfj4xw9"
+   "commit": "6b003e9dab9bd0c27d188a81f5fff740d66a2282",
+   "sha256": "0ilallavqhqjsxh37gga5k2pgz8jiwxssfhj1jlf7nj89gn2ana6"
   }
  },
  {
@@ -104454,8 +104965,8 @@
     20210902,
     228
    ],
-   "commit": "e1ccb88cdc4b482b078276960f810b82ba3b7847",
-   "sha256": "0wy53y7p6i0m9az0ca4zqrqfq40cgn202pilsawdy8rlpj9y619p"
+   "commit": "b52349948b6927f7a5da4e54a89e01c794f2095a",
+   "sha256": "1z5bcd3654zkm89mkx29bcybs97zmwi14xdmbh356di9jbwzk93s"
   },
   "stable": {
    "version": [
@@ -105104,11 +105615,11 @@
   "repo": "Dspil/text-categories",
   "unstable": {
    "version": [
-    20211031,
-    947
+    20211130,
+    1719
    ],
-   "commit": "d400c2692373c14d7cf773e7ae587cbe9c7d1e13",
-   "sha256": "1wbx74pc0lzb51gs43zhs66jid4kyaavcgckx37m5m05k17kdv97"
+   "commit": "b6afe804e23c624eec2af0f2a5c04bdcdfd833b5",
+   "sha256": "0p63ypxfd4s0ywmja3ynyn0i9mirgv8kyr2wj4a0i20havxd29gz"
   }
  },
  {
@@ -105418,18 +105929,18 @@
     20200212,
     1903
    ],
-   "commit": "c0cc1a6b7273feb1049206f58da5f469e28b56a9",
-   "sha256": "0pkwa42r33l30ddnmy8hkflwirf3xnv4fi5a6zxsm3ibi7z649fm"
+   "commit": "e1286496d4ffe5cfcb97e818b7c0f4a5acdfd4d1",
+   "sha256": "16xmix97xvivjd4g87m6fdh7ffqlwjy0y9la3x4nmxbppkbakmhi"
   },
   "stable": {
    "version": [
     2021,
-    11,
-    15,
+    12,
+    13,
     0
    ],
-   "commit": "7f44dce741f17712a5671b09f495059bd1f68d09",
-   "sha256": "1jldrq95cb2g27my88k98c8p33kbk04l0rc8vpwlyyxr602cx7k9"
+   "commit": "d99cd8529957d7595602038e55bc5cea26126b3f",
+   "sha256": "0c1aylvj0f1s6d98fza4lz806b96pb7d1677j3hfjkk8sv3cg5wf"
   }
  },
  {
@@ -105485,8 +105996,8 @@
    "deps": [
     "haskell-mode"
    ],
-   "commit": "be7c02a4df03d695c8f8dca80817a736905ecf47",
-   "sha256": "1lh92rzafapx6yi7r24yzrxgv2v6wqvzg62j0pd3zqa6s499v4k9"
+   "commit": "b0a5a3f64b1121fb83d67922f820ed168f45c84c",
+   "sha256": "1p262x6x0rxj5hh0v720h0k5x231827p5bd6qpbn4i1gdrnr3gp1"
   },
   "stable": {
    "version": [
@@ -105734,11 +106245,11 @@
   "repo": "aimebertrand/timu-spacegrey-theme",
   "unstable": {
    "version": [
-    20211115,
-    2323
+    20211213,
+    33
    ],
-   "commit": "2934363d32ba6e817e789d5ecf5e68a51cfc0e8d",
-   "sha256": "001h23yhqys90dpqka4m3zcdnwbfxvjii5lxmj67shblslx5f4sl"
+   "commit": "17b7b89334a6a87b58eaacdd54b1c2bea9b7314f",
+   "sha256": "0cvkfzf2pk8qhp2s40nv1rqqg7kayvxi4x6vlh8ggsnxbw80hj11"
   },
   "stable": {
    "version": [
@@ -105902,11 +106413,11 @@
   "repo": "dalanicolai/toc-mode",
   "unstable": {
    "version": [
-    20210714,
-    725
+    20211127,
+    801
    ],
-   "commit": "977bec00d8d448ad2a5e2e4c17b9c9ba3e194ec2",
-   "sha256": "1yshkvsa5g6gxn9agf4z5ks5bd43l4akdcblxfgqkpshp25y5plv"
+   "commit": "d5629c71652d80c5c515d30cdafb345f5a0b7595",
+   "sha256": "0jdck6if9adqwvdh0j6hx3jvr6y9mpr2hflr4lbs5pm4criq88ah"
   }
  },
  {
@@ -105926,11 +106437,11 @@
   "stable": {
    "version": [
     1,
-    1,
+    2,
     0
    ],
-   "commit": "4315afd2a408c0d432ba3d8d040c2326c222fdbf",
-   "sha256": "0lk0rji85a1c0c5r9an0fdvsm4n4jyixsknmr8ywha3lfmc2p0l8"
+   "commit": "df4ad6ff15e3b02f6322305638a441a636b9b37e",
+   "sha256": "00a2al7ghrlabf65kfj1mk30p2pl37h6ppwlgghbgiy7rwlzkdbm"
   }
  },
  {
@@ -106062,6 +106573,21 @@
    ],
    "commit": "e82c60e543933880402ede11e9423e48a17dde53",
    "sha256": "0f86aij1glmvgpbhmfpi441zy0r37zblb0q3ycgq0dp92x8yny5r"
+  }
+ },
+ {
+  "ename": "tok-theme",
+  "commit": "0ce13bfb5447542d1d582ead6a68e3b69fa739c7",
+  "sha256": "14yka2q185bpg9xkkhkcziirf78ki5lkql470hii4nxq18b8d7zc",
+  "fetcher": "github",
+  "repo": "topikettunen/tok-theme",
+  "unstable": {
+   "version": [
+    20211203,
+    2240
+   ],
+   "commit": "631e8b0b5e72983104084256d30b01ba4bc41e94",
+   "sha256": "10ajqxjwvyv79m5r8k1l98qclrdzlvr78kjlwvnn7dxlv91vrds0"
   }
  },
  {
@@ -106339,14 +106865,14 @@
   "repo": "trueroad/tr-emacs-ime-module",
   "unstable": {
    "version": [
-    20211114,
-    440
+    20211120,
+    718
    ],
    "deps": [
     "w32-ime"
    ],
-   "commit": "c35be849f2cf5470e9d9cc40ff54e285e5170e93",
-   "sha256": "0sy33f8c9l0189qhm8q2whb6yrsir52fqqq3wh54qkbqc8vvg7py"
+   "commit": "e6313639afb51d91efcc417bd0c81afd13bb079c",
+   "sha256": "0hcqpvvjndddwcg81c2xz3msjghilym5lvbayc6wj0hk47xs9ylc"
   },
   "stable": {
    "version": [
@@ -106518,11 +107044,11 @@
   "repo": "magit/transient",
   "unstable": {
    "version": [
-    20211105,
-    100
+    20211208,
+    1819
    ],
-   "commit": "349116159f707a474926b47e5f6b6240e8997a4d",
-   "sha256": "1yzjdr9rdxax8gcd0k978v9akb1wk2ff14wfigiaqkvqs3sd8zxy"
+   "commit": "459e28e28a5f29e4dd59c7d61ec8557ce9b57ef3",
+   "sha256": "1wq4d44lhifg7mhyqih1bbx42krm3j6q5fs58yibs05fd6h2zpdz"
   },
   "stable": {
    "version": [
@@ -106762,8 +107288,8 @@
   "repo": "ethan-leba/tree-edit",
   "unstable": {
    "version": [
-    20211116,
-    1613
+    20211211,
+    2301
    ],
    "deps": [
     "dash",
@@ -106773,8 +107299,8 @@
     "tree-sitter-langs",
     "tsc"
    ],
-   "commit": "6fd445dbeb158d05d785965077cc594aeeb73a61",
-   "sha256": "0h1zjdqxynxxlqdc9yxhmkjwarx4vn9anasv9i68fcmmnq7c0aw9"
+   "commit": "1a670b73cd990af3b08633b01f84b57edaeb92ba",
+   "sha256": "1sr8h96rzghxbs42rzv0c2abhrydjsxf98hijnffa7yqd8gffjdr"
   }
  },
  {
@@ -106794,31 +107320,32 @@
  },
  {
   "ename": "tree-sitter",
-  "commit": "cb5169a41c3284f1fe1887cd2d32f9e98e34fbe0",
-  "sha256": "1n08rsf1cmxsrpld9j78a8smzckcpg006za93h464gfqls4y2kl2",
+  "commit": "f07a741d1a14f99a634041cc9b4c200e75461ae5",
+  "sha256": "0rnk77pk0rmfl9azag4l2q3x2f1achykxjdm0q7aj82rvf60f5mb",
   "fetcher": "github",
   "repo": "emacs-tree-sitter/elisp-tree-sitter",
   "unstable": {
    "version": [
-    20210912,
-    1211
+    20211211,
+    1220
    ],
    "deps": [
     "tsc"
    ],
-   "commit": "2acca5c8d2e3dc66d4d0a99831b33140b5a5f973",
-   "sha256": "00qlrjh3my8w96lvxx3bfx8pshr58irzmrnvr8qrkwzyv3hs0rbl"
+   "commit": "48b06796a3b2e76ce004972d929de38146eafaa0",
+   "sha256": "04dlwpi5w1g9v62l51zwa6idsajk6km39ljk2k9z3jrcs0fj22ml"
   },
   "stable": {
    "version": [
     0,
-    15
+    16,
+    1
    ],
    "deps": [
     "tsc"
    ],
-   "commit": "2acca5c8d2e3dc66d4d0a99831b33140b5a5f973",
-   "sha256": "00qlrjh3my8w96lvxx3bfx8pshr58irzmrnvr8qrkwzyv3hs0rbl"
+   "commit": "48b06796a3b2e76ce004972d929de38146eafaa0",
+   "sha256": "04dlwpi5w1g9v62l51zwa6idsajk6km39ljk2k9z3jrcs0fj22ml"
   }
  },
  {
@@ -106829,15 +107356,15 @@
   "url": "https://codeberg.org/FelipeLema/tree-sitter-indent.el.git",
   "unstable": {
    "version": [
-    20210322,
-    2033
+    20211128,
+    2236
    ],
    "deps": [
     "seq",
     "tree-sitter"
    ],
-   "commit": "18d263720c5a8f7fde0db368c7c36ea70437fc0b",
-   "sha256": "0iwi44309837hx0sl8py175ayn7haannp1sz2d0jk7binka7n4md"
+   "commit": "5f80e89b7da2074ea7f083b769448eb7026865dc",
+   "sha256": "14pi0vv193vpbwd4kb86hsnv1h8j9pcclvipp1wllv3nxw8k2ypk"
   },
   "stable": {
    "version": [
@@ -106854,31 +107381,32 @@
  },
  {
   "ename": "tree-sitter-langs",
-  "commit": "cb5169a41c3284f1fe1887cd2d32f9e98e34fbe0",
-  "sha256": "0dqz421vwbgmp83nib9jigwi0rayb9hqsralwhj0139w6jkvxmmb",
+  "commit": "f07a741d1a14f99a634041cc9b4c200e75461ae5",
+  "sha256": "0pnnx21kip0ghb6p1x288kc79p3alcb4xyya02h8alcxz4dxlhqj",
   "fetcher": "github",
   "repo": "emacs-tree-sitter/tree-sitter-langs",
   "unstable": {
    "version": [
-    20210918,
-    1621
+    20211213,
+    159
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "2b845a70080c0edd66f13200b9dc8d6d0c3f42ce",
-   "sha256": "0w3jzy4n445nrbcj7i46nbg7jk81gjqjs6zahsjnal8dhyjqaymi"
+   "commit": "c66b03faba230868b7cb644e0b49ff64a47f6ab4",
+   "sha256": "072y9cmyn926w5vlf6flj83j3n87w6qy7jx9akrnbys0907c17s8"
   },
   "stable": {
    "version": [
     0,
-    10
+    10,
+    13
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "28e98d52e8516d73cce76e7ce5c6294a9728bb56",
-   "sha256": "1zy1wjw6ixpl5mw8f3drp47w256xbbzgxrgs2kpgj0w7wif10yjc"
+   "commit": "e537b90bbca6b4deb62042240ed12461251b3f0c",
+   "sha256": "16i3j7iv77l9cqqc2f8ynywhpapgm5sdbvq506h0swk8rg81hsnz"
   }
  },
  {
@@ -106925,8 +107453,8 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20211115,
-    2031
+    20211213,
+    2100
    ],
    "deps": [
     "ace-window",
@@ -106938,8 +107466,8 @@
     "pfuture",
     "s"
    ],
-   "commit": "d00cc19cab8df4fec7ed6608e00bd16fe797369a",
-   "sha256": "167jn29vqx5q5nd2ja9bi1srz623zmq7jpd79al0s98ngnw8hpr7"
+   "commit": "babf69971ed4c3469b0cdf6a3bf7b637bed1ab18",
+   "sha256": "1s8csgnbcyjkbycx8hwsmzd37fhs7m7qr5mn4k91j5v3vm8ndjb8"
   },
   "stable": {
    "version": [
@@ -106976,8 +107504,8 @@
     "all-the-icons",
     "treemacs"
    ],
-   "commit": "d00cc19cab8df4fec7ed6608e00bd16fe797369a",
-   "sha256": "167jn29vqx5q5nd2ja9bi1srz623zmq7jpd79al0s98ngnw8hpr7"
+   "commit": "babf69971ed4c3469b0cdf6a3bf7b637bed1ab18",
+   "sha256": "1s8csgnbcyjkbycx8hwsmzd37fhs7m7qr5mn4k91j5v3vm8ndjb8"
   },
   "stable": {
    "version": [
@@ -107008,8 +107536,8 @@
     "evil",
     "treemacs"
    ],
-   "commit": "d00cc19cab8df4fec7ed6608e00bd16fe797369a",
-   "sha256": "167jn29vqx5q5nd2ja9bi1srz623zmq7jpd79al0s98ngnw8hpr7"
+   "commit": "babf69971ed4c3469b0cdf6a3bf7b637bed1ab18",
+   "sha256": "1s8csgnbcyjkbycx8hwsmzd37fhs7m7qr5mn4k91j5v3vm8ndjb8"
   },
   "stable": {
    "version": [
@@ -107039,8 +107567,8 @@
    "deps": [
     "treemacs"
    ],
-   "commit": "d00cc19cab8df4fec7ed6608e00bd16fe797369a",
-   "sha256": "167jn29vqx5q5nd2ja9bi1srz623zmq7jpd79al0s98ngnw8hpr7"
+   "commit": "babf69971ed4c3469b0cdf6a3bf7b637bed1ab18",
+   "sha256": "1s8csgnbcyjkbycx8hwsmzd37fhs7m7qr5mn4k91j5v3vm8ndjb8"
   },
   "stable": {
    "version": [
@@ -107071,8 +107599,8 @@
     "pfuture",
     "treemacs"
    ],
-   "commit": "d00cc19cab8df4fec7ed6608e00bd16fe797369a",
-   "sha256": "167jn29vqx5q5nd2ja9bi1srz623zmq7jpd79al0s98ngnw8hpr7"
+   "commit": "babf69971ed4c3469b0cdf6a3bf7b637bed1ab18",
+   "sha256": "1s8csgnbcyjkbycx8hwsmzd37fhs7m7qr5mn4k91j5v3vm8ndjb8"
   },
   "stable": {
    "version": [
@@ -107105,8 +107633,8 @@
     "persp-mode",
     "treemacs"
    ],
-   "commit": "d00cc19cab8df4fec7ed6608e00bd16fe797369a",
-   "sha256": "167jn29vqx5q5nd2ja9bi1srz623zmq7jpd79al0s98ngnw8hpr7"
+   "commit": "babf69971ed4c3469b0cdf6a3bf7b637bed1ab18",
+   "sha256": "1s8csgnbcyjkbycx8hwsmzd37fhs7m7qr5mn4k91j5v3vm8ndjb8"
   },
   "stable": {
    "version": [
@@ -107139,8 +107667,8 @@
     "perspective",
     "treemacs"
    ],
-   "commit": "d00cc19cab8df4fec7ed6608e00bd16fe797369a",
-   "sha256": "167jn29vqx5q5nd2ja9bi1srz623zmq7jpd79al0s98ngnw8hpr7"
+   "commit": "babf69971ed4c3469b0cdf6a3bf7b637bed1ab18",
+   "sha256": "1s8csgnbcyjkbycx8hwsmzd37fhs7m7qr5mn4k91j5v3vm8ndjb8"
   },
   "stable": {
    "version": [
@@ -107172,8 +107700,8 @@
     "projectile",
     "treemacs"
    ],
-   "commit": "d00cc19cab8df4fec7ed6608e00bd16fe797369a",
-   "sha256": "167jn29vqx5q5nd2ja9bi1srz623zmq7jpd79al0s98ngnw8hpr7"
+   "commit": "babf69971ed4c3469b0cdf6a3bf7b637bed1ab18",
+   "sha256": "1s8csgnbcyjkbycx8hwsmzd37fhs7m7qr5mn4k91j5v3vm8ndjb8"
   },
   "stable": {
    "version": [
@@ -107423,25 +107951,26 @@
  },
  {
   "ename": "tsc",
-  "commit": "cb5169a41c3284f1fe1887cd2d32f9e98e34fbe0",
-  "sha256": "0di9v57sn2b6dvgf7id409drk9ir65brv2mdigk54gra8801fk64",
+  "commit": "f07a741d1a14f99a634041cc9b4c200e75461ae5",
+  "sha256": "03g9wyna387bcmqcb1z4g5ybmlsxh3vg24i0x3ynvkm8knj8nl2v",
   "fetcher": "github",
   "repo": "emacs-tree-sitter/elisp-tree-sitter",
   "unstable": {
    "version": [
-    20210912,
-    1211
+    20211211,
+    1220
    ],
-   "commit": "2acca5c8d2e3dc66d4d0a99831b33140b5a5f973",
-   "sha256": "00qlrjh3my8w96lvxx3bfx8pshr58irzmrnvr8qrkwzyv3hs0rbl"
+   "commit": "48b06796a3b2e76ce004972d929de38146eafaa0",
+   "sha256": "04dlwpi5w1g9v62l51zwa6idsajk6km39ljk2k9z3jrcs0fj22ml"
   },
   "stable": {
    "version": [
     0,
-    15
+    16,
+    1
    ],
-   "commit": "2acca5c8d2e3dc66d4d0a99831b33140b5a5f973",
-   "sha256": "00qlrjh3my8w96lvxx3bfx8pshr58irzmrnvr8qrkwzyv3hs0rbl"
+   "commit": "48b06796a3b2e76ce004972d929de38146eafaa0",
+   "sha256": "04dlwpi5w1g9v62l51zwa6idsajk6km39ljk2k9z3jrcs0fj22ml"
   }
  },
  {
@@ -107517,8 +108046,8 @@
    "deps": [
     "caml"
    ],
-   "commit": "00faf47a7c65e4cdcf040f38add1c6a08cd2ee2f",
-   "sha256": "1rjz11q9ww5bvmfp2jri0nlrv9aiw7qzl80wlkmkcv7lv3qmvblb"
+   "commit": "b9a145510518c855d5057a1e1b19a32125975202",
+   "sha256": "1jzsjxi1b6cnjrrzbrprlb2rqm5zjnhhzjj58r4aa8mkl1y04n6k"
   },
   "stable": {
    "version": [
@@ -107775,11 +108304,11 @@
   "repo": "emacs-typescript/typescript.el",
   "unstable": {
    "version": [
-    20211022,
-    1051
+    20211130,
+    1332
    ],
-   "commit": "13e6da6c5746187842d8ebb5323bf2d88d5759c2",
-   "sha256": "1vqx8nzjnjj4980yzlcn2bpph7rjmk0b7nblfspn8xp83iw3cd2m"
+   "commit": "e82416205158d4b21d42d6b60c4385f68f0ae1b1",
+   "sha256": "1gidnpwk4n9zsrv9jxb7fmn3i46sggncv62w1aaw6g6v8h3yj5ad"
   },
   "stable": {
    "version": [
@@ -109150,20 +109679,20 @@
    "deps": [
     "tuareg"
    ],
-   "commit": "c87b8b2817eefd0cd53564618911386b89b587c5",
-   "sha256": "1zf4hg33sblzh2f65vk0292jg4jlwa8702kfwpsg1kcg4w6nsfdp"
+   "commit": "676e2cd6545fd327e02330d1ccb20c02d6b26eab",
+   "sha256": "1mdpqc1b67p5rm2jsbwy0gjjgdlfqcakjyh1cwdj959ykz4zy9ld"
   },
   "stable": {
    "version": [
     2,
-    8,
+    9,
     0
    ],
    "deps": [
     "tuareg"
    ],
-   "commit": "c87b8b2817eefd0cd53564618911386b89b587c5",
-   "sha256": "1zf4hg33sblzh2f65vk0292jg4jlwa8702kfwpsg1kcg4w6nsfdp"
+   "commit": "676e2cd6545fd327e02330d1ccb20c02d6b26eab",
+   "sha256": "1mdpqc1b67p5rm2jsbwy0gjjgdlfqcakjyh1cwdj959ykz4zy9ld"
   }
  },
  {
@@ -109264,20 +109793,20 @@
   "repo": "ottbot/vagrant.el",
   "unstable": {
    "version": [
-    20170301,
-    2206
+    20211206,
+    1634
    ],
-   "commit": "636ce2f9af32ea199170335a9cf1201b64873440",
-   "sha256": "06zws69z327p00jw3zaf67niji2d4j339xmhbsrwbcr4w65dmz94"
+   "commit": "a232b7385178d5b029ccc5274dfa9b56e5ba43a1",
+   "sha256": "1i345jyhh1g10hlcvs3c34glk5r09k1i4dxmmrwfhpy1f759h10m"
   },
   "stable": {
    "version": [
     0,
     6,
-    1
+    2
    ],
-   "commit": "ef3022d290ee26597e21b17ab87acbd8d4f1071f",
-   "sha256": "1661fwfx2gpxjriy3ngi9raz8c2kkk3rgg51irdi591jr2zqmw6s"
+   "commit": "636ce2f9af32ea199170335a9cf1201b64873440",
+   "sha256": "06zws69z327p00jw3zaf67niji2d4j339xmhbsrwbcr4w65dmz94"
   }
  },
  {
@@ -110332,17 +110861,17 @@
  },
  {
   "ename": "visual-fill-column",
-  "commit": "39ada1dc39158e956a1251cd41cfa2259b51da21",
-  "sha256": "1bbly6sd77cnxl1c4n24039cgfwn0mcq6l3jgyh8z7bk6lnsjfw2",
+  "commit": "76e7a6c9e67bcea5b681dacf6725f7e313f0c1a8",
+  "sha256": "1f9j1f95zr4gjcf2rk0fwn26n1g05xfk7qnazx2vgpx52904581w",
   "fetcher": "git",
-  "url": "https://codeberg.org/joostkremers/visual-fill-column",
+  "url": "https://codeberg.org/joostkremers/visual-fill-column.git",
   "unstable": {
    "version": [
-    20211110,
-    2317
+    20211118,
+    33
    ],
-   "commit": "ae4edc225acea12a035c0586185847306ecb06ef",
-   "sha256": "18qac66mpvgmp1pw0lvarjngwh9cx75an44n1pg2msbxkkm98zkj"
+   "commit": "cf3e2bc632b68d54145c79beede85d3458a337de",
+   "sha256": "0wj6c6q1sn7q1ywkm3fyl7z967jsl5g2xp3niwqv4kz9bs60aw6v"
   },
   "stable": {
    "version": [
@@ -110666,11 +111195,11 @@
   "repo": "akermu/emacs-libvterm",
   "unstable": {
    "version": [
-    20210908,
-    640
+    20211209,
+    58
    ],
-   "commit": "2681120b770573044832ba8c22ccbac192e1a294",
-   "sha256": "173qhfj5h4xd8rrf4avzknp24hzl0nlxs783pr7900d980cpbygr"
+   "commit": "ed6e867cfab77c5a311a516d20af44f57526cfdc",
+   "sha256": "0mq2q7yj09812iklj49n8p3kfpk1l6az33hr2dyxyl5i2nqps0vs"
   }
  },
  {
@@ -110809,16 +111338,16 @@
   "repo": "d12frosted/vulpea",
   "unstable": {
    "version": [
-    20211115,
-    1433
+    20211118,
+    734
    ],
    "deps": [
     "org",
     "org-roam",
     "s"
    ],
-   "commit": "0c16e1c1adb45e8aaa32f06edc604e18d39179eb",
-   "sha256": "1217gni713nc5y37wfspnc5b790chri96an4hzv1jra33lazn49y"
+   "commit": "398ca17f83ea59f54f61898fefdb55332cd3ba46",
+   "sha256": "0qa49s0nhqbh9bmxi1zglnx3yajqcdx8j7yiy23lxbya2fpl557i"
   },
   "stable": {
    "version": [
@@ -110904,11 +111433,11 @@
   "repo": "emacs-w3m/emacs-w3m",
   "unstable": {
    "version": [
-    20211025,
-    2324
+    20211122,
+    335
    ],
-   "commit": "cb3b873063304ce5e1a5fd386c5f8c933964cd55",
-   "sha256": "19ly819cg5nnjcsr3aqk21hriyv2v8v64xfmyvk1j5p668y6mqkm"
+   "commit": "6112c6a9e13c00c2c7aecd96820a46b4800d4cda",
+   "sha256": "18c1rbcpxv289fbzl66lvyd41l1jhkia7296sksaqsgv9n79c2w6"
   }
  },
  {
@@ -111129,16 +111658,16 @@
   "repo": "wanderlust/wanderlust",
   "unstable": {
    "version": [
-    20211115,
-    1206
+    20211212,
+    909
    ],
    "deps": [
     "apel",
     "flim",
     "semi"
    ],
-   "commit": "aef23d6e50b7e29ff4ff11d288f36f6ba03f29ac",
-   "sha256": "06rj754ygv0455hkyb62ihqk844jx6cx18n5vixjmcws6hvpi9al"
+   "commit": "7b06ce86a925ce3c41a54ecacc3c27afbe00dcf1",
+   "sha256": "0p09rqaxwys2jhmlxlxf0xy3x42b183l3kbfrhbivagxpb10r608"
   }
  },
  {
@@ -111582,28 +112111,28 @@
   "repo": "etu/webpaste.el",
   "unstable": {
    "version": [
-    20210813,
-    1901
+    20211211,
+    658
    ],
    "deps": [
     "cl-lib",
     "request"
    ],
-   "commit": "bbdc5e5b689a787c6b4ae7690751fe9c10d6796e",
-   "sha256": "1pl02jvqnh6710maxxnbwy5cfdrhav61x9b4da76wdxhv9rhzjjr"
+   "commit": "78272662e6992b8614e79a571ff2395fa9630357",
+   "sha256": "07hj9nr7x6c9w2dnvc58cfbprgp9cqzdxflp5qlpglzdw0bi9s3c"
   },
   "stable": {
    "version": [
     3,
     2,
-    1
+    2
    ],
    "deps": [
     "cl-lib",
     "request"
    ],
-   "commit": "b063ddde87226281ce95f8ff0d7ce32d5dea29aa",
-   "sha256": "1d481pdnh7cnbyka7wn59czlci63zwfqms8n515svg92qm573ckd"
+   "commit": "78272662e6992b8614e79a571ff2395fa9630357",
+   "sha256": "07hj9nr7x6c9w2dnvc58cfbprgp9cqzdxflp5qlpglzdw0bi9s3c"
   }
  },
  {
@@ -111912,20 +112441,20 @@
   "repo": "justbur/emacs-which-key",
   "unstable": {
    "version": [
-    20210824,
-    11
+    20211209,
+    1317
    ],
-   "commit": "4790a14683a2f3e4f72ade197c78e4c0af1cdd4b",
-   "sha256": "1svz2048qabhy8z9m4p9q5lmdjr5i7vqnaw86x8gmn7vk052h5md"
+   "commit": "1bb1f723dab2fc8b88b7f7273d0a7fa11134b936",
+   "sha256": "0wz3bb7vzxqi3wqpn46z6ps00m9wjcpv9cfvqi7lyvm920sxzlv7"
   },
   "stable": {
    "version": [
     3,
     5,
-    3
+    4
    ],
-   "commit": "1f9c37d50f08995c8671822591c8babb893ccc6f",
-   "sha256": "144i3hkgm36wnfmqk5vq390snziy3zhwifbh6q6dzs99ic77d5g6"
+   "commit": "1bb1f723dab2fc8b88b7f7273d0a7fa11134b936",
+   "sha256": "0wz3bb7vzxqi3wqpn46z6ps00m9wjcpv9cfvqi7lyvm920sxzlv7"
   }
  },
  {
@@ -112224,15 +112753,15 @@
   "repo": "progfolio/wikinforg",
   "unstable": {
    "version": [
-    20210711,
-    302
+    20211210,
+    2116
    ],
    "deps": [
     "org",
     "wikinfo"
    ],
-   "commit": "31cf4a52990caa3f928b847ec25a5412836552bd",
-   "sha256": "0l13yi9iwi68n95wmxkjrf0zsmvxadpmxc7zm8x7v8kk5p7scnil"
+   "commit": "62842806fee863eb43c3015c3d86f5a7f0bf858f",
+   "sha256": "1rzxswfzg8lpwn1r7lq08rz7mrbrs5vr587phh60l26qpz6960c2"
   }
  },
  {
@@ -112602,8 +113131,8 @@
     20210405,
     1410
    ],
-   "commit": "a144cfd1604c308f65f990a1e994ab0d5d7fe244",
-   "sha256": "0q5ivjaxsw9ci40ap7qavziqjfbarlk7fwqivmndcgwnh0is3ddx"
+   "commit": "2c18054fb0151201f049029781a558275f78d5e5",
+   "sha256": "0dgkmwbniv5gazzaaxxwwnswrm17njdlj2frhr0079kzsddf5xd8"
   }
  },
  {
@@ -112647,8 +113176,8 @@
     20211028,
     2105
    ],
-   "commit": "cfe70f43c551852125bc139df467e28e1b6087df",
-   "sha256": "0i38y7kw0fpb1ii8bfiidh5xkinldzzz1c0i33zvwym76a28birb"
+   "commit": "d53df360e7abe31d61d6689ab39b62dfa7f064b1",
+   "sha256": "18643svb44mhjdqr0xaa56qq2lj5j7x3jnykg2vhxj9vrk528fj8"
   },
   "stable": {
    "version": [
@@ -113254,11 +113783,11 @@
   "repo": "redguardtoo/wucuo",
   "unstable": {
    "version": [
-    20210915,
-    1113
+    20211201,
+    1214
    ],
-   "commit": "cf4cfbcdc8e756986b927224a42a9006d070f36a",
-   "sha256": "1ach6c5y54gcfgq1nmgla7lri8mi7nja8a85slws4zxvl4b6802w"
+   "commit": "09fc58a02621b6c9615f8289c457e30ca6f63bcb",
+   "sha256": "15jva7qp723fpwv6f24300h8knmxrlsjb2icg9rzr0994g9f36qs"
   },
   "stable": {
    "version": [
@@ -113484,8 +114013,8 @@
   "repo": "dandavison/xenops",
   "unstable": {
    "version": [
-    20211102,
-    1607
+    20211121,
+    1953
    ],
    "deps": [
     "aio",
@@ -113495,8 +114024,8 @@
     "f",
     "s"
    ],
-   "commit": "61f4fe7b5cc2549ea7363635307279becac53ea7",
-   "sha256": "188p1lk7d6gbnshikb7qf646ljpcrsdssr0k9jd1vgga8iz22k0d"
+   "commit": "c5fafbc41ae5c4d20a1eb2de3b3226f8a55eb65e",
+   "sha256": "1lzd053b27jikgb10bpbihynx08c9c33fcswrykl0r5548qjwm4j"
   }
  },
  {
@@ -114494,11 +115023,11 @@
   "url": "https://www.yatex.org/hgrepos/yatex",
   "unstable": {
    "version": [
-    20210630,
-    2200
+    20211203,
+    2212
    ],
-   "commit": "d4831b3672f87affbb0f7f69135e7824d0bd325b",
-   "sha256": "0fga8zicxgmfw4px2zwfvwycl9hcqcwnf65izrbrj6rrljdbb3yv"
+   "commit": "907de32064c99c25fb49072438be7c1034892af3",
+   "sha256": "1anb8cwh2ph0nxxmsbi0kjkljxdsprdp4q2akqgb1xjpnlyf5g5j"
   }
  },
  {
@@ -115005,11 +115534,11 @@
   "repo": "zenobht/zeno-theme",
   "unstable": {
    "version": [
-    20181027,
-    118
+    20211205,
+    2148
    ],
-   "commit": "0914c4a5b1b9499e7f1ca5699b1c3ea2f4be3f1a",
-   "sha256": "1zl1ks7n35i9mn5w7ac3j15820fbgpbcmmysv25crvi4g9z94mqj"
+   "commit": "70fa7b7442f24ea25eab538b5a22da690745fef5",
+   "sha256": "10v6yf9c5qdsxrp6rk1n1xkv4byyfkinsikskdb2apjg05cx2273"
   }
  },
  {
@@ -115242,8 +115771,8 @@
   "repo": "WillForan/zim-wiki-mode",
   "unstable": {
    "version": [
-    20200908,
-    218
+    20211117,
+    2000
    ],
    "deps": [
     "dokuwiki-mode",
@@ -115252,8 +115781,8 @@
     "link-hint",
     "pretty-hydra"
    ],
-   "commit": "f65a2da6ea762532355fc726319ba3e3dd217ec2",
-   "sha256": "0m18giykwldj21zgv5rbni0pbpbrx5mnmkj5jyd2zpgwi1n7w3im"
+   "commit": "aa906931f22c34d77c65bed31121edfef714e4e2",
+   "sha256": "071xw635ik9jqlgmrzg11d826d3fsjgzyyj60jq6142jr5a0jpqb"
   }
  },
  {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
