### PR TITLE
scheherazade-new: 3.200 → 3.300

### DIFF
--- a/pkgs/data/fonts/scheherazade/default.nix
+++ b/pkgs/data/fonts/scheherazade/default.nix
@@ -1,10 +1,10 @@
-{ lib, fetchzip, version ? "3.200" }:
+{ lib, fetchzip, version ? "3.300" }:
 
 let
   new = lib.versionAtLeast version "3.000";
   sha256 = {
     "2.100" = "1g5f5f9gzamkq3kqyf7vbzvl4rdj3wmjf6chdrbxksrm3rnb926z";
-    "3.200" = "0qvmpsn6ja3g2hlvq0vb9pjsyk6ibna7s3w3n6q7lnhk0rhjg8bv";
+    "3.300" = "1bja1ma1mnna0qlk3dis31cvq5z1kgcqj7wjp8ml03zc5mpa2wb2";
   }."${version}";
 
 in fetchzip rec {
@@ -16,8 +16,9 @@ in fetchzip rec {
     mkdir -p $out/share/{doc,fonts}
     unzip -l $downloadedFile
     unzip -j $downloadedFile \*.ttf                        -d $out/share/fonts/truetype
+    unzip    $downloadedFile \*/documentation/\*           -d $out/share/doc/
+    mv $out/share/doc/* $out/share/doc/${name}
     unzip -j $downloadedFile \*/FONTLOG.txt  \*/README.txt -d $out/share/doc/${name}
-    unzip -j $downloadedFile \*/documentation/\*           -d $out/share/doc/${name}/documentation
   '';
 
   inherit sha256;
@@ -30,7 +31,7 @@ in fetchzip rec {
       Scheherazade${lib.optionalString new " New"}, named after the heroine of
       the classic Arabian Nights tale, is designed in a similar style to
       traditional typefaces such as Monotype Naskh, extended to cover the
-      Unicode Arabic repertoire through Unicode ${if new then "13.0" else "8.0"}.
+      Unicode Arabic repertoire through Unicode ${if new then "14.0" else "8.0"}.
 
       Scheherazade provides a “simplified” rendering of Arabic script, using
       basic connecting glyphs but not including a wide variety of additional


### PR DESCRIPTION
###### Motivation for this change

Additions & improvements: https://software.sil.org/scheherazade/release-3-300/

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
