### PR TITLE
system-tray-extensions: init at 0.1

### DIFF
--- a/pkgs/os-specific/linux/linux-laptop-system-tray-extensions/default.nix
+++ b/pkgs/os-specific/linux/linux-laptop-system-tray-extensions/default.nix
@@ -1,0 +1,149 @@
+{ stdenv, fetchurl, lib, makeWrapper, xorg, writeText, qt5, libpulseaudio, python3Packages, fetchFromGitHub, makeDesktopItem }:
+let 
+  fetchPypi = python3Packages.fetchPypi;
+
+  soundcard = python3Packages.buildPythonPackage rec {
+    pname = "SoundCard";
+    version = "0.4.1";
+    
+    src = python3Packages.fetchPypi{
+      inherit version;
+      inherit pname;
+      sha256 = "1qmm3r1qi2hh42spc729fcxk0a3slywxw941vmjmaf400hd3ping";
+    };
+    preBuild = ''
+      export LD_LIBRARY_PATH=${libpulseaudio}/lib
+    '';
+    # It tries to create a folder in /home
+    doCheck = false;
+    buildInputs = [libpulseaudio] ++ (with python3Packages; [ numpy cffi ]);
+  };
+
+  ite8291r3_ctl = python3Packages.buildPythonPackage rec {
+    pname = "ite8291r3-ctl";
+    version = "0.3";
+    
+    src = python3Packages.fetchPypi{
+      inherit version;
+      inherit pname;
+      sha256 = "0clmpvaln8s7d47c9a4qfscfirhv5vizx0asiwvxwbsmii3mlr6q";
+    };
+
+    buildInputs = with python3Packages; [ pyusb ];
+  };
+
+  mss_patched = python3Packages.buildPythonPackage rec {
+    pname = "mss";
+    version = "6.1.0";
+    
+    src = python3Packages.fetchPypi{
+      inherit version;
+      inherit pname;
+      sha256 = "152kz83cwdk94gh8q1g11iqs8hpyf4blpymrqzlpyrh57sghdgdf";
+    };
+
+    # By default it attempts to build Windows-only functionality
+    prePatch = ''
+      rm mss/windows.py
+    '';
+    # See: https://discourse.nixos.org/t/screenshot-with-mss-in-python-says-no-x11-library/14534/4
+    postPatch = ''
+      sed -i 's|ctypes.util.find_library("X11")|"${xorg.libX11}/lib/libX11.so"|' mss/linux.py
+      sed -i 's|ctypes.util.find_library("Xrandr")|"${xorg.libXrandr}/lib/libXrandr.so"|' mss/linux.py
+    '';
+    # Skipping tests due to most relying on DISPLAY being set
+    pythonImportsCheck = [ "mss" ];
+  };
+
+  udevRules = writeText "udev-rules" ''
+    SUBSYSTEMS=="usb", ATTRS{idVendor}=="048d", ATTRS{idProduct}=="ce00", GROUP="leds", MODE:="0666"
+    SUBSYSTEMS=="usb", ATTRS{idVendor}=="048d", ATTRS{idProduct}=="6004", GROUP="leds", MODE:="0666"
+  '';
+
+  icon = fetchurl {
+    url = "https://raw.githubusercontent.com/salihmarangoz/system_tray_extensions/fc506f753df412d24650889cf9c7056ef480f6e2/icon.png";
+    sha256 = "16bfradr507qdb2vw1jkgagq73hqalja03v3k585z40s2jvh0vxr";
+  };
+
+  desktopItem = makeDesktopItem {
+    desktopName = "System Tray Extensions";
+    genericName = "STE";
+    categories = "Utility";
+    exec = "ste";
+    icon = icon;
+    name = "ste";
+    type = "Application";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "linux-laptop-system-tray-extensions";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "salihmarangoz";
+    repo = "system_tray_extensions";
+    rev = "fc506f753df412d24650889cf9c7056ef480f6e2";
+    sha256 = "00jqpa7q874b09q3yp4xclb63hf360b245a9nrhrs2fswqd9rb2c";
+  };
+
+  pythonPath = with python3Packages; [
+    pyqt5
+    numpy
+    pillow
+    opencv3
+    pygobject3
+    dbus-python
+    GitPython
+    psutil
+    matplotlib
+    scipy
+    wheel
+    pynput
+    pyusb
+    cffi
+    
+    # Custom-built packages
+    ite8291r3_ctl
+    soundcard
+    mss_patched
+  ];
+
+  nativeBuildInputs = [makeWrapper];
+  
+  patches = [
+    ./state.patch
+  ];
+
+  buildPhase = ''
+    # Just copy the source
+    prefix=$out/app
+    mkdir -p $prefix
+    cp -r . $prefix
+  '';
+
+  installPhase = ''
+    # Override the start script so it matches Nix's filesystem.
+    echo "python3 $prefix/app.py" > $prefix/start.sh
+    chmod a+x $prefix/start.sh
+    makeWrapper $prefix/start.sh $out/bin/ste \
+        --run "cd $prefix" \
+        --run "mkdir -p \$HOME/.local/ste" \
+        --prefix DYLD_LIBRARY_PATH : ${lib.makeLibraryPath [xorg.libX11]} \
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [xorg.libX11]} \
+        --prefix PYTHONPATH : ${python3Packages.makePythonPath pythonPath} \
+        --prefix QT_QPA_PLATFORM_PLUGIN_PATH : ${qt5.qtbase.bin}/lib/qt-*/plugins/platforms
+
+    mkdir -p $out/lib/udev/rules.d
+    cp ${udevRules} $out/lib/udev/rules.d/99-ite8291.rules
+    mkdir -p $out/share/applications
+    ln -s ${desktopItem}/share/applications/* $out/share/applications
+  '';
+
+  meta = with lib; {
+    description = "System tray toolbox for Linux laptops. Currently includes tools for contolling keyboard and lightbar leds but new functions will be added in the future";
+    homepage = "https://github.com/salihmarangoz/system_tray_extensions";
+    license = licenses.mit;
+    maintainers = with maintainers; [ peterwilli ];
+    platforms = platforms.linux;
+  };
+} 

--- a/pkgs/os-specific/linux/linux-laptop-system-tray-extensions/state.patch
+++ b/pkgs/os-specific/linux/linux-laptop-system-tray-extensions/state.patch
@@ -1,0 +1,11 @@
+--- a/modules/Core/main.py     2021-12-14 23:16:06.182256726 +0100
++++ b/modules/Core/main.py     2021-12-15 22:43:37.415008227 +0100
+@@ -178,7 +178,7 @@
+         self.exit_code = 0
+ 
+         # init state manager
+-        self.state_manager = StateManager(filename=self.project_path + "/state.json")
++        self.state_manager = StateManager(filename=os.path.expanduser("~") + "/.local/ste/state.json")
+ 
+         # init event manager and extras
+         self.core_event_queue = queue.Queue()

--- a/pkgs/os-specific/linux/linux-laptop-system-tray-extensions/state.patch
+++ b/pkgs/os-specific/linux/linux-laptop-system-tray-extensions/state.patch
@@ -5,7 +5,7 @@
  
          # init state manager
 -        self.state_manager = StateManager(filename=self.project_path + "/state.json")
-+        self.state_manager = StateManager(filename=os.path.expanduser("~") + "/.local/ste/state.json")
++        self.state_manager = StateManager(filename=os.getenv("XDG_STATE_HOME", os.path.expanduser("~") + "/.local/state") + "/ste/state.json")
  
          # init event manager and extras
          self.core_event_queue = queue.Queue()

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22219,6 +22219,8 @@ with pkgs;
 
   linuxConsoleTools = callPackage ../os-specific/linux/consoletools { };
 
+  linux-laptop-system-tray-extensions = callPackage ../os-specific/linux/linux-laptop-system-tray-extensions { };
+
   libreelec-dvb-firmware = callPackage ../os-specific/linux/firmware/libreelec-dvb-firmware { };
 
   openiscsi = callPackage ../os-specific/linux/open-iscsi { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I really like https://github.com/salihmarangoz/system_tray_extensions which is a project that allows you to set different visuals for RGB keyboards if you have a Linux laptop like Tuxedo.

This is my first "new" package to NixPkgs. Feedback is appreciated. Love to all!

**Tested on:**

 - Tuxedo Stellaris 15 (AMD Ryzen 9 5900HX - 32GB RAM - RTX 3080 16GB)

**How to use it:**

- Add this to your configuration.nix: `hardware.tuxedo-keyboard.enable = true;`
  - This loads the `ite8291r3` driver
- Add `linux-laptop-system-tray-extensions` to your packages in configuration.nix.
- Also set:
    ```nix
    services.udev.packages = with pkgs; [
        linux-laptop-system-tray-extensions
    ];
    ```
- To allow a non-root user to control the RGB, add them to the `leds` group:
    ```nix
    users.groups.leds = { };
    users.users.foo = {
        isNormalUser = true;
        description = "Foo";
        extraGroups = [ "leds" ];
    };
    ```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
