### PR TITLE
ocamlPackages.wayland: 0.2 -> 1.0;  wayland-proxy-virtwl: unstable-2021-04-15 -> unstable-2021-12-05 

### DIFF
--- a/pkgs/development/ocaml-modules/wayland/default.nix
+++ b/pkgs/development/ocaml-modules/wayland/default.nix
@@ -12,15 +12,15 @@
 
 buildDunePackage rec {
   pname = "wayland";
-  version = "0.2";
+  version = "1.0";
 
   minimumOCamlVersion = "4.08";
 
   useDune2 = true;
 
   src = fetchurl {
-    url = "https://github.com/talex5/ocaml-wayland/releases/download/v${version}/wayland-v${version}.tbz";
-    sha256 = "4eb323e42a8c64e9e49b15a588342bfcc1e99640305cb261d128c75612d9458c";
+    url = "https://github.com/talex5/ocaml-wayland/releases/download/v${version}/wayland-${version}.tbz";
+    sha256 = "bf8fd0057242d11f1c265c11cfa5de3c517ec0ad5994eae45e1efe3aac034510";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/tools/wayland/wayland-proxy-virtwl/default.nix
+++ b/pkgs/tools/wayland/wayland-proxy-virtwl/default.nix
@@ -1,17 +1,18 @@
 { lib
 , fetchFromGitHub
 , ocamlPackages
+, buildPackages
 }:
 
 ocamlPackages.buildDunePackage rec {
   pname = "wayland-proxy-virtwl";
-  version = "unstable-2021-04-15";
+  version = "unstable-2021-12-05";
 
   src = fetchFromGitHub {
     owner = "talex5";
     repo = pname;
-    rev = "09321a28f3d4c0fa7e41ebb3014106b62090b649";
-    sha256 = "03rc2jp5d2y9y7mfis6kk9gchd49gvq0jg6fq5gi9r21ckb4k5v4";
+    rev = "d7f58d405514dd031f2f12e402c8c6a58e62a885";
+    sha256 = "0riwaqdlrx2gzkrb02v4zdl4ivpmz9g5w87lj3bhqs0l3s6c249s";
   };
 
   postPatch = ''
@@ -22,11 +23,18 @@ ocamlPackages.buildDunePackage rec {
   useDune2 = true;
   minimumOCamlVersion = "4.08";
 
+  nativeBuildInputs = [
+    buildPackages.ocamlPackages.ppx_cstruct
+  ];
+
   buildInputs = with ocamlPackages; [
     wayland
     cmdliner
     logs
+    cstruct-lwt
   ];
+
+  doCheck = true;
 
   meta = {
     homepage = "https://github.com/talex5/wayland-virtwl-proxy";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
