### PR TITLE
idris2: add package tests

### DIFF
--- a/pkgs/development/compilers/idris2/default.nix
+++ b/pkgs/development/compilers/idris2/default.nix
@@ -6,6 +6,7 @@
 , chez
 , gmp
 , zsh
+, callPackage
 }:
 
 # NOTICE: An `idris2WithPackages` is available at: https://github.com/claymager/idris2-pkgs
@@ -81,6 +82,9 @@ stdenv.mkDerivation rec {
       --suffix IDRIS2_PATH ':' "${additionalIdris2Paths}" \
       --suffix ${if stdenv.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH"} ':' "$out/${name}/lib"
   '';
+
+  # Run package tests
+  passthru.tests = callPackage ./tests.nix { inherit pname; };
 
   meta = {
     description = "A purely functional programming language with first class types";

--- a/pkgs/development/compilers/idris2/tests.nix
+++ b/pkgs/development/compilers/idris2/tests.nix
@@ -1,0 +1,67 @@
+{ stdenv, lib, pname, idris2, zsh }:
+
+let
+  testCompileAndRun = {testName, code, want, packages ? []}: let
+      packageString = builtins.concatStringsSep " " (map (p: "--package " + p) packages);
+    in stdenv.mkDerivation {
+      name = "${pname}-${testName}";
+      meta.timeout = 60;
+
+      # with idris2 compiled binaries assume zsh is available on darwin, but that
+      # is not the case with pure nix environments. Thus, we need to include zsh
+      # when we build for darwin in tests. While this is impure, this is also what
+      # we find in real darwin hosts.
+      nativeBuildInputs = lib.optional stdenv.isDarwin [ zsh ];
+
+      buildCommand = ''
+        set -eo pipefail
+
+        cat > packageTest.idr <<HERE
+        ${code}
+        HERE
+
+        ${idris2}/bin/idris2 ${packageString} -o packageTest packageTest.idr
+
+        GOT=$(./build/exec/packageTest)
+
+        if [ "$GOT" = "${want}" ]; then
+          echo "${testName} SUCCESS: '$GOT' = '${want}'"
+        else
+          >&2 echo "Got '$GOT', want: '${want}'"
+          exit 1
+        fi
+
+        touch $out
+      '';
+    };
+in {
+  # Simple hello world compiles, runs and outputs as expected
+  hello-world = testCompileAndRun {
+    testName = "hello-world";
+    code = ''
+      module Main
+
+      main : IO ()
+      main = putStrLn "Hello World!"
+    '';
+    want = "Hello World!";
+  };
+
+  # Data.Vect.Sort is available via --package contrib
+  use-contrib = testCompileAndRun {
+    testName = "use-contrib";
+    code = ''
+      module Main
+
+      import Data.Vect
+      import Data.Vect.Sort  -- from contrib
+
+      vect : Vect 3 Int
+      vect = 3 :: 1 :: 5 :: Nil
+
+      main : IO ()
+      main = putStrLn $ show (sort vect)
+    '';
+    want = "[1, 3, 5]";
+  };
+}


### PR DESCRIPTION
We had some bugs because simple compilation / execution cases
failed. This adds some very simple package tests that should
help us find these.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
