### PR TITLE
signalbackup-tools: init at 20220107

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signalbackup-tools/apple-sdk-missing-utimensat.patch
+++ b/pkgs/applications/networking/instant-messengers/signalbackup-tools/apple-sdk-missing-utimensat.patch
@@ -1,0 +1,34 @@
+diff --git a/signalbackup/setfiletimestamp.cc b/signalbackup/setfiletimestamp.cc
+index f53a168..d2d1c5e 100644
+--- a/signalbackup/setfiletimestamp.cc
++++ b/signalbackup/setfiletimestamp.cc
+@@ -21,24 +21,23 @@
+
+ #if !defined(_WIN32) && !defined(__MINGW64__)
+
+-#include <fcntl.h>
+-#include <sys/stat.h>
++#include <sys/time.h>
+
+ bool SignalBackup::setFileTimeStamp(std::string const &file, long long int time_usec) const
+ {
+-  struct timespec ntimes[] =
++  struct timeval ntimes[] =
+   {
+     {                                   // ntimes[0] =
+       time_usec / 1000,                 // tv_sec, seconds
+-      (time_usec % 1000) * 1000         // tv_usec, nanoseconds
++      static_cast<int>(time_usec)       // tv_usec, nanoseconds
+     },
+     {                                   // ntimes[1] =
+       time_usec / 1000,                 // tv_sec, seconds
+-      (time_usec % 1000) * 1000         // tv_usec, nanoseconds
++      static_cast<int>(time_usec)       // tv_usec, nanoseconds
+     }
+   };
+
+-  return (utimensat(AT_FDCWD, file.c_str(), ntimes, 0) == 0);
++  return (utimes(file.c_str(), ntimes) == 0);
+ }
+
+ #else // this is poorly tested, I don't have windows

--- a/pkgs/applications/networking/instant-messengers/signalbackup-tools/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signalbackup-tools/default.nix
@@ -1,0 +1,45 @@
+{ lib, stdenv, fetchFromGitHub, openssl, sqlite }:
+
+stdenv.mkDerivation rec {
+  pname = "signalbackup-tools";
+  version = "20220107";
+
+  src = fetchFromGitHub {
+    owner = "bepaald";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-sB8/xQgSORtwupcwSejKUhHoz04exdYS0ymefw9wXDQ=";
+  };
+
+  # Remove when Apple SDK is >= 10.13
+  patches = lib.optional (stdenv.system == "x86_64-darwin") ./apple-sdk-missing-utimensat.patch;
+
+  buildInputs = [ openssl sqlite ];
+  buildFlags = [
+    "-Wall"
+    "-Wextra"
+    "-Wshadow"
+    "-Wold-style-cast"
+    "-Woverloaded-virtual"
+    "-pedantic"
+    "-std=c++2a"
+    "-O3"
+    "-march=native"
+  ];
+  buildPhase = ''
+    $CXX $buildFlags */*.cc *.cc -lcrypto -lsqlite3 -o signalbackup-tools
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp signalbackup-tools $out/bin/
+  '';
+
+  meta = with lib; {
+    description = "Tool to work with Signal Backup files";
+    homepage = "https://github.com/bepaald/signalbackup-tools";
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.malo ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9594,6 +9594,8 @@ with pkgs;
 
   sigil = libsForQt5.callPackage ../applications/editors/sigil { };
 
+  signalbackup-tools = callPackage ../applications/networking/instant-messengers/signalbackup-tools { };
+
   signald = callPackage ../applications/networking/instant-messengers/signald { };
 
   signal-cli = callPackage ../applications/networking/instant-messengers/signal-cli { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I use this package, and would like it included in `nixpkgs`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
