### PR TITLE
gnome.epiphany: 41.2 → 41.3

### DIFF
--- a/pkgs/desktops/gnome/core/epiphany/default.nix
+++ b/pkgs/desktops/gnome/core/epiphany/default.nix
@@ -41,11 +41,11 @@
 
 stdenv.mkDerivation rec {
   pname = "epiphany";
-  version = "41.2";
+  version = "41.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "Ud5KGB+nxKEs3DDMsWQ2ElwaFt+av44/pTP8gb8Q60w=";
+    sha256 = "ugEmjuVPMY39rC4B66OKP8lpQMHL9kDtJhOuKfi8ua0=";
   };
 
   patches = lib.optionals withPantheon [


### PR DESCRIPTION
###### Motivation for this change

#### 41.3 - December 20, 2021

> https://gitlab.gnome.org/GNOME/epiphany/-/blob/41.3/NEWS
> https://gitlab.gnome.org/GNOME/epiphany/-/compare/41.2...41.3

 * Fix Reload buttons on error pages (<a href="https://gitlab.gnome.org/GNOME/epiphany/merge_requests/1050">!1050</a>)
 * Fix delete button in about:applications (<a href="https://gitlab.gnome.org/GNOME/epiphany/merge_requests/1050">!1050</a>)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
