### PR TITLE
librevenge: refactor

### DIFF
--- a/pkgs/development/libraries/librevenge/default.nix
+++ b/pkgs/development/libraries/librevenge/default.nix
@@ -1,25 +1,20 @@
-{lib, stdenv, fetchurl, boost, pkg-config, cppunit, zlib}:
-let
-  s = # Generated upstream information
-  rec {
-    baseName="librevenge";
-    version="0.0.4";
-    name="${baseName}-${version}";
-    hash="1cj76cz4mqcy2mgv9l5xlc95bypyk8zbq0ls9cswqrs2y0lhfgwk";
-    url="mirror://sourceforge/project/libwpd/librevenge/librevenge-0.0.4/librevenge-0.0.4.tar.xz";
-    sha256="1cj76cz4mqcy2mgv9l5xlc95bypyk8zbq0ls9cswqrs2y0lhfgwk";
+{ lib, stdenv, fetchurl, boost, pkg-config, cppunit, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "librevenge";
+  version = "0.0.4";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/project/libwpd/librevenge/librevenge-${version}/librevenge-${version}.tar.xz";
+    sha256 = "sha256-kz8HKfBCZ8w1S5oCvD6a/vpVEqO90LRfFZ7hSj4zR7I=";
   };
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
-    boost cppunit zlib
+    boost
+    cppunit
+    zlib
   ];
-in
-stdenv.mkDerivation {
-  inherit (s) name version;
-  inherit nativeBuildInputs buildInputs;
-  src = fetchurl {
-    inherit (s) url sha256;
-  };
 
   # Clang and gcc-7 generate warnings, and
   # -Werror causes these warnings to be interpreted as errors
@@ -32,11 +27,10 @@ stdenv.mkDerivation {
     sed -i 's,-DLIBREVENGE_BUILD,\0 -DBOOST_ERROR_CODE_HEADER_ONLY,g' src/lib/Makefile.in
   '';
 
-  meta = {
-    inherit (s) version;
+  meta = with lib; {
     description = "A base library for writing document import filters";
-    license = lib.licenses.mpl20 ;
-    maintainers = [lib.maintainers.raskin];
-    platforms = lib.platforms.unix;
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ raskin ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/librevenge/default.upstream
+++ b/pkgs/development/libraries/librevenge/default.upstream
@@ -1,4 +1,0 @@
-url https://sourceforge.net/projects/libwpd/files/librevenge/
-SF_version_dir librevenge-
-version_link '[.]tar.xz/download$'
-SF_redirect


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
cleanup with no indirections

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
