### PR TITLE
pwsafe: 3.56.0 for Windows -> 1.14.0 for Linux

### DIFF
--- a/pkgs/applications/misc/pwsafe/default.nix
+++ b/pkgs/applications/misc/pwsafe/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, zip, gettext, perl
+{ lib, stdenv, fetchFromGitHub
+, cmake, pkg-config, zip, gettext, perl
 , wxGTK30, libXext, libXi, libXt, libXtst, xercesc
 , qrencode, libuuid, libyubikey, yubikey-personalization
 , curl, openssl, file
@@ -6,13 +7,14 @@
 
 stdenv.mkDerivation rec {
   pname = "pwsafe";
-  version = "3.56.0";
+  version = "1.14.0"; # do NOT update to 3.x Windows releases
+  # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "sha256-ZLX/3cs1cdia5+32QEwE6q3V0uFNkkmiIGboKW6Xej8=";
+    hash = "sha256-s3IXe4gTwUOzQslNfWrcN/srrG9Jv02zfkGgiZN3C1s=";
   };
 
   nativeBuildInputs = [
@@ -32,19 +34,19 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     # Fix perl scripts used during the build.
-    for f in `find . -type f -name '*.pl'`; do
+    for f in $(find . -type f -name '*.pl') ; do
       patchShebangs $f
     done
 
     # Fix hard coded paths.
-    for f in `grep -Rl /usr/share/ src`; do
+    for f in $(grep -Rl /usr/share/ src) ; do
       substituteInPlace $f --replace /usr/share/ $out/share/
     done
 
     # Fix hard coded zip path.
     substituteInPlace help/Makefile.linux --replace /usr/bin/zip ${zip}/bin/zip
 
-    for f in `grep -Rl /usr/bin/ .`; do
+    for f in $(grep -Rl /usr/bin/ .) ; do
       substituteInPlace $f --replace /usr/bin/ ""
     done
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This is **not** a downgrade but a fix.
PasswordSafe 3.x are Windows releases. The current release for Unix+wxWidgets platforms is at 1.14.0.
See:
- https://www.pwsafe.org/readmore.shtml
- https://sourceforge.net/projects/passwordsafe/files/Linux/
- https://github.com/pwsafe/pwsafe/releases?q=non-windows&expanded=true

Both releases lives in the same repo. When pulling the 3.56.0 tag and building on Linux you get the 1.14.0 version.

Problem was introduced in #85709

---

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
