### PR TITLE
teleirc, nixos/teleirc: init

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -144,6 +144,13 @@
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://docs.teleirc.com/">teleirc</link>, a
+          Telegram - IRC bridge. Available at
+          <link linkend="opt-services.teleirc.bridges">services.teleirc</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://schleuder.org/">schleuder</link>, a
           mailing list manager with PGP support. Enable using
           <link linkend="opt-services.schleuder.enable">services.schleuder</link>.

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -59,6 +59,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 - [infnoise](https://github.com/leetronics/infnoise), a hardware True Random Number Generator dongle.
   Available as [services.infnoise](options.html#opt-services.infnoise.enable).
 - [persistent-evdev](https://github.com/aiberia/persistent-evdev), a daemon to add virtual proxy devices that mirror a physical input device but persist even if the underlying hardware is hot-plugged. Available as [services.persistent-evdev](#opt-services.persistent-evdev.enable).
+- [teleirc](https://docs.teleirc.com/), a Telegram - IRC bridge. Available at [services.teleirc](#opt-services.teleirc.bridges).
 
 - [schleuder](https://schleuder.org/), a mailing list manager with PGP support. Enable using [services.schleuder](#opt-services.schleuder.enable).
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -938,6 +938,7 @@
   ./services/networking/tedicross.nix
   ./services/networking/tetrd.nix
   ./services/networking/teleport.nix
+  ./services/networking/teleirc.nix
   ./services/networking/thelounge.nix
   ./services/networking/tinc.nix
   ./services/networking/tinydns.nix

--- a/nixos/modules/services/networking/teleirc.nix
+++ b/nixos/modules/services/networking/teleirc.nix
@@ -1,0 +1,127 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.teleirc;
+
+  format = pkgs.formats.keyValue {
+    mkKeyValue = generators.mkKeyValueDefault {
+      mkValueString = v:
+        # We quote string values, or channel names will be interpreted as comments
+        if builtins.isString v
+        then "\"" + strings.escape ["\""] v + "\""
+        else generators.mkValueStringDefault {} v;
+    } "=";
+  };
+
+  bridgeOpts = { ... }: {
+    options = {
+      settings = mkOption {
+        type = format.type;
+        description = ''
+          Configuration for TeleIRC. See
+          <link xlink:href="https://docs.teleirc.com/en/latest/user/config-file-glossary/" /> and
+          <link xlink:href="https://github.com/RITlug/teleirc/blob/main/env.example" />.
+          Prefer using <option>secretsFile</option> for IRC passwords and Telegram/Imgur tokens.
+        '';
+        example = literalExpression ''
+          {
+            IRC_SERVER = "irc.libera.chat";
+            IRC_PORT = 6697;
+
+            IRC_USE_SSL = true;
+            IRC_CERT_ALLOW_EXPIRED = false;
+            IRC_CERT_ALLOW_SELFSIGNED = false;
+
+            IRC_CHANNEL = "#nixos";
+
+            IRC_BOT_NAME = "my-teleirc-bridge";
+            IRC_BOT_IDENT = "teleirc";
+
+            TELEGRAM_CHAT_ID = -1000000000000;
+          }
+        '';
+      };
+      secretsFile = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Path to a file containing secret configuration values in systemd
+          environment file format.
+          Example contents of the file:
+          <literallayout>
+          IRC_SERVER_PASSWORD="hunter2";
+          TELEIRC_TOKEN="0000000000:AAAAAAA-AAAAAAAAAAAAAAAAAAAAAAAAAAA";
+          IMGUR_CLIENT_ID="000000000000000";
+          </literallayout>
+        '';
+      };
+    };
+  };
+
+  generateUnit = name: values: nameValuePair "teleirc-${name}" {
+    description = "TeleIRC IRC-Telegram bridge - ${name}";
+    requires = [ "network-online.target" ];
+    after = [ "network-online.target" ];
+    wantedBy = [ "multi-user.target" ];
+
+    serviceConfig = {
+      ExecStart = "${pkgs.teleirc}/bin/cmd -conf '${format.generate "teleirc-${name}.env" values.settings}'";
+      User = "teleirc";
+      Restart = "always"; # https://github.com/RITlug/teleirc/issues/359
+      # Hardening
+      CapabilityBoundingSet = [ "" ];
+      DeviceAllow = [ "" ];
+      LockPersonality = true;
+      MemoryDenyWriteExecute = true;
+      NoNewPrivileges = true;
+      PrivateDevices = true;
+      PrivateTmp = true;
+      PrivateUsers = true;
+      ProcSubset = "pid";
+      ProtectClock = true;
+      ProtectControlGroups = true;
+      ProtectHome = true;
+      ProtectHostname = true;
+      ProtectKernelLogs = true;
+      ProtectKernelModules = true;
+      ProtectKernelTunables = true;
+      ProtectProc = "invisible";
+      ProtectSystem = "strict";
+      RemoveIPC = true;
+      RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
+      RestrictNamespaces = true;
+      RestrictRealtime = true;
+      RestrictSUIDSGID = true;
+      SystemCallArchitectures = "native";
+      SystemCallFilter = [ "@system-service" ];
+      UMask = "0077";
+    } // optionalAttrs (values.secretsFile != null) {
+      EnvironmentFile = values.secretsFile;
+    };
+  };
+
+in {
+  # Interface
+  options.services.teleirc = {
+    bridges = mkOption {
+      description = "TeleIRC bridges";
+      default = {};
+      type = with types; attrsOf (submodule bridgeOpts);
+    };
+  };
+
+  # Implementation
+  config = mkIf (cfg.bridges != {}) {
+    users.users.teleirc = {
+      description = "TeleIRC service user";
+      isSystemUser = true;
+      group = "teleirc";
+    };
+    users.groups.teleirc = {};
+    systemd.services = mapAttrs' generateUnit cfg.bridges;
+  };
+
+  meta.maintainers = with lib.maintainers; [ fgaz ];
+}

--- a/pkgs/servers/teleirc/default.nix
+++ b/pkgs/servers/teleirc/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "teleirc";
+  version = "2.2.0";
+
+  src = fetchFromGitHub {
+    owner = "RITlug";
+    repo = "teleirc";
+    rev = "v${version}";
+    sha256 = "sha256-4ySphoMwHMjbctKEpgm6t6lOZSLsvKhAltyxRDDj0ww=";
+  };
+
+  vendorSha256 = "sha256-mum49SL5aMuSOPKBbmjb0JOVj9XN3GsnH0fCu7rnwhk=";
+
+  subPackages = [ "cmd" ];
+
+  meta = with lib; {
+    description = "Telegram - IRC bridge";
+    homepage = "https://docs.teleirc.com";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22964,6 +22964,8 @@ with pkgs;
     buildGoModule = buildGo118Module;
   };
 
+  teleirc = callPackage ../servers/teleirc { };
+
   thanos = callPackage ../servers/monitoring/thanos { };
 
   trafficserver = callPackage ../servers/http/trafficserver { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
