### PR TITLE
gotypist: fix maintainer metadata

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9044,6 +9044,12 @@
     githubId = 116740;
     name = "Paweł Pacana";
   };
+  pb- = {
+    email = "pbaecher@gmail.com";
+    github = "pb-";
+    githubId = 84886;
+    name = "Paul Baecher";
+  };
   pbogdan = {
     email = "ppbogdan@gmail.com";
     github = "pbogdan";

--- a/pkgs/games/gotypist/default.nix
+++ b/pkgs/games/gotypist/default.nix
@@ -21,6 +21,6 @@ buildGoModule rec {
     '';
     homepage = "https://github.com/pb-/gotypist";
     license = licenses.mit;
-    maintainers = [ "Paul Baecher" ];
+    maintainers = with maintainers; [ pb- ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Unbreak search.nixos.org import.

###### Things done

Added author @pb- as maintainer through `maintainers/maintainers-list.nix`.
References #147295