### PR TITLE
jami-*: 20211104.2.e80361d -> 20211213.2.37be4c3

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jami/config/ffmpeg_args_common
+++ b/pkgs/applications/networking/instant-messengers/jami/config/ffmpeg_args_common
@@ -22,6 +22,7 @@
 --enable-muxer=h263
 --enable-muxer=h264
 --enable-muxer=hevc
+--enable-muxer=matroska
 --enable-muxer=webm
 --enable-muxer=ogg
 --enable-muxer=pcm_s16be

--- a/pkgs/applications/networking/instant-messengers/jami/config/ffmpeg_patches
+++ b/pkgs/applications/networking/instant-messengers/jami/config/ffmpeg_patches
@@ -3,3 +3,4 @@ change-RTCP-ratio.patch
 rtp_ext_abs_send_time.patch
 libopusdec-enable-FEC.patch
 libopusenc-enable-FEC.patch
+screen-sharing-x11-fix.patch

--- a/pkgs/applications/networking/instant-messengers/jami/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jami/default.nix
@@ -8,11 +8,11 @@
 }:
 
 rec {
-  version = "20211104.2.e80361d";
+  version = "20211213.2.37be4c3";
 
   src = fetchzip {
     url = "https://dl.jami.net/release/tarballs/jami_${version}.tar.gz";
-    sha256 = "1l48svppshh8mg7y1dymnh0rgwswy4qwdyl7qlg25mmh4y1li21f";
+    sha256 = "08abswvxwsxh6b0smb4l4cmymsbfiy7473b2sgvghj55w603prsc";
 
     stripRoot = false;
     extraPostFetch = ''

--- a/pkgs/applications/networking/instant-messengers/jami/pjproject-src.nix
+++ b/pkgs/applications/networking/instant-messengers/jami/pjproject-src.nix
@@ -2,5 +2,5 @@
   owner = "savoirfairelinux";
   repo = "pjproject";
   rev = "e1f389d0b905011e0cb62cbdf7a8b37fc1bcde1a";
-  sha256 = "sha256-6t+3b7pvvwi+VD05vxtujabEJmWmJTAeyD/Dapav10Y=";
+  sha256 = "0inpmyb6mhrzr0g309d6clkc99lddqdvyf9xajz0igvgp9pvgpza";
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
