### PR TITLE
oven-media-engine: 0.10.9-hotfix -> 0.12.9

### DIFF
--- a/pkgs/servers/misc/oven-media-engine/default.nix
+++ b/pkgs/servers/misc/oven-media-engine/default.nix
@@ -6,53 +6,34 @@
 , bc
 , pkg-config
 , perl
-, openssl
+, openssl_3_0
 , zlib
 , ffmpeg
 , libvpx
 , libopus
+, libuuid
 , srtp
 , jemalloc
 , pcre2
 }:
 
-let
-  ffmpeg = ffmpeg_3_4.overrideAttrs (super: {
-    pname = "${super.pname}-ovenmediaengine";
-    src = fetchFromGitHub {
-      owner = "Airensoft";
-      repo = "FFmpeg";
-      rev = "142b4bb64b64e337f80066e6af935a68627fedae";  # on branch ome/3.4
-      sha256 = "0fla3940q3z0c0ik2xzkbvdfvrdg06ban7wi6y94y8mcipszpp11";
-    };
-  });
-in
 stdenv.mkDerivation rec {
   pname = "oven-media-engine";
-  version = "0.10.9-hotfix";
+  version = "0.12.9";
 
   src = fetchFromGitHub {
     owner = "AirenSoft";
     repo = "OvenMediaEngine";
     rev = "v${version}";
-    sha256 = "1fhria0vwqsgmsglv5gn858li33vfy2dwy1f1qdd2jwikskb53am";
+    sha256 = "0d3ymw747frl40w5d6r33lf1s72v7fiv742yjr1m6la2phb9h834";
   };
-
-  patches = [
-    (fetchpatch {
-      # Needed to fix compilation under GCC 10.
-      url = "https://github.com/AirenSoft/OvenMediaEngine/commit/ad83e1d2226445d649e4b7e0c75106e31af4940d.patch";
-      sha256 = "1zk1rgi1wsjl6gdx3hdmgxlgindv6a3lsnkwcgi87ga9abw4vafw";
-      stripLen = 1;
-    })
-  ];
 
   sourceRoot = "source/src";
   makeFlags = "release CONFIG_LIBRARY_PATHS= CONFIG_PKG_PATHS= GLOBAL_CC=$(CC) GLOBAL_CXX=$(CXX) GLOBAL_LD=$(CXX) SHELL=${stdenv.shell}";
   enableParallelBuilding = true;
 
   nativeBuildInputs = [ bc pkg-config perl ];
-  buildInputs = [ openssl srt zlib ffmpeg libvpx libopus srtp jemalloc pcre2 ];
+  buildInputs = [ openssl_3_0 srt zlib ffmpeg libvpx libopus srtp jemalloc pcre2 libuuid ];
 
   preBuild = ''
     patchShebangs core/colorg++


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
