### PR TITLE
nixos/privacyidea: increase buffer-size of uwsgi from 4096 to 8192

### DIFF
--- a/nixos/modules/services/security/privacyidea.nix
+++ b/nixos/modules/services/security/privacyidea.nix
@@ -204,6 +204,7 @@ in
       systemd.services.privacyidea = let
         piuwsgi = pkgs.writeText "uwsgi.json" (builtins.toJSON {
           uwsgi = {
+            buffer-size = 8192;
             plugins = [ "python3" ];
             pythonpath = "${penv}/${uwsgi.python3.sitePackages}";
             socket = "/run/privacyidea/socket";


### PR DESCRIPTION
###### Motivation for this change

When accessing the Audit log, I get an HTTP 502 when the frontend
requests `/audit` and I get the following error in my `nginx`-log:

    Dec 20 22:12:48 ldap nginx[336]: 2021/12/20 22:12:48 [error] 336#336: *8421 recv() failed (104: Connection reset by peer) while reading response header from upstream, client: 10.237.0.1, server: _, request: "GET /audit/?action=**&action_detail=**&administrator=**&client=**&date=**&duration=**&info=**&page=1&page_size=10&policies=**&privacyidea_server=**&realm=**&resolver=**&serial=**&sortorder=desc&startdate=**&success=**&tokentype=**&user=** HTTP/1.1", upstream: "uwsgi://unix:/run/privacyidea/socket:", host: "ldap.ist.nicht-so.sexy", referrer: "https://ldap.ist.nicht-so.sexy/"

This is because of an "invalid request block size"-error according to
`journalctl -u privacyidea.service`:

    Dec 20 22:12:48 ldap uwsgi[10721]: invalid request block size: 4245 (max 4096)...skip

Increasing the buffer to 8192 fixes the problem for me.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
