### PR TITLE
klingon-piqad-hasta: Init at 203

### DIFF
--- a/pkgs/data/fonts/klingon-piqad-hasta/default.nix
+++ b/pkgs/data/fonts/klingon-piqad-hasta/default.nix
@@ -1,0 +1,28 @@
+{ lib, fetchzip, stdenvNoCC, }:
+
+stdenvNoCC.mkDerivation rec {
+
+  pname = "klingon-piqad-hasta";
+  version = "203";
+
+  src = fetchzip {
+    url = "https://www.evertype.com/fonts/tlh/${pname}.zip";
+    sha256 = "08gc4pinazksyav8h6dxb61g76apdqjfjkhg0gsa4l6az5089b33";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 *.ttf -t $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A standard Klingon typeface, ‘viewscreen writing’ style";
+    homepage = "https://www.evertype.com/fonts/tlh/";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.chkno ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29019,6 +29019,8 @@ with pkgs;
 
   khmeros = callPackage ../data/fonts/khmeros { };
 
+  klingon-piqad-hasta = callPackage ../data/fonts/klingon-piqad-hasta {};
+
   knewave = callPackage ../data/fonts/knewave { };
 
   kochi-substitute = callPackage ../data/fonts/kochi-substitute { };


### PR DESCRIPTION
###### Motivation for this change
Make Klingon characters render properly:
![klingon-unicode-font](https://user-images.githubusercontent.com/1118859/146727247-330c5872-47be-4069-8541-e77394c0b61b.png)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
