### PR TITLE
papermc: added multiple versions

### DIFF
--- a/pkgs/games/papermc/1.10.nix
+++ b/pkgs/games/papermc/1.10.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, fetchurl
+, bash
+, adoptopenjdk-jre-hotspot-bin-13
+}:
+
+let
+  mcVersion = "1.10.2";
+  buildNum = "918";
+  jar = fetchurl {
+    url = "https://papermc.io/api/v2/projects/paper/versions/${mcVersion}/builds/${buildNum}/downloads/paper-${mcVersion}-${buildNum}.jar";
+    sha256 = "gzVNJKIrYmXnbAibPRelaKu0RsDM0SwkUvXhSEErFsI=";
+  };
+  jre = adoptopenjdk-jre-hotspot-bin-13;
+in stdenv.mkDerivation {
+  pname = "papermc";
+  version = "${mcVersion}r${buildNum}";
+
+  preferLocalBuild = true;
+
+  dontUnpack = true;
+  dontConfigure = true;
+
+  buildPhase = ''
+    cat > minecraft-server << EOF
+    #!${bash}/bin/sh
+    exec ${jre}/bin/java \$@ -jar $out/share/papermc/papermc.jar nogui
+  '';
+
+  installPhase = ''
+    install -Dm444 ${jar} $out/share/papermc/papermc.jar
+    install -Dm555 -t $out/bin minecraft-server
+  '';
+
+  meta = {
+    description = "High-performance Minecraft Server";
+    homepage    = "https://papermc.io/";
+    license     = lib.licenses.gpl3Only;
+    platforms   = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      alexnortung
+    ];
+  };
+}
+

--- a/pkgs/games/papermc/1.11.nix
+++ b/pkgs/games/papermc/1.11.nix
@@ -1,0 +1,47 @@
+{ lib
+, stdenv
+, fetchurl
+, bash
+, adoptopenjdk-jre-hotspot-bin-13
+}:
+
+# NOTE: Does not work with the current minecraft-server module.
+let
+  mcVersion = "1.11.2";
+  buildNum = "1106";
+  jar = fetchurl {
+    url = "https://papermc.io/api/v2/projects/paper/versions/${mcVersion}/builds/${buildNum}/downloads/paper-${mcVersion}-${buildNum}.jar";
+    sha256 = "PQ9A7B+WMN/br6YmzCDCZtf7kPwiWD3BuZXn+/t2gw0=";
+  };
+  jre = adoptopenjdk-jre-hotspot-bin-13;
+in stdenv.mkDerivation {
+  pname = "papermc";
+  version = "${mcVersion}r${buildNum}";
+
+  preferLocalBuild = true;
+
+  dontUnpack = true;
+  dontConfigure = true;
+
+  buildPhase = ''
+    cat > minecraft-server << EOF
+    #!${bash}/bin/sh
+    exec ${jre}/bin/java \$@ -jar $out/share/papermc/papermc.jar nogui
+  '';
+
+  installPhase = ''
+    install -Dm444 ${jar} $out/share/papermc/papermc.jar
+    install -Dm555 -t $out/bin minecraft-server
+  '';
+
+  meta = {
+    description = "High-performance Minecraft Server";
+    homepage    = "https://papermc.io/";
+    license     = lib.licenses.gpl3Only;
+    platforms   = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      alexnortung
+    ];
+  };
+}
+

--- a/pkgs/games/papermc/1.12.nix
+++ b/pkgs/games/papermc/1.12.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, fetchurl
+, bash
+, adoptopenjdk-jre-hotspot-bin-13
+}:
+
+let
+  mcVersion = "1.12.2";
+  buildNum = "1620";
+  jar = fetchurl {
+    url = "https://papermc.io/api/v2/projects/paper/versions/${mcVersion}/builds/${buildNum}/downloads/paper-${mcVersion}-${buildNum}.jar";
+    sha256 = "OiBBgH9JLc3DTrsySih0FJRuPgXsPfb9A/W199mvwhA=";
+  };
+  jre = adoptopenjdk-jre-hotspot-bin-13;
+in stdenv.mkDerivation {
+  pname = "papermc";
+  version = "${mcVersion}r${buildNum}";
+
+  preferLocalBuild = true;
+
+  dontUnpack = true;
+  dontConfigure = true;
+
+  buildPhase = ''
+    cat > minecraft-server << EOF
+    #!${bash}/bin/sh
+    exec ${jre}/bin/java \$@ -jar $out/share/papermc/papermc.jar nogui
+  '';
+
+  installPhase = ''
+    install -Dm444 ${jar} $out/share/papermc/papermc.jar
+    install -Dm555 -t $out/bin minecraft-server
+  '';
+
+  meta = {
+    description = "High-performance Minecraft Server";
+    homepage    = "https://papermc.io/";
+    license     = lib.licenses.gpl3Only;
+    platforms   = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      alexnortung
+    ];
+  };
+}
+

--- a/pkgs/games/papermc/1.13.nix
+++ b/pkgs/games/papermc/1.13.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, fetchurl
+, bash
+, adoptopenjdk-jre-hotspot-bin-13
+}:
+
+let
+  mcVersion = "1.13.2";
+  buildNum = "657";
+  jar = fetchurl {
+    url = "https://papermc.io/api/v2/projects/paper/versions/${mcVersion}/builds/${buildNum}/downloads/paper-${mcVersion}-${buildNum}.jar";
+    sha256 = "Eego0FZat2oKDhgMBWNkqV3kSVjP1qavP5sdxwsD6c0=";
+  };
+  jre = adoptopenjdk-jre-hotspot-bin-13;
+in stdenv.mkDerivation {
+  pname = "papermc";
+  version = "${mcVersion}r${buildNum}";
+
+  preferLocalBuild = true;
+
+  dontUnpack = true;
+  dontConfigure = true;
+
+  buildPhase = ''
+    cat > minecraft-server << EOF
+    #!${bash}/bin/sh
+    exec ${jre}/bin/java \$@ -jar $out/share/papermc/papermc.jar nogui
+  '';
+
+  installPhase = ''
+    install -Dm444 ${jar} $out/share/papermc/papermc.jar
+    install -Dm555 -t $out/bin minecraft-server
+  '';
+
+  meta = {
+    description = "High-performance Minecraft Server";
+    homepage    = "https://papermc.io/";
+    license     = lib.licenses.gpl3Only;
+    platforms   = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      alexnortung
+    ];
+  };
+}
+

--- a/pkgs/games/papermc/1.14.nix
+++ b/pkgs/games/papermc/1.14.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, fetchurl
+, bash
+, adoptopenjdk-jre-hotspot-bin-13
+}:
+
+let
+  mcVersion = "1.14.4";
+  buildNum = "245";
+  jar = fetchurl {
+    url = "https://papermc.io/api/v2/projects/paper/versions/${mcVersion}/builds/${buildNum}/downloads/paper-${mcVersion}-${buildNum}.jar";
+    sha256 = "vY7FzbIjcNN4FqbeJnmN89Kw1vnHyWyIykWhMD/qUOg=";
+  };
+  jre = adoptopenjdk-jre-hotspot-bin-13;
+in stdenv.mkDerivation {
+  pname = "papermc";
+  version = "${mcVersion}r${buildNum}";
+
+  preferLocalBuild = true;
+
+  dontUnpack = true;
+  dontConfigure = true;
+
+  buildPhase = ''
+    cat > minecraft-server << EOF
+    #!${bash}/bin/sh
+    exec ${jre}/bin/java \$@ -jar $out/share/papermc/papermc.jar nogui
+  '';
+
+  installPhase = ''
+    install -Dm444 ${jar} $out/share/papermc/papermc.jar
+    install -Dm555 -t $out/bin minecraft-server
+  '';
+
+  meta = {
+    description = "High-performance Minecraft Server";
+    homepage    = "https://papermc.io/";
+    license     = lib.licenses.gpl3Only;
+    platforms   = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      alexnortung
+    ];
+  };
+}
+

--- a/pkgs/games/papermc/1.15.nix
+++ b/pkgs/games/papermc/1.15.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, fetchurl
+, bash
+, adoptopenjdk-jre-hotspot-bin-14
+}:
+
+let
+  mcVersion = "1.15.2";
+  buildNum = "393";
+  jar = fetchurl {
+    url = "https://papermc.io/api/v2/projects/paper/versions/${mcVersion}/builds/${buildNum}/downloads/paper-${mcVersion}-${buildNum}.jar";
+    sha256 = "vS3W8sxInPniu4AMtPttY+nSk5RdOsELCd2cYJj6nzQ=";
+  };
+  jre = adoptopenjdk-jre-hotspot-bin-14;
+in stdenv.mkDerivation {
+  pname = "papermc";
+  version = "${mcVersion}r${buildNum}";
+
+  preferLocalBuild = true;
+
+  dontUnpack = true;
+  dontConfigure = true;
+
+  buildPhase = ''
+    cat > minecraft-server << EOF
+    #!${bash}/bin/sh
+    exec ${jre}/bin/java \$@ -jar $out/share/papermc/papermc.jar nogui
+  '';
+
+  installPhase = ''
+    install -Dm444 ${jar} $out/share/papermc/papermc.jar
+    install -Dm555 -t $out/bin minecraft-server
+  '';
+
+  meta = {
+    description = "High-performance Minecraft Server";
+    homepage    = "https://papermc.io/";
+    license     = lib.licenses.gpl3Only;
+    platforms   = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      alexnortung
+    ];
+  };
+}
+

--- a/pkgs/games/papermc/1.16.nix
+++ b/pkgs/games/papermc/1.16.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, fetchurl
+, bash
+, adoptopenjdk-jre-hotspot-bin-16
+}:
+
+let
+  mcVersion = "1.16.5";
+  buildNum = "794";
+  jar = fetchurl {
+    url = "https://papermc.io/api/v2/projects/paper/versions/${mcVersion}/builds/${buildNum}/downloads/paper-${mcVersion}-${buildNum}.jar";
+    sha256 = "5n2khR0IzeN4qyuJvliEkjjDAzUe0kghgamcLCtIknY=";
+  };
+  jre = adoptopenjdk-jre-hotspot-bin-16;
+in stdenv.mkDerivation {
+  pname = "papermc";
+  version = "${mcVersion}r${buildNum}";
+
+  preferLocalBuild = true;
+
+  dontUnpack = true;
+  dontConfigure = true;
+
+  buildPhase = ''
+    cat > minecraft-server << EOF
+    #!${bash}/bin/sh
+    exec ${jre}/bin/java \$@ -jar $out/share/papermc/papermc.jar nogui
+  '';
+
+  installPhase = ''
+    install -Dm444 ${jar} $out/share/papermc/papermc.jar
+    install -Dm555 -t $out/bin minecraft-server
+  '';
+
+  meta = {
+    description = "High-performance Minecraft Server";
+    homepage    = "https://papermc.io/";
+    license     = lib.licenses.gpl3Only;
+    platforms   = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      alexnortung
+    ];
+  };
+}

--- a/pkgs/games/papermc/1.17.nix
+++ b/pkgs/games/papermc/1.17.nix
@@ -31,6 +31,10 @@ in stdenv.mkDerivation {
     homepage    = "https://papermc.io/";
     license     = lib.licenses.gpl3Only;
     platforms   = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ aaronjanse neonfuz ];
+    maintainers = with lib.maintainers; [
+      aaronjanse
+      alexnortung
+      neonfuz
+    ];
   };
 }

--- a/pkgs/games/papermc/1.18.nix
+++ b/pkgs/games/papermc/1.18.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv, fetchurl, bash, jre }:
+let
+  mcVersion = "1.18.1";
+  buildNum = "83";
+  jar = fetchurl {
+    url = "https://papermc.io/api/v2/projects/paper/versions/${mcVersion}/builds/${buildNum}/downloads/paper-${mcVersion}-${buildNum}.jar";
+    sha256 = "EPMYtdGettQfQQbje3xbrAmV6P361hti5o9zm71DkcA=";
+  };
+in stdenv.mkDerivation {
+  pname = "papermc";
+  version = "${mcVersion}r${buildNum}";
+
+  preferLocalBuild = true;
+
+  dontUnpack = true;
+  dontConfigure = true;
+
+  buildPhase = ''
+    cat > minecraft-server << EOF
+    #!${bash}/bin/sh
+    exec ${jre}/bin/java \$@ -jar $out/share/papermc/papermc.jar nogui
+  '';
+
+  installPhase = ''
+    install -Dm444 ${jar} $out/share/papermc/papermc.jar
+    install -Dm555 -t $out/bin minecraft-server
+  '';
+
+  meta = {
+    description = "High-performance Minecraft Server";
+    homepage    = "https://papermc.io/";
+    license     = lib.licenses.gpl3Only;
+    platforms   = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      aaronjanse
+      alexnortung
+      neonfuz
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30652,6 +30652,8 @@ with pkgs;
 
   pacvim = callPackage ../games/pacvim { };
 
+  papermc-1_15_x = callPackage ../games/papermc/1.15.nix { };
+
   papermc-1_16_x = callPackage ../games/papermc/1.16.nix { };
 
   papermc-1_17_x = callPackage ../games/papermc/1.17.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30652,6 +30652,8 @@ with pkgs;
 
   pacvim = callPackage ../games/pacvim { };
 
+  papermc-1_12_x = callPackage ../games/papermc/1.12.nix { };
+
   papermc-1_13_x = callPackage ../games/papermc/1.13.nix { };
 
   papermc-1_14_x = callPackage ../games/papermc/1.14.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30652,6 +30652,8 @@ with pkgs;
 
   pacvim = callPackage ../games/pacvim { };
 
+  papermc-1_14_x = callPackage ../games/papermc/1.14.nix { };
+
   papermc-1_15_x = callPackage ../games/papermc/1.15.nix { };
 
   papermc-1_16_x = callPackage ../games/papermc/1.16.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30652,6 +30652,8 @@ with pkgs;
 
   pacvim = callPackage ../games/pacvim { };
 
+  papermc-1_11_x = callPackage ../games/papermc/1.11.nix { };
+
   papermc-1_12_x = callPackage ../games/papermc/1.12.nix { };
 
   papermc-1_13_x = callPackage ../games/papermc/1.13.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30652,9 +30652,11 @@ with pkgs;
 
   pacvim = callPackage ../games/pacvim { };
 
-  papermc = callPackage ../games/papermc { };
+  papermc-1_17_x = callPackage ../games/papermc/1.17.nix { };
 
   papermc-1_18_x = callPackage ../games/papermc/1.18.nix { };
+
+  papermc = papermc-1_17_x; # current stable build
 
   pentobi = libsForQt5.callPackage ../games/pentobi { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30652,6 +30652,8 @@ with pkgs;
 
   pacvim = callPackage ../games/pacvim { };
 
+  papermc-1_16_x = callPackage ../games/papermc/1.16.nix { };
+
   papermc-1_17_x = callPackage ../games/papermc/1.17.nix { };
 
   papermc-1_18_x = callPackage ../games/papermc/1.18.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30652,6 +30652,8 @@ with pkgs;
 
   pacvim = callPackage ../games/pacvim { };
 
+  papermc-1_13_x = callPackage ../games/papermc/1.13.nix { };
+
   papermc-1_14_x = callPackage ../games/papermc/1.14.nix { };
 
   papermc-1_15_x = callPackage ../games/papermc/1.15.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30652,6 +30652,8 @@ with pkgs;
 
   pacvim = callPackage ../games/pacvim { };
 
+  papermc-1_10_x = callPackage ../games/papermc/1.10.nix { };
+
   papermc-1_11_x = callPackage ../games/papermc/1.11.nix { };
 
   papermc-1_12_x = callPackage ../games/papermc/1.12.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30654,6 +30654,8 @@ with pkgs;
 
   papermc = callPackage ../games/papermc { };
 
+  papermc-1_18_x = callPackage ../games/papermc/1.18.nix { };
+
   pentobi = libsForQt5.callPackage ../games/pentobi { };
 
   performous = callPackage ../games/performous {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This pull request is related to #140499

It should be possible to choose which version of papermc to install, dirctly from nixpkgs.

Added versions
- [x] 1.18
- [x] 1.17
- [x] 1.16
- [x] 1.15
- [x] 1.14
- [x] 1.13
- [x] 1.12
- [x] 1.11 (Did not run correctly with minecraft-server module) (Fix in another pull request)
- [x] 1.10 (Did not run correctly with minecraft-server module) (Fix in another pull request)
- [ ] 1.9 (For another pull request)
- [ ] 1.8 (For another pull request)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ x Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
