### PR TITLE
vscode-extensions.matklad.rust-analyzer: fix on Darwin

### DIFF
--- a/pkgs/misc/vscode-extensions/rust-analyzer/default.nix
+++ b/pkgs/misc/vscode-extensions/rust-analyzer/default.nix
@@ -8,6 +8,8 @@
 , esbuild
 , pkg-config
 , libsecret
+, stdenv
+, darwin
 , setDefaultServerPath ? true
 }:
 
@@ -17,6 +19,8 @@ let
 
   # Use the plugin version as in vscode marketplace, updated by update script.
   inherit (vsix) version;
+
+  inherit (darwin.apple_sdk.frameworks) AppKit Security;
 
   releaseTag = "2021-11-29";
 
@@ -37,9 +41,15 @@ let
     inherit releaseTag;
 
     nativeBuildInputs = [
-      jq moreutils esbuild
+      jq
+      moreutils
+      esbuild
       # Required by `keytar`, which is a dependency of `vsce`.
-      pkg-config libsecret
+      pkg-config
+      libsecret
+    ] ++ lib.optional stdenv.isDarwin [
+      Security
+      AppKit
     ];
 
     # Follows https://github.com/rust-analyzer/rust-analyzer/blob/41949748a6123fd6061eb984a47f4fe780525e63/xtask/src/dist.rs#L39-L65


### PR DESCRIPTION
###### Motivation for this change

The package doesn't build on aarch64-darwin (Monterey).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
