### PR TITLE
powerdns-admin: 0.2.3 -> 0.2.4

### DIFF
--- a/pkgs/applications/networking/powerdns-admin/default.nix
+++ b/pkgs/applications/networking/powerdns-admin/default.nix
@@ -1,12 +1,12 @@
 { lib, stdenv, fetchFromGitHub, mkYarnPackage, nixosTests, writeText, python3 }:
 
 let
-  version = "0.2.3";
+  version = "0.2.4";
   src = fetchFromGitHub {
     owner = "ngoduykhanh";
     repo = "PowerDNS-Admin";
     rev = "v${version}";
-    sha256 = "16faz57d77mxkflkvwyi8gb9wvnq2vhw79b84v1fmqvxri1yaphw";
+    sha256 = "sha256-xJ0NNnDVwGl+t9q1INPhCxcTmQayYBYdjEG0PbPCI9E=";
   };
 
   python = python3.override {
@@ -22,7 +22,7 @@ let
   };
 
   pythonDeps = with python.pkgs; [
-    flask flask_assets flask_login flask_sqlalchemy flask_migrate flask-seasurf flask_mail flask-sslify
+    flask flask_assets flask_login flask_sqlalchemy flask_migrate flask-seasurf flask_mail flask-session flask-sslify
     mysqlclient psycopg2 sqlalchemy
     cffi configobj cryptography bcrypt requests ldap pyotp qrcode dnspython
     gunicorn python3-saml pyopenssl pytz cssmin jsmin authlib bravado-core
@@ -125,6 +125,6 @@ in stdenv.mkDerivation rec {
     description = "A PowerDNS web interface with advanced features";
     homepage = "https://github.com/ngoduykhanh/PowerDNS-Admin";
     license = licenses.mit;
-    maintainers = with maintainers; [ zhaofengli ];
+    maintainers = with maintainers; [ Flakebi zhaofengli ];
   };
 }

--- a/pkgs/applications/networking/powerdns-admin/package.json
+++ b/pkgs/applications/networking/powerdns-admin/package.json
@@ -12,5 +12,5 @@
     "multiselect": "^0.9.12"
   },
   "name": "powerdns-admin-assets",
-  "version": "0.2.3"
+  "version": "0.2.4"
 }

--- a/pkgs/applications/networking/powerdns-admin/yarndeps.nix
+++ b/pkgs/applications/networking/powerdns-admin/yarndeps.nix
@@ -114,11 +114,11 @@
       };
     }
     {
-      name = "bn.js___bn.js_4.11.9.tgz";
+      name = "bn.js___bn.js_4.12.0.tgz";
       path = fetchurl {
-        name = "bn.js___bn.js_4.11.9.tgz";
-        url  = "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.9.tgz";
-        sha1 = "26d556829458f9d1e81fc48952493d0ba3507828";
+        name = "bn.js___bn.js_4.12.0.tgz";
+        url  = "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz";
+        sha1 = "775b3f278efbb9718eec7361f483fb36fbbfea88";
       };
     }
     {
@@ -530,11 +530,11 @@
       };
     }
     {
-      name = "elliptic___elliptic_6.5.3.tgz";
+      name = "elliptic___elliptic_6.5.4.tgz";
       path = fetchurl {
-        name = "elliptic___elliptic_6.5.3.tgz";
-        url  = "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz";
-        sha1 = "cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6";
+        name = "elliptic___elliptic_6.5.4.tgz";
+        url  = "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz";
+        sha1 = "da37cebd31e79a1367e941b592ed1fbebd58abbb";
       };
     }
     {

--- a/pkgs/development/python-modules/flask-session/default.nix
+++ b/pkgs/development/python-modules/flask-session/default.nix
@@ -1,0 +1,27 @@
+{ lib, fetchPypi, buildPythonPackage, pytestCheckHook, flask, cachelib }:
+
+buildPythonPackage rec {
+  pname = "Flask-Session";
+  version = "0.4.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-ye1UMh+oxMoBMv/TNpWCdZ7aclL7SzvuSA5pDRukH0Y=";
+  };
+
+  propagatedBuildInputs = [ flask cachelib ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  # The rest of the tests require database servers and optional db connector dependencies
+  pytestFlagsArray = [ "-k" "'null_session or filesystem_session'" ];
+
+  pythonImportsCheck = [ "flask_session" ];
+
+  meta = with lib; {
+    description = "A Flask extension that adds support for server-side sessions";
+    homepage = "https://github.com/fengsp/flask-session";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ zhaofengli ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2877,6 +2877,8 @@ in {
 
   flask-seasurf = callPackage ../development/python-modules/flask-seasurf { };
 
+  flask-session = callPackage ../development/python-modules/flask-session { };
+
   flask-silk = callPackage ../development/python-modules/flask-silk { };
 
   flask-socketio = callPackage ../development/python-modules/flask-socketio { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Sadly the dnspython pin still needs to stay.

@Flakebi Would you like to be added to the maintainer list? It could really use more maintainers if you don't mind the pings :smile:

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
