### PR TITLE
gnome.gnome-desktop: make deterministic

### DIFF
--- a/pkgs/desktops/gnome/core/gnome-desktop/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-desktop/default.nix
@@ -75,6 +75,7 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-Dgtk_doc=true"
     "-Ddesktop_docs=false"
+    "-Ddate_in_gnome_version=false"
   ];
 
   separateDebugInfo = stdenv.isLinux;

--- a/pkgs/desktops/gnome/core/gnome-desktop/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-desktop/default.nix
@@ -76,6 +76,7 @@ stdenv.mkDerivation rec {
     "-Dgtk_doc=true"
     "-Ddesktop_docs=false"
     "-Ddate_in_gnome_version=false"
+    "-Dgnome_distributor=NixOS"
   ];
 
   separateDebugInfo = stdenv.isLinux;


### PR DESCRIPTION
makes it so the date wont be added to gnome-version.xml
`<date>2021-12-18</date>`

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://r13y.com/iso_gnome/diff/812e597aa95cff2b09d1fe5eb25bd681b699e8603cc4927b39cd8b656d3626e4-db893410d32a3c5e1d9d3bcbc2876fe3cecbde88c1dc675e4e8d7b8ac75be826.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
