### PR TITLE
badvpn: refactor

### DIFF
--- a/pkgs/tools/networking/badvpn/default.nix
+++ b/pkgs/tools/networking/badvpn/default.nix
@@ -1,39 +1,29 @@
-{lib, stdenv, fetchurl, cmake, openssl, nss, pkg-config, nspr, bash, debug ? false}:
-let
-  s = # Generated upstream information
-  rec {
-    baseName="badvpn";
-    version="1.999.130";
-    name="${baseName}-${version}";
-    hash="02b1fra43l75mljkhrq45vcrrqv0znicjn15g7nbqx3jppzbpm5z";
-    url="https://github.com/ambrop72/badvpn/archive/1.999.130.tar.gz";
-    sha256="02b1fra43l75mljkhrq45vcrrqv0znicjn15g7nbqx3jppzbpm5z";
+{ lib, stdenv, fetchurl, cmake, openssl, nss, pkg-config, nspr, bash, debug ? false }:
+
+stdenv.mkDerivation rec {
+  pname = "badvpn";
+  version = "1.999.130";
+  src = fetchurl {
+    url = "https://github.com/ambrop72/badvpn/archive/${version}.tar.gz";
+    sha256 = "sha256-v9S7/r1ydLzseSVYyaL9YOOc2S4EZzglreXQQVR2YQk=";
   };
-
-
-  compileFlags = "-O3 ${lib.optionalString (!debug) "-DNDEBUG"}";
-in
-stdenv.mkDerivation {
-  inherit (s) name version;
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [
-    openssl nss nspr
+    openssl
+    nss
+    nspr
   ];
-  src = fetchurl {
-    inherit (s) url sha256;
-  };
 
   preConfigure = ''
     find . -name '*.sh' -exec sed -e 's@#!/bin/sh@${stdenv.shell}@' -i '{}' ';'
     find . -name '*.sh' -exec sed -e 's@#!/bin/bash@${bash}/bin/bash@' -i '{}' ';'
-    cmakeFlagsArray=("-DCMAKE_BUILD_TYPE=" "-DCMAKE_C_FLAGS=${compileFlags}");
+    cmakeFlagsArray=("-DCMAKE_BUILD_TYPE=" "-DCMAKE_C_FLAGS=-O3 ${lib.optionalString (!debug) "-DNDEBUG"}");
   '';
 
-  meta = {
-    inherit (s) version;
+  meta = with lib; {
     description = "A set of network-related (mostly VPN-related) tools";
-    license = lib.licenses.bsd3 ;
-    maintainers = [lib.maintainers.raskin];
-    platforms = lib.platforms.linux;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ raskin ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/networking/badvpn/default.upstream
+++ b/pkgs/tools/networking/badvpn/default.upstream
@@ -1,3 +1,0 @@
-url https://github.com/ambrop72/badvpn/releases
-version_link '[0-9][.]tar[.][a-z0-9]+$'
-version '.*/([0-9.]+)[.]tar[.].*' '\1'


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
cleanup with no indirections

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
