### PR TITLE
niv: fix m1 mac build cycle

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -95,7 +95,7 @@ self: super: builtins.intersectAttrs super {
   sfml-audio = appendConfigureFlag "--extra-include-dirs=${pkgs.openal}/include/AL" super.sfml-audio;
 
   # avoid compiling twice by providing executable as a separate output (with small closure size)
-  niv = enableSeparateBinOutput super.niv;
+  niv = super.niv;
   ormolu = enableSeparateBinOutput super.ormolu;
   ghcid = enableSeparateBinOutput super.ghcid;
 


### PR DESCRIPTION
Taken from https://github.com/DeversiFi/nixpkgs/commit/3277b0f68d17b551a7df1ac0a2ce2dcf6a8cf09d

Niv won't build on m1 mac, aarch64-darwin. `nix-build -Ai nixpkgs.niv` complains...

```
Linking dist/build/niv/niv ...
running tests
Running 1 test suites...
Test suite unit: RUNNING...
Test suite unit: PASS
Test suite logged to: dist/test/niv-0.2.19-unit.log
1 of 1 test suites (1 of 1 test cases) passed.
haddockPhase
installing
Installing library in /nix/store/9ky6yil139q38z04rnfdap5fm90ra041-niv-0.2.19/lib/ghc-8.10.7/aarch64-osx-ghc-8.10.7/niv-0.2.19-1ZfoTZ1DRMJGGS0BlJHZ5X
Installing executable niv in /nix/store/bl8r3r7bim8ka5bli5syd11h7blqqj5d-niv-0.2.19-bin/bin
Warning: The directory
/nix/store/bl8r3r7bim8ka5bli5syd11h7blqqj5d-niv-0.2.19-bin/bin is not in the
system search path.
/nix/store/3fl5z9yfnz08kjb4cnhw2w8a2zsm5qim-cctools-binutils-darwin-949.0.1/bin/strip: changes being made to the file will invalidate the code signature in: /nix/store/bl8r3r7bim8ka5bli5syd11h7blqqj5d-niv-0.2.19-bin/bin/niv
Registering library for niv-0.2.19..
post-installation fixup
strip is /nix/store/bp55vzlmcyqcx9n08pkzslvks10zybwc-clang-wrapper-11.1.0/bin/strip
stripping (with command strip and flags -S) in /nix/store/9ky6yil139q38z04rnfdap5fm90ra041-niv-0.2.19/lib
patching script interpreter paths in /nix/store/9ky6yil139q38z04rnfdap5fm90ra041-niv-0.2.19
strip is /nix/store/bp55vzlmcyqcx9n08pkzslvks10zybwc-clang-wrapper-11.1.0/bin/strip
patching script interpreter paths in /nix/store/znzad93j5h0sjrwjmzqx1ah3lfwxzh2v-niv-0.2.19-data
strip is /nix/store/bp55vzlmcyqcx9n08pkzslvks10zybwc-clang-wrapper-11.1.0/bin/strip
stripping (with command strip and flags -S) in /nix/store/bl8r3r7bim8ka5bli5syd11h7blqqj5d-niv-0.2.19-bin/bin
patching script interpreter paths in /nix/store/bl8r3r7bim8ka5bli5syd11h7blqqj5d-niv-0.2.19-bin
error: cycle detected in build of '/nix/store/p7366y0791ynzayqdl05hb6m1sc8dgm1-niv-0.2.19.drv' in the references of output 'bin' from output 'out'
```

However removing `enableSeparateBinOutput` seems to solve the issue, at least on M1 Mac, however I am unable to test against other OS/Arches. Some testing against these other platforms would be beneficial to avoid regression.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
