### PR TITLE
vscode-extensions.ms-vscode.cpptools: fix wrapping of OpenDebugAD7

### DIFF
--- a/pkgs/misc/vscode-extensions/cpptools/default.nix
+++ b/pkgs/misc/vscode-extensions/cpptools/default.nix
@@ -1,7 +1,9 @@
 { lib, vscode-utils
-, fetchurl, mono, writeScript, runtimeShell
+, fetchurl, writeScript, runtimeShell
 , jq, clang-tools
 , gdbUseFixed ? true, gdb # The gdb default setting will be fixed to specified. Use version from `PATH` otherwise.
+# dependencies for native binaries
+, autoPatchelfHook, makeWrapper, stdenv, lttng-ust, libkrb5, zlib
 }:
 
 /*
@@ -29,20 +31,7 @@
 
 let
   gdbDefaultsTo = if gdbUseFixed then "${gdb}/bin/gdb" else "gdb";
-
-
-  openDebugAD7Script = writeScript "OpenDebugAD7" ''
-    #!${runtimeShell}
-    BIN_DIR="$(cd "$(dirname "$0")" && pwd -P)"
-    ${if gdbUseFixed
-        then ''
-          export PATH=''${PATH}''${PATH:+:}${gdb}/bin
-        ''
-        else ""}
-    ${mono}/bin/mono $BIN_DIR/bin/OpenDebugAD7.exe $*
-  '';
 in
-
 vscode-utils.buildVscodeMarketplaceExtension rec {
   mktplcRef = {
     name = "cpptools";
@@ -56,8 +45,17 @@ vscode-utils.buildVscodeMarketplaceExtension rec {
     sha256 = "sha256-LqndG/vv8LgVPEX6dGkikDB6M6ISneo2UJ78izXVFbk=";
   };
 
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+  ];
+
   buildInputs = [
     jq
+    lttng-ust
+    libkrb5
+    zlib
+    stdenv.cc.cc.lib
   ];
 
   postPatch = ''
@@ -73,20 +71,19 @@ vscode-utils.buildVscodeMarketplaceExtension rec {
     # Prevent download/install of extensions
     touch "./install.lock"
 
-    # Mono runtimes from nix package (used by generated `OpenDebugAD7`).
-    mv ./debugAdapters/bin/OpenDebugAD7 ./debugAdapters/bin/OpenDebugAD7_orig
-    cp -p "${openDebugAD7Script}" "./debugAdapters/bin/OpenDebugAD7"
-
     # Clang-format from nix package.
     mv  ./LLVM/ ./LLVM_orig
     mkdir "./LLVM/"
     find "${clang-tools}" -mindepth 1 -maxdepth 1 | xargs ln -s -t "./LLVM"
 
-    # Patching  cpptools and cpptools-srv
-    elfInterpreter="$(cat $NIX_CC/nix-support/dynamic-linker)"
-    patchelf --set-interpreter "$elfInterpreter" ./bin/cpptools
-    patchelf --set-interpreter "$elfInterpreter" ./bin/cpptools-srv
+    # Patching binaries
     chmod a+x ./bin/cpptools{-srv,}
+    chmod a+x ./debugAdapters/bin/OpenDebugAD7
+    patchelf --replace-needed liblttng-ust.so.0 liblttng-ust.so.1 ./debugAdapters/bin/libcoreclrtraceptprovider.so
+  '';
+
+  postFixup = lib.optionalString gdbUseFixed ''
+    wrapProgram $out/share/vscode/extensions/ms-vscode.cpptools/debugAdapters/bin/OpenDebugAD7 --prefix PATH : ${lib.makeBinPath [ gdb ]}
   '';
 
     meta = with lib; {


### PR DESCRIPTION
`OpenDebugAD7` is no longer packaged as a .NET binary but a native
Linux one. I have introduced `autoPatchelfHook` to be just done with
the wrapping.

`liblttng-ust.so` had to be replaced as the binaries were depending on
a different version. This is done similarly as is e.g. with the
`powershell` derivation.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
