### PR TITLE
llvmPackages.libcxx: unset _LIBCPP_USE_AVAILABILITY_APPLE

### DIFF
--- a/pkgs/applications/graphics/darktable/default.nix
+++ b/pkgs/applications/graphics/darktable/default.nix
@@ -27,9 +27,6 @@ stdenv.mkDerivation rec {
   ] ++ lib.optional stdenv.isDarwin gtk-mac-integration
     ++ lib.optional stdenv.cc.isClang llvmPackages.openmp;
 
-  # VC5Decompressor.cpp:718:55: error: 'value' is unavailable: introduced in macOS 10.13
-  CXXFLAGS = lib.optional (stdenv.hostPlatform.system == "x86_64-darwin") "-D_LIBCPP_DISABLE_AVAILABILITY";
-
   cmakeFlags = [
     "-DBUILD_USERMANUAL=False"
   ] ++ lib.optionals stdenv.isDarwin [

--- a/pkgs/applications/science/logic/z3/default.nix
+++ b/pkgs/applications/science/logic/z3/default.nix
@@ -49,9 +49,6 @@ stdenv.mkDerivation rec {
         ++ optional pythonBindings "--python --pypkgdir=$out/${python.sitePackages}"
     ) + "\n" + "cd build";
 
-  # ../src/ast/ast.h:183:39: error: 'get<int, int, ast *, symbol, zstring *, rational *, double, unsigned int>' is unavailable: introduced in macOS 10.13
-  NIX_CFLAGS_COMPILE = lib.optional (stdenv.hostPlatform.system == "x86_64-darwin") "-D_LIBCPP_DISABLE_AVAILABILITY";
-
   postInstall = ''
     mkdir -p $dev $lib
     mv $out/lib $lib/lib

--- a/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
@@ -41,9 +41,6 @@ in stdenv.mkDerivation rec {
   propagatedBuildInputs = lib.optional enableMpi mpi;
   propagatedUserEnvPkgs = lib.optional enableMpi mpi;
 
-  # error: 'value' is unavailable: introduced in macOS 10.13
-  CXXFLAGS = lib.optional (stdenv.hostPlatform.system == "x86_64-darwin") "-D_LIBCPP_DISABLE_AVAILABILITY";
-
   cmakeFlags = [
     "-DGMX_SIMD:STRING=${SIMD cpuAcceleration}"
     "-DGMX_OPENMP:BOOL=TRUE"

--- a/pkgs/development/compilers/llvm/10/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/10/libcxx/default.nix
@@ -21,6 +21,12 @@ stdenv.mkDerivation {
     ../../libcxx-0001-musl-hacks.patch
   ];
 
+  # Prevent errors like "error: 'foo' is unavailable: introduced in macOS yy.zz"
+  postPatch = ''
+    substituteInPlace include/__config \
+      --replace "#    define _LIBCPP_USE_AVAILABILITY_APPLE" ""
+  '';
+
   preConfigure = ''
     # Get headers from the cxxabi source so we can see private headers not installed by the cxxabi package
     cmakeFlagsArray=($cmakeFlagsArray -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$LIBCXXABI_INCLUDE_DIR")

--- a/pkgs/development/compilers/llvm/11/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/11/libcxx/default.nix
@@ -29,6 +29,12 @@ stdenv.mkDerivation {
     ../../libcxx-0001-musl-hacks.patch
   ];
 
+  # Prevent errors like "error: 'foo' is unavailable: introduced in macOS yy.zz"
+  postPatch = ''
+    substituteInPlace include/__config \
+      --replace "#    define _LIBCPP_USE_AVAILABILITY_APPLE" ""
+  '';
+
   preConfigure = lib.optionalString stdenv.hostPlatform.isMusl ''
     patchShebangs utils/cat_files.py
   '';

--- a/pkgs/development/compilers/llvm/12/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/12/libcxx/default.nix
@@ -23,6 +23,12 @@ stdenv.mkDerivation {
     ../../libcxx-0001-musl-hacks.patch
   ];
 
+  # Prevent errors like "error: 'foo' is unavailable: introduced in macOS yy.zz"
+  postPatch = ''
+    substituteInPlace include/__config \
+      --replace "#    define _LIBCPP_USE_AVAILABILITY_APPLE" ""
+  '';
+
   preConfigure = lib.optionalString stdenv.hostPlatform.isMusl ''
     patchShebangs utils/cat_files.py
   '';

--- a/pkgs/development/compilers/llvm/13/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/13/libcxx/default.nix
@@ -25,6 +25,12 @@ stdenv.mkDerivation rec {
     ../../libcxx-0001-musl-hacks.patch
   ];
 
+  # Prevent errors like "error: 'foo' is unavailable: introduced in macOS yy.zz"
+  postPatch = ''
+    substituteInPlace include/__config \
+      --replace "#    define _LIBCPP_USE_AVAILABILITY_APPLE" ""
+  '';
+
   preConfigure = lib.optionalString stdenv.hostPlatform.isMusl ''
     patchShebangs utils/cat_files.py
   '';

--- a/pkgs/development/compilers/llvm/6/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/6/libcxx/default.nix
@@ -19,6 +19,12 @@ stdenv.mkDerivation {
     ../../libcxx-0001-musl-hacks.patch
   ];
 
+  # Prevent errors like "error: 'foo' is unavailable: introduced in macOS yy.zz"
+  postPatch = ''
+    substituteInPlace include/__config \
+      --replace "#define _LIBCPP_USE_AVAILABILITY_APPLE" ""
+  '';
+
   prePatch = ''
     substituteInPlace lib/CMakeLists.txt --replace "/usr/lib/libc++" "\''${LIBCXX_LIBCXXABI_LIB_PATH}/libc++"
   '';

--- a/pkgs/development/compilers/llvm/7/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/7/libcxx/default.nix
@@ -21,6 +21,12 @@ stdenv.mkDerivation {
     ../../libcxx-0001-musl-hacks.patch
   ];
 
+  # Prevent errors like "error: 'foo' is unavailable: introduced in macOS yy.zz"
+  postPatch = ''
+    substituteInPlace include/__config \
+      --replace "#    define _LIBCPP_USE_AVAILABILITY_APPLE" ""
+  '';
+
   prePatch = ''
     substituteInPlace lib/CMakeLists.txt --replace "/usr/lib/libc++" "\''${LIBCXX_LIBCXXABI_LIB_PATH}/libc++"
   '';

--- a/pkgs/development/compilers/llvm/8/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/8/libcxx/default.nix
@@ -21,6 +21,12 @@ stdenv.mkDerivation {
     ../../libcxx-0001-musl-hacks.patch
   ];
 
+  # Prevent errors like "error: 'foo' is unavailable: introduced in macOS yy.zz"
+  postPatch = ''
+    substituteInPlace include/__config \
+      --replace "#    define _LIBCPP_USE_AVAILABILITY_APPLE" ""
+  '';
+
   prePatch = ''
     substituteInPlace lib/CMakeLists.txt --replace "/usr/lib/libc++" "\''${LIBCXX_LIBCXXABI_LIB_PATH}/libc++"
   '';

--- a/pkgs/development/compilers/llvm/9/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/9/libcxx/default.nix
@@ -21,6 +21,12 @@ stdenv.mkDerivation {
     ../../libcxx-0001-musl-hacks.patch
   ];
 
+  # Prevent errors like "error: 'foo' is unavailable: introduced in macOS yy.zz"
+  postPatch = ''
+    substituteInPlace include/__config \
+      --replace "#    define _LIBCPP_USE_AVAILABILITY_APPLE" ""
+  '';
+
   preConfigure = ''
     # Get headers from the cxxabi source so we can see private headers not installed by the cxxabi package
     cmakeFlagsArray=($cmakeFlagsArray -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$LIBCXXABI_INCLUDE_DIR")

--- a/pkgs/development/compilers/llvm/git/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/git/libcxx/default.nix
@@ -25,6 +25,12 @@ stdenv.mkDerivation rec {
     ../../libcxx-0001-musl-hacks.patch
   ];
 
+  # Prevent errors like "error: 'foo' is unavailable: introduced in macOS yy.zz"
+  postPatch = ''
+    substituteInPlace include/__config \
+      --replace "#    define _LIBCPP_USE_AVAILABILITY_APPLE" ""
+  '';
+
   preConfigure = lib.optionalString stdenv.hostPlatform.isMusl ''
     patchShebangs utils/cat_files.py
   '';

--- a/pkgs/development/haskell-modules/configuration-darwin.nix
+++ b/pkgs/development/haskell-modules/configuration-darwin.nix
@@ -30,10 +30,6 @@ self: super: ({
 
   double-conversion = addExtraLibrary pkgs.libcxx super.double-conversion;
 
-  hercules-ci-cnix-store = super.hercules-ci-cnix-store.overrideAttrs (drv: {
-    NIX_CFLAGS_COMPILE = "-D_LIBCPP_DISABLE_AVAILABILITY";
-  });
-
   apecs-physics = addPkgconfigDepends [
     darwin.apple_sdk.frameworks.ApplicationServices
   ] super.apecs-physics;

--- a/pkgs/development/libraries/caf/default.nix
+++ b/pkgs/development/libraries/caf/default.nix
@@ -26,9 +26,6 @@ stdenv.mkDerivation rec {
     export DYLD_LIBRARY_PATH=$PWD/libcaf_core:$PWD/libcaf_io
   '';
 
-  # error: 'get< ... >' is unavailable: introduced in macOS 10.13
-  CXXFLAGS = lib.optional (stdenv.hostPlatform.system == "x86_64-darwin") "-D_LIBCPP_DISABLE_AVAILABILITY";
-
   meta = with lib; {
     description = "An open source implementation of the actor model in C++";
     homepage = "http://actor-framework.org/";

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -184,12 +184,6 @@ stdenv.mkDerivation {
     ''-DNIXPKGS_LIBXCURSOR="${libXcursor.out}/lib/libXcursor"''
   ] ++ lib.optional libGLSupported ''-DNIXPKGS_MESA_GL="${libGL.out}/lib/libGL"''
     ++ lib.optional stdenv.isLinux "-DUSE_X11"
-    ++ lib.optionals (stdenv.hostPlatform.system == "x86_64-darwin") [
-      # fix "introduced in macOS 10.13"
-      "-D_LIBCPP_DISABLE_AVAILABILITY"
-      # ignore "is only available on macOS 10.12.2 or newer" in obj-c code
-      "-Wno-error=unguarded-availability"
-    ]
     ++ lib.optionals withGtk3 [
          ''-DNIXPKGS_QGTK3_XDG_DATA_DIRS="${gtk3}/share/gsettings-schemas/${gtk3.name}"''
          ''-DNIXPKGS_QGTK3_GIO_EXTRA_MODULES="${dconf.lib}/lib/gio/modules"''

--- a/pkgs/development/libraries/zxing-cpp/default.nix
+++ b/pkgs/development/libraries/zxing-cpp/default.nix
@@ -21,9 +21,6 @@ stdenv.mkDerivation rec {
     pkg-config
   ];
 
-  # error: 'path' is unavailable: introduced in macOS 10.15
-  CXXFLAGS = lib.optional (stdenv.hostPlatform.system == "x86_64-darwin") "-D_LIBCPP_DISABLE_AVAILABILITY";
-
   cmakeFlags = [
     "-DBUILD_EXAMPLES=OFF"
   ];

--- a/pkgs/development/python-modules/tweedledum/default.nix
+++ b/pkgs/development/python-modules/tweedledum/default.nix
@@ -24,9 +24,6 @@ buildPythonPackage rec {
   nativeBuildInputs = [ cmake ninja scikit-build ];
   dontUseCmakeConfigure = true;
 
-  # error: 'value' is unavailable: introduced in macOS 10.13
-  CXXFLAGS = lib.optional (stdenv.hostPlatform.system == "x86_64-darwin") "-D_LIBCPP_DISABLE_AVAILABILITY";
-
   pythonImportsCheck = [ "tweedledum" ];
 
   checkInputs = [ pytestCheckHook ];

--- a/pkgs/development/tools/build-managers/bear/default.nix
+++ b/pkgs/development/tools/build-managers/bear/default.nix
@@ -47,9 +47,6 @@ stdenv.mkDerivation rec {
     ./no-double-relative.patch
   ];
 
-  # 'path' is unavailable: introduced in macOS 10.15
-  CXXFLAGS = lib.optional (stdenv.hostPlatform.system == "x86_64-darwin") "-D_LIBCPP_DISABLE_AVAILABILITY";
-
   meta = with lib; {
     description = "Tool that generates a compilation database for clang tooling";
     longDescription = ''

--- a/pkgs/games/openrw/default.nix
+++ b/pkgs/games/openrw/default.nix
@@ -35,9 +35,6 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ cmake ];
 
-  # error: 'path' is unavailable: introduced in macOS 10.15
-  CXXFLAGS = lib.optional (stdenv.hostPlatform.system == "x86_64-darwin") "-D_LIBCPP_DISABLE_AVAILABILITY";
-
   buildInputs = [
     sfml libGLU libGL bullet glm libmad xlibsWrapper openal SDL2 boost ffmpeg
   ] ++ lib.optionals stdenv.isDarwin [ OpenAL Cocoa ];

--- a/pkgs/tools/compression/imagelol/default.nix
+++ b/pkgs/tools/compression/imagelol/default.nix
@@ -22,9 +22,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  # error: 'path' is unavailable: introduced in macOS 10.15
-  CXXFLAGS = lib.optional (stdenv.hostPlatform.system == "x86_64-darwin") "-D_LIBCPP_DISABLE_AVAILABILITY";
-
   installPhase = ''
     mkdir -p $out/bin
     cp ./ImageLOL $out/bin

--- a/pkgs/tools/graphics/waifu2x-converter-cpp/default.nix
+++ b/pkgs/tools/graphics/waifu2x-converter-cpp/default.nix
@@ -26,9 +26,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake makeWrapper ];
 
-  # main.cpp:498:12: error: 'is_directory' is unavailable: introduced in macOS 10.15
-  CXXFLAGS = lib.optional (stdenv.hostPlatform.system == "x86_64-darwin") "-D_LIBCPP_DISABLE_AVAILABILITY";
-
   preFixup = lib.optionalString stdenv.isLinux ''
     wrapProgram $out/bin/waifu2x-converter-cpp --prefix LD_LIBRARY_PATH : "${ocl-icd}/lib"
   '';

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -78,9 +78,6 @@ common =
 
       propagatedBuildInputs = [ boehmgc ];
 
-      # src/nix-build/nix-build.cc:463:41: error: 'value' is unavailable: introduced in macOS 10.13
-      NIX_CFLAGS_COMPILE = lib.optional (stdenv.hostPlatform.system == "x86_64-darwin") "-D_LIBCPP_DISABLE_AVAILABILITY";
-
       NIX_LDFLAGS = lib.optionals (!is24) [
         # https://github.com/NixOS/nix/commit/3e85c57a6cbf46d5f0fe8a89b368a43abd26daba
         (lib.optionalString enableStatic "-lssl -lbrotlicommon -lssh2 -lz -lnghttp2 -lcrypto")


### PR DESCRIPTION
Should fix a common regression from #126411
Can go to staging or staging-next depending on how fast this can be reviewed, or whether we have time for a quick darwin stdenv rebuild.
cc #148396