### PR TITLE
fuzzfetch: init at 2.0.0

### DIFF
--- a/pkgs/applications/misc/fuzzfetch/default.nix
+++ b/pkgs/applications/misc/fuzzfetch/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, buildPythonApplication
+, fetchPypi
+# build inputs
+, pytz
+, requests
+, setuptools
+# check inputs
+, freezegun
+, pytestCheckHook
+, requests-mock
+}:
+
+buildPythonApplication rec {
+  pname = "fuzzfetch";
+  version = "2.0.0";
+
+  src = fetchPypi {
+    pname = "fuzzfetch";
+    inherit version;
+    sha256 = "sha256-u5K0HW//cj3T2VG9ufPH8mF4gn+xxIv2f2KnDbDZ61I=";
+  };
+
+  propagatedBuildInputs = [
+    pytz
+    requests
+    setuptools
+  ];
+  checkInputs = [
+    freezegun
+    pytestCheckHook
+    requests-mock
+  ];
+
+  meta = with lib; {
+    description = "Tool for retrieving builds from the Firefox-CI Taskcluster instance";
+    longDescription = ''
+      Fuzzfetch can be used to retrieve nearly any build type indexed by Firefox-CI.
+      This includes AddressSanitizer, ThreadSanitizer, Valgrind, debug, and Fuzzing
+      builds for both Firefox and Spidermonkey.
+    '';
+    homepage = "https://github.com/MozillaSecurity/fuzzfetch";
+    license = licenses.mpl20;
+    maintainers = [ maintainers.kvark ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5481,6 +5481,8 @@ with pkgs;
 
   fusuma = callPackage ../tools/inputmethods/fusuma {};
 
+  fuzzfetch = python3Packages.callPackage ../applications/misc/fuzzfetch { };
+
   fdbPackages = dontRecurseIntoAttrs (callPackage ../servers/foundationdb {
     openjdk = openjdk8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
   });


### PR DESCRIPTION
###### Motivation for this change
It's a development tool for Firefox. I don't know if registering it here is the right thing to do... It could be seen in the same group as #146430

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
