### PR TITLE
octoprint: add override for celery and sentry-sdk, remove constraint of sarge

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -122,6 +122,45 @@ let
           }
         )
 
+        # Octoprint pulls in celery indirectly but has no support for the up-to-date releases
+        (
+          self: super: {
+            celery = super.celery.overrideAttrs (oldAttrs: rec {
+              version = "5.0.0";
+              src = oldAttrs.src.override {
+                inherit version;
+                sha256 = "sha256-MTkw/d3nA9jjcCmjBL+RQpzRGu72PFfebayp2Vjh8lU=";
+              };
+              doCheck = false;
+            });
+          }
+        )
+
+        # Octoprint would allow later sentry-sdk releases but not later click releases
+        (
+          self: super: {
+            sentry-sdk = super.sentry-sdk.overrideAttrs (oldAttrs: rec {
+              pname = "sentry-sdk";
+              version = "1.4.3";
+
+              src = fetchFromGitHub {
+                owner = "getsentry";
+                repo = "sentry-python";
+                rev = version;
+                sha256 = "sha256-vdE6eqELMM69CWHaNYhF0HMCTV3tQsJlMHAA96oCy8c=";
+              };
+              disabledTests = [
+                "test_apply_simulates_delivery_info"
+                "test_auto_enabling_integrations_catches_import_error"
+              ];
+              disabledTestPaths = [
+                # Don't test integrations
+                "tests/integrations"
+              ];
+            });
+          }
+        )
+
         # Built-in dependency
         (
           self: super: {
@@ -237,9 +276,15 @@ let
                 wrapt
                 zeroconf
                 zipstream-new
-              ] ++ lib.optionals stdenv.isDarwin [ py.pkgs.appdirs ];
+              ] ++ lib.optionals stdenv.isDarwin [
+                py.pkgs.appdirs
+              ];
 
-              checkInputs = with super; [ pytestCheckHook mock ddt ];
+              checkInputs = with super; [
+                ddt
+                mock
+                pytestCheckHook
+              ];
 
               patches = [
                 # substitute pip and let it find out, that it can't write anywhere
@@ -261,6 +306,7 @@ let
                   "colorlog"
                   "emoji"
                   "immutabledict"
+                  "sarge"
                   "sentry-sdk"
                   "watchdog"
                   "wrapt"
@@ -299,7 +345,7 @@ let
               meta = with lib; {
                 homepage = "https://octoprint.org/";
                 description = "The snappy web interface for your 3D printer";
-                license = licenses.agpl3;
+                license = licenses.agpl3Only;
                 maintainers = with maintainers; [ abbradar gebner WhittlesJr ];
               };
             };

--- a/pkgs/development/python-modules/celery/default.nix
+++ b/pkgs/development/python-modules/celery/default.nix
@@ -1,38 +1,80 @@
-{ lib, buildPythonPackage, fetchPypi
-, billiard, click, click-didyoumean, click-plugins, click-repl, kombu, pytz, vine
-, boto3, case, moto, pytest, pytest-celery, pytest-subtests, pytest-timeout
+{ lib
+, billiard
+, boto3
+, buildPythonPackage
+, case
+, click
+, click-didyoumean
+, click-plugins
+, click-repl
+, fetchPypi
+, kombu
+, moto
+, pymongo
+, pytest-celery
+, pytest-subtests
+, pytest-timeout
+, pytestCheckHook
+, pythonOlder
+, pytz
+, vine
 }:
 
 buildPythonPackage rec {
   pname = "celery";
   version = "5.2.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-tBpZC0nK+OZJilfbYo5YDV+Nxv69oPQt5deDrtW3+Ag=";
   };
 
-  propagatedBuildInputs = [ billiard click click-didyoumean click-plugins click-repl kombu pytz vine ];
+  propagatedBuildInputs = [
+    billiard
+    click
+    click-didyoumean
+    click-plugins
+    click-repl
+    kombu
+    pytz
+    vine
+  ];
 
-  checkInputs = [ boto3 case moto pytest pytest-celery pytest-subtests pytest-timeout ];
+  checkInputs = [
+    boto3
+    case
+    moto
+    pymongo
+    pytest-celery
+    pytest-subtests
+    pytest-timeout
+    pytestCheckHook
+  ];
 
-  # ignore test that's incompatible with pytest5
-  # test_eventlet touches network
-  # test_mongodb requires pymongo
-  # test_multi tries to create directories under /var
-  checkPhase = ''
-    pytest -k 'not restore_current_app_fallback and not msgpack and not on_apply and not pytest' \
-      --ignore=t/unit/contrib/test_pytest.py \
-      --ignore=t/unit/concurrency/test_eventlet.py \
-      --ignore=t/unit/bin/test_multi.py \
-      --ignore=t/unit/apps/test_multi.py \
-      --ignore=t/unit/backends/test_mongodb.py
-  '';
+  disabledTestPaths = [
+    # test_eventlet touches network
+    "t/unit/concurrency/test_eventlet.py"
+    # test_multi tries to create directories under /var
+    "t/unit/bin/test_multi.py"
+    "t/unit/apps/test_multi.py"
+  ];
+
+  disabledTests = [
+    "msgpack"
+    "test_check_privileges_no_fchown"
+  ];
+
+  pythonImportsCheck = [
+    "celery"
+  ];
 
   meta = with lib; {
-    homepage = "https://github.com/celery/celery/";
     description = "Distributed task queue";
+    homepage = "https://github.com/celery/celery/";
     license = licenses.bsd3;
-    maintainers = [ ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/sarge/default.nix
+++ b/pkgs/development/python-modules/sarge/default.nix
@@ -1,20 +1,32 @@
-{ lib, buildPythonPackage, fetchPypi }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "sarge";
   version = "0.1.7";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "3b810d396a75a5a2805272f64f4316f6dcc086e0a744b042cdb0effc85c0f21b";
+  src = fetchFromGitHub {
+    owner = "vsajip";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-E1alSDXj0oeyB6dN5PAtN62FPpMsCKb4R9DpfWdFtn0=";
   };
 
-  # No tests in PyPI tarball
-  doCheck = false;
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "sarge"
+  ];
 
   meta = with lib; {
+    description = "Python wrapper for subprocess which provides command pipeline functionality";
     homepage = "https://sarge.readthedocs.org/";
-    description = "A wrapper for subprocess which provides command pipeline functionality";
     license = licenses.bsd3;
     maintainers = with maintainers; [ abbradar ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build

Fixes #151456

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
