### PR TITLE
grammalecte: 0.6.5 -> 2.1.1

### DIFF
--- a/pkgs/development/python-modules/grammalecte/default.nix
+++ b/pkgs/development/python-modules/grammalecte/default.nix
@@ -7,23 +7,29 @@
 
 buildPythonPackage rec {
   pname = "grammalecte";
-  version = "0.6.5";
+  version = "2.1.1";
 
   src = fetchurl {
-    url = "http://www.dicollecte.org/grammalecte/zip/Grammalecte-fr-v${version}.zip";
-    sha256 = "11byjs3ggdhia5f4vyfqfvbbczsfqimll98h98g7hlsrm7vrifb0";
+    url = "https://grammalecte.net/grammalecte/zip/Grammalecte-fr-v${version}.zip";
+    sha256 = "076jv3ywdgqqzg92bfbagc7ypy08xjq5zn4vgna6j9350fkfqhzn";
   };
+
+  patchPhase = ''
+    runHook prePatch
+    substituteInPlace grammalecte-server.py --replace sys.version_info.major sys.version_info
+    runHook postPatch
+  '';
 
   propagatedBuildInputs = [ bottle ];
 
-  preBuild = "cd ..";
+  sourceRoot = ".";
 
   disabled = !isPy3k;
 
   meta = {
-    description = "Grammalecte is an open source grammar checker for the French language";
+    description = "An open source grammar and typographic corrector for the French language";
     homepage = "https://grammalecte.net";
-    license = with lib.licenses; [ gpl3 ];
+    license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ apeyroux ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The Grammalecte Python package had not been updated for a while, doing a big version bump.
I also fixed a few minor things in the package definition.
I added a trivial patch for an upstream bug.

CC maintainer @apeyroux 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).