### PR TITLE
quantumminigolf: refactor

### DIFF
--- a/pkgs/games/quantumminigolf/default.nix
+++ b/pkgs/games/quantumminigolf/default.nix
@@ -1,40 +1,38 @@
-{lib, stdenv, fetchurl, fftwSinglePrec, freetype, SDL, SDL_ttf}:
-let
-  s = # Generated upstream information
-  rec {
-    baseName="quantumminigolf";
-    version="1.1.1";
-    name="${baseName}-${version}";
-    hash="16av7fk0irhi5nd7y9h9vhb0kf0dk12p6976ai3f60m99qdd8wk3";
-    url="mirror://sourceforge/project/quantumminigolf/quantumminigolf/1.1.1/quantumminigolf-1.1.1.src.tar.gz";
-    sha256="16av7fk0irhi5nd7y9h9vhb0kf0dk12p6976ai3f60m99qdd8wk3";
-  };
-  buildInputs = [
-    fftwSinglePrec freetype SDL SDL_ttf
-  ];
-in
-stdenv.mkDerivation {
-  inherit (s) name version;
-  inherit buildInputs;
+{ lib, stdenv, fetchurl, fftwSinglePrec, freetype, SDL, SDL_ttf }:
+
+stdenv.mkDerivation rec {
+  pname = "quantumminigolf";
+  version = "1.1.1";
+
   src = fetchurl {
-    inherit (s) url sha256;
+    url = "mirror://sourceforge/project/quantumminigolf/quantumminigolf/${version}/quantumminigolf-${version}.src.tar.gz";
+    sha256 = "sha256-Y3LUGk6pAuNGVOYkc0WYDbgJFtwJJn+aLRHmCKY7W5k=";
   };
+
+  buildInputs = [
+    fftwSinglePrec
+    freetype
+    SDL
+    SDL_ttf
+  ];
+
   preBuild = ''
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${SDL.dev}/include/SDL -I${SDL_ttf}/include/SDL"
 
     sed -re 's@"(gfx|fonts|tracks)/@"'"$out"'/share/quantumminigolf/\1/@g' -i *.cpp
   '';
+
   installPhase = ''
     mkdir -p "$out"/{share/doc,share/quantumminigolf,bin}
     cp README THANKS LICENSE "$out/share/doc"
     cp -r fonts gfx tracks "$out/share/quantumminigolf"
     cp quantumminigolf "$out/bin"
   '';
-  meta = {
-    inherit (s) version;
+
+  meta = with lib; {
     description = "Quantum mechanics-based minigolf-like game";
-    license = lib.licenses.gpl2 ;
-    maintainers = [lib.maintainers.raskin];
-    platforms = lib.platforms.linux;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ raskin ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/games/quantumminigolf/default.upstream
+++ b/pkgs/games/quantumminigolf/default.upstream
@@ -1,4 +1,0 @@
-url https://sourceforge.net/projects/quantumminigolf/files/quantumminigolf/
-SF_version_dir
-version_link '[.]tar[.][^.]+/download$'
-SF_redirect


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
cleanup with no indirections

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
