### PR TITLE
haskell.compiler.ghcjs: Don't use upstream `config.sub`

### DIFF
--- a/pkgs/development/compilers/ghcjs/8.10/default.nix
+++ b/pkgs/development/compilers/ghcjs/8.10/default.nix
@@ -78,6 +78,11 @@ in stdenv.mkDerivation {
     ];
     dontConfigure = true;
     dontInstall = true;
+
+    # Newer versions of `config.sub` reject the `js-ghcjs` host string, but the
+    # older `config.sub` filed vendored within `ghc` still works
+    dontUpdateAutotoolsGnuConfigScripts = true;
+
     buildPhase = ''
       export HOME=$TMP
       mkdir $HOME/.cabal


### PR DESCRIPTION
###### Motivation for this change

Before this change the `ghcjs` build fails with:

```
checking host system type... Invalid configuration `js-ghcjs': machine `js-unknown' not recognized
configure: error: …/bin/bash …/configured-ghcjs-src/lib/boot/pkg/unix/config.sub js-ghcjs failed
```

This fails because the `updateAutotoolsGnuConfigScriptsHook` overrides the
`config.sub` in the `unix` boot package to use the newer upstream
version of `config.sub`, but the newer version is incompatible with the
`js-ghcjs` host string used to configure the `unix` package.  The
fix is to undo the override, because the `config.sub` vendored within
`ghc` supports the host string correctly.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
