### PR TITLE
librewolf: init at 97.0-2

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -1,7 +1,8 @@
 { pname, version, meta, updateScript ? null
 , binaryName ? "firefox", application ? "browser"
 , src, unpackPhase ? null, patches ? []
-, extraNativeBuildInputs ? [], extraConfigureFlags ? [], extraMakeFlags ? [], tests ? [] }:
+, extraNativeBuildInputs ? [], extraConfigureFlags ? [], extraMakeFlags ? [], tests ? []
+, extraPostPatch ? "", extraPassthru ? {} }:
 
 { lib, stdenv, pkg-config, pango, perl, python3, zip
 , libjpeg, zlib, dbus, dbus-glib, bzip2, xorg
@@ -177,7 +178,7 @@ buildStdenv.mkDerivation ({
       --replace 'dlopen("libpci.so' 'dlopen("${pciutils}/lib/libpci.so'
 
     patchShebangs mach
- '';
+  '' + extraPostPatch;
 
   nativeBuildInputs =
     [
@@ -374,7 +375,7 @@ buildStdenv.mkDerivation ({
     inherit applicationName;
     inherit tests;
     inherit gtk3;
-  };
+  } // extraPassthru;
 
   hardeningDisable = [ "format" ]; # -Werror=format-security
 

--- a/pkgs/applications/networking/browsers/firefox/librewolf/default.nix
+++ b/pkgs/applications/networking/browsers/firefox/librewolf/default.nix
@@ -1,0 +1,41 @@
+{ callPackage, git }:
+let
+  src = callPackage ./src.nix { };
+in
+rec {
+
+  inherit (src) packageVersion firefox source;
+
+  patches = [ ./verify-telemetry-macros.patch ];
+
+  extraConfigureFlags = [
+    "--with-app-name=librewolf"
+    "--with-app-basename=LibreWolf"
+    "--with-branding=browser/branding/librewolf"
+    "--with-distribution-id=io.gitlab.librewolf-community"
+    "--with-unsigned-addon-scopes=app,system"
+    "--allow-addon-sideload"
+  ];
+
+  extraPostPatch = ''
+    while read patch_name; do
+      echo "applying LibreWolf patch: $patch_name"
+      patch -p1 < ${source}/$patch_name
+    done <${source}/assets/patches.txt
+
+    cp -r ${source}/themes/browser .
+    cp ${source}/assets/search-config.json services/settings/dumps/main/search-config.json
+    sed -i '/MOZ_SERVICES_HEALTHREPORT/ s/True/False/' browser/moz.configure
+    sed -i '/MOZ_NORMANDY/ s/True/False/' browser/moz.configure
+  '';
+
+  extraPrefsFiles = [ "${source}/submodules/settings/librewolf.cfg" ];
+
+  extraPoliciesFiles = [ "${source}/submodules/settings/distribution/policies.json" ];
+
+  extraPassthru = {
+    librewolf = { inherit src patches; };
+    inherit extraPrefsFiles extraPoliciesFiles;
+  };
+}
+

--- a/pkgs/applications/networking/browsers/firefox/librewolf/src.json
+++ b/pkgs/applications/networking/browsers/firefox/librewolf/src.json
@@ -1,0 +1,11 @@
+{
+  "packageVersion": "97.0-2",
+  "source": {
+    "rev": "97.0-2",
+    "sha256": "00fb7xr6hrcyh3s7g52fs6f7a1iggpibj0xafblnl7118fh73g25"
+  },
+  "firefox": {
+    "version": "97.0",
+    "sha512": "a913695a42cb06ee9bda2a20e65cc573e40ca93e9f75b7ee0a43ebd1935b371e7e80d5fc8d5f126ad0712ab848635a8624bbeed43807e5c179537aa32c884186"
+  }
+}

--- a/pkgs/applications/networking/browsers/firefox/librewolf/src.nix
+++ b/pkgs/applications/networking/browsers/firefox/librewolf/src.nix
@@ -1,0 +1,18 @@
+{ fetchurl, fetchFromGitLab }:
+let src = builtins.fromJSON (builtins.readFile ./src.json);
+in
+{
+  inherit (src) packageVersion;
+  source = fetchFromGitLab {
+    owner = "librewolf-community";
+    repo = "browser/source";
+    fetchSubmodules = true;
+    inherit (src.source) rev sha256;
+  };
+  firefox = fetchurl {
+    url =
+      "mirror://mozilla/firefox/releases/${src.firefox.version}/source/firefox-${src.firefox.version}.source.tar.xz";
+    inherit (src.firefox) sha512;
+  };
+}
+

--- a/pkgs/applications/networking/browsers/firefox/librewolf/update.nix
+++ b/pkgs/applications/networking/browsers/firefox/librewolf/update.nix
@@ -1,0 +1,65 @@
+{ writeScript
+, lib
+, coreutils
+, gnused
+, gnugrep
+, curl
+, gnupg
+, jq
+, nix-prefetch-git
+, moreutils
+, runtimeShell
+, ...
+}:
+
+writeScript "update-librewolf" ''
+  #!${runtimeShell}
+  PATH=${lib.makeBinPath [ coreutils curl gnugrep gnupg gnused jq moreutils nix-prefetch-git ]}
+  set -euo pipefail
+
+  latestTag=$(curl https://gitlab.com/api/v4/projects/librewolf-community%2Fbrowser%2Fsource/repository/tags?per_page=1 | jq -r .[0].name)
+  echo "latestTag=$latestTag"
+
+  srcJson=pkgs/applications/networking/browsers/firefox/librewolf/src.json
+  localRev=$(jq -r .source.rev < $srcJson)
+  echo "localRev=$localRev"
+
+  if [ "$localRev" == "$latestTag" ]; then
+    exit 0
+  fi
+
+  prefetchOut=$(mktemp)
+  repoUrl=https://gitlab.com/librewolf-community/browser/source.git/
+  nix-prefetch-git $repoUrl --quiet --rev $latestTag --fetch-submodules > $prefetchOut
+  srcDir=$(jq -r .path < $prefetchOut)
+  srcHash=$(jq -r .sha256 < $prefetchOut)
+
+  ffVersion=$(<$srcDir/version)
+  lwRelease=$(<$srcDir/release)
+  lwVersion="$ffVersion-$lwRelease"
+  echo "lwVersion=$lwVersion"
+  echo "ffVersion=$ffVersion"
+  if [ "$lwVersion" != "$latestTag" ]; then
+    echo "error: Tag name does not match the computed LibreWolf version"
+    exit 1
+  fi
+
+  HOME=$(mktemp -d)
+  export GNUPGHOME=$(mktemp -d)
+  gpg --receive-keys 14F26682D0916CDD81E37B6D61B7B526D98F0353
+
+  mozillaUrl=https://archive.mozilla.org/pub/firefox/releases/
+
+  curl --silent --show-error -o "$HOME"/shasums "$mozillaUrl$ffVersion/SHA512SUMS"
+  curl --silent --show-error -o "$HOME"/shasums.asc "$mozillaUrl$ffVersion/SHA512SUMS.asc"
+  gpgv --keyring="$GNUPGHOME"/pubring.kbx "$HOME"/shasums.asc "$HOME"/shasums
+
+  ffHash=$(grep '\.source\.tar\.xz$' "$HOME"/shasums | grep '^[^ ]*' -o)
+  echo "ffHash=$ffHash"
+
+  jq ".source.rev = \"$latestTag\"" $srcJson | sponge $srcJson
+  jq ".source.sha256 = \"$srcHash\"" $srcJson | sponge $srcJson
+  jq ".firefox.version = \"$ffVersion\"" $srcJson | sponge $srcJson
+  jq ".firefox.sha512 = \"$ffHash\"" $srcJson | sponge $srcJson
+  jq ".packageVersion = \"$lwVersion\"" $srcJson | sponge $srcJson
+''

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -54,4 +54,29 @@ rec {
       versionSuffix = "esr";
     };
   };
+
+  librewolf =
+  let
+    librewolf-src = callPackage ./librewolf { };
+  in
+  (common rec {
+    pname = "librewolf";
+    binaryName = "librewolf";
+    version = librewolf-src.packageVersion;
+    src = librewolf-src.firefox;
+    inherit (librewolf-src) extraConfigureFlags extraPostPatch extraPassthru;
+
+    meta = {
+      description = "A fork of Firefox, focused on privacy, security and freedom";
+      homepage = "https://librewolf.net/";
+      maintainers = with lib.maintainers; [ squalus ];
+      inherit (firefox.meta) platforms badPlatforms broken maxSilent license;
+    };
+    updateScript = callPackage ./librewolf/update.nix {
+      attrPath = "librewolf-unwrapped";
+    };
+  }).override {
+    crashreporterSupport = false;
+    enableOfficialBranding = false;
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25721,6 +25721,17 @@ with pkgs;
     desktopName = "Firefox DevEdition";
   };
 
+  librewolf-unwrapped = firefoxPackages.librewolf;
+
+  librewolf = wrapFirefox librewolf-unwrapped {
+    inherit (librewolf-unwrapped) extraPrefsFiles extraPoliciesFiles;
+    libName = "librewolf";
+  };
+
+  librewolf-wayland = librewolf.override {
+    forceWayland = true;
+  };
+
   firefox_decrypt = python3Packages.callPackage ../tools/security/firefox_decrypt { };
 
   flac = callPackage ../applications/audio/flac { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This PR adds a package for the LibreWolf browser. LibreWolf is a fork of Firefox, focused on privacy, security and freedom. Fixes #94918

There are a few small changes to the existing Firefox expressions. These changes ~should not trigger any rebuilds~ will trigger a rebuild only of the Firefox wrappers (not the compiled artifacts).

An updater script is included. Updating still requires some manual analysis work. The ~patch list~, flags, and file replacements can't yet be automatically read from upstream.

Firefox updates should not be delayed by the presence of the Librewolf expressions. The versioning is disconnected. There is a small maintenance burden on Firefox: `common.nix` and `wrapper.nix` need to remain compatible with the version used by LibreWolf. Since they are also used for earlier ESR releases, I don't anticipate that to be much of a problem.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
