### PR TITLE
top-level/impure.nix: refactor by removing 'with builtins'

### DIFF
--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -1,14 +1,13 @@
 /* Impure default args for `pkgs/top-level/default.nix`. See that file
    for the meaning of each argument. */
 
-with builtins;
 
 let
 
   homeDir = builtins.getEnv "HOME";
 
   # Return ‘x’ if it evaluates, or ‘def’ if it throws an exception.
-  try = x: def: let res = tryEval x; in if res.success then res.value else def;
+  try = x: def: let res = builtins.tryEval x; in if res.success then res.value else def;
 
 in
 
@@ -25,20 +24,20 @@ in
 , # Fallback: The contents of the configuration file found at $NIXPKGS_CONFIG or
   # $HOME/.config/nixpkgs/config.nix.
   config ? let
-      configFile = getEnv "NIXPKGS_CONFIG";
+      configFile = builtins.getEnv "NIXPKGS_CONFIG";
       configFile2 = homeDir + "/.config/nixpkgs/config.nix";
       configFile3 = homeDir + "/.nixpkgs/config.nix"; # obsolete
     in
-      if configFile != "" && pathExists configFile then import configFile
-      else if homeDir != "" && pathExists configFile2 then import configFile2
-      else if homeDir != "" && pathExists configFile3 then import configFile3
+      if configFile != "" && builtins.pathExists configFile then import configFile
+      else if homeDir != "" && builtins.pathExists configFile2 then import configFile2
+      else if homeDir != "" && builtins.pathExists configFile3 then import configFile3
       else {}
 
 , # Overlays are used to extend Nixpkgs collection with additional
   # collections of packages.  These collection of packages are part of the
   # fix-point made by Nixpkgs.
   overlays ? let
-      isDir = path: pathExists (path + "/.");
+      isDir = path: builtins.pathExists (path + "/.");
       pathOverlays = try (toString <nixpkgs-overlays>) "";
       homeOverlaysFile = homeDir + "/.config/nixpkgs/overlays.nix";
       homeOverlaysDir = homeDir + "/.config/nixpkgs/overlays";
@@ -46,25 +45,25 @@ in
         # check if the path is a directory or a file
         if isDir path then
           # it's a directory, so the set of overlays from the directory, ordered lexicographically
-          let content = readDir path; in
+          let content = builtins.readDir path; in
           map (n: import (path + ("/" + n)))
-            (builtins.filter (n: builtins.match ".*\\.nix" n != null || pathExists (path + ("/" + n + "/default.nix")))
-              (attrNames content))
+            (builtins.filter (n: builtins.match ".*\\.nix" n != null || builtins.pathExists (path + ("/" + n + "/default.nix")))
+              (builtins.attrNames content))
         else
           # it's a file, so the result is the contents of the file itself
           import path;
     in
-      if pathOverlays != "" && pathExists pathOverlays then overlays pathOverlays
-      else if pathExists homeOverlaysFile && pathExists homeOverlaysDir then
+      if pathOverlays != "" && builtins.pathExists pathOverlays then overlays pathOverlays
+      else if builtins.pathExists homeOverlaysFile && builtins.pathExists homeOverlaysDir then
         throw ''
           Nixpkgs overlays can be specified with ${homeOverlaysFile} or ${homeOverlaysDir}, but not both.
           Please remove one of them and try again.
         ''
-      else if pathExists homeOverlaysFile then
+      else if builtins.pathExists homeOverlaysFile then
         if isDir homeOverlaysFile then
           throw (homeOverlaysFile + " should be a file")
         else overlays homeOverlaysFile
-      else if pathExists homeOverlaysDir then
+      else if builtins.pathExists homeOverlaysDir then
         if !(isDir homeOverlaysDir) then
           throw (homeOverlaysDir + " should be a directory")
         else overlays homeOverlaysDir


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

before `builtins.fn` and `fn` were mixed, now they are not mixed

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
