### PR TITLE
lapce: init at 0.0.2

### DIFF
--- a/pkgs/applications/editors/lapce/default.nix
+++ b/pkgs/applications/editors/lapce/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "lapce";
+  version = "0.0.2";
+
+  src = fetchFromGitHub {
+    owner = "lapce";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "gmkdBvIzDqXydeVINlAu67wkxnMBEycVVB9aakfj6Aw=";
+  };
+
+  cargoSha256 = lib.fakeSha256;
+
+  meta = with lib; {
+    description = "Lightning-fast and Powerful Code Editor written in Rust";
+    homepage = "https://github.com/lapce/lapce";
+    license = licenses.asl20;
+    maintainers = with maintainers; [
+      alexnortung
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31477,6 +31477,8 @@ with pkgs;
   lapack-reference = callPackage ../development/libraries/science/math/liblapack { };
   liblapack = lapack-reference;
 
+  lapce = callPackage ../applications/editors/lapce { };
+
   libbraiding = callPackage ../development/libraries/science/math/libbraiding { };
 
   libhomfly = callPackage ../development/libraries/science/math/libhomfly { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The package is currently not working as the same crate is being
pulled from two different sources. 
The nix rust build platform does not like this and throws an error while building.

There is a similar issue #30742 . However it seems like there is a fix by using cargoPatches, I will try this later, else feel free to try and fix this.

The following is the error outputted

```
Caused by:
  found duplicate version of package `xi-rope v0.3.0` vendored from two sources:

        source 1: registry `crates-io`
        source 2: https://github.com/lapce/xi-editor#5578c725
Traceback (most recent call last):
  File "/nix/store/q9fajyagw0ifr4fww5lnxmj562hc5f1q-cargo-vendor-normalise/bin/.cargo-vendor-normalise-wrapped", line 42, in <module>
    main()
  File "/nix/store/q9fajyagw0ifr4fww5lnxmj562hc5f1q-cargo-vendor-normalise/bin/.cargo-vendor-normalise-wrapped", line 17, in main
    assert list(data.keys()) == ["source"]
AssertionError

```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
