### PR TITLE
rocm and hip: 4.3.1 → 4.5.2

### DIFF
--- a/pkgs/development/compilers/hip/default.nix
+++ b/pkgs/development/compilers/hip/default.nix
@@ -8,9 +8,13 @@
 , fetchpatch
 , file
 , lib
+, libglvnd
+, libX11
+, libxml2
 , lld
 , llvm
 , makeWrapper
+, numactl
 , perl
 , python
 , rocclr
@@ -24,28 +28,96 @@
 , writeText
 }:
 
+let
+  hip = stdenv.mkDerivation rec {
+    pname = "hip";
+    version = "4.5.2";
+
+    src = fetchFromGitHub {
+      owner = "ROCm-Developer-Tools";
+      repo = "HIP";
+      rev = "rocm-${version}";
+      sha256 = "sha256-AuA5ubRPywXaBBrjdHg5AT8rrVKULKog6Lh8jPaUcXY=";
+    };
+
+    # - fix bash paths
+    # - fix path to rocm_agent_enumerator
+    # - fix hcc path
+    # - fix hcc version parsing
+    # - add linker flags for libhsa-runtime64 and hc_am since libhip_hcc
+    #   refers to them.
+    prePatch = ''
+      for f in $(find bin -type f); do
+        sed -e 's,#!/usr/bin/perl,#!${perl}/bin/perl,' \
+            -e 's,#!/bin/bash,#!${stdenv.shell},' \
+            -i "$f"
+      done
+
+      substituteInPlace bin/hip_embed_pch.sh \
+        --replace '$LLVM_DIR/bin/' ""
+
+      sed 's,#!/usr/bin/python,#!${python}/bin/python,' -i hip_prof_gen.py
+
+      sed -e 's,$ROCM_AGENT_ENUM = "''${ROCM_PATH}/bin/rocm_agent_enumerator";,$ROCM_AGENT_ENUM = "${rocminfo}/bin/rocm_agent_enumerator";,' \
+          -e 's,^\($DEVICE_LIB_PATH=\).*$,\1"${rocm-device-libs}/amdgcn/bitcode";,' \
+          -e 's,^\($HIP_COMPILER=\).*$,\1"clang";,' \
+          -e 's,^\($HIP_RUNTIME=\).*$,\1"ROCclr";,' \
+          -e 's,^\([[:space:]]*$HSA_PATH=\).*$,\1"${rocm-runtime}";,'g \
+          -e 's,^\([[:space:]]*\)$HIP_CLANG_INCLUDE_PATH = abs_path("$HIP_CLANG_PATH/../lib/clang/$HIP_CLANG_VERSION/include");,\1$HIP_CLANG_INCLUDE_PATH = "${clang-unwrapped}/lib/clang/$HIP_CLANG_VERSION/include";,' \
+          -e 's,^\([[:space:]]*$HIPCXXFLAGS .= " -isystem \\"$HIP_CLANG_INCLUDE_PATH/..\\"\)";,\1 -isystem ${rocm-runtime}/include";,' \
+          -e 's,`file,`${file}/bin/file,g' \
+          -e 's,`readelf,`${binutils-unwrapped}/bin/readelf,' \
+          -e 's, ar , ${binutils-unwrapped}/bin/ar ,g' \
+          -i bin/hipcc
+
+      sed -e 's,^\($HSA_PATH=\).*$,\1"${rocm-runtime}";,' \
+          -e 's,^\($HIP_CLANG_PATH=\).*$,\1"${clang}/bin";,' \
+          -e 's,^\($HIP_PLATFORM=\).*$,\1"amd";,' \
+          -e 's,$HIP_CLANG_PATH/llc,${llvm}/bin/llc,' \
+          -e 's, abs_path, Cwd::abs_path,' \
+          -i bin/hipconfig
+
+      sed -e 's, abs_path, Cwd::abs_path,' -i bin/hipvars.pm
+    '';
+
+    buildPhase = "";
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp -r * $out/
+
+      runHook postInstall
+    '';
+
+    meta = with lib; {
+      description = "C++ Heterogeneous-Compute Interface for Portability";
+      homepage = "https://github.com/ROCm-Developer-Tools/HIP";
+      license = licenses.mit;
+      maintainers = with maintainers; [ lovesegfault ];
+      platforms = platforms.linux;
+    };
+  };
+in
 stdenv.mkDerivation rec {
-  name = "hip";
-  version = "4.3.1";
+  pname = "hip";
+  version = "4.5.2";
+
   src = fetchFromGitHub {
     owner = "ROCm-Developer-Tools";
-    repo = "HIP";
+    repo = "hipamd";
     rev = "rocm-${version}";
-    sha256 = "sha256-dUdP32H0u6kVItS+VUE549vvxkV1mSN84HvyfeK2hEE=";
+    sha256 = "WvOuQu/EN81Kwcoc3ZtGlhb996edQJ3OWFsmPuqeNXE=";
   };
 
-  # FIXME: https://github.com/ROCm-Developer-Tools/HIP/issues/2317
-  postPatch = ''
-    cp ${rocm-opencl-runtime.src}/amdocl/cl_vk_amd.hpp amdocl/
-  '';
-
-  nativeBuildInputs = [ cmake python makeWrapper ];
+  nativeBuildInputs = [ cmake python makeWrapper perl ];
+  buildInputs = [ libxml2 numactl libglvnd libX11 ];
   propagatedBuildInputs = [
     clang
     compiler-rt
     lld
     llvm
-    rocclr
     rocm-comgr
     rocm-device-libs
     rocm-runtime
@@ -58,123 +130,28 @@ stdenv.mkDerivation rec {
     export DEVICE_LIB_PATH=${rocm-device-libs}/lib
   '';
 
-  # The patch version is the last two digits of year + week number +
-  # day in the week: date -d "2021-07-25" +%y%U%w
-  workweek = "21300";
-
   cmakeFlags = [
-    "-DHSA_PATH=${rocm-runtime}"
-    "-DHIP_COMPILER=clang"
     "-DHIP_PLATFORM=amd"
-    "-DHIP_VERSION_GITDATE=${workweek}"
-    "-DCMAKE_C_COMPILER=${clang}/bin/clang"
-    "-DCMAKE_CXX_COMPILER=${clang}/bin/clang++"
-    "-DLLVM_ENABLE_RTTI=ON"
-    "-DLIBROCclr_STATIC_DIR=${rocclr}/lib/cmake"
-    "-DROCclr_DIR=${rocclr}"
-    "-DHIP_CLANG_ROOT=${clang-unwrapped}"
+    "-DAMD_OPENCL_PATH=${rocm-opencl-runtime.src}"
+    "-DHIP_COMMON_DIR=${hip}"
+    "-DROCCLR_PATH=${rocclr}"
   ];
 
-  patches = [
-    (fetchpatch {
-      name = "no-git-during-build";
-      url = "https://github.com/acowley/HIP/commit/310b7e972cfb23216250c0240ba6134741679aee.patch";
-      sha256 = "08ky7v1yvajabn9m5x3afzrnz38gnrgc7vgqlbyr7s801c383ha1";
-    })
-    (fetchpatch {
-      name = "use-PATH-when-compiling-pch";
-      url = "https://github.com/acowley/HIP/commit/bfb4dd1eafa9714a2c05a98229cc35ffa3429b37.patch";
-      sha256 = "1wp0m32df7pf4rhx3k5n750fd7kz10zr60z0wllb0mw6h00w6xpz";
-    })
-  ];
-
-  # - fix bash paths
-  # - fix path to rocm_agent_enumerator
-  # - fix hcc path
-  # - fix hcc version parsing
-  # - add linker flags for libhsa-runtime64 and hc_am since libhip_hcc
-  #   refers to them.
-  prePatch = ''
-    for f in $(find bin -type f); do
-      sed -e 's,#!/usr/bin/perl,#!${perl}/bin/perl,' \
-          -e 's,#!/bin/bash,#!${stdenv.shell},' \
-          -i "$f"
-    done
-
-    for f in $(find . -regex '.*\.cpp\|.*\.h\(pp\)?'); do
-      if grep -q __hcc_workweek__ "$f" ; then
-        substituteInPlace "$f" --replace '__hcc_workweek__' '${workweek}'
-      fi
-    done
-
-    sed 's,#!/usr/bin/python,#!${python}/bin/python,' -i hip_prof_gen.py
-
-    sed -e 's,$ROCM_AGENT_ENUM = "''${ROCM_PATH}/bin/rocm_agent_enumerator";,$ROCM_AGENT_ENUM = "${rocminfo}/bin/rocm_agent_enumerator";,' \
-        -e "s,^\($HIP_LIB_PATH=\).*$,\1\"$out/lib\";," \
-        -e 's,^\($HIP_CLANG_PATH=\).*$,\1"${clang}/bin";,' \
-        -e 's,^\($DEVICE_LIB_PATH=\).*$,\1"${rocm-device-libs}/amdgcn/bitcode";,' \
-        -e 's,^\($HIP_COMPILER=\).*$,\1"clang";,' \
-        -e 's,^\($HIP_RUNTIME=\).*$,\1"ROCclr";,' \
-        -e 's,^\([[:space:]]*$HSA_PATH=\).*$,\1"${rocm-runtime}";,'g \
-        -e 's,\([[:space:]]*$HOST_OSNAME=\).*,\1"nixos";,' \
-        -e 's,\([[:space:]]*$HOST_OSVER=\).*,\1"${lib.versions.majorMinor lib.version}";,' \
-        -e 's,^\([[:space:]]*\)$HIP_CLANG_INCLUDE_PATH = abs_path("$HIP_CLANG_PATH/../lib/clang/$HIP_CLANG_VERSION/include");,\1$HIP_CLANG_INCLUDE_PATH = "${clang-unwrapped}/lib/clang/$HIP_CLANG_VERSION/include";,' \
-        -e 's,^\([[:space:]]*$HIPCXXFLAGS .= " -isystem $HIP_CLANG_INCLUDE_PATH\)";,\1 -isystem ${rocm-runtime}/include";,' \
-        -e 's,\($HIPCXXFLAGS .= " -isystem \\"$HIP_INCLUDE_PATH\\"\)" ;,\1 --rocm-path=${rocclr}";,' \
-        -e "s,\$HIP_PATH/\(bin\|lib\),$out/\1,g" \
-        -e "s,^\$HIP_LIB_PATH=\$ENV{'HIP_LIB_PATH'};,\$HIP_LIB_PATH=\"$out/lib\";," \
-        -e 's,`file,`${file}/bin/file,g' \
-        -e 's,`readelf,`${binutils-unwrapped}/bin/readelf,' \
-        -e 's, ar , ${binutils-unwrapped}/bin/ar ,g' \
-        -i bin/hipcc
-
-    sed -e 's,^\($HSA_PATH=\).*$,\1"${rocm-runtime}";,' \
-        -e 's,^\($HIP_CLANG_PATH=\).*$,\1"${clang}/bin";,' \
-        -e 's,^\($HIP_PLATFORM=\).*$,\1"amd";,' \
-        -e 's,$HIP_CLANG_PATH/llc,${llvm}/bin/llc,' \
-        -e 's, abs_path, Cwd::abs_path,' \
-        -i bin/hipconfig
-
-    sed -e 's, abs_path, Cwd::abs_path,' -i bin/hipvars.pm
-
-    sed -e 's|_IMPORT_PREFIX}/../include|_IMPORT_PREFIX}/include|g' \
-        -e 's|''${HIP_CLANG_ROOT}/lib/clang/\*/include|${clang-unwrapped}/lib/clang/*/include|' \
-        -i hip-config.cmake.in
-  '';
-
-  preInstall = ''
-    mkdir -p $out/lib/cmake
-  '';
-
-  # The upstream ROCclr setup wants everything built into the same
-  # ROCclr output directory. We copy things into the HIP output
-  # directory, since it is downstream of ROCclr in terms of dependency
-  # direction. Thus we have device-libs and rocclr pieces in the HIP
-  # output directory.
   postInstall = ''
-    mkdir -p $out/share
-    mv $out/lib/cmake $out/share/
-    mv $out/cmake/* $out/share/cmake/hip
-    mkdir -p $out/lib
-    ln -s ${rocm-device-libs}/lib $out/lib/bitcode
-    mkdir -p $out/include
-    ln -s ${clang-unwrapped}/lib/clang/11.0.0/include $out/include/clang
-    ln -s ${rocclr}/lib/*.* $out/lib
-    ln -s ${rocclr}/include/* $out/include
-    wrapProgram $out/bin/hipcc --set HIP_PATH $out --set HSA_PATH ${rocm-runtime} --set HIP_CLANG_PATH ${clang}/bin --prefix PATH : ${lld}/bin --set NIX_CC_WRAPPER_TARGET_HOST_${stdenv.cc.suffixSalt} 1 --prefix NIX_LDFLAGS ' ' -L${compiler-rt}/lib --prefix NIX_LDFLAGS_FOR_TARGET ' ' -L${compiler-rt}/lib
+    wrapProgram $out/bin/hipcc --set HIP_PATH $out --set HSA_PATH ${rocm-runtime} --set HIP_CLANG_PATH ${clang}/bin --prefix PATH : ${lld}/bin --set NIX_CC_WRAPPER_TARGET_HOST_${stdenv.cc.suffixSalt} 1 --prefix NIX_LDFLAGS ' ' -L${compiler-rt}/lib --prefix NIX_LDFLAGS_FOR_TARGET ' ' -L${compiler-rt}/lib --add-flags "-nogpuinc"
     wrapProgram $out/bin/hipconfig --set HIP_PATH $out --set HSA_PATH ${rocm-runtime} --set HIP_CLANG_PATH ${clang}/bin
   '';
 
   passthru.updateScript = writeScript "update.sh" ''
     #!/usr/bin/env nix-shell
     #!nix-shell -i bash -p curl jq common-updater-scripts
-    version="$(curl -sL "https://api.github.com/repos/ROCm-Developer-Tools/HIP/tags" | jq '.[].name | split("-") | .[1] | select( . != null )' --raw-output | sort -n | tail -1)"
+    version="$(curl -sL "https://api.github.com/repos/ROCm-Developer-Tools/hipamd/tags" | jq '.[].name | split("-") | .[1] | select( . != null )' --raw-output | sort -n | tail -1)"
     update-source-version hip "$version"
   '';
 
   meta = with lib; {
     description = "C++ Heterogeneous-Compute Interface for Portability";
-    homepage = "https://github.com/ROCm-Developer-Tools/HIP";
+    homepage = "https://github.com/ROCm-Developer-Tools/hipamd";
     license = licenses.mit;
     maintainers = with maintainers; [ lovesegfault ];
     platforms = platforms.linux;

--- a/pkgs/development/compilers/llvm/rocm/compiler-rt/68d5235cb58f988c71b403334cd9482d663841ab.patch
+++ b/pkgs/development/compilers/llvm/rocm/compiler-rt/68d5235cb58f988c71b403334cd9482d663841ab.patch
@@ -1,0 +1,78 @@
+--- a/lib/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
++++ b/lib/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
+@@ -370,15 +370,6 @@
+ 
+ #if SANITIZER_GLIBC
+   // _(SIOCDEVPLIP, WRITE, struct_ifreq_sz); // the same as EQL_ENSLAVE
+-  _(CYGETDEFTHRESH, WRITE, sizeof(int));
+-  _(CYGETDEFTIMEOUT, WRITE, sizeof(int));
+-  _(CYGETMON, WRITE, struct_cyclades_monitor_sz);
+-  _(CYGETTHRESH, WRITE, sizeof(int));
+-  _(CYGETTIMEOUT, WRITE, sizeof(int));
+-  _(CYSETDEFTHRESH, NONE, 0);
+-  _(CYSETDEFTIMEOUT, NONE, 0);
+-  _(CYSETTHRESH, NONE, 0);
+-  _(CYSETTIMEOUT, NONE, 0);
+   _(EQL_EMANCIPATE, WRITE, struct_ifreq_sz);
+   _(EQL_ENSLAVE, WRITE, struct_ifreq_sz);
+   _(EQL_GETMASTRCFG, WRITE, struct_ifreq_sz);
+--- a/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
++++ b/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+@@ -143,7 +143,6 @@
+ # include <sys/procfs.h>
+ #endif
+ #include <sys/user.h>
+-#include <linux/cyclades.h>
+ #include <linux/if_eql.h>
+ #include <linux/if_plip.h>
+ #include <linux/lp.h>
+@@ -460,7 +459,6 @@
+ 
+ #if SANITIZER_GLIBC
+   unsigned struct_ax25_parms_struct_sz = sizeof(struct ax25_parms_struct);
+-  unsigned struct_cyclades_monitor_sz = sizeof(struct cyclades_monitor);
+ #if EV_VERSION > (0x010000)
+   unsigned struct_input_keymap_entry_sz = sizeof(struct input_keymap_entry);
+ #else
+@@ -824,15 +822,6 @@
+ #endif // SANITIZER_LINUX
+ 
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID
+-  unsigned IOCTL_CYGETDEFTHRESH = CYGETDEFTHRESH;
+-  unsigned IOCTL_CYGETDEFTIMEOUT = CYGETDEFTIMEOUT;
+-  unsigned IOCTL_CYGETMON = CYGETMON;
+-  unsigned IOCTL_CYGETTHRESH = CYGETTHRESH;
+-  unsigned IOCTL_CYGETTIMEOUT = CYGETTIMEOUT;
+-  unsigned IOCTL_CYSETDEFTHRESH = CYSETDEFTHRESH;
+-  unsigned IOCTL_CYSETDEFTIMEOUT = CYSETDEFTIMEOUT;
+-  unsigned IOCTL_CYSETTHRESH = CYSETTHRESH;
+-  unsigned IOCTL_CYSETTIMEOUT = CYSETTIMEOUT;
+   unsigned IOCTL_EQL_EMANCIPATE = EQL_EMANCIPATE;
+   unsigned IOCTL_EQL_ENSLAVE = EQL_ENSLAVE;
+   unsigned IOCTL_EQL_GETMASTRCFG = EQL_GETMASTRCFG;
+--- a/lib/sanitizer_common/sanitizer_platform_limits_posix.h
++++ b/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+@@ -983,7 +983,6 @@
+ 
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID
+ extern unsigned struct_ax25_parms_struct_sz;
+-extern unsigned struct_cyclades_monitor_sz;
+ extern unsigned struct_input_keymap_entry_sz;
+ extern unsigned struct_ipx_config_data_sz;
+ extern unsigned struct_kbdiacrs_sz;
+@@ -1328,15 +1327,6 @@
+ #endif  // SANITIZER_LINUX
+ 
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID
+-extern unsigned IOCTL_CYGETDEFTHRESH;
+-extern unsigned IOCTL_CYGETDEFTIMEOUT;
+-extern unsigned IOCTL_CYGETMON;
+-extern unsigned IOCTL_CYGETTHRESH;
+-extern unsigned IOCTL_CYGETTIMEOUT;
+-extern unsigned IOCTL_CYSETDEFTHRESH;
+-extern unsigned IOCTL_CYSETDEFTIMEOUT;
+-extern unsigned IOCTL_CYSETTHRESH;
+-extern unsigned IOCTL_CYSETTIMEOUT;
+ extern unsigned IOCTL_EQL_EMANCIPATE;
+ extern unsigned IOCTL_EQL_ENSLAVE;
+ extern unsigned IOCTL_EQL_GETMASTRCFG;

--- a/pkgs/development/compilers/llvm/rocm/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/rocm/compiler-rt/default.nix
@@ -31,12 +31,8 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./compiler-rt-codesign.patch # Revert compiler-rt commit that makes codesign mandatory
-    (fetchpatch {
-      name = "libsanitizer-no-cyclades-rocm.patch";
-      url = "https://gist.github.com/lovesegfault/b255dcf2fa4e202411a6a04b61e6cc04/raw";
-      sha256 = "sha256-PMMSLr2zHuNDn1OWqumqHwB74ktJSHxhJWkqEKB7Z64=";
-      stripLen = 1;
-     })
+    # https://github.com/llvm/llvm-project/commit/68d5235cb58f988c71b403334cd9482d663841ab.diff but the compiler-rt part of the path is stripped
+    ./68d5235cb58f988c71b403334cd9482d663841ab.patch
     ];
 
 

--- a/pkgs/development/compilers/llvm/rocm/default.nix
+++ b/pkgs/development/compilers/llvm/rocm/default.nix
@@ -1,12 +1,12 @@
 { stdenv, lib, buildPackages, fetchFromGitHub, callPackage, wrapCCWith, overrideCC }:
 
 let
-  version = "4.3.1";
+  version = "4.5.2";
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "llvm-project";
     rev = "rocm-${version}";
-    hash = "sha256-7XVtHcrTpw+NYUvuKQFWWFE0FlOTt8EnfZpvepQqE1c=";
+    hash = "sha256-XWh81+2yyXQEPO+5SgxHh66fzFG1bVbvnjPfvXDC+fU=";
   };
 in rec {
   clang = wrapCCWith rec {

--- a/pkgs/development/compilers/llvm/rocm/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/rocm/llvm/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , writeScript
 , cmake
+, ninja
 , python3
 , libxml2
 , libffi
@@ -30,7 +31,7 @@ in stdenv.mkDerivation rec {
   outputs = [ "out" "python" ]
     ++ lib.optional enableSharedLibraries "lib";
 
-  nativeBuildInputs = [ cmake python3 ];
+  nativeBuildInputs = [ cmake ninja python3 ];
 
   buildInputs = [ libxml2 libffi ];
 

--- a/pkgs/development/libraries/rocm-comgr/default.nix
+++ b/pkgs/development/libraries/rocm-comgr/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rocm-comgr";
-  version = "4.3.1";
+  version = "4.5.2";
 
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "ROCm-CompilerSupport";
     rev = "rocm-${version}";
-    hash = "sha256-wHSAhp1cqR9xOreGt2M2Td/ELCuLEHjpMRRkqE9dUy0=";
+    hash = "sha256-enGzu1EOo87/S5oH1eEqPy0AtsBhCcroG3DYemeNgR0=";
   };
 
   sourceRoot = "source/lib/comgr";

--- a/pkgs/development/libraries/rocm-device-libs/default.nix
+++ b/pkgs/development/libraries/rocm-device-libs/default.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rocm-device-libs";
-  version = "4.3.1";
+  version = "4.5.2";
 
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "ROCm-Device-Libs";
     rev = "rocm-${version}";
-    hash = "sha256-fPD9vevO2UDaFaclSI0CC/lRfM5WemWmxP1K5ajXHbk=";
+    hash = "sha256-UeunsDRLhmsDOzesiEgYIzYotwecehB6VswshzdRwjw=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/rocm-opencl-runtime/default.nix
+++ b/pkgs/development/libraries/rocm-opencl-runtime/default.nix
@@ -13,7 +13,8 @@
 , lld
 , llvm
 , mesa
-, python2
+, numactl
+, python3
 , rocclr
 , rocm-comgr
 , rocm-device-libs
@@ -23,13 +24,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rocm-opencl-runtime";
-  version = "4.3.1";
+  version = "4.5.2";
 
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "ROCm-OpenCL-Runtime";
     rev = "rocm-${version}";
-    hash = "sha256-4+PNxRqvAvU0Nj2igYl3WiS5h5HGV63J+cHbIVW89LE=";
+    hash = "sha256-0OGYF4urlscr8tMkQwo2yATXwN0DjB092KQ+CBEhfIA=";
   };
 
   nativeBuildInputs = [ cmake rocm-cmake ];
@@ -43,8 +44,8 @@ stdenv.mkDerivation rec {
     lld
     llvm
     mesa
-    python2
-    rocclr
+    numactl
+    python3
     rocm-comgr
     rocm-device-libs
     rocm-runtime
@@ -52,12 +53,8 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DAMDGPU_TARGET_TRIPLE='amdgcn-amd-amdhsa'"
-    "-DCLANG_OPTIONS_APPEND=-Wno-bitwise-conditional-parentheses"
-    "-DClang_DIR=${clang-unwrapped}/lib/cmake/clang"
-    "-DLIBROCclr_STATIC_DIR=${rocclr}/lib/cmake"
-    "-DLLVM_DIR=${llvm.out}/lib/cmake/llvm"
-    "-DUSE_COMGR_LIBRARY='yes'"
+    "-DAMD_OPENCL_PATH=${src}"
+    "-DROCCLR_PATH=${rocclr}"
   ];
 
   dontStrip = true;
@@ -72,7 +69,6 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace khronos/icd/loader/linux/icd_linux.c \
       --replace 'ICD_VENDOR_PATH' '"${addOpenGLRunpath.driverLink}/etc/OpenCL/vendors/"'
-    echo 'add_dependencies(amdocl64 OpenCL)' >> amdocl/CMakeLists.txt
   '';
 
   passthru.updateScript = writeScript "update.sh" ''

--- a/pkgs/development/libraries/rocm-runtime/default.nix
+++ b/pkgs/development/libraries/rocm-runtime/default.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rocm-runtime";
-  version = "4.3.1";
+  version = "4.5.2";
 
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "ROCR-Runtime";
     rev = "rocm-${version}";
-    hash = "sha256-B67v9B8LXDbWNxYNRxM3dgFFLjFSyJmm0zd3G5Bgvek=";
+    hash = "sha256-DJDlEHnXhegcenO8BIY/8GnZdHldVs0GFLrQy4Z6heY=";
   };
 
   sourceRoot = "source/src";

--- a/pkgs/development/libraries/rocm-thunk/default.nix
+++ b/pkgs/development/libraries/rocm-thunk/default.nix
@@ -3,18 +3,19 @@
 , writeScript
 , cmake
 , pkg-config
+, libdrm
 , numactl
 }:
 
 stdenv.mkDerivation rec {
   pname = "rocm-thunk";
-  version = "4.3.1";
+  version = "4.5.2";
 
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "ROCT-Thunk-Interface";
     rev = "rocm-${version}";
-    hash = "sha256-jpwFL4UbEnWkw1AiM4U1s1t7GiqzBeOwa55VpnOG2Dk=";
+    hash = "sha256-s/N1wkAgpxYCK6rIiWH8cGQU5YFGj0q4Dxj9j3yIys8=";
   };
 
   preConfigure = ''
@@ -23,7 +24,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkg-config ];
 
-  buildInputs = [ numactl ];
+  buildInputs = [ libdrm numactl ];
 
   postInstall = ''
     cp -r $src/include $out

--- a/pkgs/development/tools/build-managers/rocm-cmake/default.nix
+++ b/pkgs/development/tools/build-managers/rocm-cmake/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rocm-cmake";
-  version = "4.3.1";
+  version = "4.5.2";
 
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "rocm-cmake";
     rev = "rocm-${version}";
-    hash = "sha256-BhpYOL7+IlBpkzeFjfy6KLO7ail472KQWFfQX/sXLGo=";
+    hash = "sha256-5RwhIIOtqeMl/Gyufl5U1gTEpoCjdPJP5MbVnhEKYMM=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/tools/system/rocm-smi/default.nix
+++ b/pkgs/tools/system/rocm-smi/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "rocm-smi";
-  version = "4.5.0";
+  version = "4.5.2";
 
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12780,9 +12780,7 @@ with pkgs;
 
   rgxg = callPackage ../tools/text/rgxg { };
 
-  rocclr = callPackage ../development/libraries/rocclr {
-    inherit (llvmPackages_rocm) clang;
-  };
+  rocclr = callPackage ../development/libraries/rocclr { };
 
   hip = callPackage ../development/compilers/hip {
     inherit (llvmPackages_rocm) clang clang-unwrapped compiler-rt lld llvm;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update all rocm packages to 4.5.2.
I tested rocm-smi, some OpenCL examples and a few hip examples from https://github.com/ROCm-Developer-Tools/HIP-Examples and they ran through fine. More testing of hip would be nice, I’m not that familiar with all its features and the binaries that are shipped.

There were a few changes in the rocm build landscape:
- rocclr needs to be integrated into other projects by source instead of as a binary.
- The hip repository was split into multiple repositories (build guide is at https://github.com/ROCm-Developer-Tools/HIP/blob/rocm-4.5.2/INSTALL.md#building-hip-from-source)
    - The repository that is built is now hipamd and the hip repo is integrated by source, similar to rocclr.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
