### PR TITLE
python310: doesn't need ctypes.util.find_library() patch

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -240,6 +240,7 @@ in with passthru; stdenv.mkDerivation {
   ] ++ optionals (pythonAtLeast "3.9" && stdenv.isDarwin) [
     # Stop checking for TCL/TK in global macOS locations
     ./3.9/darwin-tcl-tk.patch
+  ] ++ optionals (isPy39 && stdenv.isDarwin) [
     # ctypes.util.find_library() now finds macOS 11+ system libraries when built on older macOS systems
     # https://github.com/python/cpython/pull/28053
     ./3.9/bpo-44689-ctypes.util.find_library-now-finds-macOS-1.patch


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This patch is only needed on Python 3.9 version, as it is included in
3.10.0 release.

Without the patch, python310 fails to build:

```
❯ nix-build . -A python310
these derivations will be built:
  /nix/store/l9sk78d57pxcgf3bjnda0qx2z3f1svx0-python3-3.10.0.drv
building '/nix/store/l9sk78d57pxcgf3bjnda0qx2z3f1svx0-python3-3.10.0.drv'...
unpacking sources
unpacking source archive /nix/store/vqkygvlylaml6wzwhcxklnmhhj7fjlaq-Python-3.10.0.tar.xz
source root is Python-3.10.0
setting SOURCE_DATE_EPOCH to timestamp 1633370155 of file Python-3.10.0/Misc/NEWS
patching sources
applying patch /nix/store/345r2zz7pgiyk91j89qlf7mhs95jrv6f-no-ldconfig.patch
patching file Lib/ctypes/util.py
applying patch /nix/store/r112dk8w7zvdjipki58ch00m825li7fq-virtualenv-permissions.patch
patching file Lib/venv/__init__.py
Hunk #1 succeeded at 388 with fuzz 2 (offset 9 lines).
applying patch /nix/store/lpfs02z2i2hamz9f50p4bz6v0fs0600j-mimetypes.patch
patching file Lib/mimetypes.py
Hunk #1 succeeded at 46 (offset 6 lines).
applying patch /nix/store/dkb2rjyj7lwmvsn4zzwx85kx8r61nk9w-darwin-libutil.patch
patching file Modules/posixmodule.c
Hunk #1 succeeded at 7195 (offset 1315 lines).
applying patch /nix/store/x6aiw4vay2b63slqz5byimn0alhg5b1s-darwin-tcl-tk.patch
patching file setup.py
Hunk #1 succeeded at 2094 (offset 113 lines).
applying patch /nix/store/xid1jwdpp3zvg7a9zl41snb9hgvam1w3-bpo-44689-ctypes.util.find_library-now-finds-macOS-1.patch
patching file Misc/NEWS.d/next/macOS/2021-07-20-22-27-01.bpo-44689.mmT_xH.rst
patching file Modules/_ctypes/callproc.c
Reversed (or previously applied) patch detected!  Assume -R? [n]
Apply anyway? [n]
Skipping patch.
2 out of 2 hunks ignored -- saving rejects to file Modules/_ctypes/callproc.c.rej
builder for '/nix/store/l9sk78d57pxcgf3bjnda0qx2z3f1svx0-python3-3.10.0.drv' failed with exit code 1
error: build of '/nix/store/l9sk78d57pxcgf3bjnda0qx2z3f1svx0-python3-3.10.0.drv' failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
