### PR TITLE
guglielmo: init at 0.3

### DIFF
--- a/pkgs/applications/radio/guglielmo/default.nix
+++ b/pkgs/applications/radio/guglielmo/default.nix
@@ -1,0 +1,55 @@
+{ lib, mkDerivation, fetchFromGitHub, cmake, pkg-config
+, airspy
+, librtlsdr
+, fdk_aac
+, faad2
+, fftwFloat
+, libsndfile
+, libsamplerate
+, portaudio
+, qtmultimedia
+, qwt
+} :
+
+mkDerivation rec {
+  pname = "guglielmo";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "marcogrecopriolo";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0s1iz9s0k897jayiwl3yr9ylpclw6bzcpmzhxqn0mkd7jhgfl4vx";
+  };
+
+  postInstall = ''
+    mv $out/linux-bin $out/bin
+  '';
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [
+    airspy
+    librtlsdr
+    fdk_aac
+    faad2
+    fftwFloat
+    libsndfile
+    libsamplerate
+    portaudio
+    qtmultimedia
+    qwt
+  ];
+
+  postFixup = ''
+    # guglielmo opens SDR libraries at run time
+    patchelf --add-rpath "${airspy}/lib:${librtlsdr}/lib" $out/bin/.guglielmo-wrapped
+  '';
+
+  meta = with lib; {
+    description = "Qt based FM / Dab tuner";
+    homepage = "https://github.com/marcogrecopriolo/guglielmo";
+    license = licenses.gpl2Only;
+    maintainers = [ maintainers.markuskowa ];
+    platforms =  platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1815,6 +1815,8 @@ with pkgs;
 
   gucci = callPackage ../tools/text/gucci { };
 
+  guglielmo = libsForQt5.callPackage ../applications/radio/guglielmo { };
+
   grc = python3Packages.callPackage ../tools/misc/grc { };
 
   green-pdfviewer = callPackage ../applications/misc/green-pdfviewer {


### PR DESCRIPTION
###### Motivation for this change
Nice compact, little app for listening to FM/DAB radio.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
