### PR TITLE
ecl: refactor

### DIFF
--- a/pkgs/development/compilers/ecl/default.nix
+++ b/pkgs/development/compilers/ecl/default.nix
@@ -1,40 +1,48 @@
-{lib, stdenv, fetchurl, fetchpatch
-, libtool, autoconf, automake
+{ lib
+, stdenv
+, fetchurl
+, fetchpatch
+, libtool
+, autoconf
+, automake
 , texinfo
-, gmp, mpfr, libffi, makeWrapper
+, gmp
+, mpfr
+, libffi
+, makeWrapper
 , noUnicode ? false
 , gcc
 , threadSupport ? true
-, useBoehmgc ? false, boehmgc
+, useBoehmgc ? false
+, boehmgc
 }:
-let
-  s = # Generated upstream information
-  rec {
-    baseName="ecl";
-    version="21.2.1";
-    name="${baseName}-${version}";
-    url="https://common-lisp.net/project/ecl/static/files/release/${name}.tgz";
-    sha256="000906nnq25177bgsfndiw3iqqgrjc9spk10hzk653sbz3f7anmi";
+
+stdenv.mkDerivation rec {
+  pname = "ecl";
+  version = "21.2.1";
+
+  src = fetchurl {
+    url = "https://common-lisp.net/project/ecl/static/files/release/ecl-${version}.tgz";
+    sha256 = "sha256-sVp13PhLj2LmhyDMqxOT+WEcB4/NOv3WOaEIbK0BCQA=";
   };
+
   nativeBuildInputs = [
-    libtool autoconf automake texinfo makeWrapper
+    libtool
+    autoconf
+    automake
+    texinfo
+    makeWrapper
   ];
   propagatedBuildInputs = [
-    libffi gmp mpfr gcc
+    libffi
+    gmp
+    mpfr
+    gcc
     # replaces ecl's own gc which other packages can depend on, thus propagated
   ] ++ lib.optionals useBoehmgc [
     # replaces ecl's own gc which other packages can depend on, thus propagated
     boehmgc
   ];
-in
-stdenv.mkDerivation {
-  inherit (s) version;
-  pname = s.baseName;
-  inherit nativeBuildInputs propagatedBuildInputs;
-
-  src = fetchurl {
-    inherit (s) url sha256;
-  };
 
   patches = [
     # https://gitlab.com/embeddable-common-lisp/ecl/-/merge_requests/1
@@ -70,9 +78,9 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Lisp implementation aiming to be small, fast and easy to embed";
     homepage = "https://common-lisp.net/project/ecl/";
-    license = licenses.mit ;
-    maintainers = [ maintainers.raskin ];
+    license = licenses.mit;
+    maintainers = with maintainers; [ raskin ];
     platforms = platforms.unix;
-    changelog = "https://gitlab.com/embeddable-common-lisp/ecl/-/raw/${s.version}/CHANGELOG";
+    changelog = "https://gitlab.com/embeddable-common-lisp/ecl/-/raw/${version}/CHANGELOG";
   };
 }

--- a/pkgs/development/compilers/ecl/default.upstream
+++ b/pkgs/development/compilers/ecl/default.upstream
@@ -1,2 +1,0 @@
-url https://common-lisp.net/project/ecl/
-version_link '[.]tgz$'


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
cleanup with no indirections

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
