### PR TITLE
pdfstudio: init at 2021.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13430,6 +13430,6 @@
     name = "Philipp Woelfel";
     email = "philipp.woelfel@gmail.com";
     github = "PhilippWoelfel";
-    githubID = 19400064;
+    githubId = 19400064;
   };
 }

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13426,4 +13426,10 @@
     github = "jpagex";
     githubId = 635768;
   };
+  pwoelfel = {
+    name = "Philipp Woelfel";
+    email = "philipp.woelfel@gmail.com";
+    github = "PhilippWoelfel";
+    githubID = 19400064;
+  };
 }

--- a/pkgs/applications/misc/pdfstudio/default.nix
+++ b/pkgs/applications/misc/pdfstudio/default.nix
@@ -1,0 +1,93 @@
+{ stdenv,
+  lib,
+  makeWrapper,
+  fetchurl,
+  dpkg,
+  makeDesktopItem,
+  copyDesktopItems,
+  autoPatchelfHook,
+  gst_all_1,
+  sane-backends,
+  xorg,
+  gnome2,
+  alsa-lib,
+  libgccjit,
+  }:
+
+let
+  year = "2021";
+  rel = "1";
+  subrel = "1";
+in
+stdenv.mkDerivation rec {
+  pname = "pdfstudio";
+  version = "${year}.${rel}.${subrel}";
+  autoPatchelfIgnoreMissingDeps=true;
+
+  src = fetchurl {
+    url = "https://download.qoppa.com/${pname}/v${year}/PDFStudio_v${year}_${rel}_${subrel}_linux64.deb";
+    sha256 = "089jfpbsxwjhx245g8svlmg213kny3z5nl6ra1flishnrsfjjcxb";
+  };
+
+  nativeBuildInputs = [
+    gst_all_1.gst-libav
+    sane-backends
+    xorg.libXxf86vm
+    xorg.libXtst
+    gnome2.libgtkhtml
+    alsa-lib
+    libgccjit
+    autoPatchelfHook
+    makeWrapper
+    dpkg
+    copyDesktopItems
+  ];
+
+  desktopItems = lib.singleton (makeDesktopItem {
+       name = "${pname}${year}";
+       desktopName = "PDF Studio";
+       genericName = "View and edit PDF files";
+       exec = "${pname} %f";
+       icon = "${pname}${year}";
+       comment = "Views and edits PDF files";
+       mimeType = "application/pdf";
+       categories = "Office";
+       type = "Application";
+       terminal = false;
+  });
+
+  unpackPhase = "dpkg-deb -x $src .";
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mkdir -p $out/share
+    mkdir -p $out/share/applications
+    mkdir -p $out/share/pixmaps
+    cp -r opt/${pname}${year} $out/share/
+    ln -s $out/share/${pname}${year}/.install4j/${pname}${year}.png  $out/share/pixmaps/
+    makeWrapper $out/share/${pname}${year}/${pname}${year} $out/bin/${pname}
+
+    runHook postInstall
+  '';
+
+  # We need to run pdfstudio once. This will unpack some jre.pack files in jre/lib.
+  # We must do this after autoPatchelfHook, so we'll do this in preInstallCheck.
+  # An alternative would beo to patchelf manually, using this (e.g., in the fixup phase):
+  # find $out/share/${pname}${year}/jre/bin -type f -executable -exec patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) {} \;
+  doInstallCheck = true;
+  preInstallCheck = ''
+    $out/share/${pname}${year}/${pname}${year}
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.qoppa.com/pdfstudio/";
+    description = "An easy to use, full-featured PDF editing software";
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.pwoelfel ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24084,6 +24084,8 @@ with pkgs;
 
   foxitreader = libsForQt512.callPackage ../applications/misc/foxitreader { };
 
+  pdfstudio = callPackage ../applications/misc/pdfstudio { };
+
   aeolus = callPackage ../applications/audio/aeolus { };
 
   aewan = callPackage ../applications/editors/aewan { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adds package for the commercial software PDF Studio, which is a feature rich PDF editor and viewer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
