### PR TITLE
sysdig: 0.27.1 -> 0.28.0

### DIFF
--- a/pkgs/os-specific/linux/sysdig/default.nix
+++ b/pkgs/os-specific/linux/sysdig/default.nix
@@ -4,6 +4,7 @@
 
 with lib;
 let
+  # Compare with https://github.com/draios/sysdig/blob/dev/cmake/modules/falcosecurity-libs.cmake
   libsRev = "2160111cd088aea9ae2235d3385ecb0b1ab6623c";
   libsSha256 = "sha256-TOuxXtrxujyAjzAtlX3/eCfM16mwxnmZ6Wg44SG0dTs=";
 in

--- a/pkgs/os-specific/linux/sysdig/default.nix
+++ b/pkgs/os-specific/linux/sysdig/default.nix
@@ -1,38 +1,40 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, kernel, installShellFiles
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, kernel, installShellFiles, pkg-config
 , luajit, ncurses, perl, jsoncpp, libb64, openssl, curl, jq, gcc, elfutils, tbb, protobuf, grpc
 }:
 
 with lib;
+let
+  libsRev = "2160111cd088aea9ae2235d3385ecb0b1ab6623c";
+  libsSha256 = "sha256-TOuxXtrxujyAjzAtlX3/eCfM16mwxnmZ6Wg44SG0dTs=";
+in
 stdenv.mkDerivation rec {
   pname = "sysdig";
-  version = "0.27.1";
+  version = "0.28.0";
 
   src = fetchFromGitHub {
     owner = "draios";
     repo = "sysdig";
     rev = version;
-    sha256 = "sha256-lYjMvxMIReANNwMr62u881Nugrs9piOaN3EmrvGzRns=";
+    sha256 = "sha256-oE3vCmOw+gcmvGqj7Xk5injpNC/YThckJMNg5XRFhME=";
   };
 
-  patches = [
-    # Fix pending upstream inclusion for ncurses-6.3 support:
-    #  https://github.com/draios/sysdig/pull/1810
-    (fetchpatch {
-      name = "ncurses-6.3.patch";
-      url = "https://github.com/draios/sysdig/commit/1e37fffe0337b8f8f8e0b5345db2f8631851c209.patch";
-      sha256 = "sha256-T+yC6iXQ3MY+ub0c+Hv+cC18PV8YlAOKB6YB1Hdm7Yc=";
-      # change 'a/userspace/sinspui' for 'a/userspace/libsinsp' to follow upstream rename.
-      stripLen = 3;
-      extraPrefix = "userspace/libsinsp/";
-    })
-  ];
-
-  nativeBuildInputs = [ cmake perl installShellFiles ];
+  nativeBuildInputs = [ cmake perl installShellFiles pkg-config ];
   buildInputs = [
     luajit ncurses jsoncpp libb64 openssl curl jq gcc elfutils tbb protobuf grpc
   ] ++ optionals (kernel != null) kernel.moduleBuildDependencies;
 
   hardeningDisable = [ "pic" ];
+
+  postUnpack = ''
+    cp -r ${fetchFromGitHub {
+      owner = "falcosecurity";
+      repo = "libs";
+      rev = libsRev;
+      sha256 = libsSha256;
+    }} libs
+    chmod -R +w libs
+    cmakeFlagsArray+=("-DFALCOSECURITY_LIBS_SOURCE_DIR=$(pwd)/libs")
+  '';
 
   cmakeFlags = [
     "-DUSE_BUNDLED_DEPS=OFF"
@@ -45,9 +47,8 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     cmakeFlagsArray+=(-DCMAKE_EXE_LINKER_FLAGS="-ltbb -lcurl -labsl_synchronization")
-
-    export INSTALL_MOD_PATH="$out"
   '' + optionalString (kernel != null) ''
+    export INSTALL_MOD_PATH="$out"
     export KERNELDIR="${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   '';
 
@@ -64,12 +65,12 @@ stdenv.mkDerivation rec {
       kernel_dev=${kernel.dev}
       kernel_dev=''${kernel_dev#/nix/store/}
       kernel_dev=''${kernel_dev%%-linux*dev*}
-      if test -f "$out/lib/modules/${kernel.modDirVersion}/extra/sysdig-probe.ko"; then
-          sed -i "s#$kernel_dev#................................#g" $out/lib/modules/${kernel.modDirVersion}/extra/sysdig-probe.ko
+      if test -f "$out/lib/modules/${kernel.modDirVersion}/extra/scap.ko"; then
+          sed -i "s#$kernel_dev#................................#g" $out/lib/modules/${kernel.modDirVersion}/extra/scap.ko
       else
-          xz -d $out/lib/modules/${kernel.modDirVersion}/extra/sysdig-probe.ko.xz
-          sed -i "s#$kernel_dev#................................#g" $out/lib/modules/${kernel.modDirVersion}/extra/sysdig-probe.ko
-          xz $out/lib/modules/${kernel.modDirVersion}/extra/sysdig-probe.ko
+          xz -d $out/lib/modules/${kernel.modDirVersion}/extra/scap.ko.xz
+          sed -i "s#$kernel_dev#................................#g" $out/lib/modules/${kernel.modDirVersion}/extra/scap.ko
+          xz $out/lib/modules/${kernel.modDirVersion}/extra/scap.ko
       fi
     '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
