### PR TITLE
Napari

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11037,6 +11037,13 @@
     githubId = 26806;
     name = "Scott Olson";
   };
+  SomeoneSerge = {
+    email = "sergei.kozlukov@aalto.fi";
+    matrix = "@ss:someonex.net";
+    github = "SomeoneSerge";
+    githubId = 9720532;
+    name = "Sergei K";
+  };
   sondr3 = {
     email = "nilsen.sondre@gmail.com";
     github = "sondr3";

--- a/pkgs/development/python-modules/cachey/default.nix
+++ b/pkgs/development/python-modules/cachey/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, typing-extensions
+, heapdict
+, pytestCheckHook
+, pythonOlder
+}: buildPythonPackage rec {
+  pname = "cachey";
+  version = "0.2.1";
+  format = "setuptools";
+  disabled = pythonOlder "3.6";
+  src = fetchFromGitHub {
+    owner = "dask";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-5USmuufrrWtmgibpfkjo9NtgN30hdl8plJfythmxM4s=";
+  };
+  propagatedBuildInputs = [ typing-extensions heapdict ];
+  checkInputs = [ pytestCheckHook ];
+  pythonImportsCheck = [
+    "cachey"
+  ];
+  meta = with lib; {
+    description = "Caching based on computation time and storage space";
+    homepage = "https://github.com/dask/cachey/";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ SomeoneSerge ];
+  };
+}

--- a/pkgs/development/python-modules/docstring-parser/default.nix
+++ b/pkgs/development/python-modules/docstring-parser/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , setuptools
-, setuptools_scm
+, setuptools-scm
 , wheel
 , pytest
 }: buildPythonPackage rec {
@@ -14,7 +14,7 @@
     rev = "${version}";
     sha256 = "sha256-hQuPJQrGvDs4dJrMLSR4sSnqy45xrF2ufinBG+azuCg=";
   };
-  nativeBuildInputs = [ setuptools_scm ];
+  nativeBuildInputs = [ setuptools-scm ];
   propagatedBuildInputs = [ pytest setuptools wheel ];
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
 

--- a/pkgs/development/python-modules/docstring-parser/default.nix
+++ b/pkgs/development/python-modules/docstring-parser/default.nix
@@ -1,0 +1,26 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, setuptools_scm
+, wheel
+, pytest
+}: buildPythonPackage rec {
+  pname = "docstring-parser";
+  version = "0.12";
+  src = fetchFromGitHub {
+    owner = "rr-";
+    repo = "docstring_parser";
+    rev = "${version}";
+    sha256 = "sha256-hQuPJQrGvDs4dJrMLSR4sSnqy45xrF2ufinBG+azuCg=";
+  };
+  nativeBuildInputs = [ setuptools_scm ];
+  propagatedBuildInputs = [ pytest setuptools wheel ];
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  meta = with lib; {
+    description = "Parse Python docstrings in various flavors. ";
+    homepage = "https://github.com/rr-/docstring_parser";
+    license = licenses.mit;
+    maintainers = with maintainers; [ SomeoneSerge ];
+  };
+}

--- a/pkgs/development/python-modules/docstring-parser/default.nix
+++ b/pkgs/development/python-modules/docstring-parser/default.nix
@@ -1,4 +1,5 @@
-{ buildPythonPackage
+{ lib
+, buildPythonPackage
 , fetchFromGitHub
 , setuptools
 , setuptools_scm

--- a/pkgs/development/python-modules/magicgui/default.nix
+++ b/pkgs/development/python-modules/magicgui/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, setuptools_scm
+, setuptools-scm
 , pytestCheckHook
 , pytest-mypy-plugins
 , typing-extensions
@@ -18,7 +18,7 @@
     rev = "v${version}";
     sha256 = "sha256-DvL1szk2RoCrpisjp0BVNL6qFZtYc2oYDenX59Cxbug=";
   };
-  nativeBuildInputs = [ setuptools_scm ];
+  nativeBuildInputs = [ setuptools-scm ];
   propagatedBuildInputs = [ typing-extensions qtpy pyside2 psygnal docstring-parser ];
   checkInputs = [ pytestCheckHook pytest-mypy-plugins ];
   doCheck = false; # Reports "Fatal Python error"

--- a/pkgs/development/python-modules/magicgui/default.nix
+++ b/pkgs/development/python-modules/magicgui/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools_scm
+, pytestCheckHook
+, pytest-mypy-plugins
+, typing-extensions
+, qtpy
+, pyside2
+, psygnal
+, docstring-parser
+}: buildPythonPackage rec {
+  pname = "magicgui";
+  version = "0.3.0";
+  src = fetchFromGitHub {
+    owner = "napari";
+    repo = "magicgui";
+    rev = "v${version}";
+    sha256 = "sha256-DvL1szk2RoCrpisjp0BVNL6qFZtYc2oYDenX59Cxbug=";
+  };
+  nativeBuildInputs = [ setuptools_scm ];
+  propagatedBuildInputs = [ typing-extensions qtpy pyside2 psygnal docstring-parser ];
+  checkInputs = [ pytestCheckHook pytest-mypy-plugins ];
+  doCheck = false; # Reports "Fatal Python error"
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  meta = with lib; {
+    description = "Build GUIs from python functions, using magic.  (napari/magicgui)";
+    homepage = "https://github.com/napari/magicgui";
+    license = licenses.mit;
+    maintainers = with maintainers; [ SomeoneSerge ];
+  };
+}

--- a/pkgs/development/python-modules/napari-console/default.nix
+++ b/pkgs/development/python-modules/napari-console/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools_scm
+, pytestCheckHook
+, pytest
+, ipython
+, ipykernel
+, qtconsole
+, napari-plugin-engine
+, imageio
+}: buildPythonPackage rec {
+  pname = "napari-console";
+  version = "0.0.4";
+  src = fetchFromGitHub {
+    owner = "napari";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-aVdYOzkZ+dqB680oDjNCg6quXU+QgUZI09E/MSTagyA=";
+  };
+  nativeBuildInputs = [ setuptools_scm ];
+  # setup.py somehow requires pytest
+  propagatedBuildInputs = [ pytest ipython ipykernel napari-plugin-engine imageio qtconsole ];
+  chechInputs = [ pytestCheckHook ];
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  meta = with lib; {
+    description = "A plugin that adds a console to napari";
+    homepage = "https://github.com/napari/napari-console";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ SomeoneSerge ];
+  };
+}

--- a/pkgs/development/python-modules/napari-console/default.nix
+++ b/pkgs/development/python-modules/napari-console/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, setuptools_scm
+, setuptools-scm
 , pytestCheckHook
 , pytest
 , ipython
@@ -18,7 +18,7 @@
     rev = "v${version}";
     sha256 = "sha256-aVdYOzkZ+dqB680oDjNCg6quXU+QgUZI09E/MSTagyA=";
   };
-  nativeBuildInputs = [ setuptools_scm ];
+  nativeBuildInputs = [ setuptools-scm ];
   # setup.py somehow requires pytest
   propagatedBuildInputs = [ pytest ipython ipykernel napari-plugin-engine imageio qtconsole ];
   chechInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/napari-plugin-engine/default.nix
+++ b/pkgs/development/python-modules/napari-plugin-engine/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools_scm
+, pytestCheckHook
+}: buildPythonPackage rec {
+  pname = "napari-plugin-engine";
+  version = "0.2.0";
+  src = fetchFromGitHub {
+    owner = "napari";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-cKpCAEYYRq3UPje7REjzhEe1J9mmrtXs8TBnxWukcNE=";
+  };
+  nativeBuildInputs = [ setuptools_scm ];
+  checkInputs = [ pytestCheckHook ];
+  doCheck = false;
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  meta = with lib; {
+    description = "A fork of pluggy for napari - plugin management package";
+    homepage = "https://github.com/napari/napari-plugin-engine";
+    license = licenses.mit;
+    maintainers = with maintainers; [ SomeoneSerge ];
+  };
+}

--- a/pkgs/development/python-modules/napari-plugin-engine/default.nix
+++ b/pkgs/development/python-modules/napari-plugin-engine/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, setuptools_scm
+, setuptools-scm
 , pytestCheckHook
 }: buildPythonPackage rec {
   pname = "napari-plugin-engine";
@@ -12,7 +12,7 @@
     rev = "v${version}";
     sha256 = "sha256-cKpCAEYYRq3UPje7REjzhEe1J9mmrtXs8TBnxWukcNE=";
   };
-  nativeBuildInputs = [ setuptools_scm ];
+  nativeBuildInputs = [ setuptools-scm ];
   checkInputs = [ pytestCheckHook ];
   doCheck = false;
   SETUPTOOLS_SCM_PRETEND_VERSION = version;

--- a/pkgs/development/python-modules/napari-svg/default.nix
+++ b/pkgs/development/python-modules/napari-svg/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools_scm
+, pytestCheckHook
+, vispy
+, napari-plugin-engine
+, imageio
+}: buildPythonPackage rec {
+  pname = "napari-svg";
+  version = "0.1.5";
+  src = fetchFromGitHub {
+    owner = "napari";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-20NLi6JTugP+hxqF2AnhSkuvhkGGbeG+tT3M2SZbtRc=";
+  };
+  nativeBuildInputs = [ setuptools_scm ];
+  propagatedBuildInputs = [ vispy napari-plugin-engine imageio ];
+  checkInputs = [ pytestCheckHook ];
+  doCheck = false; # Circular dependency: napari
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  meta = with lib; {
+    description = "A plugin for writing svg files from napari";
+    homepage = "https://github.com/napari/napari-svg";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ SomeoneSerge ];
+  };
+}

--- a/pkgs/development/python-modules/napari-svg/default.nix
+++ b/pkgs/development/python-modules/napari-svg/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, setuptools_scm
+, setuptools-scm
 , pytestCheckHook
 , vispy
 , napari-plugin-engine
@@ -15,7 +15,7 @@
     rev = "v${version}";
     sha256 = "sha256-20NLi6JTugP+hxqF2AnhSkuvhkGGbeG+tT3M2SZbtRc=";
   };
-  nativeBuildInputs = [ setuptools_scm ];
+  nativeBuildInputs = [ setuptools-scm ];
   propagatedBuildInputs = [ vispy napari-plugin-engine imageio ];
   checkInputs = [ pytestCheckHook ];
   doCheck = false; # Circular dependency: napari

--- a/pkgs/development/python-modules/napari/default.nix
+++ b/pkgs/development/python-modules/napari/default.nix
@@ -2,7 +2,7 @@
 , mkDerivationWith
 , buildPythonPackage
 , fetchFromGitHub
-, setuptools_scm
+, setuptools-scm
 , superqt
 , typing-extensions
 , tifffile
@@ -35,7 +35,7 @@
     rev = "v${version}";
     sha256 = "sha256-0QSI0mgDjF70/X58fE7uWwlBUCGY5gsvbCm4oJkp2Yk=";
   };
-  nativeBuildInputs = [ setuptools_scm wrapQtAppsHook ];
+  nativeBuildInputs = [ setuptools-scm wrapQtAppsHook ];
   propagatedBuildInputs = [
     napari-plugin-engine
     cachey

--- a/pkgs/development/python-modules/napari/default.nix
+++ b/pkgs/development/python-modules/napari/default.nix
@@ -1,0 +1,75 @@
+{ lib
+, mkDerivationWith
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools_scm
+, superqt
+, typing-extensions
+, tifffile
+, napari-plugin-engine
+, pint
+, pyyaml
+, numpydoc
+, dask
+, magicgui
+, docstring-parser
+, appdirs
+, imageio
+, pyopengl
+, cachey
+, napari-svg
+, psutil
+, napari-console
+, wrapt
+, pydantic
+, tqdm
+, jsonschema
+, scipy
+, wrapQtAppsHook
+}: mkDerivationWith buildPythonPackage rec {
+  pname = "napari";
+  version = "0.4.12";
+  src = fetchFromGitHub {
+    owner = "napari";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-0QSI0mgDjF70/X58fE7uWwlBUCGY5gsvbCm4oJkp2Yk=";
+  };
+  nativeBuildInputs = [ setuptools_scm wrapQtAppsHook ];
+  propagatedBuildInputs = [
+    napari-plugin-engine
+    cachey
+    napari-svg
+    napari-console
+    superqt
+    magicgui
+    typing-extensions
+    tifffile
+    pint
+    pyyaml
+    numpydoc
+    dask
+    docstring-parser
+    appdirs
+    imageio
+    pyopengl
+    psutil
+    wrapt
+    pydantic
+    tqdm
+    jsonschema
+    scipy
+  ];
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+  dontUseSetuptoolsCheck = true;
+  postFixup = ''
+    wrapQtApp $out/bin/napari
+  '';
+
+  meta = with lib; {
+    description = "A fast, interactive, multi-dimensional image viewer for python";
+    homepage = "https://github.com/napari/napari";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ SomeoneSerge ];
+  };
+}

--- a/pkgs/development/python-modules/psygnal/default.nix
+++ b/pkgs/development/python-modules/psygnal/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , wheel
 , setuptools
-, setuptools_scm
+, setuptools-scm
 , pytestCheckHook
 , pytest-mypy-plugins
 , pytest-cov
@@ -20,7 +20,7 @@
     rev = "v${version}";
     sha256 = "sha256-SiG2ywNEw3aNrRXyEMFTnvHKtKowO8yqoCaNI8PT4/Y=";
   };
-  buildInputs = [ setuptools_scm ];
+  buildInputs = [ setuptools-scm ];
   propagatedBuildInputs = [ typing-extensions ];
   checkInputs = [ pytestCheckHook pytest-cov pytest-mypy-plugins ];
   doCheck = false;  # mypy checks are failing

--- a/pkgs/development/python-modules/psygnal/default.nix
+++ b/pkgs/development/python-modules/psygnal/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, wheel
+, setuptools
+, setuptools_scm
+, pytestCheckHook
+, pytest-mypy-plugins
+, pytest-cov
+, pytest
+, mypy
+, typing-extensions
+}: buildPythonPackage rec
+{
+  pname = "psygnal";
+  version = "0.2.0";
+  src = fetchFromGitHub {
+    owner = "tlambert03";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-SiG2ywNEw3aNrRXyEMFTnvHKtKowO8yqoCaNI8PT4/Y=";
+  };
+  buildInputs = [ setuptools_scm ];
+  propagatedBuildInputs = [ typing-extensions ];
+  checkInputs = [ pytestCheckHook pytest-cov pytest-mypy-plugins ];
+  doCheck = false;  # mypy checks are failing
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  meta = with lib; {
+    description = "Pure python implementation of Qt Signals";
+    homepage = "https://github.com/tlambert03/psygnal";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ SomeoneSerge ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-mypy-plugins/default.nix
+++ b/pkgs/development/python-modules/pytest-mypy-plugins/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, chevron
+, pyyaml
+, mypy
+, pytest
+, decorator
+, regex
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-mypy-plugins";
+  version = "1.9.2";
+  src = fetchFromGitHub {
+    owner = "typeddjango";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-Me5P4Q2M+gGEWlUVgQ0L048rVUOlUzVMgZZcqZPeE4Q=";
+  };
+  propagatedBuildInputs = [ chevron pyyaml mypy pytest decorator regex ];
+
+  meta = with lib; {
+    description = "pytest plugin for testing mypy types, stubs, and plugins";
+    homepage = "https://github.com/TypedDjango/pytest-mypy-plugins";
+    license = licenses.mit;
+    maintainers = with maintainers; [ SomeoneSerge ];
+  };
+}

--- a/pkgs/development/python-modules/superqt/default.nix
+++ b/pkgs/development/python-modules/superqt/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools_scm
+, pyqt5
+, typing-extensions
+, pytest
+, pytestCheckHook
+}: buildPythonPackage rec {
+  pname = "superqt";
+  version = "0.2.5-1";
+  src = fetchFromGitHub {
+    owner = "napari";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-rkTiCJ8mIogS9SDmLPiaAyhhuBx3kk6rXjCc19zbwiM=";
+  };
+  format = "pyproject";
+  nativeBuildInputs = [ setuptools_scm ];
+  propagatedBuildInputs = [ pyqt5 typing-extensions ];
+  checkInputs = [ pytestCheckHook pytest ];
+  doCheck = false; # Segfaults...
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  meta = with lib; {
+    description = "Missing widgets and components for Qt-python (napari/superqt)";
+    homepage = "https://github.com/napari/superqt";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ SomeoneSerge ];
+  };
+}

--- a/pkgs/development/python-modules/superqt/default.nix
+++ b/pkgs/development/python-modules/superqt/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, setuptools_scm
+, setuptools-scm
 , pyqt5
 , typing-extensions
 , pytest
@@ -16,7 +16,7 @@
     sha256 = "sha256-rkTiCJ8mIogS9SDmLPiaAyhhuBx3kk6rXjCc19zbwiM=";
   };
   format = "pyproject";
-  nativeBuildInputs = [ setuptools_scm ];
+  nativeBuildInputs = [ setuptools-scm ];
   propagatedBuildInputs = [ pyqt5 typing-extensions ];
   checkInputs = [ pytestCheckHook pytest ];
   doCheck = false; # Segfaults...

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30110,6 +30110,8 @@ with pkgs;
 
   masari = callPackage ../applications/blockchains/masari { boost = boost165; };
 
+  napari = with python3Packages; toPythonApplication napari;
+
   nano-wallet = libsForQt5.callPackage ../applications/blockchains/nano-wallet {
     boost = boost172;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4733,6 +4733,8 @@ in {
 
   magic = callPackage ../development/python-modules/magic { };
 
+  magicgui = callPackage ../development/python-modules/magicgui { };
+
   magic-wormhole = callPackage ../development/python-modules/magic-wormhole { };
 
   magic-wormhole-mailbox-server = callPackage ../development/python-modules/magic-wormhole-mailbox-server { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5208,6 +5208,16 @@ in {
 
   nanotime = callPackage ../development/python-modules/nanotime { };
 
+  napari = callPackage ../development/python-modules/napari {
+    inherit (pkgs.libsForQt5) mkDerivationWith wrapQtAppsHook;
+  };
+
+  napari-console = callPackage ../development/python-modules/napari-console { };
+
+  napari-plugin-engine = callPackage ../development/python-modules/napari-plugin-engine { };
+
+  napari-svg = callPackage ../development/python-modules/napari-svg { };
+
   nassl = callPackage ../development/python-modules/nassl { };
 
   nats-python = callPackage ../development/python-modules/nats-python { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6285,6 +6285,8 @@ in {
 
   psycopg2cffi = callPackage ../development/python-modules/psycopg2cffi { };
 
+  psygnal = callPackage ../development/python-modules/psygnal { };
+
   ptable = callPackage ../development/python-modules/ptable { };
 
   ptest = callPackage ../development/python-modules/ptest { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2351,6 +2351,8 @@ in {
 
   docstring-to-markdown = callPackage ../development/python-modules/docstring-to-markdown { };
 
+  docstring-parser = callPackage ../development/python-modules/docstring-parser { };
+
   docopt = callPackage ../development/python-modules/docopt { };
 
   docopt-ng = callPackage ../development/python-modules/docopt-ng { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1396,6 +1396,8 @@ in {
 
   cachetools = callPackage ../development/python-modules/cachetools { };
 
+  cachey = callPackage ../development/python-modules/cachey { };
+
   cachy = callPackage ../development/python-modules/cachy { };
 
   cadquery = callPackage ../development/python-modules/cadquery {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7633,6 +7633,8 @@ in {
 
   pytest-mypy = callPackage ../development/python-modules/pytest-mypy { };
 
+  pytest-mypy-plugins = callPackage ../development/python-modules/pytest-mypy-plugins { };
+
   pytest-openfiles = callPackage ../development/python-modules/pytest-openfiles { };
 
   pytest-order = callPackage ../development/python-modules/pytest-order { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9369,6 +9369,8 @@ in {
 
   supervisor = callPackage ../development/python-modules/supervisor { };
 
+  superqt = callPackage ../development/python-modules/superqt { };
+
   sure = callPackage ../development/python-modules/sure { };
 
   surepy = callPackage ../development/python-modules/surepy { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds [napari](https://napari.org/), a scientific image viewer.
Please note, it's my first PR to nixpkgs, I may not be aware of some rules or conventions

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Dependencies also packaged in separate commits but in the same PR - should they be merged separately?
  - One of the dependencies - [cachey](https://github.com/dask/cachey/) - is part of dask suite; should I add @FRidh to maintainers, as in other dask packages?
  - qt-related packages (like superqt, magicgui) segfault during tests, although the final app works
- I also don't know if some special steps need to be taken in regards to nixpkgs-update integration, cc @ryantm
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
