### PR TITLE
gtdialog: refactor

### DIFF
--- a/pkgs/development/libraries/gtdialog/default.nix
+++ b/pkgs/development/libraries/gtdialog/default.nix
@@ -1,32 +1,29 @@
-{lib, stdenv, fetchurl, cdk, unzip, gtk2, glib, ncurses, pkg-config}:
-let
-  s = # Generated upstream information
-  rec {
-    baseName="gtdialog";
-    version="1.4";
-    name="${baseName}-${version}";
-    hash="1lhsaz56s8m838fi6vnfcd2r6djymvy3n2pbqhii88hraapq3rfk";
-    url="https://foicica.com/gtdialog/download/gtdialog_1.4.zip";
-    sha256="1lhsaz56s8m838fi6vnfcd2r6djymvy3n2pbqhii88hraapq3rfk";
+{ lib, stdenv, fetchurl, cdk, unzip, gtk2, glib, ncurses, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "gtdialog";
+  version = "1.4";
+
+  src = fetchurl {
+    url = "https://foicica.com/gtdialog/download/gtdialog_${version}.zip";
+    sha256 = "sha256-0+WBr1IZIhQjxOsKO/yuXjaTRWPObhMdGqgibcpXGtI=";
   };
+
   nativeBuildInputs = [ pkg-config unzip ];
   buildInputs = [
-    cdk gtk2 glib ncurses
+    cdk
+    gtk2
+    glib
+    ncurses
   ];
-in
-stdenv.mkDerivation {
-  inherit (s) name version;
-  inherit nativeBuildInputs buildInputs;
-  src = fetchurl {
-    inherit (s) url sha256;
-  };
-  makeFlags = ["PREFIX=$(out)"];
-  meta = {
-    inherit (s) version;
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
     description = "Cross-platform helper for creating interactive dialogs";
-    license = lib.licenses.mit ;
-    maintainers = [lib.maintainers.raskin];
-    platforms = lib.platforms.linux;
+    license = licenses.mit;
+    maintainers = with maintainers; [ raskin ];
+    platforms = platforms.linux;
     homepage = "http://foicica.com/gtdialog";
     downloadPage = "http://foicica.com/gtdialog/download";
   };

--- a/pkgs/development/libraries/gtdialog/default.upstream
+++ b/pkgs/development/libraries/gtdialog/default.upstream
@@ -1,3 +1,0 @@
-url http://foicica.com/gtdialog/download
-version_link '[.]zip$'
-version '.*_([0-9.]*)[.]zip' '\1'


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
cleanup with no indirections

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
