### PR TITLE
treewide: bash -> bashNonInteractive & bashInteractive -> bash

### DIFF
--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -198,6 +198,7 @@ in {
     inherit passthruFun;
     pythonAttr = "python3Minimal";
     # strip down that python version as much as possible
+    bash = bashNoninteractive;
     openssl = null;
     readline = null;
     ncurses = null;

--- a/pkgs/shells/bash/4.4.nix
+++ b/pkgs/shells/bash/4.4.nix
@@ -25,7 +25,7 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "bash-${optionalString interactive "interactive-"}${version}-p${toString (builtins.length upstreamPatches)}";
+  name = "bash-${optionalString (!interactive) "noninteractive-"}${version}-p${toString (builtins.length upstreamPatches)}";
   version = "4.4";
 
   src = fetchurl {

--- a/pkgs/shells/bash/4.4.nix
+++ b/pkgs/shells/bash/4.4.nix
@@ -104,7 +104,7 @@ stdenv.mkDerivation rec {
   postFixup = if interactive
     then ''
       substituteInPlace "$out/bin/bashbug" \
-        --replace '${stdenv.shell}' "$out/bin/bash"
+        --replace '${stdenv.shellPackage}/bin/sh' "$out/bin/sh"
     ''
     # most space is taken by locale data
     else ''

--- a/pkgs/shells/bash/5.1.nix
+++ b/pkgs/shells/bash/5.1.nix
@@ -24,7 +24,7 @@ let
   });
 in
 stdenv.mkDerivation rec {
-  name = "bash-${optionalString interactive "interactive-"}${version}-p${toString (builtins.length upstreamPatches)}";
+  name = "bash-${optionalString (!interactive) "noninteractive-"}${version}-p${toString (builtins.length upstreamPatches)}";
   version = "5.1";
 
   src = fetchurl {

--- a/pkgs/shells/bash/5.1.nix
+++ b/pkgs/shells/bash/5.1.nix
@@ -95,7 +95,7 @@ stdenv.mkDerivation rec {
     if interactive
     then ''
       substituteInPlace "$out/bin/bashbug" \
-        --replace '${stdenv.shell}' "$out/bin/bash"
+        --replace '${stdenv.shellPackage}/bin/sh' "$out/bin/sh"
     ''
     # most space is taken by locale data
     else ''

--- a/pkgs/shells/bash/5.1.nix
+++ b/pkgs/shells/bash/5.1.nix
@@ -91,11 +91,11 @@ stdenv.mkDerivation rec {
     rm -f $out/lib/bash/Makefile.inc
   '';
 
-  postFixup =
+  preFixup =
     if interactive
     then ''
       substituteInPlace "$out/bin/bashbug" \
-        --replace '${stdenv.shellPackage}/bin/sh' "$out/bin/sh"
+        --replace '/bin/sh' "$out/bin/sh"
     ''
     # most space is taken by locale data
     else ''

--- a/pkgs/stdenv/common-path.nix
+++ b/pkgs/stdenv/common-path.nix
@@ -9,7 +9,7 @@
   pkgs.gzip
   pkgs.bzip2.bin
   pkgs.gnumake
-  pkgs.bash
+  pkgs.bashNoninteractive
   pkgs.patch
   pkgs.xz.bin
 ]

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -533,7 +533,7 @@ rec {
       persistent = self: super: with prevStage; {
         inherit
           patchutils m4 scons flex perl bison unifdef unzip openssl python3
-          gettext sharutils libarchive pkg-config groff bash subversion
+          gettext sharutils libarchive pkg-config groff bashNoninteractive subversion
           openssh sqlite sed serf openldap db cyrus-sasl expat apr-util
           findfreetype libssh curl cmake autoconf automake libtool cpio
           libssh2 nghttp2 libkrb5 ninja;
@@ -558,18 +558,18 @@ rec {
       };
     in
     with prevStage; stageFun 3 prevStage {
-      shell = "${pkgs.bash}/bin/bash";
+      shell = "${pkgs.bashNoninteractive}/bin/bash";
 
       # We have a valid shell here (this one has no bootstrap-tools runtime deps) so stageFun
       # enables patchShebangs above. Unfortunately, patchShebangs ignores our $SHELL setting
       # and instead goes by $PATH, which happens to contain bootstrapTools. So it goes and
       # patches our shebangs back to point at bootstrapTools. This makes sure bash comes first.
       extraNativeBuildInputs = with pkgs; [ xz ];
-      extraBuildInputs = [ pkgs.darwin.CF pkgs.bash ];
+      extraBuildInputs = [ pkgs.darwin.CF pkgs.bashNoninteractive ];
       libcxx = pkgs."${finalLlvmPackages}".libcxx;
 
       extraPreHook = ''
-        export PATH=${pkgs.bash}/bin:$PATH
+        export PATH=${pkgs.bashNoninteractive}/bin:$PATH
         export PATH_LOCALE=${pkgs.darwin.locale}/share/locale
       '';
 
@@ -578,7 +578,7 @@ rec {
         (with pkgs; [
           xz.bin
           xz.out
-          bash
+          bashNoninteractive
           zlib
           libxml2.out
           curl.out
@@ -609,7 +609,7 @@ rec {
     let
       persistent = self: super: with prevStage; {
         inherit
-          gnumake gzip gnused bzip2 gawk ed xz patch bash python3
+          gnumake gzip gnused bzip2 gawk ed xz patch bashNoninteractive python3
           ncurses libffi zlib gmp pcre gnugrep cmake
           coreutils findutils diffutils patchutils ninja libxml2;
 
@@ -648,9 +648,9 @@ rec {
       };
     in
     with prevStage; stageFun 4 prevStage {
-      shell = "${pkgs.bash}/bin/bash";
+      shell = "${pkgs.bashNoninteractive}/bin/bash";
       extraNativeBuildInputs = with pkgs; [ xz ];
-      extraBuildInputs = [ pkgs.darwin.CF pkgs.bash ];
+      extraBuildInputs = [ pkgs.darwin.CF pkgs.bashNoninteractive ];
       libcxx = pkgs."${finalLlvmPackages}".libcxx;
 
       extraPreHook = ''
@@ -665,7 +665,7 @@ rec {
       pkgs = prevStage;
       persistent = self: super: with prevStage; {
         inherit
-          gnumake gzip gnused bzip2 gawk ed xz patch bash
+          gnumake gzip gnused bzip2 gawk ed xz patch bashNoninteractive
           ncurses libffi zlib gmp pcre gnugrep
           coreutils findutils diffutils patchutils pbzx;
 
@@ -712,7 +712,7 @@ rec {
       __extraImpureHostDeps = commonImpureHostDeps;
 
       initialPath = import ../common-path.nix { inherit pkgs; };
-      shell = "${pkgs.bash}/bin/bash";
+      shell = "${pkgs.bashNoninteractive}/bin/bash";
 
       cc = pkgs."${finalLlvmPackages}".libcxxClang;
 
@@ -724,7 +724,7 @@ rec {
 
       extraAttrs = {
         libc = pkgs.darwin.Libsystem;
-        shellPackage = pkgs.bash;
+        shellPackage = pkgs.bashNoninteractive;
         inherit bootstrapTools;
       };
 
@@ -748,7 +748,7 @@ rec {
         ncurses.dev
         ncurses.man
         gnused
-        bash
+        bashNoninteractive
         gawk
         gnugrep
         patch

--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -104,7 +104,7 @@ in rec {
       cp ${coreutils_}/bin/* $out/bin
       (cd $out/bin && rm vdir dir sha*sum pinky factor pathchk runcon shuf who whoami shred users)
 
-      cp ${bash}/bin/bash $out/bin
+      cp ${bashNoninteractive}/bin/bash $out/bin
       cp ${findutils}/bin/find $out/bin
       cp ${findutils}/bin/xargs $out/bin
       cp -d ${diffutils}/bin/* $out/bin

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -334,7 +334,7 @@ in
       ${localSystem.libc} = getLibc prevStage;
       binutils = super.binutils.override {
         # Don't use stdenv's shell but our own
-        shell = self.bash + "/bin/bash";
+        shell = self.bashNoninteractive + "/bin/bash";
         # Build expand-response-params with last stage like below
         buildPackages = {
           inherit (prevStage) stdenv;
@@ -353,7 +353,7 @@ in
         libc = getLibc self;
         inherit lib;
         inherit (self) stdenvNoCC coreutils gnugrep;
-        shell = self.bash + "/bin/bash";
+        shell = self.bashNoninteractive + "/bin/bash";
       };
     };
     extraNativeBuildInputs = [ prevStage.patchelf prevStage.xz ] ++
@@ -400,14 +400,14 @@ in
         inherit (prevStage) glibc;
 
         inherit bootstrapTools;
-        shellPackage = prevStage.bash;
+        shellPackage = prevStage.bashNoninteractive;
       };
 
       # Mainly avoid reference to bootstrap tools
       allowedRequisites = with prevStage; with lib;
         # Simple executable tools
         concatMap (p: [ (getBin p) (getLib p) ]) [
-            gzip bzip2 xz bash binutils.bintools coreutils diffutils findutils
+            gzip bzip2 xz bashNoninteractive binutils.bintools coreutils diffutils findutils
             gawk gnumake gnused gnutar gnugrep gnupatch patchelf ed
           ]
         # Library dependencies
@@ -425,7 +425,7 @@ in
 
       overrides = self: super: {
         inherit (prevStage)
-          gzip bzip2 xz bash coreutils diffutils findutils gawk
+          gzip bzip2 xz bashNoninteractive coreutils diffutils findutils gawk
           gnumake gnused gnutar gnugrep gnupatch patchelf
           attr acl zlib pcre libunistring libidn2;
         ${localSystem.libc} = getLibc prevStage;

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -106,7 +106,7 @@ in with pkgs; rec {
         cp -d ${coreutilsMinimal.out}/bin/* $out/bin
         (cd $out/bin && rm vdir dir sha*sum pinky factor pathchk runcon shuf who whoami shred users)
 
-        cp ${bash.out}/bin/bash $out/bin
+        cp ${bashNoninteractive.out}/bin/bash $out/bin
         cp ${findutils.out}/bin/find $out/bin
         cp ${findutils.out}/bin/xargs $out/bin
         cp -d ${diffutils.out}/bin/* $out/bin

--- a/pkgs/stdenv/nix/default.nix
+++ b/pkgs/stdenv/nix/default.nix
@@ -31,10 +31,10 @@ bootStages ++ [
         inherit (prevStage) stdenvNoCC binutils coreutils gnugrep;
         cc = prevStage.gcc.cc;
         isGNU = true;
-        shell = prevStage.bash + "/bin/sh";
+        shell = prevStage.bashNoninteractive + "/bin/sh";
       };
 
-      shell = prevStage.bash + "/bin/sh";
+      shell = prevStage.bashNoninteractive + "/bin/sh";
 
       fetchurlBoot = prevStage.stdenv.fetchurlBoot;
 
@@ -42,7 +42,7 @@ bootStages ++ [
         inherit cc;
         inherit (cc) binutils;
         inherit (prevStage)
-          gzip bzip2 xz bash coreutils diffutils findutils gawk
+          gzip bzip2 xz bashNoninteractive coreutils diffutils findutils gawk
           gnumake gnused gnutar gnugrep gnupatch perl;
       };
     };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11304,20 +11304,23 @@ with pkgs;
 
   any-nix-shell = callPackage ../shells/any-nix-shell { };
 
-  bash_4 = lowPrio (callPackage ../shells/bash/4.4.nix {
+  bashNoninteractive_4 = lowPrio (callPackage ../shells/bash/4.4.nix {
     binutils = stdenv.cc.bintools;
   });
-  bash = lowPrio (callPackage ../shells/bash/5.1.nix {
+  bashNoninteractive = lowPrio (callPackage ../shells/bash/5.1.nix {
     binutils = stdenv.cc.bintools;
   });
   # WARNING: this attribute is used by nix-shell so it shouldn't be removed/renamed
-  bashInteractive = callPackage ../shells/bash/5.1.nix {
+  bashInteractive = bash;
+
+  bash = callPackage ../shells/bash/5.1.nix {
     binutils = stdenv.cc.bintools;
     interactive = true;
     withDocs = true;
   };
 
-  bashInteractive_4 = lowPrio (callPackage ../shells/bash/4.4.nix {
+  bashInteractive_4 = bash_4;
+  bash_4 = lowPrio (callPackage ../shells/bash/4.4.nix {
     binutils = stdenv.cc.bintools;
     interactive = true;
     withDocs = true;


### PR DESCRIPTION
stdenv changed due to
error: output '/nix/store/...-stdenv-linux' is not allowed to refer to the following paths:
         /nix/store/...-ncurses-6.2
         /nix/store/...-readline-8.1p0
         /nix/store/...-bash-interactive-5.1-p12

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Closes #59209

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
