### PR TITLE
nixos: turn vmWithBootLoader into option (`nixos-rebuild build-vm`)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,8 +47,8 @@
                   system.nixos.revision = final.mkIf (self ? rev) self.rev;
 
                   system.build = {
-                    vm = config.virtualisation.vmVariant.system.build.vm;
-                    vmWithBootLoader = config.virtualisation.vmVariantWithBootLoader.system.build.vm;
+                    vm = lib.mkDefault config.virtualisation.vmVariant.system.build.vm;
+                    vmWithBootLoader = lib.mkDefault config.virtualisation.vmVariantWithBootLoader.system.build.vm;
                   };
                 })
               ];

--- a/flake.nix
+++ b/flake.nix
@@ -45,11 +45,6 @@
                   system.nixos.versionSuffix =
                     ".${final.substring 0 8 (self.lastModifiedDate or self.lastModified or "19700101")}.${self.shortRev or "dirty"}";
                   system.nixos.revision = final.mkIf (self ? rev) self.rev;
-
-                  system.build = {
-                    vm = lib.mkDefault config.virtualisation.vmVariant.system.build.vm;
-                    vmWithBootLoader = lib.mkDefault config.virtualisation.vmVariantWithBootLoader.system.build.vm;
-                  };
                 })
               ];
           });

--- a/flake.nix
+++ b/flake.nix
@@ -41,11 +41,11 @@
 
               in
               map addModuleDeclarationFile modules ++ [
-                ({ config, ... }: {
+                {
                   system.nixos.versionSuffix =
                     ".${final.substring 0 8 (self.lastModifiedDate or self.lastModified or "19700101")}.${self.shortRev or "dirty"}";
                   system.nixos.revision = final.mkIf (self ? rev) self.rev;
-                })
+                }
               ];
           });
       });

--- a/flake.nix
+++ b/flake.nix
@@ -22,24 +22,6 @@
           import ./nixos/lib/eval-config.nix (args // {
             modules =
               let
-                vmConfig = (import ./nixos/lib/eval-config.nix
-                  (args // {
-                    modules = modules ++ [ ./nixos/modules/virtualisation/qemu-vm.nix ];
-                  })).config;
-
-                vmWithBootLoaderConfig = (import ./nixos/lib/eval-config.nix
-                  (args // {
-                    modules = modules ++ [
-                      ./nixos/modules/virtualisation/qemu-vm.nix
-                      { virtualisation.useBootLoader = true; }
-                      ({ config, ... }: {
-                        virtualisation.useEFIBoot =
-                          config.boot.loader.systemd-boot.enable ||
-                          config.boot.loader.efi.canTouchEfiVariables;
-                      })
-                    ];
-                  })).config;
-
                 moduleDeclarationFile =
                   let
                     # Even though `modules` is a mandatory argument for `nixosSystem`, it doesn't
@@ -59,16 +41,16 @@
 
               in
               map addModuleDeclarationFile modules ++ [
-                {
+                ({ config, ... }: {
                   system.nixos.versionSuffix =
                     ".${final.substring 0 8 (self.lastModifiedDate or self.lastModified or "19700101")}.${self.shortRev or "dirty"}";
                   system.nixos.revision = final.mkIf (self ? rev) self.rev;
 
                   system.build = {
-                    vm = vmConfig.system.build.vm;
-                    vmWithBootLoader = vmWithBootLoaderConfig.system.build.vm;
+                    vm = config.virtualisation.vmVariant.system.build.vm;
+                    vmWithBootLoader = config.virtualisation.vmVariantWithBootLoader.system.build.vm;
                   };
-                }
+                })
               ];
           });
       });

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -16,7 +16,5 @@ in
 
   system = eval.config.system.build.toplevel;
 
-  vm = eval.config.virtualisation.vmVariant.system.build.vm;
-
-  vmWithBootLoader = eval.config.virtualisation.vmVariantWithBootLoader.system.build.vm;
+  inherit (eval.config.system.build) vm vmWithBootLoader;
 }

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -9,24 +9,6 @@ let
     modules = [ configuration ];
   };
 
-  # This is for `nixos-rebuild build-vm'.
-  vm = eval.extendModules {
-    modules = [ ./modules/virtualisation/qemu-vm.nix ];
-  };
-
-  # This is for `nixos-rebuild build-vm-with-bootloader'.
-  vmWithBootLoader = vm.extendModules {
-    modules = [
-      ({ config, ... }: {
-        _file = "nixos/default.nix##vmWithBootLoader";
-        virtualisation.useBootLoader = true;
-        virtualisation.useEFIBoot =
-          config.boot.loader.systemd-boot.enable ||
-          config.boot.loader.efi.canTouchEfiVariables;
-      })
-    ];
-  };
-
 in
 
 {
@@ -34,7 +16,7 @@ in
 
   system = eval.config.system.build.toplevel;
 
-  vm = vm.config.system.build.vm;
+  vm = eval.config.virtualisation.vmVariant.system.build.vm;
 
-  vmWithBootLoader = vmWithBootLoader.config.system.build.vm;
+  vmWithBootLoader = eval.config.virtualisation.vmVariantWithBootLoader.system.build.vm;
 }

--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -134,6 +134,28 @@
       </listitem>
       <listitem>
         <para>
+          The option
+          <link linkend="opt-virtualisation.vmVariant">virtualisation.vmVariant</link>
+          was added to allow users to make changes to the
+          <literal>nixos-rebuild build-vm</literal> configuration that
+          do not apply to their normal system.
+        </para>
+        <para>
+          The <literal>config.system.build.vm</literal> attribute now
+          always exists and defaults to the value from
+          <literal>vmVariant</literal>. Configurations that import the
+          <literal>virtualisation/qemu-vm.nix</literal> module
+          themselves will override this value, such that
+          <literal>vmVariant</literal> is not used.
+        </para>
+        <para>
+          Similarly
+          <link linkend="opt-virtualisation.vmVariantWithBootLoader">virtualisation.vmVariantWithBootloader</link>
+          was added.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The
           <literal>writers.writePyPy2</literal>/<literal>writers.writePyPy3</literal>
           and corresponding

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -57,4 +57,14 @@ In addition to numerous new and upgraded packages, this release has the followin
   to the members of the Unix group `redis-${serverName}`
   through the Unix socket `/run/redis-${serverName}/redis.sock`.
 
+- The option [virtualisation.vmVariant](#opt-virtualisation.vmVariant) was added
+  to allow users to make changes to the `nixos-rebuild build-vm` configuration
+  that do not apply to their normal system.
+
+  The `config.system.build.vm` attribute now always exists and  defaults to the
+  value from `vmVariant`. Configurations that import the `virtualisation/qemu-vm.nix`
+  module themselves will override this value, such that `vmVariant` is not used.
+
+  Similarly [virtualisation.vmVariantWithBootloader](#opt-virtualisation.vmVariantWithBootLoader) was added.
+
 - The `writers.writePyPy2`/`writers.writePyPy3` and corresponding `writers.writePyPy2Bin`/`writers.writePyPy3Bin` convenience functions to create executable Python 2/3 scripts using the PyPy interpreter were added.

--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -88,13 +88,8 @@ let
 
   nixosWithUserModules = noUserModules.extendModules { modules = allUserModules; };
 
-in withWarnings {
-
-  # Merge the option definitions in all modules, forming the full
-  # system configuration.
-  inherit (nixosWithUserModules) config options _module type extendModules;
-
+in
+withWarnings nixosWithUserModules // {
   inherit extraArgs;
-
   inherit (nixosWithUserModules._module.args) pkgs;
 }

--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -92,7 +92,7 @@ in withWarnings {
 
   # Merge the option definitions in all modules, forming the full
   # system configuration.
-  inherit (nixosWithUserModules) config options _module type;
+  inherit (nixosWithUserModules) config options _module type extendModules;
 
   inherit extraArgs;
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1179,6 +1179,7 @@
   ./tasks/powertop.nix
   ./testing/service-runner.nix
   ./virtualisation/anbox.nix
+  ./virtualisation/build-vm.nix
   ./virtualisation/container-config.nix
   ./virtualisation/containerd.nix
   ./virtualisation/containers.nix

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -148,7 +148,7 @@ in
     system.build = mkOption {
       internal = true;
       default = {};
-      type = types.attrs;
+      type = types.lazyAttrsOf types.unspecified;
       description = ''
         Attribute set of derivations used to setup the system.
       '';

--- a/nixos/modules/virtualisation/build-vm.nix
+++ b/nixos/modules/virtualisation/build-vm.nix
@@ -1,0 +1,46 @@
+{ extendModules, lib, ... }:
+let
+
+  inherit (lib)
+    mkOption
+    ;
+
+  vmVariant = extendModules {
+    modules = [ ./qemu-vm.nix ];
+  };
+
+  vmVariantWithBootLoader = vmVariant.extendModules {
+    modules = [
+      ({ config, ... }: {
+        _file = "nixos/default.nix##vmWithBootLoader";
+        virtualisation.useBootLoader = true;
+        virtualisation.useEFIBoot =
+          config.boot.loader.systemd-boot.enable ||
+          config.boot.loader.efi.canTouchEfiVariables;
+      })
+    ];
+  };
+in
+{
+  options = {
+
+    virtualisation.vmVariant = mkOption {
+      description = ''
+        Machine configuration to be added for the vm script produced by <literal>nixos-rebuild build-vm</literal>.
+      '';
+      inherit (vmVariant) type;
+      default = {};
+      visible = "shallow";
+    };
+
+    virtualisation.vmVariantWithBootLoader = mkOption {
+      description = ''
+        Machine configuration to be added for the vm script produced by <literal>nixos-rebuild build-vm-with-bootloader</literal>.
+      '';
+      inherit (vmVariantWithBootLoader) type;
+      default = {};
+      visible = "shallow";
+    };
+
+  };
+}

--- a/nixos/modules/virtualisation/build-vm.nix
+++ b/nixos/modules/virtualisation/build-vm.nix
@@ -1,4 +1,4 @@
-{ extendModules, lib, ... }:
+{ config, extendModules, lib, ... }:
 let
 
   inherit (lib)
@@ -40,6 +40,15 @@ in
       inherit (vmVariantWithBootLoader) type;
       default = {};
       visible = "shallow";
+    };
+
+  };
+
+  config = {
+
+    system.build = {
+      vm = lib.mkDefault config.virtualisation.vmVariant.system.build.vm;
+      vmWithBootLoader = lib.mkDefault config.virtualisation.vmVariantWithBootLoader.system.build.vm;
     };
 
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

 - Clean up by not repeating `evalModules` calls or `vm` definitions.
 - Allow users to affect the `nixos-rebuild build-vm` configuration directly, by setting configs in the new options.
 - Make the `vm` and `vmWithBootloader` attrs less special. These are now in regular config values.
 - Fix the type of `system.build`.

This is similar to https://github.com/NixOS/nixpkgs/pull/144094

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
