### PR TITLE
jellyfin-ffmpeg: init at 4.4.1-4, use as default for jellyfin 

### DIFF
--- a/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
+++ b/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
@@ -16,7 +16,7 @@
       patch -p1 < debian/patches/$file
     done
 
-    ${old.postPatch}
+    ${old.postPatch or ""}
   '';
 
   doCheck = false; # https://github.com/jellyfin/jellyfin-ffmpeg/issues/79

--- a/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
+++ b/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
@@ -1,0 +1,29 @@
+{ ffmpeg_4, ffmpeg-full, fetchFromGitHub, lib }:
+(ffmpeg-full.override { ffmpeg = ffmpeg_4; }).overrideAttrs (old: rec {
+  name = "jellyfin-ffmpeg";
+  version = "4.4.1-4";
+
+  src = fetchFromGitHub {
+    owner = "jellyfin";
+    repo = "jellyfin-ffmpeg";
+    rev = "v${version}";
+    sha256 = "0y7iskamlx30f0zknbscpi308y685nbnbf5gr9cj1znr5dlfb0bn";
+  };
+
+  prePatch = ''
+    for file in $(cat debian/patches/series); do
+      patch -p1 < debian/patches/$file
+    done
+
+    ${old.prePatch}
+  '';
+
+  doCheck = false; # https://github.com/jellyfin/jellyfin-ffmpeg/issues/79
+
+  meta = with lib; {
+    description = "${old.meta.description} (Jellyfin fork)";
+    homepage = "https://github.com/jellyfin/jellyfin-ffmpeg";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ justinas ];
+  };
+})

--- a/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
+++ b/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
@@ -1,4 +1,5 @@
 { ffmpeg_4, ffmpeg-full, fetchFromGitHub, lib }:
+
 (ffmpeg-full.override { ffmpeg = ffmpeg_4; }).overrideAttrs (old: rec {
   name = "jellyfin-ffmpeg";
   version = "4.4.1-4";
@@ -10,12 +11,12 @@
     sha256 = "0y7iskamlx30f0zknbscpi308y685nbnbf5gr9cj1znr5dlfb0bn";
   };
 
-  prePatch = ''
+  postPatch = ''
     for file in $(cat debian/patches/series); do
       patch -p1 < debian/patches/$file
     done
 
-    ${old.prePatch}
+    ${old.postPatch}
   '';
 
   doCheck = false; # https://github.com/jellyfin/jellyfin-ffmpeg/issues/79

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3410,7 +3410,11 @@ with pkgs;
 
   jellycli = callPackage ../applications/audio/jellycli { };
 
-  jellyfin = callPackage ../servers/jellyfin { };
+  jellyfin = callPackage ../servers/jellyfin {
+    ffmpeg = jellyfin-ffmpeg;
+  };
+
+  jellyfin-ffmpeg = callPackage ../development/libraries/jellyfin-ffmpeg { };
 
   jellyfin-media-player = libsForQt5.callPackage ../applications/video/jellyfin-media-player {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Cocoa CoreAudio MediaPlayer;


### PR DESCRIPTION
###### Motivation for this change

Jellyfin maintain their own fork of ffmpeg which includes various patches, mostly improving hardware-accelerated transcoding support. In my use-case (Intel iGPU; H264 & H265), it at the very least fixes hardware HDR to HDR transcoding.

I am not 100% comfortable piggybacking on `ffmpeg-full`, but it is the piece that implements many of the feature flags that are required for full functionality of Jellyfin transcodes.

Considering [FFmpeg 5](https://www.phoronix.com/scan.php?page=news_item&px=FFmpeg-5.0-Released) has just been released, I'm pinning `ffmpeg` to `ffmpeg_4`, to hopefully minimize breakage of this package when `ffmpeg` is updated to 5 in nixpkgs. Historically, the Jellyfin folks seem to update their fork to new upstream releases pretty responsively.

Tagging ffmpeg maintainers for review.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
