### PR TITLE
nixos/systemd-boot: Add installBootloaderFiles option to allow only copying kernels and creating BLS entries

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -250,7 +250,11 @@ def main() -> None:
     if "@graceful@" == "1":
         bootctl_flags.append("--graceful")
 
-    if os.getenv("NIXOS_INSTALL_BOOTLOADER") == "1":
+    if not @installBootloaderFiles@:
+        # There is nothing to do here if we don't actually want to install or
+        # update the systemd-boot bootloader files on the boot partition.
+        pass
+    elif os.getenv("NIXOS_INSTALL_BOOTLOADER") == "1":
         # bootctl uses fopen() with modes "wxe" and fails if the file exists.
         if os.path.exists("@efiSysMountPoint@/loader/loader.conf"):
             os.unlink("@efiSysMountPoint@/loader/loader.conf")
@@ -299,7 +303,7 @@ def main() -> None:
             write_entry(*gen, machine_id, current=is_default)
             for specialisation in get_specialisations(*gen):
                 write_entry(*specialisation, machine_id, current=is_default)
-            if is_default:
+            if @installBootloaderFiles@ and is_default:
                 write_loader_conf(*gen)
         except OSError as e:
             # See https://github.com/NixOS/nixpkgs/issues/114552

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -79,7 +79,7 @@ def copy_from_profile(profile: Optional[str], generation: int, specialisation: O
     store_file_path = profile_path(profile, generation, specialisation, name)
     suffix = os.path.basename(store_file_path)
     store_dir = os.path.basename(os.path.dirname(store_file_path))
-    efi_file_path = "/efi/nixos/%s-%s.efi" % (store_dir, suffix)
+    efi_file_path = "@imageDir@/%s-%s.efi" % (store_dir, suffix)
     if not dry_run:
         copy_if_not_exists(store_file_path, "@efiSysMountPoint@%s" % (efi_file_path))
     return efi_file_path
@@ -205,7 +205,7 @@ def remove_old_entries(gens: List[SystemIdentifier]) -> None:
             continue
         if not (prof, gen_number, None) in gens:
             os.unlink(path)
-    for path in glob.iglob("@efiSysMountPoint@/efi/nixos/*"):
+    for path in glob.iglob("@efiSysMountPoint@@imageDir@/????????????????????????????????-*.efi"):
         if not path in known_paths and not os.path.isdir(path):
             os.unlink(path)
 
@@ -290,7 +290,7 @@ def main() -> None:
                 print("updating systemd-boot from %s to %s" % (installed_version, available_version))
                 subprocess.check_call(["@systemd@/bin/bootctl", "--esp-path=@efiSysMountPoint@"] + bootctl_flags + ["update"])
 
-    mkdir_p("@efiSysMountPoint@/efi/nixos")
+    mkdir_p("@efiSysMountPoint@@imageDir@")
     mkdir_p("@efiSysMountPoint@/loader/entries")
 
     gens = get_generations()

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -24,6 +24,8 @@ let
 
     installBootloaderFiles = if cfg.installBootloaderFiles then "True" else "False";
 
+    imageDir = if cfg.imageDir == "/" then "" else cfg.imageDir;
+
     editor = if cfg.editor then "True" else "False";
 
     configurationLimit = if cfg.configurationLimit == null then 0 else cfg.configurationLimit;
@@ -100,6 +102,29 @@ in {
         The `memtest86` option is unaffected by this option: if that option
         is set to `true`, the MemTest86 image will be copied and a boot loader
         specification entry will be created for it, even if this is set to false.
+      '';
+    };
+
+    imageDir = mkOption {
+      default = "/EFI/nixos";
+
+      type = types.str;
+
+      apply = x: assert (hasPrefix "/" x || abort "Image directory path does not start with a forward slash as required"); x;
+
+      description = lib.mdDoc ''
+        The path on the boot partition where kernels and initrd files will
+        be copied to. You must specify a value for this option that starts
+        with a forward slash, because it will be prefixed by
+        `boot.loader.efi.efiSysMountPoint` during the copy operations. Note
+        that the systemd-boot module will remove all files in this path
+        that match the path name glob pattern
+        `????????????????????????????????-*.efi` (i.e. files whose name has
+        a dash as the 33rd character - NixOS prefixes kernels and initrd
+        images with base32 hashes - and ends in `.efi`), but that aren't
+        being kept based on option
+        `boot.loader.systemd-boot.configurationLimit`. Subdirectories and
+        files inside them are not affected.
       '';
     };
 

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -22,6 +22,8 @@ let
 
     timeout = optionalString (config.boot.loader.timeout != null) config.boot.loader.timeout;
 
+    installBootloaderFiles = if cfg.installBootloaderFiles then "True" else "False";
+
     editor = if cfg.editor then "True" else "False";
 
     configurationLimit = if cfg.configurationLimit == null then 0 else cfg.configurationLimit;
@@ -80,6 +82,25 @@ in {
       type = types.bool;
 
       description = lib.mdDoc "Whether to enable the systemd-boot (formerly gummiboot) EFI boot manager";
+    };
+
+    installBootloaderFiles = mkOption {
+      default = true;
+
+      type = types.bool;
+
+      description = lib.mdDoc ''
+        Whether to actually install the systemd-boot bootloader files.
+        Setting this to false makes it so the module only copies the
+        kernels to the boot partition and generates boot loader specification
+        entries for them. This is useful for when you want to use a
+        bootloader - not managed by NixOS - that is able to boot using such
+        boot loader specification entries.
+
+        The `memtest86` option is unaffected by this option: if that option
+        is set to `true`, the MemTest86 image will be copied and a boot loader
+        specification entry will be created for it, even if this is set to false.
+      '';
     };
 
     editor = mkOption {

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -26,6 +26,12 @@ let
 
     imageDir = if cfg.imageDir == "/" then "" else cfg.imageDir;
 
+    kernelSigningKey = optionalString (cfg.kernelSigningKey != null) cfg.kernelSigningKey;
+
+    kernelSigningCert = optionalString (cfg.kernelSigningCert != null) cfg.kernelSigningCert;
+
+    sbsigntool = optionalString (cfg.kernelSigningKey != null && cfg.kernelSigningCert != null) pkgs.sbsigntool;
+
     editor = if cfg.editor then "True" else "False";
 
     configurationLimit = if cfg.configurationLimit == null then 0 else cfg.configurationLimit;
@@ -125,6 +131,38 @@ in {
         being kept based on option
         `boot.loader.systemd-boot.configurationLimit`. Subdirectories and
         files inside them are not affected.
+      '';
+    };
+
+    kernelSigningKey = mkOption {
+      default = null;
+      type = types.nullOr types.str;
+      description = lib.mdDoc ''
+        The path to the PEM-encoded RSA private key to use for signing kernels,
+        so that they may be booted as EFI images in a UEFI Secure Boot environment.
+        This option is intended to be used when using a bootloader - other than
+        systemd-boot - that can EFISTUB-boot linux kernel images. In this case,
+        `boot.loader.systemd-boot.installBootloaderFiles` should be set to false.
+        This option doesn't make the module sign the systemd-boot bootloader files.
+
+        Kernel images will not be signed if either this option or
+        `boot.loader.systemd-boot.kernelSigningCert` are `null`.
+      '';
+    };
+
+    kernelSigningCert = mkOption {
+      default = null;
+      type = types.nullOr types.str;
+      description = lib.mdDoc ''
+        The path to the X.509 certificate to use for signing kernels,
+        so that they may be booted as EFI images in a UEFI Secure Boot environment.
+        This option is intended to be used when using a bootloader - other than
+        systemd-boot - that can EFISTUB-boot linux kernel images. In this case,
+        `boot.loader.systemd-boot.installBootloaderFiles` should be set to false.
+        This option doesn't make the module sign the systemd-boot bootloader files.
+
+        Kernel images will not be signed if either this option or
+        `boot.loader.systemd-boot.kernelSigningKey` are `null`.
       '';
     };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I boot NixOS using the OpenCore bootloader. This bootloader is able to
boot into linux by searching for boot loader specification entries inside
/loader/entries directories on any partition whose filesystem it has EFI
drivers available for. In this use case, the systemd-boot module actually
installing the systemd-boot bootloader files to the boot partition is
undesirable: it pollutes the ESP partition with unnecessary files and folders,
namely /loader/loader.conf, /loader/random-seed, /EFI/Linux/, /EFI/systemd-boot/
and /EFI/BOOT/, the latter of which both contain the systemd-boot EFI image.
In turn, this pollutes the OpenCore bootloader menu since it also adds an entry
for the BOOT*.efi image under /EFI/BOOT/. Additionally, most modern motherboards
use similar logic to add BIOS boot options based on the presence of such EFI
images in a /EFI/BOOT/ folders on partitions, which is also potentially unwanted.

This pull request simply adds an option (defaulting to true so there is
no functional change unless a user specifically sets this option to false),
that avoids ever installing these bootloader files. I have provided no functionality
to "clean" up the boot partition automatically when switching from true to
false, as this is best handled manually by a system administrator (these files, after
having been copied to the boot partition aren't part of or referenced by the nix store,
unless I am mistaken). Anything memtest86-related is completely unaffected by
the option, if enabled, that image will be installed and an entry will be created
for it, even if this is set to false. This change currently applies cleanly on master
and nixos-21.11 (the branch I am using).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
