### PR TITLE
libosmium: 2.17.1 → 2.17.2

### DIFF
--- a/pkgs/development/libraries/libosmium/default.nix
+++ b/pkgs/development/libraries/libosmium/default.nix
@@ -1,19 +1,19 @@
-{ lib, stdenv, fetchFromGitHub, cmake, protozero, expat, zlib, bzip2, boost }:
+{ lib, stdenv, fetchFromGitHub, cmake, protozero, expat, zlib, bzip2, boost, lz4 }:
 
 stdenv.mkDerivation rec {
   pname = "libosmium";
-  version = "2.17.1";
+  version = "2.17.2";
 
   src = fetchFromGitHub {
     owner = "osmcode";
     repo = "libosmium";
     rev = "v${version}";
-    sha256 = "sha256-riNcIC60gw9qxF8UmPjq03XuD3of0BxKbZpgwjMNh3c=";
+    sha256 = "sha256-+WeEK7rWoUPAiAsgd5qT2bwDf+5IlP4uuyh7+i2L/HU=";
   };
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ protozero zlib bzip2 expat boost ];
+  buildInputs = [ protozero zlib bzip2 expat boost lz4 ];
 
   cmakeFlags = [ "-DINSTALL_GDALCPP:BOOL=ON" ];
 


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/osmcode/libosmium/releases/tag/v2.17.2)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
