### PR TITLE
besttrace: init at 1.3.2

### DIFF
--- a/pkgs/tools/networking/besttrace/default.nix
+++ b/pkgs/tools/networking/besttrace/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://www.ipip.net/product/client.html#besttrace";
     description = "IPIP.net 开发的加强版 traceroute，附带链路可视化";
-    license = "custom";
+    license = licenses.unfree;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/networking/besttrace/default.nix
+++ b/pkgs/tools/networking/besttrace/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchzip }:
+
+stdenv.mkDerivation rec {
+  pname = "besttrace";
+  version = "1.3.2";
+
+  src = fetchzip {
+    url = "https://cdn.ipip.net/17mon/besttrace4linux.zip";
+    sha256 = "sha256-uRRZ5nNUg0MyK2ZRCZeAYi2P2UHyxUHFNTzgnU+I8gY=";
+    stripRoot = false;
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp besttrace $out/bin
+    chmod +x $out/bin/besttrace
+  '';
+
+  postFixup = ''
+    patchelf --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" $out/bin/besttrace
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.ipip.net/product/client.html#besttrace";
+    description = "IPIP.net 开发的加强版 traceroute，附带链路可视化";
+    license = "custom";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10295,6 +10295,8 @@ with pkgs;
 
   traceroute = callPackage ../tools/networking/traceroute { };
 
+  besttrace = callPackage ../tools/networking/besttrace { };
+
   tracebox = callPackage ../tools/networking/tracebox { };
 
   tracefilegen = callPackage ../development/tools/analysis/garcosim/tracefilegen { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
