### PR TITLE
[21.11] mediawiki: 1.36.2 -> 1.36.3

### DIFF
--- a/pkgs/servers/web-apps/mediawiki/default.nix
+++ b/pkgs/servers/web-apps/mediawiki/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mediawiki";
-  version = "1.36.2";
+  version = "1.36.3";
 
   src = with lib; fetchurl {
     url = "https://releases.wikimedia.org/mediawiki/${versions.majorMinor version}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-xzV93phEnIY1E029gnkGYNcyWSywLL/zV0Nh3zn+4tQ=";
+    sha256 = "0a4bn34lwdc7nm8bnqcr0v3785gsfangizlkhfljlivysn3z4ds6";
   };
 
   prePatch = ''


### PR DESCRIPTION
###### Motivation for this change
Security update (fix #150689)

Edit: closing in favor of #150954

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).