### PR TITLE
primecount: init at 7.2

### DIFF
--- a/pkgs/development/libraries/science/math/primecount/default.nix
+++ b/pkgs/development/libraries/science/math/primecount/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchFromGitHub, cmake, primesieve }:
+
+stdenv.mkDerivation rec {
+  pname = "primecount";
+  version = "7.2";
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ primesieve ];
+
+  src = fetchFromGitHub {
+    owner = "kimwalisch";
+    repo = "primecount";
+    rev = "v${version}";
+    sha256 = "sha256-/Cb/HkD4UQ9gXsRpvRiEuQBoRd0THxNHsBaAAa+CqQo=";
+  };
+
+  meta = with lib; {
+    description = "Fast prime counting function implementations";
+    homepage = "https://github.com/kimwalisch/primecount";
+    license = licenses.bsd2;
+    platforms = platforms.unix;
+    maintainers = teams.sage.members;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19202,6 +19202,8 @@ with pkgs;
 
   prime-server = callPackage ../development/libraries/prime-server { };
 
+  primecount = callPackage ../development/libraries/science/math/primecount { };
+
   primesieve = callPackage ../development/libraries/science/math/primesieve { };
 
   prison = callPackage ../development/libraries/prison { };


### PR DESCRIPTION
###### Motivation for this change

A Sage dependency since 9.5.beta8. Mostly copied from @abbradar's primesieve package (actually introduced by @guibou, I think).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
