### PR TITLE
genericBuild: Output timestamp to get elapsed time for each phase

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1321,7 +1321,8 @@ genericBuild() {
         if [[ "$curPhase" = distPhase && -z "${doDist:-}" ]]; then continue; fi
 
         if [[ -n $NIX_LOG_FD ]]; then
-            echo "@nix { \"action\": \"setPhase\", \"phase\": \"$curPhase\" }" >&$NIX_LOG_FD
+            TIMESTAMP=$(date +"%s")
+            echo "@nix { \"action\": \"setPhase\", \"phase\": \"$curPhase\" , \"timestamp\": $TIMESTAMP }" >&$NIX_LOG_FD
         fi
 
         showPhaseHeader "$curPhase"
@@ -1335,6 +1336,10 @@ genericBuild() {
             cd "${sourceRoot:-.}"
         fi
     done
+    if [[ -n $NIX_LOG_FD ]]; then
+        TIMESTAMP=$(date +"%s")
+        echo "@nix { \"timestamp\": $TIMESTAMP }" >&$NIX_LOG_FD
+    fi
 }
 
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

To get elapsed time for each phase, this PR's `genericBuild` outputs the timestamp of each phase to log-file.
This will tell us which phase is taking time.

The current output-format is bellow.
```
@nix { "action": "setPhase", "phase": "unpackPhase" }
@nix { "action": "setPhase", "phase": "configurePhase" }
@nix { "action": "setPhase", "phase": "buildPhase" }
```

This PR output-format is bellow.
```
@nix { "action": "setPhase", "phase": "unpackPhase", "timestamp":  1639977122 }
@nix { "action": "setPhase", "phase": "configurePhase", "timestamp":  1639977142  }
@nix { "action": "setPhase", "phase": "buildPhase", "timestamp":  1639977152  }
@nix { "timestamp":  1639977162  }
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
