### PR TITLE
haskell.compiler.ghc921.hlint: 3.3.4 -> unstable-2021-12-12

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -209,11 +209,21 @@ self: super: {
   # Tests have a circular dependency on quickcheck-instances
   text-short = dontCheck super.text-short_0_1_4;
 
-  # hlint 3.3 needs a ghc-lib-parser newer than the one from stackage
-  hlint = super.hlint_3_3_4.overrideScope (self: super: {
+  # Use hlint from git for GHC 9.2.1 support
+  hlint = overrideCabal {
+    version = "unstable-2021-12-12";
+    src = pkgs.fetchFromGitHub {
+      owner = "ndmitchell";
+      repo = "hlint";
+      rev = "77a9702e10b772a7695c08682cd4f450fd0e9e46";
+      sha256 = "0hpp3iw7m7w2abr8vb86gdz3x6c8lj119zxln933k90ia7bmk8jc";
+    };
+    revision = null;
+    editedCabalFile = null;
+  } (super.hlint_3_3_4.overrideScope (self: super: {
     ghc-lib-parser = self.ghc-lib-parser_9_2_1_20211101;
     ghc-lib-parser-ex = self.ghc-lib-parser-ex_9_2_0_1;
-  });
+  }));
 
   # https://github.com/sjakobi/bsb-http-chunked/issues/38
   bsb-http-chunked = dontCheck super.bsb-http-chunked;

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -311,6 +311,7 @@ let
       funcmp = released ++ [ compilerNames.ghc921 ];
       haskell-language-server = released;
       hoogle = released ++ [ compilerNames.ghc921 ];
+      hlint = released ++ [ compilerNames.ghc921 ];
       hsdns = released ++ [ compilerNames.ghc921 ];
       jailbreak-cabal = released ++ [ compilerNames.ghc921 ];
       language-nix = released ++ [ compilerNames.ghc921 ];


### PR DESCRIPTION
hlint introduced GHC 9.2.1 support on its development branch recently.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
