### PR TITLE
kde-rounded-corners: init at 2021-11-06

### DIFF
--- a/pkgs/desktops/plasma-5/3rdparty/kwin/kde-rounded-corners.nix
+++ b/pkgs/desktops/plasma-5/3rdparty/kwin/kde-rounded-corners.nix
@@ -1,0 +1,49 @@
+{ pkgs, qtbase, qttools, qtx11extras, kconfig, kcoreaddons, ki18n,
+kio, kglobalaccel, kinit, kwin, xorg, libepoxy, lib }:
+
+{
+  kde-rounded-corner = pkgs.stdenv.mkDerivation {
+    pname = "kde-rounded-corners";
+    version = "2021-11-06";
+
+    src = pkgs.fetchFromGitHub {
+      owner = "matinlotfali";
+      repo = "KDE-Rounded-Corners";
+      rev = "8ad8f5f5eff9d1625abc57cb24dc484d51f0e1bd";
+      sha256 = "sha256-N6DBsmHGTmLTKNxqgg7bn06BmLM2fLdtFG2AJo+benU=";
+    };
+
+    dontWrapQtApps = true;
+
+    prePatch = ''
+      substituteInPlace CMakeLists.txt \
+        --replace $\{MODULEPATH} "$out/lib/qt-${qtbase.version}/plugins" \
+        --replace $\{DATAPATH} "$out/share"
+    '';
+    #for some reason, settings these in value in CMakeFlags doesn't work
+
+    nativeBuildInputs = [ pkgs.cmake pkgs.extra-cmake-modules ];
+
+    buildInputs = [
+      qtbase
+      qttools
+      qtx11extras
+      kconfig
+      kcoreaddons
+      ki18n
+      kio
+      kglobalaccel
+      kinit
+      kwin
+      xorg.libXdmcp
+      libepoxy
+    ];
+
+    meta = with lib; {
+      description = "Kwin effect making have rounded corners";
+      homepage = "https://github.com/matinlotfali/KDE-Rounded-Corners";
+      license = licenses.gpl3;
+      maintainers = [ maintainers.marius851000 ];
+    };
+  };
+}

--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -158,6 +158,7 @@ let
         plasma-applet-caffeine-plus = callPackage ./3rdparty/addons/caffeine-plus.nix { };
         plasma-applet-virtual-desktop-bar = callPackage ./3rdparty/addons/virtual-desktop-bar.nix { };
         bismuth = callPackage ./3rdparty/addons/bismuth { };
+        kde-rounded-corners = callPackage ./3rdparty/kwin/kde-rounded-corners.nix { };
         kwin-dynamic-workspaces = callPackage ./3rdparty/kwin/scripts/dynamic-workspaces.nix { };
         kwin-tiling = callPackage ./3rdparty/kwin/scripts/tiling.nix { };
         krohnkite = callPackage ./3rdparty/kwin/scripts/krohnkite.nix { };

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1228,6 +1228,7 @@ mapAliases ({
   inherit (plasma5Packages.thirdParty)
     plasma-applet-caffeine-plus
     plasma-applet-virtual-desktop-bar
+    kde-rounded-corners
     kwin-dynamic-workspaces
     kwin-tiling
     krohnkite


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Wished to add rounded corners to my KDE windows. This is the best KDE effect I found for this, but it needed compilation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [x] By using it
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Testing :
1.Option 1. Add this to ``environment.systemPackages``, reboot
1.Option 2. ``nix-shell -p kde-rounded-corners``, ``kwin_x11 --replace`` (untested)
2. windows should now be rounded. Can be configured in the effects list under the name ``ShapeCorners``