### PR TITLE
vscode-with-extensions: allow extensions from user home

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -12,7 +12,7 @@
 
 # Attributes inherit from specific versions
 , version, src, meta, sourceRoot
-, executableName, longName, shortName, pname, updateScript
+, executableName, longName, shortName, pname, updateScript, extensionHomePath
 # sourceExecutableName is the name of the binary in the source archive, over
 # which we have no control
 , sourceExecutableName ? executableName
@@ -25,7 +25,12 @@ let
     inherit pname version src sourceRoot;
 
     passthru = {
-      inherit executableName longName tests updateScript;
+      inherit executableName longName shortName tests updateScript extensionHomePath;
+      userHomePath =
+        if stdenv.isDarwin then
+          "Library/Application Support/${shortName}/User"
+        else
+          ".config/${shortName}/User";
       fhs = fhs {};
       fhsWithPackages = f: fhs { additionalPkgs = f; };
     };

--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -30,6 +30,7 @@ in
     executableName = "code" + lib.optionalString isInsiders "-insiders";
     longName = "Visual Studio Code" + lib.optionalString isInsiders " - Insiders";
     shortName = "Code" + lib.optionalString isInsiders " - Insiders";
+    extensionHomePath = ".vscode${lib.optionalString isInsiders "-insiders"}/extensions";
 
     src = fetchurl {
       name = "VSCode_${version}_${plat}.${archive_fmt}";

--- a/pkgs/applications/editors/vscode/vscodium.nix
+++ b/pkgs/applications/editors/vscode/vscodium.nix
@@ -37,6 +37,7 @@ in
     executableName = "codium";
     longName = "VSCodium";
     shortName = "vscodium";
+    extensionHomePath = ".vscode-oss/extensions";
 
     src = fetchurl {
       url = "https://github.com/VSCodium/vscodium/releases/download/${version}/VSCodium-${plat}-${version}.${archive_fmt}";

--- a/pkgs/applications/editors/vscode/with-extensions.nix
+++ b/pkgs/applications/editors/vscode/with-extensions.nix
@@ -4,50 +4,50 @@
 , vscode
 , runtimeShell
 , vscodeExtensions ? [ ]
-# TODO:change defaults when one of those issues is resolved:
-# https://github.com/rpodgorny/unionfs-fuse/issues/101
-# https://github.com/trapexit/mergerfs/issues/115
-, mountPosition ? if stdenvNoCC.isDarwin then "none" else "above"
+  # TODO:change defaults when one of those issues is resolved:
+  # https://github.com/rpodgorny/unionfs-fuse/issues/101
+  # https://github.com/trapexit/mergerfs/issues/115
+, mountPosition ? "none"
 , mergerfs ? null
 }:
 /*
   `vscodeExtensions`
-   :  A set of vscode extensions to be installed alongside the editor. Here's a an
-      example:
+  :  A set of vscode extensions to be installed alongside the editor. Here's a an
+  example:
 
-      ~~~
-      vscode-with-extensions.override {
+  ~~~
+  vscode-with-extensions.override {
 
-        # When the extension is already available in the default extensions set.
-        vscodeExtensions = with vscode-extensions; [
-          bbenoist.nix
-        ]
+  # When the extension is already available in the default extensions set.
+  vscodeExtensions = with vscode-extensions; [
+  bbenoist.nix
+  ]
 
-        # Concise version from the vscode market place when not available in the default set.
-        ++ vscode-utils.extensionsFromVscodeMarketplace [
-          {
-            name = "code-runner";
-            publisher = "formulahendry";
-            version = "0.6.33";
-            sha256 = "166ia73vrcl5c9hm4q1a73qdn56m0jc7flfsk5p5q41na9f10lb0";
-          }
-        ];
-      }
-      ~~~
+  # Concise version from the vscode market place when not available in the default set.
+  ++ vscode-utils.extensionsFromVscodeMarketplace [
+  {
+  name = "code-runner";
+  publisher = "formulahendry";
+  version = "0.6.33";
+  sha256 = "166ia73vrcl5c9hm4q1a73qdn56m0jc7flfsk5p5q41na9f10lb0";
+  }
+  ];
+  }
+  ~~~
 
-      This expression should fetch
-       -  the *nix* vscode extension from whatever source defined in the
-          default nixpkgs extensions set `vscodeExtensions`.
+  This expression should fetch
+  -  the *nix* vscode extension from whatever source defined in the
+  default nixpkgs extensions set `vscodeExtensions`.
 
-       -  the *code-runner* vscode extension from the marketplace using the
-          following url:
+  -  the *code-runner* vscode extension from the marketplace using the
+  following url:
 
-          ~~~
-          https://bbenoist.gallery.vsassets.io/_apis/public/gallery/publisher/bbenoist/extension/nix/1.0.1/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage
-          ~~~
+  ~~~
+  https://bbenoist.gallery.vsassets.io/_apis/public/gallery/publisher/bbenoist/extension/nix/1.0.1/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage
+  ~~~
 
-      The original `code` executable will be wrapped so that it uses the set of pre-installed / unpacked
-      extensions as its `--extensions-dir`.
+  The original `code` executable will be wrapped so that it uses the set of pre-installed / unpacked
+  extensions as its `--extensions-dir`.
 */
 
 assert lib.assertOneOf "mountPosition" mountPosition [ "above" "below" "none" ];

--- a/pkgs/applications/editors/vscode/with-extensions.nix
+++ b/pkgs/applications/editors/vscode/with-extensions.nix
@@ -89,9 +89,9 @@ stdenvNoCC.mkDerivation rec {
     homeExt="''${VSCODE_EXTENSIONS:-$HOME/${extensionHomePath}}"
     mkdir -p "$homeExt"
     # assume $out is unique enough it can replace a tmpdir suffix
-    export VSCODE_EXTENSIONS="''${XDG_RUNTIME_DIR:-''${TEMPDIR:-/tmp}/$PID}@out@"
+    export VSCODE_EXTENSIONS="''${XDG_RUNTIME_DIR:-''${TEMPDIR:-/tmp}/$UID}@out@"
     # avoid remounting after closing and reopening vscode
-    if ! (mount | grep "$VSCODE_EXTENSIONS" > /dev/null)
+    if ! mountpoint -q "$VSCODE_EXTENSIONS"
     then
       mkdir -p "$VSCODE_EXTENSIONS"
       ${mergerfs}/bin/mergerfs \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Using mergerfs allow us to greate an extension directory with extensions from both the user home and the nix store.
Also unlike https://github.com/NixOS/nixpkgs/pull/148235 this does not need to copy the entire vscode derivation all over again.

I've also added extensionHomePath and userHomePath so that home-manager can take it from us instead of hardcoding them.

Finally I've improved the composibility of the expression: if vscodeExtensions is void then nothing is built additionally and if vscode is itself another vscode-with-extensions then the "middle" vscode-with-extensions is similarly not built.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
