### PR TITLE
beamPackages.hex: add comment how to obtain hash

### DIFF
--- a/pkgs/development/beam-modules/hex/default.nix
+++ b/pkgs/development/beam-modules/hex/default.nix
@@ -10,6 +10,10 @@ let
     pname = "hex";
     version = "1.0.1";
 
+    # How to obtain `sha256`:
+    # nix-prefetch-url --unpack https://github.com/hexpm/hex/archive/v${version}.tar.gz
+    # Optional convert to SRI hash:
+    # nix hash to-sri --type sha256 <hash>
     src = fetchFromGitHub {
       owner = "hexpm";
       repo = "hex";


### PR DESCRIPTION
###### Motivation for this change

Discussions in https://github.com/NixOS/nixpkgs/pull/150807.
I would love to leave the comment to make it easier for inexperienced people and my future self to just update the version.

As long as `nix-prefetch-github`, ... or `nix-update` are not builtin things this would be the way to go from my side.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
