### PR TITLE
dotnet: fix createdump

### DIFF
--- a/pkgs/development/tools/misc/lttng-ust/2.12.nix
+++ b/pkgs/development/tools/misc/lttng-ust/2.12.nix
@@ -1,0 +1,4 @@
+import ./generic.nix {
+  version = "2.12.2";
+  sha256 = "sha256-vNDwZLbKiMcthOdg6sNHKuXIKEEcY0Q1kivun841n8c=";
+}

--- a/pkgs/development/tools/misc/lttng-ust/default.nix
+++ b/pkgs/development/tools/misc/lttng-ust/default.nix
@@ -1,42 +1,4 @@
-{ lib, stdenv, fetchurl, pkg-config, liburcu, numactl, python3 }:
-
-# NOTE:
-#   ./configure ...
-#   [...]
-#   LTTng-UST will be built with the following options:
-#
-#   Java support (JNI): Disabled
-#   sdt.h integration:  Disabled
-#   [...]
-#
-# Debian builds with std.h (systemtap).
-
-stdenv.mkDerivation rec {
-  pname = "lttng-ust";
-  version = "2.13.0";
-
-  src = fetchurl {
-    url = "https://lttng.org/files/lttng-ust/${pname}-${version}.tar.bz2";
-    sha256 = "0l0p6y2zrd9hgd015dhafjmpcj7waz762n6wf5ws1xlwcwrwkr2l";
-  };
-
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ numactl python3 ];
-
-  preConfigure = ''
-    patchShebangs .
-  '';
-
-  propagatedBuildInputs = [ liburcu ];
-
-  enableParallelBuilding = true;
-
-  meta = with lib; {
-    description = "LTTng Userspace Tracer libraries";
-    homepage = "https://lttng.org/";
-    license = with licenses; [ lgpl21Only gpl2Only mit ];
-    platforms = platforms.linux;
-    maintainers = [ maintainers.bjornfor ];
-  };
-
+import ./generic.nix {
+  version = "2.13.1";
+  sha256 = "sha256-Vme/Amnh5i4tnLl0xFb/huBAG9eqO/yNX9uXIzJJ7dw=";
 }

--- a/pkgs/development/tools/misc/lttng-ust/generic.nix
+++ b/pkgs/development/tools/misc/lttng-ust/generic.nix
@@ -1,0 +1,44 @@
+{ version, sha256 }:
+
+{ lib, stdenv, fetchurl, pkg-config, liburcu, numactl, python3 }:
+
+# NOTE:
+#   ./configure ...
+#   [...]
+#   LTTng-UST will be built with the following options:
+#
+#   Java support (JNI): Disabled
+#   sdt.h integration:  Disabled
+#   [...]
+#
+# Debian builds with std.h (systemtap).
+
+stdenv.mkDerivation rec {
+  pname = "lttng-ust";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://lttng.org/files/lttng-ust/${pname}-${version}.tar.bz2";
+    inherit sha256;
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ numactl python3 ];
+
+  preConfigure = ''
+    patchShebangs .
+  '';
+
+  propagatedBuildInputs = [ liburcu ];
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "LTTng Userspace Tracer libraries";
+    homepage = "https://lttng.org/";
+    license = with licenses; [ lgpl21Only gpl2Only mit ];
+    platforms = platforms.linux;
+    maintainers = [ maintainers.bjornfor ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14932,6 +14932,8 @@ with pkgs;
 
   lttng-ust = callPackage ../development/tools/misc/lttng-ust { };
 
+  lttng-ust_2_12 = callPackage ../development/tools/misc/lttng-ust/2.12.nix { };
+
   lttv = callPackage ../development/tools/misc/lttv { };
 
   luaformatter = callPackage ../development/tools/luaformatter


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Memory dumps of .NET applications.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
