### PR TITLE
[staging-next] python3Packages.grpcio-status: 1.42.0 -> 1.43.0 

### DIFF
--- a/pkgs/development/libraries/grpc/default.nix
+++ b/pkgs/development/libraries/grpc/default.nix
@@ -13,11 +13,16 @@
 , grpc
 , abseil-cpp
 , libnsl
+
+# tests
+, python3
 }:
 
 stdenv.mkDerivation rec {
   pname = "grpc";
-  version = "1.43.0"; # N.B: if you change this, change pythonPackages.grpcio-tools to a matching version too
+  version = "1.43.0"; # N.B: if you change this, please update:
+    # pythonPackages.grpcio-tools
+    # pythonPackages.grpcio-status
 
   src = fetchFromGitHub {
     owner = "grpc";
@@ -85,6 +90,10 @@ stdenv.mkDerivation rec {
     + lib.optionalString stdenv.isAarch64 "-Wno-error=format-security";
 
   enableParallelBuilds = true;
+
+  passthru.tests = {
+    inherit (python3.pkgs) grpcio-status grpcio-tools;
+  };
 
   meta = with lib; {
     description = "The C based gRPC (C++, Python, Ruby, Objective-C, PHP, C#)";

--- a/pkgs/development/python-modules/grpcio-status/default.nix
+++ b/pkgs/development/python-modules/grpcio-status/default.nix
@@ -2,7 +2,6 @@
 , buildPythonPackage
 , fetchPypi
 , googleapis-common-protos
-, grpc
 , grpcio
 , protobuf
 , pythonOlder
@@ -10,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "grpcio-status";
-  inherit (grpc) version;
+  version = "1.43.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "JVM8TWXX1ROmOPDEuIsrZnAOO/Q+aZWlWjvRXsC3eQI=";
+    sha256 = "sha256-IXWQBvNqf/v/GH1BkfQRjActiqn6aCOhGq14QqPGzNA=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
Fix build, and add more tests to upstream dependency.

#148396

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
