### PR TITLE
mopidy-jellyfin: init at 1.0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4174,6 +4174,16 @@
     githubId = 1313787;
     name = "Gabriel Gonzalez";
   };
+   gador = {
+    email = "florian.brandes@posteo.de";
+    github = "gador";
+    githubId = 1883533;
+    name = "Florian Brandes";
+    keys = [{
+      longkeyid = "rsa4096/0xBBB3E40E53797FD9";
+      fingerprint = "0200 3EF8 8D2B CF2D 8F00  FFDC BBB3 E40E 5379 7FD9";
+    }];
+  };
   gal_bolle = {
     email = "florent.becker@ens-lyon.org";
     github = "FlorentBecker";

--- a/pkgs/applications/audio/mopidy/default.nix
+++ b/pkgs/applications/audio/mopidy/default.nix
@@ -9,6 +9,8 @@ lib.makeScope newScope (self: with self; {
 
   mopidy-iris = callPackage ./iris.nix { };
 
+  mopidy-jellyfin = callPackage ./jellyfin.nix { };
+
   mopidy-local = callPackage ./local.nix { };
 
   mopidy-moped = callPackage ./moped.nix { };

--- a/pkgs/applications/audio/mopidy/jellyfin.nix
+++ b/pkgs/applications/audio/mopidy/jellyfin.nix
@@ -1,0 +1,25 @@
+{ lib, fetchFromGitHub, python3Packages, mopidy }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "mopidy-jellyfin";
+  version = "v1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "jellyfin";
+    repo = pname;
+    rev = version;
+    sha256 = "1ixx3pxf5krhj7jpg0nhxmxvpxzwj79i63a4d58zkpr7baj60iy0";
+  };
+
+  propagatedBuildInputs = [ mopidy python3Packages.websocket-client python3Packages.unidecode ];
+
+  # mopidy-jellyfin can't be imported
+  # pythonImportsCheck = [ "mopidy-jellyfin" ];
+
+  meta = with lib; {
+    homepage = "https://mopidy.com/ext/jellyfin/";
+    description = "Mopidy extension for playing music from a Jellyfin Music Server";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ maintainers.gador ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27065,6 +27065,7 @@ with pkgs;
   inherit (mopidyPackages)
     mopidy
     mopidy-iris
+    mopidy-jellyfin
     mopidy-local
     mopidy-moped
     mopidy-mopify


### PR DESCRIPTION
###### Motivation for this change

adds a jellyfin module for mopidy music server

###### Things done

add mopidy-jellyfin and tested on raspberryPi 64bit.

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
