### PR TITLE
EDA tools update

### DIFF
--- a/pkgs/development/compilers/nextpnr/default.nix
+++ b/pkgs/development/compilers/nextpnr/default.nix
@@ -14,15 +14,15 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "nextpnr";
-  version = "2021.11.24"; # tagged as 0.1, but we'll keep tracking HEAD
+  version = "2021.15.21";
 
   srcs = [
     (fetchFromGitHub {
-      owner  = "YosysHQ";
-      repo   = "nextpnr";
-      rev    = "fd2d4a8f999947ece42f791e19ddc4c2d8b823f2";
-      sha256 = "sha256-bGh3svJeVRJO0rTnSYoTndeQrTENx6j9t+GCGX4RX4k=";
-      name   = "nextpnr";
+      owner = "YosysHQ";
+      repo  = "nextpnr";
+      rev   = "d04cfd5f0f6da184f5b8a03f0ce18fbd1d98eca3";
+      hash  = "sha256-gm/+kwIZ/m10+KuCJoK45F56nKZD3tM0myHwbFKIKAs=";
+      name  = "nextpnr";
     })
     (fetchFromGitHub {
       owner  = "YosysHQ";

--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -34,13 +34,13 @@
 
 stdenv.mkDerivation rec {
   pname   = "yosys";
-  version = "0.11+52";
+  version = "0.12+36";
 
   src = fetchFromGitHub {
     owner = "YosysHQ";
     repo  = "yosys";
-    rev   = "2be110cb0ba645f95f62ee01b6a6fa46a85d5b26";
-    hash  = "sha256-A1QKu6SbtpJJPF8/LA5SMUP3/+n5giM6rOYdc6vkl90=";
+    rev   = "60c3ea367c942459a95e610ed98f277ce46c0142";
+    hash  = "sha256-NcfhNUmb3IDG08XgS+NGbRLI8sn4aQkOA7RF7wucDug=";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/embedded/fpga/trellis/default.nix
+++ b/pkgs/development/embedded/fpga/trellis/default.nix
@@ -1,25 +1,28 @@
 { lib, stdenv, fetchFromGitHub, python3, boost, cmake }:
 
 let
-  rev = "03e0070f263fbe31c247de61d259544722786210";
+  rev = "2f06397673bbca3da11928d538b8ab7d01c944c6";
   # git describe --tags
-  realVersion = "1.0-532-g${builtins.substring 0 7 rev}";
+  realVersion = "1.0-534-g${builtins.substring 0 7 rev}";
 in stdenv.mkDerivation rec {
   pname = "trellis";
-  version = "2021-09-01";
+  version = "2021-12-14";
 
   srcs = [
     (fetchFromGitHub {
        owner  = "YosysHQ";
        repo   = "prjtrellis";
        inherit rev;
-       sha256 = "joQMsjVj8d3M3IaqOkfVQ1I5qPDM8HHJiye+Ak8f3dg=";
+       hash   = "sha256-m5CalAIbzY2bhOvpBbPBeLZeDp+itk1HlRsSmtiddaA=";
        name   = "trellis";
      })
 
     (fetchFromGitHub {
       owner  = "YosysHQ";
       repo   = "prjtrellis-db";
+      # note: the upstream submodule points to revision 0ee729d20eaf,
+      # but that's just the tip of the branch that was merged into master.
+      # fdf4bf275a is the merge commit itself
       rev    = "fdf4bf275a7402654bc643db537173e2fbc86103";
       sha256 = "eDq2wU2pnfK9bOkEVZ07NQPv02Dc6iB+p5GTtVBiyQA=";
       name   = "trellis-database";


### PR DESCRIPTION
This includes some important bugfixes for Yosys I've been waiting on.

Apicula 1.0 was released this week too, but there's no update for that yet, since it's not yet on PyPI...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
