### PR TITLE
vlc: fix headphones mode; libspatialaudio: init at 0.3.0

### DIFF
--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -7,8 +7,8 @@
 , mpeg2dec, systemd, gnutls, avahi, libcddb, libjack2, SDL, SDL_image
 , libmtp, unzip, taglib, libkate, libtiger, libv4l, samba, libssh2, liboggz
 , libass, libva, libdvbpsi, libdc1394, libraw1394, libopus
-, libvdpau, libsamplerate, live555, fluidsynth, wayland, wayland-protocols
-, ncurses, srt
+, libvdpau, libsamplerate, libspatialaudio, live555, fluidsynth
+, wayland, wayland-protocols, ncurses, srt
 , onlyLibVLC ? false
 , withQt5 ? true, qtbase, qtsvg, qtx11extras, wrapQtAppsHook
 , jackSupport ? false
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     libkate libtiger libv4l samba libssh2 liboggz libass libdvbpsi libva
     xorg.xlibsWrapper xorg.libXv xorg.libXvMC xorg.libXpm xorg.xcbutilkeysyms
     libdc1394 libraw1394 libopus libebml libmatroska libvdpau libsamplerate
-    fluidsynth wayland wayland-protocols ncurses srt
+    libspatialaudio fluidsynth wayland wayland-protocols ncurses srt
   ] ++ optional (!stdenv.hostPlatform.isAarch64 && !stdenv.hostPlatform.isAarch32) live555
     ++ optionals withQt5    [ qtbase qtsvg qtx11extras ]
     ++ optionals skins2Support (with xorg; [ libXpm freetype libXext libXinerama ])
@@ -99,6 +99,12 @@ stdenv.mkDerivation rec {
   # Remove runtime dependencies on libraries
   postConfigure = ''
     sed -i 's|^#define CONFIGURE_LINE.*$|#define CONFIGURE_LINE "<removed>"|g' config.h
+  '';
+
+  # Add missing SOFA files
+  # Given in EXTRA_DIST, but not in install-data target
+  postInstall = ''
+    cp -R share/hrtfs $out/share/vlc
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/libspatialaudio/default.nix
+++ b/pkgs/development/libraries/libspatialaudio/default.nix
@@ -1,14 +1,19 @@
-{ lib, stdenv, fetchFromGitHub, cmake, libmysofa, zlib }:
-stdenv.mkDerivation {
-  name = "libspatialaudio";
+{ lib, stdenv, cmake, fetchFromGitHub, libmysofa, zlib }:
+
+let version = "0.3.0";
+in stdenv.mkDerivation {
+  pname = "libspatialaudio";
+  inherit version;
+
   src = fetchFromGitHub {
     owner = "videolabs";
     repo = "libspatialaudio";
-    rev = "0.3.0";
+    rev = version;
     hash = "sha256-sPnQPD41AceXM4uGqWXMYhuQv0TUkA6TZP8ChxUFIoI=";
   };
-  buildInputs = [ cmake libmysofa zlib ];
-  configurePhase = "cmake -DCMAKE_INSTALL_PREFIX=$out .";
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libmysofa zlib ];
 
   meta = {
     description =
@@ -16,6 +21,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/videolabs/libspatialaudio";
     license = lib.licenses.lgpl21Plus;
     platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ krav ];
   };
 }
 

--- a/pkgs/development/libraries/libspatialaudio/default.nix
+++ b/pkgs/development/libraries/libspatialaudio/default.nix
@@ -1,9 +1,8 @@
 { lib, stdenv, cmake, fetchFromGitHub, libmysofa, zlib }:
 
-let version = "0.3.0";
-in stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "libspatialaudio";
-  inherit version;
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "videolabs";
@@ -15,13 +14,12 @@ in stdenv.mkDerivation {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ libmysofa zlib ];
 
-  meta = {
+  meta = with lib; {
     description =
       "Ambisonic encoding / decoding and binauralization library in C++";
     homepage = "https://github.com/videolabs/libspatialaudio";
-    license = lib.licenses.lgpl21Plus;
-    platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ krav ];
+    license = licenses.lgpl21Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ krav ];
   };
 }
-

--- a/pkgs/development/libraries/libspatialaudio/default.nix
+++ b/pkgs/development/libraries/libspatialaudio/default.nix
@@ -1,0 +1,21 @@
+{ lib, stdenv, fetchFromGitHub, cmake, libmysofa, zlib }:
+stdenv.mkDerivation {
+  name = "libspatialaudio";
+  src = fetchFromGitHub {
+    owner = "videolabs";
+    repo = "libspatialaudio";
+    rev = "0.3.0";
+    hash = "sha256-sPnQPD41AceXM4uGqWXMYhuQv0TUkA6TZP8ChxUFIoI=";
+  };
+  buildInputs = [ cmake libmysofa zlib ];
+  configurePhase = "cmake -DCMAKE_INSTALL_PREFIX=$out .";
+
+  meta = {
+    description =
+      "Ambisonic encoding / decoding and binauralization library in C++";
+    homepage = "https://github.com/videolabs/libspatialaudio";
+    license = lib.licenses.lgpl21Plus;
+    platforms = lib.platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18324,6 +18324,8 @@ with pkgs;
 
   libstrophe = callPackage ../development/libraries/libstrophe { };
 
+  libspatialaudio = callPackage ../development/libraries/libspatialaudio { };
+
   libspatialindex = callPackage ../development/libraries/libspatialindex { };
 
   libspatialite = callPackage ../development/libraries/libspatialite { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The `binauralizer` aout filter is currently missing, causing menu option "Audio -> Stereo Mode -> Headphones" to log an error and fall back to original audio. It depends on libspatialaudio which is added in this commit, and a "Head-Related Transfer Function" file that's skipped by `make install`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
