### PR TITLE
matplotlib-inline: Don't depend on matplotlib -> smaller ipython closure

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -149,6 +149,20 @@
           migration guide</link> for more details.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          For <literal>pkgs.python3.pkgs.ipython</literal>, its direct
+          dependency
+          <literal>pkgs.python3.pkgs.matplotlib-inline</literal> (which
+          is really an adapter to integrate matplotlib in ipython if it
+          is installed) does not depend on
+          <literal>pkgs.python3.pkgs.matplotlib</literal> anymore. This
+          is closer to a non-Nix install of ipython. This has the added
+          benefit to reduce the closure size of
+          <literal>ipython</literal> from ~400MB to ~160MB (including
+          ~100MB for python itself).
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-22.05-notable-changes">

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -53,6 +53,13 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The `autorestic` package has been upgraded from 1.3.0 to 1.5.0 which introduces breaking changes in config file, check [their migration guide](https://autorestic.vercel.app/migration/1.4_1.5) for more details.
 
+- For `pkgs.python3.pkgs.ipython`, its direct dependency `pkgs.python3.pkgs.matplotlib-inline`
+  (which is really an adapter to integrate matplotlib in ipython if it is installed) does
+  not depend on `pkgs.python3.pkgs.matplotlib` anymore.
+  This is closer to a non-Nix install of ipython.
+  This has the added benefit to reduce the closure size of `ipython` from ~400MB to ~160MB
+  (including ~100MB for python itself).
+
 ## Other Notable Changes {#sec-release-22.05-notable-changes}
 
 - The option [services.redis.servers](#opt-services.redis.servers) was added

--- a/pkgs/development/python-modules/matplotlib-inline/default.nix
+++ b/pkgs/development/python-modules/matplotlib-inline/default.nix
@@ -1,5 +1,4 @@
 { lib, buildPythonPackage, fetchPypi
-, matplotlib
 , traitlets
 
 # tests
@@ -16,7 +15,6 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
-    matplotlib # not documented, but required
     traitlets
   ];
 


### PR DESCRIPTION
###### Motivation for this change

The lib `matplotlib-inline` is only a shim to integrate `matplotlib` in
ipython, but it doesn't actually require it.

If one wants to use the matplotlib integration, `matplotlib` need to be
installed separatedly, then calling `%matplotlib inline` at a ipython
prompt will work.

Not including `matplotlib` is closer to a non-Nix installation:
Installing `ipython` in a fresh venv also does not install `matplotlib`.

:arrow_right: :arrow_right: ipython's closure size is now ~160MB instead of ~400MB
(including ~100MB for python itself)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).