### PR TITLE
godspeed: init at unstable-2021-08-27

### DIFF
--- a/pkgs/tools/networking/godspeed/default.nix
+++ b/pkgs/tools/networking/godspeed/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, libpcap
+}:
+
+buildGoModule rec {
+  pname = "godspeed";
+  version = "unstable-2021-08-27";
+
+  src = fetchFromGitHub {
+    owner = "redcode-labs";
+    repo = "GodSpeed";
+    rev = "c02b184ab0fd304d1bd8cbe1566a3d3de727975e";
+    sha256 = "sha256-y/mCfNWe5ShdxEz8IUQ8zUzgVkUy/+5lX6rcJ3r6KoI=";
+  };
+
+  vendorSha256 = "sha256-MCr1ShhkxM9CeSmqqtgAW0qv0QaIPRSOzASj8gt2ZAg=";
+
+  buildInputs = [
+    libpcap
+  ];
+
+  postFixup = ''
+    mv $out/bin/GodSpeed $out/bin/${pname}
+  '';
+
+  meta = with lib; {
+    description = "Manager for reverse shells";
+    homepage = "https://github.com/redcode-labs/GodSpeed";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/tools/networking/godspeed/default.nix
+++ b/pkgs/tools/networking/godspeed/default.nix
@@ -29,6 +29,6 @@ buildGoModule rec {
     description = "Manager for reverse shells";
     homepage = "https://github.com/redcode-labs/GodSpeed";
     license = with licenses; [ mit ];
-    maintainers = with maintainers; [ fab ];
+    maintainers = with maintainers; [ fab ] ++ teams.redcodelabs.members;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -999,6 +999,8 @@ with pkgs;
 
   godns = callPackage ../tools/networking/godns { };
 
+  godspeed = callPackage ../tools/networking/godspeed { };
+
   ksnip = libsForQt5.callPackage ../tools/misc/ksnip { };
 
   linux-router = callPackage ../tools/networking/linux-router { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Manager for reverse shells

https://github.com/redcode-labs/GodSpeed

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

CC: @unrooted. @wr0belj, @wintrmvte