### PR TITLE
grafana: 8.3.2 -> 8.3.3

### DIFF
--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -2,7 +2,7 @@
 
 buildGo117Module rec {
   pname = "grafana";
-  version = "8.3.2";
+  version = "8.3.3";
 
   excludedPackages = "\\(alert_webhook_listener\\|clean-swagger\\|release_publisher\\|slow_proxy\\|slow_proxy_mac\\|macaron\\)";
 
@@ -10,15 +10,15 @@ buildGo117Module rec {
     rev = "v${version}";
     owner = "grafana";
     repo = "grafana";
-    sha256 = "sha256-oPCeK9SHRpShAjLK3l8yMIwcrGvoUNjaeNNWZBjCIas=";
+    sha256 = "sha256-kfeYAEwHal5bfCmNe2l5iBLM4D3eYFaVtVhXdN90o+I=";
   };
 
   srcStatic = fetchurl {
     url = "https://dl.grafana.com/oss/release/grafana-${version}.linux-amd64.tar.gz";
-    sha256 = "sha256-EA+SxQqmEvITBSxVWU5Ytot9pkG3UcXxRAA9cEcw0Yk=";
+    sha256 = "sha256-iUKMUg4AS8ufr3YY3UyB/2JJYGTL8urT4bnbz0dsbxg=";
   };
 
-  vendorSha256 = "sha256-aS9yz0JODZtichaIkiBJLiMjbjGY93eSYwuactbRqOY=";
+  vendorSha256 = "sha256-FHVlCL4ZyHO7Ebi31K1wXcMiN6hiQjVz+5jkJx8R7jc=";
 
   nativeBuildInputs = [ wire ];
 
@@ -62,6 +62,8 @@ buildGo117Module rec {
     tar -xvf $srcStatic
     mkdir -p $out/share/grafana
     mv grafana-*/{public,conf,tools} $out/share/grafana/
+
+    cp ./conf/defaults.ini $out/share/grafana/conf/
   '';
 
   passthru.tests = { inherit (nixosTests) grafana; };


### PR DESCRIPTION
###### Motivation for this change
ChangeLog: https://github.com/grafana/grafana/releases/tag/v8.3.3

Note: I had to copy `defaults.ini` from the Git repo rather than from
`srcStatic`. This is because the `srcStatic`-variant missed some config
changes[1] which caused the test to fail like this:

    postgresql # [   24.754735] grafana-start[900]: Failed to start grafana. error: section "tracing.opentelemetry.jaeger" does not exist
    postgresql # [   24.756013] grafana-start[900]: section "tracing.opentelemetry.jaeger" does not exist
    postgresql # [   24.762057] systemd[1]: grafana.service: Main process exited, code=exited, status=1/FAILURE
    postgresql # [   24.765443] systemd[1]: grafana.service: Failed with result 'exit-code'.
    postgresql # [   24.767419] systemd[1]: grafana.service: Consumed 1.598s CPU time, no IP traffic.

[1] https://github.com/grafana/grafana/commit/d993b1241582b2ba93f323946a9e52e3a1e3ca9a#diff-0c326c4f02797b088fc566e64fbfe2162390f52f2fec1483ec3a413a7f11c910


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
