### PR TITLE
kubergrunt: init at 0.7.11

### DIFF
--- a/pkgs/applications/networking/cluster/kubergrunt/default.nix
+++ b/pkgs/applications/networking/cluster/kubergrunt/default.nix
@@ -1,0 +1,33 @@
+{ buildGoModule, lib, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "kubergrunt";
+  version = "0.7.11";
+
+  src = fetchFromGitHub {
+    owner = "gruntwork-io";
+    repo = "kubergrunt";
+    rev = "v${version}";
+    sha256 = "1224ssqdz9ak0vylyfbr9c2w0yfdp4hw9jh99qmfi2j5nhw9kzcc";
+  };
+
+  vendorSha256 = "1hbb3hn8mzz9h9p1rl35izz3l6c2rqsg8aq6dgpbpsf5krp3zs3v";
+
+  # Disable tests since it requires network access and relies on the
+  # presence of certain AWS infrastructure
+  doCheck = false;
+
+  runVend = true;
+
+  postInstall = ''
+    # The binary is named kubergrunt
+    mv $out/bin/cmd $out/bin/kubergrunt
+  '';
+
+  meta = with lib; {
+    description = "Collection of commands to fill in the gaps between Terraform, Helm, and Kubectl";
+    homepage = "https://github.com/gruntwork-io/kubergrunt";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ psibi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6906,6 +6906,8 @@ with pkgs;
 
   kubepug = callPackage ../development/tools/kubepug { };
 
+  kubergrunt = callPackage ../applications/networking/cluster/kubergrunt { };
+
   kwalletcli = libsForQt5.callPackage ../tools/security/kwalletcli { };
 
   peruse = libsForQt5.callPackage ../tools/misc/peruse { };


### PR DESCRIPTION
This is a helper utility which allows to configure EKS clusters etc.

Tested it locally on a NixOS machine:

``` shellsession
❯ kubergrunt help
Usage: kubergrunt [--loglevel] [--help] command [options] [args]

A CLI tool to help setup and manage a Kubernetes cluster.

Commands:

   eks      Helper commands to configure EKS.
   k8s      Helper scripts for managing Kubernetes resources directly.
   tls      Helper commands to manage TLS certificate key pairs as Kubernetes Secrets.
   help, h  Shows a list of commands or help for one command
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
