### PR TITLE
coreutils: patch for uname to show the correct arch on arm macos

### DIFF
--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -33,6 +33,9 @@ stdenv.mkDerivation (rec {
     ./fix-chmod-exit-code.patch
     # Workaround for https://debbugs.gnu.org/cgi/bugreport.cgi?bug=51433
     ./disable-seek-hole.patch
+    # Workaround for https://debbugs.gnu.org/cgi/bugreport.cgi?bug=52330
+    # This patch can be dropped, once we upgrade to the next coreutils version after 9.0
+    ./fix-arm64-macos.patch
   ];
 
   postPatch = ''

--- a/pkgs/tools/misc/coreutils/fix-arm64-macos.patch
+++ b/pkgs/tools/misc/coreutils/fix-arm64-macos.patch
@@ -1,0 +1,124 @@
+diff --git a/src/uname.c b/src/uname.c
+index ae9b8e29d..e84fc477a 100644
+--- a/src/uname.c
++++ b/src/uname.c
+@@ -27,7 +27,7 @@
+ # include <sys/systeminfo.h>
+ #endif
+ 
+-#if HAVE_SYS_SYSCTL_H && ! defined __GLIBC__
++#if HAVE_SYS_SYSCTL_H && ! defined __GLIBC__ && ! defined __APPLE__
+ # if HAVE_SYS_PARAM_H
+ #  include <sys/param.h> /* needed for OpenBSD 3.0 */
+ # endif
+@@ -44,11 +44,6 @@
+ # endif
+ #endif
+ 
+-#ifdef __APPLE__
+-# include <mach/machine.h>
+-# include <mach-o/arch.h>
+-#endif
+-
+ #include "system.h"
+ #include "die.h"
+ #include "error.h"
+@@ -167,6 +162,24 @@ print_element (char const *element)
+   fputs (element, stdout);
+ }
+ 
++/* Print ELEMENT, preceded by a space if something has already been
++   printed.  But if the environment variable ENVVAR is set, print its
++   value instead of ELEMENT.  */
++
++static void
++print_element_env (char const *element, char const *envvar)
++{
++#ifdef __APPLE__
++  if (envvar)
++    {
++      char const *val = getenv (envvar);
++      if (val)
++        element = val;
++    }
++#endif
++  print_element (element);
++}
++
+ 
+ /* Set all the option flags according to the switches specified.
+    Return the mask indicating which elements to print.  */
+@@ -287,26 +300,36 @@ main (int argc, char **argv)
+         die (EXIT_FAILURE, errno, _("cannot get system name"));
+ 
+       if (toprint & PRINT_KERNEL_NAME)
+-        print_element (name.sysname);
++        print_element_env (name.sysname, "UNAME_SYSNAME");
+       if (toprint & PRINT_NODENAME)
+-        print_element (name.nodename);
++        print_element_env (name.nodename, "UNAME_NODENAME");
+       if (toprint & PRINT_KERNEL_RELEASE)
+-        print_element (name.release);
++        print_element_env (name.release, "UNAME_RELEASE");
+       if (toprint & PRINT_KERNEL_VERSION)
+-        print_element (name.version);
++        print_element_env (name.version, "UNAME_VERSION");
+       if (toprint & PRINT_MACHINE)
+-        print_element (name.machine);
++        print_element_env (name.machine, "UNAME_MACHINE");
+     }
+ 
+   if (toprint & PRINT_PROCESSOR)
+     {
+       char const *element = unknown;
++#ifdef __APPLE__
++# if defined __arm__ || defined __arm64__
++      element = "arm";
++# elif defined __i386__ || defined __x86_64__
++      element = "i386";
++# elif defined __ppc__ || defined __ppc64__
++      element = "powerpc";
++# endif
++#endif
+ #if HAVE_SYSINFO && defined SI_ARCHITECTURE
+-      {
+-        static char processor[257];
+-        if (0 <= sysinfo (SI_ARCHITECTURE, processor, sizeof processor))
+-          element = processor;
+-      }
++      if (element == unknown)
++        {
++          static char processor[257];
++          if (0 <= sysinfo (SI_ARCHITECTURE, processor, sizeof processor))
++            element = processor;
++        }
+ #endif
+ #ifdef UNAME_PROCESSOR
+       if (element == unknown)
+@@ -316,26 +339,6 @@ main (int argc, char **argv)
+           static int mib[] = { CTL_HW, UNAME_PROCESSOR };
+           if (sysctl (mib, 2, processor, &s, 0, 0) >= 0)
+             element = processor;
+-
+-# ifdef __APPLE__
+-          /* This kludge works around a bug in Mac OS X.  */
+-          if (element == unknown)
+-            {
+-              cpu_type_t cputype;
+-              size_t cs = sizeof cputype;
+-              NXArchInfo const *ai;
+-              if (sysctlbyname ("hw.cputype", &cputype, &cs, NULL, 0) == 0
+-                  && (ai = NXGetArchInfoFromCpuType (cputype,
+-                                                     CPU_SUBTYPE_MULTIPLE))
+-                  != NULL)
+-                element = ai->name;
+-
+-              /* Hack "safely" around the ppc vs. powerpc return value. */
+-              if (cputype == CPU_TYPE_POWERPC
+-                  && STRNCMP_LIT (element, "ppc") == 0)
+-                element = "powerpc";
+-            }
+-# endif
+         }
+ #endif
+       if (! (toprint == UINT_MAX && element == unknown))


### PR DESCRIPTION
###### Motivation for this change

Until a recent patch in coreutils, gnus uname -p returned a different
arch on apple silicon macs, compared to the uname shipped with macos.
This causes config.guess to produce incorrect build system triplets
for various projects on these systems when in a nix-shell.[23][42]

As coreutils only releases every few months/years and no release is
planned at the moment, I'm introducing the patch here. We can drop it
once the next coreutils version is released.

I made a tiny adjustment to the patch from [23]. I removed the usage
of MAYBE_UNUSED, which currently only compiles against HEAD.

[23] https://debbugs.gnu.org/cgi/bugreport.cgi?bug=52330
[42] https://github.com/NixOS/nixpkgs/issues/147914

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
**^ I think so, as sandbox is not set in my /etc/nix/nix.conf and it defaults true.**
- [ ] Tested, as applicable:
**^ Seems to require nixos and not nix on macos.**
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages

- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
**^ Unfeasible for coreutils changes due to large dependency tree.**
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
**^ Unfeasible for coreutils changes. I did verify the uname build and desired behavior though.**
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
