### PR TITLE
nixos/stage1: shellcheck fixes

### DIFF
--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -54,9 +54,9 @@ EOF
 
     read -r -n 1 reply
 
-    if [ -n "$allowShell" -a "$reply" = f ]; then
+    if [[ -n "$allowShell" && "$reply" = "f" ]]; then
         exec setsid @shell@ -c "exec @shell@ < /dev/$console >/dev/$console 2>/dev/$console"
-    elif [ -n "$allowShell" -a "$reply" = i ]; then
+    elif [[ -n "$allowShell" && "$reply" = "i" ]]; then
         echo "Starting interactive shell..."
         setsid @shell@ -c "exec @shell@ < /dev/$console >/dev/$console 2>/dev/$console" || fail
     elif [ "$reply" = r ]; then
@@ -291,10 +291,10 @@ checkFS() {
     if [ ! -b "$device" ]; then return 0; fi
 
     # Don't check ROM filesystems.
-    if [ "$fsType" = iso9660 -o "$fsType" = udf ]; then return 0; fi
+    if [[ "$fsType" = "iso9660" || "$fsType" = "udf" ]]; then return 0; fi
 
     # Don't check resilient COWs as they validate the fs structures at mount time
-    if [ "$fsType" = btrfs -o "$fsType" = zfs -o "$fsType" = bcachefs ]; then return 0; fi
+    if [[ "$fsType" = "btrfs" || "$fsType" = "zfs" || "$fsType" = "bcachefs" ]]; then return 0; fi
 
     # Skip fsck for nilfs2 - not needed by design and no fsck tool for this filesystem.
     if [ "$fsType" = nilfs2 ]; then return 0; fi
@@ -386,7 +386,7 @@ mountFS() {
     # Optionally resize the filesystem.
     case $options in
         *x-nixos.autoresize*)
-            if [ "$fsType" = ext2 -o "$fsType" = ext3 -o "$fsType" = ext4 ]; then
+            if [[ "$fsType" = ext2 || "$fsType" = ext3 || "$fsType" = ext4 ]]; then
                 modprobe "$fsType"
                 echo "resizing $device..."
                 e2fsck -fp "$device"
@@ -416,7 +416,7 @@ mountFS() {
     local n=0
     while true; do
         mount "/mnt-root$mountPoint" && break
-        if [ \( "$fsType" != cifs -a "$fsType" != zfs \) -o "$n" -ge 10 ]; then fail; break; fi
+        if [[ "$fsType" != "cifs" && "$fsType" != "zfs" || "$n" -ge 10 ]]; then fail; break; fi
         echo "retrying..."
         sleep 1
         n=$((n + 1))
@@ -600,7 +600,7 @@ if [ -e /mnt-root/iso ]; then
 else
     eval "$(udevadm info --export --export-prefix=ROOT_ --device-id-of-file=$targetRoot)"
 fi
-if [ "$ROOT_MAJOR" -a "$ROOT_MINOR" -a "$ROOT_MAJOR" != 0 ]; then
+if [[ "$ROOT_MAJOR" && "$ROOT_MINOR" && "$ROOT_MAJOR" != 0 ]]; then
     mkdir -p /run/udev/rules.d
     # shellcheck disable=SC2086
     echo 'ACTION=="add|change", SUBSYSTEM=="block", ENV{MAJOR}=="'$ROOT_MAJOR'", ENV{MINOR}=="'$ROOT_MINOR'", SYMLINK+="root"' > /run/udev/rules.d/61-dev-root-link.rules

--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -1,4 +1,5 @@
 #! @shell@
+# shellcheck shell=bash
 
 targetRoot=/mnt-root
 console=tty1
@@ -51,7 +52,7 @@ EOF
   *) to ignore the error and continue
 EOF
 
-    read -n 1 reply
+    read -r -n 1 reply
 
     if [ -n "$allowShell" -a "$reply" = f ]; then
         exec setsid @shell@ -c "exec @shell@ < /dev/$console >/dev/$console 2>/dev/$console"
@@ -449,7 +450,7 @@ lustrateRoot () {
 
     echo
     echo "Restoring selected impurities:"
-    while read -u 4 keeper; do
+    while read -r -u 4 keeper; do
         dirname="$(dirname "$keeper")"
         mkdir -m 0755 -p "$root/$dirname"
         cp -av "$root/old-root/$keeper" "$root/$keeper"
@@ -513,10 +514,10 @@ mkdir -p $targetRoot
 
 exec 3< @fsInfo@
 
-while read -u 3 mountPoint; do
-    read -u 3 device
-    read -u 3 fsType
-    read -u 3 options
+while read  -r -u 3 mountPoint; do
+    read -r -u 3 device
+    read -r -u 3 fsType
+    read -r -u 3 options
 
     # !!! Really quick hack to support bind mounts, i.e., where the
     # "device" should be taken relative to /mnt-root, not /.  Assume

--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -19,6 +19,7 @@ ln -s @extraUtils@/bin /bin
 
 # Copy the secrets to their needed location
 if [ -d "@extraUtils@/secrets" ]; then
+    # shellcheck disable=SC2043
     for secret in $(cd "@extraUtils@/secrets"; find . -type f); do
         mkdir -p "$(dirname "/$secret")"
         ln -s "@extraUtils@/secrets/$secret" "$secret"
@@ -239,6 +240,7 @@ mkdir -p /lib
 ln -s @modulesClosure@/lib/modules /lib/modules
 ln -s @modulesClosure@/lib/firmware /lib/firmware
 echo @extraUtils@/bin/modprobe > /proc/sys/kernel/modprobe
+# shellcheck disable=SC2043
 for i in @kernelModules@; do
     info "loading module $(basename $i)..."
     modprobe $i
@@ -472,6 +474,7 @@ lustrateRoot () {
 
 
 if test -e /sys/power/resume -a -e /sys/power/disk; then
+    # shellcheck disable=SC2043
     if test -n "@resumeDevice@" && waitDevice "@resumeDevice@"; then
         resumeDev="@resumeDevice@"
         resumeInfo="$(udevadm info -q property "$resumeDev" )"

--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -1,5 +1,6 @@
 #! @shell@
-# shellcheck shell=bash
+# shellcheck shell=bash disable=SC2174
+# SC2174 warning: When used with (mkdir) -p, -m only applies to the deepest directory.
 
 targetRoot=/mnt-root
 console=tty1

--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -377,10 +377,11 @@ mountFS() {
         if [ -z "$fsType" ]; then fsType=auto; fi
     fi
 
+    local optionsFiltered optionsPrefixed
     # Filter out x- options, which busybox doesn't do yet. https://www.mail-archive.com/busybox@busybox.net/msg27642.html
-    local optionsFiltered="$(IFS=,; for i in $options; do if [ "${i:0:2}" != "x-" ]; then echo -n "$i,"; fi; done)"
+    optionsFiltered="$(IFS=,; for i in $options; do if [ "${i:0:2}" != "x-" ]; then echo -n "$i,"; fi; done)"
     # Prefix (lower|upper|work)dir with /mnt-root (overlayfs)
-    local optionsPrefixed="$( echo "$optionsFiltered" | sed -E 's#\<(lowerdir|upperdir|workdir)=#\1=/mnt-root#g' )"
+    optionsPrefixed="$( echo "$optionsFiltered" | sed -E 's#\<(lowerdir|upperdir|workdir)=#\1=/mnt-root#g' )"
 
     echo "$device /mnt-root$mountPoint $fsType $optionsPrefixed" >> /etc/fstab
 

--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -90,7 +90,7 @@ waitDevice() {
     # great if we had a way to synchronously wait for them, but
     # alas...  So just wait for a few seconds for the device to
     # appear.
-    if test ! -e $device; then
+    if test ! -e "$device"; then
         echo -n "waiting for device $device to appear..."
         try=20
         while [ $try -gt 0 ]; do
@@ -99,7 +99,7 @@ waitDevice() {
             lvm vgchange -ay
             # and tell udev to create nodes for the new LVs
             udevadm trigger --action=add
-            if test -e $device; then break; fi
+            if test -e "$device"; then break; fi
             echo -n "."
             try=$((try - 1))
         done
@@ -207,9 +207,9 @@ for o in $(cat /proc/cmdline); do
             # Recognise LABEL= and UUID= to support UNetbootin.
             # shellcheck disable=SC2046,SC2086
             set -- $(IFS==; echo $o)
-            if [ $2 = "LABEL" ]; then
+            if [ "$2" = "LABEL" ]; then
                 root="/dev/disk/by-label/$3"
-            elif [ $2 = "UUID" ]; then
+            elif [ "$2" = "UUID" ]; then
                 root="/dev/disk/by-uuid/$3"
             else
                 root=$2
@@ -375,7 +375,7 @@ mountFS() {
     fi
 
     # Filter out x- options, which busybox doesn't do yet.
-    local optionsFiltered="$(IFS=,; for i in $options; do if [ "${i:0:2}" != "x-" ]; then echo -n $i,; fi; done)"
+    local optionsFiltered="$(IFS=,; for i in $options; do if [ "${i:0:2}" != "x-" ]; then echo -n "$i,"; fi; done)"
     # Prefix (lower|upper|work)dir with /mnt-root (overlayfs)
     local optionsPrefixed="$( echo "$optionsFiltered" | sed -E 's#\<(lowerdir|upperdir|workdir)=#\1=/mnt-root#g' )"
 
@@ -602,6 +602,7 @@ else
 fi
 if [ "$ROOT_MAJOR" -a "$ROOT_MINOR" -a "$ROOT_MAJOR" != 0 ]; then
     mkdir -p /run/udev/rules.d
+    # shellcheck disable=SC2086
     echo 'ACTION=="add|change", SUBSYSTEM=="block", ENV{MAJOR}=="'$ROOT_MAJOR'", ENV{MINOR}=="'$ROOT_MINOR'", SYMLINK+="root"' > /run/udev/rules.d/61-dev-root-link.rules
 fi
 
@@ -624,7 +625,7 @@ for pid in $(pgrep -v -f '^@'); do
     # http://stackoverflow.com/questions/12213445/identifying-kernel-threads
     readlink "/proc/$pid/exe" &> /dev/null || continue
     # Try to avoid killing ourselves.
-    [ $pid -eq $$ ] && continue
+    [ "$pid" -eq $$ ] && continue
     kill -9 "$pid"
 done
 

--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -157,25 +157,25 @@ for o in $(cat /proc/cmdline); do
     # switch_root: can't execute '': No such file or directory
     case $o in
         console=*)
-            # shellcheck disable=SC2046,SC2086
+            # shellcheck disable=SC2046,SC2086,SC1097
             set -- $(IFS==; echo $o)
             params=$2
-            # shellcheck disable=SC2046,SC2086
+            # shellcheck disable=SC2046,SC2086,SC1097
             set -- $(IFS=,; echo $params)
             console=$1
             ;;
         init=*)
-            # shellcheck disable=SC2046,SC2086
+            # shellcheck disable=SC2046,SC2086,SC1097
             set -- $(IFS==; echo $o)
             stage2Init=$2
             ;;
         boot.persistence=*)
-            # shellcheck disable=SC2046,SC2086
+            # shellcheck disable=SC2046,SC2086,SC1097
             set -- $(IFS==; echo $o)
             persistence=$2
             ;;
         boot.persistence.opt=*)
-            # shellcheck disable=SC2046,SC2086
+            # shellcheck disable=SC2046,SC2086,SC1097
             set -- $(IFS==; echo $o)
             persistence_opt=$2
             ;;
@@ -205,7 +205,7 @@ for o in $(cat /proc/cmdline); do
             # If a root device is specified on the kernel command
             # line, make it available through the symlink /dev/root.
             # Recognise LABEL= and UUID= to support UNetbootin.
-            # shellcheck disable=SC2046,SC2086
+            # shellcheck disable=SC2046,SC2086,SC1097
             set -- $(IFS==; echo $o)
             if [ "$2" = "LABEL" ]; then
                 root="/dev/disk/by-label/$3"
@@ -222,7 +222,7 @@ for o in $(cat /proc/cmdline); do
         findiso=*)
             # if an iso name is supplied, try to find the device where
             # the iso resides on
-            # shellcheck disable=SC2046,SC2086
+            # shellcheck disable=SC2046,SC2086,SC1097
             set -- $(IFS==; echo $o)
             isoPath=$2
             ;;

--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -374,7 +374,7 @@ mountFS() {
         if [ -z "$fsType" ]; then fsType=auto; fi
     fi
 
-    # Filter out x- options, which busybox doesn't do yet.
+    # Filter out x- options, which busybox doesn't do yet. https://www.mail-archive.com/busybox@busybox.net/msg27642.html
     local optionsFiltered="$(IFS=,; for i in $options; do if [ "${i:0:2}" != "x-" ]; then echo -n "$i,"; fi; done)"
     # Prefix (lower|upper|work)dir with /mnt-root (overlayfs)
     local optionsPrefixed="$( echo "$optionsFiltered" | sed -E 's#\<(lowerdir|upperdir|workdir)=#\1=/mnt-root#g' )"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

@l0b0 
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
