### PR TITLE
readline: default to readline81 instead of readline6

### DIFF
--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -24,7 +24,7 @@
 , vulkan-loader
 , webrtc-audio-processing
 , ncurses
-, readline81 # meson can't find <7 as those versions don't have a .pc file
+, readline # meson can't find <7 as those versions don't have a .pc file
 , lilv
 , makeFontsConf
 , callPackage
@@ -123,7 +123,7 @@ let
       libsndfile
       lilv
       ncurses
-      readline81
+      readline
       udev
       vulkan-headers
       vulkan-loader

--- a/pkgs/shells/bash/5.1.nix
+++ b/pkgs/shells/bash/5.1.nix
@@ -7,7 +7,7 @@
 
   # patch for cygwin requires readline support
 , interactive ? stdenv.isCygwin
-, readline81 ? null
+, readline ? null
 , withDocs ? false
 , texinfo ? null
 , forFHSEnv ? false
@@ -15,7 +15,7 @@
 
 with lib;
 
-assert interactive -> readline81 != null;
+assert interactive -> readline != null;
 assert withDocs -> texinfo != null;
 assert stdenv.hostPlatform.isDarwin -> binutils != null;
 let
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
     ++ optional withDocs texinfo
     ++ optional stdenv.hostPlatform.isDarwin binutils;
 
-  buildInputs = optional interactive readline81;
+  buildInputs = optional interactive readline;
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1009,7 +1009,7 @@ mapAliases ({
   rdmd = throw "'rdmd' has been renamed to/replaced by 'dtools'"; # Converted to throw 2022-02-22
   readline5 = throw "readline-5 is no longer supported in nixpkgs, please use 'readline' for main supported version"; # Added 2022-02-20
   readline62 = throw "readline-6.2 is no longer supported in nixpkgs, please use 'readline' for main supported version"; # Added 2022-02-20
-  readline80 = throw "readline-8.0 is no longer supported in nixpkgs, please use 'readline' for main supported version or 'readline81' for most recent version"; # Added 2021-04-22
+  readline80 = throw "readline-8.0 is no longer supported in nixpkgs, please use 'readline' for main supported version"; # Added 2021-04-22
   redkite = throw "redkite was archived by upstream"; # Added 2021-04-12
   redshift-wlr = throw "redshift-wlr has been replaced by gammastep"; # Added 2021-12-25
   renpy = throw "renpy has been removed from nixpkgs, it was unmaintained and the latest packaged version required python2"; # Added 2022-01-12

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16044,7 +16044,6 @@ with pkgs;
 
   gdb = callPackage ../development/tools/misc/gdb {
     guile = null;
-    readline = readline81;
   };
 
   java-language-server = callPackage ../development/tools/java/java-language-server { };
@@ -18785,9 +18784,7 @@ with pkgs;
     python = python3;
   };
 
-  libqalculate = callPackage ../development/libraries/libqalculate {
-    readline = readline81;
-  };
+  libqalculate = callPackage ../development/libraries/libqalculate { };
 
   libqt5pas = libsForQt5.callPackage ../development/compilers/fpc/libqt5pas.nix { };
 
@@ -19981,7 +19978,7 @@ with pkgs;
 
   raylib = callPackage ../development/libraries/raylib { };
 
-  readline = readline6;
+  readline = readline81;
   readline6 = readline63;
 
   readline63 = callPackage ../development/libraries/readline/6.3.nix { };


### PR DESCRIPTION
###### Motivation for this change

I see a tig crash aarch64-darwin when attempting to search by pressing `/`, and `rl_initialize` is in the backtrace. The crash doesn't occur with the current version of readline (8.1). There's a ticket for keeping default versions current (#40015), but I couldn't find much discussion of updating readline in particular outside of a [comment](https://github.com/NixOS/nixpkgs/issues/40015#issuecomment-661458522) on that thread.

So I'm being bold and proposing to update readline to its latest version.

<details>
<summary>backtrace of tig crash</summary>

```
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x9f4)
    frame #0: 0x00000001002ccc6c libreadline.6.3.dylib`_rl_init_terminal_io + 272
libreadline.6.3.dylib`_rl_init_terminal_io:
->  0x1002ccc6c <+272>: ldr    w8, [x22, #0x9f4]
    0x1002ccc70 <+276>: cmp    w8, #0x0                  ; =0x0
    0x1002ccc74 <+280>: b.gt   0x1002ccc88               ; <+300>
    0x1002ccc78 <+284>: mov    w8, #0x4f
Target 0: (.tig-wrapped) stopped.
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x9f4)
  * frame #0: 0x00000001002ccc6c libreadline.6.3.dylib`_rl_init_terminal_io + 272
    frame #1: 0x00000001002b7c2c libreadline.6.3.dylib`readline_initialize_everything + 164
    frame #2: 0x00000001002b6dd0 libreadline.6.3.dylib`rl_initialize + 44
    frame #3: 0x00000001002b6d48 libreadline.6.3.dylib`readline + 36
    frame #4: 0x0000000100017f58 .tig-wrapped`read_prompt + 80
    frame #5: 0x0000000100020c20 .tig-wrapped`search_view + 56
    frame #6: 0x00000001000077f8 .tig-wrapped`main + 2608
    frame #7: 0x00000001000bd0f4 dyld`start + 520
```

</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s) (Tested `bashInteractive`, `postgresql_13`, `tig`)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
