### PR TITLE
terraform-providers.teleport: 7.3.0 -> 8.0.6

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/teleport/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/teleport/default.nix
@@ -1,16 +1,18 @@
-{ lib, fetchFromGitHub, buildGoModule }:
+{ lib, fetchFromGitHub, buildGoModule, teleport }:
 
 buildGoModule rec {
   pname = "terraform-provider-teleport";
-  version = "7.3.0";
+  version = "8.0.6";
 
   src = fetchFromGitHub {
     owner = "gravitational";
     repo = "teleport-plugins";
     rev = "v${version}";
-    sha256 = "19zn78nn64gc0nm7ycblzi4549a0asql07pfxvrphi6s9fjr5m3y";
+    sha256 = "1rhvpbw4dga256dp2cr5f912d2j7rh8pd1v88dlgq3mmw8n5c7vy";
   };
   vendorSha256 = null;
+
+  checkInputs = [ teleport ];
 
   sourceRoot = "source/terraform";
 
@@ -23,7 +25,7 @@ buildGoModule rec {
   passthru.provider-source-address = "gravitational.com/teleport/teleport";
 
   meta = with lib; {
-    description = "Provider for managing resources in Teleport, a SSH CA management suite";
+    description = "Provider for managing resources in Teleport access plane";
     homepage = "https://github.com/gravitational/teleport-plugins";
     license = licenses.asl20;
     maintainers = with maintainers; [ justinas ];


### PR DESCRIPTION
###### Motivation for this change

Corresponding to the new major version of Teleport proper. (#149085).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
