### PR TITLE
pythonPackages.ete3: init at 3.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2754,6 +2754,12 @@
     github = "delan";
     githubId = 465303;
   };
+  delehef = {
+    name = "Franklin Delehelle";
+    email = "nix@odena.eu";
+    github = "delehef";
+    githubId = 1153808;
+  };
   deliciouslytyped = {
     email = "47436522+deliciouslytyped@users.noreply.github.com";
     github = "deliciouslytyped";

--- a/pkgs/development/python-modules/ete3/default.nix
+++ b/pkgs/development/python-modules/ete3/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+, numpy
+, six
+, withTreeVisualization ? false
+, lxml
+, withXmlSupport ? false
+, pyqt4
+, pyqt5
+}:
+
+buildPythonPackage rec {
+  pname = "ete3";
+  version = "3.1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "4fc987b8c529889d6608fab1101f1455cb5cbd42722788de6aea9c7d0a8e59e9";
+  };
+
+
+  doCheck = false; # Tests are (i) not 3.x compatible, (ii) broken under 2.7
+  pythonImportsCheck = [ "ete3" ];
+
+  propagatedBuildInputs = [ six numpy ]
+    ++ lib.optional withTreeVisualization (if isPy3k then pyqt5 else pyqt4)
+    ++ lib.optional withXmlSupport lxml;
+
+  meta = with lib; {
+    description = "A Python framework for the analysis and visualization of trees";
+    homepage = "http://etetoolkit.org/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ delehef ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2560,6 +2560,8 @@ in {
 
   etcd = callPackage ../development/python-modules/etcd { };
 
+  ete3 = callPackage ../development/python-modules/ete3 { };
+
   etelemetry = callPackage ../development/python-modules/etelemetry { };
 
   etebase = callPackage ../development/python-modules/etebase {


### PR DESCRIPTION
###### Motivation for this change

The ETE toolkit is a reference python library for manipulation of phylogenetic trees in Newick or Phyloxml format.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? **No**
- [x] Tested **package tests are broken; tested with `pythonImportsCheck`**
- [x] Tested compilation of all packages that depend on this change **no packages depend on this change**
- [x] Tested basic functionality of all **library files**
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
