### PR TITLE
[Backport release-21.05] firefox-bin: 94.0.2 -> 95.0

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "94.0.2";
+  version = "95.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/ach/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/ach/firefox-95.0.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "bd5c9faa119d8e16b24840ad5843b7a4c64f664ea29c1512a41756d19d2cb65e";
+      sha256 = "baa9aae395c8ce157bdde4741c298153e864eb16b3ebb5c5ff02ec5427a4be7a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/af/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/af/firefox-95.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "9ed0fff3ccfef43b467e295daf21c776ab9419b00a0524de75d0f3b985baef5a";
+      sha256 = "ba77c17049bb0773d792705e95963f8097142c1107b392db0b8a57a80f62f3d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/an/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/an/firefox-95.0.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "989a16767a92a91ba100af7f4fc97e1cb26ab718adbd5f0a14bebf9c0cba0495";
+      sha256 = "63ca2166a44bb00cea7f78b12bb32a3910192f32fb3a421182470c300481f9fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/ar/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/ar/firefox-95.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "8937403e15eac062bee7b189acb52c87e33b6177eb5e8e0f9dfd9167fd5b01cb";
+      sha256 = "88c7b793915b6e0a7568637913ebbd915595be0d16e6fc56162dcc4629ac72a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/ast/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/ast/firefox-95.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "18a4051fbc0fdde0faeaee72951e2994a50a6f041d180075c4f38ee4b7f9fd3e";
+      sha256 = "63dd7cf9eb56588977e9e1ae767cd951419c32a5d1995f42d76ea1a41913154c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/az/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/az/firefox-95.0.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "bdcddebdf3e5619a916b23da26cb22dc7afb0d25304c17c167fbec030de5ca5c";
+      sha256 = "4f2e42edbf2df416a9ce92b6fdb06ad4fff11e2116845a5fe50ea6e60bea7fd0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/be/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/be/firefox-95.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "d0aab54e67d2782c06f1e8f5aa8b4cca8ac65c0bc146885b78449e16656fc6a8";
+      sha256 = "cba02b799d49dbff0207c3c35c1d0545eb435c10c2414b355a7189cdcb29e4ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/bg/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/bg/firefox-95.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "d952c92e179ae599da578a92fd0495ccff3b82b2eba7f2613e91aa6695a87830";
+      sha256 = "618998ea66f5ca3c50b81c276fafb4a8ec98a4dc947a6fafdd15567e831b3421";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/bn/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/bn/firefox-95.0.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "e5934d418976a77fa926c06fb0482ba108ba91cef9019bcb0771b2d4c7101dbb";
+      sha256 = "2f2854f7ec2d485283e01c07aab545b1d2a82f1911f8f178c8a8da210ce01303";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/br/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/br/firefox-95.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "a5a15f3bf0157f21617fca0e3b58e02916d8665fd082e028617911cffb8f03b8";
+      sha256 = "835cc39aef8abb56efd235d1f2a40910a89f347a55516d6e535a73af90c63690";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/bs/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/bs/firefox-95.0.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "f9c06ab4e3c56475e0bedfa31ee1e2b6a7743251b42381d8d9330dee6e2bb4ae";
+      sha256 = "55aee6e59d7621a057395068ab3d7607e2afe914e7f702c898f7d0cd5c3f4224";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/ca-valencia/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/ca-valencia/firefox-95.0.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "d5e8779f846f0f533d895d66e4ac98f5eb38e1054f448ff7dae855270bfb3bec";
+      sha256 = "2b20ea86d0c373f5e30d0613b7fd292b8688d8efcab49f48ea01bc69b282c127";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/ca/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/ca/firefox-95.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "e8d95aff6b9f383429a24b246e59b5b4abaf2d5074163b8df829296296dd2c2b";
+      sha256 = "fbff6e874bb0157da7537606caa05e79ab6e32051e0cf7a7256d97c29030234c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/cak/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/cak/firefox-95.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "997d6162c891115d36fb3612115b00e37e1976de838a5f25a0c829361e7006fe";
+      sha256 = "653ed03acbec86de19801a17a56db21cfc5b83a03a6410e2d700a49a4764e4d3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/cs/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/cs/firefox-95.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "9224d79a6f918018baba8e8767d1d28ef2a5f85051b1dc23e09803b4d345b8eb";
+      sha256 = "4e9318161e27eb06321e89bf35f5c91bae91b538b1a8d8b72444acb582d3e6b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/cy/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/cy/firefox-95.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "4afebf3248ad98b19f2eb8e743672ff28aa40e305735a8c68b99af967fc45d25";
+      sha256 = "b16523a2ed527384caf84bd496fcf20b99204378b650fd236246b502cd9848f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/da/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/da/firefox-95.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "d834b34eec2432f704a6ff4e122b08c157a5fc9f856e0f3983ae220ba1edffc9";
+      sha256 = "6be5b08d06bd54e93d7cf83a54738efe7172596db8b0a4ad6748b7c31775d0e1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/de/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/de/firefox-95.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "73312ba296f0efc2178dc0bf8d90f6fd7723d6c1cd53372ffc058a4d6f565cf3";
+      sha256 = "d606f35b5c34d77810c22044475c26b1d0f0035ff53b05b9b2a55736a786bc19";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/dsb/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/dsb/firefox-95.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "af604fde6da04d8a6afc044dcbfb354d8e45415afaf7964244d5190e0d79aa45";
+      sha256 = "86dd9dfbc03e71dd306a6845ad565ac7bc6bbe00dec27501959bc436a1747023";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/el/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/el/firefox-95.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "6a8b3aa0c49c2b0a101fc9045842b55846bbaab4b9504e54dfc0831b70008e2d";
+      sha256 = "d8aa815d9168a52b5573dcbb57dbe4399b811ad1d3845297bbf4a97df6a0ba5f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/en-CA/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/en-CA/firefox-95.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "8ce4c830b1c6ff8de5c7a594a55919fb1d8a6f24b8ae963aad10fc4e65b29f96";
+      sha256 = "74784c48615d4537708af71d52350c0630aafba46a2bc957e0de853a79574cc2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/en-GB/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/en-GB/firefox-95.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "f6ffd778e7587e537d4376102de619ed70b5689a854a1f89e8e46b09d8f2a4c0";
+      sha256 = "3e1251f33163c986b371489209f2704f408fc156bfeb6d1087e5a0514cdd248e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/en-US/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/en-US/firefox-95.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "975ac4e4cccd91b10d997ecbc183b557e45a1cd54fb488aaf85a45b06dfbaa9e";
+      sha256 = "244ec7d444e340116eb4d0f21c513c5cde7f8d5bee75ad9cf492d563a6842554";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/eo/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/eo/firefox-95.0.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "89b36aa02a95263d7e1b271c27f73672a5c4631abb9023bf3bfe4dd85aa3051b";
+      sha256 = "45de848c53f75be24d2a193863af4a7d64b8625a90a24b99dc582d3aa9369e2c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/es-AR/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/es-AR/firefox-95.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "e011a0f14585115e93f9f68e03246b4d5f2e7874729596f917227fff0b7fe6a3";
+      sha256 = "057107d1a382484cf39ee4dbb171fed219fa480cf4c01f2d7df1998a7205cbfa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/es-CL/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/es-CL/firefox-95.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "6f7e829c67feaecbebefe3144f21b939eff22afcfd33e97de6371c471426996d";
+      sha256 = "aef658a4f607e137507496317c04b16f228a33338d81bf2a733458e031b8b96e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/es-ES/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/es-ES/firefox-95.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "2e48ff3b6b839fdf88026e2cf27182a6e6256242f994aad3e4c8ef3203c8659a";
+      sha256 = "cca26806cfa1ce2864431f26d0f759a9f91eb283afe3ff369af9aa89228d6fac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/es-MX/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/es-MX/firefox-95.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "399004ccf9cea84f614cb55460dc988e148a7b2d0913278cd7be0c7eee898bcf";
+      sha256 = "f12c94f8e9cbfdbff5436c93bf77f8405d2fa0b31488a616c8b23b7c02af5e1d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/et/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/et/firefox-95.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "4c790bf5a4b87a3bd8efa975f768e99e05f726e915d936d296f381f0051c38c8";
+      sha256 = "4c0e482f764d0b8ad71a82040c62dd5744707ce537a8b44721e50f5902a6204b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/eu/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/eu/firefox-95.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "fb96089adc354dad4dcdf43b8c65609add8022285470df4edd9bfa814e761f02";
+      sha256 = "5932a656e9aada3b0230b284abec1b00be5e69adb08425459df7f50dc2b102e7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/fa/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/fa/firefox-95.0.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "1a13b4dc79d4ccd0aef20f0d3d29d42ee835e9bb4d2d90521c7a92cb327c96de";
+      sha256 = "d905ffbe0a3d1de35457d8a6eb3e7573471d14f0b302041a30fa8b3edf8983a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/ff/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/ff/firefox-95.0.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "93f4bd4fdb7dde118f06247bda2d3fb72b1f072bb996d8a52e9e01abe4f248a9";
+      sha256 = "9e9ab77234fe8778b92ec9a0e67465243ebee6564d9f7eecc6a3b54ef684d244";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/fi/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/fi/firefox-95.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "fe2b5cbb25010d7624b1fa799dc2820df057d2419f9ddd07e660cb5e32143ce4";
+      sha256 = "6355fd54bbac7b4b621f983bbb504b6cac4f9db2060648b8755247176ac8a096";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/fr/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/fr/firefox-95.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "f916b9d0e1fb6b28248a443cb4ae31c3350eca1f6a7b7a794758792417e91105";
+      sha256 = "3b72353e3caf132e88e47853abf2de51aae70dd11dfe853b7ebf7c483aaaf50d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/fy-NL/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/fy-NL/firefox-95.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "f998b9475930a6517836b260e43b0a8e37424e223d1eb213755a0efb46aafa38";
+      sha256 = "3af7b6385611e5874641bc1ca6090bd6ff3d5309c7d718579082c2ab2f763b76";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/ga-IE/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/ga-IE/firefox-95.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "0ff51d3fbe979bce2335d0e250f21ba2d2618ad09c999e0be929053548b30d3b";
+      sha256 = "8f007391d9da8271f76eda6b15bbe99f7e3ce6b0b36ec18a98bf49b49904abb7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/gd/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/gd/firefox-95.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "31a34aacf048ca6dfd5c96fdf6b618532d368de0afe38835541cc8cdeefae9c6";
+      sha256 = "3cf3500b574dc7feea15df2c9d7e2849ce4ef8b2fd5fcab16ceb4081214149e2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/gl/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/gl/firefox-95.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "7dfee546ae528bd7888131efbb5797b0e2f7bf84764843ee88eb53a7c4b9cd78";
+      sha256 = "5ff72519e9c849b6d5e493405c030abf1211ee0a37cc6bb420f056ac8ca40270";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/gn/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/gn/firefox-95.0.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "ccd7986942c61b254d25b09db75729b82db5d7324f0be5f997bfcd8c96f2325b";
+      sha256 = "b1dcb67a545411e0b54a3b9c2841c590802d9cdd33fe54439183d3d9cd60906f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/gu-IN/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/gu-IN/firefox-95.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "c93484e19a7134494c1f5473deead034dc6d6bae163f8103b063949bdb119703";
+      sha256 = "e94ef0238ee276189d91c90efe8547838c06d5ab65fcabfcee88d7d1e0eaff3f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/he/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/he/firefox-95.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "297ef303e6cb27bfdab73512b2a184fa2e3ac575ae99852244a29365370fb042";
+      sha256 = "07deed3310507e706c0984de5a3da02549d393aa10cbf23f38d56079605d9013";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/hi-IN/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/hi-IN/firefox-95.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "a41625cc6fda655aa420602f2eecd8e88177c088ade770ee80b9dc34d2802b9c";
+      sha256 = "82ce6607f1ad5df058b58960231a05c5644453170ff4e2a6d6149f545d781f43";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/hr/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/hr/firefox-95.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "dfedafaad51d27e1fb7f24a02b3149805073f37fc20f89e903ce9301b656b9d2";
+      sha256 = "8d7aeaae29bcdaf991879fcd4e991c66abf10deccee70490d0fe3115a249e59f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/hsb/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/hsb/firefox-95.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "15acfff1d07bcd0201f4407cdd3c51d17ede6e3fada977b496acfdc924fa6606";
+      sha256 = "0558a426a0633a087b74dd3335a3058e9c80dde01a8030e0551ee88a822d5320";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/hu/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/hu/firefox-95.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "dabc87d3fad5633b460eda4b7d4f751a33af6ded74bb9a1f992fa93d022ecdb6";
+      sha256 = "0c3aa5f841b9b5a18dea64991d8578b69c55d8d1b7e98257e9a1cad3cc38f06e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/hy-AM/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/hy-AM/firefox-95.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "5aea20d14846d87c9249e28520b44c9693f8d5a69b1e9490d817d50c7d2e0381";
+      sha256 = "4dc589986cf48bd51347d87009b0e4e296086046535b149ab0a973a7c72a491b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/ia/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/ia/firefox-95.0.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "ec4972e7494a0755e2fd3bf8d697fc5f6b6069b34dd083abdc93f625db24cac5";
+      sha256 = "06b3253d7f01424e3bf7735707a0092f9d578f3c6d0d335f3f9befb1e5aab85c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/id/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/id/firefox-95.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "3621afd47043f87741f2cf6c70fc4c749b134bbd3284f42b7cf220f500111d4d";
+      sha256 = "abd11ec916db3b548a453f77d61e4c33c698928bfc3eae47f9aaec5bd8ca7540";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/is/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/is/firefox-95.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "0fdbbb65a5ccb04113b39e1257079543ed0a0a044104321b568b4c7079a0c126";
+      sha256 = "dab3669a92a8632ebdb2303e0962186ecd86896fc0bb6bf5749d337430f05fb8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/it/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/it/firefox-95.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "eb68a8b1167f964d3538c86d1276137ca3cdd6ccfd6cf66bee4286ea052d8f53";
+      sha256 = "2572d4f3235658a5ac94d69c7e1d12e289b548c0c7443ff665840c9960bcf470";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/ja/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/ja/firefox-95.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "772943d646877a7845b23d05c940b4f41c7399cd81068b26793066065dd9bf9c";
+      sha256 = "d8c46fb80f6324d04b2dc99edd23d59d8f7c043c5ef598137dc2055fd1a1dd5d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/ka/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/ka/firefox-95.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "e410b7999f0f59dc58a777a9e3c4b5439b45ed2dd7d8bbff7060b5bbd380d12a";
+      sha256 = "9358fa80b30d5f1787084e4e0cfc82a0b231bbbfa196942cbc7f5e8679530d0f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/kab/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/kab/firefox-95.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "764c473c7abea8cdd91b88eea4bc294dd682196ecd8672e613ba4f6b50077c7e";
+      sha256 = "d30cb205c3f4be385df74b3145bee60fbde879c2b67e1eb4e665dd7347d12f7b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/kk/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/kk/firefox-95.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "4d2ae9dbeec20d34648e4799d11b257a4897f1a9d37de04ffd59f7a0ad79d15b";
+      sha256 = "4dc2d6a0284c498986806bf13b47c06e6d40c7f462e1b605d8e82ca7a56014a3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/km/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/km/firefox-95.0.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "eb60a5083d30d3f98b063213da4d51e1dedfd71d6a2b5b6cdff02baedd4985c4";
+      sha256 = "9de0952da56730f1d8fd3d9906259f5198ee36f189b510bddca93afe4d59be43";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/kn/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/kn/firefox-95.0.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "8e43fabef02e33500552429f71d548db1b6c5a9d63095b53a76b7f15418accd1";
+      sha256 = "f7f406c1f6d0af09aa47bb544f9819e3f60b0f07d88e63d618854082b5fe05d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/ko/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/ko/firefox-95.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "932edd7633e23ed5318491dae495f210707f6eaac3d253263e615f3092a856cd";
+      sha256 = "36485ad2370218ac0577ce9c0045cace447943e8bdb252aa6f9a3d9437272833";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/lij/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/lij/firefox-95.0.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "b9326e61ae16f33bc200fe3712acc5e069df4c5575b38c48d765bf64c078c22b";
+      sha256 = "07b1db708ce1e0c2412bfb25f5cf343ebc3043441fc50bb67437f796b5c2019a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/lt/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/lt/firefox-95.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "2d857aa44cc17532d6f8691c78a1a6511e87016ef95eac2a5e184dc70987ed65";
+      sha256 = "012db635331490afda012450f30f6b0c03119e964bccae9734eb138d8ad905ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/lv/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/lv/firefox-95.0.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "595887befdf74b3ef4d37b7881661341a199e85d71cddfbbb62406015a60b585";
+      sha256 = "90a9b9a41c6bd13c72dd7af41f815c26b7ad1e50837f7a5530d5e8676921dea5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/mk/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/mk/firefox-95.0.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "5408c46f1a23321b34c8a78a3af4afcc2b3bccbfd7f2188db9ae1f5db391de13";
+      sha256 = "2ca9cf3a4084c9dcdc9fea68623afc1a51f11ae752aa9427d350b477eb850326";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/mr/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/mr/firefox-95.0.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "85ac81aa121f611a12ee09f3c07c487e6c4af5a31999db7891ad388075a8239d";
+      sha256 = "cb26b2267e6e8a6618b9abe8c9b3f30181bb96098792f78fc916f62bbc93804d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/ms/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/ms/firefox-95.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "95b98338001c1f4d6c0e2fa22750bf4216c754a64a7a11b063e172efa1f0c163";
+      sha256 = "ef7260b1a60362f8a6a53a038daa87d46f8704a1a3b22a7b696699cbdaeab2c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/my/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/my/firefox-95.0.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "dded4e09e56fdf55afefaef54e7d7b4451f3590e1c3bb4768635abce02b10891";
+      sha256 = "41dd943b89aa611479c91cee4a8ad5c371c9383e37c2b33715f8af8a91c915e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/nb-NO/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/nb-NO/firefox-95.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "ef6b6fd0c21c4563267551d5ee9ad805023fe12552fac44199c7a2bbe3ec81f3";
+      sha256 = "9c6069b9b1f55083b733d9051bad33b62e9f7662d3493385ac238052901b0a94";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/ne-NP/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/ne-NP/firefox-95.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "7dad25866efe784ea6b5cd244cbbd9890ddd813f386ef1a5e98530cfdbc64a49";
+      sha256 = "74195c151bd830fc2b465a4c3f746a3623d7079d38c929babee64193b3a0a9b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/nl/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/nl/firefox-95.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "4518d9c4d6645285e4b337acda7b0bdee7733cae60c8515d8923cc85c470c596";
+      sha256 = "3b4f506a30fde52ec32d643e0c9704e340d6a6314c006e2629297a685a816313";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/nn-NO/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/nn-NO/firefox-95.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "6df50c1c01a9bf0c43a36277d6d17213c3d5a3a273b2a6257aaa5168f727e02e";
+      sha256 = "c5daf05a026075c293a1b07a125c5c6bca8708d3ec32788ed864f640ce7a5ea8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/oc/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/oc/firefox-95.0.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "3d253d2280607b5f4ce252cd730cfd282703c3a8ec90a1efd70084349bb14dd1";
+      sha256 = "4880d83693cc1e2d59e46708bfcf11cf1a5554a4112786c711f239749433b013";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/pa-IN/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/pa-IN/firefox-95.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "564892d7c26d757b85754f06a8481152d24a86dc32c64d63d32de0a2e7d2ccfa";
+      sha256 = "f2f17bb3512fea2308ce57e641ac67d4d66fae9afa6d5e3d85d86f0262b382e1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/pl/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/pl/firefox-95.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "8201d195237c9902494627c95116f9e19f08224eacd1037e69b370d2ad6ec046";
+      sha256 = "db38542cc14db8e81638538e1457561c3f5aa84232bd81b01a0cb307810469d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/pt-BR/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/pt-BR/firefox-95.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "ecc6009cc5d29c4e9ab7374fa5d36faae08eda78993a7fe81816a1ed6f2da654";
+      sha256 = "dfec0d003fad9289075086758843c5e743ddb866d80343f7dc6885a45cfded73";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/pt-PT/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/pt-PT/firefox-95.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "1810fe3d1660f8e8d28c667aa6bf6b0430aeb0d0a1008fca4658a04c33951bed";
+      sha256 = "a465df64671b5a6ea654dd6da45ff2c0759d55d13157f92db4a3da9bd01e3d3d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/rm/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/rm/firefox-95.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "eba9fdd5cbee26f88c0e29a1765376bd2b7a6bab635e20afc29face8e9e64885";
+      sha256 = "b3504230febc7cee42493b9d6f40dd2a5bbe53cc49989dff161520588eb5a470";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/ro/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/ro/firefox-95.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "59d3c57654c742ac7d2424df278f3a4da50b76fcc751026d937d598160934ac1";
+      sha256 = "dc1a1506008e922f9a24311a492ce9f5782d5bfabd2c367a377d503b6c9dcde3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/ru/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/ru/firefox-95.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "e5e4289edd4d7ae420aad87ce38b65eb3c1978aa4d97df144f958dd24e905afe";
+      sha256 = "0873ffd9748d237a092af955a8a2cc18979b94b6fa9ca8fa3869ed352fad428c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/sco/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/sco/firefox-95.0.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "83638c4728dfe9a486ac748c84ee721937b003989622b3b8725f6bc6b66bfb59";
+      sha256 = "631ab970b1ae2a3c6b3bd68298e35619d99baac10f5bfb3d573deaeba228906b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/si/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/si/firefox-95.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "7537ce71b85d195eae40e9695bd139e624180833c358e9633e4037c1052c02e0";
+      sha256 = "82bb94b5144937115072569b8a6e81d7a1fdbe79c0ad581e23d0cbbef45fb708";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/sk/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/sk/firefox-95.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "d2073ba06b23f4b65f1fea49eb9f04a7b2f35d73ed4de16ccebc7c109b5dcbf1";
+      sha256 = "4aba124990ae7ab68c2d5a3a6f5866d79f900614bb8a01387b80916aa91d11f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/sl/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/sl/firefox-95.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "059f2fc2d0cc02a1b92e8cd6b3006b13bda20d412682979113683423b73d20c8";
+      sha256 = "a9a24b17498a39393cc326e2bc25e1e79c9c8be62ea96b9e1b31d8ec1ede6adc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/son/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/son/firefox-95.0.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "c36e332c7d264a997d162fbd008c97bb56da46507872d58bcaf67760398a5c56";
+      sha256 = "2063c717103962c9f3e0eaa9ba4fe27ce93ed9c18ef7427d7b99e9b7429fb8f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/sq/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/sq/firefox-95.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "270d37e65ae60be7a44e19bcae22cce56f418db70d38098a634ab38bd85be924";
+      sha256 = "359dd64cbdc1c3a905c14184f5cc2d9019d82abae35850f718daea2e139c8f25";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/sr/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/sr/firefox-95.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "edfe02b63134dc88afcb326395e24f9bb7be7b58d88c2f80eaf12253f40df0a8";
+      sha256 = "33a0cc70a9654f93b7d01a10b49e890b4fb56c72b95a2e5ab29884e902c7bd41";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/sv-SE/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/sv-SE/firefox-95.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "9ae2294f5c757261e5b320814ef11875f05a74fcf8d7001c8b9e896f761ff2ec";
+      sha256 = "7c935aadd46b14f89ca5357f36108965d18c0c2fd4b470b51c0bd3110c9b0f2e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/szl/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/szl/firefox-95.0.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "fedbd7bc7aa4b187eab423ec612eb4a9a6e8d7bb8ad5d7474a422c8093875c87";
+      sha256 = "ec4c7bc828df6bb42d5551ab16a654406cd16e0d80ce52af5ed8e7ff37c38a45";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/ta/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/ta/firefox-95.0.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "cc302405c4d0319ec699297b78e3a38400ebee0806ebaca4bb246f5df781afdf";
+      sha256 = "85edd369185287c09e68eb45614199d27fe20ce3352a89a04c30a5823bc59ef1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/te/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/te/firefox-95.0.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "27c8ed45bc287db8c4973ab422efba9eb4680f8347ebf79a862521582b5bb9df";
+      sha256 = "75af554b90f0e591882b173ba73439110ab3eb39da6d55ca46ffcd3ae3001fe9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/th/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/th/firefox-95.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "f93d1114c4dc4ca98f85a5508ae0c0288196ee484697da13fb9166ef00e423c5";
+      sha256 = "2751b94c8896689e37d98399cfe8ce91af6ddfa927bd8b071fbb6841b94a4b17";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/tl/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/tl/firefox-95.0.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "23724a1880b7de10b7d8d5fff714454afebdf93d37e6aab2a492f3e3fcb67b08";
+      sha256 = "a3f44ac0e29f273617a5e47c79bffd46ed81bf87d633ace1596696d060a4a053";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/tr/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/tr/firefox-95.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "9e0f630b441241da1203cc22536843ff924dd470fcb0baaa7a05650f3b47533b";
+      sha256 = "c85fff23b1aafd3385384d365b357db941735d070e009f63c0f44b5af61be17f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/trs/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/trs/firefox-95.0.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "3e0b76977ad714dd05192330042ffb4388146c7f1e18193e3438b126a9c23ce2";
+      sha256 = "d22fd5d0768bf5e514c885aecdb4bb28f905362349cb23ff284c8f160b829589";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/uk/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/uk/firefox-95.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "40a30fccb01be981bf2dd47e8990b34fdf595bb7ba5837b8cc98ed4137eafc9c";
+      sha256 = "071eecdd89c97e9da18952e08cb00db4d15dc32ed07a958b011634646c1b8cf8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/ur/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/ur/firefox-95.0.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "cafd95a645be820483369766250a7d1331893c40dd2cf8bf9fae7b050e10a5c6";
+      sha256 = "d7be441c1f3e35e0f96654978040645965017fbfab9e05150bbd7839f6e3f4ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/uz/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/uz/firefox-95.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "9e08b5d962c3e3f2375be1847a9386777459baf4a477950649700e66dfa52f6e";
+      sha256 = "3df397b4c56e87407bf4c6d8507ae240ed31e76176f2c4eddb7ee928f4ea66f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/vi/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/vi/firefox-95.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "d28802eebe7928fce570a06aaa33ac83a100fadff9df92d5a4c073d653f41807";
+      sha256 = "8c1d6216ffec804d14e75a7f44f0dbbb566e6265bfda8aac225d42bcd0c2782e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/xh/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/xh/firefox-95.0.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "4661018a1d62fe87a32a85cb4d492f53c8fd98f639f48da04236132844eb674a";
+      sha256 = "dee937b1ae586b456f846d943163ceb5243f67c1c2185c56c1190b1543b136ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/zh-CN/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/zh-CN/firefox-95.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "26fd90a4d04e9432e237e82cd33f0f633a9667e84714444f79a970216a7cca1e";
+      sha256 = "4504bd20b5161cdedf2289040b93c00fe486102033d00181eede0c01990b9661";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-x86_64/zh-TW/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-x86_64/zh-TW/firefox-95.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "de1b466c4f786de15df1bb3491757c92d982a196b347fdfab7dda0bbdaf7ec7d";
+      sha256 = "31b6d0b818458297ada27bc01bd752dda8f22965c233e66f975c2580736117de";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/ach/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/ach/firefox-95.0.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "ef462def6dd6ba17dca0e360879aa6f2007f0c7cfdb1398c68efc2736dae7f29";
+      sha256 = "cc75ccf528eb8b7631d9a9f1fc6c3630c6c454fef108d510d6f6bb4c76f20500";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/af/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/af/firefox-95.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "90aafdc86bc22b76cb1f1a3d93a5fbbff1b3acb41f194e707f028230273119e9";
+      sha256 = "8a41e9225d2098dae45e55d3376607fd23dc014cada61acd5cfc8a05646911a2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/an/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/an/firefox-95.0.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "3669136c7c039eb0bd6f06f0fb84d927d700b2c31985b0074ccb2e397c2331ed";
+      sha256 = "bd7fbc5a40e9c496d25d3a84513a5c209752a62b33caa7ae1d96a5d1ab28f08b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/ar/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/ar/firefox-95.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "37e329462cbf7c21080494c1026fbdd1686b95fc4351d1dc25fb8339cb93cd02";
+      sha256 = "dc7405a5710a03474bed35a2be62445578d1ad25944a641f3498ee683f2f043a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/ast/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/ast/firefox-95.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "e0a7dd866d2bb74e444c5fbaf2a4adf354953a7119d0a399c872939e02fee46c";
+      sha256 = "0adf72fe71be6043e9f94f97b29dc0f29c0e45925f61b99a4afb5400531890ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/az/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/az/firefox-95.0.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "2f30b1b3c2baf0c6b8cc568f11d758851954c4842d59481729cb4485b6955638";
+      sha256 = "4bd717814aeb0072a365b0d095cefb236c3e728f50be1e11e74db218daa49e3c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/be/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/be/firefox-95.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "98e54be798769dcda2875f4b56432abba93a775801d54a7792ac0d13068bedee";
+      sha256 = "9f74759b23c44e64a49ad7de046af7f1f6dc2b520a57053721125536f9dee993";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/bg/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/bg/firefox-95.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "969e80bc391c016769af80eae52f907ea3c260a4d5dbb6fba0393aca76f45628";
+      sha256 = "376eda6be2803529cfd913e1fba1b9aed37561563eb9339172d310300520deb3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/bn/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/bn/firefox-95.0.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "080802a1c60a2760296fdc6851944dffc5842ec8d9efb836977d3e9105ec3c13";
+      sha256 = "740a3223f951fca7b51d44707db9ae5f9d73e9a69a7a8b0f9086eda405c3dae4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/br/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/br/firefox-95.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "0f4f7da4274d5a73d7b4d0e8e1a47f82e5c40061b6cf7c2dcdafc4425603bbc7";
+      sha256 = "5488cdaed093da089cfbbb985fd2b3a0338067fedbe761ce557fac36b9c856ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/bs/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/bs/firefox-95.0.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "ca212c38fdc4d8ebdffbfee80e82518ee4476d4d962c5ac7476df2254cd58843";
+      sha256 = "a869c7eab0a99527221f4fe7bebbe3b5027843f1c4c18f82129398bf0d976ad3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/ca-valencia/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/ca-valencia/firefox-95.0.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "d55dc5a8295f18cad6d94f548e14c4f03214b2239d40f4b177e94767a0d333bd";
+      sha256 = "407aa59bf97828b477688b2467fb036fa6b258c27db020202813c4ed3f628ae3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/ca/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/ca/firefox-95.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "6f0393c75586ecc4ad877401292b18e43b245c5b9aa575d7df4ed1ca56d7cd98";
+      sha256 = "b4237a23abbe94df193cd97d224814e9f4d1a9917c3e0fa5f2bc963e69f0ac8b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/cak/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/cak/firefox-95.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "6e4f2f3d3fad7a8935faee284d8b99ac0a5484248a08b63b7cab1f3b5d0e79c6";
+      sha256 = "a7d59111decada5f71662f61ad4b751f94fb471e9f3ac556a409ea990d080f50";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/cs/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/cs/firefox-95.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "6f6373d00d264e84672cc6e94ec5225f9202b20704a61515756b5ace6049f50a";
+      sha256 = "ddcae74269b833142bd4f074fc17a90ac21e0c4bc30cbfa92a6777868e8cea02";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/cy/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/cy/firefox-95.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "8c9a5f5792a7560d752e255a7930c71266fa964fb13170e194ea7db6f81129a9";
+      sha256 = "24a117c1ecebe391a51dd6dcda6f35c4e0a67c1ce874968ef356538155090e47";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/da/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/da/firefox-95.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "25ad12a625cdc842ae2dbb04f2eb4b6e6a8991b5f1d966993a045fce9bbfcd66";
+      sha256 = "9ed7cfe2fc57966276230c88babc60841da95144686e5437404028cb20f2e07a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/de/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/de/firefox-95.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "12ed455d581af8b0c16c0e40681d0d7594797eb54e388a2db4aaff83616d46f8";
+      sha256 = "4d152c48347566d9c518456bcc2776aaf4959c05067843953f3ae7dcc4c7e150";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/dsb/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/dsb/firefox-95.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "5bdb29c4a0582647cc9ff2fab7e2e4d6a1ec4a56f76fd16d4ae9880621097675";
+      sha256 = "58fce69bd6a5b4c5558756dd2e3cabbadd8e37169a8521b4ef0b0fc5d3e5e256";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/el/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/el/firefox-95.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "dd6be6a586fec66b58e748f4afa7a1385fc01d4146bba7fb778322cf48bdd985";
+      sha256 = "28373344f2c1004961665a9a0a593674950396c65e15c17404d482cf584b0eb6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/en-CA/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/en-CA/firefox-95.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "e0e87a73a8c4d22dc106753ee212455f583fabc993251cbe236d0bb53c60d0d7";
+      sha256 = "d5dbc14a08dda403c80ffa7102d5044fe6422890b4f98f41a873372a7bc9f88f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/en-GB/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/en-GB/firefox-95.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "5dfd49072ce81697c22a70cfe97ada4bbaf1a7dbe5c09bd8b7a8b7c5832ce102";
+      sha256 = "4c1ac8c5b2e6faa5e9aea22539cb582f721659ce5f91aaf9a02cd5a2ea1a0236";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/en-US/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/en-US/firefox-95.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "98ee74af986cec68df541fb5256e1c075cb2527680ba226b56e08cbea4a04217";
+      sha256 = "3d007099ea060e4f2f5ac2d8272cab6c2c47b5d084b2fb46291851b3a3a34662";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/eo/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/eo/firefox-95.0.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "a193c7f70565c5f2882adee337d8957da29051b31f64bfee8b92ec3c99e017c3";
+      sha256 = "7b80a915b6aab7caf5e8d0ecda625700cf65bd1cbafac22123c3a3c940b46cc5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/es-AR/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/es-AR/firefox-95.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "6c5a0470625a36d5537cd10935a2cdd432fd51a695521cc3f7d4b4773208e7b5";
+      sha256 = "17d0ebb9a65e1d178545da02fd8a2e30dc3efcc3852dd4151d0f302185aeeb38";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/es-CL/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/es-CL/firefox-95.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "fdf83c78cf72c85d815acb85e7f46eaee24c1b3e884fe7f43a7eec29de81962c";
+      sha256 = "49842dc33d13b8ea0420c42f9c5e1d93cf8bf27c94ba8348c3ef9bd7c43cef96";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/es-ES/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/es-ES/firefox-95.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "422fcf77fa884be57605aed5cd87cdbb8c9854901fd16ed0b02ed44edc7a62b0";
+      sha256 = "bda3356795b781d6a0cb44861e973c0b429f3a4567c6d19bd609b99d08668b1e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/es-MX/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/es-MX/firefox-95.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "364d5706f34ca48623de35af2e42124fead5a17f9a81c0a41a28c60b8962703c";
+      sha256 = "b1ea0f018a62d47f1fec31423f7fbe7fbdf5571a0354307880de8ffbbd4ac6e7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/et/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/et/firefox-95.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "f4c2214b858afc9b5441d41203349e9fde7a9e6624808f194f57f1481a86e197";
+      sha256 = "70774afb5aec486c63b6bcaf324b3d9d780ea5ade0db889afe8b381f697c485a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/eu/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/eu/firefox-95.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "c55c4355c69a868107152ff48cc54afb184ef76c65b8fa9696ca6ef4ad0a240f";
+      sha256 = "741ecc912aaf732da0ea2a2f0b29e75c86af5b2dbe382ac857852a4a589d4582";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/fa/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/fa/firefox-95.0.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "6340d0db75076cb2d9c4d1c844071a97f7db79e531a6c91b0ab078f2b1674494";
+      sha256 = "1521a32450d77eadcee4dbf60b0cc69dab0a56e668a0679e98d1406a2a943fc8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/ff/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/ff/firefox-95.0.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "5c636999e880b9247b5efdcb8a4d286f2b98c8b010c93f1a804091f0306a9533";
+      sha256 = "1be559b1e2e34718fabf031d9a86d51e10277db08c705ecb24293376d61a0acd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/fi/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/fi/firefox-95.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "4ba17ee9089216df574c3757e760d1930ee327d66e6a3b862eccf3f9c8735080";
+      sha256 = "ac970e4dd896c0119a29a3c1b83ef6ea49abd1c2db3df10f31074345a938f110";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/fr/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/fr/firefox-95.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "1b877fee35061d3ba5decaca3a1d81e6844f272c5d0a94cef374bda45cc65641";
+      sha256 = "576b3fad11ca409d30d3a8e79b38e1691048d0a727d20e1901d66abfa8e6bc43";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/fy-NL/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/fy-NL/firefox-95.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "46cb4202a12b95d112d5749613cd1c80deaa52edc386f484e23d12407e09a21a";
+      sha256 = "a636aa013c5801d48a1e4bcfdbb49558cff3d4daa553d09e26e8672c7b6863ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/ga-IE/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/ga-IE/firefox-95.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "59a54b4cf76e66bac93f205d5ab7d7991bf3d6362e332164f28f09090eb7cc60";
+      sha256 = "621ec0e14c7e33a7152f163393a730c8e0f60a2425fe5d7ff99600955c5cee5a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/gd/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/gd/firefox-95.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "2994005051ad51dc1392e2bc69e52a06113d3323577c6514aaf48837b1158136";
+      sha256 = "bd8ed6d2ce3a96ab48fe84f9b438a5e5f06afe5c8da2c97390fa58a79c651cad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/gl/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/gl/firefox-95.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "07344a3a9602714f4291fdc451469d9d428d3b330cb6997544ee89b500214dd4";
+      sha256 = "56aea4182c10376796bd2b7a28abb83fadf183d71462317b9c3bf32f0b0d9a67";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/gn/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/gn/firefox-95.0.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "75b22ae12362337a74b94a3fbe7b4b3cecf49b6df819b997966fb5d4a308cdd7";
+      sha256 = "98bc2499d03481333b4704bc4fccf43cebbdd5ade97c5336b38fc19bbe0f7e75";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/gu-IN/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/gu-IN/firefox-95.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "d80aae36b364920e46c03e683328f0d07357232399a3a79b9844495f100c0e99";
+      sha256 = "36ed43fd439ff12ea56ffb8cbc35ad58a6c28b946529d8e40b9e80f91b447077";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/he/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/he/firefox-95.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "116afab0741c6092a5932f932a33972b8da97df07e3f329069044a4976bb71ba";
+      sha256 = "5d7c3c285ddcef14e54ea0998ac89b0b1bc1e96b80d44ae98bdefd06ff32650f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/hi-IN/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/hi-IN/firefox-95.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "ac77a85108c1b3ede1db709829d24baa6906a73a804d9af475162bd25d9d3012";
+      sha256 = "c560aa53eeab811821e8c0c9981c89bc1fd9e96e5e95895e7c27eedb9c8b5ccb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/hr/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/hr/firefox-95.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "d21ed0e4ccfd41ae59cdd0760cd66a8b065c1a451667332dd8e3d00ec509e766";
+      sha256 = "ee078f88bcbc04b484c0768a554465aec6ff6c7bdcc8a7c57910e22fa0ad4b27";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/hsb/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/hsb/firefox-95.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "9bea8a4fb0eda357164d1418dfd6af37f55499ef76578600badf69cee629779d";
+      sha256 = "1c561e157a3dcdd79866784e442683bc028a3b99bf088c323138dae87e1d1ae7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/hu/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/hu/firefox-95.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "f315bcf6a4b8bd50d3177d4c3d1b3634c6d20664dbb8c896fcd73f523012ce39";
+      sha256 = "8d5e7f800f312267dd2ebb388bd5d82b2b5570af4964d420cfc770a80d386afd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/hy-AM/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/hy-AM/firefox-95.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "7965b4e7d9da034c57377a76534d1b501eda9cff74e6963b5ab0ae57c8b3a5bc";
+      sha256 = "d85ecfb1cee8aac613d9cb02813d7a96967d50996fbc1a31c2d439d5d3aa6f4e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/ia/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/ia/firefox-95.0.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "bd2d2bc58df8343b3f01258971616ffa7475f4da1872fdf15082073e97c94fbe";
+      sha256 = "0e836a7f7017cbf29b6960d7b072380a879e764c42dcf2b32b1f89a4009415c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/id/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/id/firefox-95.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "8ce031a74917f6ba2ab28d18c3bf90889e2220a669ab4089967b25d4e79ad924";
+      sha256 = "02b5821c24c1b7124faaed34fd3aedf80fa4db2616fa9d6ba7f2d1d3ced524e9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/is/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/is/firefox-95.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "04ddaed817aa5697895221a0db3ae7101b8233f125bc7fef922abb1a0e7723d9";
+      sha256 = "3d0c544e1886ebe3b957eee0a0167fee4a8b81f86fb5816f46a0b694115e9bc7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/it/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/it/firefox-95.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "8aa73f43364cb54102f77cf47ebc87add3099370b843625c5eb265e3329720f9";
+      sha256 = "3f1a4c25b671ad1a83614f965b3294bc2147969078f331887a1a00f5d4410c64";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/ja/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/ja/firefox-95.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "fd17973256956c8b0034ce4ec9da209d07c433434d72f41623a754aade1e5b35";
+      sha256 = "303487f5bc53fdf81de218e56fbe289419debe43f9ea6152305a4d597734d1ad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/ka/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/ka/firefox-95.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "d8058f0d613b048ca9406a7c4f635aa48c03b09cae5ef0d1e26adc7ac5cdf349";
+      sha256 = "9a5847b1cb64d0c26c3f2c7461251d3bfc94614bec406830fc4a201dacfa8fe9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/kab/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/kab/firefox-95.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "055e18fdad70268697b777b14ce17b7dc6c7c84a1b02bb3520260733add2edfd";
+      sha256 = "0d372c08f22ba13d3b5496e53f065b55b09e0899e62018f343636c1bac426f18";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/kk/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/kk/firefox-95.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "58054d22cdeb34d96bbe99b0883aec10c73e9a30b928af7ae866a5892388dc75";
+      sha256 = "d38b5dbea246202124cfe708bc22991305765f67130c816b04e96e75c1756268";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/km/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/km/firefox-95.0.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "1929d50933ae722c9fc65f630099fd5f022e9dcebff4849392a78fbee79a0e60";
+      sha256 = "c596c6e585ff5560b3bcd93fef6da771008b296c226bbe3d80b03a7f4599ffac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/kn/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/kn/firefox-95.0.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "2ac09ba601c391fafdf09ca8524818ea46af3e5a6d2467cb4c42c36257bdfa52";
+      sha256 = "fce6d171e94bca48915a20aae377bb3b92e5e3c6f64803bd732519e039853ed1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/ko/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/ko/firefox-95.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "d4a16e36c13156761914758ba254815db1769f86aee95887a373b7cc218bdece";
+      sha256 = "cf6383fb59b08da5b69bef818fe3d1cc4458a2319fe5f8fd55077a7464054535";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/lij/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/lij/firefox-95.0.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "8ac33659d6a1621940c1d70bc573e7bf9bf867cb87e6e75f17eab5aa27f41833";
+      sha256 = "70f8da49e6f62b8837e7cf56d628980b47abe291a18717b4b12809e863b3eb76";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/lt/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/lt/firefox-95.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "ba99c9137ce112fa2e26e0ea5c7a9852d0801042a756047f6c4114fc7ac779c5";
+      sha256 = "be9bfc950e8480c34331c5ea4118e63c27f9845ad9478e676ea1f1b130ae0afd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/lv/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/lv/firefox-95.0.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "3f5ae08ad7b17f9bff80d61a984715ed12653d9a4f459d69b429225afa9f372c";
+      sha256 = "5e50d2592f1282c333840dad77d990c7b6ec2ea6ff708ccb600bafc0f973be38";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/mk/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/mk/firefox-95.0.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "6e60beeceb67b09921b383aa2e920c37425cfa2000ea497c9a0ff90e106029f0";
+      sha256 = "0840349cefa0ac4b2831132bec2fffbadb58858d84566cbbae20ed751be85449";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/mr/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/mr/firefox-95.0.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "ee80850f99f616687b554370873b1adc2308d8dacac346a6ee091be636268c66";
+      sha256 = "e34eabbfe097b0672159d5bb78502956dcb600553bf44456e1ae1fc4146e9332";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/ms/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/ms/firefox-95.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "d191ca6a6879586ce647c9118724048ebafe13c11058eb4499aff9a42bd13572";
+      sha256 = "bfeb480b4f1f885f8fa20d25c5d66fd60fcc73d7403809b3d5ac54065e8ed2b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/my/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/my/firefox-95.0.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "7d2b9ddeb1de9bde70e06ff946af4061ccc8f9bb073835f4a45aca21109e8456";
+      sha256 = "3645f4555133a5cbd2445453281e7fb9ca31fd78f977800a0a932e87d2bb21f9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/nb-NO/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/nb-NO/firefox-95.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "77d52d4d3f9637546d3880d1751dff795095df2baa8dc1d5b7f7f1cd312499dc";
+      sha256 = "17f3092a79d955ac428c89eb1c9de7f87329b7cc70a05ef1ec1b6ae8e8799966";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/ne-NP/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/ne-NP/firefox-95.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "7fef351583a662b87db4691cb2b3f4f26a683d2746fa51da3e89babd07f863bd";
+      sha256 = "0af38c47e0455bfc7beadf6ad67a2efeda8f9d199728284cf7a27966fe28c827";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/nl/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/nl/firefox-95.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "ac25c3e4149a36b972f76e2635aa4736d5281bb467d89ac8ea8545f9446497f4";
+      sha256 = "d15581b93acf1f0dcf5da2b803718e81447c3bfca5f56b85aecdf30f5e50524f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/nn-NO/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/nn-NO/firefox-95.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "f85164e71b79178460a673a34fd68165b58fd2354b846c128cf614471325f89c";
+      sha256 = "aff9b26e755f32eaf4a8de9d7e0e604d2e275aec1a85b041dbaf6b2a0a6e77b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/oc/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/oc/firefox-95.0.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "2e4208811215f7e893043b1c2b36263957360000f302d656044075792b8537bd";
+      sha256 = "4a0926db56d9562cbc3254f07df0e065d1010a998227dc84d9b77eef178d4283";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/pa-IN/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/pa-IN/firefox-95.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "0630046a3521fe19123fc75848f147ef82e07de7cb7c0539b1f70f699f3037c2";
+      sha256 = "b16ddfd2baff64ce836429c73e4eb2ab7a6580227b1ddc9bcfcbb19bd0669c2b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/pl/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/pl/firefox-95.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "6f0a8a98624a20d111598a1e522e987b0c8d7857a2af9a8cf0a32a8d4545490f";
+      sha256 = "fdcf593d53278eedda628ada66831fbe6f2d48f3adb1655f48793b86fb842d8b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/pt-BR/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/pt-BR/firefox-95.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "27aece21464ce9ce455f5d9fbcc2f153d20df17584db3b0f293aadc5408821d0";
+      sha256 = "70f75817de5c329946514036f51a93498500dec61ab9feda84c30c12ee539881";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/pt-PT/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/pt-PT/firefox-95.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "0cdf45e3191b07bef1ada272ef65124c5daa591f29ea5adbd3fbe3a6edde095e";
+      sha256 = "02feb1fdfa83ececf169be3313fd2b18c438b2e2e2e9312e0a3fed46d1d6df8f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/rm/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/rm/firefox-95.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "f5da93fd882199b00672ab5644a5f9a9662a0371bfd0dac034ae819c8c7af07d";
+      sha256 = "4af7ff39aef89e677d8350974106d6bb033ec1d0caa7cea3977d3e187fa249c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/ro/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/ro/firefox-95.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "c35390e2e94dd991b147ef30cf5e3ba74546219c36ee137d440a40d7e6a1fdb2";
+      sha256 = "de7fcdea9cc12d81c33ce12dd3800a106cbf950314b96f20744bb43faf9adc4d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/ru/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/ru/firefox-95.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "1353f9d55a1e74954210d4c3fc93c24e8c01b478053ca1a849812262fa119aba";
+      sha256 = "4c6558c904cf3271fefcbb8d6151013e6bf006ad8e35b2d344e7a92d7b7b1a23";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/sco/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/sco/firefox-95.0.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "604268a66d7a772a2cd6dfaeaaed40cd65b896fe3af36844e204128ae84a9e39";
+      sha256 = "fdcc0dee6b7b21e91dfa85efeefb6f20034053611bf73656901618231ee4f292";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/si/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/si/firefox-95.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "5a14d6f00ab3f7aa1240ceb471f3454fe9a0b095c7d98fd6624577cc8a11bb5d";
+      sha256 = "a8bcb47f663e4e723279a52e4db1566059021e23d4727db0d390c01bb12721d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/sk/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/sk/firefox-95.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "bad43a5b54fde29e19dd1324662ccae0f213cbbf0a2a1802c7d230aec4fbbe60";
+      sha256 = "214ca20e6e3af96c4af3a0679a9d93de4c4f9428a2d4e451d5880a36bcef7186";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/sl/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/sl/firefox-95.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "df05a9c60a03d50797a8fbb72f72900d68ad776f5ab27f72a0f9b50a58e46439";
+      sha256 = "3b7e3374533ef821618203d72c4daac774e69692f849286fc32c2d79f16353ed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/son/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/son/firefox-95.0.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "2a502080c97053ff44ac3f910d12a5f3950a892887f24b44fd1b516c3ba237a9";
+      sha256 = "0f371b37d6c66047d630f0c4d405b1db182d5bc1706fdaab8d757504666c4bfc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/sq/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/sq/firefox-95.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "bd883d16edc899e4ba43c8125b321b468652f8eb8b39ef0285b65cb8e4e14782";
+      sha256 = "0e4ebae09edd895a00615459b6f10b573cd7a584fd12e8ad14b7fd35144b0739";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/sr/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/sr/firefox-95.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "bde21919dc650524f00c94fe085981d13c4be77917a370d874dff6fbc0acd400";
+      sha256 = "48a8bace93131d0dbb1b18e6de55dab40b116894e890dc5a0f4128323b522886";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/sv-SE/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/sv-SE/firefox-95.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "6856ffabf236e03d1ee16fd34cd9b75485d5bfcb5f94356a0c636c8d886dec31";
+      sha256 = "ed4f22a819a35ed67cfeeeed1f3e5110ec0df80102e7e14fc24bb2e50c600374";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/szl/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/szl/firefox-95.0.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "b793d4afc5b1d67b9f90461b1a82d389970ea1550876797b9ae031f9acb1f939";
+      sha256 = "226c7b2474bc079fce8f7e3eff7f3d07c28603533301df36845c1e5e58882a88";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/ta/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/ta/firefox-95.0.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "4b4a5d317c535d23e49c341da57563b10eca4fed88f269d3fd4b2d88d58efb51";
+      sha256 = "59f352b471823393d7bc94bd2f27190a5f8714b715f4e275b1ace658aa1963cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/te/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/te/firefox-95.0.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "ebe97cb46f66a10a429437c44ee7fc58112502ff72dd496a1deaf08deb35a492";
+      sha256 = "8ac438f4751f34bfd84a0257dfb2c6ac8d3a044b8d2f0fc75154b73b61ca8f0e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/th/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/th/firefox-95.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "e14f130d454ad543c26acc04fb8ae10b163e50f886eee95422976cce3109cc0d";
+      sha256 = "5ad4843b8a4b89117228bad779aa317c042dc5de408f61383dc8db8835243ff8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/tl/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/tl/firefox-95.0.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "8fbec4b22f4abedc1f08e86f06b0bd58c4c9b37475dc036c48430dcf1221e2c0";
+      sha256 = "714f87ba16bd6650b1e32c7e5a42edf184720fd23677e6e80ad11431e6f3558f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/tr/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/tr/firefox-95.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "99403ff004eee5e88098e37f3e5d62c56c72fb86358609f22826326751b81461";
+      sha256 = "b306db5728e47834f38702a1751f418de967c6f99d67c98ca999cdcc42e0d8eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/trs/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/trs/firefox-95.0.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "ff0edf90e4122347430a9df1ad2d0e6fd05b7bbcf00ba92345d31b8bbaae67c2";
+      sha256 = "e8aafa349540d8ef612f085ba49c583958075525df8e9e6d8f958f8d79be7620";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/uk/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/uk/firefox-95.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "3ddab9ade8f193ea1c5a61a92bfd502c8264de6f4b145793158c9cce99bf1cf5";
+      sha256 = "8d3a3164dd9919bcc0ef0c95bb9be6a994bee95c2f51685b7ccc7ec583c8b9f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/ur/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/ur/firefox-95.0.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "5b9c92ab2ff9acf88148b9d9c9261aaf353740821fc62a2e2051217fde9c09e0";
+      sha256 = "cb243dfee7f738643d2008bf0985e21e8a8f282bbc085eb0231a4d30a96b2b78";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/uz/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/uz/firefox-95.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "f1f4b441e1d76b0b92bc3af3f8bb4545699a1860935d008de12784d4a9fe0b9b";
+      sha256 = "915c7a7d20668973e93196f3c0aad833646aa90c8eb492d68663c468f0c7cee4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/vi/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/vi/firefox-95.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "a10fa164778d39194d898d9e5159ba1db917751d63e0a84d7d52e5a12747753b";
+      sha256 = "1c3cd736af3a54512c60d38ac14529cfce2cede3495774cf45ebcb22d1777b46";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/xh/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/xh/firefox-95.0.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "3fdd7069f4f6d546f1eed76edd33b440b658c7519ef97368844f02aa8be6e851";
+      sha256 = "935e1cef0bf29fcd0476e91c40431c330c10ad58ae304024f4a22c2f5802a06c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/zh-CN/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/zh-CN/firefox-95.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "942611c8165b14eff15ebaf00415d60e45982e3eac4cdc79b765c1461a3f42fa";
+      sha256 = "48e44f731e148d01168255522c902e3eaa61a52662b6def5fa3b99b26a0256a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/94.0.2/linux-i686/zh-TW/firefox-94.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0/linux-i686/zh-TW/firefox-95.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "60c2b8946b79d8d32248e7624c5292cf9d141beffbccb046f6c2a7308d16b23c";
+      sha256 = "dc4e3791021743cfef6030f557df9a9134b56ca92791edb6db0dfacaedd2ccfe";
     }
     ];
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Backport of PR #149661.

(cherry picked from commit e0da0b7c6a1142798215e69a93b6eaa2514d6c03)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
