### PR TITLE
log4j-scan: init at unstable-2021-12-14

### DIFF
--- a/pkgs/tools/security/log4j-scan/default.nix
+++ b/pkgs/tools/security/log4j-scan/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "log4j-scan";
+  version = "unstable-2021-12-14";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "fullhunt";
+    repo = pname;
+    rev = "7be0f1c02ce3494469dc73a177e6f0c96f0016d9";
+    sha256 = "sha256-HazxK0wJ8xeFauD2xOxmOwWw1nEpQh+QdcBVZNaUgrM=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    pycryptodome
+    requests
+    termcolor
+  ];
+
+  postPatch = ''
+    substituteInPlace log4j-scan.py \
+      --replace "headers.txt" "../share/headers.txt"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -vD ${pname}.py $out/bin/${pname}
+    install -vD headers.txt headers-large.txt -t $out/share
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Scanner for finding hosts which are vulnerable for log4j";
+    homepage = "https://github.com/fullhunt/log4j-scan";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7463,6 +7463,8 @@ with pkgs;
 
   localtime = callPackage ../tools/system/localtime { };
 
+  log4j-scan = callPackage ../tools/security/log4j-scan { };
+
   logcheck = callPackage ../tools/system/logcheck { };
 
   logmein-hamachi = callPackage ../tools/networking/logmein-hamachi { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Scanner for finding hosts which are vulnerable for log4j

https://github.com/fullhunt/log4j-scan

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
