### PR TITLE
calamares: fix module functionality

### DIFF
--- a/pkgs/tools/misc/calamares/default.nix
+++ b/pkgs/tools/misc/calamares/default.nix
@@ -33,18 +33,17 @@ mkDerivation rec {
 
   postPatch = ''
     sed -e "s,/usr/bin/calamares,$out/bin/calamares," \
-        -i calamares.desktop \
         -i com.github.calamares.calamares.policy
+
+    sed -e "s,pkexec calamares,pkexec $out/bin/calamares," \
+        -i calamares.desktop
 
     sed -e 's,/usr/share/zoneinfo,${tzdata}/share/zoneinfo,' \
         -i src/modules/locale/SetTimezoneJob.cpp \
-        -i src/modules/locale/Tests.cpp \
         -i src/libcalamares/locale/TimeZone.cpp \
-        -i src/libcalamares/locale/zone-extractor.py
 
     sed -e 's,/usr/share/X11/xkb/rules/base.lst,${xkeyboard_config}/share/X11/xkb/rules/base.lst,' \
         -i src/modules/keyboard/keyboardwidget/keyboardglobal.cpp \
-        -i src/modules/keyboard/layout-extractor.py
 
     sed -e 's,"ckbcomp","${ckbcomp}/bin/ckbcomp",' \
         -i src/modules/keyboard/keyboardwidget/keyboardpreview.cpp

--- a/pkgs/tools/misc/calamares/default.nix
+++ b/pkgs/tools/misc/calamares/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchurl, boost, cmake, extra-cmake-modules, kparts, kpmcore
-, kservice, libatasmart, libxcb, libyamlcpp, parted, polkit-qt, python, qtbase
-, qtquickcontrols, qtsvg, qttools, qtwebengine, util-linux, tzdata
+, kservice, libatasmart, libxcb, libyamlcpp, libpwquality, parted, polkit-qt, python
+, qtbase, qtquickcontrols, qtsvg, qttools, qtwebengine, util-linux, tzdata
 , ckbcomp, xkeyboard_config, mkDerivation
 }:
 
@@ -17,8 +17,8 @@ mkDerivation rec {
   nativeBuildInputs = [ cmake extra-cmake-modules ];
   buildInputs = [
     boost kparts.dev kpmcore.out kservice.dev
-    libatasmart libxcb libyamlcpp parted polkit-qt python qtbase
-    qtquickcontrols qtsvg qttools qtwebengine.dev util-linux
+    libatasmart libxcb libyamlcpp libpwquality parted polkit-qt python
+    qtbase qtquickcontrols qtsvg qttools qtwebengine.dev util-linux
   ];
 
   cmakeFlags = [
@@ -37,10 +37,14 @@ mkDerivation rec {
         -i com.github.calamares.calamares.policy
 
     sed -e 's,/usr/share/zoneinfo,${tzdata}/share/zoneinfo,' \
-        -i src/modules/locale/SetTimezoneJob.cpp
+        -i src/modules/locale/SetTimezoneJob.cpp \
+        -i src/modules/locale/Tests.cpp \
+        -i src/libcalamares/locale/TimeZone.cpp \
+        -i src/libcalamares/locale/zone-extractor.py
 
     sed -e 's,/usr/share/X11/xkb/rules/base.lst,${xkeyboard_config}/share/X11/xkb/rules/base.lst,' \
-        -i src/modules/keyboard/keyboardwidget/keyboardglobal.h
+        -i src/modules/keyboard/keyboardwidget/keyboardglobal.cpp \
+        -i src/modules/keyboard/layout-extractor.py
 
     sed -e 's,"ckbcomp","${ckbcomp}/bin/ckbcomp",' \
         -i src/modules/keyboard/keyboardwidget/keyboardpreview.cpp


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The calamares locale module segfaults and crashes calamares when loaded. When the keyboard module is used, no options are available. Both of these modules were broken due to hardcoded paths pointing to the wrong files. Also, the password quality checking functionality in the users module was missing.

###### Things done

Changed hardcoded paths to fix the issues in the locale and keyboard modules. Also added libpwquality dependency to enable password quality checking in the users module.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
