### PR TITLE
opentoonz: 1.4.0 -> 1.5.0

### DIFF
--- a/pkgs/applications/graphics/opentoonz/default.nix
+++ b/pkgs/applications/graphics/opentoonz/default.nix
@@ -1,6 +1,6 @@
 { boost, cmake, fetchFromGitHub, freeglut, freetype, glew, libjpeg, libmypaint
-, libpng, libtiff, libusb1, lz4, xz, lzo, openblas, pkg-config, qtbase
-, qtmultimedia, qtscript, lib, stdenv, superlu, wrapQtAppsHook, }:
+, libpng, libtiff, libusb1, lz4, xz, lzo, openblas, opencv, pkg-config, qtbase
+, qtmultimedia, qtscript, qtserialport, lib, stdenv, superlu, wrapQtAppsHook, }:
 let source = import ./source.nix { inherit fetchFromGitHub; };
 in stdenv.mkDerivation rec {
   inherit (source) src;
@@ -24,9 +24,11 @@ in stdenv.mkDerivation rec {
     xz
     lzo
     openblas
+    opencv
     qtbase
     qtmultimedia
     qtscript
+    qtserialport
     superlu
   ];
 

--- a/pkgs/applications/graphics/opentoonz/libtiff.nix
+++ b/pkgs/applications/graphics/opentoonz/libtiff.nix
@@ -34,6 +34,23 @@ in stdenv.mkDerivation {
   '';
 
   meta = libtiff.meta // {
+    knownVulnerabilities = [''
+      Do not open untrusted files with Opentoonz:
+      Opentoonz uses an old custom fork of tibtiff from 2012 that is known to
+      be affected by at least these 50 vulnerabilities:
+        CVE-2012-4564 CVE-2013-4232 CVE-2013-4243 CVE-2013-4244 CVE-2014-8127
+        CVE-2014-8128 CVE-2014-8129 CVE-2014-8130 CVE-2014-9330 CVE-2015-1547
+        CVE-2015-8781 CVE-2015-8782 CVE-2015-8783 CVE-2015-8784 CVE-2015-8870
+        CVE-2016-3620 CVE-2016-3621 CVE-2016-3623 CVE-2016-3624 CVE-2016-3625
+        CVE-2016-3631 CVE-2016-3632 CVE-2016-3633 CVE-2016-3634 CVE-2016-3658
+        CVE-2016-3945 CVE-2016-3990 CVE-2016-3991 CVE-2016-5102 CVE-2016-5314
+        CVE-2016-5315 CVE-2016-5316 CVE-2016-5318 CVE-2016-5319 CVE-2016-5321
+        CVE-2016-5322 CVE-2016-5323 CVE-2016-6223 CVE-2016-9453 CVE-2016-9532
+        CVE-2017-9935 CVE-2017-9937 CVE-2018-10963 CVE-2018-5360
+        CVE-2019-14973 CVE-2019-17546 CVE-2020-35521 CVE-2020-35522
+        CVE-2020-35523 CVE-2020-35524
+      More info at https://github.com/opentoonz/opentoonz/issues/4193
+    ''];
     maintainers = with lib.maintainers; [ chkno ];
   };
 }

--- a/pkgs/applications/graphics/opentoonz/libtiff.nix
+++ b/pkgs/applications/graphics/opentoonz/libtiff.nix
@@ -2,20 +2,38 @@
 # opentoonz requires its own modified version of libtiff.  We still build it as
 # a separate package
 #  1. For visibility for tools like vulnix, and
-#  2. To avoid a diamond-dependency problem with qt linking the normal libtiff
-#     and opentoonz linking qt and this modified libtiff, we build a qt against
-#     this modified libtiff as well.
+#  2. To avoid a diamond-dependency problem with opencv linking the normal libtiff
+#     and opentoonz linking opencv and this modified libtiff, we build an opencv
+#     against this modified libtiff as well.
+#
+# We use a separate mkDerivation rather than a minimal libtiff.overrideAttrs
+# because the main libtiff builds with cmake and this version of libtiff was
+# forked before libtiff gained CMake build capability (added in libtiff-4.0.5).
 
-{ fetchFromGitHub, libtiff }:
+{ lib, fetchFromGitHub, stdenv, pkg-config, zlib, libjpeg, xz, libtiff, }:
+
 let source = import ./source.nix { inherit fetchFromGitHub; };
-in libtiff.overrideAttrs (old: {
-  inherit (source) src;
+
+in stdenv.mkDerivation {
+  pname = "libtiff";
   version = source.versions.libtiff + "-opentoonz";
-  postUnpack = (old.postUnpack or "") + ''
+
+  inherit (source) src;
+  outputs = [ "bin" "dev" "out" "man" "doc" ];
+
+  nativeBuildInputs = [ pkg-config ];
+  propagatedBuildInputs = [ zlib libjpeg xz ];
+
+  postUnpack = ''
     sourceRoot="$sourceRoot/thirdparty/tiff-${source.versions.libtiff}"
   '';
+
   # opentoonz uses internal libtiff headers
-  postInstall = (old.postInstall or "") + ''
+  postInstall = ''
     cp libtiff/{tif_config,tif_dir,tiffiop}.h $dev/include
   '';
-})
+
+  meta = libtiff.meta // {
+    maintainers = with lib.maintainers; [ chkno ];
+  };
+}

--- a/pkgs/applications/graphics/opentoonz/source.nix
+++ b/pkgs/applications/graphics/opentoonz/source.nix
@@ -3,14 +3,14 @@
 
 { fetchFromGitHub, }: rec {
   versions = {
-    opentoonz = "1.4.0";
-    libtiff = "4.0.3";
+    opentoonz = "1.5.0";
+    libtiff = "4.0.3";  # The version in thirdparty/tiff-*
   };
 
   src = fetchFromGitHub {
     owner = "opentoonz";
     repo = "opentoonz";
     rev = "v${versions.opentoonz}";
-    sha256 = "0vgclx2yydsm5i2smff3fj8m750nhf35wfhva37kywgws01s189b";
+    sha256 = "1rw30ksw3zjph1cwxkfvqj0330v8wd4333gn0fdf3cln1w0549lk";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27591,9 +27591,12 @@ with pkgs;
 
   opentimestamps-client = python3Packages.callPackage ../tools/misc/opentimestamps-client {};
 
-  opentoonz = (qt514.overrideScope' (_: _: {
-    libtiff = callPackage ../applications/graphics/opentoonz/libtiff.nix { };
-  })).callPackage ../applications/graphics/opentoonz { };
+  opentoonz = let
+    opentoonz-libtiff = callPackage ../applications/graphics/opentoonz/libtiff.nix { };
+  in qt5.callPackage ../applications/graphics/opentoonz {
+    libtiff = opentoonz-libtiff;
+    opencv = opencv.override { libtiff = opentoonz-libtiff; };
+  };
 
   opentabletdriver = callPackage ../tools/X11/opentabletdriver { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix opentoonz build.

Fixes #132964.

Addresses #151469 for opentoonz (I verified that opentoonz works in `staging-next` after this version bump).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
