### PR TITLE
openssl_3_0: 3.0.0 -> 3.0.1

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -207,8 +207,8 @@ in {
   };
 
   openssl_3_0 = common {
-    version = "3.0.0";
-    sha256 = "sha256-We7fy0bCUhTJvTftYHgpe03wHQEiZ/6enu4x9hvHBTY=";
+    version = "3.0.1";
+    sha256 = "sha256-wxGthTNTvOeW7a0BqGLFCopYf2Ln4hAO9GWrU+ybBtE=";
     patches = [
       ./3.0/nix-ssl-cert-file.patch
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
OpenSSL 3.0.1 update, split out of #150733.

```
### Changes between 3.0.0 and 3.0.1 [14 Dec 2021]

 * Fixed invalid handling of X509_verify_cert() internal errors in libssl
   Internally libssl in OpenSSL calls X509_verify_cert() on the client side to
   verify a certificate supplied by a server. That function may return a
   negative return value to indicate an internal error (for example out of
   memory). Such a negative return value is mishandled by OpenSSL and will cause
   an IO function (such as SSL_connect() or SSL_do_handshake()) to not indicate
   success and a subsequent call to SSL_get_error() to return the value
   SSL_ERROR_WANT_RETRY_VERIFY. This return value is only supposed to be
   returned by OpenSSL if the application has previously called
   SSL_CTX_set_cert_verify_callback(). Since most applications do not do this
   the SSL_ERROR_WANT_RETRY_VERIFY return value from SSL_get_error() will be
   totally unexpected and applications may not behave correctly as a result. The
   exact behaviour will depend on the application but it could result in
   crashes, infinite loops or other similar incorrect responses.

   This issue is made more serious in combination with a separate bug in OpenSSL
   3.0 that will cause X509_verify_cert() to indicate an internal error when
   processing a certificate chain. This will occur where a certificate does not
   include the Subject Alternative Name extension but where a Certificate
   Authority has enforced name constraints. This issue can occur even with valid
   chains.
   ([CVE-2021-4044])

   *Matt Caswell*

 * Corrected a few file name and file reference bugs in the build,
   installation and setup scripts, which lead to installation verification
   failures.  Slightly enhanced the installation verification script.

   *Richard Levitte*

 * Fixed EVP_PKEY_eq() to make it possible to use it with strictly private
   keys.

   *Richard Levitte*

 * Fixed PVK encoder to properly query for the passphrase.

   *Tomáš Mráz*

 * Multiple fixes in the OSSL_HTTP API functions.

   *David von Oheimb*

 * Allow sign extension in OSSL_PARAM_allocate_from_text() for the
   OSSL_PARAM_INTEGER data type and return error on negative numbers
   used with the OSSL_PARAM_UNSIGNED_INTEGER data type. Make
   OSSL_PARAM_BLD_push_BN{,_pad}() return an error on negative numbers.

   *Richard Levitte*

 * Allow copying uninitialized digest contexts with EVP_MD_CTX_copy_ex.

   *Tomáš Mráz*

 * Fixed detection of ARMv7 and ARM64 CPU features on FreeBSD.

   *Allan Jude*

 * Multiple threading fixes.

   *Matt Caswell*

 * Added NULL digest implementation to keep compatibility with 1.1.1 version.

   *Tomáš Mráz*

 * Allow fetching an operation from the provider that owns an unexportable key
   as a fallback if that is still allowed by the property query.

   *Richard Levitte*
```
https://www.openssl.org/news/cl30.txt

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
