### PR TITLE
zpaqd: refactor

### DIFF
--- a/pkgs/tools/archivers/zpaq/default.upstream
+++ b/pkgs/tools/archivers/zpaq/default.upstream
@@ -1,6 +1,0 @@
-url http://mattmahoney.net/dc/zpaq.html
-version_link 'zpaq[0-9]+[.]zip'
-version "[^0-9]*([0-9]+)[^0-9]*" '\1'
-name zpaq
-attribute_name zpaq
-minimize_overwrite

--- a/pkgs/tools/archivers/zpaq/zpaqd.nix
+++ b/pkgs/tools/archivers/zpaq/zpaqd.nix
@@ -1,25 +1,17 @@
 { lib, stdenv, fetchurl, unzip }:
 
 let
-  # Generated upstream information
-  s = rec {
-    baseName="zpaqd";
-    version="715";
-    name="${baseName}-${version}";
-    hash="0868lynb45lm79yvx5f10lj5h6bfv0yck8whcls2j080vmk3n7rk";
-    url="http://mattmahoney.net/dc/zpaqd715.zip";
-    sha256="0868lynb45lm79yvx5f10lj5h6bfv0yck8whcls2j080vmk3n7rk";
-  };
-
   compileFlags = lib.concatStringsSep " " ([ "-O3" "-DNDEBUG" ]
     ++ lib.optional (stdenv.hostPlatform.isUnix) "-Dunix -pthread"
     ++ lib.optional (!stdenv.hostPlatform.isx86) "-DNOJIT");
 in
-stdenv.mkDerivation {
-  inherit (s) name version;
+stdenv.mkDerivation rec {
+  pname = "zpaqd";
+  version = "715";
 
   src = fetchurl {
-    inherit (s) url sha256;
+    url = "http://mattmahoney.net/dc/zpaqd${version}.zip";
+    sha256 = "sha256-Mx87Zt0AASk0ZZCjyTzYbhlYJAXBlb59OpUWsqynyCA=";
   };
 
   sourceRoot = ".";
@@ -41,7 +33,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "ZPAQ archive (de)compressor and algorithm development tool";
-    license = licenses.gpl3Plus ;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ raskin ];
     platforms = platforms.linux;
   };

--- a/pkgs/tools/archivers/zpaq/zpaqd.upstream
+++ b/pkgs/tools/archivers/zpaq/zpaqd.upstream
@@ -1,5 +1,0 @@
-url http://mattmahoney.net/dc/zpaqutil.html
-version_link 'zpaqd[0-9]+[.]zip'
-version "[^0-9]*([0-9]+)[^0-9]*" '\1'
-name zpaqd
-attribute_name zpaqd


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
cleanup with no indirections

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
