### PR TITLE
cryptopp: 8.4.0 -> 8.6.0

### DIFF
--- a/pkgs/development/libraries/crypto++/default.nix
+++ b/pkgs/development/libraries/crypto++/default.nix
@@ -5,30 +5,22 @@
 
 stdenv.mkDerivation rec {
   pname = "crypto++";
-  version = "8.4.0";
+  version = "8.6.0";
   underscoredVersion = lib.strings.replaceStrings ["."] ["_"] version;
 
   src = fetchFromGitHub {
     owner = "weidai11";
     repo = "cryptopp";
     rev = "CRYPTOPP_${underscoredVersion}";
-    sha256 = "1gwn8yh1mh41hkh6sgnhb9c3ygrdazd7645msl20i0zdvcp7f5w3";
+    hash = "sha256-a3TYaK34WvKEXN7LKAfGwQ3ZL6a3k/zMZyyVfnkQqO4=";
   };
 
   outputs = [ "out" "dev" ];
 
   postPatch = ''
     substituteInPlace GNUmakefile \
-        --replace "AR = libtool" "AR = ar" \
-        --replace "ARFLAGS = -static -o" "ARFLAGS = -cru"
-
-    # See https://github.com/weidai11/cryptopp/issues/1011
-    substituteInPlace GNUmakefile \
-      --replace "ZOPT = -O0" "ZOPT ="
-  '';
-
-  preConfigure = ''
-    sh TestScripts/configure.sh
+      --replace "AR = libtool" "AR = ar" \
+      --replace "ARFLAGS = -static -o" "ARFLAGS = -cru"
   '';
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
@@ -37,10 +29,11 @@ stdenv.mkDerivation rec {
     ++ lib.optional enableShared "shared"
     ++ [ "libcryptopp.pc" ];
   enableParallelBuilding = true;
+  hardeningDisable = [ "fortify" ];
 
   doCheck = true;
 
-  # built for checks but we don't install static lib into the nix store
+  # always built for checks but install static lib only when necessary
   preInstall = lib.optionalString (!enableStatic) "rm libcryptopp.a";
 
   installTargets = [ "install-lib" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Package update ;
Disabling fortify because it clashes with upstream optimisation flags

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
