### PR TITLE
mailsend: refactor

### DIFF
--- a/pkgs/tools/networking/mailsend/default.nix
+++ b/pkgs/tools/networking/mailsend/default.nix
@@ -1,24 +1,17 @@
-{lib, stdenv, fetchurl, openssl}:
-let
-  s = # Generated upstream information
-  rec {
-    baseName="mailsend";
-    version="1.19";
-    name="${baseName}-${version}";
-    hash="1xwk6jvl5li8ddlik1lj88qswnyminp9wlf5cm8gg3n54szgcpjn";
-    url="https://github.com/muquit/mailsend/archive/1.19.tar.gz";
-    sha256="1xwk6jvl5li8ddlik1lj88qswnyminp9wlf5cm8gg3n54szgcpjn";
+{ lib, stdenv, fetchurl, openssl }:
+
+stdenv.mkDerivation rec {
+  pname = "mailsend";
+  version = "1.19";
+
+  src = fetchurl {
+    url = "https://github.com/muquit/mailsend/archive/${version}.tar.gz";
+    sha256 = "sha256-Vl72vibFjvdQZcVRnq6N1VuuMUKShhlpayjSQrc0k/c=";
   };
+
   buildInputs = [
     openssl
   ];
-in
-stdenv.mkDerivation {
-  inherit (s) name version;
-  inherit buildInputs;
-  src = fetchurl {
-    inherit (s) url sha256;
-  };
   configureFlags = [
     "--with-openssl=${openssl.dev}"
   ];
@@ -29,12 +22,11 @@ stdenv.mkDerivation {
       sha256 = "0vz373zcfl19inflybfjwshcq06rvhx0i5g0f4b021cxfhyb1sm0";
     })
   ];
-  meta = {
-    inherit (s) version;
+  meta = with lib; {
     description = "CLI email sending tool";
-    license = lib.licenses.bsd3 ;
-    maintainers = [lib.maintainers.raskin];
-    platforms = lib.platforms.linux;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ raskin ];
+    platforms = platforms.linux;
     homepage = "https://github.com/muquit/mailsend";
     downloadPage = "https://github.com/muquit/mailsend/releases";
   };

--- a/pkgs/tools/networking/mailsend/default.upstream
+++ b/pkgs/tools/networking/mailsend/default.upstream
@@ -1,3 +1,0 @@
-url "https://github.com/muquit/mailsend/releases"
-ensure_choice
-version '.*/([0-9][0-9.a-z]*)[.]tar[.].*' '\1'


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
cleanup with no indirections

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
