### PR TITLE
haskellPackages.shellFor: fix value of NIX_GHC_DOCDIR

### DIFF
--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -45,7 +45,9 @@ let
                   else "$out/lib/${ghcCommand}-${ghc.version}";
   docDir        = "$out/share/doc/ghc/html";
   packageCfgDir = "${libDir}/package.conf.d";
-  paths         = lib.filter (x: x ? isHaskellLibrary) (lib.closePropagation packages);
+  paths'1         = lib.filter (x: x ? isHaskellLibrary) (lib.closePropagation packages);
+  paths'2 = map (x: x.doc or null) paths'1;
+  paths = lib.filter (x: x != null) (paths'1 ++ paths'2 ++ [ghc.doc]);
   hasLibraries  = lib.any (x: x.isHaskellLibrary) paths;
   # CLang is needed on Darwin for -fllvm to work:
   # https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/codegens.html#llvm-code-generator-fllvm


### PR DESCRIPTION
Before this commit it pointed to non-existent directory, now it points to GHC
user manual. What is more important, now $NIX_GHC_DOCDIR/../.. contains
documentation with all dependenices, one subdirectory for dependency.

Closes: #150666

Ping: @sterneseemann, @maralorn
