### PR TITLE
 quicklispPackages: 2021-10-21 -> 2021-12-09 

### DIFF
--- a/pkgs/development/compilers/sbcl/2.1.11.nix
+++ b/pkgs/development/compilers/sbcl/2.1.11.nix
@@ -1,0 +1,4 @@
+import ./common.nix {
+  version = "2.1.11";
+  sha256 = "1zgypmn19c58pv7j33ga7m1l7lzghj70w3xbybpgmggxwwflihdz";
+}

--- a/pkgs/development/lisp-modules/lisp-packages.nix
+++ b/pkgs/development/lisp-modules/lisp-packages.nix
@@ -24,8 +24,8 @@ let lispPackages = rec {
       quicklispdist = pkgs.fetchurl {
         # Will usually be replaced with a fresh version anyway, but needs to be
         # a valid distinfo.txt
-        url = "http://beta.quicklisp.org/dist/quicklisp/2021-10-21/distinfo.txt";
-        sha256 = "sha256:0ihi3p6fvagzfzkkyzs6b3jrz5yidj4f5dcgnh73qas19mk345ai";
+        url = "http://beta.quicklisp.org/dist/quicklisp/2021-12-09/distinfo.txt";
+        sha256 = "sha256:0gc4cv73nl7xkfwvmkmfhfx6yqf876nfm2v24v6fky9n24sh4y6w";
       };
       buildPhase = "true; ";
       postInstall = ''
@@ -233,7 +233,7 @@ let lispPackages = rec {
     description = "Multi-dimensional arrays with FFI/CUDA support";
     deps = with pkgs.lispPackages; [
       alexandria bordeaux-threads cffi cffi-grovel cl-cuda flexi-streams ieee-floats
-      lla mgl-pax static-vectors trivial-garbage
+      lla mgl-pax static-vectors trivial-garbage cl-fad
     ];
     src = pkgs.fetchFromGitHub {
       owner = "melisgl";

--- a/pkgs/development/lisp-modules/lisp-packages.nix
+++ b/pkgs/development/lisp-modules/lisp-packages.nix
@@ -124,7 +124,7 @@ let lispPackages = rec {
   };
   nyxt = pkgs.lispPackages.buildLispPackage rec {
     baseName = "nyxt";
-    version = "2.0.0";
+    version = "2.2.3";
 
     description = "Browser";
 
@@ -146,6 +146,9 @@ let lispPackages = rec {
         ' "$out/bin/nyxt-lisp-launcher.sh"
         cp "$out/lib/common-lisp/nyxt/nyxt" "$out/bin/"
       '';
+
+      # Prevent nyxt from trying to obtain dependencies as submodules
+      makeFlags = [ "NYXT_SUBMODULES=false" ] ++ x.buildFlags or [];
     };
 
     deps = with pkgs.lispPackages; [
@@ -160,6 +163,8 @@ let lispPackages = rec {
             cl-prevalence
             closer-mop
             cl-containers
+            cl-qrencode
+            clss
             cluffer
             moptilities
             dexador
@@ -168,17 +173,20 @@ let lispPackages = rec {
             iolib
             local-time
             log4cl
+            lparallel
             mk-string-metrics
             osicat
             parenscript
             quri
             serapeum
+            spinneret
             str
             plump
             swank
             trivia
             trivial-clipboard
             trivial-features
+            trivial-garbage
             trivial-package-local-nicknames
             trivial-types
             unix-opts
@@ -194,7 +202,7 @@ let lispPackages = rec {
       owner = "atlas-engineer";
       repo = "nyxt";
       rev = "${version}";
-      sha256 = "sha256-eSRNfzkAzGTorLjdHo1LQEKLx4ASdv3RGXIFZ5WFIXk=";
+      sha256 = "1v1szbj44pwxh3k70fvg78xjfkab29dqnlafa722sppdyqd06cqp";
     };
 
     packageName = "nyxt";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/alexandria.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/alexandria.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "alexandria";
-  version = "20210807-git";
+  version = "20211209-git";
 
   description = "Alexandria is a collection of portable public domain utilities.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/alexandria/2021-08-07/alexandria-20210807-git.tgz";
-    sha256 = "0y2x3xapx06v8083ls4pz12s63gv33d6ix05r61m62h4qqm8qk3j";
+    url = "http://beta.quicklisp.org/archive/alexandria/2021-12-09/alexandria-20211209-git.tgz";
+    sha256 = "13xyajg5n3ad3x2hrmzni1w87b0wc41wn7manbvc3dc5n55afxk0";
   };
 
   packageName = "alexandria";
@@ -20,8 +20,8 @@ rec {
 }
 /* (SYSTEM alexandria DESCRIPTION
     Alexandria is a collection of portable public domain utilities. SHA256
-    0y2x3xapx06v8083ls4pz12s63gv33d6ix05r61m62h4qqm8qk3j URL
-    http://beta.quicklisp.org/archive/alexandria/2021-08-07/alexandria-20210807-git.tgz
-    MD5 0193fd1a1d702b4a0fafa19361b1e644 NAME alexandria FILENAME alexandria
-    DEPS NIL DEPENDENCIES NIL VERSION 20210807-git SIBLINGS (alexandria-tests)
+    13xyajg5n3ad3x2hrmzni1w87b0wc41wn7manbvc3dc5n55afxk0 URL
+    http://beta.quicklisp.org/archive/alexandria/2021-12-09/alexandria-20211209-git.tgz
+    MD5 4f578a956567ea0d6c99c2babd1752f3 NAME alexandria FILENAME alexandria
+    DEPS NIL DEPENDENCIES NIL VERSION 20211209-git SIBLINGS (alexandria-tests)
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/anaphora.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/anaphora.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "anaphora";
-  version = "20210124-git";
+  version = "20211209-git";
 
   parasites = [ "anaphora/test" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."rt" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/anaphora/2021-01-24/anaphora-20210124-git.tgz";
-    sha256 = "0b4xwrnv007sfcqkxkarrbf99v3md8h199z1z69r4vx7r5pq2i4v";
+    url = "http://beta.quicklisp.org/archive/anaphora/2021-12-09/anaphora-20211209-git.tgz";
+    sha256 = "1pi166qwf3zwswhgq8c4r84rl5d6lnn0rkb3cdf5afyxmminsadg";
   };
 
   packageName = "anaphora";
@@ -21,8 +21,8 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM anaphora DESCRIPTION The Anaphoric Macro Package from Hell SHA256
-    0b4xwrnv007sfcqkxkarrbf99v3md8h199z1z69r4vx7r5pq2i4v URL
-    http://beta.quicklisp.org/archive/anaphora/2021-01-24/anaphora-20210124-git.tgz
-    MD5 09a11971206da9d259b34c050783b74b NAME anaphora FILENAME anaphora DEPS
-    ((NAME rt FILENAME rt)) DEPENDENCIES (rt) VERSION 20210124-git SIBLINGS NIL
+    1pi166qwf3zwswhgq8c4r84rl5d6lnn0rkb3cdf5afyxmminsadg URL
+    http://beta.quicklisp.org/archive/anaphora/2021-12-09/anaphora-20211209-git.tgz
+    MD5 81827cd43d29293e967916bb11c4df88 NAME anaphora FILENAME anaphora DEPS
+    ((NAME rt FILENAME rt)) DEPENDENCIES (rt) VERSION 20211209-git SIBLINGS NIL
     PARASITES (anaphora/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-form-types.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-form-types.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-form-types";
-  version = "20211020-git";
+  version = "20211209-git";
 
   parasites = [ "cl-form-types/test" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."agutil" args."alexandria" args."anaphora" args."arrows" args."cl-environments" args."closer-mop" args."collectors" args."fiveam" args."introspect-environment" args."iterate" args."optima" args."parse-declarations-1_dot_0" args."symbol-munger" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-form-types/2021-10-20/cl-form-types-20211020-git.tgz";
-    sha256 = "1f5wni1jrd5jbra2z2smw4vdw4k3bkbas8n676y3g3yv10lhddg8";
+    url = "http://beta.quicklisp.org/archive/cl-form-types/2021-12-09/cl-form-types-20211209-git.tgz";
+    sha256 = "1w1918a9rjw9dp5qpwq3mf0p4yyd2xladnd6sz4zk645y7wxd08i";
   };
 
   packageName = "cl-form-types";
@@ -22,9 +22,9 @@ rec {
 }
 /* (SYSTEM cl-form-types DESCRIPTION
     Library for determining types of Common Lisp forms. SHA256
-    1f5wni1jrd5jbra2z2smw4vdw4k3bkbas8n676y3g3yv10lhddg8 URL
-    http://beta.quicklisp.org/archive/cl-form-types/2021-10-20/cl-form-types-20211020-git.tgz
-    MD5 53e67d9fd55ac6a382635b119aeb5431 NAME cl-form-types FILENAME
+    1w1918a9rjw9dp5qpwq3mf0p4yyd2xladnd6sz4zk645y7wxd08i URL
+    http://beta.quicklisp.org/archive/cl-form-types/2021-12-09/cl-form-types-20211209-git.tgz
+    MD5 2c128061c2e8a97b70fbf8939708d53e NAME cl-form-types FILENAME
     cl-form-types DEPS
     ((NAME agutil FILENAME agutil) (NAME alexandria FILENAME alexandria)
      (NAME anaphora FILENAME anaphora) (NAME arrows FILENAME arrows)
@@ -39,4 +39,4 @@ rec {
     (agutil alexandria anaphora arrows cl-environments closer-mop collectors
      fiveam introspect-environment iterate optima parse-declarations-1.0
      symbol-munger)
-    VERSION 20211020-git SIBLINGS NIL PARASITES (cl-form-types/test)) */
+    VERSION 20211209-git SIBLINGS NIL PARASITES (cl-form-types/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-l10n.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-l10n.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-l10n";
-  version = "20161204-darcs";
+  version = "20211209-git";
 
   parasites = [ "cl-l10n/test" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cl-fad" args."cl-l10n-cldr" args."cl-ppcre" args."closer-mop" args."closure-common" args."cxml" args."flexi-streams" args."hu_dot_dwim_dot_stefil" args."iterate" args."local-time" args."metabang-bind" args."parse-number" args."puri" args."trivial-features" args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-l10n/2016-12-04/cl-l10n-20161204-darcs.tgz";
-    sha256 = "1r8jgwks21az78c5kdxgw5llk9ml423vjkv1f93qg1vx3zma6vzl";
+    url = "http://beta.quicklisp.org/archive/cl-l10n/2021-12-09/cl-l10n-20211209-git.tgz";
+    sha256 = "0l67xg282pim6167g27zcqk4xj51cfpmcbzc8bjg8933w42fdjf4";
   };
 
   packageName = "cl-l10n";
@@ -21,9 +21,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-l10n DESCRIPTION Portable CL Locale Support SHA256
-    1r8jgwks21az78c5kdxgw5llk9ml423vjkv1f93qg1vx3zma6vzl URL
-    http://beta.quicklisp.org/archive/cl-l10n/2016-12-04/cl-l10n-20161204-darcs.tgz
-    MD5 c7cb0bb584b061799abaaaf2bd65c9c5 NAME cl-l10n FILENAME cl-l10n DEPS
+    0l67xg282pim6167g27zcqk4xj51cfpmcbzc8bjg8933w42fdjf4 URL
+    http://beta.quicklisp.org/archive/cl-l10n/2021-12-09/cl-l10n-20211209-git.tgz
+    MD5 e575bb4ff3a6d0bbba5220c631f9c83a NAME cl-l10n FILENAME cl-l10n DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cl-fad FILENAME cl-fad) (NAME cl-l10n-cldr FILENAME cl-l10n-cldr)
@@ -40,4 +40,4 @@ rec {
     (alexandria babel bordeaux-threads cl-fad cl-l10n-cldr cl-ppcre closer-mop
      closure-common cxml flexi-streams hu.dwim.stefil iterate local-time
      metabang-bind parse-number puri trivial-features trivial-gray-streams)
-    VERSION 20161204-darcs SIBLINGS NIL PARASITES (cl-l10n/test)) */
+    VERSION 20211209-git SIBLINGS NIL PARASITES (cl-l10n/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-postgres.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-postgres.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-postgres";
-  version = "postmodern-20211020-git";
+  version = "postmodern-20211209-git";
 
   parasites = [ "cl-postgres/simple-date-tests" "cl-postgres/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-base64" args."cl-ppcre" args."fiveam" args."ironclad" args."md5" args."simple-date" args."simple-date_slash_postgres-glue" args."split-sequence" args."uax-15" args."uiop" args."usocket" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/postmodern/2021-10-20/postmodern-20211020-git.tgz";
-    sha256 = "0iw0sbjra3g57ivfqgx3c97mlcdzlh2kgqp12d1r2i9pw8z0ckh6";
+    url = "http://beta.quicklisp.org/archive/postmodern/2021-12-09/postmodern-20211209-git.tgz";
+    sha256 = "1qcbg31mz5r7ibmq2y7r3vqvdwpznxvwdnwd94hfil7pg4j119d6";
   };
 
   packageName = "cl-postgres";
@@ -21,9 +21,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-postgres DESCRIPTION Low-level client library for PostgreSQL
-    SHA256 0iw0sbjra3g57ivfqgx3c97mlcdzlh2kgqp12d1r2i9pw8z0ckh6 URL
-    http://beta.quicklisp.org/archive/postmodern/2021-10-20/postmodern-20211020-git.tgz
-    MD5 84f4ad8ce7ac0f7f78cbfcf2f0bd3aa4 NAME cl-postgres FILENAME cl-postgres
+    SHA256 1qcbg31mz5r7ibmq2y7r3vqvdwpznxvwdnwd94hfil7pg4j119d6 URL
+    http://beta.quicklisp.org/archive/postmodern/2021-12-09/postmodern-20211209-git.tgz
+    MD5 6d14c4b5fec085594dc66d520174e0e6 NAME cl-postgres FILENAME cl-postgres
     DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -37,5 +37,5 @@ rec {
     DEPENDENCIES
     (alexandria bordeaux-threads cl-base64 cl-ppcre fiveam ironclad md5
      simple-date simple-date/postgres-glue split-sequence uax-15 uiop usocket)
-    VERSION postmodern-20211020-git SIBLINGS (postmodern s-sql simple-date)
+    VERSION postmodern-20211209-git SIBLINGS (postmodern s-sql simple-date)
     PARASITES (cl-postgres/simple-date-tests cl-postgres/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-qrencode.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-qrencode.nix
@@ -1,0 +1,30 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "cl-qrencode";
+  version = "20191007-git";
+
+  description = "QR code 2005 encoder in Common Lisp";
+
+  deps = [ args."salza2" args."trivial-gray-streams" args."zpng" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/cl-qrencode/2019-10-07/cl-qrencode-20191007-git.tgz";
+    sha256 = "0jc4bmw498bxkw5imvsj4p49njyybsjhbbvnmykivc38k5nlypz4";
+  };
+
+  packageName = "cl-qrencode";
+
+  asdFilesToKeep = ["cl-qrencode.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM cl-qrencode DESCRIPTION QR code 2005 encoder in Common Lisp SHA256
+    0jc4bmw498bxkw5imvsj4p49njyybsjhbbvnmykivc38k5nlypz4 URL
+    http://beta.quicklisp.org/archive/cl-qrencode/2019-10-07/cl-qrencode-20191007-git.tgz
+    MD5 e94ac1137949ef70dea11ca78431e956 NAME cl-qrencode FILENAME cl-qrencode
+    DEPS
+    ((NAME salza2 FILENAME salza2)
+     (NAME trivial-gray-streams FILENAME trivial-gray-streams)
+     (NAME zpng FILENAME zpng))
+    DEPENDENCIES (salza2 trivial-gray-streams zpng) VERSION 20191007-git
+    SIBLINGS (cl-qrencode-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-webkit2.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-webkit2.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-webkit2";
-  version = "cl-webkit-20211020-git";
+  version = "cl-webkit-20211209-git";
 
   description = "An FFI binding to WebKit2GTK+";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl-cffi-gtk" args."cl-cffi-gtk-cairo" args."cl-cffi-gtk-gdk" args."cl-cffi-gtk-gdk-pixbuf" args."cl-cffi-gtk-gio" args."cl-cffi-gtk-glib" args."cl-cffi-gtk-gobject" args."cl-cffi-gtk-pango" args."closer-mop" args."iterate" args."trivial-features" args."trivial-garbage" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-webkit/2021-10-20/cl-webkit-20211020-git.tgz";
-    sha256 = "0kx9mjk8zgzkm60g0469mp53mj2jzxdb2baqr7sj0rkijc609821";
+    url = "http://beta.quicklisp.org/archive/cl-webkit/2021-12-09/cl-webkit-20211209-git.tgz";
+    sha256 = "1lpzp9rb011zbl8j2jpqhal38slyqq1p6cxxjk51h6mdq7x7z1a0";
   };
 
   packageName = "cl-webkit2";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-webkit2 DESCRIPTION An FFI binding to WebKit2GTK+ SHA256
-    0kx9mjk8zgzkm60g0469mp53mj2jzxdb2baqr7sj0rkijc609821 URL
-    http://beta.quicklisp.org/archive/cl-webkit/2021-10-20/cl-webkit-20211020-git.tgz
-    MD5 fc73d56d8289729e93dd8c4793ea82e4 NAME cl-webkit2 FILENAME cl-webkit2
+    1lpzp9rb011zbl8j2jpqhal38slyqq1p6cxxjk51h6mdq7x7z1a0 URL
+    http://beta.quicklisp.org/archive/cl-webkit/2021-12-09/cl-webkit-20211209-git.tgz
+    MD5 cf710088281b691a91aa29566f50f83a NAME cl-webkit2 FILENAME cl-webkit2
     DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -41,4 +41,4 @@ rec {
      cl-cffi-gtk-gdk cl-cffi-gtk-gdk-pixbuf cl-cffi-gtk-gio cl-cffi-gtk-glib
      cl-cffi-gtk-gobject cl-cffi-gtk-pango closer-mop iterate trivial-features
      trivial-garbage)
-    VERSION cl-webkit-20211020-git SIBLINGS NIL PARASITES NIL) */
+    VERSION cl-webkit-20211209-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl_plus_ssl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl_plus_ssl.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl_plus_ssl";
-  version = "cl+ssl-20211020-git";
+  version = "cl+ssl-20211209-git";
 
   parasites = [ "cl+ssl/config" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."flexi-streams" args."split-sequence" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."uiop" args."usocket" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl+ssl/2021-10-20/cl+ssl-20211020-git.tgz";
-    sha256 = "05yzc736lnsaniv76753flsbzvip0sma4jy3fl124r704gknsvsl";
+    url = "http://beta.quicklisp.org/archive/cl+ssl/2021-12-09/cl+ssl-20211209-git.tgz";
+    sha256 = "1m1dx4jfqpd2jdica7safq3fig31xyn96a0yslvszbhkyn22r0nb";
   };
 
   packageName = "cl+ssl";
@@ -21,9 +21,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl+ssl DESCRIPTION Common Lisp interface to OpenSSL. SHA256
-    05yzc736lnsaniv76753flsbzvip0sma4jy3fl124r704gknsvsl URL
-    http://beta.quicklisp.org/archive/cl+ssl/2021-10-20/cl+ssl-20211020-git.tgz
-    MD5 2122250563c6454ba1abdd36e9432f0c NAME cl+ssl FILENAME cl_plus_ssl DEPS
+    1m1dx4jfqpd2jdica7safq3fig31xyn96a0yslvszbhkyn22r0nb URL
+    http://beta.quicklisp.org/archive/cl+ssl/2021-12-09/cl+ssl-20211209-git.tgz
+    MD5 900134876fea38710e6535420ec60864 NAME cl+ssl FILENAME cl_plus_ssl DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cffi FILENAME cffi) (NAME flexi-streams FILENAME flexi-streams)
@@ -35,5 +35,5 @@ rec {
     DEPENDENCIES
     (alexandria babel bordeaux-threads cffi flexi-streams split-sequence
      trivial-features trivial-garbage trivial-gray-streams uiop usocket)
-    VERSION cl+ssl-20211020-git SIBLINGS (cl+ssl.test) PARASITES
+    VERSION cl+ssl-20211209-git SIBLINGS (cl+ssl.test) PARASITES
     (cl+ssl/config)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-socket.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-socket.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "clack-socket";
-  version = "clack-20210807-git";
+  version = "clack-20211209-git";
 
   description = "System lacks description";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/clack/2021-08-07/clack-20210807-git.tgz";
-    sha256 = "00bwpw04d6rri4hww9n1fa9ygvjgr5d18r7iadqwz0ns795p2pva";
+    url = "http://beta.quicklisp.org/archive/clack/2021-12-09/clack-20211209-git.tgz";
+    sha256 = "1gp323083ds89cw3vd6w40d4cwx04y0qaqdz4wx2332klhvvdnsd";
   };
 
   packageName = "clack-socket";
@@ -19,10 +19,10 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM clack-socket DESCRIPTION System lacks description SHA256
-    00bwpw04d6rri4hww9n1fa9ygvjgr5d18r7iadqwz0ns795p2pva URL
-    http://beta.quicklisp.org/archive/clack/2021-08-07/clack-20210807-git.tgz
-    MD5 a518c42a4d433be7da579b2d46caa438 NAME clack-socket FILENAME
-    clack-socket DEPS NIL DEPENDENCIES NIL VERSION clack-20210807-git SIBLINGS
+    1gp323083ds89cw3vd6w40d4cwx04y0qaqdz4wx2332klhvvdnsd URL
+    http://beta.quicklisp.org/archive/clack/2021-12-09/clack-20211209-git.tgz
+    MD5 c223a854a79b257e0489e185abe48e16 NAME clack-socket FILENAME
+    clack-socket DEPS NIL DEPENDENCIES NIL VERSION clack-20211209-git SIBLINGS
     (clack-handler-fcgi clack-handler-hunchentoot clack-handler-toot
      clack-handler-wookie clack-test clack t-clack-handler-fcgi
      t-clack-handler-hunchentoot t-clack-handler-toot t-clack-handler-wookie)

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "clack";
-  version = "20210807-git";
+  version = "20211209-git";
 
   description = "Web application environment for Common Lisp";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."ironclad" args."lack" args."lack-component" args."lack-middleware-backtrace" args."lack-util" args."split-sequence" args."uiop" args."usocket" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/clack/2021-08-07/clack-20210807-git.tgz";
-    sha256 = "00bwpw04d6rri4hww9n1fa9ygvjgr5d18r7iadqwz0ns795p2pva";
+    url = "http://beta.quicklisp.org/archive/clack/2021-12-09/clack-20211209-git.tgz";
+    sha256 = "1gp323083ds89cw3vd6w40d4cwx04y0qaqdz4wx2332klhvvdnsd";
   };
 
   packageName = "clack";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM clack DESCRIPTION Web application environment for Common Lisp SHA256
-    00bwpw04d6rri4hww9n1fa9ygvjgr5d18r7iadqwz0ns795p2pva URL
-    http://beta.quicklisp.org/archive/clack/2021-08-07/clack-20210807-git.tgz
-    MD5 a518c42a4d433be7da579b2d46caa438 NAME clack FILENAME clack DEPS
+    1gp323083ds89cw3vd6w40d4cwx04y0qaqdz4wx2332klhvvdnsd URL
+    http://beta.quicklisp.org/archive/clack/2021-12-09/clack-20211209-git.tgz
+    MD5 c223a854a79b257e0489e185abe48e16 NAME clack FILENAME clack DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME ironclad FILENAME ironclad) (NAME lack FILENAME lack)
@@ -33,7 +33,7 @@ rec {
     DEPENDENCIES
     (alexandria bordeaux-threads ironclad lack lack-component
      lack-middleware-backtrace lack-util split-sequence uiop usocket)
-    VERSION 20210807-git SIBLINGS
+    VERSION 20211209-git SIBLINGS
     (clack-handler-fcgi clack-handler-hunchentoot clack-handler-toot
      clack-handler-wookie clack-socket clack-test t-clack-handler-fcgi
      t-clack-handler-hunchentoot t-clack-handler-toot t-clack-handler-wookie)

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/closer-mop.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/closer-mop.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "closer-mop";
-  version = "20211020-git";
+  version = "20211209-git";
 
   description = "Closer to MOP is a compatibility layer that rectifies many of the absent or incorrect CLOS MOP features across a broad range of Common Lisp implementations.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/closer-mop/2021-10-20/closer-mop-20211020-git.tgz";
-    sha256 = "1m5ri5br262li2w4qljbplrgk6pm1w5vil5qa71bc1h7fbl0qh07";
+    url = "http://beta.quicklisp.org/archive/closer-mop/2021-12-09/closer-mop-20211209-git.tgz";
+    sha256 = "1zrjsibbph8dz8k0qjawp9c22094rag3aasd4r761m2r482xf5zl";
   };
 
   packageName = "closer-mop";
@@ -20,7 +20,7 @@ rec {
 }
 /* (SYSTEM closer-mop DESCRIPTION
     Closer to MOP is a compatibility layer that rectifies many of the absent or incorrect CLOS MOP features across a broad range of Common Lisp implementations.
-    SHA256 1m5ri5br262li2w4qljbplrgk6pm1w5vil5qa71bc1h7fbl0qh07 URL
-    http://beta.quicklisp.org/archive/closer-mop/2021-10-20/closer-mop-20211020-git.tgz
-    MD5 09606b3803a2b3d727fb94cc59313bd8 NAME closer-mop FILENAME closer-mop
-    DEPS NIL DEPENDENCIES NIL VERSION 20211020-git SIBLINGS NIL PARASITES NIL) */
+    SHA256 1zrjsibbph8dz8k0qjawp9c22094rag3aasd4r761m2r482xf5zl URL
+    http://beta.quicklisp.org/archive/closer-mop/2021-12-09/closer-mop-20211209-git.tgz
+    MD5 0b2a02f6b6a57b5b707df5e1d51950cd NAME closer-mop FILENAME closer-mop
+    DEPS NIL DEPENDENCIES NIL VERSION 20211209-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dexador.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dexador.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "dexador";
-  version = "20210807-git";
+  version = "20211209-git";
 
   description = "Yet another HTTP client for Common Lisp";
 
-  deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."chipz" args."chunga" args."cl_plus_ssl" args."cl-base64" args."cl-cookie" args."cl-ppcre" args."cl-reexport" args."cl-utilities" args."fast-http" args."fast-io" args."flexi-streams" args."local-time" args."proc-parse" args."quri" args."smart-buffer" args."split-sequence" args."static-vectors" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."trivial-mimes" args."usocket" args."xsubseq" ];
+  deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."chipz" args."chunga" args."cl_plus_ssl" args."cl-base64" args."cl-cookie" args."cl-ppcre" args."cl-utilities" args."fast-http" args."fast-io" args."flexi-streams" args."local-time" args."proc-parse" args."quri" args."smart-buffer" args."split-sequence" args."static-vectors" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."trivial-mimes" args."uiop" args."usocket" args."xsubseq" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/dexador/2021-08-07/dexador-20210807-git.tgz";
-    sha256 = "04x29nr2h70b08yail6mf2pgpcgqwx3zxdizkzrj4mv6mi8pdy29";
+    url = "http://beta.quicklisp.org/archive/dexador/2021-12-09/dexador-20211209-git.tgz";
+    sha256 = "0cknpgz9cbqnaa0wafs7nfqlis8cikfxi11gd5r9md8zm0iw3gi7";
   };
 
   packageName = "dexador";
@@ -19,16 +19,16 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM dexador DESCRIPTION Yet another HTTP client for Common Lisp SHA256
-    04x29nr2h70b08yail6mf2pgpcgqwx3zxdizkzrj4mv6mi8pdy29 URL
-    http://beta.quicklisp.org/archive/dexador/2021-08-07/dexador-20210807-git.tgz
-    MD5 92b460917f8fa1c668c770fa850de5c7 NAME dexador FILENAME dexador DEPS
+    0cknpgz9cbqnaa0wafs7nfqlis8cikfxi11gd5r9md8zm0iw3gi7 URL
+    http://beta.quicklisp.org/archive/dexador/2021-12-09/dexador-20211209-git.tgz
+    MD5 211593b3d20b0be78f8c525a9a1f5cfb NAME dexador FILENAME dexador DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cffi FILENAME cffi) (NAME cffi-grovel FILENAME cffi-grovel)
      (NAME cffi-toolchain FILENAME cffi-toolchain) (NAME chipz FILENAME chipz)
      (NAME chunga FILENAME chunga) (NAME cl+ssl FILENAME cl_plus_ssl)
      (NAME cl-base64 FILENAME cl-base64) (NAME cl-cookie FILENAME cl-cookie)
-     (NAME cl-ppcre FILENAME cl-ppcre) (NAME cl-reexport FILENAME cl-reexport)
+     (NAME cl-ppcre FILENAME cl-ppcre)
      (NAME cl-utilities FILENAME cl-utilities)
      (NAME fast-http FILENAME fast-http) (NAME fast-io FILENAME fast-io)
      (NAME flexi-streams FILENAME flexi-streams)
@@ -40,12 +40,12 @@ rec {
      (NAME trivial-features FILENAME trivial-features)
      (NAME trivial-garbage FILENAME trivial-garbage)
      (NAME trivial-gray-streams FILENAME trivial-gray-streams)
-     (NAME trivial-mimes FILENAME trivial-mimes)
+     (NAME trivial-mimes FILENAME trivial-mimes) (NAME uiop FILENAME uiop)
      (NAME usocket FILENAME usocket) (NAME xsubseq FILENAME xsubseq))
     DEPENDENCIES
     (alexandria babel bordeaux-threads cffi cffi-grovel cffi-toolchain chipz
-     chunga cl+ssl cl-base64 cl-cookie cl-ppcre cl-reexport cl-utilities
-     fast-http fast-io flexi-streams local-time proc-parse quri smart-buffer
-     split-sequence static-vectors trivial-features trivial-garbage
-     trivial-gray-streams trivial-mimes usocket xsubseq)
-    VERSION 20210807-git SIBLINGS (dexador-test) PARASITES NIL) */
+     chunga cl+ssl cl-base64 cl-cookie cl-ppcre cl-utilities fast-http fast-io
+     flexi-streams local-time proc-parse quri smart-buffer split-sequence
+     static-vectors trivial-features trivial-garbage trivial-gray-streams
+     trivial-mimes uiop usocket xsubseq)
+    VERSION 20211209-git SIBLINGS (dexador-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/djula.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/djula.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "djula";
-  version = "20211020-git";
+  version = "20211209-git";
 
   description = "An implementation of Django templates for Common Lisp.";
 
   deps = [ args."access" args."alexandria" args."anaphora" args."arnesi" args."babel" args."cl-annot" args."cl-interpol" args."cl-locale" args."cl-ppcre" args."cl-slice" args."cl-syntax" args."cl-syntax-annot" args."cl-unicode" args."closer-mop" args."collectors" args."flexi-streams" args."gettext" args."iterate" args."let-plus" args."local-time" args."named-readtables" args."parser-combinators" args."split-sequence" args."symbol-munger" args."trivial-backtrace" args."trivial-features" args."trivial-gray-streams" args."trivial-types" args."yacc" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/djula/2021-10-20/djula-20211020-git.tgz";
-    sha256 = "1izz1bl5yjcfx7hldj2scdwwr6fybxrw2h4wwkpkwisadh42b648";
+    url = "http://beta.quicklisp.org/archive/djula/2021-12-09/djula-20211209-git.tgz";
+    sha256 = "0csr3c12wf1qcwwfabgz9rvkramj74l15cwj8c01pmcraly8cya7";
   };
 
   packageName = "djula";
@@ -20,9 +20,9 @@ rec {
 }
 /* (SYSTEM djula DESCRIPTION
     An implementation of Django templates for Common Lisp. SHA256
-    1izz1bl5yjcfx7hldj2scdwwr6fybxrw2h4wwkpkwisadh42b648 URL
-    http://beta.quicklisp.org/archive/djula/2021-10-20/djula-20211020-git.tgz
-    MD5 0b6464f786f65c14d71499fc0114733d NAME djula FILENAME djula DEPS
+    0csr3c12wf1qcwwfabgz9rvkramj74l15cwj8c01pmcraly8cya7 URL
+    http://beta.quicklisp.org/archive/djula/2021-12-09/djula-20211209-git.tgz
+    MD5 f7cb3581b5eb40c8609e90cdf87a2a06 NAME djula FILENAME djula DEPS
     ((NAME access FILENAME access) (NAME alexandria FILENAME alexandria)
      (NAME anaphora FILENAME anaphora) (NAME arnesi FILENAME arnesi)
      (NAME babel FILENAME babel) (NAME cl-annot FILENAME cl-annot)
@@ -51,4 +51,4 @@ rec {
      named-readtables parser-combinators split-sequence symbol-munger
      trivial-backtrace trivial-features trivial-gray-streams trivial-types
      yacc)
-    VERSION 20211020-git SIBLINGS (djula-demo djula-test) PARASITES NIL) */
+    VERSION 20211209-git SIBLINGS (djula-demo djula-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/enchant.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/enchant.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "enchant";
-  version = "cl-20190521-git";
+  version = "cl-20211209-git";
 
   description = "Programming interface for Enchant spell-checker library";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."trivial-features" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-enchant/2019-05-21/cl-enchant-20190521-git.tgz";
-    sha256 = "16ag48fr74m536an8fak5z0lfjdb265gv1ajai1lqg0vq2l5mr14";
+    url = "http://beta.quicklisp.org/archive/cl-enchant/2021-12-09/cl-enchant-20211209-git.tgz";
+    sha256 = "1j9qliyxfjfz4bbc6snysccnmmk2d2y8kb613rna239dh5g6c03c";
   };
 
   packageName = "enchant";
@@ -20,11 +20,11 @@ rec {
 }
 /* (SYSTEM enchant DESCRIPTION
     Programming interface for Enchant spell-checker library SHA256
-    16ag48fr74m536an8fak5z0lfjdb265gv1ajai1lqg0vq2l5mr14 URL
-    http://beta.quicklisp.org/archive/cl-enchant/2019-05-21/cl-enchant-20190521-git.tgz
-    MD5 2a868c280fd5a74f9c298c384567e31b NAME enchant FILENAME enchant DEPS
+    1j9qliyxfjfz4bbc6snysccnmmk2d2y8kb613rna239dh5g6c03c URL
+    http://beta.quicklisp.org/archive/cl-enchant/2021-12-09/cl-enchant-20211209-git.tgz
+    MD5 c12162b3a7c383815ff77c96aca0c11f NAME enchant FILENAME enchant DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME cffi FILENAME cffi)
      (NAME trivial-features FILENAME trivial-features))
     DEPENDENCIES (alexandria babel cffi trivial-features) VERSION
-    cl-20190521-git SIBLINGS (enchant-autoload) PARASITES NIL) */
+    cl-20211209-git SIBLINGS (enchant-autoload) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/fiveam.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/fiveam.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "fiveam";
-  version = "20200925-git";
+  version = "20211209-git";
 
   parasites = [ "fiveam/test" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."net_dot_didierverna_dot_asdf-flv" args."trivial-backtrace" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/fiveam/2020-09-25/fiveam-20200925-git.tgz";
-    sha256 = "0j9dzjs4prlx33f5idbcic4amx2mcgnjcyrpc3dd4b7lrw426l0d";
+    url = "http://beta.quicklisp.org/archive/fiveam/2021-12-09/fiveam-20211209-git.tgz";
+    sha256 = "0kyyr2dlgpzkn2cw9i4fwyip1d1la4cbv8l4b8jz31f5c1p76ab7";
   };
 
   packageName = "fiveam";
@@ -21,11 +21,11 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM fiveam DESCRIPTION A simple regression testing framework SHA256
-    0j9dzjs4prlx33f5idbcic4amx2mcgnjcyrpc3dd4b7lrw426l0d URL
-    http://beta.quicklisp.org/archive/fiveam/2020-09-25/fiveam-20200925-git.tgz
-    MD5 858ecfdf7821630ad11e6859100d4650 NAME fiveam FILENAME fiveam DEPS
+    0kyyr2dlgpzkn2cw9i4fwyip1d1la4cbv8l4b8jz31f5c1p76ab7 URL
+    http://beta.quicklisp.org/archive/fiveam/2021-12-09/fiveam-20211209-git.tgz
+    MD5 10d6a5a19f47ed94cbd9edf1d4c20933 NAME fiveam FILENAME fiveam DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME net.didierverna.asdf-flv FILENAME net_dot_didierverna_dot_asdf-flv)
      (NAME trivial-backtrace FILENAME trivial-backtrace))
     DEPENDENCIES (alexandria net.didierverna.asdf-flv trivial-backtrace)
-    VERSION 20200925-git SIBLINGS NIL PARASITES (fiveam/test)) */
+    VERSION 20211209-git SIBLINGS NIL PARASITES (fiveam/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_common-lisp.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_common-lisp.nix
@@ -1,0 +1,29 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "hu_dot_dwim_dot_common-lisp";
+  version = "stable-git";
+
+  description = "A redefinition of the standard Common Lisp package that includes a number of renames and shadows.";
+
+  deps = [ args."hu_dot_dwim_dot_asdf" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/hu.dwim.common-lisp/2021-02-28/hu.dwim.common-lisp-stable-git.tgz";
+    sha256 = "1v111qvpfs0jml54a4qccyicgq4jg3h72z8484wa1x0acc9hgz76";
+  };
+
+  packageName = "hu.dwim.common-lisp";
+
+  asdFilesToKeep = ["hu.dwim.common-lisp.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM hu.dwim.common-lisp DESCRIPTION
+    A redefinition of the standard Common Lisp package that includes a number of renames and shadows.
+    SHA256 1v111qvpfs0jml54a4qccyicgq4jg3h72z8484wa1x0acc9hgz76 URL
+    http://beta.quicklisp.org/archive/hu.dwim.common-lisp/2021-02-28/hu.dwim.common-lisp-stable-git.tgz
+    MD5 4f0c7a375cc55381efdbeb17ef17dd7d NAME hu.dwim.common-lisp FILENAME
+    hu_dot_dwim_dot_common-lisp DEPS
+    ((NAME hu.dwim.asdf FILENAME hu_dot_dwim_dot_asdf)) DEPENDENCIES
+    (hu.dwim.asdf) VERSION stable-git SIBLINGS
+    (hu.dwim.common-lisp.documentation) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_common.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_common.nix
@@ -1,0 +1,37 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "hu_dot_dwim_dot_common";
+  version = "20150709-darcs";
+
+  description = "An extended Common Lisp package to the general needs of other hu.dwim systems.";
+
+  deps = [ args."alexandria" args."anaphora" args."closer-mop" args."hu_dot_dwim_dot_asdf" args."hu_dot_dwim_dot_common-lisp" args."iterate" args."metabang-bind" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/hu.dwim.common/2015-07-09/hu.dwim.common-20150709-darcs.tgz";
+    sha256 = "12l1rr6w9m99w0b5gc6hv58ainjfhbc588kz6vwshn4gqsxyzbhp";
+  };
+
+  packageName = "hu.dwim.common";
+
+  asdFilesToKeep = ["hu.dwim.common.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM hu.dwim.common DESCRIPTION
+    An extended Common Lisp package to the general needs of other hu.dwim systems.
+    SHA256 12l1rr6w9m99w0b5gc6hv58ainjfhbc588kz6vwshn4gqsxyzbhp URL
+    http://beta.quicklisp.org/archive/hu.dwim.common/2015-07-09/hu.dwim.common-20150709-darcs.tgz
+    MD5 fff7f05c24e71a0270021909ca86a9ef NAME hu.dwim.common FILENAME
+    hu_dot_dwim_dot_common DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
+     (NAME closer-mop FILENAME closer-mop)
+     (NAME hu.dwim.asdf FILENAME hu_dot_dwim_dot_asdf)
+     (NAME hu.dwim.common-lisp FILENAME hu_dot_dwim_dot_common-lisp)
+     (NAME iterate FILENAME iterate)
+     (NAME metabang-bind FILENAME metabang-bind))
+    DEPENDENCIES
+    (alexandria anaphora closer-mop hu.dwim.asdf hu.dwim.common-lisp iterate
+     metabang-bind)
+    VERSION 20150709-darcs SIBLINGS (hu.dwim.common.documentation) PARASITES
+    NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_def.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_def.nix
@@ -1,0 +1,36 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "hu_dot_dwim_dot_def";
+  version = "20201016-darcs";
+
+  description = "General purpose, homogenous, extensible definer macro.";
+
+  deps = [ args."alexandria" args."anaphora" args."hu_dot_dwim_dot_asdf" args."iterate" args."metabang-bind" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/hu.dwim.def/2020-10-16/hu.dwim.def-20201016-darcs.tgz";
+    sha256 = "0m9id405f0s1438yr2qppdw5z7xdx3ajaa1frd04pibqgf4db4cj";
+  };
+
+  packageName = "hu.dwim.def";
+
+  asdFilesToKeep = ["hu.dwim.def.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM hu.dwim.def DESCRIPTION
+    General purpose, homogenous, extensible definer macro. SHA256
+    0m9id405f0s1438yr2qppdw5z7xdx3ajaa1frd04pibqgf4db4cj URL
+    http://beta.quicklisp.org/archive/hu.dwim.def/2020-10-16/hu.dwim.def-20201016-darcs.tgz
+    MD5 c4d7469472f57cd700d8319e35dd5f32 NAME hu.dwim.def FILENAME
+    hu_dot_dwim_dot_def DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
+     (NAME hu.dwim.asdf FILENAME hu_dot_dwim_dot_asdf)
+     (NAME iterate FILENAME iterate)
+     (NAME metabang-bind FILENAME metabang-bind))
+    DEPENDENCIES (alexandria anaphora hu.dwim.asdf iterate metabang-bind)
+    VERSION 20201016-darcs SIBLINGS
+    (hu.dwim.def+cl-l10n hu.dwim.def+contextl hu.dwim.def+hu.dwim.common
+     hu.dwim.def+hu.dwim.delico hu.dwim.def+swank hu.dwim.def.documentation
+     hu.dwim.def.namespace hu.dwim.def.test)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_def_plus_swank.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_def_plus_swank.nix
@@ -1,0 +1,37 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "hu_dot_dwim_dot_def_plus_swank";
+  version = "hu.dwim.def-20201016-darcs";
+
+  description = "System lacks description";
+
+  deps = [ args."alexandria" args."anaphora" args."hu_dot_dwim_dot_asdf" args."hu_dot_dwim_dot_def" args."iterate" args."metabang-bind" args."swank" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/hu.dwim.def/2020-10-16/hu.dwim.def-20201016-darcs.tgz";
+    sha256 = "0m9id405f0s1438yr2qppdw5z7xdx3ajaa1frd04pibqgf4db4cj";
+  };
+
+  packageName = "hu.dwim.def+swank";
+
+  asdFilesToKeep = ["hu.dwim.def+swank.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM hu.dwim.def+swank DESCRIPTION System lacks description SHA256
+    0m9id405f0s1438yr2qppdw5z7xdx3ajaa1frd04pibqgf4db4cj URL
+    http://beta.quicklisp.org/archive/hu.dwim.def/2020-10-16/hu.dwim.def-20201016-darcs.tgz
+    MD5 c4d7469472f57cd700d8319e35dd5f32 NAME hu.dwim.def+swank FILENAME
+    hu_dot_dwim_dot_def_plus_swank DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
+     (NAME hu.dwim.asdf FILENAME hu_dot_dwim_dot_asdf)
+     (NAME hu.dwim.def FILENAME hu_dot_dwim_dot_def)
+     (NAME iterate FILENAME iterate)
+     (NAME metabang-bind FILENAME metabang-bind) (NAME swank FILENAME swank))
+    DEPENDENCIES
+    (alexandria anaphora hu.dwim.asdf hu.dwim.def iterate metabang-bind swank)
+    VERSION hu.dwim.def-20201016-darcs SIBLINGS
+    (hu.dwim.def+cl-l10n hu.dwim.def+contextl hu.dwim.def+hu.dwim.common
+     hu.dwim.def+hu.dwim.delico hu.dwim.def hu.dwim.def.documentation
+     hu.dwim.def.namespace hu.dwim.def.test)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_defclass-star.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_defclass-star.nix
@@ -4,13 +4,15 @@ rec {
   baseName = "hu_dot_dwim_dot_defclass-star";
   version = "stable-git";
 
+  parasites = [ "hu.dwim.defclass-star/test" ];
+
   description = "Simplify class like definitions with defclass* and friends.";
 
-  deps = [ args."hu_dot_dwim_dot_asdf" ];
+  deps = [ args."hu_dot_dwim_dot_asdf" args."hu_dot_dwim_dot_common" args."hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def_plus_swank" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/hu.dwim.defclass-star/2021-02-28/hu.dwim.defclass-star-stable-git.tgz";
-    sha256 = "1zj4c9pz7y69gclyd7kzf6d6s1r0am49czgvp2axbv7w50j5caf9";
+    url = "http://beta.quicklisp.org/archive/hu.dwim.defclass-star/2021-12-09/hu.dwim.defclass-star-stable-git.tgz";
+    sha256 = "0draahmhi5mmrj9aqabqdaipqcb9adxqdypjbdiawg55dw36g0cy";
   };
 
   packageName = "hu.dwim.defclass-star";
@@ -20,13 +22,16 @@ rec {
 }
 /* (SYSTEM hu.dwim.defclass-star DESCRIPTION
     Simplify class like definitions with defclass* and friends. SHA256
-    1zj4c9pz7y69gclyd7kzf6d6s1r0am49czgvp2axbv7w50j5caf9 URL
-    http://beta.quicklisp.org/archive/hu.dwim.defclass-star/2021-02-28/hu.dwim.defclass-star-stable-git.tgz
-    MD5 adb295fecbe4570f4c03dbd857b2ddbc NAME hu.dwim.defclass-star FILENAME
+    0draahmhi5mmrj9aqabqdaipqcb9adxqdypjbdiawg55dw36g0cy URL
+    http://beta.quicklisp.org/archive/hu.dwim.defclass-star/2021-12-09/hu.dwim.defclass-star-stable-git.tgz
+    MD5 e35fa9767089eb2fb03befaec18d5081 NAME hu.dwim.defclass-star FILENAME
     hu_dot_dwim_dot_defclass-star DEPS
-    ((NAME hu.dwim.asdf FILENAME hu_dot_dwim_dot_asdf)) DEPENDENCIES
-    (hu.dwim.asdf) VERSION stable-git SIBLINGS
+    ((NAME hu.dwim.asdf FILENAME hu_dot_dwim_dot_asdf)
+     (NAME hu.dwim.common FILENAME hu_dot_dwim_dot_common)
+     (NAME hu.dwim.stefil+hu.dwim.def+swank FILENAME
+      hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def_plus_swank))
+    DEPENDENCIES (hu.dwim.asdf hu.dwim.common hu.dwim.stefil+hu.dwim.def+swank)
+    VERSION stable-git SIBLINGS
     (hu.dwim.defclass-star+contextl hu.dwim.defclass-star+hu.dwim.def+contextl
-     hu.dwim.defclass-star+hu.dwim.def hu.dwim.defclass-star+swank
-     hu.dwim.defclass-star.documentation hu.dwim.defclass-star.test)
-    PARASITES NIL) */
+     hu.dwim.defclass-star+hu.dwim.def hu.dwim.defclass-star+swank)
+    PARASITES (hu.dwim.defclass-star/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def.nix
@@ -1,0 +1,37 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def";
+  version = "hu.dwim.stefil-20200218-darcs";
+
+  description = "System lacks description";
+
+  deps = [ args."alexandria" args."anaphora" args."hu_dot_dwim_dot_asdf" args."hu_dot_dwim_dot_def" args."hu_dot_dwim_dot_stefil" args."iterate" args."metabang-bind" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/hu.dwim.stefil/2020-02-18/hu.dwim.stefil-20200218-darcs.tgz";
+    sha256 = "16p25pq9fhk0dny6r43yl9z24g6qm6dag9zf2cila9v9jh3r76qf";
+  };
+
+  packageName = "hu.dwim.stefil+hu.dwim.def";
+
+  asdFilesToKeep = ["hu.dwim.stefil+hu.dwim.def.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM hu.dwim.stefil+hu.dwim.def DESCRIPTION System lacks description
+    SHA256 16p25pq9fhk0dny6r43yl9z24g6qm6dag9zf2cila9v9jh3r76qf URL
+    http://beta.quicklisp.org/archive/hu.dwim.stefil/2020-02-18/hu.dwim.stefil-20200218-darcs.tgz
+    MD5 3e87e0973f8373e342b75b13c802cc53 NAME hu.dwim.stefil+hu.dwim.def
+    FILENAME hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
+     (NAME hu.dwim.asdf FILENAME hu_dot_dwim_dot_asdf)
+     (NAME hu.dwim.def FILENAME hu_dot_dwim_dot_def)
+     (NAME hu.dwim.stefil FILENAME hu_dot_dwim_dot_stefil)
+     (NAME iterate FILENAME iterate)
+     (NAME metabang-bind FILENAME metabang-bind))
+    DEPENDENCIES
+    (alexandria anaphora hu.dwim.asdf hu.dwim.def hu.dwim.stefil iterate
+     metabang-bind)
+    VERSION hu.dwim.stefil-20200218-darcs SIBLINGS
+    (hu.dwim.stefil+hu.dwim.def+swank hu.dwim.stefil+swank hu.dwim.stefil)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def_plus_swank.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def_plus_swank.nix
@@ -1,0 +1,43 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def_plus_swank";
+  version = "hu.dwim.stefil-20200218-darcs";
+
+  description = "System lacks description";
+
+  deps = [ args."alexandria" args."anaphora" args."hu_dot_dwim_dot_asdf" args."hu_dot_dwim_dot_def" args."hu_dot_dwim_dot_def_plus_swank" args."hu_dot_dwim_dot_stefil" args."hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def" args."hu_dot_dwim_dot_stefil_plus_swank" args."iterate" args."metabang-bind" args."swank" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/hu.dwim.stefil/2020-02-18/hu.dwim.stefil-20200218-darcs.tgz";
+    sha256 = "16p25pq9fhk0dny6r43yl9z24g6qm6dag9zf2cila9v9jh3r76qf";
+  };
+
+  packageName = "hu.dwim.stefil+hu.dwim.def+swank";
+
+  asdFilesToKeep = ["hu.dwim.stefil+hu.dwim.def+swank.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM hu.dwim.stefil+hu.dwim.def+swank DESCRIPTION
+    System lacks description SHA256
+    16p25pq9fhk0dny6r43yl9z24g6qm6dag9zf2cila9v9jh3r76qf URL
+    http://beta.quicklisp.org/archive/hu.dwim.stefil/2020-02-18/hu.dwim.stefil-20200218-darcs.tgz
+    MD5 3e87e0973f8373e342b75b13c802cc53 NAME hu.dwim.stefil+hu.dwim.def+swank
+    FILENAME hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def_plus_swank DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
+     (NAME hu.dwim.asdf FILENAME hu_dot_dwim_dot_asdf)
+     (NAME hu.dwim.def FILENAME hu_dot_dwim_dot_def)
+     (NAME hu.dwim.def+swank FILENAME hu_dot_dwim_dot_def_plus_swank)
+     (NAME hu.dwim.stefil FILENAME hu_dot_dwim_dot_stefil)
+     (NAME hu.dwim.stefil+hu.dwim.def FILENAME
+      hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def)
+     (NAME hu.dwim.stefil+swank FILENAME hu_dot_dwim_dot_stefil_plus_swank)
+     (NAME iterate FILENAME iterate)
+     (NAME metabang-bind FILENAME metabang-bind) (NAME swank FILENAME swank))
+    DEPENDENCIES
+    (alexandria anaphora hu.dwim.asdf hu.dwim.def hu.dwim.def+swank
+     hu.dwim.stefil hu.dwim.stefil+hu.dwim.def hu.dwim.stefil+swank iterate
+     metabang-bind swank)
+    VERSION hu.dwim.stefil-20200218-darcs SIBLINGS
+    (hu.dwim.stefil+hu.dwim.def hu.dwim.stefil+swank hu.dwim.stefil) PARASITES
+    NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_stefil_plus_swank.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_stefil_plus_swank.nix
@@ -1,0 +1,34 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "hu_dot_dwim_dot_stefil_plus_swank";
+  version = "hu.dwim.stefil-20200218-darcs";
+
+  description = "System lacks description";
+
+  deps = [ args."alexandria" args."hu_dot_dwim_dot_asdf" args."hu_dot_dwim_dot_stefil" args."swank" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/hu.dwim.stefil/2020-02-18/hu.dwim.stefil-20200218-darcs.tgz";
+    sha256 = "16p25pq9fhk0dny6r43yl9z24g6qm6dag9zf2cila9v9jh3r76qf";
+  };
+
+  packageName = "hu.dwim.stefil+swank";
+
+  asdFilesToKeep = ["hu.dwim.stefil+swank.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM hu.dwim.stefil+swank DESCRIPTION System lacks description SHA256
+    16p25pq9fhk0dny6r43yl9z24g6qm6dag9zf2cila9v9jh3r76qf URL
+    http://beta.quicklisp.org/archive/hu.dwim.stefil/2020-02-18/hu.dwim.stefil-20200218-darcs.tgz
+    MD5 3e87e0973f8373e342b75b13c802cc53 NAME hu.dwim.stefil+swank FILENAME
+    hu_dot_dwim_dot_stefil_plus_swank DEPS
+    ((NAME alexandria FILENAME alexandria)
+     (NAME hu.dwim.asdf FILENAME hu_dot_dwim_dot_asdf)
+     (NAME hu.dwim.stefil FILENAME hu_dot_dwim_dot_stefil)
+     (NAME swank FILENAME swank))
+    DEPENDENCIES (alexandria hu.dwim.asdf hu.dwim.stefil swank) VERSION
+    hu.dwim.stefil-20200218-darcs SIBLINGS
+    (hu.dwim.stefil+hu.dwim.def+swank hu.dwim.stefil+hu.dwim.def
+     hu.dwim.stefil)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hunchensocket.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hunchensocket.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "hunchensocket";
-  version = "20180711-git";
+  version = "20210531-git";
 
   parasites = [ "hunchensocket-tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."chunga" args."cl_plus_ssl" args."cl-base64" args."cl-fad" args."cl-ppcre" args."fiasco" args."flexi-streams" args."hunchentoot" args."ironclad" args."md5" args."rfc2388" args."split-sequence" args."trivial-backtrace" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."trivial-utf-8" args."usocket" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/hunchensocket/2018-07-11/hunchensocket-20180711-git.tgz";
-    sha256 = "03igrp8svb4gkwhhhgmxwrnp5vq5ndp15mxqsafyi065xj3ppw48";
+    url = "http://beta.quicklisp.org/archive/hunchensocket/2021-05-31/hunchensocket-20210531-git.tgz";
+    sha256 = "18zy11fir6vlg5vh29pr221dydbl9carfj9xkmsnygyzxkl6jghl";
   };
 
   packageName = "hunchensocket";
@@ -21,9 +21,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM hunchensocket DESCRIPTION WebSockets for Hunchentoot SHA256
-    03igrp8svb4gkwhhhgmxwrnp5vq5ndp15mxqsafyi065xj3ppw48 URL
-    http://beta.quicklisp.org/archive/hunchensocket/2018-07-11/hunchensocket-20180711-git.tgz
-    MD5 bf6cd52c13e3b1f464c8a45a8bac85b8 NAME hunchensocket FILENAME
+    18zy11fir6vlg5vh29pr221dydbl9carfj9xkmsnygyzxkl6jghl URL
+    http://beta.quicklisp.org/archive/hunchensocket/2021-05-31/hunchensocket-20210531-git.tgz
+    MD5 a529901753a54eb48c93aa86b0c3747d NAME hunchensocket FILENAME
     hunchensocket DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -45,4 +45,4 @@ rec {
      cl-ppcre fiasco flexi-streams hunchentoot ironclad md5 rfc2388
      split-sequence trivial-backtrace trivial-features trivial-garbage
      trivial-gray-streams trivial-utf-8 usocket)
-    VERSION 20180711-git SIBLINGS NIL PARASITES (hunchensocket-tests)) */
+    VERSION 20210531-git SIBLINGS NIL PARASITES (hunchensocket-tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-component.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-component.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "lack-component";
-  version = "lack-20211020-git";
+  version = "lack-20211209-git";
 
   description = "System lacks description";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/lack/2021-10-20/lack-20211020-git.tgz";
-    sha256 = "0ly7bdvrl5xsls9syybcf0qm2981m434rhr3gr756kvvk4s9mdn2";
+    url = "http://beta.quicklisp.org/archive/lack/2021-12-09/lack-20211209-git.tgz";
+    sha256 = "0vd36hjcf98s9slkm6rmgsa7r10wvzl9s4xhfmcwh7qv7jxdgkhg";
   };
 
   packageName = "lack-component";
@@ -19,10 +19,10 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM lack-component DESCRIPTION System lacks description SHA256
-    0ly7bdvrl5xsls9syybcf0qm2981m434rhr3gr756kvvk4s9mdn2 URL
-    http://beta.quicklisp.org/archive/lack/2021-10-20/lack-20211020-git.tgz MD5
-    4a98955fb9cd5db45b796a0b269a57e1 NAME lack-component FILENAME
-    lack-component DEPS NIL DEPENDENCIES NIL VERSION lack-20211020-git SIBLINGS
+    0vd36hjcf98s9slkm6rmgsa7r10wvzl9s4xhfmcwh7qv7jxdgkhg URL
+    http://beta.quicklisp.org/archive/lack/2021-12-09/lack-20211209-git.tgz MD5
+    610b1aea0280193d6f125aa1317a2d79 NAME lack-component FILENAME
+    lack-component DEPS NIL DEPENDENCIES NIL VERSION lack-20211209-git SIBLINGS
     (lack-app-directory lack-app-file lack-middleware-accesslog
      lack-middleware-auth-basic lack-middleware-backtrace lack-middleware-csrf
      lack-middleware-mount lack-middleware-session lack-middleware-static

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-middleware-backtrace.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-middleware-backtrace.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "lack-middleware-backtrace";
-  version = "lack-20211020-git";
+  version = "lack-20211209-git";
 
   description = "System lacks description";
 
   deps = [ args."uiop" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/lack/2021-10-20/lack-20211020-git.tgz";
-    sha256 = "0ly7bdvrl5xsls9syybcf0qm2981m434rhr3gr756kvvk4s9mdn2";
+    url = "http://beta.quicklisp.org/archive/lack/2021-12-09/lack-20211209-git.tgz";
+    sha256 = "0vd36hjcf98s9slkm6rmgsa7r10wvzl9s4xhfmcwh7qv7jxdgkhg";
   };
 
   packageName = "lack-middleware-backtrace";
@@ -19,11 +19,11 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM lack-middleware-backtrace DESCRIPTION System lacks description
-    SHA256 0ly7bdvrl5xsls9syybcf0qm2981m434rhr3gr756kvvk4s9mdn2 URL
-    http://beta.quicklisp.org/archive/lack/2021-10-20/lack-20211020-git.tgz MD5
-    4a98955fb9cd5db45b796a0b269a57e1 NAME lack-middleware-backtrace FILENAME
+    SHA256 0vd36hjcf98s9slkm6rmgsa7r10wvzl9s4xhfmcwh7qv7jxdgkhg URL
+    http://beta.quicklisp.org/archive/lack/2021-12-09/lack-20211209-git.tgz MD5
+    610b1aea0280193d6f125aa1317a2d79 NAME lack-middleware-backtrace FILENAME
     lack-middleware-backtrace DEPS ((NAME uiop FILENAME uiop)) DEPENDENCIES
-    (uiop) VERSION lack-20211020-git SIBLINGS
+    (uiop) VERSION lack-20211209-git SIBLINGS
     (lack-app-directory lack-app-file lack-component lack-middleware-accesslog
      lack-middleware-auth-basic lack-middleware-csrf lack-middleware-mount
      lack-middleware-session lack-middleware-static lack-request lack-response

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-util.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-util.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "lack-util";
-  version = "lack-20211020-git";
+  version = "lack-20211209-git";
 
   description = "System lacks description";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."ironclad" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/lack/2021-10-20/lack-20211020-git.tgz";
-    sha256 = "0ly7bdvrl5xsls9syybcf0qm2981m434rhr3gr756kvvk4s9mdn2";
+    url = "http://beta.quicklisp.org/archive/lack/2021-12-09/lack-20211209-git.tgz";
+    sha256 = "0vd36hjcf98s9slkm6rmgsa7r10wvzl9s4xhfmcwh7qv7jxdgkhg";
   };
 
   packageName = "lack-util";
@@ -19,14 +19,14 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM lack-util DESCRIPTION System lacks description SHA256
-    0ly7bdvrl5xsls9syybcf0qm2981m434rhr3gr756kvvk4s9mdn2 URL
-    http://beta.quicklisp.org/archive/lack/2021-10-20/lack-20211020-git.tgz MD5
-    4a98955fb9cd5db45b796a0b269a57e1 NAME lack-util FILENAME lack-util DEPS
+    0vd36hjcf98s9slkm6rmgsa7r10wvzl9s4xhfmcwh7qv7jxdgkhg URL
+    http://beta.quicklisp.org/archive/lack/2021-12-09/lack-20211209-git.tgz MD5
+    610b1aea0280193d6f125aa1317a2d79 NAME lack-util FILENAME lack-util DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME ironclad FILENAME ironclad))
     DEPENDENCIES (alexandria bordeaux-threads ironclad) VERSION
-    lack-20211020-git SIBLINGS
+    lack-20211209-git SIBLINGS
     (lack-app-directory lack-app-file lack-component lack-middleware-accesslog
      lack-middleware-auth-basic lack-middleware-backtrace lack-middleware-csrf
      lack-middleware-mount lack-middleware-session lack-middleware-static

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "lack";
-  version = "20211020-git";
+  version = "20211209-git";
 
   description = "A minimal Clack";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."ironclad" args."lack-component" args."lack-util" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/lack/2021-10-20/lack-20211020-git.tgz";
-    sha256 = "0ly7bdvrl5xsls9syybcf0qm2981m434rhr3gr756kvvk4s9mdn2";
+    url = "http://beta.quicklisp.org/archive/lack/2021-12-09/lack-20211209-git.tgz";
+    sha256 = "0vd36hjcf98s9slkm6rmgsa7r10wvzl9s4xhfmcwh7qv7jxdgkhg";
   };
 
   packageName = "lack";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM lack DESCRIPTION A minimal Clack SHA256
-    0ly7bdvrl5xsls9syybcf0qm2981m434rhr3gr756kvvk4s9mdn2 URL
-    http://beta.quicklisp.org/archive/lack/2021-10-20/lack-20211020-git.tgz MD5
-    4a98955fb9cd5db45b796a0b269a57e1 NAME lack FILENAME lack DEPS
+    0vd36hjcf98s9slkm6rmgsa7r10wvzl9s4xhfmcwh7qv7jxdgkhg URL
+    http://beta.quicklisp.org/archive/lack/2021-12-09/lack-20211209-git.tgz MD5
+    610b1aea0280193d6f125aa1317a2d79 NAME lack FILENAME lack DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME ironclad FILENAME ironclad)
@@ -29,7 +29,7 @@ rec {
      (NAME lack-util FILENAME lack-util))
     DEPENDENCIES
     (alexandria bordeaux-threads ironclad lack-component lack-util) VERSION
-    20211020-git SIBLINGS
+    20211209-git SIBLINGS
     (lack-app-directory lack-app-file lack-component lack-middleware-accesslog
      lack-middleware-auth-basic lack-middleware-backtrace lack-middleware-csrf
      lack-middleware-mount lack-middleware-session lack-middleware-static

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lift.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lift.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "lift";
-  version = "20190521-git";
+  version = "20211209-git";
 
   description = "LIsp Framework for Testing";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/lift/2019-05-21/lift-20190521-git.tgz";
-    sha256 = "0cinilin9bxzsj3mzd4488zx2irvyl5qpbykv0xbyfz2mjh94ac9";
+    url = "http://beta.quicklisp.org/archive/lift/2021-12-09/lift-20211209-git.tgz";
+    sha256 = "1r3i1gi2kggxbvh6mk58cddp5mi9kh7v23gd3z5q70w7cy69iiy7";
   };
 
   packageName = "lift";
@@ -19,8 +19,8 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM lift DESCRIPTION LIsp Framework for Testing SHA256
-    0cinilin9bxzsj3mzd4488zx2irvyl5qpbykv0xbyfz2mjh94ac9 URL
-    http://beta.quicklisp.org/archive/lift/2019-05-21/lift-20190521-git.tgz MD5
-    c03d3fa715792440c7b51a852ad581e3 NAME lift FILENAME lift DEPS NIL
-    DEPENDENCIES NIL VERSION 20190521-git SIBLINGS
+    1r3i1gi2kggxbvh6mk58cddp5mi9kh7v23gd3z5q70w7cy69iiy7 URL
+    http://beta.quicklisp.org/archive/lift/2021-12-09/lift-20211209-git.tgz MD5
+    b98c58658dba0b84a034aa1f0f68dcc9 NAME lift FILENAME lift DEPS NIL
+    DEPENDENCIES NIL VERSION 20211209-git SIBLINGS
     (lift-documentation lift-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/log4cl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/log4cl.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "log4cl";
-  version = "20211020-git";
+  version = "20211209-git";
 
   parasites = [ "log4cl/syslog" "log4cl/test" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."bordeaux-threads" args."stefil" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/log4cl/2021-10-20/log4cl-20211020-git.tgz";
-    sha256 = "1nqryqd5z4grg75hffqs2x6nzdf972cp4f41l1dr8wdf3fp0ifz8";
+    url = "http://beta.quicklisp.org/archive/log4cl/2021-12-09/log4cl-20211209-git.tgz";
+    sha256 = "17jwxhc2ysh3m3cp7wvh8cy359v7w6kz9vk9f07japzi3krv9iq9";
   };
 
   packageName = "log4cl";
@@ -21,12 +21,12 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM log4cl DESCRIPTION System lacks description SHA256
-    1nqryqd5z4grg75hffqs2x6nzdf972cp4f41l1dr8wdf3fp0ifz8 URL
-    http://beta.quicklisp.org/archive/log4cl/2021-10-20/log4cl-20211020-git.tgz
-    MD5 d4eb0d4c8a9bc2f2037d7a64d44292d4 NAME log4cl FILENAME log4cl DEPS
+    17jwxhc2ysh3m3cp7wvh8cy359v7w6kz9vk9f07japzi3krv9iq9 URL
+    http://beta.quicklisp.org/archive/log4cl/2021-12-09/log4cl-20211209-git.tgz
+    MD5 569122fed30c089b67527926468dcf44 NAME log4cl FILENAME log4cl DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME stefil FILENAME stefil))
-    DEPENDENCIES (alexandria bordeaux-threads stefil) VERSION 20211020-git
+    DEPENDENCIES (alexandria bordeaux-threads stefil) VERSION 20211209-git
     SIBLINGS (log4cl-examples log4cl.log4slime log4cl.log4sly) PARASITES
     (log4cl/syslog log4cl/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/mgl-pax.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/mgl-pax.nix
@@ -2,18 +2,18 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "mgl-pax";
-  version = "20211020-git";
+  version = "20211209-git";
 
-  parasites = [ "mgl-pax/full" ];
+  parasites = [ "mgl-pax/document" "mgl-pax/navigate" ];
 
   description = "Exploratory programming tool and documentation
   generator.";
 
-  deps = [ args."_3bmd" args."_3bmd-ext-code-blocks" args."alexandria" args."babel" args."cl-fad" args."colorize" args."ironclad" args."named-readtables" args."pythonic-string-reader" args."swank" ];
+  deps = [ args."_3bmd" args."_3bmd-ext-code-blocks" args."alexandria" args."colorize" args."md5" args."named-readtables" args."pythonic-string-reader" args."swank" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/mgl-pax/2021-10-20/mgl-pax-20211020-git.tgz";
-    sha256 = "04vddyvyxja8dabksfqqr80xjnvdiiv61zidjvijlpkk8shwaw1g";
+    url = "http://beta.quicklisp.org/archive/mgl-pax/2021-12-09/mgl-pax-20211209-git.tgz";
+    sha256 = "19d47msc8240bldkc0fi60cpzsx1q9392dxhmqn28gn7998pdkgh";
   };
 
   packageName = "mgl-pax";
@@ -23,18 +23,17 @@ rec {
 }
 /* (SYSTEM mgl-pax DESCRIPTION Exploratory programming tool and documentation
   generator.
-    SHA256 04vddyvyxja8dabksfqqr80xjnvdiiv61zidjvijlpkk8shwaw1g URL
-    http://beta.quicklisp.org/archive/mgl-pax/2021-10-20/mgl-pax-20211020-git.tgz
-    MD5 2ad25d62d83b98e3e855b35414a5093d NAME mgl-pax FILENAME mgl-pax DEPS
+    SHA256 19d47msc8240bldkc0fi60cpzsx1q9392dxhmqn28gn7998pdkgh URL
+    http://beta.quicklisp.org/archive/mgl-pax/2021-12-09/mgl-pax-20211209-git.tgz
+    MD5 605583bb2910e0fe2211c8152fe38e0e NAME mgl-pax FILENAME mgl-pax DEPS
     ((NAME 3bmd FILENAME _3bmd)
      (NAME 3bmd-ext-code-blocks FILENAME _3bmd-ext-code-blocks)
-     (NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
-     (NAME cl-fad FILENAME cl-fad) (NAME colorize FILENAME colorize)
-     (NAME ironclad FILENAME ironclad)
-     (NAME named-readtables FILENAME named-readtables)
+     (NAME alexandria FILENAME alexandria) (NAME colorize FILENAME colorize)
+     (NAME md5 FILENAME md5) (NAME named-readtables FILENAME named-readtables)
      (NAME pythonic-string-reader FILENAME pythonic-string-reader)
      (NAME swank FILENAME swank))
     DEPENDENCIES
-    (3bmd 3bmd-ext-code-blocks alexandria babel cl-fad colorize ironclad
-     named-readtables pythonic-string-reader swank)
-    VERSION 20211020-git SIBLINGS NIL PARASITES (mgl-pax/full)) */
+    (3bmd 3bmd-ext-code-blocks alexandria colorize md5 named-readtables
+     pythonic-string-reader swank)
+    VERSION 20211209-git SIBLINGS NIL PARASITES
+    (mgl-pax/document mgl-pax/navigate)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/named-readtables.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/named-readtables.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "named-readtables";
-  version = "20210531-git";
+  version = "20211209-git";
 
   parasites = [ "named-readtables/test" ];
 
@@ -12,8 +12,8 @@ rec {
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/named-readtables/2021-05-31/named-readtables-20210531-git.tgz";
-    sha256 = "1z9c02924wqmxmcr1m1fzhw0gib138yllg70j5imiww9dmqbm9wf";
+    url = "http://beta.quicklisp.org/archive/named-readtables/2021-12-09/named-readtables-20211209-git.tgz";
+    sha256 = "0mlxbs7r6ksjk9ilsgp756qp4jlgplr30kxdn7npq27wg0rpvz2n";
   };
 
   packageName = "named-readtables";
@@ -24,8 +24,8 @@ rec {
 /* (SYSTEM named-readtables DESCRIPTION
     Library that creates a namespace for named readtable
   akin to the namespace of packages.
-    SHA256 1z9c02924wqmxmcr1m1fzhw0gib138yllg70j5imiww9dmqbm9wf URL
-    http://beta.quicklisp.org/archive/named-readtables/2021-05-31/named-readtables-20210531-git.tgz
-    MD5 a79f2cc78e84c4b474f818132c8cc4d8 NAME named-readtables FILENAME
-    named-readtables DEPS NIL DEPENDENCIES NIL VERSION 20210531-git SIBLINGS
+    SHA256 0mlxbs7r6ksjk9ilsgp756qp4jlgplr30kxdn7npq27wg0rpvz2n URL
+    http://beta.quicklisp.org/archive/named-readtables/2021-12-09/named-readtables-20211209-git.tgz
+    MD5 52def9392c93bb9c6da4b957549bcb0b NAME named-readtables FILENAME
+    named-readtables DEPS NIL DEPENDENCIES NIL VERSION 20211209-git SIBLINGS
     NIL PARASITES (named-readtables/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/nibbles.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/nibbles.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "nibbles";
-  version = "20210531-git";
+  version = "20211209-git";
 
   parasites = [ "nibbles/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."rt" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/nibbles/2021-05-31/nibbles-20210531-git.tgz";
-    sha256 = "1gwk44l86z6yyyn1fqf72rvlh93i61v6430njl9c6cmm05hf8lzz";
+    url = "http://beta.quicklisp.org/archive/nibbles/2021-12-09/nibbles-20211209-git.tgz";
+    sha256 = "1zkywrhz8p09pwdsa2mklr0yspqvvwa5fi6cz22n1z6fzvxz7m2s";
   };
 
   packageName = "nibbles";
@@ -22,8 +22,8 @@ rec {
 }
 /* (SYSTEM nibbles DESCRIPTION
     A library for accessing octet-addressed blocks of data in big- and little-endian orders
-    SHA256 1gwk44l86z6yyyn1fqf72rvlh93i61v6430njl9c6cmm05hf8lzz URL
-    http://beta.quicklisp.org/archive/nibbles/2021-05-31/nibbles-20210531-git.tgz
-    MD5 ec4ee1a201aef6325e071a9d9e3f6380 NAME nibbles FILENAME nibbles DEPS
-    ((NAME rt FILENAME rt)) DEPENDENCIES (rt) VERSION 20210531-git SIBLINGS NIL
+    SHA256 1zkywrhz8p09pwdsa2mklr0yspqvvwa5fi6cz22n1z6fzvxz7m2s URL
+    http://beta.quicklisp.org/archive/nibbles/2021-12-09/nibbles-20211209-git.tgz
+    MD5 c6e7348a8a979da7cd4852b5df8a4384 NAME nibbles FILENAME nibbles DEPS
+    ((NAME rt FILENAME rt)) DEPENDENCIES (rt) VERSION 20211209-git SIBLINGS NIL
     PARASITES (nibbles/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/osicat.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/osicat.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "osicat";
-  version = "20211020-git";
+  version = "20211209-git";
 
   parasites = [ "osicat/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."babel" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."rt" args."trivial-features" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/osicat/2021-10-20/osicat-20211020-git.tgz";
-    sha256 = "0rb53m4hg8dllljjvj9a76mq4hn9cl7wp0lqg50gs0l6v2c7qlbw";
+    url = "http://beta.quicklisp.org/archive/osicat/2021-12-09/osicat-20211209-git.tgz";
+    sha256 = "0c85aapyvr2f5c3lvpfv3hfdghwmsqf40qgyk9hwjva8s9242pgl";
   };
 
   packageName = "osicat";
@@ -21,13 +21,13 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM osicat DESCRIPTION A lightweight operating system interface SHA256
-    0rb53m4hg8dllljjvj9a76mq4hn9cl7wp0lqg50gs0l6v2c7qlbw URL
-    http://beta.quicklisp.org/archive/osicat/2021-10-20/osicat-20211020-git.tgz
-    MD5 2cf6739bb39a2bf414de19037f867c87 NAME osicat FILENAME osicat DEPS
+    0c85aapyvr2f5c3lvpfv3hfdghwmsqf40qgyk9hwjva8s9242pgl URL
+    http://beta.quicklisp.org/archive/osicat/2021-12-09/osicat-20211209-git.tgz
+    MD5 3581652999e0b16c6a1a8295585e7491 NAME osicat FILENAME osicat DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME cffi FILENAME cffi) (NAME cffi-grovel FILENAME cffi-grovel)
      (NAME cffi-toolchain FILENAME cffi-toolchain) (NAME rt FILENAME rt)
      (NAME trivial-features FILENAME trivial-features))
     DEPENDENCIES
     (alexandria babel cffi cffi-grovel cffi-toolchain rt trivial-features)
-    VERSION 20211020-git SIBLINGS NIL PARASITES (osicat/tests)) */
+    VERSION 20211209-git SIBLINGS NIL PARASITES (osicat/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/postmodern.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/postmodern.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "postmodern";
-  version = "20211020-git";
+  version = "20211209-git";
 
   parasites = [ "postmodern/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-base64" args."cl-postgres" args."cl-postgres_plus_local-time" args."cl-postgres_slash_tests" args."cl-ppcre" args."closer-mop" args."fiveam" args."global-vars" args."ironclad" args."local-time" args."md5" args."s-sql" args."s-sql_slash_tests" args."simple-date" args."simple-date_slash_postgres-glue" args."split-sequence" args."uax-15" args."uiop" args."usocket" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/postmodern/2021-10-20/postmodern-20211020-git.tgz";
-    sha256 = "0iw0sbjra3g57ivfqgx3c97mlcdzlh2kgqp12d1r2i9pw8z0ckh6";
+    url = "http://beta.quicklisp.org/archive/postmodern/2021-12-09/postmodern-20211209-git.tgz";
+    sha256 = "1qcbg31mz5r7ibmq2y7r3vqvdwpznxvwdnwd94hfil7pg4j119d6";
   };
 
   packageName = "postmodern";
@@ -21,9 +21,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM postmodern DESCRIPTION PostgreSQL programming API SHA256
-    0iw0sbjra3g57ivfqgx3c97mlcdzlh2kgqp12d1r2i9pw8z0ckh6 URL
-    http://beta.quicklisp.org/archive/postmodern/2021-10-20/postmodern-20211020-git.tgz
-    MD5 84f4ad8ce7ac0f7f78cbfcf2f0bd3aa4 NAME postmodern FILENAME postmodern
+    1qcbg31mz5r7ibmq2y7r3vqvdwpznxvwdnwd94hfil7pg4j119d6 URL
+    http://beta.quicklisp.org/archive/postmodern/2021-12-09/postmodern-20211209-git.tgz
+    MD5 6d14c4b5fec085594dc66d520174e0e6 NAME postmodern FILENAME postmodern
     DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -46,5 +46,5 @@ rec {
      cl-postgres/tests cl-ppcre closer-mop fiveam global-vars ironclad
      local-time md5 s-sql s-sql/tests simple-date simple-date/postgres-glue
      split-sequence uax-15 uiop usocket)
-    VERSION 20211020-git SIBLINGS (cl-postgres s-sql simple-date) PARASITES
+    VERSION 20211209-git SIBLINGS (cl-postgres s-sql simple-date) PARASITES
     (postmodern/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/rove.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/rove.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "rove";
-  version = "20211020-git";
+  version = "20211209-git";
 
   description = "Yet another testing framework intended to be a successor of Prove";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."dissect" args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/rove/2021-10-20/rove-20211020-git.tgz";
-    sha256 = "1p54dp4m2wnmff6dyfh2k4crk83n38nyix1g8csixvn8jkk2gi4b";
+    url = "http://beta.quicklisp.org/archive/rove/2021-12-09/rove-20211209-git.tgz";
+    sha256 = "1b1fajdxnba743l7mv4nc31az2g7mapalq3z3l57j7r5sximf0qr";
   };
 
   packageName = "rove";
@@ -20,12 +20,12 @@ rec {
 }
 /* (SYSTEM rove DESCRIPTION
     Yet another testing framework intended to be a successor of Prove SHA256
-    1p54dp4m2wnmff6dyfh2k4crk83n38nyix1g8csixvn8jkk2gi4b URL
-    http://beta.quicklisp.org/archive/rove/2021-10-20/rove-20211020-git.tgz MD5
-    119a5c0f506db2b301eb19bfed7c403d NAME rove FILENAME rove DEPS
+    1b1fajdxnba743l7mv4nc31az2g7mapalq3z3l57j7r5sximf0qr URL
+    http://beta.quicklisp.org/archive/rove/2021-12-09/rove-20211209-git.tgz MD5
+    d9f6cb2e26f06cfbd5c83bf3fa4fc206 NAME rove FILENAME rove DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME dissect FILENAME dissect)
      (NAME trivial-gray-streams FILENAME trivial-gray-streams))
     DEPENDENCIES (alexandria bordeaux-threads dissect trivial-gray-streams)
-    VERSION 20211020-git SIBLINGS NIL PARASITES NIL) */
+    VERSION 20211209-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/s-sql.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/s-sql.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "s-sql";
-  version = "postmodern-20211020-git";
+  version = "postmodern-20211209-git";
 
   parasites = [ "s-sql/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-base64" args."cl-postgres" args."cl-postgres_slash_tests" args."cl-ppcre" args."closer-mop" args."fiveam" args."global-vars" args."ironclad" args."md5" args."postmodern" args."split-sequence" args."uax-15" args."usocket" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/postmodern/2021-10-20/postmodern-20211020-git.tgz";
-    sha256 = "0iw0sbjra3g57ivfqgx3c97mlcdzlh2kgqp12d1r2i9pw8z0ckh6";
+    url = "http://beta.quicklisp.org/archive/postmodern/2021-12-09/postmodern-20211209-git.tgz";
+    sha256 = "1qcbg31mz5r7ibmq2y7r3vqvdwpznxvwdnwd94hfil7pg4j119d6";
   };
 
   packageName = "s-sql";
@@ -21,9 +21,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM s-sql DESCRIPTION Lispy DSL for SQL SHA256
-    0iw0sbjra3g57ivfqgx3c97mlcdzlh2kgqp12d1r2i9pw8z0ckh6 URL
-    http://beta.quicklisp.org/archive/postmodern/2021-10-20/postmodern-20211020-git.tgz
-    MD5 84f4ad8ce7ac0f7f78cbfcf2f0bd3aa4 NAME s-sql FILENAME s-sql DEPS
+    1qcbg31mz5r7ibmq2y7r3vqvdwpznxvwdnwd94hfil7pg4j119d6 URL
+    http://beta.quicklisp.org/archive/postmodern/2021-12-09/postmodern-20211209-git.tgz
+    MD5 6d14c4b5fec085594dc66d520174e0e6 NAME s-sql FILENAME s-sql DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cl-base64 FILENAME cl-base64)
@@ -39,5 +39,5 @@ rec {
     (alexandria bordeaux-threads cl-base64 cl-postgres cl-postgres/tests
      cl-ppcre closer-mop fiveam global-vars ironclad md5 postmodern
      split-sequence uax-15 usocket)
-    VERSION postmodern-20211020-git SIBLINGS
+    VERSION postmodern-20211209-git SIBLINGS
     (cl-postgres postmodern simple-date) PARASITES (s-sql/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/serapeum.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/serapeum.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "serapeum";
-  version = "20211020-git";
+  version = "20211209-git";
 
   description = "Utilities beyond Alexandria.";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."closer-mop" args."fare-quasiquote" args."fare-quasiquote-extras" args."fare-quasiquote-optima" args."fare-quasiquote-readtable" args."fare-utils" args."global-vars" args."introspect-environment" args."iterate" args."lisp-namespace" args."named-readtables" args."parse-declarations-1_dot_0" args."parse-number" args."split-sequence" args."string-case" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_quasiquote" args."trivia_dot_trivial" args."trivial-cltl2" args."trivial-features" args."trivial-file-size" args."trivial-garbage" args."trivial-macroexpand-all" args."type-i" args."uiop" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/serapeum/2021-10-20/serapeum-20211020-git.tgz";
-    sha256 = "1lax10p8apgsm09wcnmxn1p52hgngwp8j6dsk5y8r2dj7h73529v";
+    url = "http://beta.quicklisp.org/archive/serapeum/2021-12-09/serapeum-20211209-git.tgz";
+    sha256 = "19ndbi69b60rxh1jvs7jrwg6bgzpkrfd22cnhyd2mir4ybmrdllh";
   };
 
   packageName = "serapeum";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM serapeum DESCRIPTION Utilities beyond Alexandria. SHA256
-    1lax10p8apgsm09wcnmxn1p52hgngwp8j6dsk5y8r2dj7h73529v URL
-    http://beta.quicklisp.org/archive/serapeum/2021-10-20/serapeum-20211020-git.tgz
-    MD5 2f15c5635215fd23ddd43dba01647f82 NAME serapeum FILENAME serapeum DEPS
+    19ndbi69b60rxh1jvs7jrwg6bgzpkrfd22cnhyd2mir4ybmrdllh URL
+    http://beta.quicklisp.org/archive/serapeum/2021-12-09/serapeum-20211209-git.tgz
+    MD5 be358e1693fd0883042d849199ab72d1 NAME serapeum FILENAME serapeum DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME closer-mop FILENAME closer-mop)
@@ -60,4 +60,4 @@ rec {
      trivia.level2 trivia.quasiquote trivia.trivial trivial-cltl2
      trivial-features trivial-file-size trivial-garbage trivial-macroexpand-all
      type-i uiop)
-    VERSION 20211020-git SIBLINGS NIL PARASITES NIL) */
+    VERSION 20211209-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/simple-date.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/simple-date.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "simple-date";
-  version = "postmodern-20211020-git";
+  version = "postmodern-20211209-git";
 
   parasites = [ "simple-date/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."fiveam" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/postmodern/2021-10-20/postmodern-20211020-git.tgz";
-    sha256 = "0iw0sbjra3g57ivfqgx3c97mlcdzlh2kgqp12d1r2i9pw8z0ckh6";
+    url = "http://beta.quicklisp.org/archive/postmodern/2021-12-09/postmodern-20211209-git.tgz";
+    sha256 = "1qcbg31mz5r7ibmq2y7r3vqvdwpznxvwdnwd94hfil7pg4j119d6";
   };
 
   packageName = "simple-date";
@@ -22,9 +22,9 @@ rec {
 }
 /* (SYSTEM simple-date DESCRIPTION
     Simple date library that can be used with postmodern SHA256
-    0iw0sbjra3g57ivfqgx3c97mlcdzlh2kgqp12d1r2i9pw8z0ckh6 URL
-    http://beta.quicklisp.org/archive/postmodern/2021-10-20/postmodern-20211020-git.tgz
-    MD5 84f4ad8ce7ac0f7f78cbfcf2f0bd3aa4 NAME simple-date FILENAME simple-date
+    1qcbg31mz5r7ibmq2y7r3vqvdwpznxvwdnwd94hfil7pg4j119d6 URL
+    http://beta.quicklisp.org/archive/postmodern/2021-12-09/postmodern-20211209-git.tgz
+    MD5 6d14c4b5fec085594dc66d520174e0e6 NAME simple-date FILENAME simple-date
     DEPS ((NAME fiveam FILENAME fiveam)) DEPENDENCIES (fiveam) VERSION
-    postmodern-20211020-git SIBLINGS (cl-postgres postmodern s-sql) PARASITES
+    postmodern-20211209-git SIBLINGS (cl-postgres postmodern s-sql) PARASITES
     (simple-date/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/spinneret.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/spinneret.nix
@@ -1,0 +1,67 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "spinneret";
+  version = "20211020-git";
+
+  description = "Common Lisp HTML5 generator.";
+
+  deps = [ args."alexandria" args."anaphora" args."babel" args."bordeaux-threads" args."cl-ppcre" args."closer-mop" args."fare-quasiquote" args."fare-quasiquote-extras" args."fare-quasiquote-optima" args."fare-quasiquote-readtable" args."fare-utils" args."global-vars" args."introspect-environment" args."iterate" args."lisp-namespace" args."named-readtables" args."parenscript" args."parse-declarations-1_dot_0" args."parse-number" args."serapeum" args."split-sequence" args."string-case" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_quasiquote" args."trivia_dot_trivial" args."trivial-cltl2" args."trivial-features" args."trivial-file-size" args."trivial-garbage" args."trivial-gray-streams" args."trivial-macroexpand-all" args."type-i" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/spinneret/2021-10-20/spinneret-20211020-git.tgz";
+    sha256 = "1j3z2sr98j7rd8ssxp8r1yxlj8chvldn0k2nh2vf2jaynhwk3slq";
+  };
+
+  packageName = "spinneret";
+
+  asdFilesToKeep = ["spinneret.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM spinneret DESCRIPTION Common Lisp HTML5 generator. SHA256
+    1j3z2sr98j7rd8ssxp8r1yxlj8chvldn0k2nh2vf2jaynhwk3slq URL
+    http://beta.quicklisp.org/archive/spinneret/2021-10-20/spinneret-20211020-git.tgz
+    MD5 f10e1537f3bfd16a0a189d16fd86790b NAME spinneret FILENAME spinneret DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
+     (NAME babel FILENAME babel)
+     (NAME bordeaux-threads FILENAME bordeaux-threads)
+     (NAME cl-ppcre FILENAME cl-ppcre) (NAME closer-mop FILENAME closer-mop)
+     (NAME fare-quasiquote FILENAME fare-quasiquote)
+     (NAME fare-quasiquote-extras FILENAME fare-quasiquote-extras)
+     (NAME fare-quasiquote-optima FILENAME fare-quasiquote-optima)
+     (NAME fare-quasiquote-readtable FILENAME fare-quasiquote-readtable)
+     (NAME fare-utils FILENAME fare-utils)
+     (NAME global-vars FILENAME global-vars)
+     (NAME introspect-environment FILENAME introspect-environment)
+     (NAME iterate FILENAME iterate)
+     (NAME lisp-namespace FILENAME lisp-namespace)
+     (NAME named-readtables FILENAME named-readtables)
+     (NAME parenscript FILENAME parenscript)
+     (NAME parse-declarations-1.0 FILENAME parse-declarations-1_dot_0)
+     (NAME parse-number FILENAME parse-number)
+     (NAME serapeum FILENAME serapeum)
+     (NAME split-sequence FILENAME split-sequence)
+     (NAME string-case FILENAME string-case) (NAME trivia FILENAME trivia)
+     (NAME trivia.balland2006 FILENAME trivia_dot_balland2006)
+     (NAME trivia.level0 FILENAME trivia_dot_level0)
+     (NAME trivia.level1 FILENAME trivia_dot_level1)
+     (NAME trivia.level2 FILENAME trivia_dot_level2)
+     (NAME trivia.quasiquote FILENAME trivia_dot_quasiquote)
+     (NAME trivia.trivial FILENAME trivia_dot_trivial)
+     (NAME trivial-cltl2 FILENAME trivial-cltl2)
+     (NAME trivial-features FILENAME trivial-features)
+     (NAME trivial-file-size FILENAME trivial-file-size)
+     (NAME trivial-garbage FILENAME trivial-garbage)
+     (NAME trivial-gray-streams FILENAME trivial-gray-streams)
+     (NAME trivial-macroexpand-all FILENAME trivial-macroexpand-all)
+     (NAME type-i FILENAME type-i))
+    DEPENDENCIES
+    (alexandria anaphora babel bordeaux-threads cl-ppcre closer-mop
+     fare-quasiquote fare-quasiquote-extras fare-quasiquote-optima
+     fare-quasiquote-readtable fare-utils global-vars introspect-environment
+     iterate lisp-namespace named-readtables parenscript parse-declarations-1.0
+     parse-number serapeum split-sequence string-case trivia trivia.balland2006
+     trivia.level0 trivia.level1 trivia.level2 trivia.quasiquote trivia.trivial
+     trivial-cltl2 trivial-features trivial-file-size trivial-garbage
+     trivial-gray-streams trivial-macroexpand-all type-i)
+    VERSION 20211020-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/static-dispatch.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/static-dispatch.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "static-dispatch";
-  version = "20211020-git";
+  version = "20211209-git";
 
   parasites = [ "static-dispatch/test" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."agutil" args."alexandria" args."anaphora" args."arrows" args."cl-environments" args."cl-form-types" args."closer-mop" args."collectors" args."fiveam" args."introspect-environment" args."iterate" args."optima" args."parse-declarations-1_dot_0" args."symbol-munger" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/static-dispatch/2021-10-20/static-dispatch-20211020-git.tgz";
-    sha256 = "0zm8haaf65a6mw1jwkzf2fhlh19ixq1asjc2kiz1jhdy40qdkkfj";
+    url = "http://beta.quicklisp.org/archive/static-dispatch/2021-12-09/static-dispatch-20211209-git.tgz";
+    sha256 = "04hvwn5fvxlblhicdbj0sbvlgcxsnykak05j3pdv5laic50jz192";
   };
 
   packageName = "static-dispatch";
@@ -22,9 +22,9 @@ rec {
 }
 /* (SYSTEM static-dispatch DESCRIPTION
     Static generic function dispatch for Common Lisp. SHA256
-    0zm8haaf65a6mw1jwkzf2fhlh19ixq1asjc2kiz1jhdy40qdkkfj URL
-    http://beta.quicklisp.org/archive/static-dispatch/2021-10-20/static-dispatch-20211020-git.tgz
-    MD5 f26f461213b1c8b78ede26c692e00442 NAME static-dispatch FILENAME
+    04hvwn5fvxlblhicdbj0sbvlgcxsnykak05j3pdv5laic50jz192 URL
+    http://beta.quicklisp.org/archive/static-dispatch/2021-12-09/static-dispatch-20211209-git.tgz
+    MD5 f74cb2bd29ef9cfe966f470c7f63420f NAME static-dispatch FILENAME
     static-dispatch DEPS
     ((NAME agutil FILENAME agutil) (NAME alexandria FILENAME alexandria)
      (NAME anaphora FILENAME anaphora) (NAME arrows FILENAME arrows)
@@ -40,4 +40,4 @@ rec {
     (agutil alexandria anaphora arrows cl-environments cl-form-types closer-mop
      collectors fiveam introspect-environment iterate optima
      parse-declarations-1.0 symbol-munger)
-    VERSION 20211020-git SIBLINGS NIL PARASITES (static-dispatch/test)) */
+    VERSION 20211209-git SIBLINGS NIL PARASITES (static-dispatch/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/stumpwm.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/stumpwm.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "stumpwm";
-  version = "20210807-git";
+  version = "20211209-git";
 
   description = "A tiling, keyboard driven window manager";
 
   deps = [ args."alexandria" args."cl-ppcre" args."clx" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/stumpwm/2021-08-07/stumpwm-20210807-git.tgz";
-    sha256 = "0j9wb6djsyf2r2a4paj2s1f2sbw70wnr999abrsrkljxpayyma82";
+    url = "http://beta.quicklisp.org/archive/stumpwm/2021-12-09/stumpwm-20211209-git.tgz";
+    sha256 = "1n7wj2jn6sydnyrjmic53lqkqigk1cg140b9pcnk09ngsrq3cn60";
   };
 
   packageName = "stumpwm";
@@ -19,10 +19,10 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM stumpwm DESCRIPTION A tiling, keyboard driven window manager SHA256
-    0j9wb6djsyf2r2a4paj2s1f2sbw70wnr999abrsrkljxpayyma82 URL
-    http://beta.quicklisp.org/archive/stumpwm/2021-08-07/stumpwm-20210807-git.tgz
-    MD5 ec6d05208e0899fc929d2ea4ba61de9d NAME stumpwm FILENAME stumpwm DEPS
+    1n7wj2jn6sydnyrjmic53lqkqigk1cg140b9pcnk09ngsrq3cn60 URL
+    http://beta.quicklisp.org/archive/stumpwm/2021-12-09/stumpwm-20211209-git.tgz
+    MD5 a556b95108398e56159bafe31c4dbabf NAME stumpwm FILENAME stumpwm DEPS
     ((NAME alexandria FILENAME alexandria) (NAME cl-ppcre FILENAME cl-ppcre)
      (NAME clx FILENAME clx))
-    DEPENDENCIES (alexandria cl-ppcre clx) VERSION 20210807-git SIBLINGS
+    DEPENDENCIES (alexandria cl-ppcre clx) VERSION 20211209-git SIBLINGS
     (stumpwm-tests) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-features.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-features.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "trivial-features";
-  version = "20210411-git";
+  version = "20211209-git";
 
   description = "Ensures consistent *FEATURES* across multiple CLs.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/trivial-features/2021-04-11/trivial-features-20210411-git.tgz";
-    sha256 = "0z6nzql8z7bz8kzd08mh36h0r54vqx7pwigy8r617jhvb0r0n0n4";
+    url = "http://beta.quicklisp.org/archive/trivial-features/2021-12-09/trivial-features-20211209-git.tgz";
+    sha256 = "1sxblr86hvbb99isr86y08snfpcajd6ra3396ibqkfnw33hhkgql";
   };
 
   packageName = "trivial-features";
@@ -20,8 +20,8 @@ rec {
 }
 /* (SYSTEM trivial-features DESCRIPTION
     Ensures consistent *FEATURES* across multiple CLs. SHA256
-    0z6nzql8z7bz8kzd08mh36h0r54vqx7pwigy8r617jhvb0r0n0n4 URL
-    http://beta.quicklisp.org/archive/trivial-features/2021-04-11/trivial-features-20210411-git.tgz
-    MD5 5ec554fff48d38af5023604a1ae42d3a NAME trivial-features FILENAME
-    trivial-features DEPS NIL DEPENDENCIES NIL VERSION 20210411-git SIBLINGS
+    1sxblr86hvbb99isr86y08snfpcajd6ra3396ibqkfnw33hhkgql URL
+    http://beta.quicklisp.org/archive/trivial-features/2021-12-09/trivial-features-20211209-git.tgz
+    MD5 eca3e353c7d7f100a07a5aeb4de02098 NAME trivial-features FILENAME
+    trivial-features DEPS NIL DEPENDENCIES NIL VERSION 20211209-git SIBLINGS
     (trivial-features-tests) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-utf-8.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-utf-8.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "trivial-utf-8";
-  version = "20200925-git";
+  version = "20211209-git";
 
   parasites = [ "trivial-utf-8/doc" "trivial-utf-8/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."mgl-pax" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/trivial-utf-8/2020-09-25/trivial-utf-8-20200925-git.tgz";
-    sha256 = "06v9jif4f5xyl5jd7ldg69ds7cypf72xl7nda5q55fssmgcydi1b";
+    url = "http://beta.quicklisp.org/archive/trivial-utf-8/2021-12-09/trivial-utf-8-20211209-git.tgz";
+    sha256 = "1bis8shbdva1diwms2lvhlbdz9rvazqqxi9h8d33vlbw4xai075y";
   };
 
   packageName = "trivial-utf-8";
@@ -22,9 +22,9 @@ rec {
 }
 /* (SYSTEM trivial-utf-8 DESCRIPTION
     A small library for doing UTF-8-based input and output. SHA256
-    06v9jif4f5xyl5jd7ldg69ds7cypf72xl7nda5q55fssmgcydi1b URL
-    http://beta.quicklisp.org/archive/trivial-utf-8/2020-09-25/trivial-utf-8-20200925-git.tgz
-    MD5 799ece1f87cc4a83e81e598bc6b1dd1d NAME trivial-utf-8 FILENAME
+    1bis8shbdva1diwms2lvhlbdz9rvazqqxi9h8d33vlbw4xai075y URL
+    http://beta.quicklisp.org/archive/trivial-utf-8/2021-12-09/trivial-utf-8-20211209-git.tgz
+    MD5 65603f3c4421a93d5d8c214bb406988d NAME trivial-utf-8 FILENAME
     trivial-utf-8 DEPS ((NAME mgl-pax FILENAME mgl-pax)) DEPENDENCIES (mgl-pax)
-    VERSION 20200925-git SIBLINGS NIL PARASITES
+    VERSION 20211209-git SIBLINGS NIL PARASITES
     (trivial-utf-8/doc trivial-utf-8/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/uax-15.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/uax-15.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "uax-15";
-  version = "20211020-git";
+  version = "20211209-git";
 
   parasites = [ "uax-15/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."cl-ppcre" args."parachute" args."split-sequence" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/uax-15/2021-10-20/uax-15-20211020-git.tgz";
-    sha256 = "1g6mbwxv8cbv9gbpkj267lwdgq8k21qx0isy1gbrc158h0al7bp9";
+    url = "http://beta.quicklisp.org/archive/uax-15/2021-12-09/uax-15-20211209-git.tgz";
+    sha256 = "0haqp2vgnwq6p4j44xz0xzz4lcf15pj3pla4ybnpral2218j2cdz";
   };
 
   packageName = "uax-15";
@@ -22,10 +22,10 @@ rec {
 }
 /* (SYSTEM uax-15 DESCRIPTION
     Common lisp implementation of Unicode normalization functions :nfc, :nfd, :nfkc and :nfkd (Uax-15)
-    SHA256 1g6mbwxv8cbv9gbpkj267lwdgq8k21qx0isy1gbrc158h0al7bp9 URL
-    http://beta.quicklisp.org/archive/uax-15/2021-10-20/uax-15-20211020-git.tgz
-    MD5 27503fd1e91e494cc9ac10a985dbf95e NAME uax-15 FILENAME uax-15 DEPS
+    SHA256 0haqp2vgnwq6p4j44xz0xzz4lcf15pj3pla4ybnpral2218j2cdz URL
+    http://beta.quicklisp.org/archive/uax-15/2021-12-09/uax-15-20211209-git.tgz
+    MD5 431f4e399305c7ed8d3ce151ea6ff132 NAME uax-15 FILENAME uax-15 DEPS
     ((NAME cl-ppcre FILENAME cl-ppcre) (NAME parachute FILENAME parachute)
      (NAME split-sequence FILENAME split-sequence))
-    DEPENDENCIES (cl-ppcre parachute split-sequence) VERSION 20211020-git
+    DEPENDENCIES (cl-ppcre parachute split-sequence) VERSION 20211209-git
     SIBLINGS NIL PARASITES (uax-15/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/vas-string-metrics.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/vas-string-metrics.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "vas-string-metrics";
-  version = "20160208-git";
+  version = "20211209-git";
 
   description = "Jaro-Winkler and Levenshtein string distance algorithms.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/vas-string-metrics/2016-02-08/vas-string-metrics-20160208-git.tgz";
-    sha256 = "1s9a9bgc2ibknjr6mlbr4gsxcwpjivz5hbl1wz57fsh4n0w8h7ch";
+    url = "http://beta.quicklisp.org/archive/vas-string-metrics/2021-12-09/vas-string-metrics-20211209-git.tgz";
+    sha256 = "0q8zzfmwprjw6wmj8aifizx06xw9yrq0c8qhwhrak62cyz9lvf8n";
   };
 
   packageName = "vas-string-metrics";
@@ -20,8 +20,8 @@ rec {
 }
 /* (SYSTEM vas-string-metrics DESCRIPTION
     Jaro-Winkler and Levenshtein string distance algorithms. SHA256
-    1s9a9bgc2ibknjr6mlbr4gsxcwpjivz5hbl1wz57fsh4n0w8h7ch URL
-    http://beta.quicklisp.org/archive/vas-string-metrics/2016-02-08/vas-string-metrics-20160208-git.tgz
-    MD5 5f38d4ee241c11286be6147f481e7fd0 NAME vas-string-metrics FILENAME
-    vas-string-metrics DEPS NIL DEPENDENCIES NIL VERSION 20160208-git SIBLINGS
+    0q8zzfmwprjw6wmj8aifizx06xw9yrq0c8qhwhrak62cyz9lvf8n URL
+    http://beta.quicklisp.org/archive/vas-string-metrics/2021-12-09/vas-string-metrics-20211209-git.tgz
+    MD5 b1264bac0f9516d9617397e1b7a7c20e NAME vas-string-metrics FILENAME
+    vas-string-metrics DEPS NIL DEPENDENCIES NIL VERSION 20211209-git SIBLINGS
     (test.vas-string-metrics) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/woo.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/woo.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "woo";
-  version = "20210630-git";
+  version = "20211209-git";
 
   description = "An asynchronous HTTP server written in Common Lisp";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."cl-utilities" args."clack-socket" args."fast-http" args."fast-io" args."flexi-streams" args."lev" args."proc-parse" args."quri" args."smart-buffer" args."split-sequence" args."static-vectors" args."swap-bytes" args."trivial-features" args."trivial-gray-streams" args."trivial-utf-8" args."vom" args."xsubseq" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/woo/2021-06-30/woo-20210630-git.tgz";
-    sha256 = "0znpjcrw2gskcgf8ipgvqg87b9b2n4x6jkm25rizj6h7bms6v21r";
+    url = "http://beta.quicklisp.org/archive/woo/2021-12-09/woo-20211209-git.tgz";
+    sha256 = "0pm4l4sp3zgygkhjzd03kjjk032m5cra628fs25lvcshbrpmkcp3";
   };
 
   packageName = "woo";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM woo DESCRIPTION An asynchronous HTTP server written in Common Lisp
-    SHA256 0znpjcrw2gskcgf8ipgvqg87b9b2n4x6jkm25rizj6h7bms6v21r URL
-    http://beta.quicklisp.org/archive/woo/2021-06-30/woo-20210630-git.tgz MD5
-    f7b2586ed1ab916c43bfab9de5693450 NAME woo FILENAME woo DEPS
+    SHA256 0pm4l4sp3zgygkhjzd03kjjk032m5cra628fs25lvcshbrpmkcp3 URL
+    http://beta.quicklisp.org/archive/woo/2021-12-09/woo-20211209-git.tgz MD5
+    8f4926c010491996b1ffe39882fafb2b NAME woo FILENAME woo DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cffi FILENAME cffi) (NAME cffi-grovel FILENAME cffi-grovel)
@@ -44,4 +44,4 @@ rec {
      cl-utilities clack-socket fast-http fast-io flexi-streams lev proc-parse
      quri smart-buffer split-sequence static-vectors swap-bytes
      trivial-features trivial-gray-streams trivial-utf-8 vom xsubseq)
-    VERSION 20210630-git SIBLINGS (clack-handler-woo woo-test) PARASITES NIL) */
+    VERSION 20211209-git SIBLINGS (clack-handler-woo woo-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
@@ -292,17 +292,5 @@ $out/lib/common-lisp/query-fs"
     };
   };
   lla = addNativeLibs [ pkgs.openblas ];
-  uax-15 = x: {
-    overrides = y: (x.overrides y) // {
-      postPatch = ''
-        patch -p1 < ${
-          pkgs.fetchurl {
-            # https://github.com/sabracrolleton/uax-15/pull/12
-            url = "https://github.com/nuddyco/uax-15/commit/d553181669f488636df03d60ad7f5bec64d566bf.diff";
-            sha256 = "sha256:1608jzw7giy18vlw7pz4pl8prwlprgif8zcl9hwa0wf5gdxwd7gn";
-          }}
-      '';
-    };
-  };
 #  cl-opengl = addNativeLibs [ pkgs.libGL pkgs.glfw ];
 }

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
@@ -206,6 +206,7 @@ simple-date
 simple-date-time
 smart-buffer
 smug
+spinneret
 split-sequence
 sqlite
 static-vectors

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
@@ -69,6 +69,7 @@ cl-ppcre-template
 cl-ppcre-unicode
 cl-prevalence
 cl-protobufs
+cl-qrencode
 cl-qprint
 cl-reexport
 cl-shellwords

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -2263,6 +2263,50 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "spinneret" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."spinneret" or (x: {}))
+       (import ./quicklisp-to-nix-output/spinneret.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "anaphora" = quicklisp-to-nix-packages."anaphora";
+           "babel" = quicklisp-to-nix-packages."babel";
+           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
+           "cl-ppcre" = quicklisp-to-nix-packages."cl-ppcre";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "fare-quasiquote" = quicklisp-to-nix-packages."fare-quasiquote";
+           "fare-quasiquote-extras" = quicklisp-to-nix-packages."fare-quasiquote-extras";
+           "fare-quasiquote-optima" = quicklisp-to-nix-packages."fare-quasiquote-optima";
+           "fare-quasiquote-readtable" = quicklisp-to-nix-packages."fare-quasiquote-readtable";
+           "fare-utils" = quicklisp-to-nix-packages."fare-utils";
+           "global-vars" = quicklisp-to-nix-packages."global-vars";
+           "introspect-environment" = quicklisp-to-nix-packages."introspect-environment";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "lisp-namespace" = quicklisp-to-nix-packages."lisp-namespace";
+           "named-readtables" = quicklisp-to-nix-packages."named-readtables";
+           "parenscript" = quicklisp-to-nix-packages."parenscript";
+           "parse-declarations-1_dot_0" = quicklisp-to-nix-packages."parse-declarations-1_dot_0";
+           "parse-number" = quicklisp-to-nix-packages."parse-number";
+           "serapeum" = quicklisp-to-nix-packages."serapeum";
+           "split-sequence" = quicklisp-to-nix-packages."split-sequence";
+           "string-case" = quicklisp-to-nix-packages."string-case";
+           "trivia" = quicklisp-to-nix-packages."trivia";
+           "trivia_dot_balland2006" = quicklisp-to-nix-packages."trivia_dot_balland2006";
+           "trivia_dot_level0" = quicklisp-to-nix-packages."trivia_dot_level0";
+           "trivia_dot_level1" = quicklisp-to-nix-packages."trivia_dot_level1";
+           "trivia_dot_level2" = quicklisp-to-nix-packages."trivia_dot_level2";
+           "trivia_dot_quasiquote" = quicklisp-to-nix-packages."trivia_dot_quasiquote";
+           "trivia_dot_trivial" = quicklisp-to-nix-packages."trivia_dot_trivial";
+           "trivial-cltl2" = quicklisp-to-nix-packages."trivial-cltl2";
+           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
+           "trivial-file-size" = quicklisp-to-nix-packages."trivial-file-size";
+           "trivial-garbage" = quicklisp-to-nix-packages."trivial-garbage";
+           "trivial-gray-streams" = quicklisp-to-nix-packages."trivial-gray-streams";
+           "trivial-macroexpand-all" = quicklisp-to-nix-packages."trivial-macroexpand-all";
+           "type-i" = quicklisp-to-nix-packages."type-i";
+       }));
+
+
   "smug" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."smug" or (x: {}))

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -14,6 +14,70 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "hu_dot_dwim_dot_stefil_plus_swank" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."hu_dot_dwim_dot_stefil_plus_swank" or (x: {}))
+       (import ./quicklisp-to-nix-output/hu_dot_dwim_dot_stefil_plus_swank.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "hu_dot_dwim_dot_asdf" = quicklisp-to-nix-packages."hu_dot_dwim_dot_asdf";
+           "hu_dot_dwim_dot_stefil" = quicklisp-to-nix-packages."hu_dot_dwim_dot_stefil";
+           "swank" = quicklisp-to-nix-packages."swank";
+       }));
+
+
+  "hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def" or (x: {}))
+       (import ./quicklisp-to-nix-output/hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "anaphora" = quicklisp-to-nix-packages."anaphora";
+           "hu_dot_dwim_dot_asdf" = quicklisp-to-nix-packages."hu_dot_dwim_dot_asdf";
+           "hu_dot_dwim_dot_def" = quicklisp-to-nix-packages."hu_dot_dwim_dot_def";
+           "hu_dot_dwim_dot_stefil" = quicklisp-to-nix-packages."hu_dot_dwim_dot_stefil";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "metabang-bind" = quicklisp-to-nix-packages."metabang-bind";
+       }));
+
+
+  "hu_dot_dwim_dot_def_plus_swank" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."hu_dot_dwim_dot_def_plus_swank" or (x: {}))
+       (import ./quicklisp-to-nix-output/hu_dot_dwim_dot_def_plus_swank.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "anaphora" = quicklisp-to-nix-packages."anaphora";
+           "hu_dot_dwim_dot_asdf" = quicklisp-to-nix-packages."hu_dot_dwim_dot_asdf";
+           "hu_dot_dwim_dot_def" = quicklisp-to-nix-packages."hu_dot_dwim_dot_def";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "metabang-bind" = quicklisp-to-nix-packages."metabang-bind";
+           "swank" = quicklisp-to-nix-packages."swank";
+       }));
+
+
+  "hu_dot_dwim_dot_def" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."hu_dot_dwim_dot_def" or (x: {}))
+       (import ./quicklisp-to-nix-output/hu_dot_dwim_dot_def.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "anaphora" = quicklisp-to-nix-packages."anaphora";
+           "hu_dot_dwim_dot_asdf" = quicklisp-to-nix-packages."hu_dot_dwim_dot_asdf";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "metabang-bind" = quicklisp-to-nix-packages."metabang-bind";
+       }));
+
+
+  "hu_dot_dwim_dot_common-lisp" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."hu_dot_dwim_dot_common-lisp" or (x: {}))
+       (import ./quicklisp-to-nix-output/hu_dot_dwim_dot_common-lisp.nix {
+         inherit fetchurl;
+           "hu_dot_dwim_dot_asdf" = quicklisp-to-nix-packages."hu_dot_dwim_dot_asdf";
+       }));
+
+
   "rove" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."rove" or (x: {}))
@@ -59,16 +123,6 @@ let quicklisp-to-nix-packages = rec {
        (qlOverrides."clack-socket" or (x: {}))
        (import ./quicklisp-to-nix-output/clack-socket.nix {
          inherit fetchurl;
-       }));
-
-
-  "zpng" = buildLispPackage
-    ((f: x: (x // (f x)))
-       (qlOverrides."zpng" or (x: {}))
-       (import ./quicklisp-to-nix-output/zpng.nix {
-         inherit fetchurl;
-           "salza2" = quicklisp-to-nix-packages."salza2";
-           "trivial-gray-streams" = quicklisp-to-nix-packages."trivial-gray-streams";
        }));
 
 
@@ -377,6 +431,40 @@ let quicklisp-to-nix-packages = rec {
            "trivia_dot_quasiquote" = quicklisp-to-nix-packages."trivia_dot_quasiquote";
            "trivia_dot_trivial" = quicklisp-to-nix-packages."trivia_dot_trivial";
            "trivial-cltl2" = quicklisp-to-nix-packages."trivial-cltl2";
+       }));
+
+
+  "hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def_plus_swank" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def_plus_swank" or (x: {}))
+       (import ./quicklisp-to-nix-output/hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def_plus_swank.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "anaphora" = quicklisp-to-nix-packages."anaphora";
+           "hu_dot_dwim_dot_asdf" = quicklisp-to-nix-packages."hu_dot_dwim_dot_asdf";
+           "hu_dot_dwim_dot_def" = quicklisp-to-nix-packages."hu_dot_dwim_dot_def";
+           "hu_dot_dwim_dot_def_plus_swank" = quicklisp-to-nix-packages."hu_dot_dwim_dot_def_plus_swank";
+           "hu_dot_dwim_dot_stefil" = quicklisp-to-nix-packages."hu_dot_dwim_dot_stefil";
+           "hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def" = quicklisp-to-nix-packages."hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def";
+           "hu_dot_dwim_dot_stefil_plus_swank" = quicklisp-to-nix-packages."hu_dot_dwim_dot_stefil_plus_swank";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "metabang-bind" = quicklisp-to-nix-packages."metabang-bind";
+           "swank" = quicklisp-to-nix-packages."swank";
+       }));
+
+
+  "hu_dot_dwim_dot_common" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."hu_dot_dwim_dot_common" or (x: {}))
+       (import ./quicklisp-to-nix-output/hu_dot_dwim_dot_common.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "anaphora" = quicklisp-to-nix-packages."anaphora";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "hu_dot_dwim_dot_asdf" = quicklisp-to-nix-packages."hu_dot_dwim_dot_asdf";
+           "hu_dot_dwim_dot_common-lisp" = quicklisp-to-nix-packages."hu_dot_dwim_dot_common-lisp";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "metabang-bind" = quicklisp-to-nix-packages."metabang-bind";
        }));
 
 
@@ -1285,6 +1373,16 @@ let quicklisp-to-nix-packages = rec {
        (qlOverrides."clunit" or (x: {}))
        (import ./quicklisp-to-nix-output/clunit.nix {
          inherit fetchurl;
+       }));
+
+
+  "zpng" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."zpng" or (x: {}))
+       (import ./quicklisp-to-nix-output/zpng.nix {
+         inherit fetchurl;
+           "salza2" = quicklisp-to-nix-packages."salza2";
+           "trivial-gray-streams" = quicklisp-to-nix-packages."trivial-gray-streams";
        }));
 
 
@@ -2582,10 +2680,8 @@ let quicklisp-to-nix-packages = rec {
            "_3bmd" = quicklisp-to-nix-packages."_3bmd";
            "_3bmd-ext-code-blocks" = quicklisp-to-nix-packages."_3bmd-ext-code-blocks";
            "alexandria" = quicklisp-to-nix-packages."alexandria";
-           "babel" = quicklisp-to-nix-packages."babel";
-           "cl-fad" = quicklisp-to-nix-packages."cl-fad";
            "colorize" = quicklisp-to-nix-packages."colorize";
-           "ironclad" = quicklisp-to-nix-packages."ironclad";
+           "md5" = quicklisp-to-nix-packages."md5";
            "named-readtables" = quicklisp-to-nix-packages."named-readtables";
            "pythonic-string-reader" = quicklisp-to-nix-packages."pythonic-string-reader";
            "swank" = quicklisp-to-nix-packages."swank";
@@ -2984,6 +3080,8 @@ let quicklisp-to-nix-packages = rec {
        (import ./quicklisp-to-nix-output/hu_dot_dwim_dot_defclass-star.nix {
          inherit fetchurl;
            "hu_dot_dwim_dot_asdf" = quicklisp-to-nix-packages."hu_dot_dwim_dot_asdf";
+           "hu_dot_dwim_dot_common" = quicklisp-to-nix-packages."hu_dot_dwim_dot_common";
+           "hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def_plus_swank" = quicklisp-to-nix-packages."hu_dot_dwim_dot_stefil_plus_hu_dot_dwim_dot_def_plus_swank";
        }));
 
 
@@ -3351,7 +3449,6 @@ let quicklisp-to-nix-packages = rec {
            "cl-base64" = quicklisp-to-nix-packages."cl-base64";
            "cl-cookie" = quicklisp-to-nix-packages."cl-cookie";
            "cl-ppcre" = quicklisp-to-nix-packages."cl-ppcre";
-           "cl-reexport" = quicklisp-to-nix-packages."cl-reexport";
            "cl-utilities" = quicklisp-to-nix-packages."cl-utilities";
            "fast-http" = quicklisp-to-nix-packages."fast-http";
            "fast-io" = quicklisp-to-nix-packages."fast-io";
@@ -3366,6 +3463,7 @@ let quicklisp-to-nix-packages = rec {
            "trivial-garbage" = quicklisp-to-nix-packages."trivial-garbage";
            "trivial-gray-streams" = quicklisp-to-nix-packages."trivial-gray-streams";
            "trivial-mimes" = quicklisp-to-nix-packages."trivial-mimes";
+           "uiop" = quicklisp-to-nix-packages."uiop";
            "usocket" = quicklisp-to-nix-packages."usocket";
            "xsubseq" = quicklisp-to-nix-packages."xsubseq";
        }));
@@ -4049,6 +4147,17 @@ let quicklisp-to-nix-packages = rec {
          inherit fetchurl;
            "flexi-streams" = quicklisp-to-nix-packages."flexi-streams";
            "trivial-gray-streams" = quicklisp-to-nix-packages."trivial-gray-streams";
+       }));
+
+
+  "cl-qrencode" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."cl-qrencode" or (x: {}))
+       (import ./quicklisp-to-nix-output/cl-qrencode.nix {
+         inherit fetchurl;
+           "salza2" = quicklisp-to-nix-packages."salza2";
+           "trivial-gray-streams" = quicklisp-to-nix-packages."trivial-gray-streams";
+           "zpng" = quicklisp-to-nix-packages."zpng";
        }));
 
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix/system-info.lisp
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix/system-info.lisp
@@ -245,7 +245,10 @@ dependencies that are detected during the install."
     "symbol-munger-test" ;; Dependency cycle between lisp-unit2 and symbol-munger
     "cl-postgres-simple-date-tests" ;; Dependency cycle between cl-postgres and simple-date
     "cl-containers/with-variates" ;; Symbol conflict between cl-variates:next-element, metabang.utilities:next-element
-    "serapeum/docs") ;; Weird issue with FUN-INFO redefinition
+    "serapeum/docs" ;; Weird issue with FUN-INFO redefinition
+    "spinneret/cl-markdown" ;; Weird issue with FUN-INFO redefinition
+    "spinneret/ps" ;; Weird issue with FUN-INFO redefinition
+    "spinneret/tests") ;; Weird issue with FUN-INFO redefinition
   "A vector of systems that shouldn't be loaded by `quickload-parasitic-systems'.
 
 These systems are known to be troublemakers.  In some sense, all

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13045,7 +13045,8 @@ with pkgs;
   sbcl_2_1_2 = callPackage ../development/compilers/sbcl/2.1.2.nix {};
   sbcl_2_1_9 = callPackage ../development/compilers/sbcl/2.1.9.nix {};
   sbcl_2_1_10 = callPackage ../development/compilers/sbcl/2.1.10.nix {};
-  sbcl = sbcl_2_1_9;
+  sbcl_2_1_11 = callPackage ../development/compilers/sbcl/2.1.11.nix {};
+  sbcl = sbcl_2_1_11;
 
   roswell = callPackage ../development/tools/roswell { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

~~Last remaining regression is `nyxt`, I'm not quite sure what is going wrong so far, trying if an update makes it go away doesn't work since it's blocked by [adding spinneret](https://discourse.nixos.org/t/adding-spinneret-to-quicklisp-to-nix-systems-txt/15310).~~

<details>

```
these derivations will be built:
  /nix/store/yjgmhsh9cm32wzr06c5vhh58176c2j8s-lisp-nyxt-2.0.0.drv
building '/nix/store/yjgmhsh9cm32wzr06c5vhh58176c2j8s-lisp-nyxt-2.0.0.drv'...
mkdir: cannot create directory '/homeless-shelter': Permission denied
unpacking sources
unpacking source archive /nix/store/96hls3chdikl4hgvgzcg6y345azcbcsx-source
source root is source
patching sources
configuring
no configure script, doing nothing
glibPreInstallPhase
installing
cp: cannot stat 'LICENCE': No such file or directory
cp: cannot stat 'LICENSE': No such file or directory
cp: cannot stat 'COPYING': No such file or directory
cp: cannot stat 'README': No such file or directory
cp: cannot stat 'README.html': No such file or directory
cp: cannot stat 'README.md': No such file or directory
cp: cannot stat 'readme.html': No such file or directory
/nyxt.asd /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/build-scripts/darwin-app.asd 101 n-app.asd
/nyxt.asd /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/nyxt-quicklisp.asd 91 klisp.asd
/nyxt.asd /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/nyxt-ubuntu-package.asd 96 ckage.asd
/nyxt.asd /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/nyxt.asd 81 /nyxt.asd
This is SBCL 2.1.11.nixos, an implementation of ANSI Common Lisp.
More information about SBCL is available at <http://www.sbcl.org/>.

SBCL is free software, provided as is, with absolutely no warranty.
It is mostly in the public domain; some portions are provided under
BSD-style licenses.  See the CREDITS and COPYING files in the
distribution for more information.
WARNING: System definition file #P"/nix/store/wh3392vqhvsxbdrzj2mr76gb6skjr3nx-lisp-calispel-20170830-git/lib/common-lisp/calispel/calispel.asd" contains definition for system "calispel-test". Please only define "calispel" and secondary systems with a name starting with "calispel/" (e.g. "calispel/test") in that file.
WARNING: System definition file #P"/nix/store/83vbxykp158j1ar557pqqxik8hsxd7gc-lisp-cl-json-20141217-git/lib/common-lisp/cl-json/cl-json.asd" contains definition for system "cl-json.test". Please only define "cl-json" and secondary systems with a name starting with "cl-json/" (e.g. "cl-json/test") in that file.
WARNING: System definition file #P"/nix/store/w54f13wqjy9qx8fi145m3vzk5rzcpc5b-lisp-cl-ppcre-unicode-cl-ppcre-20190521-git/lib/common-lisp/cl-ppcre-unicode/cl-ppcre-unicode.asd" contains definition for system "cl-ppcre-unicode-test". Please only define "cl-ppcre-unicode" and secondary systems with a name starting with "cl-ppcre-unicode/" (e.g. "cl-ppcre-unicode/test") in that file.
WARNING: System definition file #P"/nix/store/3lnm7wqfwqmz4ym2gz5b6lakgcniwfp4-lisp-s-xml-20150608-git/lib/common-lisp/s-xml/s-xml.asd" contains definition for system "s-xml.test". Please only define "s-xml" and secondary systems with a name starting with "s-xml/" (e.g. "s-xml/test") in that file.
WARNING: System definition file #P"/nix/store/3lnm7wqfwqmz4ym2gz5b6lakgcniwfp4-lisp-s-xml-20150608-git/lib/common-lisp/s-xml/s-xml.asd" contains definition for system "s-xml.examples". Please only define "s-xml" and secondary systems with a name starting with "s-xml/" (e.g. "s-xml/test") in that file.
WARNING: System definition file #P"/nix/store/sj2x31cdkqzn6k7c7p5b7drmzcyfwbkc-lisp-flexi-streams-20210807-git/lib/common-lisp/flexi-streams/flexi-streams.asd" contains definition for system "flexi-streams-test". Please only define "flexi-streams" and secondary systems with a name starting with "flexi-streams/" (e.g. "flexi-streams/test") in that file.
WARNING: redefining UIOP/PACKAGE:FIND-PACKAGE* in DEFUN
WARNING: redefining UIOP/PACKAGE:FIND-SYMBOL* in DEFUN
WARNING: redefining UIOP/PACKAGE:SYMBOL-CALL in DEFUN
WARNING: redefining UIOP/PACKAGE:INTERN* in DEFUN
WARNING: redefining UIOP/PACKAGE:EXPORT* in DEFUN
WARNING: redefining UIOP/PACKAGE:IMPORT* in DEFUN
WARNING: redefining UIOP/PACKAGE:SHADOWING-IMPORT* in DEFUN
WARNING: redefining UIOP/PACKAGE:SHADOW* in DEFUN
WARNING: redefining UIOP/PACKAGE:MAKE-SYMBOL* in DEFUN
WARNING: redefining UIOP/PACKAGE:UNINTERN* in DEFUN
WARNING: redefining UIOP/PACKAGE:SYMBOL-SHADOWING-P in DEFUN
WARNING: redefining UIOP/PACKAGE:HOME-PACKAGE-P in DEFUN
WARNING: redefining UIOP/PACKAGE:SYMBOL-PACKAGE-NAME in DEFUN
WARNING: redefining UIOP/PACKAGE:STANDARD-COMMON-LISP-SYMBOL-P in DEFUN
WARNING: redefining UIOP/PACKAGE:REIFY-PACKAGE in DEFUN
WARNING: redefining UIOP/PACKAGE:UNREIFY-PACKAGE in DEFUN
WARNING: redefining UIOP/PACKAGE:REIFY-SYMBOL in DEFUN
WARNING: redefining UIOP/PACKAGE:UNREIFY-SYMBOL in DEFUN
WARNING: redefining UIOP/PACKAGE::RECORD-FISHY in DEFUN
WARNING: redefining UIOP/PACKAGE::WHEN-PACKAGE-FISHINESS in DEFMACRO
WARNING: redefining UIOP/PACKAGE::NOTE-PACKAGE-FISHINESS in DEFMACRO
WARNING: redefining UIOP/PACKAGE::SET-DUMMY-SYMBOL in DEFUN
WARNING: redefining UIOP/PACKAGE::MAKE-DUMMY-SYMBOL in DEFUN
WARNING: redefining UIOP/PACKAGE::DUMMY-SYMBOL in DEFUN
WARNING: redefining UIOP/PACKAGE::GET-DUMMY-SYMBOL in DEFUN
WARNING: redefining UIOP/PACKAGE:NUKE-SYMBOL-IN-PACKAGE in DEFUN
WARNING: redefining UIOP/PACKAGE:NUKE-SYMBOL in DEFUN
WARNING: redefining UIOP/PACKAGE:REHOME-SYMBOL in DEFUN
WARNING: redefining UIOP/PACKAGE:ENSURE-PACKAGE-UNUSED in DEFUN
WARNING: redefining UIOP/PACKAGE:DELETE-PACKAGE* in DEFUN
WARNING: redefining UIOP/PACKAGE:PACKAGE-NAMES in DEFUN
WARNING: redefining UIOP/PACKAGE:PACKAGES-FROM-NAMES in DEFUN
WARNING: redefining UIOP/PACKAGE:FRESH-PACKAGE-NAME in DEFUN
WARNING: redefining UIOP/PACKAGE:RENAME-PACKAGE-AWAY in DEFUN
WARNING: redefining UIOP/PACKAGE:PACKAGE-DEFINITION-FORM in DEFUN
WARNING: redefining UIOP/PACKAGE::ENSURE-SHADOWING-IMPORT in DEFUN
WARNING: redefining UIOP/PACKAGE::ENSURE-IMPORTED in DEFUN
WARNING: redefining UIOP/PACKAGE::ENSURE-IMPORT in DEFUN
WARNING: redefining UIOP/PACKAGE::ENSURE-INHERITED in DEFUN
WARNING: redefining UIOP/PACKAGE::ENSURE-MIX in DEFUN
WARNING: redefining UIOP/PACKAGE::RECYCLE-SYMBOL in DEFUN
WARNING: redefining UIOP/PACKAGE::SYMBOL-RECYCLED-P in DEFUN
WARNING: redefining UIOP/PACKAGE::ENSURE-SYMBOL in DEFUN
WARNING: redefining UIOP/PACKAGE::ENSURE-EXPORTED-TO-USER in DEFUN
WARNING: redefining UIOP/PACKAGE::ENSURE-EXPORTED in DEFUN
WARNING: redefining UIOP/PACKAGE::ENSURE-EXPORT in DEFUN
WARNING: redefining UIOP/PACKAGE:ENSURE-PACKAGE in DEFUN
WARNING: redefining UIOP/PACKAGE:PARSE-DEFINE-PACKAGE-FORM in DEFUN
WARNING: redefining UIOP/PACKAGE:DEFINE-PACKAGE in DEFMACRO
WARNING: redefining UIOP/COMMON-LISP::FROB-SUBSTRINGS in DEFUN
WARNING: redefining UIOP/COMMON-LISP::COMPATFMT in DEFMACRO
WARNING: redefining UIOP/UTILITY:WITH-UPGRADABILITY in DEFMACRO
WARNING: redefining UIOP/UTILITY:UIOP-DEBUG in DEFMACRO
WARNING: redefining UIOP/UTILITY:LOAD-UIOP-DEBUG-UTILITY in DEFUN
WARNING: redefining UIOP/UTILITY:NEST in DEFMACRO
WARNING: redefining UIOP/UTILITY:IF-LET in DEFMACRO
WARNING: redefining UIOP/UTILITY:PARSE-BODY in DEFUN
WARNING: redefining UIOP/UTILITY:WHILE-COLLECTING in DEFMACRO
WARNING: redefining UIOP/UTILITY:APPENDF in DEFMACRO
WARNING: redefining UIOP/UTILITY:LENGTH=N-P in DEFUN
WARNING: redefining UIOP/UTILITY:ENSURE-LIST in DEFUN
WARNING: redefining UIOP/UTILITY:REMOVE-PLIST-KEY in DEFUN
WARNING: redefining UIOP/UTILITY:REMOVE-PLIST-KEYS in DEFUN
WARNING: redefining UIOP/UTILITY:EMPTYP in DEFUN
WARNING: redefining UIOP/UTILITY:CHARACTER-TYPE-INDEX in DEFUN
WARNING: redefining UIOP/UTILITY:BASE-STRING-P in DEFUN
WARNING: redefining UIOP/UTILITY:STRINGS-COMMON-ELEMENT-TYPE in DEFUN
WARNING: redefining UIOP/UTILITY:REDUCE/STRCAT in DEFUN
WARNING: redefining UIOP/UTILITY:STRCAT in DEFUN
WARNING: redefining UIOP/UTILITY:FIRST-CHAR in DEFUN
WARNING: redefining UIOP/UTILITY:LAST-CHAR in DEFUN
WARNING: redefining UIOP/UTILITY:SPLIT-STRING in DEFUN
WARNING: redefining UIOP/UTILITY:STRING-PREFIX-P in DEFUN
WARNING: redefining UIOP/UTILITY:STRING-SUFFIX-P in DEFUN
WARNING: redefining UIOP/UTILITY:STRING-ENCLOSED-P in DEFUN
WARNING: redefining UIOP/UTILITY:STRIPLN in DEFUN
WARNING: redefining UIOP/UTILITY:STANDARD-CASE-SYMBOL-NAME in DEFUN
WARNING: redefining UIOP/UTILITY:FIND-STANDARD-CASE-SYMBOL in DEFUN
WARNING: redefining UIOP/UTILITY:TIMESTAMP< in DEFUN
WARNING: redefining UIOP/UTILITY:TIMESTAMPS< in DEFUN
WARNING: redefining UIOP/UTILITY:TIMESTAMP*< in DEFUN
WARNING: redefining UIOP/UTILITY:TIMESTAMP<= in DEFUN
WARNING: redefining UIOP/UTILITY:EARLIER-TIMESTAMP in DEFUN
WARNING: redefining UIOP/UTILITY:TIMESTAMPS-EARLIEST in DEFUN
WARNING: redefining UIOP/UTILITY:EARLIEST-TIMESTAMP in DEFUN
WARNING: redefining UIOP/UTILITY:LATER-TIMESTAMP in DEFUN
WARNING: redefining UIOP/UTILITY:TIMESTAMPS-LATEST in DEFUN
WARNING: redefining UIOP/UTILITY:LATEST-TIMESTAMP in DEFUN
WARNING: redefining UIOP/UTILITY:LATEST-TIMESTAMP-F in DEFMACRO
WARNING: redefining UIOP/UTILITY:ENSURE-FUNCTION in DEFUN
WARNING: redefining UIOP/UTILITY:ACCESS-AT in DEFUN
WARNING: redefining UIOP/UTILITY:ACCESS-AT-COUNT in DEFUN
WARNING: redefining UIOP/UTILITY:CALL-FUNCTION in DEFUN
WARNING: redefining UIOP/UTILITY:CALL-FUNCTIONS in DEFUN
WARNING: redefining UIOP/UTILITY:REGISTER-HOOK-FUNCTION in DEFUN
WARNING: redefining UIOP/UTILITY:COERCE-CLASS in DEFUN
WARNING: redefining UIOP/UTILITY:ENSURE-GETHASH in DEFUN
WARNING: redefining UIOP/UTILITY:LIST-TO-HASH-SET in DEFUN
WARNING: redefining UIOP/UTILITY:LEXICOGRAPHIC< in DEFUN
WARNING: redefining UIOP/UTILITY:LEXICOGRAPHIC<= in DEFUN
WARNING: redefining UIOP/UTILITY:STYLE-WARN in DEFUN
WARNING: redefining UIOP/UTILITY:MATCH-CONDITION-P in DEFUN
WARNING: redefining UIOP/UTILITY:MATCH-ANY-CONDITION-P in DEFUN
WARNING: redefining UIOP/UTILITY:CALL-WITH-MUFFLED-CONDITIONS in DEFUN
WARNING: redefining UIOP/UTILITY:WITH-MUFFLED-CONDITIONS in DEFMACRO
WARNING: redefining UIOP/UTILITY:NOT-IMPLEMENTED-ERROR in DEFUN
WARNING: redefining UIOP/UTILITY:PARAMETER-ERROR in DEFUN
WARNING: redefining UIOP/UTILITY:BOOLEAN-TO-FEATURE-EXPRESSION in DEFUN
WARNING: redefining UIOP/UTILITY:SYMBOL-TEST-TO-FEATURE-EXPRESSION in DEFUN
WARNING: redefining UIOP/VERSION:UNPARSE-VERSION in DEFUN
WARNING: redefining UIOP/VERSION:PARSE-VERSION in DEFUN
WARNING: redefining UIOP/VERSION:NEXT-VERSION in DEFUN
WARNING: redefining UIOP/VERSION:VERSION< in DEFUN
WARNING: redefining UIOP/VERSION:VERSION<= in DEFUN
WARNING: redefining UIOP/VERSION::DEPRECATED-FUNCTION-CONDITION-KIND in DEFUN
WARNING: redefining PRINT-OBJECT (#<SB-PCL::CONDITION-CLASS UIOP/VERSION:DEPRECATED-FUNCTION-CONDITION> #<SB-PCL:SYSTEM-CLASS COMMON-LISP:T>) in DEFMETHOD
WARNING: redefining UIOP/VERSION::NOTIFY-DEPRECATED-FUNCTION in DEFUN
WARNING: redefining UIOP/VERSION:VERSION-DEPRECATION in DEFUN
WARNING: redefining UIOP/VERSION:WITH-DEPRECATION in DEFMACRO
WARNING: redefining UIOP/OS:FEATUREP in DEFUN
WARNING: redefining UIOP/OS:OS-MACOSX-P in DEFUN
WARNING: redefining UIOP/OS:OS-UNIX-P in DEFUN
WARNING: redefining UIOP/OS:OS-WINDOWS-P in DEFUN
WARNING: redefining UIOP/OS:OS-GENERA-P in DEFUN
WARNING: redefining UIOP/OS::OS-OLDMAC-P in DEFUN
WARNING: redefining UIOP/OS::OS-HAIKU-P in DEFUN
WARNING: redefining UIOP/OS::OS-MEZZANO-P in DEFUN
WARNING: redefining UIOP/OS:DETECT-OS in DEFUN
WARNING: redefining UIOP/OS:OS-COND in DEFMACRO
WARNING: redefining UIOP/OS:GETENV in DEFUN
WARNING: redefining UIOP/OS:GETENVP in DEFUN
WARNING: redefining UIOP/OS::FIRST-FEATURE in DEFUN
WARNING: redefining UIOP/OS:IMPLEMENTATION-TYPE in DEFUN
WARNING: redefining UIOP/OS:OPERATING-SYSTEM in DEFUN
WARNING: redefining UIOP/OS:ARCHITECTURE in DEFUN
WARNING: redefining UIOP/OS:LISP-VERSION-STRING in DEFUN
WARNING: redefining UIOP/OS:IMPLEMENTATION-IDENTIFIER in DEFUN
WARNING: redefining UIOP/OS:HOSTNAME in DEFUN
WARNING: redefining UIOP/OS:GETCWD in DEFUN
WARNING: redefining UIOP/OS:CHDIR in DEFUN
WARNING: redefining UIOP/OS:READ-NULL-TERMINATED-STRING in DEFUN
WARNING: redefining UIOP/OS:READ-LITTLE-ENDIAN in DEFUN
WARNING: redefining UIOP/OS:PARSE-FILE-LOCATION-INFO in DEFUN
WARNING: redefining UIOP/OS:PARSE-WINDOWS-SHORTCUT in DEFUN
WARNING: redefining UIOP/PATHNAME:NORMALIZE-PATHNAME-DIRECTORY-COMPONENT in DEFUN
WARNING: redefining UIOP/PATHNAME:DENORMALIZE-PATHNAME-DIRECTORY-COMPONENT in DEFUN
WARNING: redefining UIOP/PATHNAME:MERGE-PATHNAME-DIRECTORY-COMPONENTS in DEFUN
WARNING: redefining UIOP/PATHNAME:MAKE-PATHNAME* in DEFUN
WARNING: redefining UIOP/PATHNAME:MAKE-PATHNAME-COMPONENT-LOGICAL in DEFUN
WARNING: redefining UIOP/PATHNAME:MAKE-PATHNAME-LOGICAL in DEFUN
WARNING: redefining UIOP/PATHNAME:MERGE-PATHNAMES* in DEFUN
WARNING: redefining UIOP/PATHNAME:LOGICAL-PATHNAME-P in DEFUN
WARNING: redefining UIOP/PATHNAME:PHYSICAL-PATHNAME-P in DEFUN
WARNING: redefining UIOP/PATHNAME:PHYSICALIZE-PATHNAME in DEFUN
WARNING: redefining UIOP/PATHNAME:NIL-PATHNAME in DEFUN
WARNING: redefining UIOP/PATHNAME:WITH-PATHNAME-DEFAULTS in DEFMACRO
WARNING: redefining UIOP/PATHNAME:PATHNAME-EQUAL in DEFUN
WARNING: redefining UIOP/PATHNAME:ABSOLUTE-PATHNAME-P in DEFUN
WARNING: redefining UIOP/PATHNAME:RELATIVE-PATHNAME-P in DEFUN
WARNING: redefining UIOP/PATHNAME:HIDDEN-PATHNAME-P in DEFUN
WARNING: redefining UIOP/PATHNAME:FILE-PATHNAME-P in DEFUN
WARNING: redefining UIOP/PATHNAME:PATHNAME-DIRECTORY-PATHNAME in DEFUN
WARNING: redefining UIOP/PATHNAME:PATHNAME-PARENT-DIRECTORY-PATHNAME in DEFUN
WARNING: redefining UIOP/PATHNAME:DIRECTORY-PATHNAME-P in DEFUN
WARNING: redefining UIOP/PATHNAME:ENSURE-DIRECTORY-PATHNAME in DEFUN
WARNING: redefining UIOP/PATHNAME:SPLIT-UNIX-NAMESTRING-DIRECTORY-COMPONENTS in DEFUN
WARNING: redefining UIOP/PATHNAME:SPLIT-NAME-TYPE in DEFUN
WARNING: redefining UIOP/PATHNAME:PARSE-UNIX-NAMESTRING in DEFUN
WARNING: redefining UIOP/PATHNAME:UNIX-NAMESTRING in DEFUN
WARNING: redefining UIOP/PATHNAME:SUBPATHNAME in DEFUN
WARNING: redefining UIOP/PATHNAME:SUBPATHNAME* in DEFUN
WARNING: redefining UIOP/PATHNAME:PATHNAME-ROOT in DEFUN
WARNING: redefining UIOP/PATHNAME:PATHNAME-HOST-PATHNAME in DEFUN
WARNING: redefining UIOP/PATHNAME:ENSURE-ABSOLUTE-PATHNAME in DEFUN
WARNING: redefining UIOP/PATHNAME:SUBPATHP in DEFUN
WARNING: redefining UIOP/PATHNAME:ENOUGH-PATHNAME in DEFUN
WARNING: redefining UIOP/PATHNAME:CALL-WITH-ENOUGH-PATHNAME in DEFUN
WARNING: redefining UIOP/PATHNAME:WITH-ENOUGH-PATHNAME in DEFMACRO
WARNING: redefining UIOP/PATHNAME:WILDEN in DEFUN
WARNING: redefining UIOP/PATHNAME:RELATIVIZE-DIRECTORY-COMPONENT in DEFUN
WARNING: redefining UIOP/PATHNAME:RELATIVIZE-PATHNAME-DIRECTORY in DEFUN
WARNING: redefining UIOP/PATHNAME:DIRECTORY-SEPARATOR-FOR-HOST in DEFUN
WARNING: redefining UIOP/PATHNAME:DIRECTORIZE-PATHNAME-HOST-DEVICE in DEFUN
WARNING: redefining UIOP/PATHNAME:TRANSLATE-PATHNAME* in DEFUN
WARNING: redefining UIOP/FILESYSTEM:NATIVE-NAMESTRING in DEFUN
WARNING: redefining UIOP/FILESYSTEM:PARSE-NATIVE-NAMESTRING in DEFUN
WARNING: redefining UIOP/FILESYSTEM:TRUENAME* in DEFUN
WARNING: redefining UIOP/FILESYSTEM:SAFE-FILE-WRITE-DATE in DEFUN
WARNING: redefining UIOP/FILESYSTEM:PROBE-FILE* in DEFUN
WARNING: redefining UIOP/FILESYSTEM:DIRECTORY-EXISTS-P in DEFUN
WARNING: redefining UIOP/FILESYSTEM:FILE-EXISTS-P in DEFUN
WARNING: redefining UIOP/FILESYSTEM:DIRECTORY* in DEFUN
WARNING: redefining UIOP/FILESYSTEM:FILTER-LOGICAL-DIRECTORY-RESULTS in DEFUN
WARNING: redefining UIOP/FILESYSTEM:DIRECTORY-FILES in DEFUN
WARNING: redefining UIOP/FILESYSTEM:SUBDIRECTORIES in DEFUN
WARNING: redefining UIOP/FILESYSTEM:COLLECT-SUB*DIRECTORIES in DEFUN
WARNING: redefining UIOP/FILESYSTEM:TRUENAMIZE in DEFUN
WARNING: redefining UIOP/FILESYSTEM:RESOLVE-SYMLINKS in DEFUN
WARNING: redefining UIOP/FILESYSTEM:RESOLVE-SYMLINKS* in DEFUN
WARNING: redefining UIOP/PATHNAME:ENSURE-PATHNAME in DEFUN
WARNING: redefining UIOP/FILESYSTEM:GET-PATHNAME-DEFAULTS in DEFUN
WARNING: redefining UIOP/FILESYSTEM:CALL-WITH-CURRENT-DIRECTORY in DEFUN
WARNING: redefining UIOP/FILESYSTEM:WITH-CURRENT-DIRECTORY in DEFMACRO
WARNING: redefining UIOP/FILESYSTEM:INTER-DIRECTORY-SEPARATOR in DEFUN
WARNING: redefining UIOP/FILESYSTEM:SPLIT-NATIVE-PATHNAMES-STRING in DEFUN
WARNING: redefining UIOP/FILESYSTEM:GETENV-PATHNAME in DEFUN
WARNING: redefining UIOP/FILESYSTEM:GETENV-PATHNAMES in DEFUN
WARNING: redefining UIOP/FILESYSTEM:GETENV-ABSOLUTE-DIRECTORY in DEFUN
WARNING: redefining UIOP/FILESYSTEM:GETENV-ABSOLUTE-DIRECTORIES in DEFUN
WARNING: redefining UIOP/FILESYSTEM:LISP-IMPLEMENTATION-DIRECTORY in DEFUN
WARNING: redefining UIOP/FILESYSTEM:LISP-IMPLEMENTATION-PATHNAME-P in DEFUN
WARNING: redefining UIOP/FILESYSTEM:ENSURE-ALL-DIRECTORIES-EXIST in DEFUN
WARNING: redefining UIOP/FILESYSTEM:DELETE-FILE-IF-EXISTS in DEFUN
WARNING: redefining UIOP/FILESYSTEM:RENAME-FILE-OVERWRITING-TARGET in DEFUN
WARNING: redefining UIOP/FILESYSTEM:DELETE-EMPTY-DIRECTORY in DEFUN
WARNING: redefining UIOP/FILESYSTEM:DELETE-DIRECTORY-TREE in DEFUN
WARNING: redefining UIOP/STREAM:SETUP-STDIN in DEFUN
WARNING: redefining UIOP/STREAM:SETUP-STDOUT in DEFUN
WARNING: redefining UIOP/STREAM:SETUP-STDERR in DEFUN
WARNING: redefining UIOP/STREAM:ALWAYS-DEFAULT-ENCODING in DEFUN
WARNING: redefining UIOP/STREAM:DETECT-ENCODING in DEFUN
WARNING: redefining UIOP/STREAM:DEFAULT-ENCODING-EXTERNAL-FORMAT in DEFUN
WARNING: redefining UIOP/STREAM:ENCODING-EXTERNAL-FORMAT in DEFUN
WARNING: redefining UIOP/STREAM:WITH-SAFE-IO-SYNTAX in DEFMACRO
WARNING: redefining UIOP/STREAM:CALL-WITH-SAFE-IO-SYNTAX in DEFUN
WARNING: redefining UIOP/STREAM:SAFE-READ-FROM-STRING in DEFUN
WARNING: redefining UIOP/STREAM:CALL-WITH-OUTPUT-FILE in DEFUN
WARNING: redefining UIOP/STREAM:WITH-OUTPUT-FILE in DEFMACRO
WARNING: redefining UIOP/STREAM::CALL-WITH-OUTPUT in DEFUN
WARNING: redefining UIOP/STREAM:OUTPUT-STRING in DEFUN
WARNING: redefining UIOP/STREAM:CALL-WITH-INPUT-FILE in DEFUN
WARNING: redefining UIOP/STREAM:WITH-INPUT-FILE in DEFMACRO
WARNING: redefining UIOP/STREAM::CALL-WITH-INPUT in DEFUN
WARNING: redefining UIOP/STREAM:WITH-INPUT in DEFMACRO
WARNING: redefining UIOP/STREAM:INPUT-STRING in DEFUN
WARNING: redefining UIOP/STREAM:NULL-DEVICE-PATHNAME in DEFUN
WARNING: redefining UIOP/STREAM:CALL-WITH-NULL-INPUT in DEFUN
WARNING: redefining UIOP/STREAM:WITH-NULL-INPUT in DEFMACRO
WARNING: redefining UIOP/STREAM:CALL-WITH-NULL-OUTPUT in DEFUN
WARNING: redefining UIOP/STREAM:WITH-NULL-OUTPUT in DEFMACRO
WARNING: redefining UIOP/STREAM:FINISH-OUTPUTS in DEFUN
WARNING: redefining UIOP/STREAM:FORMAT! in DEFUN
WARNING: redefining UIOP/STREAM:SAFE-FORMAT! in DEFUN
WARNING: redefining UIOP/STREAM:COPY-STREAM-TO-STREAM in DEFUN
WARNING: redefining UIOP/STREAM:CONCATENATE-FILES in DEFUN
WARNING: redefining UIOP/STREAM:COPY-FILE in DEFUN
WARNING: redefining UIOP/STREAM:SLURP-STREAM-STRING in DEFUN
WARNING: redefining UIOP/STREAM:SLURP-STREAM-LINES in DEFUN
WARNING: redefining UIOP/STREAM:SLURP-STREAM-LINE in DEFUN
WARNING: redefining UIOP/STREAM:SLURP-STREAM-FORMS in DEFUN
WARNING: redefining UIOP/STREAM:SLURP-STREAM-FORM in DEFUN
WARNING: redefining UIOP/STREAM:READ-FILE-STRING in DEFUN
WARNING: redefining UIOP/STREAM:READ-FILE-LINES in DEFUN
WARNING: redefining UIOP/STREAM:READ-FILE-LINE in DEFUN
WARNING: redefining UIOP/STREAM:READ-FILE-FORMS in DEFUN
WARNING: redefining UIOP/STREAM:READ-FILE-FORM in DEFUN
WARNING: redefining UIOP/STREAM:SAFE-READ-FILE-LINE in DEFUN
WARNING: redefining UIOP/STREAM:SAFE-READ-FILE-FORM in DEFUN
WARNING: redefining UIOP/STREAM:EVAL-INPUT in DEFUN
WARNING: redefining UIOP/STREAM:EVAL-THUNK in DEFUN
WARNING: redefining UIOP/STREAM:STANDARD-EVAL-THUNK in DEFUN
WARNING: redefining UIOP/STREAM:PRINTLN in DEFUN
WARNING: redefining UIOP/STREAM:WRITELN in DEFUN
WARNING: redefining UIOP/STREAM:DEFAULT-TEMPORARY-DIRECTORY in DEFUN
WARNING: redefining UIOP/STREAM:TEMPORARY-DIRECTORY in DEFUN
WARNING: redefining UIOP/STREAM:SETUP-TEMPORARY-DIRECTORY in DEFUN
WARNING: redefining UIOP/STREAM:CALL-WITH-TEMPORARY-FILE in DEFUN
WARNING: redefining UIOP/STREAM:WITH-TEMPORARY-FILE in DEFMACRO
WARNING: redefining UIOP/STREAM::GET-TEMPORARY-FILE in DEFUN
WARNING: redefining UIOP/STREAM:ADD-PATHNAME-SUFFIX in DEFUN
WARNING: redefining UIOP/STREAM:TMPIZE-PATHNAME in DEFUN
WARNING: redefining UIOP/STREAM:CALL-WITH-STAGING-PATHNAME in DEFUN
WARNING: redefining UIOP/STREAM:WITH-STAGING-PATHNAME in DEFMACRO
WARNING: redefining UIOP/STREAM:FILE-STREAM-P in DEFUN
WARNING: redefining UIOP/STREAM:FILE-OR-SYNONYM-STREAM-P in DEFUN
WARNING: redefining UIOP/IMAGE:QUIT in DEFUN
WARNING: redefining UIOP/IMAGE:DIE in DEFUN
WARNING: redefining UIOP/IMAGE:RAW-PRINT-BACKTRACE in DEFUN
WARNING: redefining UIOP/IMAGE:PRINT-BACKTRACE in DEFUN
WARNING: redefining UIOP/IMAGE:PRINT-CONDITION-BACKTRACE in DEFUN
WARNING: redefining UIOP/IMAGE:FATAL-CONDITION-P in DEFUN
WARNING: redefining UIOP/IMAGE:HANDLE-FATAL-CONDITION in DEFUN
WARNING: redefining UIOP/IMAGE:CALL-WITH-FATAL-CONDITION-HANDLER in DEFUN
WARNING: redefining UIOP/IMAGE:WITH-FATAL-CONDITION-HANDLER in DEFMACRO
WARNING: redefining UIOP/IMAGE:SHELL-BOOLEAN-EXIT in DEFUN
WARNING: redefining UIOP/IMAGE:REGISTER-IMAGE-RESTORE-HOOK in DEFUN
WARNING: redefining UIOP/IMAGE:REGISTER-IMAGE-DUMP-HOOK in DEFUN
WARNING: redefining UIOP/IMAGE:CALL-IMAGE-RESTORE-HOOK in DEFUN
WARNING: redefining UIOP/IMAGE:CALL-IMAGE-DUMP-HOOK in DEFUN
WARNING: redefining UIOP/IMAGE:RAW-COMMAND-LINE-ARGUMENTS in DEFUN
WARNING: redefining UIOP/IMAGE:COMMAND-LINE-ARGUMENTS in DEFUN
WARNING: redefining UIOP/IMAGE:ARGV0 in DEFUN
WARNING: redefining UIOP/IMAGE:SETUP-COMMAND-LINE-ARGUMENTS in DEFUN
WARNING: redefining UIOP/IMAGE:RESTORE-IMAGE in DEFUN
WARNING: redefining UIOP/IMAGE:DUMP-IMAGE in DEFUN
WARNING: redefining UIOP/IMAGE:CREATE-IMAGE in DEFUN
WARNING: redefining UIOP/LISP-BUILD:GET-OPTIMIZATION-SETTINGS in DEFUN
WARNING: redefining UIOP/LISP-BUILD:PROCLAIM-OPTIMIZATION-SETTINGS in DEFUN
WARNING: redefining UIOP/LISP-BUILD:WITH-OPTIMIZATION-SETTINGS in DEFMACRO
WARNING: redefining UIOP/LISP-BUILD::SB-GROVEL-UNKNOWN-CONSTANT-CONDITION-P in DEFUN
WARNING: redefining UIOP/LISP-BUILD:CALL-WITH-MUFFLED-COMPILER-CONDITIONS in DEFUN
WARNING: redefining UIOP/LISP-BUILD:WITH-MUFFLED-COMPILER-CONDITIONS in DEFMACRO
WARNING: redefining UIOP/LISP-BUILD:CALL-WITH-MUFFLED-LOADER-CONDITIONS in DEFUN
WARNING: redefining UIOP/LISP-BUILD:WITH-MUFFLED-LOADER-CONDITIONS in DEFMACRO
WARNING: redefining UIOP/LISP-BUILD:CHECK-LISP-COMPILE-WARNINGS in DEFUN
WARNING: redefining UIOP/LISP-BUILD:CHECK-LISP-COMPILE-RESULTS in DEFUN
WARNING: redefining UIOP/LISP-BUILD:REIFY-SIMPLE-SEXP in DEFUN
WARNING: redefining UIOP/LISP-BUILD:UNREIFY-SIMPLE-SEXP in DEFUN
WARNING: redefining UIOP/LISP-BUILD::REIFY-UNDEFINED-WARNING in DEFUN
WARNING: redefining UIOP/LISP-BUILD:REIFY-DEFERRED-WARNINGS in DEFUN
WARNING: redefining UIOP/LISP-BUILD:UNREIFY-DEFERRED-WARNINGS in DEFUN
WARNING: redefining UIOP/LISP-BUILD:RESET-DEFERRED-WARNINGS in DEFUN
WARNING: redefining UIOP/LISP-BUILD:SAVE-DEFERRED-WARNINGS in DEFUN
WARNING: redefining UIOP/LISP-BUILD:WARNINGS-FILE-TYPE in DEFUN
WARNING: redefining UIOP/LISP-BUILD:ENABLE-DEFERRED-WARNINGS-CHECK in DEFUN
WARNING: redefining UIOP/LISP-BUILD:DISABLE-DEFERRED-WARNINGS-CHECK in DEFUN
WARNING: redefining UIOP/LISP-BUILD:WARNINGS-FILE-P in DEFUN
WARNING: redefining UIOP/LISP-BUILD:CHECK-DEFERRED-WARNINGS in DEFUN
WARNING: redefining UIOP/LISP-BUILD::CALL-WITH-SAVED-DEFERRED-WARNINGS in DEFUN
WARNING: redefining UIOP/LISP-BUILD:WITH-SAVED-DEFERRED-WARNINGS in DEFMACRO
WARNING: redefining UIOP/LISP-BUILD:CURRENT-LISP-FILE-PATHNAME in DEFUN
WARNING: redefining UIOP/LISP-BUILD:LOAD-PATHNAME in DEFUN
WARNING: redefining UIOP/LISP-BUILD:LISPIZE-PATHNAME in DEFUN
WARNING: redefining UIOP/LISP-BUILD:COMPILE-FILE-TYPE in DEFUN
WARNING: redefining UIOP/LISP-BUILD:CALL-AROUND-HOOK in DEFUN
WARNING: redefining UIOP/LISP-BUILD:COMPILE-FILE-PATHNAME* in DEFUN
WARNING: redefining UIOP/LISP-BUILD:COMPILE-FILE* in DEFUN
WARNING: redefining UIOP/LISP-BUILD:LOAD* in DEFUN
WARNING: redefining UIOP/LISP-BUILD:LOAD-FROM-STRING in DEFUN
WARNING: redefining UIOP/LISP-BUILD:COMBINE-FASLS in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM::REQUIRES-ESCAPING-P in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM:ESCAPE-TOKEN in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM::ESCAPE-WINDOWS-TOKEN-WITHIN-DOUBLE-QUOTES in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM::EASY-WINDOWS-CHARACTER-P in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM:ESCAPE-WINDOWS-TOKEN in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM::ESCAPE-SH-TOKEN-WITHIN-DOUBLE-QUOTES in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM:EASY-SH-CHARACTER-P in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM:ESCAPE-SH-TOKEN in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM:ESCAPE-SHELL-TOKEN in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM:ESCAPE-COMMAND in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM:ESCAPE-WINDOWS-COMMAND in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM:ESCAPE-SH-COMMAND in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM:ESCAPE-SHELL-COMMAND in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM::%NORMALIZE-IO-SPECIFIER in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM::%INTERACTIVEP in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM::%SIGNAL-TO-EXIT-CODE in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM::%CODE-TO-STATUS in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM::%HANDLE-IF-EXISTS in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM::%HANDLE-IF-DOES-NOT-EXIST in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM:PROCESS-INFO-ERROR-OUTPUT in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM:PROCESS-INFO-INPUT in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM:PROCESS-INFO-OUTPUT in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM:PROCESS-INFO-PID in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM::%PROCESS-STATUS in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM:PROCESS-ALIVE-P in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM:WAIT-PROCESS in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM::%POSIX-SEND-SIGNAL in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM:TERMINATE-PROCESS in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM:CLOSE-STREAMS in DEFUN
WARNING: redefining UIOP/LAUNCH-PROGRAM:LAUNCH-PROGRAM in DEFUN
WARNING: redefining UIOP/RUN-PROGRAM::CALL-STREAM-PROCESSOR in DEFUN
WARNING: redefining UIOP/RUN-PROGRAM:SLURP-INPUT-STREAM in DEFGENERIC
WARNING: redefining SLURP-INPUT-STREAM (#<SB-PCL:SYSTEM-CLASS COMMON-LISP:FUNCTION> #<SB-PCL:SYSTEM-CLASS COMMON-LISP:T>) in DEFMETHOD
WARNING: redefining SLURP-INPUT-STREAM (#<BUILT-IN-CLASS COMMON-LISP:CONS> #<SB-PCL:SYSTEM-CLASS COMMON-LISP:T>) in DEFMETHOD
WARNING: redefining SLURP-INPUT-STREAM (#<SB-PCL:SYSTEM-CLASS COMMON-LISP:STREAM> #<SB-PCL:SYSTEM-CLASS COMMON-LISP:T>) in DEFMETHOD
WARNING: redefining SLURP-INPUT-STREAM (#<SB-MOP:EQL-SPECIALIZER STRING> #<SB-PCL:SYSTEM-CLASS COMMON-LISP:T>) in DEFMETHOD
WARNING: redefining SLURP-INPUT-STREAM (#<SB-MOP:EQL-SPECIALIZER :STRING> #<SB-PCL:SYSTEM-CLASS COMMON-LISP:T>) in DEFMETHOD
WARNING: redefining SLURP-INPUT-STREAM (#<SB-MOP:EQL-SPECIALIZER :LINES> #<SB-PCL:SYSTEM-CLASS COMMON-LISP:T>) in DEFMETHOD
WARNING: redefining SLURP-INPUT-STREAM (#<SB-MOP:EQL-SPECIALIZER :LINE> #<SB-PCL:SYSTEM-CLASS COMMON-LISP:T>) in DEFMETHOD
WARNING: redefining SLURP-INPUT-STREAM (#<SB-MOP:EQL-SPECIALIZER :FORMS> #<SB-PCL:SYSTEM-CLASS COMMON-LISP:T>) in DEFMETHOD
WARNING: redefining SLURP-INPUT-STREAM (#<SB-MOP:EQL-SPECIALIZER :FORM> #<SB-PCL:SYSTEM-CLASS COMMON-LISP:T>) in DEFMETHOD
WARNING: redefining SLURP-INPUT-STREAM (#<SB-MOP:EQL-SPECIALIZER T> #<SB-PCL:SYSTEM-CLASS COMMON-LISP:T>) in DEFMETHOD
WARNING: redefining SLURP-INPUT-STREAM (#<BUILT-IN-CLASS COMMON-LISP:NULL> #<SB-PCL:SYSTEM-CLASS COMMON-LISP:T>) in DEFMETHOD
WARNING: redefining SLURP-INPUT-STREAM (#<BUILT-IN-CLASS COMMON-LISP:PATHNAME> #<SB-PCL:SYSTEM-CLASS COMMON-LISP:T>) in DEFMETHOD
WARNING: redefining SLURP-INPUT-STREAM (#<SB-PCL:SYSTEM-CLASS COMMON-LISP:T> #<SB-PCL:SYSTEM-CLASS COMMON-LISP:T>) in DEFMETHOD
WARNING: redefining UIOP/RUN-PROGRAM:VOMIT-OUTPUT-STREAM in DEFGENERIC
WARNING: redefining VOMIT-OUTPUT-STREAM (#<SB-PCL:SYSTEM-CLASS COMMON-LISP:FUNCTION> #<SB-PCL:SYSTEM-CLASS COMMON-LISP:T>) in DEFMETHOD
WARNING: redefining VOMIT-OUTPUT-STREAM (#<BUILT-IN-CLASS COMMON-LISP:CONS> #<SB-PCL:SYSTEM-CLASS COMMON-LISP:T>) in DEFMETHOD
WARNING: redefining VOMIT-OUTPUT-STREAM (#<SB-PCL:SYSTEM-CLASS COMMON-LISP:STREAM> #<SB-PCL:SYSTEM-CLASS COMMON-LISP:T>) in DEFMETHOD
WARNING: redefining VOMIT-OUTPUT-STREAM (#<BUILT-IN-CLASS COMMON-LISP:STRING> #<SB-PCL:SYSTEM-CLASS COMMON-LISP:T>) in DEFMETHOD
WARNING: redefining VOMIT-OUTPUT-STREAM (#<SB-MOP:EQL-SPECIALIZER T> #<SB-PCL:SYSTEM-CLASS COMMON-LISP:T>) in DEFMETHOD
WARNING: redefining VOMIT-OUTPUT-STREAM (#<BUILT-IN-CLASS COMMON-LISP:NULL> #<SB-PCL:SYSTEM-CLASS COMMON-LISP:T>) in DEFMETHOD
WARNING: redefining VOMIT-OUTPUT-STREAM (#<BUILT-IN-CLASS COMMON-LISP:PATHNAME> #<SB-PCL:SYSTEM-CLASS COMMON-LISP:T>) in DEFMETHOD
WARNING: redefining VOMIT-OUTPUT-STREAM (#<SB-PCL:SYSTEM-CLASS COMMON-LISP:T> #<SB-PCL:SYSTEM-CLASS COMMON-LISP:T>) in DEFMETHOD
WARNING: redefining UIOP/RUN-PROGRAM::%CHECK-RESULT in DEFUN
WARNING: redefining UIOP/RUN-PROGRAM::%ACTIVE-IO-SPECIFIER-P in DEFUN
WARNING: redefining UIOP/RUN-PROGRAM::%RUN-PROGRAM in DEFUN
WARNING: redefining UIOP/RUN-PROGRAM::%CALL-WITH-PROGRAM-IO in DEFUN
WARNING: redefining UIOP/RUN-PROGRAM::PLACE-SETTER in DEFMACRO
WARNING: redefining UIOP/RUN-PROGRAM::WITH-PROGRAM-INPUT in DEFMACRO
WARNING: redefining UIOP/RUN-PROGRAM::WITH-PROGRAM-OUTPUT in DEFMACRO
WARNING: redefining UIOP/RUN-PROGRAM::WITH-PROGRAM-ERROR-OUTPUT in DEFMACRO
WARNING: redefining UIOP/RUN-PROGRAM::%USE-LAUNCH-PROGRAM in DEFUN
WARNING: redefining UIOP/RUN-PROGRAM::%NORMALIZE-SYSTEM-COMMAND in DEFUN
WARNING: redefining UIOP/RUN-PROGRAM::%REDIRECTED-SYSTEM-COMMAND in DEFUN
WARNING: redefining UIOP/RUN-PROGRAM::%SYSTEM in DEFUN
WARNING: redefining UIOP/RUN-PROGRAM::%USE-SYSTEM in DEFUN
WARNING: redefining UIOP/RUN-PROGRAM:RUN-PROGRAM in DEFUN
WARNING: redefining UIOP/CONFIGURATION:CONFIGURATION-INHERITANCE-DIRECTIVE-P in DEFUN
WARNING: redefining UIOP/CONFIGURATION:REPORT-INVALID-FORM in DEFUN
WARNING: redefining UIOP/CONFIGURATION:VALIDATE-CONFIGURATION-FORM in DEFUN
WARNING: redefining UIOP/CONFIGURATION:VALIDATE-CONFIGURATION-FILE in DEFUN
WARNING: redefining UIOP/CONFIGURATION:VALIDATE-CONFIGURATION-DIRECTORY in DEFUN
WARNING: redefining UIOP/CONFIGURATION:RESOLVE-RELATIVE-LOCATION in DEFUN
WARNING: redefining UIOP/CONFIGURATION:RESOLVE-ABSOLUTE-LOCATION in DEFUN
WARNING: redefining UIOP/CONFIGURATION:RESOLVE-LOCATION in DEFUN
WARNING: redefining UIOP/CONFIGURATION:LOCATION-DESIGNATOR-P in DEFUN
WARNING: redefining UIOP/CONFIGURATION:LOCATION-FUNCTION-P in DEFUN
WARNING: redefining UIOP/CONFIGURATION:REGISTER-CLEAR-CONFIGURATION-HOOK in DEFUN
WARNING: redefining UIOP/CONFIGURATION:CLEAR-CONFIGURATION in DEFUN
WARNING: redefining UIOP/CONFIGURATION:UPGRADE-CONFIGURATION in DEFUN
WARNING: redefining UIOP/CONFIGURATION:GET-FOLDER-PATH in DEFUN
WARNING: redefining UIOP/CONFIGURATION:XDG-DATA-HOME in DEFUN
WARNING: redefining UIOP/CONFIGURATION:XDG-CONFIG-HOME in DEFUN
WARNING: redefining UIOP/CONFIGURATION:XDG-DATA-DIRS in DEFUN
WARNING: redefining UIOP/CONFIGURATION:XDG-CONFIG-DIRS in DEFUN
WARNING: redefining UIOP/CONFIGURATION:XDG-CACHE-HOME in DEFUN
WARNING: redefining UIOP/CONFIGURATION:XDG-RUNTIME-DIR in DEFUN
WARNING: redefining UIOP/CONFIGURATION:SYSTEM-CONFIG-PATHNAMES in DEFUN
WARNING: redefining UIOP/CONFIGURATION:FILTER-PATHNAME-SET in DEFUN
WARNING: redefining UIOP/CONFIGURATION:XDG-DATA-PATHNAMES in DEFUN
WARNING: redefining UIOP/CONFIGURATION:XDG-CONFIG-PATHNAMES in DEFUN
WARNING: redefining UIOP/CONFIGURATION:FIND-PREFERRED-FILE in DEFUN
WARNING: redefining UIOP/CONFIGURATION:XDG-DATA-PATHNAME in DEFUN
WARNING: redefining UIOP/CONFIGURATION:XDG-CONFIG-PATHNAME in DEFUN
WARNING: redefining UIOP/CONFIGURATION::COMPUTE-USER-CACHE in DEFUN
WARNING: redefining UIOP/CONFIGURATION:UIOP-DIRECTORY in DEFUN
WARNING: redefining UIOP/BACKWARD-DRIVER:COERCE-PATHNAME in DEFUN
WARNING: redefining UIOP/CONFIGURATION:USER-CONFIGURATION-DIRECTORIES in DEFUN
WARNING: redefining UIOP/CONFIGURATION:SYSTEM-CONFIGURATION-DIRECTORIES in DEFUN
WARNING: redefining UIOP/CONFIGURATION:IN-FIRST-DIRECTORY in DEFUN
WARNING: redefining UIOP/CONFIGURATION:IN-USER-CONFIGURATION-DIRECTORY in DEFUN
WARNING: redefining UIOP/CONFIGURATION:IN-SYSTEM-CONFIGURATION-DIRECTORY in DEFUN
WARNING: redefining UIOP/BACKWARD-DRIVER:VERSION-COMPATIBLE-P in DEFUN
;;; Computing Hangul syllable namesWARNING: redefining S-SERIALIZATION::SERIALIZE-SEXP-INTERNAL in DEFGENERIC
WARNING: redefining CL-PREVALENCE:GET-ID in DEFGENERIC
WARNING: redefining CL-PREVALENCE:GET-NAME in DEFGENERIC
WARNING: redefining (COMMON-LISP:SETF CL-PREVALENCE:GET-NAME) in DEFGENERIC
WARNING: redefining CL-PREVALENCE:GET-SIZE in DEFGENERIC
WARNING: redefining CL-PREVALENCE:GET-MIME-TYPE in DEFGENERIC
WARNING: redefining (COMMON-LISP:SETF CL-PREVALENCE:GET-MIME-TYPE) in DEFGENERIC
WARNING: redefining CL-PREVALENCE:GET-KEYWORDS in DEFGENERIC
WARNING: redefining (COMMON-LISP:SETF CL-PREVALENCE:GET-KEYWORDS) in DEFGENERIC
WARNING: redefining LOG4CL-IMPL:APPENDER-ADDED in DEFGENERIC
WARNING: redefining LOG4CL-IMPL:APPENDER-REMOVED in DEFGENERIC
WARNING: redefining LOG4CL-IMPL::PROPERTY-ALIST in DEFGENERIC
WARNING:
   redefining EMACS-INSPECT (#<SB-PCL:SYSTEM-CLASS COMMON-LISP:T>) in DEFMETHOD

; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/user-interface/package.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/user-interface/package-tmpAAURSO1.fasl
; compilation finished in 0:00:00.004
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/user-interface/user-interface.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/user-interface/user-interface-tmp5GEXGEG5.fasl
; compilation finished in 0:00:00.026
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/text-buffer/package.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/text-buffer/package-tmpAR3FSGEY.fasl
; compilation finished in 0:00:00.105
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/text-buffer/text-buffer.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/text-buffer/text-buffer-tmpJAIDFZTC.fasl
; compilation finished in 0:00:00.045
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/analysis/package.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/analysis/package-tmp8V3J6PE9.fasl
; compilation finished in 0:00:00.005
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/analysis/data.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/analysis/data-tmp9V47YWQF.fasl
; compilation finished in 0:00:00.012
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/analysis/stem.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/analysis/stem-tmp9BN22RMA.fasl
; compilation finished in 0:00:00.081
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/analysis/tokenize.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/analysis/tokenize-tmp1CXFJSK9.fasl
; compilation finished in 0:00:00.010
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/analysis/analysis.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/analysis/analysis-tmpX4BRKI0R.fasl
; compilation finished in 0:00:00.032
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/analysis/document-vector.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/analysis/document-vector-tmpQ371UGST.fasl
; compilation finished in 0:00:00.031
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/analysis/text-rank.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/analysis/text-rank-tmp2OWI3Q7U.fasl
; compilation finished in 0:00:00.027
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/analysis/dbscan.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/analysis/dbscan-tmp9KKTJMYV.fasl
; compilation finished in 0:00:00.021
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/download-manager/package.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/download-manager/package-tmpJU0JWO19.fasl
; compilation finished in 0:00:00.003
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/download-manager/engine.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/download-manager/engine-tmpZX2WN8N4.fasl
; compilation finished in 0:00:00.024
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/download-manager/native.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/download-manager/native-tmpOU81XRV0.fasl
; compilation finished in 0:00:00.029
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/class-star/package.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/class-star/package-tmpY2ML9CFA.fasl
; compilation finished in 0:00:00.001
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/class-star/patch.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/class-star/patch-tmpX2JYJDQE.fasl
; compilation finished in 0:00:00.016
WARNING: redefining HU.DWIM.DEFCLASS-STAR::PROCESS-SLOT-DEFINITION in DEFUN
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/class-star/class-star.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/class-star/class-star-tmpOPCILR65.fasl
; compilation finished in 0:00:00.036
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/history-tree/package.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/history-tree/package-tmpRV9F8A9A.fasl
; compilation finished in 0:00:00.006
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/history-tree/history-tree.lisp" (written 18 DEC 2021 05:26:04 PM):

; file: /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/history-tree/history-tree.lisp
; in: DEFUN DATA-LAST-ACCESS
;     (DEFUN HISTORY-TREE:DATA-LAST-ACCESS
;            (HISTORY-TREE::HISTORY HISTORY-TREE::DATA)
;       "Return data last access across all its nodes, regardless of the owner.
;   Return Epoch if DATA is not found or if entry has no timestamp."
;       (LET* ((HISTORY-TREE:ENTRY
;               (HISTORY-TREE::FIND-ENTRY HISTORY-TREE::HISTORY
;                HISTORY-TREE::DATA))
;              (HISTORY-TREE::NODES (WHEN HISTORY-TREE:ENTRY #)))
;         (THE (VALUES LOCAL-TIME:TIMESTAMP &OPTIONAL)
;              (IF HISTORY-TREE::NODES
;                  (LET #
;                    #
;                    HISTORY-TREE::NEW-LAST-ACCESS)
;                  (IF HISTORY-TREE:ENTRY
;                      #
;                      #)))))
; --> SB-IMPL::%DEFUN SB-IMPL::%DEFUN SB-INT:NAMED-LAMBDA FUNCTION
; ==>
;   (SB-C::%FUNCALL #'DATA-LAST-ACCESS #:G9 #:G10)
;
; note: can't open-code test of unknown type HISTORY-TREE


; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/history-tree/history-tree-tmpK2ZAJT4I.fasl
; compilation finished in 0:00:00.138
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/password-manager/package.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/password-manager/package-tmpUX5S4ADN.fasl
; compilation finished in 0:00:00.004
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/password-manager/password.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/password-manager/password-tmp10401X32.fasl
; compilation finished in 0:00:00.013
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/password-manager/password-keepassxc.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/password-manager/password-keepassxc-tmpZ7CBRM0G.fasl
; compilation finished in 0:00:00.015
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/password-manager/password-security.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/password-manager/password-security-tmp9OZEQ0G2.fasl
; compilation finished in 0:00:00.008
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/password-manager/password-pass.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/password-manager/password-pass-tmpB2JTL1W9.fasl
; compilation finished in 0:00:00.012
STYLE-WARNING:
   Generic function FSET:ITERATOR clobbers an earlier FTYPE proclamation
   (FUNCTION (T &KEY &ALLOW-OTHER-KEYS) (VALUES FUNCTION &REST T)) for the same
   name with (FUNCTION (T &KEY &ALLOW-OTHER-KEYS) *).
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/keymap/package.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/keymap/package-tmpP3BI68WQ.fasl
; compilation finished in 0:00:00.007
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/keymap/types.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/keymap/types-tmpQDARA81Z.fasl
; compilation finished in 0:00:00.006
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/keymap/conditions.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/keymap/conditions-tmpYEMMM7SE.fasl
; compilation finished in 0:00:00.006
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/keymap/keymap.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/keymap/keymap-tmp73HU0RPK.fasl
; compilation finished in 0:00:00.152
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/keymap/scheme.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/keymap/scheme-tmpIO5N7K88.fasl
; compilation finished in 0:00:00.024
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/keymap/scheme-names.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/keymap/scheme-names-tmpCM21U60Z.fasl
; compilation finished in 0:00:00.001
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/ospm/package.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/ospm/package-tmp9DT7SEFG.fasl
; compilation finished in 0:00:00.003
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/ospm/scheme-syntax.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/ospm/scheme-syntax-tmp8065ESJT.fasl
; compilation finished in 0:00:00.005
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/ospm/guix-backend.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/ospm/guix-backend-tmp7S8Z6FGF.fasl
; compilation finished in 0:00:00.007
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/ospm/ospm.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/ospm/ospm-tmpSIT3QPKP.fasl
; compilation finished in 0:00:00.040
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/ospm/ospm-guix.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/ospm/ospm-guix-tmpE0PA0714.fasl
; compilation finished in 0:00:00.079
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/prompter/package.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/prompter/package-tmpJRWHHVG0.fasl
; compilation finished in 0:00:00.012
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/prompter/filter-preprocessor.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/prompter/filter-preprocessor-tmp4WZVROCX.fasl
; compilation finished in 0:00:00.007
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/prompter/filter.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/prompter/filter-tmpA0I3UKX8.fasl
; compilation finished in 0:00:00.008
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/prompter/prompter-source.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/prompter/prompter-source-tmp267Y2N80.fasl
; compilation finished in 0:00:00.077
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/prompter/prompter.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/libraries/prompter/prompter-tmpOUPE5FSJ.fasl
; compilation finished in 0:00:00.100
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/package.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/package-tmpIGHCU6ZA.fasl
; compilation finished in 0:00:00.013
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/time.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/time-tmpBO0TUGLK.fasl
; compilation finished in 0:00:00.008
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/types.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/types-tmpIIXPIQNW.fasl
; compilation finished in 0:00:00.008
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/conditions.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/conditions-tmpOHM494YR.fasl
; compilation finished in 0:00:00.002
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/user-interface.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/user-interface-tmpOVFB07XF.fasl
; compilation finished in 0:00:00.023
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/global.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/global-tmpG6VFGMYP.fasl
; compilation finished in 0:00:00.027
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/concurrency.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/concurrency-tmp4QIPRMOF.fasl
; compilation finished in 0:00:00.013
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/data-storage.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/data-storage-tmpGW0QV22K.fasl
; compilation finished in 0:00:00.165
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/configuration.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/configuration-tmp2K9J0HSR.fasl
; compilation finished in 0:00:00.060
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/command.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/command-tmpP44I4E0Y.fasl
; compilation finished in 0:00:00.101
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/parenscript-macro.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/parenscript-macro-tmp63LQ7EX6.fasl
; compilation finished in 0:00:00.016
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/renderer-script.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/renderer-script-tmp86F1A8FB.fasl
; compilation finished in 0:00:00.027
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/buffer.lisp" (written 18 DEC 2021 05:26:04 PM):

; file: /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/buffer.lisp
; in: DEFUN BUFFER-MAKE
;     (DEFUN NYXT::BUFFER-MAKE
;            (NYXT::BROWSER
;             &KEY NYXT:DATA-PROFILE NYXT:TITLE NYXT::EXTRA-MODES NYXT::DEAD-BUFFER
;             (NYXT::BUFFER-CLASS 'NYXT:USER-WEB-BUFFER) NYXT::PARENT-BUFFER
;             NYXT::NO-HISTORY-P
;             (NYXT:NOSAVE-BUFFER-P (NYXT:NOSAVE-BUFFER-P NYXT::PARENT-BUFFER)))
;       #<(SIMPLE-ARRAY CHARACTER
;          (208)) Make buffer with title TITLE and with EXTRA-MODES.
;   Run `*browser*'s `buffer-make-hook' over the created buffer before returning it.
;   If DEAD-BUFFER is a dead buffer, recreate its web view and give it a... {1007A214AF}>
;       (LET ((NYXT:BUFFER
;              (IF NYXT::DEAD-BUFFER
;                  #
;                  #)))
;         (SERAPEUM:RUN-HOOK (NYXT::BUFFER-BEFORE-MAKE-HOOK NYXT:*BROWSER*)
;                            NYXT:BUFFER)
;         (NYXT::INITIALIZE-MODES NYXT:BUFFER)
;         (MAPC (ALEXANDRIA:RCURRY #'NYXT::MAKE-MODE NYXT:BUFFER)
;               NYXT::EXTRA-MODES)
;         (WHEN NYXT::DEAD-BUFFER (SETF # #))
;         (NYXT::BUFFERS-SET (NYXT:ID NYXT:BUFFER) NYXT:BUFFER)
;         (UNLESS NYXT::NO-HISTORY-P
;           (NYXT:WITH-CURRENT-BUFFER NYXT:BUFFER
;             (NYXT:WITH-DATA-ACCESS #
;               #)))
;         (SERAPEUM:RUN-HOOK (NYXT::BUFFER-MAKE-HOOK NYXT::BROWSER) NYXT:BUFFER)
;         NYXT:BUFFER))
; --> SB-IMPL::%DEFUN SB-IMPL::%DEFUN SB-INT:NAMED-LAMBDA FUNCTION LOCALLY
; ==>
;   (SB-C::%FUNCALL #'BUFFER-MAKE NYXT::BROWSER
;                   (SB-C::WITH-SOURCE-FORM NYXT:DATA-PROFILE NIL)
;                   (SB-C::WITH-SOURCE-FORM NYXT:TITLE NIL)
;                   (SB-C::WITH-SOURCE-FORM NYXT::EXTRA-MODES NIL)
;                   (SB-C::WITH-SOURCE-FORM NYXT::DEAD-BUFFER NIL)
;                   (SB-C::WITH-SOURCE-FORM
;                    (NYXT::BUFFER-CLASS 'NYXT:USER-WEB-BUFFER)
;                    'NYXT:USER-WEB-BUFFER)
;                   (SB-C::WITH-SOURCE-FORM NYXT::PARENT-BUFFER NIL)
;                   (SB-C::WITH-SOURCE-FORM NYXT::NO-HISTORY-P NIL) NIL 0)
;
; note: can't open-code test of unknown type BROWSER

; --> SB-IMPL::%DEFUN SB-IMPL::%DEFUN SB-INT:NAMED-LAMBDA FUNCTION LET
; ==>
;   (SB-C::%FUNCALL #'BUFFER-MAKE NYXT::BROWSER #:N-VALUE-36 #:N-VALUE-37
;                   #:N-VALUE-38 #:N-VALUE-39 #:N-VALUE-40 #:N-VALUE-41
;                   #:N-VALUE-42 #:N-VALUE-43 #:N-SUPPLIED-44)
;
; note: can't open-code test of unknown type BROWSER

; in: DEFUN BUFFER-LOAD
;     (DEFUN NYXT:BUFFER-LOAD
;            (NYXT::URL-DESIGNATOR &KEY (NYXT:BUFFER (NYXT:CURRENT-BUFFER)))
;       "Load INPUT-URL in BUFFER.
;   URL is then transformed by BUFFER's `buffer-load-hook'."
;       (LET* ((NYXT:URL (NYXT:URL NYXT::URL-DESIGNATOR))
;              (NYXT::NEW-URL (HANDLER-CASE # #)))
;         (WHEN NYXT::NEW-URL
;           (CHECK-TYPE NYXT::NEW-URL QURI.URI:URI)
;           (SETF NYXT:URL NYXT::NEW-URL)
;           (COND (# #) (# #) (# #) (T #)))))
; --> SB-IMPL::%DEFUN SB-IMPL::%DEFUN SB-INT:NAMED-LAMBDA FUNCTION LOCALLY
; ==>
;   (SB-C::%FUNCALL #'BUFFER-LOAD NYXT::URL-DESIGNATOR NIL 0)
;
; note: can't open-code test of unknown type URL-DESIGNATOR

; --> SB-IMPL::%DEFUN SB-IMPL::%DEFUN SB-INT:NAMED-LAMBDA FUNCTION LET
; ==>
;   (SB-C::%FUNCALL #'BUFFER-LOAD NYXT::URL-DESIGNATOR #:N-VALUE-21
;                   #:N-SUPPLIED-22)
;
; note: can't open-code test of unknown type URL-DESIGNATOR


; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/buffer-tmpH7D4HL98.fasl
; compilation finished in 0:00:00.592
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/window.lisp" (written 18 DEC 2021 05:26:04 PM):

; file: /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/window.lisp
; in: DEFUN WINDOW-MAKE
;     (DEFUN NYXT:WINDOW-MAKE (NYXT::BROWSER)
;       (LET* ((NYXT:WINDOW (NYXT::FFI-WINDOW-MAKE NYXT::BROWSER)))
;         (SETF (GETHASH # #) NYXT:WINDOW)
;         (UNLESS (SLOT-VALUE NYXT::BROWSER 'NYXT::LAST-ACTIVE-WINDOW)
;           (SETF # NYXT:WINDOW))
;         (SERAPEUM:RUN-HOOK (NYXT::WINDOW-MAKE-HOOK NYXT::BROWSER) NYXT:WINDOW)
;         NYXT:WINDOW))
; --> SB-IMPL::%DEFUN SB-IMPL::%DEFUN SB-INT:NAMED-LAMBDA FUNCTION
; ==>
;   (SB-C::%FUNCALL #'WINDOW-MAKE #:G1)
;
; note: can't open-code test of unknown type BROWSER


; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/window-tmpCDM7YXYI.fasl
; compilation finished in 0:00:00.218
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/mode.lisp" (written 18 DEC 2021 05:26:04 PM):

; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/mode-tmpLM57P5P.fasl
; compilation finished in 0:00:00.056
; compiling file "/nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/search-engine.lisp" (written 18 DEC 2021 05:26:04 PM):

; file: /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/search-engine.lisp
; in:
;      DECLAIM (FTYPE
;           (FUNCTION
;            (&KEY (:BASE-URL STRING) (:REQUEST-FUNCTION (FUNCTION # *))
;             (:REQUEST-ARGS LIST)
;             (:PROCESSING-FUNCTION (FUNCTION # LIST-OF-STRINGS)))
;            (FUNCTION (STRING) LIST-OF-STRINGS))
;           MAKE-SEARCH-COMPLETION-FUNCTION)
;     (DECLAIM
;      (FTYPE
;       (FUNCTION
;        (&KEY (:BASE-URL STRING) (:REQUEST-FUNCTION #) (:REQUEST-ARGS LIST)
;         (:PROCESSING-FUNCTION #))
;        (FUNCTION (STRING) NYXT:LIST-OF-STRINGS))
;       NYXT:MAKE-SEARCH-COMPLETION-FUNCTION))
; ==>
;   (SB-C::%PROCLAIM
;    '(FTYPE
;      (FUNCTION
;       (&KEY (:BASE-URL STRING) (:REQUEST-FUNCTION #) (:REQUEST-ARGS LIST)
;        (:PROCESSING-FUNCTION #))
;       (FUNCTION (STRING) NYXT:LIST-OF-STRINGS))
;      NYXT:MAKE-SEARCH-COMPLETION-FUNCTION)
;    (SB-C:SOURCE-LOCATION))
;
; caught WARNING:
;   * is not permitted as an argument to the FUNCTION type specifier
;
; caught WARNING:
;   * is not permitted as an argument to the FUNCTION type specifier
;
; caught WARNING:
;   * is not permitted as an argument to the FUNCTION type specifier
;
; caught WARNING:
;   * is not permitted as an argument to the FUNCTION type specifier


; wrote /nix/store/0yy5zz2gcqnwwr44lamqr74vn802a2jl-lisp-nyxt-2.0.0/lib/common-lisp/nyxt/source/search-engine-tmpZE69DN33.fasl
; compilation finished in 0:00:00.024
Unhandled UIOP/LISP-BUILD:COMPILE-FILE-ERROR in thread #<SB-THREAD:THREAD "main thread" RUNNING
                                                          {10015142E3}>:
  COMPILE-FILE-ERROR while compiling #<CL-SOURCE-FILE "nyxt" "search-engine">

Backtrace for: #<SB-THREAD:THREAD "main thread" RUNNING {10015142E3}>
0: (SB-DEBUG::DEBUGGER-DISABLED-HOOK #<UIOP/LISP-BUILD:COMPILE-FILE-ERROR {100550A643}> #<unused argument> :QUIT T)
1: (SB-DEBUG::RUN-HOOK *INVOKE-DEBUGGER-HOOK* #<UIOP/LISP-BUILD:COMPILE-FILE-ERROR {100550A643}>)
2: (INVOKE-DEBUGGER #<UIOP/LISP-BUILD:COMPILE-FILE-ERROR {100550A643}>)
3: (ERROR UIOP/LISP-BUILD:COMPILE-FILE-ERROR :CONTEXT-FORMAT "~/asdf-action::format-action/" :CONTEXT-ARGUMENTS ((#<ASDF/LISP-ACTION:COMPILE-OP > . #<ASDF/LISP-ACTION:CL-SOURCE-FILE "nyxt" "search-engine">)))
4: (UIOP/LISP-BUILD:CHECK-LISP-COMPILE-RESULTS NIL T T "~/asdf-action::format-action/" ((#<ASDF/LISP-ACTION:COMPILE-OP > . #<ASDF/LISP-ACTION:CL-SOURCE-FILE "nyxt" "search-engine">)))
5: ((SB-PCL::EMF ASDF/ACTION:PERFORM) #<unused argument> #<unused argument> #<ASDF/LISP-ACTION:COMPILE-OP > #<ASDF/LISP-ACTION:CL-SOURCE-FILE "nyxt" "search-engine">)
6: ((LAMBDA NIL :IN ASDF/ACTION:CALL-WHILE-VISITING-ACTION))
7: ((:METHOD ASDF/ACTION:PERFORM-WITH-RESTARTS :AROUND (T T)) #<ASDF/LISP-ACTION:COMPILE-OP > #<ASDF/LISP-ACTION:CL-SOURCE-FILE "nyxt" "search-engine">) [fast-method]
8: ((:METHOD ASDF/PLAN:PERFORM-PLAN (T)) #<ASDF/PLAN:SEQUENTIAL-PLAN {1002D1DD23}>) [fast-method]
9: ((FLET SB-C::WITH-IT :IN SB-C::%WITH-COMPILATION-UNIT))
10: ((:METHOD ASDF/PLAN:PERFORM-PLAN :AROUND (T)) #<ASDF/PLAN:SEQUENTIAL-PLAN {1002D1DD23}>) [fast-method]
11: ((:METHOD ASDF/OPERATE:OPERATE (ASDF/OPERATION:OPERATION ASDF/COMPONENT:COMPONENT)) #<ASDF/LISP-ACTION:COMPILE-OP > #<ASDF/SYSTEM:SYSTEM "nyxt"> :PLAN-CLASS NIL :PLAN-OPTIONS NIL) [fast-method]
12: ((SB-PCL::EMF ASDF/OPERATE:OPERATE) #<unused argument> #<unused argument> #<ASDF/LISP-ACTION:COMPILE-OP > #<ASDF/SYSTEM:SYSTEM "nyxt">)
13: ((LAMBDA NIL :IN ASDF/OPERATE:OPERATE))
14: ((:METHOD ASDF/OPERATE:OPERATE :AROUND (T T)) #<ASDF/LISP-ACTION:COMPILE-OP > #<ASDF/SYSTEM:SYSTEM "nyxt">) [fast-method]
15: ((SB-PCL::EMF ASDF/OPERATE:OPERATE) #<unused argument> #<unused argument> ASDF/LISP-ACTION:COMPILE-OP :NYXT)
16: ((LAMBDA NIL :IN ASDF/OPERATE:OPERATE))
17: ((:METHOD ASDF/OPERATE:OPERATE :AROUND (T T)) ASDF/LISP-ACTION:COMPILE-OP :NYXT) [fast-method]
18: (ASDF/SESSION:CALL-WITH-ASDF-SESSION #<FUNCTION (LAMBDA NIL :IN ASDF/OPERATE:OPERATE) {10015AF8AB}> :OVERRIDE T :KEY NIL :OVERRIDE-CACHE T :OVERRIDE-FORCING NIL)
19: ((LAMBDA NIL :IN ASDF/OPERATE:OPERATE))
20: (ASDF/SESSION:CALL-WITH-ASDF-SESSION #<FUNCTION (LAMBDA NIL :IN ASDF/OPERATE:OPERATE) {100338E5EB}> :OVERRIDE NIL :KEY NIL :OVERRIDE-CACHE NIL :OVERRIDE-FORCING NIL)
21: ((:METHOD ASDF/OPERATE:OPERATE :AROUND (T T)) ASDF/LISP-ACTION:COMPILE-OP :NYXT) [fast-method]
22: (ASDF/OPERATE:COMPILE-SYSTEM :NYXT)
23: (SB-INT:SIMPLE-EVAL-IN-LEXENV (ASDF/OPERATE:COMPILE-SYSTEM :NYXT) #<NULL-LEXENV>)
24: (SB-IMPL::SIMPLE-EVAL-PROGN-BODY ((ASDF/OPERATE:COMPILE-SYSTEM :NYXT) (ASDF/OPERATE:LOAD-SYSTEM :NYXT) (ASDF/OPERATE:OPERATE (QUOTE ASDF/BUNDLE:COMPILE-BUNDLE-OP) :NYXT) (IGNORE-ERRORS (ASDF/OPERATE:OPERATE (QUOTE ASDF/INTERFACE::DEPLOY-ASD-OP) :NYXT))) #<NULL-LEXENV>)
25: (SB-INT:SIMPLE-EVAL-IN-LEXENV (PROGN (ASDF/OPERATE:COMPILE-SYSTEM :NYXT) (ASDF/OPERATE:LOAD-SYSTEM :NYXT) (ASDF/OPERATE:OPERATE (QUOTE ASDF/BUNDLE:COMPILE-BUNDLE-OP) :NYXT) (IGNORE-ERRORS (ASDF/OPERATE:OPERATE (QUOTE ASDF/INTERFACE::DEPLOY-ASD-OP) :NYXT))) #<NULL-LEXENV>)
26: (EVAL (PROGN (ASDF/OPERATE:COMPILE-SYSTEM :NYXT) (ASDF/OPERATE:LOAD-SYSTEM :NYXT) (ASDF/OPERATE:OPERATE (QUOTE ASDF/BUNDLE:COMPILE-BUNDLE-OP) :NYXT) (IGNORE-ERRORS (ASDF/OPERATE:OPERATE (QUOTE ASDF/INTERFACE::DEPLOY-ASD-OP) :NYXT))))
27: (SB-IMPL::PROCESS-EVAL/LOAD-OPTIONS ((:EVAL . "(load \"/nix/store/1b9a4zc7zpk6clr4h8vdxb4425j2cb48-cl-wrapper-script/lib/common-lisp/asdf/build/asdf.fasl\")") (:EVAL . #<(SIMPLE-ARRAY CHARACTER (16592))
  (progn
    (setf asdf:*source-registry-parameter*
      '(:source-registry
        (:tree "/nix/store/02a9hn5r4x1n5dd4z07dcgv9z3li3izn-lisp-jpl-util-cl-20151031-git/lib/common-lisp/jpl-util")
(:tre... {100152000F}>) (:EVAL . "(progn
      (asdf:compile-system :nyxt)
(asdf:load-system :nyxt)
(asdf:operate (quote asdf::compile-bundle-op) :nyxt)
(ignore-errors (asdf:operate (quote asdf::deploy-asd-op) :nyxt))

      )") (:EVAL . "(quit)") (:QUIT)))
28: (SB-IMPL::TOPLEVEL-INIT)
29: ((FLET SB-UNIX::BODY :IN SB-IMPL::START-LISP))
30: ((FLET "WITHOUT-INTERRUPTS-BODY-3" :IN SB-IMPL::START-LISP))
31: (SB-IMPL::START-LISP)

unhandled condition in --disable-debugger mode, quitting
;
; compilation unit aborted
;   caught 1 fatal ERROR condition
;   caught 4 WARNING conditions
;   printed 6 notes
builder for '/nix/store/yjgmhsh9cm32wzr06c5vhh58176c2j8s-lisp-nyxt-2.0.0.drv' failed with exit code 1
error: build of '/nix/store/yjgmhsh9cm32wzr06c5vhh58176c2j8s-lisp-nyxt-2.0.0.drv' failed
```

</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
