### PR TITLE
tworld2: init at 2.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3113,6 +3113,16 @@
     githubId = 10198051;
     name = "Drew Risinger";
   };
+  drperceptron = {
+    email = "92106371+drperceptron@users.noreply.github.com";
+    github = "drperceptron";
+    githubId = 92106371;
+    name = "Dr Perceptron";
+    keys = [{
+      longkeyid = "rsa4096/0x95EB6DFF26D1CEB0";
+      fingerprint = "7E38 89D9 B1A8 B381 C8DE  A15F 95EB 6DFF 26D1 CEB0";
+    }];
+  };
   drupol = {
     name = "Pol Dellaiera";
     email = "pol.dellaiera@protonmail.com";

--- a/pkgs/games/tworld2/default.nix
+++ b/pkgs/games/tworld2/default.nix
@@ -1,0 +1,45 @@
+{ stdenv
+, lib
+, fetchurl
+, qt4
+, SDL
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tworld2";
+  version = "2.2.0";
+
+  src = fetchurl {
+    url = "https://tw2.bitbusters.club/downloads/tworld-${version}-src.tar.gz";
+    sha256 = "sha256:1y55v2shk2xxcds7bdwdjaq9lka31sgdp2469zqnvldchwbvcb2i";
+  };
+
+  buildInputs = [ qt4 SDL ];
+  enableParallelBuilding = true;
+
+  postConfigure = ''
+    echo "#define COMPILE_TIME \"$(date -ud "@$SOURCE_DATE_EPOCH" '+%Y %b %e %T %Z')\"" >comptime.h
+  '';
+
+  makeFlags = [
+    "bindir=${placeholder "out"}/bin"
+    "sharedir=${placeholder "out"}/share"
+    "mandir=${placeholder "out"}/share/man/en"
+  ];
+
+  postInstall = ''
+    mkdir -p $out/share/doc/${pname}
+    cp COPYING README docs/tworld2.html $out/share/doc/${pname}
+
+    mkdir $out/share/icons
+    cp tworld.ico tworld2.ico $out/share/icons
+  '';
+
+  meta = with lib; {
+    description = "Tile World 2: Tile World is a reimplementation of the game Chip's Challenge";
+    homepage = "https://tw2.bitbusters.club/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ drperceptron ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31061,6 +31061,8 @@ with pkgs;
 
   tuxtype = callPackage ../games/tuxtype { };
 
+  tworld2 = callPackage ../games/tworld2 { };
+
   speed_dreams = callPackage ../games/speed-dreams {
     # Torcs wants to make shared libraries linked with plib libraries (it provides static).
     # i686 is the only platform I know than can do that linking without plib built with -fPIC


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes #151513

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
