### PR TITLE
matrix-synapse-tools.rust-synapse-compress-state: 0.1.0 -> 0.1.2

### DIFF
--- a/pkgs/servers/matrix-synapse/tools/rust-synapse-compress-state.nix
+++ b/pkgs/servers/matrix-synapse/tools/rust-synapse-compress-state.nix
@@ -1,17 +1,25 @@
-{ lib, rustPlatform, fetchFromGitHub }:
+{ lib, rustPlatform, python3, fetchFromGitHub, pkg-config, openssl }:
 
 rustPlatform.buildRustPackage rec {
   pname = "rust-synapse-compress-state";
-  version = "0.1.0";
+  version = "0.1.2";
 
   src = fetchFromGitHub {
     owner = "matrix-org";
     repo = pname;
     rev = "v${version}";
-    sha256 = "15jvkpbq6pgdc91wnni8fj435yqlwqgx3bb0vqjgsdyxs5lzalfh";
+    sha256 = "sha256-uL7uoJPvZoTbrmEFY7jiBphvjWSRpH9pyk3x7s3Yvrs=";
   };
 
-  cargoSha256 = "173nylp9xj88cm42yggj41iqvgb25s3awhf1dqssy8f1zyw2cf3d";
+  cargoSha256 = "sha256-3w5RyVrpCnetXnxnzgVl94kUZa+1i9bU2O8vp7sb3lY=";
+
+  cargoBuildFlags = [
+    "--all"
+  ];
+
+  nativeBuildInputs = [ python3 pkg-config ];
+
+  buildInputs = [ openssl ];
 
   meta = with lib; {
     description = "A tool to compress some state in a Synapse instance's database";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/matrix-org/rust-synapse-compress-state/releases/tag/v0.1.2

Automatic compressor release!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
