### PR TITLE
cernlib: implement a more complete install using imake

### DIFF
--- a/pkgs/development/libraries/physics/cernlib/default.nix
+++ b/pkgs/development/libraries/physics/cernlib/default.nix
@@ -19,15 +19,23 @@ stdenv.mkDerivation rec {
   patches = [ ./patch.patch ./0001-Use-strerror-rather-than-sys_errlist-to-fix-compilat.patch ];
 
   postPatch = ''
+    echo 'InstallBinSubdirs(packlib scripts)' >> 2006/src/Imakefile
     substituteInPlace 2006/src/config/site.def \
       --replace "# define MakeCmd gmake" "# define MakeCmd make"
     substituteInPlace 2006/src/config/lnxLib.rules \
       --replace "# lib" "// lib"
+
+    substituteInPlace 2006/src/config/linux.cf \
+      --replace "# ifdef Hasgfortran" "# if 1" \
+      --replace "# define CcCmd			gcc4" "# define CcCmd			gcc"
+    substituteInPlace 2006/src/scripts/cernlib \
+      --replace "-lnsl" ""
+
     # binutils 2.37 fix
     substituteInPlace 2006/src/config/Imake.tmpl --replace "clq" "cq"
   '';
 
-  configurePhase = ''
+  preConfigure = ''
     export CERN=`pwd`
     export CERN_LEVEL=${version}
     export CERN_ROOT=$CERN/$CERN_LEVEL
@@ -43,32 +51,39 @@ stdenv.mkDerivation rec {
     "-fallow-argument-mismatch"
   ];
 
+  NIX_CFLAGS = [ "-Wno-return-type" ];
+
   makeFlags = [
     "FORTRANOPTIONS=$(FFLAGS)"
+    "CCOPTIONS=$(NIX_CFLAGS)"
   ];
 
-  buildPhase = ''
-    cd $CERN_ROOT
-    mkdir -p build bin lib
+  configurePhase = ''
+    runHook preConfigure
 
+    cd $CERN_ROOT
+    mkdir -p build
     cd $CERN_ROOT/build
     $CVSCOSRC/config/imake_boot
+
+    runHook postConfigure
+  '';
+
+  preBuild = ''
     make -j $NIX_BUILD_CORES $makeFlags bin/kuipc
     make -j $NIX_BUILD_CORES $makeFlags scripts/Makefile
     pushd scripts
-    make -j $NIX_BUILD_CORES $makeFlags install.bin
+    make -j $NIX_BUILD_CORES $makeFlags bin/cernlib
     popd
-    make -j $NIX_BUILD_CORES $makeFlags
   '';
 
-  installPhase = ''
-    mkdir "$out"
-    cp -r "$CERN_ROOT/bin" "$out"
-    cp -r "$CERN_ROOT/lib" "$out"
-    mkdir "$out/$CERN_LEVEL"
-    ln -s "$out/bin" "$out/$CERN_LEVEL/bin"
-    ln -s "$out/lib" "$out/$CERN_LEVEL/lib"
-  '';
+  installTargets = [ "install.bin" "install.lib" "install.include" ];
+  installFlags = [
+    "CERN_BINDIR=${placeholder "out"}/bin"
+    "CERN_INCLUDEDIR=${placeholder "out"}/include"
+    "CERN_LIBDIR=${placeholder "out"}/lib"
+    "CERN_SHLIBDIR=${placeholder "out"}/libexec"
+  ];
 
   setupHook = ./setup-hook.sh;
 


### PR DESCRIPTION
The previous installation and build scheme was not producing a
complete installation. For example, the include headers were missing,
some programs were not installed as well.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
