### PR TITLE
mplus-outline-fonts: add github release

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12765,6 +12765,12 @@
     githubId = 1983821;
     name = "Eric Wolf";
   };
+  uakci = {
+    name = "uakci";
+    email = "uakci@uakci.pl";
+    github = "uakci";
+    githubId = 6961268;
+  };
   udono = {
     email = "udono@virtual-things.biz";
     github = "udono";

--- a/pkgs/data/fonts/mplus-outline-fonts/default.nix
+++ b/pkgs/data/fonts/mplus-outline-fonts/default.nix
@@ -1,25 +1,45 @@
-{ lib, fetchzip }:
+{ lib, fetchzip, fetchFromGitHub }:
 
-let
-  version = "063a";
-in fetchzip {
-  name = "mplus-${version}";
+let pname = "mplus-outline-fonts";
+in {
+  osdnRelease = fetchzip {
+    name = "${pname}-osdn";
+    url = "mirror://osdn/mplus-fonts/62344/mplus-TESTFLIGHT-063a.tar.xz";
+    sha256 = "16jirhkjs46ac8cdk2w4xkpv989gmz7i8gnrq9bck13rbil7wlzr";
+    postFetch = ''
+      mkdir -p $out/share/fonts/truetype/${pname}
+      tar xvJf $downloadedFile
+      mv */*.ttf $out/share/fonts/truetype/${pname}
+    '';
 
-  url = "mirror://osdn/mplus-fonts/62344/mplus-TESTFLIGHT-${version}.tar.xz";
+    meta = with lib; {
+      description = "M+ Outline Fonts (legacy OSDN release)";
+      homepage = "https://mplus-fonts.osdn.jp";
+      maintainers = with maintainers; [ henrytill ];
+      platforms = platforms.all;
+      license = licenses.mit;
+    };
+  };
 
-  postFetch = ''
-    tar -xJf $downloadedFile --strip-components=1
-    mkdir -p $out/share/fonts/truetype
-    cp *.ttf $out/share/fonts/truetype
-  '';
+  githubRelease = fetchFromGitHub {
+    name = "${pname}-github";
+    owner = "coz-m";
+    repo = "MPLUS_FONTS";
+    rev = "336fec4e9e7c1e61bd22b82e6364686121cf3932";
+    sha256 = "1ha92hyzcfbbq682c50k8clbhigc09rcb9mxjzjwqfj9rfp348id";
+    postFetch = ''
+      mkdir -p $out/share/fonts/{truetype,opentype}/${pname}
+      tar xvzf $downloadedFile
+      mv */fonts/ttf/* $out/share/fonts/truetype/${pname}
+      mv */fonts/otf/* $out/share/fonts/opentype/${pname}
+    '';
 
-  sha256 = "1khbkch2r96ppifc93bmy1v047pgciyhfmcjb98ggncp5ix885xz";
-
-  meta = with lib; {
-    description = "M+ Outline Fonts";
-    homepage = "https://mplus-fonts.osdn.jp/about-en.html";
-    license = licenses.mit;
-    maintainers = with maintainers; [ henrytill ];
-    platforms = platforms.all;
+    meta = with lib; {
+      description = "M+ Outline Fonts (GitHub release)";
+      homepage = "https://mplusfonts.github.io";
+      maintainers = with maintainers; [ henrytill ];
+      platforms = platforms.all;
+      license = licenses.ofl;
+    };
   };
 }

--- a/pkgs/data/fonts/mplus-outline-fonts/default.nix
+++ b/pkgs/data/fonts/mplus-outline-fonts/default.nix
@@ -15,7 +15,7 @@ in {
     meta = with lib; {
       description = "M+ Outline Fonts (legacy OSDN release)";
       homepage = "https://mplus-fonts.osdn.jp";
-      maintainers = with maintainers; [ henrytill ];
+      maintainers = with maintainers; [ henrytill uakci ];
       platforms = platforms.all;
       license = licenses.mit;
     };
@@ -37,7 +37,7 @@ in {
     meta = with lib; {
       description = "M+ Outline Fonts (GitHub release)";
       homepage = "https://mplusfonts.github.io";
-      maintainers = with maintainers; [ henrytill ];
+      maintainers = with maintainers; [ henrytill uakci ];
       platforms = platforms.all;
       license = licenses.ofl;
     };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24084,7 +24084,7 @@ with pkgs;
 
   mph_2b_damase = callPackage ../data/fonts/mph-2b-damase { };
 
-  mplus-outline-fonts = callPackage ../data/fonts/mplus-outline-fonts { };
+  mplus-outline-fonts = recurseIntoAttrs (callPackage ../data/fonts/mplus-outline-fonts { });
 
   mro-unicode = callPackage ../data/fonts/mro-unicode { };
 


### PR DESCRIPTION
###### Motivation for this change

[The new, revamped (pre)release](https://github.com/coz-m/MPLUS_FONTS) of the M+ font superfamily is highly deserving of inclusion, and is meant to replace the OSDN release for good. I've chosen to add a (sub)package instead of replacing the existing one so that we don't break existing user configurations (the fonts have been renamed and reshuffled across the two releases).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux, NixOS (with `--option sandbox true`)
- ~~Tested, as applicable~~ (inapplicable)
- ~~Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)~~ (nothing depends on this package)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @henrytill 