### PR TITLE
subread: init 2.0.3

### DIFF
--- a/pkgs/applications/science/biology/subread/default.nix
+++ b/pkgs/applications/science/biology/subread/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, fetchurl
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "subread";
+  version = "2.0.3";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/subread/subread-${version}/subread-${version}-source.tar.gz";
+    sha256 = "sha256-Vs7zovkU1DJxMGnVwoL0iDHDoezIlDKtVYDKoyKl9Ws=";
+  };
+
+  buildInputs = [
+    zlib
+  ];
+
+  configurePhase = ''
+    cd src
+    cp Makefile.${if stdenv.isLinux then "Linux" else "MacOS"} Makefile
+  '';
+
+  makeFlags = [ "CC_EXEC=cc" ];
+
+  installPhase = ''
+    mkdir $out
+    cp -r ../bin $out
+  '';
+
+  meta = with lib; {
+    description = "High-performance read alignment, quantification and mutation discovery";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ jbedo ];
+    platforms = [ "x86_64-darwin" "x86_64-linux" ];
+    homepage = "http://subread.sourceforge.net/";
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31565,6 +31565,8 @@ with pkgs;
   sage = callPackage ../applications/science/math/sage { };
   sageWithDoc = sage.override { withDoc = true; };
 
+  subread = callPackage ../applications/science/biology/subread { };
+
   suitesparse_4_2 = callPackage ../development/libraries/science/math/suitesparse/4.2.nix { };
   suitesparse_4_4 = callPackage ../development/libraries/science/math/suitesparse/4.4.nix {};
   suitesparse_5_3 = callPackage ../development/libraries/science/math/suitesparse {};


### PR DESCRIPTION
###### Motivation for this change

Init subread.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
