### PR TITLE
wlroots: 0.14.1 -> 0.15.0

### DIFF
--- a/pkgs/development/libraries/wlroots/0.14.nix
+++ b/pkgs/development/libraries/wlroots/0.14.nix
@@ -1,0 +1,63 @@
+{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, wayland-scanner
+, libGL, wayland, wayland-protocols, libinput, libxkbcommon, pixman
+, xcbutilwm, libX11, libcap, xcbutilimage, xcbutilerrors, mesa
+, libpng, ffmpeg, xcbutilrenderutil, seatd
+
+, enableXWayland ? true, xwayland ? null
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wlroots";
+  version = "0.14.1";
+
+  src = fetchFromGitHub {
+    owner = "swaywm";
+    repo = "wlroots";
+    rev = version;
+    sha256 = "1sshp3lvlkl1i670kxhwsb4xzxl8raz6769kqvgmxzcb63ns9ay1";
+  };
+
+  # $out for the library and $examples for the example programs (in examples):
+  outputs = [ "out" "examples" ];
+
+  depsBuildBuild = [ pkg-config ];
+
+  nativeBuildInputs = [ meson ninja pkg-config wayland-scanner ];
+
+  buildInputs = [
+    libGL wayland wayland-protocols libinput libxkbcommon pixman
+    xcbutilwm libX11 libcap xcbutilimage xcbutilerrors mesa
+    libpng ffmpeg xcbutilrenderutil seatd
+  ]
+    ++ lib.optional enableXWayland xwayland
+  ;
+
+  mesonFlags =
+    lib.optional (!enableXWayland) "-Dxwayland=disabled"
+  ;
+
+  postFixup = ''
+    # Install ALL example programs to $examples:
+    # screencopy dmabuf-capture input-inhibitor layer-shell idle-inhibit idle
+    # screenshot output-layout multi-pointer rotation tablet touch pointer
+    # simple
+    mkdir -p $examples/bin
+    cd ./examples
+    for binary in $(find . -executable -type f -printf '%P\n' | grep -vE '\.so'); do
+      cp "$binary" "$examples/bin/wlroots-$binary"
+    done
+  '';
+
+  meta = with lib; {
+    description = "A modular Wayland compositor library";
+    longDescription = ''
+      Pluggable, composable, unopinionated modules for building a Wayland
+      compositor; or about 50,000 lines of code you were going to write anyway.
+    '';
+    inherit (src.meta) homepage;
+    changelog = "https://github.com/swaywm/wlroots/releases/tag/${version}";
+    license     = licenses.mit;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ primeos synthetica ];
+  };
+}

--- a/pkgs/development/libraries/wlroots/0.15.nix
+++ b/pkgs/development/libraries/wlroots/0.15.nix
@@ -1,20 +1,21 @@
-{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, wayland-scanner
+{ lib, stdenv, fetchFromGitLab, meson_0_60, ninja, pkg-config, wayland-scanner
 , libGL, wayland, wayland-protocols, libinput, libxkbcommon, pixman
 , xcbutilwm, libX11, libcap, xcbutilimage, xcbutilerrors, mesa
-, libpng, ffmpeg, xcbutilrenderutil, seatd
+, libpng, ffmpeg, xcbutilrenderutil, seatd, vulkan-loader, glslang
 
 , enableXWayland ? true, xwayland ? null
 }:
 
 stdenv.mkDerivation rec {
   pname = "wlroots";
-  version = "0.14.1";
+  version = "0.15.0";
 
-  src = fetchFromGitHub {
-    owner = "swaywm";
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "wlroots";
     repo = "wlroots";
     rev = version;
-    sha256 = "1sshp3lvlkl1i670kxhwsb4xzxl8raz6769kqvgmxzcb63ns9ay1";
+    sha256 = "0wdzs0wpv61pxgy3mx3xjsndyfmbj30v47d3w9ymmnd4r479n41n";
   };
 
   # $out for the library and $examples for the example programs (in examples):
@@ -22,12 +23,12 @@ stdenv.mkDerivation rec {
 
   depsBuildBuild = [ pkg-config ];
 
-  nativeBuildInputs = [ meson ninja pkg-config wayland-scanner ];
+  nativeBuildInputs = [ meson_0_60 ninja pkg-config wayland-scanner ];
 
   buildInputs = [
     libGL wayland wayland-protocols libinput libxkbcommon pixman
     xcbutilwm libX11 libcap xcbutilimage xcbutilerrors mesa
-    libpng ffmpeg xcbutilrenderutil seatd
+    libpng ffmpeg xcbutilrenderutil seatd vulkan-loader glslang
   ]
     ++ lib.optional enableXWayland xwayland
   ;
@@ -55,7 +56,7 @@ stdenv.mkDerivation rec {
       compositor; or about 50,000 lines of code you were going to write anyway.
     '';
     inherit (src.meta) homepage;
-    changelog = "https://github.com/swaywm/wlroots/releases/tag/${version}";
+    changelog = "https://gitlab.freedesktop.org/wlroots/wlroots/-/tags/${version}";
     license     = licenses.mit;
     platforms   = platforms.linux;
     maintainers = with maintainers; [ primeos synthetica ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3586,7 +3586,9 @@ with pkgs;
 
   reg = callPackage ../tools/virtualization/reg { };
 
-  river = callPackage ../applications/window-managers/river { };
+  river = callPackage ../applications/window-managers/river {
+    wlroots = wlroots_0_14;
+  };
 
   rmapi = callPackage ../applications/misc/remarkable/rmapi { };
 
@@ -24459,7 +24461,9 @@ with pkgs;
 
   cardboard = callPackage ../applications/window-managers/cardboard { };
 
-  cage = callPackage ../applications/window-managers/cage { };
+  cage = callPackage ../applications/window-managers/cage {
+    wlroots = wlroots_0_14;
+  };
 
   calf = callPackage ../applications/audio/calf {
       inherit (gnome2) libglade;
@@ -24866,7 +24870,9 @@ with pkgs;
 
   dyff = callPackage ../development/tools/dyff {};
 
-  dwl = callPackage ../applications/window-managers/dwl { };
+  dwl = callPackage ../applications/window-managers/dwl {
+    wlroots = wlroots_0_14;
+  };
 
   dwm = callPackage ../applications/window-managers/dwm {
     # dwm is configured entirely through source modification. Allow users to
@@ -26071,13 +26077,18 @@ with pkgs;
 
   super-productivity = callPackage ../applications/office/super-productivity { };
 
-  wlroots = wlroots_0_14;
+  wlroots = wlroots_0_15;
   wlroots_0_12 = callPackage ../development/libraries/wlroots/0.12.nix {};
   wlroots_0_14 = callPackage ../development/libraries/wlroots/0.14.nix {
     inherit (xorg) xcbutilrenderutil;
   };
+  wlroots_0_15 = callPackage ../development/libraries/wlroots/0.15.nix {
+    inherit (xorg) xcbutilrenderutil;
+  };
 
-  sway-unwrapped = callPackage ../applications/window-managers/sway { };
+  sway-unwrapped = callPackage ../applications/window-managers/sway {
+    wlroots = wlroots_0_14;
+  };
   sway = callPackage ../applications/window-managers/sway/wrapper.nix { };
   swaybg = callPackage ../applications/window-managers/sway/bg.nix { };
   swayidle = callPackage ../applications/window-managers/sway/idle.nix { };
@@ -26097,7 +26108,9 @@ with pkgs;
 
   wbg = callPackage ../applications/misc/wbg { };
 
-  hikari = callPackage ../applications/window-managers/hikari { };
+  hikari = callPackage ../applications/window-managers/hikari {
+    wlroots = wlroots_0_14;
+  };
 
   i3 = callPackage ../applications/window-managers/i3 {
     xcb-util-cursor = if stdenv.isDarwin then xcb-util-cursor-HEAD else xcb-util-cursor;
@@ -26161,7 +26174,9 @@ with pkgs;
 
   i3-wk-switch = callPackage ../applications/window-managers/i3/wk-switch.nix { };
 
-  waybox = callPackage ../applications/window-managers/waybox { };
+  waybox = callPackage ../applications/window-managers/waybox {
+    wlroots = wlroots_0_14;
+  };
 
   workstyle = callPackage ../applications/window-managers/i3/workstyle.nix { };
 
@@ -26623,7 +26638,9 @@ with pkgs;
 
   lame = callPackage ../development/libraries/lame { };
 
-  labwc = callPackage ../applications/window-managers/labwc { };
+  labwc = callPackage ../applications/window-managers/labwc {
+    wlroots = wlroots_0_14;
+  };
 
   larswm = callPackage ../applications/window-managers/larswm { };
 
@@ -29295,7 +29312,8 @@ with pkgs;
   wayfireApplications = wayfireApplications-unwrapped.withPlugins (plugins: [ plugins.wf-shell ]);
   inherit (wayfireApplications) wayfire wcm;
   wayfireApplications-unwrapped = recurseIntoAttrs (
-    callPackage ../applications/window-managers/wayfire/applications.nix { }
+    (callPackage ../applications/window-managers/wayfire/applications.nix { }).
+    extend (_: _: { wlroots = wlroots_0_14; })
   );
   wayfirePlugins = recurseIntoAttrs (
     callPackage ../applications/window-managers/wayfire/plugins.nix {
@@ -29349,7 +29367,9 @@ with pkgs;
     electron = electron_14;
   };
 
-  wio = callPackage ../applications/window-managers/wio { };
+  wio = callPackage ../applications/window-managers/wio {
+    wlroots = wlroots_0_14;
+  };
 
   whitebox-tools = callPackage ../applications/gis/whitebox-tools {
     inherit (darwin.apple_sdk.frameworks) Security;
@@ -34030,7 +34050,9 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) DiskArbitration Foundation IOKit;
   };
 
-  cagebreak = callPackage ../applications/window-managers/cagebreak { };
+  cagebreak = callPackage ../applications/window-managers/cagebreak {
+    wlroots = wlroots_0_14;
+  };
 
   psftools = callPackage ../os-specific/linux/psftools {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26071,11 +26071,11 @@ with pkgs;
 
   super-productivity = callPackage ../applications/office/super-productivity { };
 
-  wlroots = callPackage ../development/libraries/wlroots {
+  wlroots = wlroots_0_14;
+  wlroots_0_12 = callPackage ../development/libraries/wlroots/0.12.nix {};
+  wlroots_0_14 = callPackage ../development/libraries/wlroots/0.14.nix {
     inherit (xorg) xcbutilrenderutil;
   };
-
-  wlroots_0_12 = callPackage ../development/libraries/wlroots/0.12.nix {};
 
   sway-unwrapped = callPackage ../applications/window-managers/sway { };
   sway = callPackage ../applications/window-managers/sway/wrapper.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8092,7 +8092,9 @@ in {
 
   pywizlight = callPackage ../development/python-modules/pywizlight { };
 
-  pywlroots = callPackage ../development/python-modules/pywlroots { };
+  pywlroots = callPackage ../development/python-modules/pywlroots {
+    wlroots = pkgs.wlroots_0_14;
+  };
 
   pyxattr = callPackage ../development/python-modules/pyxattr { };
 


### PR DESCRIPTION
Release notes: https://gitlab.freedesktop.org/wlroots/wlroots/-/tags/0.15.0

https://gitlab.freedesktop.org/wlroots/wlroots/-/tags/0.15.0#changes-for-packagers

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Note: Needs to target `staging` because https://github.com/NixOS/nixpkgs/pull/148588 isn't even in `staging-next` yet.

~~It might also be possible to avoid overriding Meson but reverting https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/31db23270426e47ca6487997ef3af25474593802 alone isn't sufficient (I might revisit this later but overriding Meson might be the better solution for now). Update: It looks like https://github.com/NixOS/nixpkgs/pull/144779 might make it in time :)~~ I missed https://github.com/NixOS/nixpkgs/pull/150486. There are quite a few PRs regarding Meson... :o

Anyway, this is only a preliminary draft as most packages don't support wlroots 0.15.0 yet. We're in no hurry as this depends on staging so we can wait for a few reverse-dependencies to release updates (and for the rest we might have to keep wlroots 0.14 around).

###### nixpkgs-review

<details>
<summary>output</summary>
<pre>
25 packages updated:
cage cagebreak dwl fnott grimshot hikari labwc nwg-panel python3.8-pywlroots python3.9-pywlroots qt-video-wlr qtile river sway sway-unwrapped tinywl (0.14.1 → 0.15.0) waybar waybox-unstable wayfire wayfire wcm wcm wf-shell wio wlroots (0.14.1 → 0.15.0)

$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /home/michael/.cache/nixpkgs-review/rev-2cda05aa1891ff30d9d1741da64f45e4bf54caa2/build.nix
error: builder for '/nix/store/ib4sikcymvhp2z5jqm4a1z48hlhzjhqj-cage-0.1.4.drv' failed with exit code 1;
       last 10 log lines:
       > [11/12] Compiling C object cage.p/seat.c.o
       > In file included from ../view.h:8,
       >                  from ../seat.h:12,
       >                  from ../server.h:16,
       >                  from ../output.h:8,
       >                  from ../seat.c:30:
       > /nix/store/viwpmq9yjklm864bf4flcf2bqwzn3g25-wlroots-0.15.0/include/wlr/types/wlr_box.h:4:2: warning: #warning "wlr_box has been moved to wlr/util/box.h" [-Wcpp]
       >     4 | #warning "wlr_box has been moved to wlr/util/box.h"
       >       |  ^~~~~~~
       > ninja: build stopped: subcommand failed.
       For full logs, run 'nix log /nix/store/ib4sikcymvhp2z5jqm4a1z48hlhzjhqj-cage-0.1.4.drv'.
error: builder for '/nix/store/r65n9ym6kc0snikh5sssji0v2sjg5mwb-dwl-0.2.1.drv' failed with exit code 2;
       last 10 log lines:
       > dwl.c: In function 'setup':
       > dwl.c:2006:8: error: implicit declaration of function 'wlr_backend_get_renderer'; did you mean 'wlr_backend_get_session'? [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wimplicit-function-declaration-Werror=implicit-function-declaration8;;]
       >  2006 |  drw = wlr_backend_get_renderer(backend);
       >       |        ^~~~~~~~~~~~~~~~~~~~~~~~
       >       |        wlr_backend_get_session
       > dwl.c:2006:6: error: assignment to 'struct wlr_renderer *' from 'int' makes pointer from integer without a cast [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wint-conversion-Werror=int-conversion8;;]
       >  2006 |  drw = wlr_backend_get_renderer(backend);
       >       |      ^
       > cc1: all warnings being treated as errors
       > make: *** [<builtin>: dwl.o] Error 1
       For full logs, run 'nix log /nix/store/r65n9ym6kc0snikh5sssji0v2sjg5mwb-dwl-0.2.1.drv'.
error: builder for '/nix/store/a51fcgsljmqyg0yv1vpqf7975igz4nhs-cagebreak-1.8.1.drv' failed with exit code 1;
       last 10 log lines:
       > Host machine cpu: x86_64
       > Found pkg-config: /nix/store/7qz8f0waphy9w9k72n10dsnp469cbnx0-pkg-config-wrapper-0.29.2/bin/pkg-config (0.29.2)
       > Dependency wlroots found: NO found 0.15.0 but need: '< 0.15.0' ; matched: '>=0.14.1'
       > Did not find CMake 'cmake'
       > Found CMake: NO
       > Run-time dependency wlroots found: NO
       >
       > meson.build:56:0: ERROR: Invalid version of dependency, need 'wlroots' ['< 0.15.0'] found '0.15.0'.
       >
       > A full log can be found at /build/source/build/meson-logs/meson-log.txt
       For full logs, run 'nix log /nix/store/a51fcgsljmqyg0yv1vpqf7975igz4nhs-cagebreak-1.8.1.drv'.
error: builder for '/nix/store/6vmziaxrj3bgpc6hhmk8v8apw37gw0wx-hikari-2.3.2.drv' failed with exit code 2;
       last 10 log lines:
       > --- layout_config.o ---
       > gcc -g  -DNDEBUG -D_POSIX_C_SOURCE=200809L -DHAVE_XWAYLAND=1 -DHAVE_GAMMACONTROL=1 -DHAVE_SCREENCOPY=1 -DHAVE_LAYERSHELL=1 -Wall -I. -Iinclude -DHIKARI_ETC_PREFIX=/nix/store/f9fkxbf8xvrn98xswldjahc34c67lf9k-hikari-2.3.2 -I/nix/store/viwpmq9yjklm864bf4flcf2bqwzn3g25-wlroots-0.15.0/include -DWLR_USE_UNSTABLE=1  -I/nix/store/zmxymm75klwac50jgl9a420rpgfg6my2-cairo-1.16.0-dev/include/cairo -I/nix/store/706b004d0pxn8d46a56lxm43rhsr2wmd-freetype-2.11.1-dev/include/freetype2 -I/nix/store/706b004d0pxn8d46a56lxm43rhsr2wmd-freetype-2.11.1-dev/include -I/nix/store/p8ykq0gnbwsa794d8mj4yakmk67bp19n-glib-2.70.2-dev/include -I/nix/store/p8ykq0gnbwsa794d8mj4yakmk67bp19n-glib-2.70.2-dev/include/glib-2.0 -I/nix/store/j8p94v2z2nyswfgrwx8apf8x8ybhs6h0-glib-2.70.2/lib/glib-2.0/include -I/nix/store/247v8a736k31lvk91ckhv6isjahxibqk-pango-1.50.0-dev/include/pango-1.0 -I/nix/store/ngisypcp2av7lq3nd1xnxncb8crs0j4h-harfbuzz-3.1.2-dev/include/harfbuzz  -I/nix/store/zmxymm75klwac50jgl9a420rpgfg6my2-cairo-1.16.0-dev/include/cairo -I/nix/store/706b004d0pxn8d46a56lxm43rhsr2wmd-freetype-2.11.1-dev/include/freetype2 -I/nix/store/706b004d0pxn8d46a56lxm43rhsr2wmd-freetype-2.11.1-dev/include  -I/nix/store/wczr3m65fw2vrdk326lvy6rvmj5jfijb-pixman-0.38.4/include/pixman-1  -I/nix/store/0clba7vlkxjf30andxcirvm8byswyp0g-libxkbcommon-1.3.1-dev/include  -I/nix/store/4jvpab4vm58bk5pgvf8v78vczwy2gw69-wayland-1.20.0-dev/include  -I/nix/store/pgz5qlaisq2nsv503n8v2q5iwska2wgm-libinput-1.19.1-dev/include  -I/nix/store/93pr07i9afpxi665n4i48y6ikbvq3yw1-libucl-0.8.1/include/  -c src/layout_config.c
       > In file included from include/hikari/split.h:4,
       >                  from src/layout_config.c:6:
       > /nix/store/viwpmq9yjklm864bf4flcf2bqwzn3g25-wlroots-0.15.0/include/wlr/types/wlr_box.h:4:2: warning: #warning "wlr_box has been moved to wlr/util/box.h" [-Wcpp]
       >     4 | #warning "wlr_box has been moved to wlr/util/box.h"
       >       |  ^~~~~~~
       > 1 error
       >
       > bmake: stopped in /build/source
       For full logs, run 'nix log /nix/store/6vmziaxrj3bgpc6hhmk8v8apw37gw0wx-hikari-2.3.2.drv'.
error: builder for '/nix/store/9iji64icrrkb3z9xzvpqv49lnlwy97vr-labwc-0.3.0.drv' failed with exit code 1;
       last 10 log lines:
       > Found pkg-config: /nix/store/7qz8f0waphy9w9k72n10dsnp469cbnx0-pkg-config-wrapper-0.29.2/bin/pkg-config (0.29.2)
       > Dependency wlroots found: NO found 0.15.0 but need: '<0.15.0' ; matched: '>=0.14.0'
       > Did not find CMake 'cmake'
       > Found CMake: NO
       > Run-time dependency wlroots found: NO (tried pkgconfig and cmake)
       > Looking for a fallback subproject for the dependency wlroots
       >
       > meson.build:52:2: ERROR: Subproject "subprojects/wlroots" required but not found.
       >
       > A full log can be found at /build/source/build/meson-logs/meson-log.txt
       For full logs, run 'nix log /nix/store/9iji64icrrkb3z9xzvpqv49lnlwy97vr-labwc-0.3.0.drv'.
error: builder for '/nix/store/r67hfgvijb2gmnb5vbp7mxdyzb60i09v-go-1.16.12.drv' failed with exit code 1;
       last 10 log lines:
       > ok          cmd/link/internal/benchmark     0.030s
       > ok      cmd/link/internal/ld    4.772s
       > ok      cmd/link/internal/loader        0.039s
       > ok      cmd/nm  3.105s
       > ok      cmd/objdump     4.912s
       > ok      cmd/pack        3.497s
       > ok      cmd/trace       0.264s
       > ok      cmd/vet 17.931s
       > FAIL
       > go tool dist: Failed: exit status 1
       For full logs, run 'nix log /nix/store/r67hfgvijb2gmnb5vbp7mxdyzb60i09v-go-1.16.12.drv'.
error: builder for '/nix/store/19jcpc96xbbm8nhv7kg7fikf6jvhzz96-python3.9-pywlroots-0.14.11.drv' failed with exit code 1;
       last 10 log lines:
       > 17350 |   { "wlr_output_state_buffer_type", 801, _cffi_prim_int(sizeof(enum wlr_output_state_buffer_type), ((enum wlr_output_state_buffer_type)-1) <= 0),
       >       |                                          ^~~~~~~~~~~~~~
       > build/temp.linux-x86_64-3.9/wlroots._ffi.c:17350:107: error: conversion to incomplete type
       > 17350 |   { "wlr_output_state_buffer_type", 801, _cffi_prim_int(sizeof(enum wlr_output_state_buffer_type), ((enum wlr_output_state_buffer_type)-1) <= 0),
       >       |                                                                                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
       > build/temp.linux-x86_64-3.9/wlroots._ffi.c:541:22: note: in definition of macro ‘_cffi_prim_int’
       >   541 |     ((size) == 1 ? ((sign) ? _CFFI_PRIM_INT8  : _CFFI_PRIM_UINT8)  :    \
       >       |                      ^~~~
       > build/temp.linux-x86_64-3.9/wlroots._ffi.c:17350: confused by earlier errors, bailing out
       > error: command '/nix/store/69z43737d703p0q8c5liv27qfsd126ld-gcc-wrapper-10.3.0/bin/gcc' failed with exit code 1
       For full logs, run 'nix log /nix/store/19jcpc96xbbm8nhv7kg7fikf6jvhzz96-python3.9-pywlroots-0.14.11.drv'.
error: builder for '/nix/store/18mlf7mn0d5nnb5k9fqbycjz75h7zwyq-python3.8-pywlroots-0.14.11.drv' failed with exit code 1;
       last 10 log lines:
       > 17350 |   { "wlr_output_state_buffer_type", 801, _cffi_prim_int(sizeof(enum wlr_output_state_buffer_type), ((enum wlr_output_state_buffer_type)-1) <= 0),
       >       |                                          ^~~~~~~~~~~~~~
       > build/temp.linux-x86_64-3.8/wlroots._ffi.c:17350:107: error: conversion to incomplete type
       > 17350 |   { "wlr_output_state_buffer_type", 801, _cffi_prim_int(sizeof(enum wlr_output_state_buffer_type), ((enum wlr_output_state_buffer_type)-1) <= 0),
       >       |                                                                                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
       > build/temp.linux-x86_64-3.8/wlroots._ffi.c:541:22: note: in definition of macro ‘_cffi_prim_int’
       >   541 |     ((size) == 1 ? ((sign) ? _CFFI_PRIM_INT8  : _CFFI_PRIM_UINT8)  :    \
       >       |                      ^~~~
       > build/temp.linux-x86_64-3.8/wlroots._ffi.c:17350: confused by earlier errors, bailing out
       > error: command 'gcc' failed with exit status 1
       For full logs, run 'nix log /nix/store/18mlf7mn0d5nnb5k9fqbycjz75h7zwyq-python3.8-pywlroots-0.14.11.drv'.
error: builder for '/nix/store/6028wc3zm358nk7xzn1p0rfi9qzg6xq0-sway-unwrapped-1.6.1.drv' failed with exit code 1;
       last 10 log lines:
       > Library m found: YES
       > Library rt found: YES
       > Neither a subproject directory nor a wlroots.wrap file was found.
       > Subproject  wlroots is buildable: NO (disabling)
       > Dependency wlroots found: NO found 0.15.0 but need: '<0.15.0' ; matched: '>=0.14.0'
       > Run-time dependency wlroots found: NO
       >
       > meson.build:74:1: ERROR: Invalid version of dependency, need 'wlroots' ['<0.15.0'] found '0.15.0'.
       >
       > A full log can be found at /build/source/build/meson-logs/meson-log.txt
       For full logs, run 'nix log /nix/store/6028wc3zm358nk7xzn1p0rfi9qzg6xq0-sway-unwrapped-1.6.1.drv'.
error: 1 dependencies of derivation '/nix/store/dl1552pw5716ll1bxbr9pfrfl5yjr0ak-sway.drv' failed to build
error: 2 dependencies of derivation '/nix/store/srwqqcsd5m4sd7898shnkn8zylx5s6zk-sway-1.6.1.drv' failed to build
error: builder for '/nix/store/i1nnb4jaikzg5dm9ahzjhh507whhxvfc-waybox-unstable-2021-04-07.drv' failed with exit code 1;
       last 10 log lines:
       > ../waybox/server.c: In function 'wb_create_backend':
       > ../waybox/server.c:18:21: error: implicit declaration of function 'wlr_backend_get_renderer'; did you mean 'wlr_backend_get_session'? [-Werror=implicit-function-declaration]
       >    18 |  server->renderer = wlr_backend_get_renderer(server->backend);
       >       |                     ^~~~~~~~~~~~~~~~~~~~~~~~
       >       |                     wlr_backend_get_session
       > ../waybox/server.c:18:19: error: assignment to 'struct wlr_renderer *' from 'int' makes pointer from integer without a cast [-Werror=int-conversion]
       >    18 |  server->renderer = wlr_backend_get_renderer(server->backend);
       >       |                   ^
       > cc1: all warnings being treated as errors
       > ninja: build stopped: subcommand failed.
       For full logs, run 'nix log /nix/store/i1nnb4jaikzg5dm9ahzjhh507whhxvfc-waybox-unstable-2021-04-07.drv'.
error: builder for '/nix/store/16m71ph8yq6bqfky43j183dbwfffbczj-wayfire-0.7.2.drv' failed with exit code 1;
       last 10 log lines:
       > |Run-time dependency xcb-dri3 found: YES 1.14
       > |Run-time dependency xcb-present found: YES 1.14
       > |Run-time dependency xcb-render found: YES 1.14
       > |Run-time dependency xcb-renderutil found: NO (tried pkgconfig and cmake)
       > |Message: Install "xcb-renderutil" or pass "-Dx11-backend=disabled" to disable it.
       > |Required for X11 backend support.
       >
       > subprojects/wlroots/backend/x11/meson.build:22:1: ERROR: Dependency "xcb-renderutil" not found, tried pkgconfig and cmake
       >
       > A full log can be found at /build/wayfire-0.7.2/build/meson-logs/meson-log.txt
       For full logs, run 'nix log /nix/store/16m71ph8yq6bqfky43j183dbwfffbczj-wayfire-0.7.2.drv'.
error: 1 dependencies of derivation '/nix/store/d8iclihg29pic4324fp2s0aym1m1zgcg-grimshot-1.6.1.drv' failed to build
error: 1 dependencies of derivation '/nix/store/4gm2098jfydydiws3smrc0is00mwijgg-python3.9-qtile-0.18.1.drv' failed to build
error: 2 dependencies of derivation '/nix/store/fhsrk4bl27d23pp9nk2qgvnwhqhhdlsq-qtile-0.18.1.drv' failed to build
error: 1 dependencies of derivation '/nix/store/p6s7hr30acl48l02s51cbx81fjqs773a-nwg-menu-0.1.1.drv' failed to build
error: 1 dependencies of derivation '/nix/store/c7bmmk1dlijm7657xzfrwxv281cb9x10-wio-0.pre+unstable=2021-06-27.drv' failed to build
error: 2 dependencies of derivation '/nix/store/7jgzwhbin5rcx4rwr1ib2hil6i926371-nwg-panel-0.5.0.drv' failed to build
error: 1 dependencies of derivation '/nix/store/xciqxlrar5n4hpvxa68awvsjhxi8879a-waybar-0.9.8.drv' failed to build
error: 1 dependencies of derivation '/nix/store/brjvxb0005196jkp5f93csjqvaw54ydd-wf-shell-0.7.0.drv' failed to build
error: 2 dependencies of derivation '/nix/store/sq25d6baxp2hdr83zbc7brrknqbbszcv-wayfire-0.7.2-wrapped.drv' failed to build
error: 2 dependencies of derivation '/nix/store/1c0ss4xsv5agvjnzvi3fa02ly5830zfx-wcm-0.7.0.drv' failed to build
error: 2 dependencies of derivation '/nix/store/rvvpsgwdc1ap3w7fs8y1rr0n63gjpp1q-wcm-0.7.0-wrapped.drv' failed to build
[2/335/354 built (11 failed), 322 copied (1265.8/1266.9 MiB), 691.5 MiB DL] building qtbase-5.15.3 (buildPhase): g++ -c -include .pch/Qt5Widgets -pipe -O2 -std=c++1z -fvisibility=hidden -fvisibility-inlines-hidd [2/335/354 built (11 failed), 322 copied (1265.8/1266.9 MiB), 691.5 MiB DL] building qtbase-5.15.3 (buildPhase): g++ -c -include .pch/Qt5OpenGL -pipe -O2 -std=c++1z -fvisibility=hidden -fvisibility-inlines-hidde error: builder for '/nix/store/c7rw7vxfp7yd73m3m0x775nl1j60714y-river-0.1.0.drv' failed with exit code 1;
       last 10 log lines:
       > building
       > no Makefile, doing nothing
       > installing
       > 7LLVM Emit Object... 878787Semantic Analysis... 87Semantic Analysis [83/203] 87Semantic Analysis [199/597] 87Semantic Analysis [428/929] 87Semantic Analysis [653/1208] 87Semantic Analysis [787/1457] 87Semantic Analysis [909/1703] 87Semantic Analysis [953/1745] 87Semantic Analysis [965/1775] 87Semantic Analysis [965/1810] 87Semantic Analysis [965/1830] 87Semantic Analysis [967/1852] 87Semantic Analysis [967/1855] 87Semantic Analysis [967/1862] 87Semantic Analysis [967/1862] 87Semantic Analysis [1042/2022] 87Semantic Analysis [1124/2308] 87Semantic Analysis [1230/2414] 87Semantic Analysis [1293/2545] 87Semantic Analysis [1419/2707] 87Semantic Analysis [1443/2780] 87Semantic Analysis [1476/2806] 87Semantic Analysis [1593/2959] 87Semantic Analysis [1723/3044] 87Semantic Analysis [1850/3152] 87Semantic Analysis [1984/3375] 87Semantic Analysis [2192/3515] 87Semantic Analysis [2221/3625] 87Semantic Analysis [2251/3741] 87Semantic Analysis [2387/3851] 87Semantic Analysis [2460/3965] 87Semantic Analysis [2523/4010] 87Semantic Analysis [2550/4032] 87Semantic Analysis [2625/4136] 87Semantic Analysis [2783/4223] 87Semantic Analysis [2869/4303] 87Semantic Analysis [3483/4375] 87Code Generation [112/2926] std.leb128.readULEB128... 87Code Generation [593/2926] std.build.Builder.validateUserInputDidItFail... 87Code Generation [1055/2926] std.io.writer.Writer(*std.io.fixed_buffer_stream.FixedBu... 87Code Generation [1433/2926] std.zig.binNameAlloc... 87Code Generation [1803/2926] std.buf_set.BufSet.init... 87Code Generation [2216/2926] std.fmt.format... 87Code Generation [2643/2926] std.fmt.formatIntValue... 87LLVM Emit Object... 87LLVM Emit Object... 8787LLVM Emit Object... 8787Semantic Analysis... 87Semantic Analysis [129/190] 87Semantic Analysis [129/968] 87Semantic Analysis [129/1329] 87Semantic Analysis [400/1901] 87Semantic Analysis [568/2456] 87Semantic Analysis [893/2852] 87Semantic Analysis [1059/3111] 87Semantic Analysis [1293/3310] 87Semantic Analysis [1532/3686] 87Semantic Analysis [1747/3833] 87Semantic Analysis [1929/3991] 87Semantic Analysis [1994/4136] 87Semantic Analysis [2124/4301] 87Semantic Analysis [2243/4399] 87Semantic Analysis [2357/4498] 87Semantic Analysis [2451/4597] 87Semantic Analysis [2581/4674] 87Semantic Analysis [2661/4748] 87Semantic Analysis [3962/4850] 878./deps/zig-wlroots/src/wlroots.zig:165:9: error: zig-wlroots requires wlroots version 0.14
       >         @compileError("zig-wlroots requires wlroots version 0.14");
       >         ^
       > river...The following command exited with error code 1:
       > /nix/store/frb7ahy5lzv6zncy3h9f60g05l6jpwwp-zig-0.8.1/bin/zig build-exe /build/source/river/main.zig -lc -levdev -linput -lwayland-server -lxkbcommon -lpixman-1 -lwlroots -cflags -std=c99 -O2 -- /build/source/river/wlroots_log_wrapper.c -cflags -std=c99 -- /build/source/zig-cache/zig-wayland/xdg-shell-protocol.c -cflags -std=c99 -- /build/source/zig-cache/zig-wayland/pointer-gestures-unstable-v1-protocol.c -cflags -std=c99 -- /build/source/zig-cache/zig-wayland/xdg-output-unstable-v1-protocol.c -cflags -std=c99 -- /build/source/zig-cache/zig-wayland/pointer-constraints-unstable-v1-protocol.c -cflags -std=c99 -- /build/source/zig-cache/zig-wayland/river-control-unstable-v1-protocol.c -cflags -std=c99 -- /build/source/zig-cache/zig-wayland/river-status-unstable-v1-protocol.c -cflags -std=c99 -- /build/source/zig-cache/zig-wayland/river-layout-v3-protocol.c -cflags -std=c99 -- /build/source/zig-cache/zig-wayland/wlr-layer-shell-unstable-v1-protocol.c -cflags -std=c99 -- /build/source/zig-cache/zig-wayland/wlr-output-power-management-unstable-v1-protocol.c --pkg-begin build_options /build/source/zig-cache/river_build_options.zig --pkg-end -OReleaseSafe --cache-dir /build/source/zig-cache --global-cache-dir /build/.cache/zig --name river --pkg-begin wayland /build/source/zig-cache/zig-wayland/wayland.zig --pkg-end --pkg-begin xkbcommon /build/source/deps/zig-xkbcommon/src/xkbcommon.zig --pkg-end --pkg-begin pixman /build/source/deps/zig-pixman/pixman.zig --pkg-end --pkg-begin wlroots /build/source/deps/zig-wlroots/src/wlroots.zig --pkg-begin wayland /build/source/zig-cache/zig-wayland/wayland.zig --pkg-end --pkg-begin xkbcommon /build/source/deps/zig-xkbcommon/src/xkbcommon.zig --pkg-end --pkg-begin pixman /build/source/deps/zig-pixman/pixman.zig --pkg-end --pkg-end --pkg-begin flags /build/source/common/flags.zig --pkg-end -I /nix/store/zdjdgnfpbd934z6a34mnsrd7v7603qy7-libevdev-1.11.0/include/libevdev-1.0 -I /nix/store/pgz5qlaisq2nsv503n8v2q5iwska2wgm-libinput-1.19.1-dev/include -I /nix/store/4jvpab4vm58bk5pgvf8v78vczwy2gw69-wayland-1.20.0-dev/include -I /nix/store/0clba7vlkxjf30andxcirvm8byswyp0g-libxkbcommon-1.3.1-dev/include -I /nix/store/wczr3m65fw2vrdk326lvy6rvmj5jfijb-pixman-0.38.4/include/pixman-1 -I /nix/store/viwpmq9yjklm864bf4flcf2bqwzn3g25-wlroots-0.15.0/include -L /nix/store/zdjdgnfpbd934z6a34mnsrd7v7603qy7-libevdev-1.11.0/lib -L /nix/store/8pgxy693dvi33b62xvi455zhjdm9v20w-libinput-1.19.1/lib -L /nix/store/df0dzhc32haz9qwc9pvzv8ga7sm5yhqy-wayland-1.20.0/lib -L /nix/store/viwwaij8rg308q9fgsnbffsvvpp4v6pi-libxkbcommon-1.3.1/lib -L /nix/store/wczr3m65fw2vrdk326lvy6rvmj5jfijb-pixman-0.38.4/lib -L /nix/store/viwpmq9yjklm864bf4flcf2bqwzn3g25-wlroots-0.15.0/lib --enable-cache
       > error: the following build command failed with exit code 1:
       > /build/source/zig-cache/o/adaced282b5169c0cbb795b10fc8562f/build /nix/store/frb7ahy5lzv6zncy3h9f60g05l6jpwwp-zig-0.8.1/bin/zig /build/source /build/source/zig-cache /build/.cache/zig -Drelease-safe -Dcpu=baseline -Dxwayland -Dman-pages --prefix /nix/store/jjvgyp855vil183h63xpl5nq323wdys2-river-0.1.0 install
       For full logs, run 'nix log /nix/store/c7rw7vxfp7yd73m3m0x775nl1j60714y-river-0.1.0.drv'.
error: 21 dependencies of derivation '/nix/store/p2n723lrc328nngs5364c1l1lvwqh87y-review-shell.drv' failed to build
21 packages failed to build:
cage cagebreak dwl hikari labwc nwg-panel python38Packages.pywlroots python39Packages.pywlroots qtile river sway sway-contrib.grimshot sway-unwrapped waybar waybox wayfire wayfireApplications-unwrapped.wayfire wayfireApplications-unwrapped.wayfirePlugins.wf-shell wayfireApplications-unwrapped.wcm wcm wio

4 packages built:
fnott qt-video-wlr tinywl wlroots
</pre>
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
