### PR TITLE
log4shell-detector: unstable-2021-12-15 -> unstable-2021-12-16

### DIFF
--- a/pkgs/tools/security/log4shell-detector/default.nix
+++ b/pkgs/tools/security/log4shell-detector/default.nix
@@ -5,15 +5,19 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "log4shell-detector";
-  version = "unstable-2021-12-15";
-  format = "other";
+  version = "unstable-2021-12-16";
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "Neo23x0";
     repo = pname;
-    rev = "66d974af40049c0cab7b0d7f988e5d705031f3af";
-    sha256 = "sha256-wKNJWbnDPY3+k7RwEjJws1h4nIqL22Dr2m88CbJZ/rg=";
+    rev = "622b88e7ea36819da23ce6ac090785cd6cca77f9";
+    sha256 = "sha256-N81x9hq473LfM+bQIQLWizCAsVc/pzyB84PV7/N5jk4=";
   };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    zstandard
+  ];
 
   checkInputs = with python3.pkgs; [
     pytestCheckHook
@@ -22,14 +26,15 @@ python3.pkgs.buildPythonApplication rec {
   installPhase = ''
     runHook preInstall
     install -vD ${pname}.py $out/bin/${pname}
+    install -vd $out/${python3.sitePackages}/
+    cp -R Log4ShellDetector $out/${python3.sitePackages}
     runHook postInstall
   '';
 
   meta = with lib; {
     description = "Detector for Log4Shell exploitation attempts";
     homepage = "https://github.com/Neo23x0/log4shell-detector";
-    # https://github.com/Neo23x0/log4shell-detector/issues/24
-    license = licenses.unfree;
+    license = licenses.mit;
     maintainers = with maintainers; [ fab ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to later code base.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
