### PR TITLE
podman-compose: 0.1.8 -> 1.0.3

### DIFF
--- a/pkgs/applications/virtualization/podman-compose/default.nix
+++ b/pkgs/applications/virtualization/podman-compose/default.nix
@@ -1,18 +1,17 @@
-{ lib, buildPythonApplication, fetchFromGitHub, pyyaml }:
+{ lib, buildPythonApplication, fetchFromGitHub, python-dotenv, pyyaml }:
 
 buildPythonApplication rec {
-  version = "0.1.8";
+  version = "1.0.3";
   pname = "podman-compose";
 
-  # "This project is still under development." -- README.md
   src = fetchFromGitHub {
     repo = "podman-compose";
     owner = "containers";
-    rev = version;
-    sha256 = "sha256-BN6rG46ejYY6UCNjKYQpxPQGTW3x12zpGDnH2SKn304=";
+    rev = "v${version}";
+    sha256 = "sha256-Si/O4dx9bqqRp/hTv3WbTXj46OM+PpyPBnQQWUqcZfs=";
   };
 
-  propagatedBuildInputs = [ pyyaml ];
+  propagatedBuildInputs = [ pyyaml python-dotenv ];
 
   meta = {
     description = "An implementation of docker-compose with podman backend";


### PR DESCRIPTION
###### Motivation for this change

podman-compose is outdated.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
