### PR TITLE
pyscf: disable parts of test suite and aarch64

### DIFF
--- a/pkgs/development/python-modules/pyscf/default.nix
+++ b/pkgs/development/python-modules/pyscf/default.nix
@@ -104,7 +104,7 @@ buildPythonPackage rec {
     description = "Python-based simulations of chemistry framework";
     homepage = "https://github.com/pyscf/pyscf";
     license = licenses.asl20;
-    platforms = platforms.unix;
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
     maintainers = [ maintainers.sheepforce ];
   };
 }

--- a/pkgs/development/python-modules/pyscf/default.nix
+++ b/pkgs/development/python-modules/pyscf/default.nix
@@ -66,6 +66,7 @@ buildPythonPackage rec {
     nosetests pyscf/ -v \
       --exclude-dir=examples --exclude-dir=pyscf/pbc/grad \
       --exclude-dir=pyscf/x2c \
+      --exclude-dir=pyscf/adc \
       --exclude-dir=pyscf/pbc/tdscf \
       -e test_bz \
       -e h2o_vdz \


### PR DESCRIPTION
###### Motivation for this change
The PySCF package has some hardware-dependent numerical problems, that leads to faulty behaviour on at least AArch64. It works fine on x86-64, though. Also, build problems caused by too many open files have been observed. After all attempts in #144253 have not solved the problem, at least on Hydra, this PR disables the particular tests, that may cause the problem and also restricts the package to x86-64. [The problem has been reported upstream](https://github.com/pyscf/pyscf/issues/1123), but this is the currently feasible workaround. Note, that I could not reproduce any of the errors on my machines, and am therefore not able to ultimately test if this solves the problem entirely.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
