### PR TITLE
nixosTests.gnome: add autologin delay to catch GDM failures

### DIFF
--- a/nixos/tests/gnome.nix
+++ b/nixos/tests/gnome.nix
@@ -18,6 +18,8 @@ import ./make-test-python.nix ({ pkgs, lib, ...} : {
           enable = true;
           user = "alice";
         };
+        # Catch GDM failures that don't happen with AutomaticLoginEnable, e.g. https://github.com/NixOS/nixpkgs/issues/149539
+        gdm.autoLogin.delay = 1;
       };
 
       services.xserver.desktopManager.gnome.enable = true;


### PR DESCRIPTION
Add a 1 second delay to autologin for the `gnome` test, which would have caught #149539.

We still have a 0-delay autologin test in `gnome-xorg`, in case there's ever an issue that only arises with `AutomaticLoginEnable`.

The test times out on failure because it's waiting for a file to appear; is there a way to make it watch for failures *while* it waits?
