### PR TITLE
lirc: fix build against pyyaml-6.0

### DIFF
--- a/pkgs/development/libraries/lirc/default.nix
+++ b/pkgs/development/libraries/lirc/default.nix
@@ -24,6 +24,10 @@ stdenv.mkDerivation rec {
       Makefile.in
     sed -i 's,PYTHONPATH=,PYTHONPATH=$(PYTHONPATH):,' \
       doc/Makefile.in
+
+    # Pull fix for new pyyaml pending upstream inclusion
+    #   https://sourceforge.net/p/lirc/git/merge-requests/39/
+    substituteInPlace python-pkg/lirc/database.py --replace 'yaml.load(' 'yaml.safe_load('
   '';
 
   preConfigure = ''


### PR DESCRIPTION
Without the change `lirc` build fails as:

```
$ nix build -f. -L lirc
...
PYTHONPATH=../python-pkg/lirc \
/nix/store/gn4gyzv93izh3lg5iqjb7l04k9r4hxv0-python3-3.9.9-env/bin/python ./data2hwdb ../configs ../configs \
    > lirc.hwdb
Traceback (most recent call last):
  File "/build/lirc-0.10.1/doc/./data2hwdb", line 112, in <module>
    main()
  File "/build/lirc-0.10.1/doc/./data2hwdb", line 100, in main
    db = database.Database(configdir, yamldir)
  File "/build/lirc-0.10.1/python-pkg/lirc/database.py", line 135, in __init__
    cf = yaml.load(f.read())
TypeError: load() missing 1 required positional argument: 'Loader'
make[2]: *** [Makefile:1263: lirc.hwdb] Error 1
```
