### PR TITLE
conspy: refactor

### DIFF
--- a/pkgs/os-specific/linux/conspy/default.nix
+++ b/pkgs/os-specific/linux/conspy/default.nix
@@ -1,25 +1,21 @@
-{lib, stdenv, fetchurl, autoconf, automake, ncurses}:
-let
-  s = # Generated upstream information
-  rec {
-    baseName="conspy";
-    version="1.16";
-    name="${baseName}-${version}";
-    hash="02andak806vd04bgjlr0y0d2ddx7cazyf8nvca80vlh8x94gcppf";
-    url="mirror://sourceforge/project/conspy/conspy-1.16-1/conspy-1.16.tar.gz";
-    sha256="02andak806vd04bgjlr0y0d2ddx7cazyf8nvca80vlh8x94gcppf";
-  };
-  buildInputs = [
-    autoconf automake ncurses
-  ];
-in
-stdenv.mkDerivation {
-  inherit (s) name version;
-  inherit buildInputs;
+{ lib, stdenv, fetchurl, autoconf, automake, ncurses }:
+
+stdenv.mkDerivation rec {
+  pname = "conspy";
+  version = "1.16";
+
   src = fetchurl {
-    inherit (s) url sha256;
+    url = "mirror://sourceforge/project/conspy/conspy-${version}-1/conspy-${version}.tar.gz";
+    sha256 = "02andak806vd04bgjlr0y0d2ddx7cazyf8nvca80vlh8x94gcppf";
     curlOpts = " -A application/octet-stream ";
   };
+
+  buildInputs = [
+    autoconf
+    automake
+    ncurses
+  ];
+
   preConfigure = ''
     touch NEWS
     echo "EPL 1.0" > COPYING
@@ -27,11 +23,11 @@ stdenv.mkDerivation {
     automake --add-missing
     autoconf
   '';
-  meta = {
-    inherit (s) version;
+
+  meta = with lib; {
     description = "Linux text console viewer";
-    license = lib.licenses.epl10 ;
-    maintainers = [lib.maintainers.raskin];
-    platforms = lib.platforms.linux;
+    license = licenses.epl10;
+    maintainers = with maintainers; [ raskin ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/conspy/default.upstream
+++ b/pkgs/os-specific/linux/conspy/default.upstream
@@ -1,5 +1,0 @@
-url https://sourceforge.net/projects/conspy/files/
-version_link 'conspy-[-0-9.]+/$'
-version_link '[-0-9.]+[.]tar[.][a-z0-9]+/download$'
-SF_redirect
-version '.*-([-0-9.]+)[.]tar[.].*' '\1'


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
cleanup with no indirections

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
