### PR TITLE
ocamlPackages.{x509,tls}*: 0.14.1 -> 0.15.2 and related updates

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jackline/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jackline/default.nix
@@ -4,7 +4,7 @@ with ocamlPackages;
 
 buildDunePackage rec {
   pname = "jackline";
-  version = "unstable-2021-08-10";
+  version = "unstable-2021-12-28";
 
   minimumOCamlVersion = "4.08";
 
@@ -13,8 +13,8 @@ buildDunePackage rec {
   src = fetchFromGitHub {
     owner  = "hannesm";
     repo   = "jackline";
-    rev    = "73d87e9a62d534566bb0fbe64990d32d75487f11";
-    sha256 = "0wk574rqfg2vqz27nasxzwf67x51pj5fgl4vkc27r741dg4q6c5a";
+    rev    = "ca1012098d123c555e9fa5244466d2e009521700";
+    sha256 = "1j1azskcdrp4g44rv3a4zylkzbzpcs23zzzrx94llbgssw6cd9ih";
   };
 
   nativeBuildInpts = [

--- a/pkgs/development/ocaml-modules/awa/default.nix
+++ b/pkgs/development/ocaml-modules/awa/default.nix
@@ -1,21 +1,21 @@
 { lib, buildDunePackage, fetchurl
 , ppx_sexp_conv, ppx_cstruct
 , mirage-crypto, mirage-crypto-rng, mirage-crypto-pk
-, x509, cstruct, cstruct-unix, cstruct-sexp, sexplib
+, x509, cstruct, cstruct-unix, cstruct-sexp, sexplib, eqaf
 , rresult, mtime, logs, fmt, cmdliner, base64, hacl_x25519
 , zarith
 }:
 
 buildDunePackage rec {
   pname = "awa";
-  version = "0.0.4";
+  version = "0.0.5";
 
   minimumOCamlVersion = "4.07";
   useDune2 = true;
 
   src = fetchurl {
-    url = "https://github.com/mirage/awa-ssh/releases/download/v${version}/awa-v${version}.tbz";
-    sha256 = "1l7nsd8jifxjq78xyzcc0z9igc02m2qlvv4cxzsgdim6n1jfzxj2";
+    url = "https://github.com/mirage/awa-ssh/releases/download/v${version}/awa-${version}.tbz";
+    sha256 = "14hqzmikp3hlynhs0wnwj2491106if183swsl7ldk4215a0b7ms4";
   };
 
   nativeBuildInputs = [ ppx_cstruct ];
@@ -24,7 +24,7 @@ buildDunePackage rec {
     mirage-crypto mirage-crypto-rng mirage-crypto-pk x509
     cstruct cstruct-sexp sexplib mtime
     logs base64 hacl_x25519 zarith
-    ppx_sexp_conv
+    ppx_sexp_conv eqaf
   ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/ca-certs-nss/default.nix
+++ b/pkgs/development/ocaml-modules/ca-certs-nss/default.nix
@@ -1,13 +1,11 @@
 { lib
 , buildDunePackage
 , fetchurl
-, rresult
 , mirage-crypto
 , mirage-clock
 , x509
 , logs
 , fmt
-, hex
 , bos
 , astring
 , cmdliner
@@ -16,19 +14,18 @@
 
 buildDunePackage rec {
   pname = "ca-certs-nss";
-  version = "3.66";
+  version = "3.71.0.1";
 
   minimumOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/mirage/ca-certs-nss/releases/download/v${version}/ca-certs-nss-v${version}.tbz";
-    sha256 = "f0f8035b470f2a48360b92d0e6287f41f98e4ba71576a1cd4c9246c468932f09";
+    sha256 = "b83749d983781631745079dccb7345d9ee1b52c1844ce865e97a25349289a124";
   };
 
   useDune2 = true;
 
   propagatedBuildInputs = [
-    rresult
     mirage-crypto
     mirage-clock
     x509
@@ -37,7 +34,6 @@ buildDunePackage rec {
   buildInputs = [
     logs
     fmt
-    hex
     bos
     astring
     cmdliner

--- a/pkgs/development/ocaml-modules/conduit/default.nix
+++ b/pkgs/development/ocaml-modules/conduit/default.nix
@@ -5,14 +5,14 @@
 
 buildDunePackage rec {
   pname = "conduit";
-  version = "4.0.1";
+  version = "4.0.2";
   useDune2 = true;
 
   minimumOCamlVersion = "4.03";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-conduit/releases/download/v${version}/conduit-v${version}.tbz";
-    sha256 = "500d95bf2a524f4851e94373e32d26b6e99ee04e5134db69fe6e151c3aad9b1f";
+    sha256 = "2a37ffaa352a1e145ef3d80ac28661213c69a741b238623e59f29e3d5a12c537";
   };
 
   buildInputs = [ ppx_sexp_conv ];

--- a/pkgs/development/ocaml-modules/letsencrypt/app.nix
+++ b/pkgs/development/ocaml-modules/letsencrypt/app.nix
@@ -12,6 +12,7 @@
 , bos
 , fpath
 , randomconv
+, cstruct
 }:
 
 buildDunePackage {
@@ -37,6 +38,7 @@ buildDunePackage {
     bos
     fpath
     randomconv
+    cstruct
   ];
 
   meta = letsencrypt.meta // {

--- a/pkgs/development/ocaml-modules/letsencrypt/default.nix
+++ b/pkgs/development/ocaml-modules/letsencrypt/default.nix
@@ -1,15 +1,14 @@
 { buildDunePackage
 , lib
 , fetchurl
-, astring
 , asn1-combinators
 , uri
-, rresult
 , base64
 , logs
 , fmt
 , lwt
 , mirage-crypto
+, mirage-crypto-ec
 , mirage-crypto-pk
 , mirage-crypto-rng
 , x509
@@ -17,15 +16,16 @@
 , ounit
 , ptime
 , domain-name
+, cstruct
 }:
 
 buildDunePackage rec {
   pname = "letsencrypt";
-  version = "0.3.0";
+  version = "0.4.1";
 
   src = fetchurl {
     url = "https://github.com/mmaker/ocaml-letsencrypt/releases/download/v${version}/letsencrypt-v${version}.tbz";
-    sha256 = "8772b7e6dbda0559a03a7b23b75c1431d42ae09a154eefd64b4c7e23b8d92deb";
+    sha256 = "f90875f5c9bdcab4c8be5ec7ebe9ea763030fa708e02857300996bb16e7c2070";
   };
 
   minimumOCamlVersion = "4.08";
@@ -43,12 +43,12 @@ buildDunePackage rec {
     lwt
     base64
     mirage-crypto
+    mirage-crypto-ec
     mirage-crypto-pk
     asn1-combinators
     x509
     uri
-    rresult
-    astring
+    cstruct
   ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/paf/default.nix
+++ b/pkgs/development/ocaml-modules/paf/default.nix
@@ -7,17 +7,10 @@
 , h2
 , tls-mirage
 , mimic
-, cohttp-lwt
-, letsencrypt
-, emile
 , ke
 , bigstringaf
-, domain-name
-, duration
 , faraday
-, ipaddr
 , tls
-, x509
 , lwt
 , logs
 , fmt
@@ -32,11 +25,11 @@
 
 buildDunePackage rec {
   pname = "paf";
-  version = "0.0.5";
+  version = "0.0.6";
 
   src = fetchurl {
     url = "https://github.com/dinosaure/paf-le-chien/releases/download/${version}/paf-${version}.tbz";
-    sha256 = "e85a018046eb062d2399fdbe8d9d3400a4d5cd51bb62840446503f557c3eeff1";
+    sha256 = "21adbe0f7f9c0242354fa996468d01bf21d5cbcbdd978c911df8e2e299e8f9ae";
   };
 
   useDune2 = true;
@@ -48,17 +41,10 @@ buildDunePackage rec {
     h2
     tls-mirage
     mimic
-    cohttp-lwt
-    letsencrypt
-    emile
     ke
     bigstringaf
-    domain-name
-    ipaddr
-    duration
     faraday
     tls
-    x509
     cstruct
   ];
 

--- a/pkgs/development/ocaml-modules/paf/le.nix
+++ b/pkgs/development/ocaml-modules/paf/le.nix
@@ -8,6 +8,7 @@
 , mirage-stack
 , mirage-time
 , tls-mirage
+, x509
 }:
 
 buildDunePackage {
@@ -29,6 +30,7 @@ buildDunePackage {
     mirage-stack
     mirage-time
     tls-mirage
+    x509
   ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/tls/async.nix
+++ b/pkgs/development/ocaml-modules/tls/async.nix
@@ -1,4 +1,4 @@
-{ lib, buildDunePackage, tls, async, cstruct-async, core, cstruct, mirage-crypto-rng-async, async_find }:
+{ lib, buildDunePackage, tls, async, cstruct-async, core, cstruct, mirage-crypto-rng-async }:
 
 buildDunePackage rec {
   pname = "tls-async";
@@ -12,7 +12,6 @@ buildDunePackage rec {
 
   propagatedBuildInputs = [
     async
-    async_find
     core
     cstruct
     cstruct-async

--- a/pkgs/development/ocaml-modules/tls/default.nix
+++ b/pkgs/development/ocaml-modules/tls/default.nix
@@ -1,15 +1,16 @@
 { lib, fetchurl, buildDunePackage
-, cstruct, cstruct-sexp, domain-name, fmt, ppx_cstruct, ppx_sexp_conv, logs, hkdf, mirage-crypto, mirage-crypto-ec, mirage-crypto-pk, mirage-crypto-rng, ocaml_lwt, ptime, rresult, sexplib, x509
+, cstruct, cstruct-sexp, domain-name, fmt, ppx_cstruct, ppx_sexp_conv, logs, hkdf, mirage-crypto, mirage-crypto-ec, mirage-crypto-pk, mirage-crypto-rng, ocaml_lwt, ptime, sexplib, x509
+, ipaddr, ipaddr-sexp
 , alcotest, cstruct-unix, ounit2, randomconv
 }:
 
 buildDunePackage rec {
   pname = "tls";
-  version = "0.14.1";
+  version = "0.15.2";
 
   src = fetchurl {
     url = "https://github.com/mirleft/ocaml-tls/releases/download/v${version}/tls-v${version}.tbz";
-    sha256 = "58cf2d517d6eac5b1ccc5eeb656da690aef2125a19c1eca3fbececd858046216";
+    sha256 = "b76371757249bbeabb12c333de4ea2a09c095767bdbbc83322538c0da1fc1e36";
   };
 
   minimumOCamlVersion = "4.08";
@@ -30,9 +31,10 @@ buildDunePackage rec {
     mirage-crypto-rng
     ocaml_lwt
     ptime
-    rresult
     sexplib
     x509
+    ipaddr
+    ipaddr-sexp
   ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/x509/default.nix
+++ b/pkgs/development/ocaml-modules/x509/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchurl, buildDunePackage
 , alcotest, cstruct-unix
-, asn1-combinators, domain-name, fmt, gmap, pbkdf, rresult, mirage-crypto, mirage-crypto-ec, mirage-crypto-pk
+, asn1-combinators, domain-name, fmt, gmap, pbkdf, mirage-crypto, mirage-crypto-ec, mirage-crypto-pk, ipaddr
 , logs, base64
 }:
 
@@ -8,17 +8,17 @@ buildDunePackage rec {
   minimumOCamlVersion = "4.07";
 
   pname = "x509";
-  version = "0.14.1";
+  version = "0.15.2";
 
   src = fetchurl {
     url = "https://github.com/mirleft/ocaml-x509/releases/download/v${version}/x509-v${version}.tbz";
-    sha256 = "d91eb4f2790f9d098713c71cc4b5d12706aedb1795666b5e6d667fe5c262f9c3";
+    sha256 = "4034afdd83a0cb8291b1f809403015da9139bd772813d59d6093e42ec31ba643";
   };
 
   useDune2 = true;
 
   buildInputs = [ alcotest cstruct-unix ];
-  propagatedBuildInputs = [ asn1-combinators domain-name fmt gmap mirage-crypto mirage-crypto-pk mirage-crypto-ec pbkdf rresult logs base64 ];
+  propagatedBuildInputs = [ asn1-combinators domain-name fmt gmap mirage-crypto mirage-crypto-pk mirage-crypto-ec pbkdf logs base64 ipaddr ];
 
   doCheck = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Waiting on:

* [x] https://github.com/ocaml/opam-repository/pull/20229 being merged
* [x] Feedback on https://github.com/hannesm/jackline/pull/226

Verified entire `ocamlPackages` set still compiles.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
