### PR TITLE
jellyfin-media-player: 1.6.1 -> 1.7.0

### DIFF
--- a/pkgs/applications/video/jellyfin-media-player/default.nix
+++ b/pkgs/applications/video/jellyfin-media-player/default.nix
@@ -22,22 +22,18 @@
 , qtwebchannel
 , qtwebengine
 , qtx11extras
+, jellyfin-web
 }:
 
 mkDerivation rec {
   pname = "jellyfin-media-player";
-  version = "1.6.1";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "jellyfin";
     repo = "jellyfin-media-player";
     rev = "v${version}";
-    sha256 = "sha256-iqwOv95JFxQ1j/9B+oBFAp7mD1/1g2EJYvvUKbrDQes=";
-  };
-
-  jmpDist = fetchzip {
-    url = "https://github.com/iwalton3/jellyfin-web-jmp/releases/download/jwc-10.7.3/dist.zip";
-    sha256 = "sha256-P7WEYbVvpaVLwMgqC2e8QtMOaJclg0bX78J1fdGzcCU=";
+    sha256 = "sha256-eDCfqSNkKVm8MC4XA1NhQSByy9zhfyQRPM8OlSKcIvc=";
   };
 
   patches = [
@@ -81,9 +77,8 @@ mkDerivation rec {
   ];
 
   preBuild = ''
-    # copy the webclient-files to the expected "dist" directory
-    mkdir -p dist
-    cp -a ${jmpDist}/* dist
+    # link the jellyfin-web files to the expected "dist" directory
+    ln -s ${jellyfin-web}/share/jellyfin-web dist
   '';
 
   postInstall = lib.optionalString stdenv.isDarwin ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* https://github.com/jellyfin/jellyfin-media-player/releases/tag/v1.7.0-pre1
* https://github.com/jellyfin/jellyfin-media-player/releases/tag/v1.7.0-pre2
* https://github.com/jellyfin/jellyfin-media-player/releases/tag/v1.7.0-pre3
* https://github.com/jellyfin/jellyfin-media-player/releases/tag/v1.7.0-pre4
* https://github.com/jellyfin/jellyfin-media-player/releases/tag/v1.7.0

Now the `jellyfin-media-player` does not depend on a custom build `jellyfin-web` anymore, so we can reuse the `jellyfin-web` from nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
