### PR TITLE
WIP: wxwidgets: fix build on darwin

### DIFF
--- a/pkgs/development/libraries/wxwidgets/3.0/default.nix
+++ b/pkgs/development/libraries/wxwidgets/3.0/default.nix
@@ -90,6 +90,5 @@ stdenv.mkDerivation rec {
     homepage = "https://www.wxwidgets.org/";
     description = "a C++ library that lets developers create applications for Windows, macOS, Linux and other platforms with a single code base";
     longDescription = "wxWidgets gives you a single, easy-to-use API for writing GUI applications on multiple platforms that still utilize the native platform's controls and utilities. Link with the appropriate library for your platform and compiler, and your application will adopt the look and feel appropriate to that platform. On top of great GUI functionality, wxWidgets gives you: online help, network programming, streams, clipboard and drag and drop, multithreading, image loading and saving in a variety of popular formats, database support, HTML viewing and printing, and much more.";
-    badPlatforms = [ "x86_64-darwin" ];
   };
 }

--- a/pkgs/development/libraries/wxwidgets/3.0/default.nix
+++ b/pkgs/development/libraries/wxwidgets/3.0/default.nix
@@ -8,7 +8,7 @@
 , compat24 ? false, compat26 ? true, unicode ? true
 , withGtk2 ? true
 , withWebKit ? !stdenv.isDarwin, webkitgtk  # Disable webkitgtk on darwin pending #126101
-, AGL, Carbon, Cocoa, Kernel, QTKit
+, AGL, AVFoundation, Carbon, Cocoa, Kernel, QTKit
 }:
 
 with lib;
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     ++ optional (!withGtk2) gtk3
     ++ optional withMesa libGLU
     ++ optional withWebKit webkitgtk
-    ++ optionals stdenv.isDarwin [ setfile Carbon Cocoa Kernel QTKit ];
+    ++ optionals stdenv.isDarwin [ setfile AVFoundation Carbon Cocoa Kernel QTKit ];
 
   propagatedBuildInputs = optional stdenv.isDarwin AGL;
 

--- a/pkgs/development/libraries/wxwidgets/3.0/default.nix
+++ b/pkgs/development/libraries/wxwidgets/3.0/default.nix
@@ -7,7 +7,7 @@
 , libGLU, libGL
 , compat24 ? false, compat26 ? true, unicode ? true
 , withGtk2 ? true
-, withWebKit ? false, webkitgtk
+, withWebKit ? !stdenv.isDarwin, webkitgtk  # Disable webkitgtk on darwin pending #126101
 , AGL, Carbon, Cocoa, Kernel, QTKit
 }:
 

--- a/pkgs/development/libraries/wxwidgets/3.1/default.nix
+++ b/pkgs/development/libraries/wxwidgets/3.1/default.nix
@@ -23,6 +23,7 @@
 , withWebKit ? false
 , webkitgtk ? null
 , AGL ? null
+, AVFoundation ? null
 , Carbon ? null
 , Cocoa ? null
 , Kernel ? null
@@ -60,7 +61,7 @@ stdenv.mkDerivation rec {
   ++ optional (!withGtk2) gtk3
   ++ optional withMesa libGLU
   ++ optional (withWebKit && !stdenv.isDarwin) webkitgtk # Disable webkitgtk on darwin pending #126101
-  ++ optionals stdenv.isDarwin [ setfile Carbon Cocoa Kernel QTKit ];
+  ++ optionals stdenv.isDarwin [ setfile AVFoundation Carbon Cocoa Kernel QTKit ];
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/libraries/wxwidgets/3.1/default.nix
+++ b/pkgs/development/libraries/wxwidgets/3.1/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
   ] ++ optionals withGtk2 [ gtk2 GConf ]
   ++ optional (!withGtk2) gtk3
   ++ optional withMesa libGLU
-  ++ optional withWebKit webkitgtk
+  ++ optional (withWebKit && !stdenv.isDarwin) webkitgtk # Disable webkitgtk on darwin pending #126101
   ++ optionals stdenv.isDarwin [ setfile Carbon Cocoa Kernel QTKit ];
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20232,25 +20232,25 @@ with pkgs;
   wxGTK30-gtk2 = callPackage ../development/libraries/wxwidgets/3.0 {
     withGtk2 = true;
     inherit (darwin.stubs) setfile;
-    inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QTKit;
+    inherit (darwin.apple_sdk.frameworks) AGL AVFoundation Carbon Cocoa Kernel QTKit;
   };
 
   wxGTK30-gtk3 = callPackage ../development/libraries/wxwidgets/3.0 {
     withGtk2 = false;
     inherit (darwin.stubs) setfile;
-    inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QTKit;
+    inherit (darwin.apple_sdk.frameworks) AGL AVFoundation Carbon Cocoa Kernel QTKit;
   };
 
   wxGTK31-gtk2 = callPackage ../development/libraries/wxwidgets/3.1 {
     withGtk2 = true;
     inherit (darwin.stubs) setfile;
-    inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QTKit;
+    inherit (darwin.apple_sdk.frameworks) AGL AVFoundation Carbon Cocoa Kernel QTKit;
   };
 
   wxGTK31-gtk3 = callPackage ../development/libraries/wxwidgets/3.1 {
     withGtk2 = false;
     inherit (darwin.stubs) setfile;
-    inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QTKit;
+    inherit (darwin.apple_sdk.frameworks) AGL AVFoundation Carbon Cocoa Kernel QTKit;
   };
 
   wxmac = callPackage ../development/libraries/wxwidgets/3.0/mac.nix {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

darwin packaging depending on wxwidgets fail due to #126101. Rather than forcing all upstream dependencies not needing webkitgtk to exclude it, it may be simpler to exclude here until fixed. Additionally, AVFoundation appears to be needed on my x86 machine to complete a build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
