### PR TITLE
haskell.compiler.ghcjs: Fix Linux build

### DIFF
--- a/pkgs/development/compilers/ghcjs/8.10/configured-ghcjs-src.nix
+++ b/pkgs/development/compilers/ghcjs/8.10/configured-ghcjs-src.nix
@@ -26,8 +26,7 @@ runCommand "configured-ghcjs-src" {
     happy
     alex
     cabal-install
-  ] ++ lib.optionals stdenv.isDarwin [
-    gcc # https://github.com/ghcjs/ghcjs/issues/663
+    gcc
   ];
   inherit ghcjsSrc;
 } ''


### PR DESCRIPTION
###### Motivation for this change

Before this change the GHCJS build fails on Linux with:

```
Setup: Missing dependency on a foreign library:
* Missing (or bad) header file: ghc/utils/unlit/fs.h
```

The root cause is that the `./ghc/configure.ac` script is
responsible for copying `./ghc/utils/fs/fs.h` to
`./ghc/utils/unlit/fs.h`, but the script exits early if a C
compiler is not present.

This fixes that by ensuring that the C compiler is present
on all platforms (not just Darwin), so that the build now
works on Linux, too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
