### PR TITLE
pythonInterpreters.pypy{}_prebuilt: 7.3.3 -> 7.3.7

### DIFF
--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -267,16 +267,16 @@ in {
     inherit passthruFun;
   };
 
-  pypy36_prebuilt = callPackage ./pypy/prebuilt.nix {
+  pypy38_prebuilt = callPackage ./pypy/prebuilt.nix {
     # Not included at top-level
-    self = pythonInterpreters.pypy36_prebuilt;
+    self = pythonInterpreters.pypy38_prebuilt;
     sourceVersion = {
       major = "7";
       minor = "3";
-      patch = "3";
+      patch = "7";
     };
-    sha256 = "02lys9bjky9bqg6ggv8djirbd3zzcsq7755v4yvwm0k4a7fmzf2g"; # linux64
-    pythonVersion = "3.6";
+    sha256 = "sha256-Xe43x8PLixYAKPveOlkBxoBD36VFoWeUUCuJfUvEDX4="; # linux64
+    pythonVersion = "3.8";
     inherit passthruFun;
   };
 

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -254,15 +254,15 @@ in {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
-  pypy27_prebuilt = callPackage ./pypy/prebuilt.nix {
+  pypy27_prebuilt = callPackage ./pypy/prebuilt_2_7.nix {
     # Not included at top-level
     self = pythonInterpreters.pypy27_prebuilt;
     sourceVersion = {
       major = "7";
       minor = "3";
-      patch = "3";
+      patch = "6";
     };
-    sha256 = "1cfpdyvbvzwc0ynjr7248jhwgcpl7073wlp7w3g2v4fnrh1bc4pl"; # linux64
+    sha256 = "sha256-ghJ/Q/rmznXUfWxFOfjB6jcunC2/pA+ui1g1HVInk6Q="; # linux64
     pythonVersion = "2.7";
     inherit passthruFun;
   };

--- a/pkgs/development/interpreters/python/pypy/prebuilt_2_7.nix
+++ b/pkgs/development/interpreters/python/pypy/prebuilt_2_7.nix
@@ -1,0 +1,132 @@
+{ lib
+, stdenv
+, fetchurl
+, python-setup-hook
+, self
+, which
+# Dependencies
+, bzip2
+, zlib
+, openssl_1_0_2
+, expat
+, ncurses6
+, tcl-8_5
+, tk-8_5
+# For the Python package set
+, packageOverrides ? (self: super: {})
+, sourceVersion
+, pythonVersion
+, sha256
+, passthruFun
+}:
+
+# This version of PyPy is primarily added to speed-up translation of
+# our PyPy source build when developing that expression.
+
+with lib;
+
+let
+  isPy3k = majorVersion == "3";
+  passthru = passthruFun {
+    inherit self sourceVersion pythonVersion packageOverrides;
+    implementation = "pypy";
+    libPrefix = "pypy${pythonVersion}";
+    executable = "pypy${if isPy3k then "3" else ""}";
+    sitePackages = "site-packages";
+    hasDistutilsCxxPatch = false;
+
+    # Not possible to cross-compile with.
+    pythonOnBuildForBuild = throw "${pname} does not support cross compilation";
+    pythonOnBuildForHost = self;
+    pythonOnBuildForTarget = throw "${pname} does not support cross compilation";
+    pythonOnHostForHost = throw "${pname} does not support cross compilation";
+    pythonOnTargetForTarget = throw "${pname} does not support cross compilation";
+  };
+  pname = "${passthru.executable}_prebuilt";
+  version = with sourceVersion; "${major}.${minor}.${patch}";
+
+  majorVersion = substring 0 1 pythonVersion;
+
+  deps = [
+    bzip2
+    zlib
+    openssl_1_0_2
+    expat
+    ncurses6
+    tcl-8_5
+    tk-8_5
+  ];
+
+in with passthru; stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchurl {
+    url = "https://downloads.python.org/pypy/pypy${pythonVersion}-v${version}-linux64.tar.bz2";
+    inherit sha256;
+  };
+
+  buildInputs = [ which ];
+
+  installPhase = ''
+    mkdir -p $out/lib
+    echo "Moving files to $out"
+    mv -t $out bin include lib-python lib_pypy site-packages
+    mv lib/libffi.so.6* $out/lib/
+
+    mv $out/bin/libpypy*-c.so $out/lib/
+
+    rm $out/bin/*.debug
+
+    echo "Patching binaries"
+    interpreter=$(patchelf --print-interpreter $(readlink -f $(which patchelf)))
+    patchelf --set-interpreter $interpreter \
+             --set-rpath $out/lib \
+             $out/bin/pypy*
+
+    pushd $out
+    find {lib,lib_pypy*} -name "*.so" -exec patchelf --remove-needed libncursesw.so.6 --replace-needed libtinfow.so.6 libncursesw.so.6 {} \;
+    find {lib,lib_pypy*} -name "*.so" -exec patchelf --set-rpath ${lib.makeLibraryPath deps}:$out/lib {} \;
+
+    echo "Removing bytecode"
+    find . -name "__pycache__" -type d -depth -exec rm -rf {} \;
+    popd
+
+    # Include a sitecustomize.py file
+    cp ${../sitecustomize.py} $out/${sitePackages}/sitecustomize.py
+
+  '';
+
+  doInstallCheck = true;
+
+  # Check whether importing of (extension) modules functions
+  installCheckPhase = let
+    modules = [
+      "ssl"
+      "sys"
+      "curses"
+    ] ++ optionals (!isPy3k) [
+      "Tkinter"
+    ] ++ optionals isPy3k [
+      "tkinter"
+    ];
+    imports = concatMapStringsSep "; " (x: "import ${x}") modules;
+  in ''
+    echo "Testing whether we can import modules"
+    $out/bin/${executable} -c '${imports}'
+  '';
+
+  setupHook = python-setup-hook sitePackages;
+
+  donPatchElf = true;
+  dontStrip = true;
+
+  inherit passthru;
+
+  meta = with lib; {
+    homepage = "http://pypy.org/";
+    description = "Fast, compliant alternative implementation of the Python language (${pythonVersion})";
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" ];
+  };
+
+}


### PR DESCRIPTION
New versions of pypy were released. In this commit pypy36_prebuilt is
changed to pypy38_prebuilt and its version is updated from 7.3.3 to
7.7.7. This requires changes in the expression, breaking
pypy27_prebuilt. Thus the old expression is kept for pypy27.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
