### PR TITLE
SDL_{image,net,mixer}: use pkg-config

### DIFF
--- a/pkgs/development/libraries/SDL_image/default.nix
+++ b/pkgs/development/libraries/SDL_image/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchpatch, SDL, libpng, libjpeg, libtiff, giflib, libXpm }:
+{ lib, stdenv, fetchurl, fetchpatch, SDL, libpng, libjpeg, libtiff, giflib, libXpm, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "SDL_image";
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
     "--disable-tif-shared"
   ] ++ lib.optional stdenv.isDarwin "--disable-sdltest";
 
+  nativeBuildInputs = [ pkg-config ];
   buildInputs = [ SDL libpng libjpeg libtiff giflib libXpm ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/SDL_mixer/default.nix
+++ b/pkgs/development/libraries/SDL_mixer/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl
 , SDL, libogg, libvorbis, smpeg, libmikmod
-, fluidsynth
+, fluidsynth, pkg-config
 , enableNativeMidi ? false
 }:
 
@@ -13,6 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "0alrhqgm40p4c92s26mimg9cm1y7rzr6m0p49687jxd9g6130i0n";
   };
 
+  nativeBuildInputs = [ pkg-config ];
   buildInputs = [ SDL libogg libvorbis fluidsynth smpeg libmikmod ];
 
   configureFlags = [ "--disable-music-ogg-shared" "--disable-music-mod-shared" ]

--- a/pkgs/development/libraries/SDL_net/default.nix
+++ b/pkgs/development/libraries/SDL_net/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, SDL }:
+{ lib, stdenv, fetchurl, SDL, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "SDL_net";
@@ -11,6 +11,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = lib.optional stdenv.isDarwin "--disable-sdltest";
 
+  nativeBuildInputs = [ pkg-config ];
   propagatedBuildInputs = [ SDL ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Without pkg-config, these packages will try to execute `sdl-config` to locate SDL, which failes when cross compiling.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
