### PR TITLE
session-desktop-appimage: 1.7.4 -> 1.7.6

### DIFF
--- a/pkgs/applications/networking/instant-messengers/session-desktop-appimage/default.nix
+++ b/pkgs/applications/networking/instant-messengers/session-desktop-appimage/default.nix
@@ -5,10 +5,10 @@
 
 appimageTools.wrapType2 rec {
   pname = "session-desktop-appimage";
-  version = "1.7.5";
+  version = "1.7.6";
   src = fetchurl {
     url = "https://github.com/oxen-io/session-desktop/releases/download/v${version}/session-desktop-linux-x86_64-${version}.AppImage";
-    sha256 = "We1/1UIMJ8JnI9V4Z7TA0Vx3YNOfqLBW9DtklwwqUVE=";
+    sha256 = "PNjUslqLcSxkRSXFpesBr2sfre4wetZWfUQTjywdClU=";
   };
 
   meta = with lib; {

--- a/pkgs/applications/networking/instant-messengers/session-desktop-appimage/default.nix
+++ b/pkgs/applications/networking/instant-messengers/session-desktop-appimage/default.nix
@@ -3,14 +3,12 @@
 , appimageTools
 }:
 
-let
-  version = "1.7.4";
-in
-appimageTools.wrapType2 {
-  name = "session-desktop-appimage-${version}";
+appimageTools.wrapType2 rec {
+  pname = "session-desktop-appimage";
+  version = "1.7.5";
   src = fetchurl {
     url = "https://github.com/oxen-io/session-desktop/releases/download/v${version}/session-desktop-linux-x86_64-${version}.AppImage";
-    sha256 = "1yjah9ip3r2irvv2g9j0ql55nkmpwml7lngmq954xrkq9smrdrm5";
+    sha256 = "We1/1UIMJ8JnI9V4Z7TA0Vx3YNOfqLBW9DtklwwqUVE=";
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Update session-dekstop-appimage to the latest release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
