### PR TITLE
bottles: 2021.7.28-treviso-2 -> 2021.12.28-treviso

### DIFF
--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -1,20 +1,21 @@
 { lib, fetchFromGitHub
 , meson, ninja, pkg-config, wrapGAppsHook
-, desktop-file-utils, gsettings-desktop-schemas, libnotify, libhandy
+, desktop-file-utils, gsettings-desktop-schemas, libnotify, libhandy, webkitgtk
 , python3Packages, gettext
-, appstream-glib, gdk-pixbuf, glib, gobject-introspection, gspell, gtk3
+, appstream-glib, gdk-pixbuf, glib, gobject-introspection, gspell, gtk3, gnome
 , steam-run, xdg-utils, pciutils, cabextract, wineWowPackages
+, freetype, p7zip, gamemode
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "bottles";
-  version = "2021.7.28-treviso-2";
+  version = "2021.12.28-treviso";
 
   src = fetchFromGitHub {
     owner = "bottlesdevs";
     repo = pname;
     rev = version;
-    sha256 = "0kvwcajm9izvkwfg7ir7bks39bpc665idwa8mc8d536ajyjriysn";
+    sha256 = "lZbSLLBg7XM6PuOmu5rJ15dg+QHHRcjijRYE6u3WT9Y=";
   };
 
   postPatch = ''
@@ -41,10 +42,13 @@ python3Packages.buildPythonApplication rec {
     gtk3
     libhandy
     libnotify
+    webkitgtk
+    gnome.adwaita-icon-theme
   ];
 
   propagatedBuildInputs = with python3Packages; [
     pyyaml
+    pytoml
     requests
     pycairo
     pygobject3
@@ -53,12 +57,16 @@ python3Packages.buildPythonApplication rec {
     gst-python
     liblarch
     patool
+    markdown
   ] ++ [
     steam-run
     xdg-utils
     pciutils
     cabextract
     wineWowPackages.minimal
+    freetype
+    p7zip
+    gamemode # programs.gamemode.enable
   ];
 
   format = "other";
@@ -66,13 +74,9 @@ python3Packages.buildPythonApplication rec {
   dontWrapGApps = true; # prevent double wrapping
 
   preConfigure = ''
-    substituteInPlace build-aux/meson/postinstall.py \
-      --replace "'update-desktop-database'" "'${desktop-file-utils}/bin/update-desktop-database'"
-    substituteInPlace src/runner.py \
-      --replace " {runner}" " ${steam-run}/bin/steam-run {runner}" \
-      --replace " {dxvk_setup}" " ${steam-run}/bin/steam-run {dxvk_setup}"
-      substituteInPlace src/runner_utilities.py \
-        --replace " {runner}" " ${steam-run}/bin/steam-run {runner}" \
+    patchShebangs build-aux/meson/postinstall.py
+    substituteInPlace src/backend/runner.py \
+      --replace "{Paths.runners}" "${steam-run}/bin/steam-run {Paths.runners}"
   '';
 
   preFixup = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`bottles` updated from 2021.7.28-treviso-2 to 2021.12.28-treviso
~`bottles` updated from 2021.7.28-treviso-2 to 2021.12.14-treviso-3~

@bloomvdomino @shamilton

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
