### PR TITLE
mi2ly: fix build and refactor

### DIFF
--- a/pkgs/applications/audio/mi2ly/default.nix
+++ b/pkgs/applications/audio/mi2ly/default.nix
@@ -1,27 +1,19 @@
-{lib, stdenv, fetchurl}:
-let
-  s = # Generated upstream information
-  rec {
-    baseName="mi2ly";
-    version="0.12";
-    name="${baseName}-${version}";
-    hash="1b14zcwlvnxhjxr3ymyzg0mg4sbijkinzpxm641s859jxcgylmll";
-    url="https://download.savannah.gnu.org/releases/mi2ly/mi2ly.0.12.tar.bz2";
-    sha256="1b14zcwlvnxhjxr3ymyzg0mg4sbijkinzpxm641s859jxcgylmll";
-  };
-  buildInputs = [
-  ];
-in
-stdenv.mkDerivation {
-  inherit (s) name version;
-  inherit buildInputs;
+{ lib, stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "mi2ly";
+  version = "0.12";
+
   src = fetchurl {
-    inherit (s) url sha256;
+    url = "https://download.savannah.gnu.org/releases/mi2ly/mi2ly.${version}.tar.bz2";
+    sha256 = "sha256-lFbqH+syFaQDMbXfb+OUcWnyKnjfVz9yl7DbTTn7JKw=";
   };
 
-  sourceRoot=".";
+  sourceRoot = ".";
 
   hardeningDisable = [ "format" ];
+
+  NIX_CFLAGS_COMPILE = [ "-fgnu89-inline" ];
 
   buildPhase = "./cc";
   installPhase = ''
@@ -30,12 +22,11 @@ stdenv.mkDerivation {
     cp README Doc.txt COPYING Manual.txt "$out/share/doc/mi2ly"
   '';
 
-  meta = {
-    inherit (s) version;
+  meta = with lib; {
     description = "MIDI to Lilypond converter";
-    license = lib.licenses.gpl2Plus ;
-    maintainers = [lib.maintainers.raskin];
-    platforms = lib.platforms.linux;
-    broken = true; # 2018-04-11
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ raskin ];
+    platforms = platforms.linux;
+    homepage = "https://www.nongnu.org/mi2ly/";
   };
 }

--- a/pkgs/applications/audio/mi2ly/default.upstream
+++ b/pkgs/applications/audio/mi2ly/default.upstream
@@ -1,3 +1,0 @@
-url https://download.savannah.gnu.org/releases/mi2ly/
-ensure_choice
-version '.*/mi2ly[.]([0-9.]+)[.]tar.*' '\1'


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
initially i wanted to cleanup the file, but noticed it was broken.
By adding `NIX_CFLAGS_COMPILE = [ "-fgnu89-inline" ];` it compiled sucesfully. @7c6f434c can you confirm it still works?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
