### PR TITLE
Add timetagger

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -150,6 +150,14 @@
           <link linkend="opt-services.prosody-filer.enable">services.prosody-filer</link>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://timetagger.app">timetagger</link>,
+          an open source time-tracker with an intuitive user experience
+          and powerful reporting.
+          <link xlink:href="options.html#opt-services.timetagger.enable">services.timetagger</link>.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-22.05-incompatibilities">

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -46,6 +46,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [prosody-filer](https://github.com/ThomasLeister/prosody-filer), a server for handling XMPP HTTP Upload requests. Available at [services.prosody-filer](#opt-services.prosody-filer.enable).
 
+- [timetagger](https://timetagger.app), an open source time-tracker with an intuitive user experience and powerful reporting. [services.timetagger](options.html#opt-services.timetagger.enable).
+
 ## Backward Incompatibilities {#sec-release-22.05-incompatibilities}
 
 - `pkgs.ghc` now refers to `pkgs.targetPackages.haskellPackages.ghc`.

--- a/nixos/modules/services/web-apps/timetagger.nix
+++ b/nixos/modules/services/web-apps/timetagger.nix
@@ -43,20 +43,19 @@ in {
           If you do so, the 'bindAddr' and 'port' options are ignored.
         '';
 
-        default = null;
+        default = pkgs.timetagger.override { addr = cfg.bindAddr; port = cfg.port; };
+        defaultText = literalExpression ''
+          pkgs.timetagger.override {
+            addr = ${cfg.bindAddr};
+            port = ${cfg.port};
+          };
+        '';
         type = types.package;
       };
     };
   };
 
-  config = let
-    timetaggerPkg = if !isNull cfg.package then cfg.package else
-      pkgs.timetagger.overwriteAttrs {
-        addr = cfg.bindAddr;
-        port = cfg.port;
-      };
-
-  in mkIf cfg.enable {
+  config = mkIf cfg.enable {
     systemd.services.timetagger = {
       description = "Timetagger service";
       wantedBy = [ "multi-user.target" ];
@@ -66,7 +65,7 @@ in {
         Group = "timetagger";
         StateDirectory = "timetagger";
 
-        ExecStart = "${timetaggerPkg}/bin/timetagger";
+        ExecStart = "${cfg.package}/bin/timetagger";
 
         Restart = "on-failure";
         RestartSec = 1;

--- a/nixos/modules/services/web-apps/timetagger.nix
+++ b/nixos/modules/services/web-apps/timetagger.nix
@@ -1,0 +1,77 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkEnableOption mkIf mkOption types literalExpression;
+
+  cfg = config.services.timetagger;
+in {
+
+  options = {
+    services.timetagger = {
+      enable = mkEnableOption ''
+        Tag your time, get the insight
+
+        <note><para>
+          This app does not do authentication.
+          You must setup authentication yourself or run it in an environment where
+          only allowed users have access.
+        </para></note>
+      '';
+
+      bindAddr = mkOption {
+        description = "Address to bind to.";
+        type = types.str;
+        default = "127.0.0.1";
+      };
+
+      port = mkOption {
+        description = "Port to bind to.";
+        type = types.port;
+        default = 8080;
+      };
+
+      package = mkOption {
+        description = ''
+          Use own package for starting timetagger web application.
+
+          The ${literalExpression ''pkgs.timetagger''} package only provides a
+          "run.py" script for the actual package
+          ${literalExpression ''pkgs.python3Packages.timetagger''}.
+
+          If you want to provide a "run.py" script for starting timetagger
+          yourself, you can do so with this option.
+          If you do so, the 'bindAddr' and 'port' options are ignored.
+        '';
+
+        default = null;
+        type = types.package;
+      };
+    };
+  };
+
+  config = let
+    timetaggerPkg = if !isNull cfg.package then cfg.package else
+      pkgs.timetagger.overwriteAttrs {
+        addr = cfg.bindAddr;
+        port = cfg.port;
+      };
+
+  in mkIf cfg.enable {
+    systemd.services.timetagger = {
+      description = "Timetagger service";
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        User = "timetagger";
+        Group = "timetagger";
+        StateDirectory = "timetagger";
+
+        ExecStart = "${timetaggerPkg}/bin/timetagger";
+
+        Restart = "on-failure";
+        RestartSec = 1;
+      };
+    };
+  };
+}
+

--- a/nixos/modules/services/web-apps/timetagger.nix
+++ b/nixos/modules/services/web-apps/timetagger.nix
@@ -8,15 +8,19 @@ in {
 
   options = {
     services.timetagger = {
-      enable = mkEnableOption ''
-        Tag your time, get the insight
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Tag your time, get the insight
 
-        <note><para>
-          This app does not do authentication.
-          You must setup authentication yourself or run it in an environment where
-          only allowed users have access.
-        </para></note>
-      '';
+          <note><para>
+            This app does not do authentication.
+            You must setup authentication yourself or run it in an environment where
+            only allowed users have access.
+          </para></note>
+        '';
+      };
 
       bindAddr = mkOption {
         description = "Address to bind to.";

--- a/pkgs/development/python-modules/asgineer/default.nix
+++ b/pkgs/development/python-modules/asgineer/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  pname = "asgineer";
+  version = "0.8.1";
+
+  # PyPI tarball doesn't include tests directory
+  src = fetchFromGitHub {
+    owner = "almarklein";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0hd1i9pc8m7sc8bkn31q4ygkmnl5vklrcziq9zkdiqaqm8clyhcx";
+  };
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A really thin ASGI web framework";
+    license = licenses.bsd2;
+    homepage = "https://asgineer.readthedocs.io";
+    maintainers = [ maintainers.matthiasbeyer ];
+  };
+}
+

--- a/pkgs/development/python-modules/asgineer/default.nix
+++ b/pkgs/development/python-modules/asgineer/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, pytestCheckHook
+, requests
 }:
 
 buildPythonPackage rec {
@@ -15,7 +17,10 @@ buildPythonPackage rec {
     sha256 = "0hd1i9pc8m7sc8bkn31q4ygkmnl5vklrcziq9zkdiqaqm8clyhcx";
   };
 
-  doCheck = false;
+  checkInputs = [
+    pytestCheckHook
+    requests
+  ];
 
   meta = with lib; {
     description = "A really thin ASGI web framework";

--- a/pkgs/development/python-modules/itemdb/default.nix
+++ b/pkgs/development/python-modules/itemdb/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  pname = "itemdb";
+  version = "1.1.1";
+
+  # PyPI tarball doesn't include tests directory
+  src = fetchFromGitHub {
+    owner = "almarklein";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0ksad5j91nlbsn0a11clf994qz7r9ijand5hxnjhgd66i9hl3y78";
+  };
+
+  meta = with lib; {
+    description = "Easy transactional database for Python dicts, backed by SQLite";
+    license = licenses.bsd2;
+    homepage = "https://itemdb.readthedocs.io";
+    maintainers = [ maintainers.matthiasbeyer ];
+  };
+}
+
+

--- a/pkgs/development/python-modules/pscript/default.nix
+++ b/pkgs/development/python-modules/pscript/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  pname = "pscript";
+  version = "0.7.6";
+
+  # PyPI tarball doesn't include tests directory
+  src = fetchFromGitHub {
+    owner = "flexxui";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "169px5n4jjnpdn9y86f28qwd95bwf1q1rz0a1h3lb5nn5c6ym8c4";
+  };
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Python to JavaScript compiler";
+    license = licenses.bsd2;
+    homepage = "https://pscript.readthedocs.io";
+    maintainers = [ maintainers.matthiasbeyer ];
+  };
+}
+
+
+

--- a/pkgs/development/python-modules/pscript/default.nix
+++ b/pkgs/development/python-modules/pscript/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, pytestCheckHook
+, nodejs
 }:
 
 buildPythonPackage rec {
@@ -15,7 +17,15 @@ buildPythonPackage rec {
     sha256 = "169px5n4jjnpdn9y86f28qwd95bwf1q1rz0a1h3lb5nn5c6ym8c4";
   };
 
-  doCheck = false;
+  checkInputs = [
+    pytestCheckHook
+    nodejs
+  ];
+
+  preCheck = ''
+    # do not execute legacy tests
+    rm -rf pscript_legacy
+  '';
 
   meta = with lib; {
     description = "Python to JavaScript compiler";

--- a/pkgs/development/python-modules/timetagger/default.nix
+++ b/pkgs/development/python-modules/timetagger/default.nix
@@ -1,6 +1,8 @@
 { lib
 , python3Packages
 , fetchFromGitHub
+, pytestCheckHook
+, requests
 }:
 
 python3Packages.buildPythonPackage rec {
@@ -21,7 +23,16 @@ python3Packages.buildPythonPackage rec {
     maintainers = with maintainers; [ matthiasbeyer ];
   };
 
-  doCheck = false;
+  checkInputs = [
+    pytestCheckHook
+    requests
+  ];
+
+  preCheck = ''
+    # https://github.com/NixOS/nixpkgs/issues/12591
+    mkdir -p check-phase
+    export HOME=$(pwd)/check-phase
+  '';
 
   propagatedBuildInputs = with python3Packages; [
     asgineer

--- a/pkgs/development/python-modules/timetagger/default.nix
+++ b/pkgs/development/python-modules/timetagger/default.nix
@@ -7,13 +7,13 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "timetagger";
-  version = "21.11.2";
+  version = "22.1.2";
 
   src = fetchFromGitHub {
     owner = "almarklein";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0fyxlm5l3xhbp2p9di51pkkb65mrwzyix74nizr2ady43ylpm07p";
+    sha256 = "0xrajx0iij7r70ch17m4y6ydyh368dn6nbjsv74pn1x8frd686rw";
   };
 
   meta = with lib; {

--- a/pkgs/development/python-modules/timetagger/default.nix
+++ b/pkgs/development/python-modules/timetagger/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+}:
+
+python3Packages.buildPythonPackage rec {
+  pname = "timetagger";
+  version = "21.11.2";
+
+  src = fetchFromGitHub {
+    owner = "almarklein";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0fyxlm5l3xhbp2p9di51pkkb65mrwzyix74nizr2ady43ylpm07p";
+  };
+
+  meta = with lib; {
+    homepage = "https://timetagger.app";
+    license = licenses.gpl3;
+    description = "Tag your time, get the insight";
+    maintainers = with maintainers; [ matthiasbeyer ];
+  };
+
+  doCheck = false;
+
+  propagatedBuildInputs = with python3Packages; [
+    asgineer
+    itemdb
+    jinja2
+    markdown
+    pscript
+    pyjwt
+    uvicorn
+  ];
+
+}

--- a/pkgs/servers/timetagger/default.nix
+++ b/pkgs/servers/timetagger/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, pkgs
+, python3Packages
+, fetchFromGitHub
+
+, addr ? "127.0.0.1"
+, port ? 8082
+}:
+
+#
+# Timetagger itself is a library that a user must write a "run.py" script for
+# We provide a basic "run.py" script with this package, which simply starts
+# timetagger.
+#
+
+let
+  tt = python3Packages.timetagger;
+in
+python3Packages.buildPythonPackage rec {
+  pname = tt.name;
+  version = tt.version;
+  src = tt.src;
+  meta = tt.meta;
+
+  propagatedBuildInputs = [ tt ]
+    ++ (with python3Packages; [
+      setuptools
+    ]);
+
+  format = "custom";
+  installPhase = ''
+    mkdir -p $out/bin
+    echo "#!${pkgs.python3}/bin/python3" >> $out/bin/timetagger
+    cat run.py >> $out/bin/timetagger
+    sed -Ei 's,0\.0\.0\.0:80,${addr}:${toString port},' $out/bin/timetagger
+    chmod +x $out/bin/timetagger
+  '';
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10200,6 +10200,8 @@ with pkgs;
 
   timetrap = callPackage ../applications/office/timetrap { };
 
+  timetagger = callPackage ../servers/timetagger { };
+
   timekeeper = callPackage ../applications/office/timekeeper { };
 
   timezonemap = callPackage ../development/libraries/timezonemap { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4055,6 +4055,8 @@ in {
 
   itemadapter = callPackage ../development/python-modules/itemadapter { };
 
+  itemdb = callPackage ../development/python-modules/itemdb { };
+
   itemloaders = callPackage ../development/python-modules/itemloaders { };
 
   iterm2 = callPackage ../development/python-modules/iterm2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6330,6 +6330,8 @@ in {
 
   psautohint = callPackage ../development/python-modules/psautohint { };
 
+  pscript = callPackage ../development/python-modules/pscript { };
+
   psd-tools = callPackage ../development/python-modules/psd-tools { };
 
   psutil = callPackage ../development/python-modules/psutil { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -634,6 +634,8 @@ in {
 
   asgi-csrf = callPackage ../development/python-modules/asgi-csrf { };
 
+  asgineer = callPackage ../development/python-modules/asgineer { };
+
   asgiref = callPackage ../development/python-modules/asgiref { };
 
   asmog = callPackage ../development/python-modules/asmog { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9719,6 +9719,8 @@ in {
 
   timeout-decorator = callPackage ../development/python-modules/timeout-decorator { };
 
+  timetagger = callPackage ../development/python-modules/timetagger { };
+
   timezonefinder = callPackage ../development/python-modules/timezonefinder { };
 
   tinycss2 = callPackage ../development/python-modules/tinycss2 { };


### PR DESCRIPTION
###### Motivation for this change

Want to try this app

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

The `./result` is empty after a successful build, and I don't understand why (I am not a python guy) ...

Maybe some nixpkgs+python guru can tell me?

I also want to write a service module as soon as I can test this!