### PR TITLE
gnome.epiphany: 41.0 → 41.2

### DIFF
--- a/pkgs/desktops/gnome/core/epiphany/default.nix
+++ b/pkgs/desktops/gnome/core/epiphany/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , meson
 , ninja
 , gettext
@@ -40,21 +41,14 @@
 
 stdenv.mkDerivation rec {
   pname = "epiphany";
-  version = "41.0";
+  version = "41.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "s50YJUkllbC3TF1qZoaoV/lBnfpMAvgBPCl7yHDibdA=";
+    sha256 = "Ud5KGB+nxKEs3DDMsWQ2ElwaFt+av44/pTP8gb8Q60w=";
   };
 
-  patches = [
-    # tab-view: Update close button position on startup
-    # https://gitlab.gnome.org/GNOME/epiphany/-/merge_requests/1025
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/epiphany/-/commit/6e9d6d3cf7fa7ddf21a70e9816a5cd4767a79523.patch";
-      sha256 = "sha256-lBVliGCIKwTvsYnWjAcmJxhTg1HS/2x4wlOh+4sx/xQ=";
-    })
-  ] ++ lib.optionals withPantheon [
+  patches = lib.optionals withPantheon [
     # Pantheon specific patches for epiphany
     # https://github.com/elementary/browser
     #


### PR DESCRIPTION
###### Motivation for this change

Diff: https://gitlab.gnome.org/GNOME/epiphany/-/compare/41.0...41.2
For pantheon.epiphany, there is no change in https://github.com/elementary/browser/



#### 41.1 - December 16, 2021 (https://ftp.gnome.org/pub/GNOME/sources/epiphany/41/epiphany-41.1.news)

 * Fix crash opening PDFs not loaded via HTTP (<a href="https://gitlab.gnome.org/GNOME/epiphany/issues/1611">#1611</a>)
 * Fix CVE-2021-45085, CVE-2021-45086, CVE-2021-45087, CVE-2021-45088 (<a href="https://gitlab.gnome.org/GNOME/epiphany/issues/1612">#1612</a>)
 * Fix web applications with non-Latin characters (<a href="https://gitlab.gnome.org/GNOME/epiphany/issues/1626">#1626</a>, <a href="https://gitlab.gnome.org/GNOME/epiphany/issues/1627">#1627</a>)
 * Fix close button position in Firefox Sync dialog (<a href="https://gitlab.gnome.org/GNOME/epiphany/issues/1647">#1647</a>)
 * Properly quote desktop file Exec line (<a href="https://gitlab.gnome.org/GNOME/epiphany/merge_requests/1013">!1013</a>, Martin Puppe)
 * Somewhat improve password manager robustness (<a href="https://gitlab.gnome.org/GNOME/epiphany/merge_requests/1014">!1014</a>)
 * Use correct tab close button position (<a href="https://gitlab.gnome.org/GNOME/epiphany/merge_requests/1025">!1025</a>)
 * Various fixes for Firefox bookmark import (<a href="https://gitlab.gnome.org/GNOME/epiphany/merge_requests/1036">!1036</a>)


#### 41.2 - December 16, 2021 (https://ftp.gnome.org/pub/GNOME/sources/epiphany/41/epiphany-41.2.news)

 * Fix reader mode (<a href="https://gitlab.gnome.org/GNOME/epiphany/merge_requests/1047">!1047</a>)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
