### PR TITLE
liquibase: add support for Amazon Redshift

### DIFF
--- a/pkgs/development/java-modules/liquibase_redshift_extension/default.nix
+++ b/pkgs/development/java-modules/liquibase_redshift_extension/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchMavenArtifact }:
+
+stdenv.mkDerivation rec {
+  pname = "liquibase-redshift-extension";
+  version = "4.8.0";
+
+  src = fetchMavenArtifact {
+    artifactId = "liquibase-redshift";
+    groupId = "org.liquibase.ext";
+    sha256 = "sha256-jZdDKAC4Cvmkih8VH84Z3Q8BzsqGO55Uefr8vOlbDAk=";
+    inherit version;
+  };
+
+  installPhase = ''
+    runHook preInstall
+    install -m444 -D $src/share/java/liquibase-redshift-${version}.jar $out/share/java/liquibase-redshift.jar
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/liquibase/liquibase-redshift/";
+    description = "Amazon Redshift extension for Liquibase";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ sir4ur0n ];
+  };
+}

--- a/pkgs/development/java-modules/redshift_jdbc/default.nix
+++ b/pkgs/development/java-modules/redshift_jdbc/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchMavenArtifact }:
+
+stdenv.mkDerivation rec {
+  pname = "redshift-jdbc";
+  version = "2.1.0.3";
+
+  src = fetchMavenArtifact {
+    artifactId = "redshift-jdbc42";
+    groupId = "com.amazon.redshift";
+    sha256 = "sha256-TO/JXh/pZ7tUZGfHqkzgZx18gLnISvnPVyGavzFv6vo=";
+    inherit version;
+  };
+
+  installPhase = ''
+    runHook preInstall
+    install -m444 -D $src/share/java/redshift-jdbc42-${version}.jar $out/share/java/redshift-jdbc42.jar
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/aws/amazon-redshift-jdbc-driver/";
+    description =
+      "JDBC 4.2 driver for Amazon Redshift allowing Java programs to connect to a Redshift database";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ sir4ur0n ];
+  };
+}

--- a/pkgs/development/tools/database/liquibase/default.nix
+++ b/pkgs/development/tools/database/liquibase/default.nix
@@ -1,11 +1,25 @@
-{ lib, stdenv, fetchurl, jre, makeWrapper
-, mysqlSupport ? true, mysql_jdbc
-, postgresqlSupport ? true, postgresql_jdbc }:
+{ lib
+, stdenv
+, fetchurl
+, jre
+, makeWrapper
+, mysqlSupport ? true
+, mysql_jdbc
+, postgresqlSupport ? true
+, postgresql_jdbc
+, redshiftSupport ? true
+, redshift_jdbc
+, liquibase_redshift_extension
+}:
 
 let
   extraJars =
     lib.optional mysqlSupport mysql_jdbc
-    ++ lib.optional postgresqlSupport postgresql_jdbc;
+    ++ lib.optional postgresqlSupport postgresql_jdbc
+    ++ lib.optionals redshiftSupport [
+      redshift_jdbc
+      liquibase_redshift_extension
+    ];
 in
 
 stdenv.mkDerivation rec {
@@ -30,7 +44,8 @@ stdenv.mkDerivation rec {
         CP="\$CP":"\$jar"
       done
     '';
-    in ''
+    in
+    ''
       mkdir -p $out
       mv ./{lib,licenses,liquibase.jar} $out/
 
@@ -54,7 +69,7 @@ stdenv.mkDerivation rec {
         liquibase.integration.commandline.Main \''${1+"\$@"}
       EOF
       chmod +x $out/bin/liquibase
-  '';
+    '';
 
   meta = with lib; {
     description = "Version Control for your database";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22281,6 +22281,8 @@ with pkgs;
 
   postgresqlTestHook = callPackage ../build-support/setup-hooks/postgresql-test-hook { };
 
+  redshift_jdbc = callPackage ../development/java-modules/redshift_jdbc { };
+
   prom2json = callPackage ../servers/monitoring/prometheus/prom2json.nix { };
   prometheus = callPackage ../servers/monitoring/prometheus { };
   prometheus-alertmanager = callPackage ../servers/monitoring/prometheus/alertmanager.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22283,6 +22283,8 @@ with pkgs;
 
   redshift_jdbc = callPackage ../development/java-modules/redshift_jdbc { };
 
+  liquibase_redshift_extension = callPackage ../development/java-modules/liquibase_redshift_extension { };
+
   prom2json = callPackage ../servers/monitoring/prometheus/prom2json.nix { };
   prometheus = callPackage ../servers/monitoring/prometheus { };
   prometheus-alertmanager = callPackage ../servers/monitoring/prometheus/alertmanager.nix { };


### PR DESCRIPTION
- [x] Prerequisite: https://github.com/NixOS/nixpkgs/pull/168177 is merged

The Liquibase package already provided PostgreSQL and MySQL support, this commit
also adds support for Amazon Redshift.

As per Liquibase Redshift documentation, 2 JARs must be added to the classpath:
* Redshift JDBC
* Liquibase Redshift extension JAR

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Without this, using Nixpkgs `liquibase` to interact with a Redshift database is inconvenient: manually download the JARs, copy and update the `liquibase` script to add those to the classpath, etc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
