### PR TITLE
hledger-check-fancyassertions: tie version to hledger-lib

### DIFF
--- a/pkgs/applications/office/hledger-check-fancyassertions/default.nix
+++ b/pkgs/applications/office/hledger-check-fancyassertions/default.nix
@@ -1,12 +1,17 @@
 {lib, stdenvNoCC, haskellPackages, fetchurl, writers}:
 
+let
+  hledger-lib = haskellPackages.hledger-lib_1_24_1;
+in
+
 stdenvNoCC.mkDerivation rec {
   pname = "hledger-check-fancyassertions";
-  version = "1.23";
+  inherit (hledger-lib) version;
 
   src = fetchurl {
+    name = "hledger-check-fancyassertion-${version}.hs";
     url = "https://raw.githubusercontent.com/simonmichael/hledger/hledger-lib-${version}/bin/hledger-check-fancyassertions.hs";
-    sha256 = "08p2din1j7l4c29ipn68k8vvs3ys004iy8a3zf318lzby4h04h0n";
+    sha256 = "0naggvivc6szsc8haa52a6lm079ikz5qfva0ljnqx0f1zlkxv984";
   };
 
   dontUnpack = true;
@@ -15,11 +20,13 @@ stdenvNoCC.mkDerivation rec {
   executable = writers.writeHaskell
     "hledger-check-fancyassertions"
     {
-      libraries = with haskellPackages; [
-        base base-compat base-compat-batteries filepath hledger-lib_1_24_1
+      libraries = [
+        hledger-lib
+      ] ++ (with haskellPackages; [
+        base base-compat base-compat-batteries filepath
         megaparsec microlens optparse-applicative string-qq text time
         transformers
-      ];
+      ]);
       inherit (haskellPackages) ghc;
     }
     src;


### PR DESCRIPTION
This means that updating hledger-lib will automatically force us to
update hledger-check-fancyassertions. Any new hash mismatch will be
caught by src.name changing, forcing a rebuild of the derivation.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
