### PR TITLE
duckstation: unstable-2021-10-29 -> 0.pre+date=2021-12-16

### DIFF
--- a/pkgs/misc/emulators/duckstation/default.nix
+++ b/pkgs/misc/emulators/duckstation/default.nix
@@ -1,51 +1,59 @@
 { lib
 , mkDerivation
 , fetchFromGitHub
-, cmake
-, extra-cmake-modules
-, pkg-config
 , SDL2
-, qtbase
-, wrapQtAppsHook
-, qttools
-, ninja
+, cmake
+, curl
+, extra-cmake-modules
 , gtk3
 , libevdev
-, curl
 , libpulseaudio
-, sndio
 , mesa
+, ninja
+, pkg-config
+, qtbase
+, qttools
+, sndio
 , vulkan-loader
 , wayland
+, wrapQtAppsHook
 }:
+
 mkDerivation rec {
   pname = "duckstation";
-  version = "unstable-2021-10-29";
+  version = "0.pre+date=2021-12-16";
 
   src = fetchFromGitHub {
     owner = "stenzek";
     repo = pname;
-    rev = "287b1e1abc98ef3f01d8530e0b428b58d8e77e96";
-    sha256 = "sha256-1s7oBdOOkK6a3DKCZ70dAilFzlzrURwhx+MRTmOPWJE=";
+    rev = "59cb7c03432f5f8d9f6283c71a34825d05e118c6";
+    sha256 = "sha256-vF3YEpicbwCtR6QW2huNk0+pJ7BBjn/x9/Ae1c00gN4=";
   };
 
-  nativeBuildInputs = [ cmake ninja pkg-config extra-cmake-modules wrapQtAppsHook qttools ];
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    ninja
+    pkg-config
+    qttools
+    wrapQtAppsHook
+  ];
 
   buildInputs = [
     SDL2
-    qtbase
+    curl
     gtk3
     libevdev
-    sndio
-    mesa
-    curl
     libpulseaudio
-    wayland
+    mesa
+    qtbase
+    sndio
     vulkan-loader
+    wayland
   ];
 
   cmakeFlags = [
-    "-DUSE_DRMKMS=ON" # Broken in combination with Wayland, https://github.com/stenzek/duckstation/issues/2630
+    "-DUSE_DRMKMS=ON"
     "-DUSE_WAYLAND=ON"
   ];
 
@@ -62,6 +70,7 @@ mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
+
     mkdir -p $out/bin $out/share $out/share/pixmaps $out/share/applications
     rm bin/common-tests
 
@@ -70,6 +79,7 @@ mkDerivation rec {
 
     cp ../extras/icons/icon-256px.png $out/share/pixmaps/duckstation.png
     cp ../extras/linux-desktop-files/* $out/share/applications/
+
     runHook postInstall
   '';
 
@@ -84,14 +94,13 @@ mkDerivation rec {
     "--prefix LD_LIBRARY_PATH : ${vulkan-loader}/lib"
   ];
 
-  # TODO:
-  # - default sound backend (cubeb) does not work, but SDL does. Strangely, switching to cubeb while a game is running makes it work.
-
   meta = with lib; {
-    description = "PlayStation 1 emulator focusing on playability, speed and long-term maintainability";
     homepage = "https://github.com/stenzek/duckstation";
+    description = "Fast PlayStation 1 emulator for x86-64/AArch32/AArch64";
     license = licenses.gpl3Only;
+    maintainers = with maintainers; [ guibou AndersonTorres ];
     platforms = platforms.linux;
-    maintainers = [ maintainers.guibou ];
   };
 }
+# TODO: default sound backend (cubeb) does not work, but SDL does. Strangely,
+# switching to cubeb while a game is running makes it work.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
