### PR TITLE
librime: add support for plugins

### DIFF
--- a/pkgs/development/libraries/librime/rime-plugin-dir.patch
+++ b/pkgs/development/libraries/librime/rime-plugin-dir.patch
@@ -1,0 +1,34 @@
+diff --git a/plugins/plugins_module.cc b/plugins/plugins_module.cc
+index 7a567be..2dd776c 100644
+--- a/plugins/plugins_module.cc
++++ b/plugins/plugins_module.cc
+@@ -13,6 +13,10 @@
+ #include <rime/registry.h>
+ #include <rime_api.h>
+ 
++#include <cstdlib>
++#include <cstdio>
++#include <unistd.h>
++
+ namespace fs = boost::filesystem;
+ 
+ namespace rime {
+@@ -95,7 +99,17 @@ PluginManager& PluginManager::instance() {
+ }  // namespace rime
+ 
+ static void rime_plugins_initialize() {
+-  rime::PluginManager::instance().LoadPlugins(RIME_PLUGINS_DIR);
++  char *plugin_dir_env = getenv("RIME_PLUGINS_DIR");
++  char plugins_dir[256];
++  if (plugin_dir_env == NULL) {
++    snprintf(plugins_dir, sizeof(plugins_dir),
++        "%s/%s/%s",
++        "/etc/profiles/per-user", getlogin(), RIME_PLUGINS_DIR
++        );
++  } else {
++    snprintf(plugins_dir, sizeof(plugins_dir), "%s", plugin_dir_env);
++  }
++  rime::PluginManager::instance().LoadPlugins(plugins_dir);
+ }
+ 
+ static void rime_plugins_finalize() {}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
There are two way to add plugins. One is put sources into RIME_SRC_DIR/pluigns
which will cause mass rebuilding for referrers if new plugins are added.
The other is set this one and loads shared libraries at runtime. The external plugins loading can inject plugins dynamically so that rebuilding librime and its referrers such as fcitx5-rime is not needed.

RIME_PLUGINS_DIR is passed by cmake so it cannot be changed at runtime why I add a patch to let it be set by environment variable.

A plugin is packed [here](https://github.com/Vonfry/nixpkgs/blob/init/librime-lua/pkgs/development/libraries/librime/librime-lua.nix). However, the wrapper is ugly because some plugins must be put under librime source tree for librime's CMakeLists.txt when building.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
