### PR TITLE
[staging-next] vala-lint: fix build on vala-0.54

### DIFF
--- a/pkgs/development/tools/vala-lint/default.nix
+++ b/pkgs/development/tools/vala-lint/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , glib
 , meson
 , ninja
@@ -21,6 +22,16 @@ stdenv.mkDerivation rec {
     rev = "5b06cc2341ae7e9f7f8c35c542ef78c36e864c30";
     sha256 = "KwJ5sCp9ZrrxIqc6qi2+ZdHBt1esNOO1+uDkS+d9mW8=";
   };
+
+  patches = [
+    # Fix build against vala-0.54+. Pull fix pending upstream
+    # inclusion: https://github.com/vala-lang/vala-lint/pull/155
+    (fetchpatch {
+      name = "vala-0.54.patch";
+      url = "https://github.com/vala-lang/vala-lint/commit/739f9a0b7d3e92db41eb32f2bfa527efdacc223b.patch";
+      sha256 = "sha256-1IbQu3AQXRCrrjoMZKhEOqzExmPAo1SQOFHa/IrqnNA=";
+    })
+  ];
 
   nativeBuildInputs = [
     gettext


### PR DESCRIPTION
Without the change the build fails as:

    ../lib/Utils.vala:103.21-103.27: error: too many type arguments for `bool'
        public delegate bool<G> FilterFunction<G> (G element);
                        ^^^^^^^
