### PR TITLE
nkdfu: init at 0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3301,7 +3301,7 @@
       fingerprint = "16D3 6E7B FBB0 0641 BBF6  574D 9DEB B56F E610 BAD1";
     }];
     github = "emgrav";
-    githubId = "614975";
+    githubId = 614975;
   };
   emily = {
     email = "nixpkgs@emily.moe";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3293,15 +3293,15 @@
     name = "embr";
   };
   emgrav = {
-    name = "Emelie Graven"
+    name = "Emelie Graven";
     email = "emelie@graven.dev";
-    matrix = "@emelie:graven.dev"
+    matrix = "@emelie:graven.dev";
     keys = [{
       longkeyid = "ed25519/0x9DEBB56FE610BAD1";
       fingerprint = "16D3 6E7B FBB0 0641 BBF6  574D 9DEB B56F E610 BAD1";
     }];
     github = "emgrav";
-    githubId = "614975"
+    githubId = "614975";
   };
   emily = {
     email = "nixpkgs@emily.moe";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3292,6 +3292,17 @@
     githubId = 428026;
     name = "embr";
   };
+  emgrav = {
+    name = "Emelie Graven"
+    email = "emelie@graven.dev";
+    matrix = "@emelie:graven.dev"
+    keys = [{
+      longkeyid = "ed25519/0x9DEBB56FE610BAD1";
+      fingerprint = "16D3 6E7B FBB0 0641 BBF6  574D 9DEB B56F E610 BAD1";
+    }];
+    github = "emgrav";
+    githubId = "614975"
+  };
   emily = {
     email = "nixpkgs@emily.moe";
     github = "emilazy";

--- a/pkgs/development/python-modules/nkdfu/default.nix
+++ b/pkgs/development/python-modules/nkdfu/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27, fire, tqdm, intelhex, libusb1 }:
+
+buildPythonPackage rec {
+  pname = "nkdfu";
+  version = "0.1";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-Y8GonfCBi3BNMhZ99SN6/SDSa0+dbfPIMPoVzALwH5A=";
+  };
+
+  propagatedBuildInputs = [
+    fire
+    tqdm
+    intelhex
+    libusb1
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/Nitrokey/nkdfu";
+    description = "DFU tool for updating Nitrokeys' firmware";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ emgrav ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7194,6 +7194,8 @@ with pkgs;
 
   nkeys = callPackage ../tools/system/nkeys { };
 
+  nkdfu = with pythonPackages; toPythonApplication nkdfu;
+
   nyxt = callPackage ../applications/networking/browsers/nyxt { };
 
   nfpm = callPackage ../tools/package-management/nfpm { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5258,6 +5258,8 @@ in {
 
   nix-prefetch-github = callPackage ../development/python-modules/nix-prefetch-github { };
 
+  nkdfu = callPackage ../development/python-modules/nkdfu { };
+
   nltk = callPackage ../development/python-modules/nltk { };
 
   nmapthon2 = callPackage ../development/python-modules/nmapthon2 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
