### PR TITLE
wavegain: pull upstream fix for -fno-common toolchains

### DIFF
--- a/pkgs/applications/audio/wavegain/default.nix
+++ b/pkgs/applications/audio/wavegain/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch }:
 
 stdenv.mkDerivation {
   pname = "wavegain";
@@ -10,6 +10,17 @@ stdenv.mkDerivation {
     rev = "c928eaf97aeec5732625491b64c882e08e314fee";
     sha256 = "0wghqnsbypmr4xcrhb568bfjdnxzzp8qgnws3jslzmzf34dpk5ls";
   };
+
+  patches = [
+    # Upstream fix for -fno-common toolchains.
+    (fetchpatch {
+      name = "fno-common.patch";
+      url = "https://github.com/MestreLion/wavegain/commit/ee5e0f9a0ce34c0cf2769ea6566685a54b938304.patch";
+      sha256 = "11yi0czdn5h5bsqp23cww6yn9lm60cij8i1pzfwcfhgyf6f8ym1n";
+    })
+  ];
+
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   installPhase = ''
     strip -s wavegain


### PR DESCRIPTION
Without the change the build fails on clang and upstream gcc as:

    $ nix build --impure --expr 'with import ./.{}; wavegain.override { stdenv = clang12Stdenv; }' -L
    ...
    ld: /build/main-51a0e2.o:(.bss+0x310): multiple definition of `file_formats';
      /build/audio-d7ad83.o:(.bss+0x8): first defined here
    ld: /build/wavegain-ea60c8.o:(.bss+0x140): multiple definition of `file_formats';
      /build/audio-d7ad83.o:(.bss+0x8): first defined here
