### PR TITLE
[staging-next] python3Packages.matplotlib: 3.5.0 -> 3.5.1

### DIFF
--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -17,7 +17,7 @@ let
 in
 
 buildPythonPackage rec {
-  version = "3.5.0";
+  version = "3.5.1";
   pname = "matplotlib";
   format = "setuptools";
 
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "38892a254420d95594285077276162a5e9e9c30b6da08bdc2a4d53331ad9a6fa";
+    sha256 = "b2e9810e09c3a47b73ce9cab5a72243a1258f61e7900969097a817232246ce1c";
   };
 
   XDG_RUNTIME_DIR = "/tmp";


### PR DESCRIPTION
###### Motivation for this change

Staging-next updated matplotlib to 3.5.0, but there's a new dot release with a bunch of bugfixes. One of the fixed bugs (regarding horizontal colorbars, https://github.com/matplotlib/matplotlib/pull/21686) was affecting Sage, as can be seen in the backtrace below.

<details>
<summary>Backtrace</summary>
<pre>
**********************************************************************
File "/nix/store/6jr4iv32zhrn6rk0kxjcb9nmm4ms4vfc-sage-src-9.4/src/sage/plot/contour_plot.py", line 680, in sage.plot.contour_plot.contour_plot
Failed example:
    contour_plot(f, (x,-3,3), (y,-3,3), colorbar=True, colorbar_orientation='horizontal')
Expected:
    Graphics object consisting of 1 graphics primitive
Got:
    doctest:warning
      File "/nix/store/r3x2nb1i59r1lanv2qmrhf2yhibqi8nh-sage-with-env-9.4/bin/sage-runtests", line 144, in <module>
        err = DC.run()
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/doctest/control.py", line 1208, in run
        self.run_doctests()
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/doctest/control.py", line 910, in run_doctests
        self.dispatcher.dispatch()
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/doctest/forker.py", line 2052, in dispatch
        self.parallel_dispatch()
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/doctest/forker.py", line 1947, in parallel_dispatch
        w.start()  # This might take some time
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/doctest/forker.py", line 2219, in start
        super(DocTestWorker, self).start()
      File "/nix/store/rppr9s436950i1dlzknbmz40m2xqqnxc-python3-3.9.9/lib/python3.9/multiprocessing/process.py", line 121, in start
        self._popen = self._Popen(self)
      File "/nix/store/rppr9s436950i1dlzknbmz40m2xqqnxc-python3-3.9.9/lib/python3.9/multiprocessing/context.py", line 224, in _Popen
        return _default_context.get_context().Process._Popen(process_obj)
      File "/nix/store/rppr9s436950i1dlzknbmz40m2xqqnxc-python3-3.9.9/lib/python3.9/multiprocessing/context.py", line 277, in _Popen
        return Popen(process_obj)
      File "/nix/store/rppr9s436950i1dlzknbmz40m2xqqnxc-python3-3.9.9/lib/python3.9/multiprocessing/popen_fork.py", line 19, in __init__
        self._launch(process_obj)
      File "/nix/store/rppr9s436950i1dlzknbmz40m2xqqnxc-python3-3.9.9/lib/python3.9/multiprocessing/popen_fork.py", line 71, in _launch
        code = process_obj._bootstrap(parent_sentinel=child_r)
      File "/nix/store/rppr9s436950i1dlzknbmz40m2xqqnxc-python3-3.9.9/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap
        self.run()
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/doctest/forker.py", line 2191, in run
        task(self.options, self.outtmpfile, msgpipe, self.result_queue)
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/doctest/forker.py", line 2520, in __call__
        doctests, extras = self._run(runner, options, results)
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/doctest/forker.py", line 2567, in _run
        result = runner.run(test)
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/doctest/forker.py", line 910, in run
        return self._run(test, compileflags, out)
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/doctest/forker.py", line 718, in _run
        self.compile_and_execute(example, compiler, test.globs)
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/doctest/forker.py", line 1145, in compile_and_execute
        exec(compiled, globs)
      File "<doctest sage.plot.contour_plot.contour_plot[40]>", line 1, in <module>
        contour_plot(f, (x,-Integer(3),Integer(3)), (y,-Integer(3),Integer(3)), colorbar=True, colorbar_orientation='horizontal')
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/repl/rich_output/display_manager.py", line 825, in displayhook
        plain_text, rich_output = self._rich_output_formatter(obj, dict())
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/repl/rich_output/display_manager.py", line 643, in _rich_output_formatter
        rich_output = self._call_rich_repr(obj, rich_repr_kwds)
      File "/nix/store/hkhbp4f7i6a3zxhrzcmiz2bprvm17pxp-python3-3.9.9-env/lib/python3.9/site-packages/sage/repl/rich_output/display_manager.py", line 608, in _call_rich_repr
        warnings.warn(
      File "/nix/store/rppr9s436950i1dlzknbmz40m2xqqnxc-python3-3.9.9/lib/python3.9/warnings.py", line 109, in _showwarnmsg
        sw(msg.message, msg.category, msg.filename, msg.lineno,
    :
    sage.repl.rich_output.display_manager.RichReprWarning: Exception in _rich_repr_ while displaying object: 'vertices' must be 2D with shape (M, 2). Your input has shape (2, 5).
    Graphics object consisting of 1 graphics primitive
</pre>
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
