### PR TITLE
opencbm: init at 0.4.99.103

### DIFF
--- a/pkgs/tools/misc/opencbm/default.nix
+++ b/pkgs/tools/misc/opencbm/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cc65
+, ncurses
+, pkg-config
+, libusb1
+}:
+
+stdenv.mkDerivation rec {
+  pname = "opencbm";
+  version = "0.4.99.103";
+
+  src = fetchFromGitHub {
+    owner = "OpenCBM";
+    repo = "OpenCBM";
+    rev = "v${version}";
+    sha256 = "06844yfgcbbwrp3iz5k8zd1zjawzbpvl131lgmkwz6d542c2k4k9";
+  };
+
+  makefile = "LINUX/Makefile";
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "ETCDIR=${placeholder "out"}/etc"
+    "UDEVRULESDIR=${placeholder "out"}/etc/udev/rules.d/"
+    "LDCONFIG=true"
+  ];
+  installTargets = "install-all";
+
+  nativeBuildInputs = [
+    cc65
+    pkg-config
+  ];
+  buildInputs = [
+    libusb1
+    ncurses
+  ];
+
+  meta = with lib; {
+    description = "Kernel driver and development library to control serial CBM devices";
+    longDescription = ''
+      Win 7/8/10, and Linux/i386/AMD64 kernel driver and development library to
+      control serial CBM devices, such as the Commodore 1541 disk drive,
+      connected to the PC's parallel port via a XM1541 or XA1541 cable. Fast
+      disk copier included. Successor of cbm4linux. Also supports the XU1541
+      and the XUM1541 devices (a.k.a. "ZoomFloppy").
+    '';
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.sander ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1885,6 +1885,8 @@ with pkgs;
 
   pacparser = callPackage ../tools/networking/pacparser { };
 
+  opencbm = callPackage ../tools/misc/opencbm { };
+
   parquet-tools = callPackage ../tools/misc/parquet-tools { };
 
   pass = callPackage ../tools/security/pass { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds opencbm: a package that can be used to interface with Commodore's IEC bus making it possible to transfer data to and from 1541 floppy disk drives and other models.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
