### PR TITLE
busybox: enable tests

### DIFF
--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -147,7 +147,41 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  doCheck = false; # tries to access the net
+  enableParallelChecking = false;
+  doCheck = true;
+  preCheck = ''
+    export SKIP_KNOWN_BUGS=1
+    export SKIP_INTERNET_TESTS=1
+
+    # tests rely on external tools we'd rather not depend on
+    rm testsuite/unzip.tests \
+      testsuite/hostname/hostname-works\
+      testsuite/hostname/hostname-s-works
+
+    # trips up on SIGPIPE issues from https://github.com/NixOS/nix/issues/2803
+    # resulting in a never-terminating `yes`
+    rm testsuite/md5sum.tests testsuite/sha*sum.tests
+
+    # build environment won't have /usr/bin and won't be able
+    # to create suid files
+    sed -i -e '/cpio -p with absolute paths/iSKIP=1;' \
+      -e '/cpio restores suid/iSKIP=1;' \
+      testsuite/cpio.tests
+
+    # won't work when our coreutils is also a multi-call-binary
+    sed -i '/start-stop-daemon with both -x and -a/iSKIP=1;' \
+      testsuite/start-stop-daemon.tests
+
+    # build environment won't have `ls` in the "default path" but
+    # should have `sh`
+    sed -i 's/\bls\b/sh/g' testsuite/which/which-uses-default-path
+
+    # help tests find tools in non-standard locations
+    substituteInPlace testsuite/date/date-works-1 \
+      --replace '/bin/date' "$(type -P date)"
+    substituteInPlace testsuite/pwd/pwd-prints-working-directory \
+      --replace '`which pwd`' "$(type -P pwd)"
+  '';
 
   meta = with lib; {
     description = "Tiny versions of common UNIX utilities in a single small executable";


### PR DESCRIPTION
###### Motivation for this change
~Note the draft nature of this PR.~ Disabling problematic test for now, see further down :point_down: https://github.com/NixOS/nixpkgs/pull/151035#issuecomment-1086638712

It doesn't look like there should be many obstacles to enabling the tests for busybox, and they mostly run fine - except they are currently stuck hanging on a test for the `md5sum` applet. In a line

```
text=`yes "$text" | head -c 9999`
```
@ https://github.com/mirror/busybox/blob/cb91a818c8f7730d8f3b30b5b4e75fd21496609f/testsuite/md5sum.tests#L29

**somehow** the `yes` process is having its `SIGPIPE` handler set to `SIG_IGN`, and therefore `head`'s early termination is not resulting in `yes` similarly terminating. Instead, because it ignores the `write` `EPIPE` return value (https://github.com/mirror/busybox/blob/cb91a818c8f7730d8f3b30b5b4e75fd21496609f/coreutils/yes.c#L46), it just continues forever attempting to continue writing.

Oh, and this only happens in the nix sandbox. Running through the build in a regular `nix-shell`, it behaves as expected. So it's painful to debug, too.

If anyone has any ideas what's going on here, I'd love to know. Otherwise I'll come back to this when I'm feeling cleverer.

(there are some other minor failures yet to be addressed that would require `date` and `hostname` to allow the tests to compare outputs, so I'll likely disable those tests to avoid adding the dependency)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
