### PR TITLE
python3Packages.gehomesdk: init at 0.4.22, python3Packages.gekitchen: init at 0.2.19

### DIFF
--- a/pkgs/development/python-modules/gehomesdk/default.nix
+++ b/pkgs/development/python-modules/gehomesdk/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, aiohttp
+, bidict
+, buildPythonPackage
+, fetchPypi
+, humanize
+, lxml
+, pythonOlder
+, requests
+, slixmpp
+, websockets
+}:
+
+buildPythonPackage rec {
+  pname = "gehomesdk";
+  version = "0.4.22";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-3HErbW9/YD8Jd6zr5O2hjoLZ9x5P/vzZLjqPmSm09EM=";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    bidict
+    humanize
+    lxml
+    requests
+    slixmpp
+    websockets
+  ];
+
+  # Tests are not shipped and source is not tagged
+  # https://github.com/simbaja/gehome/issues/32
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "gehomesdk"
+  ];
+
+  meta = with lib; {
+    description = "Python SDK for GE smart appliances";
+    homepage = "https://github.com/simbaja/gehome";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/gekitchen/default.nix
+++ b/pkgs/development/python-modules/gekitchen/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, aiohttp
+, bidict
+, buildPythonPackage
+, fetchFromGitHub
+, humanize
+, lxml
+, pytestCheckHook
+, pythonOlder
+, requests
+, slixmpp
+, websockets
+}:
+
+buildPythonPackage rec {
+  pname = "gekitchen";
+  version = "0.2.19";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "ajmarks";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-eKGundh7j9LqFd71bx86rNBVu2iAcgLN25JfFa39+VA=";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    bidict
+    humanize
+    lxml
+    requests
+    slixmpp
+    websockets
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "gekitchen"
+  ];
+
+  meta = with lib; {
+    description = "Python SDK for GE smart appliances";
+    homepage = "https://github.com/ajmarks/gekitchen";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3074,6 +3074,8 @@ in {
 
   geeknote = callPackage ../development/python-modules/geeknote { };
 
+  gehomesdk = callPackage ../development/python-modules/gehomesdk { };
+
   gemfileparser = callPackage ../development/python-modules/gemfileparser { };
 
   genanki = callPackage ../development/python-modules/genanki { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3076,6 +3076,8 @@ in {
 
   gehomesdk = callPackage ../development/python-modules/gehomesdk { };
 
+  gekitchen = callPackage ../development/python-modules/gekitchen { };
+
   gemfileparser = callPackage ../development/python-modules/gemfileparser { };
 
   genanki = callPackage ../development/python-modules/genanki { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python SDK for GE smart appliances

https://github.com/simbaja/gehome
https://github.com/ajmarks/gekitchen

Use by Home Assistant integrations which are included by HACS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
