### PR TITLE
[Backport 21.11] qcelemental: 0.23.0 -> 0.24.0

### DIFF
--- a/pkgs/development/python-modules/qcelemental/default.nix
+++ b/pkgs/development/python-modules/qcelemental/default.nix
@@ -26,6 +26,8 @@ buildPythonPackage rec {
 
   doCheck = true;
 
+  disabledTestPaths = [ "qcelemental/tests/test_molparse_pubchem.py" ];
+
   meta = with lib; {
     description = "Periodic table, physical constants, and molecule parsing for quantum chemistry";
     homepage = "http://docs.qcarchive.molssi.org/projects/qcelemental/en/latest/";

--- a/pkgs/development/python-modules/qcelemental/default.nix
+++ b/pkgs/development/python-modules/qcelemental/default.nix
@@ -1,18 +1,28 @@
-{ buildPythonPackage, lib, fetchPypi, numpy
-, pydantic, pint,  networkx, pytest-runner, pytest-cov, pytest
+{ buildPythonPackage, lib, fetchPypi
+, networkx
+, numpy
+, pint
+, pydantic
+, pytestCheckHook
 } :
 
 buildPythonPackage rec {
   pname = "qcelemental";
-  version = "0.23.0";
-
-  checkInputs = [ pytest-runner pytest-cov pytest ];
-  propagatedBuildInputs = [ numpy pydantic pint networkx ];
+  version = "0.24.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "642bc86ce937621ddfb1291cbff0851be16b26feb5eec562296999e36181cee3";
+    sha256 = "sha256-XcsR89tu26EG5AcXqmndkESLGWZ8eKmTkjaLziosawE=";
   };
+
+  propagatedBuildInputs = [
+    numpy
+    pydantic
+    pint
+    networkx
+  ];
+
+  checkInputs = [ pytestCheckHook ];
 
   doCheck = true;
 
@@ -20,7 +30,6 @@ buildPythonPackage rec {
     description = "Periodic table, physical constants, and molecule parsing for quantum chemistry";
     homepage = "http://docs.qcarchive.molssi.org/projects/qcelemental/en/latest/";
     license = licenses.bsd3;
-    platforms = platforms.linux;
     maintainers = [ maintainers.sheepforce ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Non-breaking update of QCelemental, see [changelog](https://github.com/MolSSI/QCElemental/blob/master/docs/source/changelog.rst) and https://github.com/markuskowa/NixOS-QChem/issues/128

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
