### PR TITLE
Update zinit meta information to match source

### DIFF
--- a/pkgs/shells/zsh/zinit/default.nix
+++ b/pkgs/shells/zsh/zinit/default.nix
@@ -34,7 +34,7 @@ stdenvNoCC.mkDerivation rec {
   #TODO:doc output
 
   meta = with lib; {
-    homepage = "https://github.com/zdharma/zinit";
+    homepage = "https://github.com/zdharma-continuum/zinit";
     description = "Flexible zsh plugin manager";
     license = licenses.mit;
     maintainers = with maintainers; [ pasqui23 sei40kr ];


### PR DESCRIPTION
Trying again, purely meta data change.

Previous update to zinit (https://github.com/NixOS/nixpkgs/commit/4d539648017dc07618eabb3a369226e675efe85e) updated `fetchFromGitHub` location but not the homepage URL