### PR TITLE
amdvlk: 2021.Q4.1 -> 2021.Q4.2

### DIFF
--- a/pkgs/development/libraries/amdvlk/default.nix
+++ b/pkgs/development/libraries/amdvlk/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchRepoProject
+, writeScript
 , cmake
 , ninja
 , patchelf
@@ -21,17 +22,18 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "amdvlk";
-  version = "2021.Q4.1";
+  version = "2021.Q4.2";
 
   src = fetchRepoProject {
     name = "${pname}-src";
     manifest = "https://github.com/GPUOpen-Drivers/AMDVLK.git";
     rev = "refs/tags/v-${version}";
-    sha256 = "sha256-yvpHLreBNhiSxnZis5+XcTOSZPRLq5K8YNJsjpYqD6s=";
+    sha256 = "DpylZjIqWmCnUI0lEvd/HQcY+lr8asMurt1K9MI3qQw=";
   };
 
   buildInputs = [
     expat
+    libdrm
     ncurses
     openssl
     wayland
@@ -66,15 +68,35 @@ in stdenv.mkDerivation rec {
   cmakeDir = "../drivers/xgl";
 
   installPhase = ''
+    runHook preInstall
+
     install -Dm755 -t $out/lib icd/amdvlk${suffix}.so
     install -Dm644 -t $out/share/vulkan/icd.d icd/amd_icd${suffix}.json
     install -Dm644 -t $out/share/vulkan/implicit_layer.d icd/amd_icd${suffix}.json
 
     patchelf --set-rpath "$rpath" $out/lib/amdvlk${suffix}.so
+
+    runHook postInstall
   '';
 
   # Keep the rpath, otherwise vulkaninfo and vkcube segfault
   dontPatchELF = true;
+
+  passthru.updateScript = writeScript "update.sh" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p coreutils curl gnused jq common-updater-scripts
+
+    function setHash() {
+      sed -i "pkgs/development/libraries/amdvlk/default.nix" -e 's,sha256 = "[^.'"'"']*",sha256 = "'"$1"'",'
+    }
+
+    version="$(curl -sL "https://api.github.com/repos/GPUOpen-Drivers/AMDVLK/releases?per_page=1" | jq '.[0].tag_name | split("-") | .[1]' --raw-output)"
+    sed -i "pkgs/development/libraries/amdvlk/default.nix" -e 's/version = "[^.'"'"']*"/version = "'"$version"'"/'
+
+    setHash "$(nix-instantiate --eval -A lib.fakeSha256 | xargs echo)"
+    hash="$(nix to-base64 $(nix-build -A amdvlk 2>&1 | tail -n3 | grep 'got:' | cut -d: -f2- | xargs echo || true))"
+    setHash "$hash"
+  '';
 
   meta = with lib; {
     description = "AMD Open Source Driver For Vulkan";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
amdvlk 2021.Q4.2 was published: https://github.com/GPUOpen-Drivers/AMDVLK/releases/tag/v-2021.Q4.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested vkcube
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
