### PR TITLE
mathematica: 12.3.1 -> 13.0.0

### DIFF
--- a/pkgs/applications/science/math/mathematica/l10ns.nix
+++ b/pkgs/applications/science/math/mathematica/l10ns.nix
@@ -8,31 +8,34 @@ let allVersions = with lib; flip map
   # N.B. Versions in this list should be ordered from newest to oldest.
   [
     {
-      version = "12.3.1";
+      version = "13.0.0";
       lang = "en";
       language = "English";
-      sha256 = "51b9cab12fd91b009ea7ad4968a2c8a59e94dc55d2e6cc1d712acd5ba2c4d509";
+      sha256 = "15bbad39a5995031325d1d178f63b00e71706d3ec9001eba6d1681fbc991d3e1";
+      installer = "Mathematica_13.0.0_BNDL_LINUX.sh";
     }
     {
       version = "11.3.0";
       lang = "en";
       language = "English";
       sha256 = "0fcfe208c1eac8448e7be3af0bdb84370b17bd9c5d066c013928c8ee95aed10e";
+      installer = "Mathematica_11.3.0_LINUX.sh";
     }
     {
       version = "11.2.0";
       lang = "ja";
       language = "Japanese";
       sha256 = "916392edd32bed8622238df435dd8e86426bb043038a3336f30df10d819b49b1";
+      installer = "Mathematica_11.2.0_ja_LINUX.sh";
     }
   ]
-  ({ version, lang, language, sha256 }: {
+  ({ version, lang, language, sha256, installer }: {
     inherit version lang;
     name = "mathematica-${version}" + optionalString (lang != "en") "-${lang}";
-    src = requireFile rec {
-      name = "Mathematica_${version}" + optionalString (lang != "en") "_${language}" + "_LINUX.sh";
+    src = requireFile {
+      name = installer;
       message = ''
-        This nix expression requires that ${name} is
+        This nix expression requires that ${installer} is
         already part of the store. Find the file on your Mathematica CD
         and add it to the nix store with nix-store --add-fixed sha256 <FILE>.
       '';

--- a/pkgs/applications/science/math/mathematica/l10ns.nix
+++ b/pkgs/applications/science/math/mathematica/l10ns.nix
@@ -15,6 +15,48 @@ let allVersions = with lib; flip map
       installer = "Mathematica_13.0.0_BNDL_LINUX.sh";
     }
     {
+      version = "12.3.1";
+      lang = "en";
+      language = "English";
+      sha256 = "51b9cab12fd91b009ea7ad4968a2c8a59e94dc55d2e6cc1d712acd5ba2c4d509";
+      installer = "Mathematica_12.3.1_LINUX.sh";
+    }
+    {
+      version = "12.3.0";
+      lang = "en";
+      language = "English";
+      sha256 = "045df045f6e796ded59f64eb2e0f1949ac88dcba1d5b6e05fb53ea0a4aed7215";
+      installer = "Mathematica_12.3.0_LINUX.sh";
+    }
+    {
+      version = "12.2.0";
+      lang = "en";
+      language = "English";
+      sha256 = "3b6676a203c6adb7e9c418a5484b037974287b5be09c64e7dfea74ddc0e400d7";
+      installer = "Mathematica_12.2.0_LINUX.sh";
+    }
+    {
+      version = "12.1.1";
+      lang = "en";
+      language = "English";
+      sha256 = "02mk8gmv8idnakva1nc7r7mx8ld02lk7jgsj1zbn962aps3bhixd";
+      installer = "Mathematica_12.1.1_LINUX.sh";
+    }
+    {
+      version = "12.1.0";
+      lang = "en";
+      language = "English";
+      sha256 = "15m9l20jvkxh5w6mbp81ys7mx2lx5j8acw5gz0il89lklclgb8z7";
+      installer = "Mathematica_12.1.0_LINUX.sh";
+    }
+    {
+      version = "12.0.0";
+      lang = "en";
+      language = "English";
+      sha256 = "b9fb71e1afcc1d72c200196ffa434512d208fa2920e207878433f504e58ae9d7";
+      installer = "Mathematica_12.0.0_LINUX.sh";
+    }
+    {
       version = "11.3.0";
       lang = "en";
       language = "English";


### PR DESCRIPTION
###### Motivation for this change

https://wolfram.com/mathematica/quick-revision-history.html#v130

###### Things done

- Built on platform(s)
  -  [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of binary files: mathematica, wolfram
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Tested using one of my notebooks that uses data from a SQLite database.

Built on NixOS.