### PR TITLE
python3.pkgs.pint: 0.14 -> 0.18

### DIFF
--- a/pkgs/development/python-modules/pint/default.nix
+++ b/pkgs/development/python-modules/pint/default.nix
@@ -7,6 +7,7 @@
 , packaging
 # Check Inputs
 , pytestCheckHook
+, pytest-subtests
 , numpy
 , matplotlib
 , uncertainties
@@ -14,12 +15,12 @@
 
 buildPythonPackage rec {
   pname = "pint";
-  version = "0.14";
+  version = "0.18";
 
   src = fetchPypi {
     inherit version;
     pname = "Pint";
-    sha256 = "0wkzb7g20wzpqr3xaqpq96dlfv6irw202icsz81ys8npp7mm194s";
+    sha256 = "sha256-jEvOiEwmkFH+t6vGnb/RhAPAx2SryD2hMuinIi+LqAE=";
   };
 
   disabled = pythonOlder "3.6";
@@ -32,6 +33,7 @@ buildPythonPackage rec {
   # Test suite explicitly requires pytest
   checkInputs = [
     pytestCheckHook
+    pytest-subtests
     numpy
     matplotlib
     uncertainties
@@ -42,7 +44,7 @@ buildPythonPackage rec {
     description = "Physical quantities module";
     license = licenses.bsd3;
     homepage = "https://github.com/hgrecco/pint/";
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc doronbehar ];
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
