### PR TITLE
gnome-themes-extra: Make gtk2 dependency optional

### DIFF
--- a/pkgs/desktops/gnome/core/gnome-themes-extra/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-themes-extra/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchurl, intltool, gtk3, gnome, librsvg, pkg-config, pango, atk, gtk2
-, gdk-pixbuf, hicolor-icon-theme }:
+, gdk-pixbuf, hicolor-icon-theme
+, withGtk2 ? true }:
 
 let
   pname = "gnome-themes-extra";
@@ -19,10 +20,13 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config intltool ];
-  buildInputs = [ gtk3 librsvg pango atk gtk2 gdk-pixbuf ];
+  buildInputs = [ gtk3 librsvg pango atk gdk-pixbuf ]
+    ++ lib.optional withGtk2 gtk2;
   propagatedBuildInputs = [ gnome.adwaita-icon-theme hicolor-icon-theme ];
 
   dontDropIconThemeCache = true;
+
+  configureFlags = lib.optional (!withGtk2) "--disable-gtk2-engine";
 
   postInstall = ''
     gtk-update-icon-cache "$out"/share/icons/HighContrast


### PR DESCRIPTION
###### Motivation for this change

gtk2 is unmaintained, trying to remove it as much as possible

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
