### PR TITLE
webkitgtk: 2.34.1 -> 2.34.3

### DIFF
--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -64,7 +64,7 @@ assert enableGeoLocation -> geoclue2 != null;
 
 stdenv.mkDerivation rec {
   pname = "webkitgtk";
-  version = "2.34.1";
+  version = "2.34.2";
 
   outputs = [ "out" "dev" ];
 
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://webkitgtk.org/releases/${pname}-${version}.tar.xz";
-    sha256 = "sha256-RDwTFnBd4CR0F0joX+MjJNKZ2e5o5v6zQLieSgQHPe4=";
+    sha256 = "sha256-WEZ31ufK4S4nzcyOBbTPc7VISaJK/D16QM7JEBbe/wA=";
   };
 
   patches = lib.optionals stdenv.isLinux [

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -64,7 +64,7 @@ assert enableGeoLocation -> geoclue2 != null;
 
 stdenv.mkDerivation rec {
   pname = "webkitgtk";
-  version = "2.34.2";
+  version = "2.34.3";
 
   outputs = [ "out" "dev" ];
 
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://webkitgtk.org/releases/${pname}-${version}.tar.xz";
-    sha256 = "sha256-WEZ31ufK4S4nzcyOBbTPc7VISaJK/D16QM7JEBbe/wA=";
+    sha256 = "sha256-DS83qjLiGjbk3Vpc565c4nQ1wp1oA7liuMkMsMxJxS0=";
   };
 
   patches = lib.optionals stdenv.isLinux [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://webkitgtk.org/2021/12/20/webkitgtk2.34.3-released.html
https://webkitgtk.org/security/WSA-2021-0007.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages marked as broken and skipped:</summary>
  <ul>
    <li>gnome.gnome-documents</li>
    <li>xmonad_log_applet</li>
  </ul>
</details>
<details>
  <summary>24 packages failed to build:</summary>
  <ul>
    <li>citrix_workspace</li>
    <li>citrix_workspace_20_04_0</li>
    <li>citrix_workspace_20_06_0</li>
    <li>citrix_workspace_20_09_0</li>
    <li>citrix_workspace_20_10_0</li>
    <li>citrix_workspace_20_12_0</li>
    <li>citrix_workspace_21_01_0</li>
    <li>citrix_workspace_21_03_0</li>
    <li>citrix_workspace_21_06_0</li>
    <li>citrix_workspace_21_08_0</li>
    <li>gnome.yelp</li>
    <li>gnucash</li>
    <li>mate.mate-user-guide</li>
    <li>onboard</li>
    <li>pantheon.elementary-greeter</li>
    <li>pantheon.elementary-session-settings</li>
    <li>pantheon.switchboard-plug-a11y</li>
    <li>pantheon.switchboard-plug-keyboard</li>
    <li>pantheon.switchboard-with-plugs</li>
    <li>pantheon.wingpanel-applications-menu</li>
    <li>pantheon.wingpanel-with-indicators</li>
    <li>quodlibet-full</li>
    <li>webkitgtk_4_1</li>
    <li>xiphos</li>
  </ul>
</details>
<details>
  <summary>187 packages built:</summary>
  <ul>
    <li>ChowKick</li>
    <li>adapta-gtk-theme</li>
    <li>alfis</li>
    <li>almanah</li>
    <li>apostrophe</li>
    <li>astroid</li>
    <li>aws-workspaces</li>
    <li>balsa</li>
    <li>bespokesynth</li>
    <li>birdfont</li>
    <li>bookworm</li>
    <li>bubblemail</li>
    <li>calls</li>
    <li>chatty</li>
    <li>chrome-gnome-shell</li>
    <li>cinnamon.cinnamon-common</li>
    <li>cinnamon.cinnamon-control-center</li>
    <li>cinnamon.cinnamon-gsettings-overrides</li>
    <li>cinnamon.cinnamon-screensaver</li>
    <li>cinnamon.pix</li>
    <li>cinnamon.xreader</li>
    <li>claws-mail</li>
    <li>cog</li>
    <li>dbeaver</li>
    <li>dropbox-cli</li>
    <li>eclipse-mat</li>
    <li>eclipses.eclipse-committers</li>
    <li>eclipses.eclipse-cpp</li>
    <li>eclipses.eclipse-java</li>
    <li>eclipses.eclipse-jee</li>
    <li>eclipses.eclipse-modeling</li>
    <li>eclipses.eclipse-platform</li>
    <li>eclipses.eclipse-rcp</li>
    <li>eclipses.eclipse-scala-sdk</li>
    <li>eclipses.eclipse-sdk</li>
    <li>elementary-planner</li>
    <li>empathy</li>
    <li>eolie</li>
    <li>ephemeral</li>
    <li>epiphany</li>
    <li>evolution</li>
    <li>evolution-data-server</li>
    <li>evolution-ews</li>
    <li>evolutionWithPlugins</li>
    <li>feedreader</li>
    <li>foliate</li>
    <li>folks</li>
    <li>font-manager</li>
    <li>formiko</li>
    <li>gfbgraph</li>
    <li>giara</li>
    <li>glade</li>
    <li>gnome-builder</li>
    <li>gnome-feeds</li>
    <li>gnome-inform7</li>
    <li>gnome-online-accounts</li>
    <li>gnome-photos</li>
    <li>gnome-recipes</li>
    <li>gnome.cheese</li>
    <li>gnome.devhelp</li>
    <li>gnome.file-roller</li>
    <li>gnome.geary</li>
    <li>gnome.gnome-applets</li>
    <li>gnome.gnome-books</li>
    <li>gnome.gnome-boxes</li>
    <li>gnome.gnome-calendar</li>
    <li>gnome.gnome-contacts</li>
    <li>gnome.gnome-control-center</li>
    <li>gnome.gnome-flashback</li>
    <li>gnome.gnome-initial-setup</li>
    <li>gnome.gnome-maps</li>
    <li>gnome.gnome-music</li>
    <li>gnome.gnome-notes</li>
    <li>gnome.gnome-online-miners</li>
    <li>gnome.gnome-panel</li>
    <li>gnome.gnome-session</li>
    <li>gnome.gnome-shell</li>
    <li>gnome.gnome-terminal</li>
    <li>gnome.gnome-todo</li>
    <li>gnome.gnome-tweaks</li>
    <li>gnome.gnome-user-share</li>
    <li>gnome.gvfs</li>
    <li>gnome.nautilus</li>
    <li>gnome.nautilus-python</li>
    <li>gnome.polari</li>
    <li>gnome.sushi</li>
    <li>gnome.totem</li>
    <li>gnomeExtensions.easyScreenCast</li>
    <li>gnomeExtensions.gsconnect</li>
    <li>gnomeExtensions.night-theme-switcher</li>
    <li>gnunet-gtk</li>
    <li>gnvim</li>
    <li>gnvim-unwrapped</li>
    <li>grilo-plugins</li>
    <li>gthumb</li>
    <li>jami-client-gnome</li>
    <li>kgx</li>
    <li>kicad</li>
    <li>kicad-small</li>
    <li>kicad-unstable</li>
    <li>kicad-unstable-small</li>
    <li>kotatogram-desktop</li>
    <li>libgdata</li>
    <li>libgepub</li>
    <li>libzapojit</li>
    <li>liferea</li>
    <li>lispPackages.cl-webkit2</li>
    <li>lispPackages.nyxt</li>
    <li>loxodo</li>
    <li>luakit</li>
    <li>lutris</li>
    <li>lutris-free</li>
    <li>lutris-unwrapped</li>
    <li>mailnagWithPlugins</li>
    <li>marker</li>
    <li>mate.atril</li>
    <li>mavproxy</li>
    <li>meteo</li>
    <li>midori</li>
    <li>midori-unwrapped</li>
    <li>mmex</li>
    <li>nasc</li>
    <li>newsflash</li>
    <li>notes-up</li>
    <li>nyxt</li>
    <li>osmo</li>
    <li>pantheon.elementary-calendar</li>
    <li>pantheon.elementary-capnet-assist</li>
    <li>pantheon.elementary-code</li>
    <li>pantheon.elementary-gsettings-schemas</li>
    <li>pantheon.elementary-mail</li>
    <li>pantheon.elementary-photos</li>
    <li>pantheon.elementary-tasks</li>
    <li>pantheon.epiphany</li>
    <li>pantheon.file-roller</li>
    <li>pantheon.file-roller-contract</li>
    <li>pantheon.switchboard-plug-onlineaccounts</li>
    <li>pantheon.wingpanel-indicator-datetime</li>
    <li>pdfpc</li>
    <li>phosh</li>
    <li>playonlinux</li>
    <li>poedit</li>
    <li>portfolio</li>
    <li>printrun</li>
    <li>protonvpn-gui</li>
    <li>python38Packages.humblewx</li>
    <li>python38Packages.kicad</li>
    <li>python38Packages.wxPython_4_0</li>
    <li>python38Packages.wxPython_4_1</li>
    <li>python39Packages.humblewx</li>
    <li>python39Packages.kicad</li>
    <li>python39Packages.wxPython_4_0</li>
    <li>python39Packages.wxPython_4_1</li>
    <li>pytrainer</li>
    <li>quisk</li>
    <li>quodlibet</li>
    <li>quodlibet-without-gst-plugins</li>
    <li>quodlibet-xine</li>
    <li>quodlibet-xine-full</li>
    <li>rednotebook</li>
    <li>remmina</li>
    <li>rymcast</li>
    <li>setzer</li>
    <li>shotwell</li>
    <li>skytemple</li>
    <li>sparkleshare</li>
    <li>surf</li>
    <li>surf-display</li>
    <li>synology-drive</li>
    <li>tangram</li>
    <li>tdesktop</li>
    <li>thiefmd</li>
    <li>timeline</li>
    <li>tonelib-zoom</li>
    <li>tracker-miners</li>
    <li>tunefish</li>
    <li>ulauncher</li>
    <li>vala-language-server</li>
    <li>vimb</li>
    <li>vimb-unwrapped</li>
    <li>vimix-gtk-themes</li>
    <li>vocal</li>
    <li>webkit2-sharp</li>
    <li>webkitgtk</li>
    <li>whatsapp-for-linux</li>
    <li>whitesur-gtk-theme</li>
    <li>wike</li>
  </ul>
</details>


