### PR TITLE
astrolog: init at 7.30

### DIFF
--- a/pkgs/applications/science/astronomy/astrolog/default.nix
+++ b/pkgs/applications/science/astronomy/astrolog/default.nix
@@ -1,0 +1,44 @@
+{ lib, stdenv, fetchzip, fetchurl, xorg, gnused }:
+stdenv.mkDerivation rec {
+  pname = "astrolog";
+  version = "7.30";
+
+  src = fetchzip {
+    url = "http://www.astrolog.org/ftp/ast73src.zip";
+    sha256 = "0nry4gxwy5aa99zzr8dlb6babpachsc3jjyk0vw82c7x3clbhl7l";
+    stripRoot = false;
+  };
+
+  patchPhase = ''
+    ${gnused}/bin/sed -i "s:~/astrolog:$out/astrolog:g" astrolog.h
+  '';
+
+  buildInputs = [ xorg.libX11 ];
+  NIX_CFLAGS_COMPILE = "-Wno-format-security";
+
+  installPhase =
+  let
+    ephemeris = fetchzip {
+      url = "http://astrolog.org/ftp/ephem/astephem.zip";
+      sha256 = "1mwvpvfk3lxjcc79zvwl4ypqzgqzipnc01cjldxrmx56xkc35zn7";
+      stripRoot = false;
+    };
+    atlas = fetchurl {
+      url = "http://astrolog.org/ftp/atlas/atlasbig.as";
+      sha256 = "1k8cy8gpcvkwkhyz248qhvrv5xiwp1n1s3b7rlz86krh7vzz01mp";
+    };
+  in ''
+    mkdir -p $out/bin $out/astrolog
+    cp -r ${ephemeris}/*.se1 $out/astrolog
+    cp *.as $out/astrolog
+    install astrolog $out/bin
+  '';
+
+  meta = with lib; {
+    maintainers = [ maintainers.kmein ];
+    homepage = "https://astrolog.org/astrolog.htm";
+    description = "Freeware astrology program";
+    platforms = platforms.linux;
+    license = licenses.gpl2Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -186,6 +186,8 @@ with pkgs;
 
   antsimulator = callPackage ../games/antsimulator { };
 
+  astrolog = callPackage ../applications/science/astronomy/astrolog { };
+
   atkinson-hyperlegible = callPackage ../data/fonts/atkinson-hyperlegible { };
 
   atuin = callPackage ../tools/misc/atuin {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
