### PR TITLE
forktty: refactor

### DIFF
--- a/pkgs/os-specific/linux/forktty/default.nix
+++ b/pkgs/os-specific/linux/forktty/default.nix
@@ -1,36 +1,29 @@
-{lib, stdenv, fetchurl}:
-let
-  s = # Generated upstream information
-  rec {
-    baseName="forktty";
-    version="1.3";
-    name="${baseName}-${version}";
-    hash="0nd55zdqly6nl98k9lc7j751x86cw9hayx1qn0725f22r1x3j5zb";
-    url="http://sunsite.unc.edu/pub/linux/utils/terminal/forktty-1.3.tgz";
-    sha256="0nd55zdqly6nl98k9lc7j751x86cw9hayx1qn0725f22r1x3j5zb";
-  };
-  buildInputs = [
-  ];
-in
-stdenv.mkDerivation {
-  inherit (s) name version;
-  inherit buildInputs;
+{ lib, stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "forktty";
+  version = "1.3";
+
   src = fetchurl {
-    inherit (s) url sha256;
+    url = "http://sunsite.unc.edu/pub/linux/utils/terminal/forktty-${version}.tgz";
+    sha256 = "sha256-6xc5eshCuCIOsDh0r2DizKAeypGH0TRRotZ4itsvpVk=";
   };
+
   preBuild = ''
     sed -e s@/usr/bin/ginstall@install@g -i Makefile
   '';
+
   preInstall = ''
     mkdir -p "$out/bin"
     mkdir -p "$out/share/man/man8"
   '';
+
   makeFlags = [ "prefix=$(out)" "manprefix=$(out)/share/" ];
-  meta = {
-    inherit (s) version;
+
+  meta = with lib; {
     description = "Tool to detach from controlling TTY and attach to another";
-    license = lib.licenses.gpl2 ;
-    maintainers = [lib.maintainers.raskin];
-    platforms = lib.platforms.linux;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ raskin ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/forktty/default.upstream
+++ b/pkgs/os-specific/linux/forktty/default.upstream
@@ -1,2 +1,0 @@
-url http://sunsite.unc.edu/pub/linux/utils/terminal/
-version_link 'forktty.*tgz'


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
cleanup with no indirections

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
