### PR TITLE
goverlay: 0.7 → 0.7.1

### DIFF
--- a/pkgs/tools/graphics/goverlay/default.nix
+++ b/pkgs/tools/graphics/goverlay/default.nix
@@ -6,6 +6,7 @@
 , fpc
 , lazarus-qt
 , wrapQtAppsHook
+, breeze-qt5
 , libGL
 , libGLU
 , libqt5pas
@@ -37,13 +38,13 @@ let
   '';
 in stdenv.mkDerivation rec {
   pname = "goverlay";
-  version = "0.7";
+  version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "benjamimgois";
     repo = pname;
     rev = version;
-    sha256 = "sha256-LdpgEfCNbf0/sY8v8D3KiapYEd23tVy4nQ7RuGwl7jM=";
+    sha256 = "sha256-oXkGrMHjs8uui0pzGYW8jnttet/5IX0r8eat0n5saFk=";
   };
 
   outputs = [ "out" "man" ];
@@ -68,6 +69,7 @@ in stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    breeze-qt5
     libGL
     libGLU
     libqt5pas

--- a/pkgs/tools/graphics/goverlay/find-xdg-data-files.patch
+++ b/pkgs/tools/graphics/goverlay/find-xdg-data-files.patch
@@ -1,8 +1,8 @@
 diff --git a/overlayunit.pas b/overlayunit.pas
-index 537491b..744f604 100644
+index 97a088d..4c42414 100644
 --- a/overlayunit.pas
 +++ b/overlayunit.pas
-@@ -5011,7 +5011,7 @@ begin
+@@ -5007,7 +5007,7 @@ begin
     //Determine Mangohud dependency status
  
            //locate MangoHud and store result in tmp folder
@@ -11,7 +11,7 @@ index 537491b..744f604 100644
  
            // Assign Text file dependency_mangohud to variable mangohudVAR
            AssignFile(mangohudVAR, '/tmp/goverlay/dependency_mangohud');
-@@ -5020,7 +5020,7 @@ begin
+@@ -5016,7 +5016,7 @@ begin
            CloseFile(mangohudVAR);
  
            // Read String and store value on mangohuddependencyVALUE based on result
@@ -20,7 +20,7 @@ index 537491b..744f604 100644
            mangohuddependencyVALUE := 1
            else
            mangohuddependencyVALUE := 0;
-@@ -5029,7 +5029,7 @@ begin
+@@ -5025,7 +5025,7 @@ begin
     //Determine vkBasalt dependency staus
  
             //locate vkBasalt and store result in tmp folder
@@ -29,7 +29,7 @@ index 537491b..744f604 100644
  
             // Assign Text file dependency_mangohud to variable mangohudVAR
             AssignFile(vkbasaltVAR, '/tmp/goverlay/dependency_vkbasalt');
-@@ -5038,7 +5038,7 @@ begin
+@@ -5034,7 +5034,7 @@ begin
             CloseFile(vkbasaltVAR);
  
             // Read String and store value on vkbasaltdependencyVALUE based on result

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5999,6 +5999,7 @@ with pkgs;
 
   goverlay = callPackage ../tools/graphics/goverlay {
     inherit (qt5) wrapQtAppsHook;
+    inherit (plasma5Packages) breeze-qt5;
   };
 
   gpart = callPackage ../tools/filesystems/gpart { };


### PR DESCRIPTION
###### Motivation for this change
Update to the latest version: https://github.com/benjamimgois/goverlay/releases/tag/0.7.1

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).