### PR TITLE
clingcon: 3.3.0 -> 5.0.0

### DIFF
--- a/pkgs/applications/science/logic/potassco/clingcon.nix
+++ b/pkgs/applications/science/logic/potassco/clingcon.nix
@@ -1,39 +1,33 @@
 { lib, stdenv
 , fetchFromGitHub
 , cmake
-, bison
-, re2c
+, clingo
 }:
 
 stdenv.mkDerivation rec {
   pname = "clingcon";
-  version = "3.3.0";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "potassco";
     repo = pname;
     rev = "v${version}";
-    fetchSubmodules = true;
-    sha256 = "1q7517h10jfvjdk2czq8d6y57r8kr1j1jj2k2ip2qxkpyfigk4rs";
+    sha256 = "1g2xkz9nsgqnrw3fdf5jchl16f0skj5mm32va61scc2yrchll166";
    };
 
-  # deal with clingcon through git submodules recursively importing
-  # an outdated version of libpotassco which uses deprecated <xlocale.h> header in .cpp files
-  postPatch = ''
-    find ./ -type f -exec sed -i 's/<xlocale.h>/<locale.h>/g' {} \;
-  '';
-
-  nativeBuildInputs = [ cmake bison re2c ];
+  nativeBuildInputs = [ cmake clingo ];
 
   cmakeFlags = [
     "-DCLINGCON_MANAGE_RPATH=ON"
-    "-DCLINGO_BUILD_WITH_PYTHON=OFF"
-    "-DCLINGO_BUILD_WITH_LUA=OFF"
+    "-DPYCLINGCON_ENABLE=OFF"
+    "-DCLINGCON_BUILD_TESTS=ON"
   ];
+
+  doCheck = true;
 
   meta = {
     description = "Extension of clingo to handle constraints over integers";
-    license = lib.licenses.gpl3; # for now GPL3, next version MIT!
+    license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     homepage = "https://potassco.org/";
     downloadPage = "https://github.com/potassco/clingcon/releases/";


### PR DESCRIPTION
###### Motivation for this change

Package update

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Is `sandbox = true` set in `nix.conf`?
- [x] Tested, as applicable:
  - enabled cmake tests
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`
  - no packages depend on this package
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
    No changes need to be documented here, simple package update
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

pinging previous version reviewer's @doronbehar @7c6f434c in case they are interested