### PR TITLE
[staging-next] python3Packages.fonttools: avoid deprecation warnings from fontTools.misc.py23

### DIFF
--- a/pkgs/development/python-modules/fonttools/default.nix
+++ b/pkgs/development/python-modules/fonttools/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , pythonOlder
 , brotlipy
 , zopfli
@@ -28,6 +29,15 @@ buildPythonPackage rec {
     rev    = version;
     sha256 = "1zp9idjkn4bn1a4pn8x64vi8j1ijdsd4qvgf1f70dfwqvw6ak1i6";
   };
+
+  patches = [
+    # avoid deprecation warnings. patch already in 4.27.0
+    # https://github.com/fonttools/fonttools/pull/2400
+    (fetchpatch {
+      url = "https://github.com/fonttools/fonttools/commit/232b2ccbc4a4c9b043b23131a30ec93b821d7e39.patch";
+      sha256 = "sha256-B/EYCv7fYRyzZHhd0bOWEAZzJrOojRw6Vr/xvsC75S4=";
+    })
+  ];
 
   # all dependencies are optional, but
   # we run the checks with them


### PR DESCRIPTION
###### Motivation for this change

In the upcoming staging-next update (#148396), `fonttools.misc.xmlWriter`(not deprecated AFAIK) imports a deprecated module, `fontTools.misc.py23`, generating a warning. This is affecting Sage tests on `staging-next`, see below.

<details>
<summary>Backtrace</summary>
<pre>**********************************************************************
File "/nix/store/6jr4iv32zhrn6rk0kxjcb9nmm4ms4vfc-sage-src-9.4/src/doc/en/prep/Advanced-2DPlotting.rst", line 697, in doc.en.prep.Advanced-2DPlotting
Failed example:
    p.save(pdf_savename)
Expected nothing
Got:
    doctest:warning
      File "/nix/store/r3x2nb1i59r1lanv2qmrhf2yhibqi8nh-sage-with-env-9.4/bin/sage-runtests", line 144, in <module>
        err = DC.run()
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/doctest/control.py", line 1208, in run
        self.run_doctests()
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/doctest/control.py", line 910, in run_doctests
        self.dispatcher.dispatch()
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/doctest/forker.py", line 2052, in dispatch
        self.parallel_dispatch()
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/doctest/forker.py", line 1947, in parallel_dispatch
        w.start()  # This might take some time
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/doctest/forker.py", line 2219, in start
        super(DocTestWorker, self).start()
      File "/nix/store/rppr9s436950i1dlzknbmz40m2xqqnxc-python3-3.9.9/lib/python3.9/multiprocessing/process.py", line 121, in start
        self._popen = self._Popen(self)
      File "/nix/store/rppr9s436950i1dlzknbmz40m2xqqnxc-python3-3.9.9/lib/python3.9/multiprocessing/context.py", line 224, in _Popen
        return _default_context.get_context().Process._Popen(process_obj)
      File "/nix/store/rppr9s436950i1dlzknbmz40m2xqqnxc-python3-3.9.9/lib/python3.9/multiprocessing/context.py", line 277, in _Popen
        return Popen(process_obj)
      File "/nix/store/rppr9s436950i1dlzknbmz40m2xqqnxc-python3-3.9.9/lib/python3.9/multiprocessing/popen_fork.py", line 19, in __init__
        self._launch(process_obj)
      File "/nix/store/rppr9s436950i1dlzknbmz40m2xqqnxc-python3-3.9.9/lib/python3.9/multiprocessing/popen_fork.py", line 71, in _launch
        code = process_obj._bootstrap(parent_sentinel=child_r)
      File "/nix/store/rppr9s436950i1dlzknbmz40m2xqqnxc-python3-3.9.9/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap
        self.run()
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/doctest/forker.py", line 2191, in run
        task(self.options, self.outtmpfile, msgpipe, self.result_queue)
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/doctest/forker.py", line 2520, in __call__
        doctests, extras = self._run(runner, options, results)
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/doctest/forker.py", line 2567, in _run
        result = runner.run(test)
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/doctest/forker.py", line 910, in run
        return self._run(test, compileflags, out)
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/doctest/forker.py", line 718, in _run
        self.compile_and_execute(example, compiler, test.globs)
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/doctest/forker.py", line 1145, in compile_and_execute
        exec(compiled, globs)
      File "<doctest doc.en.prep.Advanced-2DPlotting[77]>", line 1, in <module>
        p.save(pdf_savename)
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/misc/decorators.py", line 410, in wrapper
        return func(*args, **kwds)
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/plot/graphics.py", line 3363, in save
        figure.savefig(filename, **opts)
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/matplotlib/figure.py", line 3012, in savefig
        self.canvas.print_figure(fname, **kwargs)
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/matplotlib/backend_bases.py", line 2254, in print_figure
        canvas = self._get_output_canvas(backend, format)
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/matplotlib/backend_bases.py", line 2179, in _get_output_canvas
        canvas_class = get_registered_canvas_class(fmt)
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/matplotlib/backend_bases.py", line 144, in get_registered_canvas_class
        backend_class = importlib.import_module(backend_class).FigureCanvas
      File "/nix/store/rppr9s436950i1dlzknbmz40m2xqqnxc-python3-3.9.9/lib/python3.9/importlib/__init__.py", line 127, in import_module
        return _bootstrap._gcd_import(name[level:], package, level)
      File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
      File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
      File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
      File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
      File "<frozen importlib._bootstrap_external>", line 850, in exec_module
      File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/matplotlib/backends/backend_pdf.py", line 47, in <module>
        from . import _backend_pdf_ps
      File "<frozen importlib._bootstrap>", line 1058, in _handle_fromlist
      File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
      File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
      File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
      File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
      File "<frozen importlib._bootstrap_external>", line 850, in exec_module
      File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/matplotlib/backends/_backend_pdf_ps.py", line 8, in <module>
        from fontTools import subset
      File "<frozen importlib._bootstrap>", line 1058, in _handle_fromlist
      File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
      File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
      File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
      File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
      File "<frozen importlib._bootstrap_external>", line 850, in exec_module
      File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/fontTools/subset/__init__.py", line 6, in <module>
        from fontTools import ttLib
      File "<frozen importlib._bootstrap>", line 1058, in _handle_fromlist
      File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
      File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
      File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
      File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
      File "<frozen importlib._bootstrap_external>", line 850, in exec_module
      File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/fontTools/ttLib/__init__.py", line 57, in <module>
        from fontTools.ttLib.ttFont import *
      File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
      File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
      File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
      File "<frozen importlib._bootstrap_external>", line 850, in exec_module
      File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/fontTools/ttLib/ttFont.py", line 1, in <module>
        from fontTools.misc import xmlWriter
      File "<frozen importlib._bootstrap>", line 1058, in _handle_fromlist
      File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
      File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
      File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
      File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
      File "<frozen importlib._bootstrap_external>", line 850, in exec_module
      File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/fontTools/misc/xmlWriter.py", line 3, in <module>
        from fontTools.misc.py23 import byteord, strjoin, tobytes, tostr
      File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
      File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
      File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
      File "<frozen importlib._bootstrap_external>", line 850, in exec_module
      File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/fontTools/misc/py23.py", line 11, in <module>
        warnings.warn(
      File "/nix/store/rppr9s436950i1dlzknbmz40m2xqqnxc-python3-3.9.9/lib/python3.9/warnings.py", line 109, in _showwarnmsg
        sw(msg.message, msg.category, msg.filename, msg.lineno,
    :
    DeprecationWarning: The py23 module has been deprecated and will be removed in a future release. Please update your code.
</pre>
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
