### PR TITLE
postgresql: support JIT

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -221,7 +221,7 @@ in
       extraPlugins = mkOption {
         type = types.listOf types.path;
         default = [];
-        example = literalExpression "with pkgs.postgresql_11.pkgs; [ postgis pg_repack ]";
+        example = literalExpression "with config.services.postgresql.package.pkgs; [ postgis pg_repack ]";
         description = ''
           List of PostgreSQL plugins. PostgreSQL version for each plugin should
           match version for <literal>services.postgresql.package</literal> value.

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -10,9 +10,8 @@ let
       , enableSystemd ? (lib.versionAtLeast version "9.6" && !stdenv.isDarwin)
       , gssSupport ? with stdenv.hostPlatform; !isWindows && !isStatic, libkrb5
 
-
       # for postgreql.pkgs
-      , this, self, newScope, buildEnv
+      , self, newScope, buildEnv
 
       # source specification
       , version, sha256, psqlSchema,
@@ -24,151 +23,150 @@ let
     atLeast = lib.versionAtLeast version;
     icuEnabled = atLeast "10";
     lz4Enabled = atLeast "14";
+    this = stdenv.mkDerivation rec {
+      pname = "postgresql";
+      inherit version;
 
-  in stdenv.mkDerivation rec {
-    pname = "postgresql";
-    inherit version;
+      src = fetchurl {
+        url = "mirror://postgresql/source/v${version}/${pname}-${version}.tar.bz2";
+        inherit sha256;
+      };
 
-    src = fetchurl {
-      url = "mirror://postgresql/source/v${version}/${pname}-${version}.tar.bz2";
-      inherit sha256;
-    };
+      hardeningEnable = lib.optionals (!stdenv.cc.isClang) [ "pie" ];
 
-    hardeningEnable = lib.optionals (!stdenv.cc.isClang) [ "pie" ];
+      outputs = [ "out" "lib" "doc" "man" ];
+      setOutputFlags = false; # $out retains configureFlags :-/
 
-    outputs = [ "out" "lib" "doc" "man" ];
-    setOutputFlags = false; # $out retains configureFlags :-/
+      buildInputs =
+        [ zlib readline openssl libxml2 ]
+        ++ lib.optionals icuEnabled [ icu ]
+        ++ lib.optionals lz4Enabled [ lz4 ]
+        ++ lib.optionals enableSystemd [ systemd ]
+        ++ lib.optionals gssSupport [ libkrb5 ]
+        ++ lib.optionals (!stdenv.isDarwin) [ libossp_uuid ];
 
-    buildInputs =
-      [ zlib readline openssl libxml2 ]
-      ++ lib.optionals icuEnabled [ icu ]
-      ++ lib.optionals lz4Enabled [ lz4 ]
-      ++ lib.optionals enableSystemd [ systemd ]
-      ++ lib.optionals gssSupport [ libkrb5 ]
-      ++ lib.optionals (!stdenv.isDarwin) [ libossp_uuid ];
+      nativeBuildInputs = [ makeWrapper ] ++ lib.optionals icuEnabled [ pkg-config ];
 
-    nativeBuildInputs = [ makeWrapper ] ++ lib.optionals icuEnabled [ pkg-config ];
+      enableParallelBuilding = !stdenv.isDarwin;
 
-    enableParallelBuilding = !stdenv.isDarwin;
+      separateDebugInfo = true;
 
-    separateDebugInfo = true;
+      buildFlags = [ "world" ];
 
-    buildFlags = [ "world" ];
+      NIX_CFLAGS_COMPILE = "-I${libxml2.dev}/include/libxml2";
 
-    NIX_CFLAGS_COMPILE = "-I${libxml2.dev}/include/libxml2";
+      # Otherwise it retains a reference to compiler and fails; see #44767.  TODO: better.
+      preConfigure = "CC=${stdenv.cc.targetPrefix}cc";
 
-    # Otherwise it retains a reference to compiler and fails; see #44767.  TODO: better.
-    preConfigure = "CC=${stdenv.cc.targetPrefix}cc";
+      configureFlags = [
+        "--with-openssl"
+        "--with-libxml"
+        "--sysconfdir=/etc"
+        "--libdir=$(lib)/lib"
+        "--with-system-tzdata=${tzdata}/share/zoneinfo"
+        "--enable-debug"
+        (lib.optionalString enableSystemd "--with-systemd")
+        (if stdenv.isDarwin then "--with-uuid=e2fs" else "--with-ossp-uuid")
+      ] ++ lib.optionals icuEnabled [ "--with-icu" ]
+        ++ lib.optionals lz4Enabled [ "--with-lz4" ]
+        ++ lib.optionals gssSupport [ "--with-gssapi" ]
+        ++ lib.optionals stdenv.hostPlatform.isRiscV [ "--disable-spinlocks" ];
 
-    configureFlags = [
-      "--with-openssl"
-      "--with-libxml"
-      "--sysconfdir=/etc"
-      "--libdir=$(lib)/lib"
-      "--with-system-tzdata=${tzdata}/share/zoneinfo"
-      "--enable-debug"
-      (lib.optionalString enableSystemd "--with-systemd")
-      (if stdenv.isDarwin then "--with-uuid=e2fs" else "--with-ossp-uuid")
-    ] ++ lib.optionals icuEnabled [ "--with-icu" ]
-      ++ lib.optionals lz4Enabled [ "--with-lz4" ]
-      ++ lib.optionals gssSupport [ "--with-gssapi" ]
-      ++ lib.optionals stdenv.hostPlatform.isRiscV [ "--disable-spinlocks" ];
+      patches =
+        [ (if atLeast "9.4" then ./patches/disable-resolve_symlinks-94.patch else ./patches/disable-resolve_symlinks.patch)
+          (if atLeast "9.6" then ./patches/less-is-more-96.patch             else ./patches/less-is-more.patch)
+          (if atLeast "9.6" then ./patches/hardcode-pgxs-path-96.patch       else ./patches/hardcode-pgxs-path.patch)
+          ./patches/specify_pkglibdir_at_runtime.patch
+          ./patches/findstring.patch
+        ]
+        ++ lib.optional stdenv.isLinux (if atLeast "13" then ./patches/socketdir-in-run-13.patch else ./patches/socketdir-in-run.patch);
 
-    patches =
-      [ (if atLeast "9.4" then ./patches/disable-resolve_symlinks-94.patch else ./patches/disable-resolve_symlinks.patch)
-        (if atLeast "9.6" then ./patches/less-is-more-96.patch             else ./patches/less-is-more.patch)
-        (if atLeast "9.6" then ./patches/hardcode-pgxs-path-96.patch       else ./patches/hardcode-pgxs-path.patch)
-        ./patches/specify_pkglibdir_at_runtime.patch
-        ./patches/findstring.patch
-      ]
-      ++ lib.optional stdenv.isLinux (if atLeast "13" then ./patches/socketdir-in-run-13.patch else ./patches/socketdir-in-run.patch);
+      installTargets = [ "install-world" ];
 
-    installTargets = [ "install-world" ];
+      LC_ALL = "C";
 
-    LC_ALL = "C";
+      postConfigure =
+        let path = if atLeast "9.6" then "src/common/config_info.c" else "src/bin/pg_config/pg_config.c"; in
+          ''
+            # Hardcode the path to pgxs so pg_config returns the path in $out
+            substituteInPlace "${path}" --replace HARDCODED_PGXS_PATH $out/lib
+          '';
 
-    postConfigure =
-      let path = if atLeast "9.6" then "src/common/config_info.c" else "src/bin/pg_config/pg_config.c"; in
+      postInstall =
         ''
-          # Hardcode the path to pgxs so pg_config returns the path in $out
-          substituteInPlace "${path}" --replace HARDCODED_PGXS_PATH $out/lib
+          moveToOutput "lib/pgxs" "$out" # looks strange, but not deleting it
+          moveToOutput "lib/libpgcommon*.a" "$out"
+          moveToOutput "lib/libpgport*.a" "$out"
+          moveToOutput "lib/libecpg*" "$out"
+
+          # Prevent a retained dependency on gcc-wrapper.
+          substituteInPlace "$out/lib/pgxs/src/Makefile.global" --replace ${stdenv.cc}/bin/ld ld
+
+          if [ -z "''${dontDisableStatic:-}" ]; then
+            # Remove static libraries in case dynamic are available.
+            for i in $out/lib/*.a $lib/lib/*.a; do
+              name="$(basename "$i")"
+              ext="${stdenv.hostPlatform.extensions.sharedLibrary}"
+              if [ -e "$lib/lib/''${name%.a}$ext" ] || [ -e "''${i%.a}$ext" ]; then
+                rm "$i"
+              fi
+            done
+          fi
         '';
 
-    postInstall =
-      ''
-        moveToOutput "lib/pgxs" "$out" # looks strange, but not deleting it
-        moveToOutput "lib/libpgcommon*.a" "$out"
-        moveToOutput "lib/libpgport*.a" "$out"
-        moveToOutput "lib/libecpg*" "$out"
+      postFixup = lib.optionalString (!stdenv.isDarwin && stdenv.hostPlatform.libc == "glibc")
+        ''
+          # initdb needs access to "locale" command from glibc.
+          wrapProgram $out/bin/initdb --prefix PATH ":" ${glibc.bin}/bin
+        '';
 
-        # Prevent a retained dependency on gcc-wrapper.
-        substituteInPlace "$out/lib/pgxs/src/Makefile.global" --replace ${stdenv.cc}/bin/ld ld
+      doCheck = !stdenv.isDarwin;
+      # autodetection doesn't seem to able to find this, but it's there.
+      checkTarget = "check";
 
-        if [ -z "''${dontDisableStatic:-}" ]; then
-          # Remove static libraries in case dynamic are available.
-          for i in $out/lib/*.a $lib/lib/*.a; do
-            name="$(basename "$i")"
-            ext="${stdenv.hostPlatform.extensions.sharedLibrary}"
-            if [ -e "$lib/lib/''${name%.a}$ext" ] || [ -e "''${i%.a}$ext" ]; then
-              rm "$i"
-            fi
-          done
-        fi
-      '';
+      preCheck =
+        # On musl, comment skip the following tests, because they break due to
+        #     ! ERROR:  could not load library "/build/postgresql-11.5/tmp_install/nix/store/...-postgresql-11.5-lib/lib/libpqwalreceiver.so": Error loading shared library libpq.so.5: No such file or directory (needed by /build/postgresql-11.5/tmp_install/nix/store/...-postgresql-11.5-lib/lib/libpqwalreceiver.so)
+        # See also here:
+        #     https://git.alpinelinux.org/aports/tree/main/postgresql/disable-broken-tests.patch?id=6d7d32c12e073a57a9e5946e55f4c1fbb68bd442
+        if stdenv.hostPlatform.isMusl then ''
+          substituteInPlace src/test/regress/parallel_schedule \
+            --replace "subscription" "" \
+            --replace "object_address" ""
+        '' else null;
 
-    postFixup = lib.optionalString (!stdenv.isDarwin && stdenv.hostPlatform.libc == "glibc")
-      ''
-        # initdb needs access to "locale" command from glibc.
-        wrapProgram $out/bin/initdb --prefix PATH ":" ${glibc.bin}/bin
-      '';
+      doInstallCheck = false; # needs a running daemon?
 
-    doCheck = !stdenv.isDarwin;
-    # autodetection doesn't seem to able to find this, but it's there.
-    checkTarget = "check";
+      disallowedReferences = [ stdenv.cc ];
 
-    preCheck =
-      # On musl, comment skip the following tests, because they break due to
-      #     ! ERROR:  could not load library "/build/postgresql-11.5/tmp_install/nix/store/...-postgresql-11.5-lib/lib/libpqwalreceiver.so": Error loading shared library libpq.so.5: No such file or directory (needed by /build/postgresql-11.5/tmp_install/nix/store/...-postgresql-11.5-lib/lib/libpqwalreceiver.so)
-      # See also here:
-      #     https://git.alpinelinux.org/aports/tree/main/postgresql/disable-broken-tests.patch?id=6d7d32c12e073a57a9e5946e55f4c1fbb68bd442
-      if stdenv.hostPlatform.isMusl then ''
-        substituteInPlace src/test/regress/parallel_schedule \
-          --replace "subscription" "" \
-          --replace "object_address" ""
-      '' else null;
+      passthru = {
+        inherit readline psqlSchema;
 
-    doInstallCheck = false; # needs a running daemon?
+        pkgs = let
+          scope = { postgresql = this; };
+          newSelf = self // scope;
+          newSuper = { callPackage = newScope (scope // this.pkgs); };
+        in import ./packages.nix newSelf newSuper;
 
-    disallowedReferences = [ stdenv.cc ];
+        withPackages = postgresqlWithPackages {
+                         inherit makeWrapper buildEnv;
+                         postgresql = this;
+                       }
+                       this.pkgs;
 
-    passthru = {
-      inherit readline psqlSchema;
+        tests.postgresql = nixosTests.postgresql-wal-receiver.${thisAttr};
+      };
 
-      pkgs = let
-        scope = { postgresql = this; };
-        newSelf = self // scope;
-        newSuper = { callPackage = newScope (scope // this.pkgs); };
-      in import ./packages.nix newSelf newSuper;
-
-      withPackages = postgresqlWithPackages {
-                       inherit makeWrapper buildEnv;
-                       postgresql = this;
-                     }
-                     this.pkgs;
-
-      tests.postgresql = nixosTests.postgresql-wal-receiver.${thisAttr};
-    };
-
-    meta = with lib; {
-      homepage    = "https://www.postgresql.org";
-      description = "A powerful, open source object-relational database system";
-      license     = licenses.postgresql;
-      maintainers = with maintainers; [ thoughtpolice danbst globin marsam ivan ];
-      platforms   = platforms.unix;
-      knownVulnerabilities = optional (!atLeast "9.4")
-        "PostgreSQL versions older than 9.4 are not maintained anymore!";
-    };
-  };
+      meta = with lib; {
+        homepage    = "https://www.postgresql.org";
+        description = "A powerful, open source object-relational database system";
+        license     = licenses.postgresql;
+        maintainers = with maintainers; [ thoughtpolice danbst globin marsam ivan ];
+        platforms   = platforms.unix;
+        knownVulnerabilities = optional (!atLeast "9.4")
+          "PostgreSQL versions older than 9.4 are not maintained anymore!";
+      };
+    }; in this;
 
   postgresqlWithPackages = { postgresql, makeWrapper, buildEnv }: pkgs: f: buildEnv {
     name = "postgresql-and-plugins-${postgresql.version}";
@@ -205,7 +203,6 @@ in self: {
     version = "10.19";
     psqlSchema = "10.0"; # should be 10, but changing it is invasive
     sha256 = "sha256-brgwtCi2DoSuh+IENrzmecTZ0CAr567A5BsMZ9kTQjk=";
-    this = self.postgresql_10;
     thisAttr = "postgresql_10";
     inherit self;
     icu = self.icu67;
@@ -215,7 +212,6 @@ in self: {
     version = "11.14";
     psqlSchema = "11.1"; # should be 11, but changing it is invasive
     sha256 = "sha256-llx/S+lvtk+VgYUsWMTwXDgS1K2CPA8+K9/nd8Fi+Zk=";
-    this = self.postgresql_11;
     thisAttr = "postgresql_11";
     inherit self;
   };
@@ -224,7 +220,6 @@ in self: {
     version = "12.9";
     psqlSchema = "12";
     sha256 = "sha256-if2i3jPtBKmFSOQ/PuXxW4gr4XUF1jH+DdGlQKK1bc4=";
-    this = self.postgresql_12;
     thisAttr = "postgresql_12";
     inherit self;
   };
@@ -233,7 +228,6 @@ in self: {
     version = "13.5";
     psqlSchema = "13";
     sha256 = "sha256-m4EGelXtuqvEGKrO9FfdhHdkKCdJlWCwBhWm6mwT9rM=";
-    this = self.postgresql_13;
     thisAttr = "postgresql_13";
     inherit self;
   };
@@ -242,7 +236,6 @@ in self: {
     version = "14.1";
     psqlSchema = "14";
     sha256 = "sha256-TTwQHqeuOJgvBr3HN1i1Nyf7ZALs2TggBvpezHwspB8=";
-    this = self.postgresql_14;
     thisAttr = "postgresql_14";
     inherit self;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21433,7 +21433,7 @@ with pkgs;
     postgresql_13
     postgresql_14
   ;
-  postgresql = postgresql_13.override { this = postgresql; };
+  postgresql = postgresql_13;
   postgresqlPackages = recurseIntoAttrs postgresql.pkgs;
   postgresql11Packages = recurseIntoAttrs postgresql_11.pkgs;
   postgresql12Packages = recurseIntoAttrs postgresql_12.pkgs;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

JIT compilation of PostgreSQL queries. Disabled by default for now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Tested by `EXPLAIN ANALYZE`ing queries with JIT force-enabled.