### PR TITLE
thunderbird-bin: bring in-line with firefox-bin

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -2,34 +2,25 @@
 #
 # To update `thunderbird-bin`'s `release_sources.nix`, run from the nixpkgs root:
 #
-#     nix-shell maintainers/scripts/update.nix --argstr package pkgs.firefox-bin-unwrapped
-{ stdenv, lib, fetchurl, config, makeWrapper
+#     nix-shell maintainers/scripts/update.nix --argstr package pkgs.thunderbird-bin-unwrapped
+{ lib, stdenv, fetchurl, config, wrapGAppsHook
 , alsa-lib
-, at-spi2-atk
 , atk
 , cairo
-, coreutils
-, cups
 , curl
-, dbus
+, cups
 , dbus-glib
+, dbus
 , fontconfig
 , freetype
 , gdk-pixbuf
 , glib
 , glibc
-, gnome
-, gnugrep
-, gnupg
-, gnused
-, gpgme
 , gtk2
 , gtk3
 , libkrb5
-, libcanberra
-, libGL
-, libGLU
 , libX11
+, libXScrnSaver
 , libxcb
 , libXcomposite
 , libXcursor
@@ -39,24 +30,43 @@
 , libXi
 , libXinerama
 , libXrender
-, libXScrnSaver
+, libXrandr
 , libXt
+, libXtst
+, libcanberra
+, libnotify
+, adwaita-icon-theme
+, libGLU, libGL
 , nspr
 , nss
 , pango
-, runtimeShell
+, pipewire
+, pciutils
+, libheimdal
+, libpulseaudio
+, systemd
 , writeScript
-, xdg-utils
+, writeText
 , xidel
+, coreutils
+, gnused
+, gnugrep
+, gnupg
+, ffmpeg
+, runtimeShell
+, mesa # thunderbird wants gbm for drm+dmabuf
+, systemLocale ? config.i18n.defaultLocale or "en_US"
 }:
 
-# imports `version` and `sources`
-with (import ./release_sources.nix);
-
 let
-  arch = if stdenv.hostPlatform.system == "i686-linux"
-    then "linux-i686"
-    else "linux-x86_64";
+  inherit (import ./release_sources.nix) version sources;
+
+  mozillaPlatforms = {
+    i686-linux = "linux-i686";
+    x86_64-linux = "linux-x86_64";
+  };
+
+  arch = mozillaPlatforms.${stdenv.hostPlatform.system};
 
   isPrefixOf = prefix: string:
     builtins.substring 0 (builtins.stringLength prefix) string == prefix;
@@ -64,11 +74,17 @@ let
   sourceMatches = locale: source:
       (isPrefixOf source.locale locale) && source.arch == arch;
 
-  systemLocale = config.i18n.defaultLocale or "en-US";
+  policies = { DisableAppUpdate = true; } // config.thunderbird.policies or { };
+  policiesJson = writeText "thunderbird-policies.json" (builtins.toJSON { inherit policies; });
 
   defaultSource = lib.findFirst (sourceMatches "en-US") {} sources;
 
-  source = lib.findFirst (sourceMatches systemLocale) defaultSource sources;
+  mozLocale =
+    if systemLocale == "ca_ES@valencia"
+    then "ca-valencia"
+    else lib.replaceStrings ["_"] ["-"] systemLocale;
+
+  source = lib.findFirst (sourceMatches mozLocale) defaultSource sources;
 in
 
 stdenv.mkDerivation {
@@ -83,11 +99,10 @@ stdenv.mkDerivation {
   libPath = lib.makeLibraryPath
     [ stdenv.cc.cc
       alsa-lib
-      at-spi2-atk
       atk
       cairo
-      cups
       curl
+      cups
       dbus-glib
       dbus
       fontconfig
@@ -98,34 +113,55 @@ stdenv.mkDerivation {
       gtk2
       gtk3
       libkrb5
+      mesa
       libX11
       libXScrnSaver
       libXcomposite
       libXcursor
+      libxcb
       libXdamage
       libXext
       libXfixes
       libXi
       libXinerama
       libXrender
+      libXrandr
       libXt
-      libxcb
+      libXtst
       libcanberra
+      libnotify
       libGLU libGL
       nspr
       nss
       pango
+      pipewire
+      pciutils
+      libheimdal
+      libpulseaudio
+      systemd
+      ffmpeg
     ] + ":" + lib.makeSearchPathOutput "lib" "lib64" [
       stdenv.cc.cc
     ];
 
-  buildInputs = [ gtk3 gnome.adwaita-icon-theme ];
+  inherit gtk3;
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ wrapGAppsHook ];
+
+  buildInputs = [ gtk3 adwaita-icon-theme ];
+
+  # "strip" after "patchelf" may break binaries.
+  # See: https://github.com/NixOS/patchelf/issues/10
+  dontStrip = true;
+  dontPatchELF = true;
+
+  patchPhase = ''
+    # Don't download updates from Mozilla directly
+    echo 'pref("app.update.auto", "false");' >> defaults/pref/channel-prefs.js
+  '';
 
   # See "Note on GPG support" in `../thunderbird/default.nix` for explanations
   # on adding `gnupg` and `gpgme` into PATH/LD_LIBRARY_PATH.
-
   installPhase =
     ''
       mkdir -p "$prefix/usr/lib/thunderbird-bin-${version}"
@@ -135,41 +171,27 @@ stdenv.mkDerivation {
       ln -s "$prefix/usr/lib/thunderbird-bin-${version}/thunderbird" "$out/bin/"
 
       for executable in \
-        thunderbird crashreporter thunderbird-bin plugin-container updater
+        thunderbird thunderbird-bin plugin-container \
+        updater crashreporter webapprt-stub
       do
-        patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-          "$out/usr/lib/thunderbird-bin-${version}/$executable"
+        if [ -e "$out/usr/lib/thunderbird-bin-${version}/$executable" ]; then
+          patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+            "$out/usr/lib/thunderbird-bin-${version}/$executable"
+        fi
       done
 
       find . -executable -type f -exec \
         patchelf --set-rpath "$libPath" \
           "$out/usr/lib/thunderbird-bin-${version}/{}" \;
 
-      # Create a desktop item.
-      mkdir -p $out/share/applications
-      cat > $out/share/applications/thunderbird.desktop <<EOF
-      [Desktop Entry]
-      Type=Application
-      Exec=$out/bin/thunderbird
-      Icon=$out/usr/lib/thunderbird-bin-${version}/chrome/icons/default/default256.png
-      Name=Thunderbird
-      GenericName=Mail Reader
-      Categories=Application;Network;
-      EOF
+      # wrapThunderbird expects "$out/lib" instead of "$out/usr/lib"
+      ln -s "$out/usr/lib" "$out/lib"
 
-      # SNAP_NAME: https://github.com/NixOS/nixpkgs/pull/61980
-      # MOZ_LEGACY_PROFILES and MOZ_ALLOW_DOWNGRADE:
-      #   commit 87e261843c4236c541ee0113988286f77d2fa1ee
-      wrapProgram "$out/bin/thunderbird" \
-        --argv0 "$out/bin/.thunderbird-wrapped" \
-        --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:" \
-        --suffix XDG_DATA_DIRS : "$XDG_ICON_DIRS" \
-        --set SNAP_NAME "thunderbird" \
-        --set MOZ_LEGACY_PROFILES 1 \
-        --set MOZ_ALLOW_DOWNGRADE 1 \
-        --prefix PATH : "${lib.getBin gnupg}/bin" \
-        --prefix PATH : "${lib.getBin xdg-utils}/bin" \
-        --prefix LD_LIBRARY_PATH : "${lib.getLib gpgme}/lib"
+      gappsWrapperArgs+=(--argv0 "$out/bin/.thunderbird-wrapped")
+
+      # See: https://github.com/mozilla/policy-templates/blob/master/README.md
+      mkdir -p "$out/lib/thunderbird-bin-${version}/distribution";
+      ln -s ${policiesJson} "$out/lib/thunderbird-bin-${version}/distribution/policies.json";
     '';
 
   passthru.updateScript = import ./../../browsers/firefox-bin/update.nix {
@@ -180,12 +202,13 @@ stdenv.mkDerivation {
     basePath = "pkgs/applications/networking/mailreaders/thunderbird-bin";
     baseUrl = "http://archive.mozilla.org/pub/thunderbird/releases/";
   };
+
   meta = with lib; {
     description = "Mozilla Thunderbird, a full-featured email client (binary package)";
     homepage = "http://www.mozilla.org/thunderbird/";
     license = licenses.mpl20;
-    maintainers = with lib.maintainers; [ ];
-    platforms = platforms.linux;
+    maintainers = with lib.maintainers; [ lovesegfault ];
+    platforms = builtins.attrNames mozillaPlatforms;
     hydraPlatforms = [ ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28793,10 +28793,19 @@ with pkgs;
   thunderbird = wrapThunderbird thunderbird-unwrapped { };
   thunderbird-wayland = wrapThunderbird thunderbird-unwrapped { forceWayland = true; };
 
-  thunderbolt = callPackage ../os-specific/linux/thunderbolt {};
-
   thunderbird-bin = thunderbird-bin-91;
-  thunderbird-bin-91 = callPackage ../applications/networking/mailreaders/thunderbird-bin { };
+  thunderbird-bin-unwrapped = thunderbird-bin-91-unwrapped;
+
+  thunderbird-bin-91 = wrapThunderbird thunderbird-bin-91-unwrapped {
+    applicationName = "thunderbird";
+    pname = "thunderbird-bin";
+    desktopName = "Thunderbird";
+  };
+  thunderbird-bin-91-unwrapped = callPackage ../applications/networking/mailreaders/thunderbird-bin {
+    inherit (gnome) adwaita-icon-theme;
+  };
+
+  thunderbolt = callPackage ../os-specific/linux/thunderbolt {};
 
   ticpp = callPackage ../development/libraries/ticpp { };
 


### PR DESCRIPTION
This brings our thunderbird-bin drv in-line with the firefox-bin one,
hopefully making it work a bit better. We also now use the proper
wrapper with `wrapThunderbird`.

Tested locally and works great :)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
