### PR TITLE
[staging-next] sage: assume fonttools DeprecationWarnings are expected for now

### DIFF
--- a/pkgs/applications/science/math/sage/patches/fonttools-deprecation-warnings.patch
+++ b/pkgs/applications/science/math/sage/patches/fonttools-deprecation-warnings.patch
@@ -1,0 +1,39 @@
+diff --git a/src/doc/en/prep/Advanced-2DPlotting.rst b/src/doc/en/prep/Advanced-2DPlotting.rst
+index 337457afef..f7c76f4b56 100644
+--- a/src/doc/en/prep/Advanced-2DPlotting.rst
++++ b/src/doc/en/prep/Advanced-2DPlotting.rst
+@@ -695,6 +695,8 @@ by the cells.
+ 
+     sage: pdf_savename = name+'.pdf'
+     sage: p.save(pdf_savename)
++    ...
++    DeprecationWarning: The py23 module has been deprecated and will be removed in a future release. Please update your code.
+ 
+ Notably, we can export in formats ready for inclusion in web pages.
+ 
+diff --git a/src/sage/plot/disk.py b/src/sage/plot/disk.py
+index 8680a1c9b1..e83763b678 100644
+--- a/src/sage/plot/disk.py
++++ b/src/sage/plot/disk.py
+@@ -156,6 +156,8 @@ class Disk(GraphicPrimitive):
+             sage: f = tmp_filename(ext='.pdf')
+             sage: p = disk((0,0), 5, (0, pi/4), alpha=0.5)
+             sage: p.save(f)
++            ...
++            DeprecationWarning: The py23 module has been deprecated and will be removed in a future release. Please update your code.
+ 
+         """
+         import matplotlib.patches as patches
+diff --git a/src/sage/plot/text.py b/src/sage/plot/text.py
+index 04cbdedf76..a970f97b79 100644
+--- a/src/sage/plot/text.py
++++ b/src/sage/plot/text.py
+@@ -325,6 +325,8 @@ def text(string, xy, **options):
+     You can save text as part of PDF output::
+ 
+         sage: text("sage", (0,0), rgbcolor=(0,0,0)).save(os.path.join(SAGE_TMP, 'a.pdf'))
++        ...
++        DeprecationWarning: The py23 module has been deprecated and will be removed in a future release. Please update your code.
+ 
+     Some examples of bounding box::
+ 

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -109,6 +109,14 @@ stdenv.mkDerivation rec {
     # strictly necessary, but keeps us from littering in the user's HOME.
     ./patches/sympow-cache.patch
 
+    # fonttools 4.26.2, used by matplotlib, uses deprecated methods internally.
+    # This is fixed in fonttools 4.27.0, but since fonttools is a dependency of
+    # 2000+ packages and DeprecationWarnings are hidden almost everywhere by
+    # default (not on Sage's doctest harness, though), it doesn't make sense to
+    # backport the fix (see https://github.com/NixOS/nixpkgs/pull/151415).
+    # Let's just assume warnings are expected until we update to 4.27.0.
+    ./patches/fonttools-deprecation-warnings.patch
+
     # https://trac.sagemath.org/ticket/32305
     (fetchSageDiff {
       base = "9.4";


### PR DESCRIPTION
###### Motivation for this change

fonttools, a dependency of matplotlib, was updated recently. Unfortunately, non-deprecated fonttools modules import deprecated modules and this generated a warning. Since fonttools is a reverse dep of 2000+ packages, it does not make much sense to backport the warning removal (see https://github.com/NixOS/nixpkgs/pull/151415). Let's apply a quick band-aid to this situation and remove it when fonttools gets updated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
