### PR TITLE
slimerjs: refactor

### DIFF
--- a/pkgs/development/tools/slimerjs/default.nix
+++ b/pkgs/development/tools/slimerjs/default.nix
@@ -1,33 +1,24 @@
-{lib, stdenv, fetchFromGitHub, zip, unzip, firefox, bash}:
-let
-  s = # Generated upstream information
-  rec {
-    baseName="slimerjs";
-    version="1.0.0";
-    name="${baseName}-${version}";
+{ lib, stdenv, fetchFromGitHub, zip, unzip, firefox, bash }:
+
+stdenv.mkDerivation rec {
+  pname = "slimerjs";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
     owner = "laurentj";
-    repo = baseName;
-    sha256="1w4sfrv520isbs7r1rlzl5y3idrpad7znw9fc92yz40jlwz7sxs4";
+    repo = "slimerjs";
+    sha256 = "sha256-RHd9PqcSkO9FYi5x+09TN7c4fKGf5pCPXjoCUXZ2mvA=";
     rev = version;
   };
-in
-stdenv.mkDerivation {
-  inherit (s) name version;
+
   buildInputs = [ zip ];
   nativeBuildInputs = [ unzip ];
-  #src = fetchurl {
-  #  inherit (s) url sha256;
-  #};
-  #src = fetchgit {
-  #  inherit (s) url sha256 rev;
-  #};
-  src = fetchFromGitHub {
-    inherit (s) owner repo rev sha256;
-  };
+
   preConfigure = ''
     test -d src && cd src
     test -f omni.ja || zip omni.ja -r */
   '';
+
   installPhase = ''
     mkdir -p "$out"/{bin,share/doc/slimerjs,lib/slimerjs}
     cp LICENSE README* "$out/share/doc/slimerjs"
@@ -38,11 +29,11 @@ stdenv.mkDerivation {
     chmod a+x "$out/bin/slimerjs"
     sed -e 's@MaxVersion=[3456][0-9][.]@MaxVersion=99.@' -i "$out/lib/slimerjs/application.ini"
   '';
-  meta = {
-    inherit (s) version;
+
+  meta = with lib; {
     description = "Gecko-based programmatically-driven browser";
-    license = lib.licenses.mpl20 ;
-    maintainers = [lib.maintainers.raskin];
-    platforms = lib.platforms.linux;
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ raskin ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/tools/slimerjs/default.upstream
+++ b/pkgs/development/tools/slimerjs/default.upstream
@@ -1,2 +1,0 @@
-url http://slimerjs.org/download.html
-version_link '/slimerjs-[0-9.]+[.]zip$'

--- a/pkgs/development/tools/slimerjs/default.upstream.git
+++ b/pkgs/development/tools/slimerjs/default.upstream.git
@@ -1,3 +1,0 @@
-url https://github.com/laurentj/slimerjs
-target default.nix
-GH_latest


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
cleanup with no indirections

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
