### PR TITLE
nanosaur: init at unstable-2021-12-03

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7054,6 +7054,12 @@
       fingerprint = "BA3A 5886 AE6D 526E 20B4  57D6 6A37 DF94 8318 8492";
     }];
   };
+  lux = {
+    email = "lux@lux.name";
+    githubId = 1208273;
+    matrix = "@lux:ontheblueplanet.com";
+    name = "Lux";
+  };
   luz = {
     email = "luz666@daum.net";
     github = "Luz";

--- a/pkgs/games/nanosaur/default.nix
+++ b/pkgs/games/nanosaur/default.nix
@@ -1,0 +1,48 @@
+{ lib, stdenv, fetchFromGitHub, SDL2, cmake, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "nanosaur";
+  version = "unstable-2021-12-03";
+
+  src = fetchFromGitHub {
+    owner = "jorio";
+    repo = pname;
+    rev = "b567a3e6d7fd1cbc43800cfaa1bd82f31c6d9fae";
+    sha256 = "sha256-P/o6uSwUV6O8u8XNXN9YyA8XlgEUkqGj3SC+oD2/GKQ=";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [
+    SDL2
+    cmake
+    makeWrapper
+  ];
+
+  configurePhase = ''
+    cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+  '';
+
+  buildPhase = ''
+    cmake --build build
+  '';
+
+  installPhase = ''
+    mv build $out
+    makeWrapper $out/Nanosaur $out/bin/Nanosaur --run "cd $out"
+  '';
+
+  meta = with lib; {
+    description = "A port of Nanosaur, a 1998 Macintosh game by Pangea Software, for modern operating systems";
+    longDescription = ''
+      Nanosaur is a 1998 Macintosh game by Pangea Software.
+      In it, you’re a cybernetic dinosaur from the future who’s sent back in time 20 minutes before a giant asteroid hits the Earth.
+      And you get to shoot at T-Rexes with nukes.
+    '';
+    homepage = "https://github.com/jorio/Nanosaur";
+    license = with licenses; [
+      cc-by-sa-40
+    ];
+    maintainers = with maintainers; [ lux ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30492,6 +30492,8 @@ with pkgs;
 
   naev = callPackage ../games/naev { };
 
+  nanosaur = callPackage ../games/nanosaur { };
+
   nethack = callPackage ../games/nethack { };
 
   nethack-qt = callPackage ../games/nethack {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add [nanosaur](https://github.com/jorio/Nanosaur) package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
