### PR TITLE
radicle-upstream: 0.2.10 -> 0.2.12

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/radicle-upstream/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/radicle-upstream/default.nix
@@ -2,17 +2,17 @@
 
 let
   pname = "radicle-upstream";
-  version = "0.2.10";
+  version = "0.2.12";
   name = "${pname}-${version}";
 
   srcs = {
     x86_64-linux = fetchurl {
       url = "https://releases.radicle.xyz/radicle-upstream-${version}.AppImage";
-      sha256 = "sha256-iZC7FzYaQsCoAq/soi5g2oo/Xd2PtZgO/wR8zDgN4Fk=";
+      sha256 = "7520c7feb94234df6f8523689d098e0d19510e2ac0122e482d1e01086c9b02fe";
     };
     x86_64-darwin = fetchurl {
       url = "https://releases.radicle.xyz/radicle-upstream-${version}.dmg";
-      sha256 = "sha256-gc5OrNu7t0VJrjLQO7+7TWvEj7D51WmMJfL/KQDMgvA=";
+      sha256 = "8bbff051f169f029044e4c4965cad88f48e939b945fd5c253f0c39665a19ce44";
     };
   };
   src = srcs.${stdenv.hostPlatform.system};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
