### PR TITLE
invidious: unstable-2021-11-08 -> unstable-2022-03-16

### DIFF
--- a/pkgs/servers/invidious/default.nix
+++ b/pkgs/servers/invidious/default.nix
@@ -8,17 +8,17 @@ let
   #  * shards.nix (by running `crystal2nix` in invidious’ source tree)
   #  * If the lsquic.cr dependency changed: lsquic in lsquic.nix (version, sha256)
   #  * If the lsquic version changed: boringssl' in lsquic.nix (version, sha256)
-  rev = "21879da80d2dfa97e789a13b90e82e466c4854e3";
+  rev = "00904ae3f2ab6a3cf5f96012d36c5672c3aa17b4";
 in
 crystal.buildCrystalPackage rec {
   pname = "invidious";
-  version = "unstable-2021-11-08";
+  version = "unstable-2021-11-13";
 
   src = fetchFromGitHub {
     owner = "iv-org";
     repo = pname;
     inherit rev;
-    sha256 = "0jvnwjdh2l0hxfvzim00r3zbs528bb93y1nk0bjrbbrcfv5cn5ss";
+    sha256 = "sha256-DET4jvB5epkpl5/HTORNTWDL4Ck4IsqhdTApJE8t6Tg=";
   };
 
   postPatch =

--- a/pkgs/servers/invidious/default.nix
+++ b/pkgs/servers/invidious/default.nix
@@ -88,7 +88,11 @@ crystal.buildCrystalPackage rec {
     INVIDIOUS_CONFIG="database_url: sqlite3:///dev/null" $out/bin/invidious --help
   '';
 
-  passthru.tests = { inherit (nixosTests) invidious; };
+  passthru = {
+    inherit lsquic;
+    tests = { inherit (nixosTests) invidious; };
+    updateScript = ./update.sh;
+  };
 
   meta = with lib; {
     description = "An open source alternative front-end to YouTube";

--- a/pkgs/servers/invidious/default.nix
+++ b/pkgs/servers/invidious/default.nix
@@ -1,13 +1,17 @@
 { lib, crystal, fetchFromGitHub, librsvg, pkg-config, libxml2, openssl, shards, sqlite, lsquic, videojs, nixosTests }:
 let
-  # When updating, always update the following:
-  #  * the git revision
-  #  * the version attribute
-  #  * the source hash (sha256)
-  # If the shards.lock file changed, also the following:
-  #  * shards.nix (by running `crystal2nix` in invidious’ source tree)
-  #  * If the lsquic.cr dependency changed: lsquic in lsquic.nix (version, sha256)
-  #  * If the lsquic version changed: boringssl' in lsquic.nix (version, sha256)
+  # All versions, revisions, and checksums are stored in ./versions.json.
+  # The update process is the following:
+  #   * pick the latest commit
+  #   * update .invidious.rev, .invidious.version, and .invidious.sha256
+  #   * prefetch the videojs dependencies with scripts/fetch-player-dependencies.cr
+  #     and update .videojs.sha256 (they are normally fetched during build
+  #     but nix's sandboxing does not allow that)
+  #   * if shard.lock changed
+  #     * recreate shards.nix by running crystal2nix
+  #     * update lsquic and boringssl if necessarry, lsquic.cr depends on
+  #       the same version of lsquic and lsquic requires the boringssl
+  #       commit mentioned in its README
   versions = builtins.fromJSON (builtins.readFile ./versions.json);
 in
 crystal.buildCrystalPackage rec {

--- a/pkgs/servers/invidious/default.nix
+++ b/pkgs/servers/invidious/default.nix
@@ -1,4 +1,4 @@
-{ lib, crystal, fetchFromGitHub, librsvg, pkg-config, libxml2, openssl, shards, sqlite, lsquic, videojs, nixosTests }:
+{ lib, stdenv, crystal, fetchFromGitHub, librsvg, pkg-config, libxml2, openssl, shards, sqlite, lsquic, videojs, nixosTests }:
 let
   # All versions, revisions, and checksums are stored in ./versions.json.
   # The update process is the following:
@@ -107,5 +107,6 @@ crystal.buildCrystalPackage rec {
     homepage = "https://invidious.io/";
     license = licenses.agpl3;
     maintainers = with maintainers; [ infinisil sbruder ];
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/servers/invidious/default.nix
+++ b/pkgs/servers/invidious/default.nix
@@ -8,17 +8,16 @@ let
   #  * shards.nix (by running `crystal2nix` in invidious’ source tree)
   #  * If the lsquic.cr dependency changed: lsquic in lsquic.nix (version, sha256)
   #  * If the lsquic version changed: boringssl' in lsquic.nix (version, sha256)
-  rev = "081fd541afc9b2f9b821e0f8f4c66dda0839295c";
+  versions = builtins.fromJSON (builtins.readFile ./versions.json);
 in
 crystal.buildCrystalPackage rec {
   pname = "invidious";
-  version = "unstable-2022-02-25";
+  inherit (versions.invidious) version;
 
   src = fetchFromGitHub {
     owner = "iv-org";
     repo = pname;
-    inherit rev;
-    sha256 = "12m1fd8yfs6fqchvf9masr837dcghsg5x2nb8vcpzakzia5qc2kf";
+    inherit (versions.invidious) rev sha256;
   };
 
   postPatch =
@@ -39,9 +38,9 @@ crystal.buildCrystalPackage rec {
       # build-time
       substituteInPlace src/invidious.cr \
           --replace ${lib.escapeShellArg branchTemplate} '"master"' \
-          --replace ${lib.escapeShellArg commitTemplate} '"${lib.substring 0 7 rev}"' \
+          --replace ${lib.escapeShellArg commitTemplate} '"${lib.substring 0 7 versions.invidious.rev}"' \
           --replace ${lib.escapeShellArg versionTemplate} '"${lib.replaceChars ["-"] ["."] (lib.substring 9 10 version)}"' \
-          --replace ${lib.escapeShellArg assetCommitTemplate} '"${lib.substring 0 7 rev}"'
+          --replace ${lib.escapeShellArg assetCommitTemplate} '"${lib.substring 0 7 versions.invidious.rev}"'
 
       # Patch the assets and locales paths to be absolute
       substituteInPlace src/invidious.cr \

--- a/pkgs/servers/invidious/lsquic.nix
+++ b/pkgs/servers/invidious/lsquic.nix
@@ -8,6 +8,11 @@ let
       rev = version;
       sha256 = "sha256-EU6T9yQCdOLx98Io8o01rEsgxDFF/Xoy42LgPopD2/A=";
     };
+
+    patches = [
+      # Use /etc/ssl/certs/ca-certificates.crt instead of /etc/ssl/cert.pem
+      ./use-etc-ssl-certs.patch
+    ];
   });
 in
 stdenv.mkDerivation rec {

--- a/pkgs/servers/invidious/lsquic.nix
+++ b/pkgs/servers/invidious/lsquic.nix
@@ -1,12 +1,13 @@
 { lib, boringssl, stdenv, fetchgit, fetchFromGitHub, cmake, zlib, perl, libevent }:
 let
+  versions = builtins.fromJSON (builtins.readFile ./versions.json);
+
   # lsquic requires a specific boringssl version (noted in its README)
-  boringssl' = boringssl.overrideAttrs (old: rec {
-    version = "251b5169fd44345f455438312ec4e18ae07fd58c";
+  boringssl' = boringssl.overrideAttrs (old: {
+    version = versions.boringssl.rev;
     src = fetchgit {
       url = "https://boringssl.googlesource.com/boringssl";
-      rev = version;
-      sha256 = "sha256-EU6T9yQCdOLx98Io8o01rEsgxDFF/Xoy42LgPopD2/A=";
+      inherit (versions.boringssl) rev sha256;
     };
 
     patches = [
@@ -17,13 +18,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "lsquic";
-  version = "2.18.1";
+  version = versions.lsquic.version;
 
   src = fetchFromGitHub {
     owner = "litespeedtech";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-hG8cUvhbCNeMOsKkaJlgGpzUrIx47E/WhmPIdI5F3qM=";
+    inherit (versions.lsquic) sha256;
     fetchSubmodules = true;
   };
 
@@ -53,6 +54,8 @@ stdenv.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  passthru.boringssl = boringssl';
 
   meta = with lib; {
     description = "A library for QUIC and HTTP/3 (version for Invidious)";

--- a/pkgs/servers/invidious/shards.nix
+++ b/pkgs/servers/invidious/shards.nix
@@ -59,10 +59,22 @@
     rev = "v0.4.1";
     sha256 = "1l08cydkdidq9yyil1wl240hvk41iycv04jrg6nx5mkvzw4z1bzg";
   };
+  spectator = {
+    owner = "icy-arctic-fox";
+    repo = "spectator";
+    rev = "v0.10.4";
+    sha256 = "0rcxq2nbslvwrd8m9ajw6dzaw3hagxmkdy9s8p34cgnr4c9dijdq";
+  };
   sqlite3 = {
     owner = "crystal-lang";
     repo = "crystal-sqlite3";
     rev = "v0.18.0";
     sha256 = "03nnvpchhq9f9ywsm3pk2rrj4a3figw7xs96zdziwgr5znkz6x93";
+  };
+  ameba = {
+    owner = "crystal-ameba";
+    repo = "ameba";
+    rev = "v0.14.3";
+    sha256 = "1cfr95xi6hsyxw1wlrh571hc775xhwmssk3k14i8b7dgbwfmm5x1";
   };
 }

--- a/pkgs/servers/invidious/update.sh
+++ b/pkgs/servers/invidious/update.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p common-updater-scripts curl crystal2nix jq git gnused nix nix-prefetch-git nix-update
+git_url='https://github.com/iv-org/invidious.git'
+git_branch='master'
+git_dir='/var/tmp/invidious.git'
+nix_file="$(dirname "${BASH_SOURCE[0]}")/default.nix"
+pkg='invidious'
+
+set -euo pipefail
+
+info() {
+    if [ -t 2 ]; then
+        set -- '\033[32m%s\033[39m\n' "$@"
+    else
+        set -- '%s\n' "$@"
+    fi
+    printf "$@" >&2
+}
+
+old_rev=$(nix-instantiate --eval --strict --json -A "$pkg.src.rev" | jq -r)
+old_version=$(nix-instantiate --eval --strict --json -A "$pkg.version" | jq -r)
+today=$(LANG=C date -u +'%Y-%m-%d')
+
+info "fetching $git_url..."
+if [ ! -d "$git_dir" ]; then
+    git init --initial-branch="$git_branch" "$git_dir"
+    git -C "$git_dir" remote add origin "$git_url"
+fi
+git -C "$git_dir" fetch origin "$git_branch"
+
+# use latest commit before today, we should not call the version *today*
+# because there might still be commits coming
+# use the day of the latest commit we picked as version
+new_rev=$(git -C "$git_dir" log -n 1 --format='format:%H' --before="${today}T00:00:00Z" "origin/$git_branch")
+new_version="unstable-$(git -C "$git_dir" log -n 1 --format='format:%cs' "$new_rev")"
+info "latest commit before $today: $new_rev"
+
+if [ "$new_rev" = "$old_rev" ]; then
+    info "$pkg is up-to-date."
+    exit
+fi
+
+new_sha256=$(nix-prefetch-git --rev "$new_rev" "$git_dir" | jq -r .sha256)
+update-source-version "$pkg" \
+    "$new_version" \
+    "$new_sha256" \
+    --rev="$new_rev"
+git add "$nix_file"
+commit_msg="$pkg: $old_version -> $new_version"
+
+cd "${nix_file%/*}"
+if git -C "$git_dir" diff-tree --quiet "${old_rev}..${new_rev}" -- 'shard.lock'; then
+    info "shard.lock did not change since $old_rev."
+else
+    info "Updating shards.nix..."
+    git -C "$git_dir" reset --hard "$new_rev"
+    crystal2nix -- "$git_dir/shard.lock"  # argv's index seems broken
+    git add 'shards.nix'
+
+    lsquic_old_version=$(nix-instantiate --eval --strict --json -A "${pkg}.lsquic.version" '../../..' | jq -r)
+    lsquic_new_version=$(nix eval --raw -f 'shards.nix' lsquic.rev \
+        | sed -e 's/^v//' -e 's/-[0-9]*$//')
+    if [ "$lsquic_old_version" != "$lsquic_new_version" ]; then
+        info "Updating lsquic to $lsquic_new_version..."
+        nix-update --version "$lsquic_new_version" -f '../../..' invidious.lsquic
+        if git diff-index --quiet HEAD -- 'lsquic.nix'; then
+            info "lsquic is up-to-date."
+        else
+            boringssl_new_version=$(curl -LSsf "https://github.com/litespeedtech/lsquic/raw/v${lsquic_new_version}/README.md" \
+                | grep -Pom1 '(?<=^git checkout ).*')
+            boringssl_new_sha256=$(nix-prefetch-git --rev "$boringssl_new_version" 'https://boringssl.googlesource.com/boringssl' \
+                | jq -r .sha256)
+            sed -e "0,/^ *version = .*/ s//    version = \"$boringssl_new_version\";/" \
+                -e "0,/^ *sha256 = .*/ s//      sha256 = \"$boringssl_new_sha256\";/" \
+                -i lsquic.nix
+            git add 'lsquic.nix'
+            commit_msg="$commit_msg
+
+lsquic: $lsquic_old_version -> $lsquic_new_version"
+        fi
+    fi
+fi
+
+git commit --verbose --message "$commit_msg"

--- a/pkgs/servers/invidious/use-etc-ssl-certs.patch
+++ b/pkgs/servers/invidious/use-etc-ssl-certs.patch
@@ -1,0 +1,13 @@
+diff --git a/crypto/x509/x509_def.c b/crypto/x509/x509_def.c
+index d2bc3e5c1..329580075 100644
+--- a/crypto/x509/x509_def.c
++++ b/crypto/x509/x509_def.c
+@@ -67,7 +67,7 @@
+ 
+ #define X509_CERT_AREA          OPENSSLDIR
+ #define X509_CERT_DIR           OPENSSLDIR "/certs"
+-#define X509_CERT_FILE          OPENSSLDIR "/cert.pem"
++#define X509_CERT_FILE          "/etc/ssl/certs/ca-certificates.crt"
+ #define X509_PRIVATE_DIR        OPENSSLDIR "/private"
+ #define X509_CERT_DIR_EVP        "SSL_CERT_DIR"
+ #define X509_CERT_FILE_EVP       "SSL_CERT_FILE"

--- a/pkgs/servers/invidious/versions.json
+++ b/pkgs/servers/invidious/versions.json
@@ -4,9 +4,9 @@
     "sha256": "sha256-EU6T9yQCdOLx98Io8o01rEsgxDFF/Xoy42LgPopD2/A="
   },
   "invidious": {
-    "rev": "081fd541afc9b2f9b821e0f8f4c66dda0839295c",
-    "sha256": "12m1fd8yfs6fqchvf9masr837dcghsg5x2nb8vcpzakzia5qc2kf",
-    "version": "unstable-2022-02-25"
+    "rev": "ed265cfdcd131b9df5398d899cc5d7036a5b7846",
+    "sha256": "0hhnq4s0slwbgxra7gxapl7dcz60a7k71cndi4crqcikmazzac3b",
+    "version": "unstable-2022-03-16"
   },
   "lsquic": {
     "sha256": "sha256-hG8cUvhbCNeMOsKkaJlgGpzUrIx47E/WhmPIdI5F3qM=",

--- a/pkgs/servers/invidious/versions.json
+++ b/pkgs/servers/invidious/versions.json
@@ -1,0 +1,18 @@
+{
+  "boringssl": {
+    "rev": "251b5169fd44345f455438312ec4e18ae07fd58c",
+    "sha256": "sha256-EU6T9yQCdOLx98Io8o01rEsgxDFF/Xoy42LgPopD2/A="
+  },
+  "invidious": {
+    "rev": "081fd541afc9b2f9b821e0f8f4c66dda0839295c",
+    "sha256": "12m1fd8yfs6fqchvf9masr837dcghsg5x2nb8vcpzakzia5qc2kf",
+    "version": "unstable-2022-02-25"
+  },
+  "lsquic": {
+    "sha256": "sha256-hG8cUvhbCNeMOsKkaJlgGpzUrIx47E/WhmPIdI5F3qM=",
+    "version": "2.18.1"
+  },
+  "videojs": {
+    "sha256": "0b4vxd29kpvy60yhqm376r1872gds17s6wljqw0zlr16j762k50r"
+  }
+}

--- a/pkgs/servers/invidious/videojs.nix
+++ b/pkgs/servers/invidious/videojs.nix
@@ -1,0 +1,15 @@
+{ stdenvNoCC, cacert, crystal, openssl, pkg-config, invidious }:
+
+stdenvNoCC.mkDerivation {
+  name = "videojs";
+
+  inherit (invidious) src;
+
+  builder = ./videojs.sh;
+
+  nativeBuildInputs = [ cacert crystal openssl pkg-config ];
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "0b4vxd29kpvy60yhqm376r1872gds17s6wljqw0zlr16j762k50r";
+}

--- a/pkgs/servers/invidious/videojs.nix
+++ b/pkgs/servers/invidious/videojs.nix
@@ -1,5 +1,8 @@
 { stdenvNoCC, cacert, crystal, openssl, pkg-config, invidious }:
 
+let
+  versions = builtins.fromJSON (builtins.readFile ./versions.json);
+in
 stdenvNoCC.mkDerivation {
   name = "videojs";
 
@@ -11,5 +14,5 @@ stdenvNoCC.mkDerivation {
 
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
-  outputHash = "0b4vxd29kpvy60yhqm376r1872gds17s6wljqw0zlr16j762k50r";
+  outputHash = versions.videojs.sha256;
 }

--- a/pkgs/servers/invidious/videojs.sh
+++ b/pkgs/servers/invidious/videojs.sh
@@ -1,0 +1,9 @@
+source $stdenv/setup
+
+unpackPhase
+cd source
+# this helper downloads the videojs files and checks their checksums
+# against videojs-dependencies.yml so it should be pure
+crystal run scripts/fetch-player-dependencies.cr -- --minified
+rm -f assets/videojs/.gitignore
+mv assets/videojs "$out"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6437,6 +6437,8 @@ with pkgs;
   invidious = callPackage ../servers/invidious {
     # needs a specific version of lsquic
     lsquic = callPackage ../servers/invidious/lsquic.nix { };
+    # normally video.js is downloaded at build time
+    videojs = callPackage ../servers/invidious/videojs.nix { };
   };
 
   invoice2data  = callPackage ../tools/text/invoice2data  { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add update script.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
