### PR TITLE
pyradio: add requests and dnspython modules

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5232,6 +5232,12 @@
     githubId = 3081095;
     name = "Jürgen Keck";
   };
+  j-steinbach = {
+    email = "steinbach_j@web.de";
+    github = "j-steinbach";
+    githubId = 69524139;
+    name = "J. Steinbach";
+  };
   j03 = {
     email = "github@johannesloetzsch.de";
     github = "johannesloetzsch";

--- a/pkgs/applications/audio/pyradio/default.nix
+++ b/pkgs/applications/audio/pyradio/default.nix
@@ -28,6 +28,6 @@ python3Packages.buildPythonApplication rec {
     homepage = "http://www.coderholic.com/pyradio/";
     description = "Curses based internet radio player";
     license = licenses.mit;
-    maintainers = with maintainers; [ contrun ];
+    maintainers = with maintainers; [ contrun j-steinbach ];
   };
 }

--- a/pkgs/applications/audio/pyradio/default.nix
+++ b/pkgs/applications/audio/pyradio/default.nix
@@ -11,6 +11,15 @@ python3Packages.buildPythonApplication rec {
     sha256 = "04asw5alkkf2q5iixswarj6ddb0y4a6ixm7cckl6204jiyxpv6kc";
   };
 
+  propagatedBuildInputs = with python3Packages; [
+    dnspython
+    requests
+  ];
+
+  prePatch = ''
+    sed -i 's/distro = None/distro = NixOS/' pyradio/config
+  '';
+
   checkPhase = ''
     $out/bin/pyradio --help
   '';


### PR DESCRIPTION
This commit adds the missing 'requests' and 'dnspython' modules for the
radio-browser functionality, based on the pyradio packaging readme.

See https://github.com/coderholic/pyradio#packaging-pyradio and https://github.com/NixOS/nixpkgs/issues/151428.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

### Important

This is only my second pull request ever. I am still not very comfortable with this, so carefully scrutinize!