### PR TITLE
ocamlPackages.pfff: init at 2021-12-14

### DIFF
--- a/pkgs/development/ocaml-modules/easy_logging/default.nix
+++ b/pkgs/development/ocaml-modules/easy_logging/default.nix
@@ -1,0 +1,37 @@
+{ buildDunePackage
+, lib
+, fetchFromGitHub
+, ocaml
+, calendar
+}:
+
+buildDunePackage rec {
+  pname = "easy_logging";
+  version = "0.8.2";
+
+  src = fetchFromGitHub {
+    owner = "sapristi";
+    repo = "easy_logging";
+    rev = "v${version}";
+    sha256 = "Xy6Rfef7r2K8DTok7AYa/9m3ZEV07LlUeMQSRayLBco=";
+  };
+
+  nativeBuildInputs = [
+    ocaml
+  ];
+
+  propagatedBuildInputs = [
+    calendar
+  ];
+
+  useDune2 = true;
+  strictDeps = true;
+
+  meta = with lib; {
+    description = "Module to log messages";
+    homepage = "https://sapristi.github.io/easy_logging/";
+    license = licenses.mpl20;
+    maintainers = [ ];
+    platforms = ocaml.meta.platforms or [];
+  };
+}

--- a/pkgs/development/ocaml-modules/easy_logging_yojson/default.nix
+++ b/pkgs/development/ocaml-modules/easy_logging_yojson/default.nix
@@ -1,0 +1,34 @@
+{ buildDunePackage
+, lib
+, fetchFromGitHub
+, ocaml
+, ppx_deriving
+, ppx_deriving_yojson
+, easy_logging
+}:
+
+buildDunePackage rec {
+  pname = "easy_logging_yojson";
+  inherit (easy_logging) version src;
+
+  nativeBuildInputs = [
+    ocaml
+  ];
+
+  propagatedBuildInputs = [
+    ppx_deriving
+    ppx_deriving_yojson
+    easy_logging
+  ];
+
+  useDune2 = true;
+  strictDeps = true;
+
+  meta = with lib; {
+    description = "Configuration loader for easy_logging with yojson backend";
+    homepage = "https://sapristi.github.io/easy_logging/";
+    license = licenses.mpl20;
+    maintainers = [ ];
+    platforms = ocaml.meta.platforms or [];
+  };
+}

--- a/pkgs/development/ocaml-modules/grain_dypgen/default.nix
+++ b/pkgs/development/ocaml-modules/grain_dypgen/default.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, ocaml
+, findlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "grain_dypgen";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "grain-lang";
+    repo = "dypgen";
+    rev = version;
+    sha256 = "vTt1hCItFEskiotIbRaHjGz3aAbpaLnPZaXAReOuuPI=";
+  };
+
+  nativeBuildInputs = [
+    ocaml
+    findlib
+  ];
+
+  makeFlags = [
+    "BINDIR=$(out)/bin"
+    "MANDIR=$(out)/usr/share/man/man1"
+    "DYPGENLIBDIR=$(out)/lib/ocaml/${ocaml.version}/site-lib"
+  ];
+
+  strictDeps = true;
+
+  meta = {
+    homepage = "https://github.com/grain-lang/dypgen";
+    description = "Dypgen GLR self extensible parser generator";
+    license = lib.licenses.cecill-b;
+    platforms = ocaml.meta.platforms or [];
+  };
+}

--- a/pkgs/development/ocaml-modules/json-wheel/default.nix
+++ b/pkgs/development/ocaml-modules/json-wheel/default.nix
@@ -1,0 +1,54 @@
+{ stdenv
+, lib
+, fetchurl
+, ocaml
+, findlib
+, which
+, ocamlnet
+}:
+
+stdenv.mkDerivation rec {
+  pname = "json-wheel";
+  version = "1.0.6";
+
+  src = fetchurl {
+    url = "https://github.com/mjambon/mjambon2016/raw/bd644e0a42cacba56d0260982614d1ef5c8305b3/json-wheel-1.0.6.tar.bz2";
+    sha256 = "BYLDP2iG4Yr8izqcMsdjcqFdO8OXSci8G+iLvYrXH8U=";
+  };
+
+  patches = [
+    # Fix build.
+    (fetchurl {
+      name = "json-wheel-1.0.6-safe-string.patch";
+      url = "https://github.com/ocaml/opam-repository/raw/master/packages/json-wheel/json-wheel.1.0.6%2Bsafe-string/files/json-wheel-1.0.6%2Bsafe-string.patch";
+      sha256 = "dvouBFBauQxNElBrhQxVNpos5G+7FYqLwniXGLQTsqQ=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    ocaml
+    findlib
+    which
+  ];
+
+  buildInputs = [
+    ocamlnet
+  ];
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  preInstall = ''
+    mkdir -p "$out/lib/ocaml/${ocaml.version}/site-lib" "$out/bin"
+  '';
+
+  strictDeps = true;
+
+  meta = {
+    homepage = "https://opam.ocaml.org/packages/json-wheel/";
+    description = "JSON parser and writer, with optional C-style comments";
+    license = lib.licenses.bsd3;
+    platforms = ocaml.meta.platforms or [];
+  };
+}

--- a/pkgs/development/ocaml-modules/pfff/default.nix
+++ b/pkgs/development/ocaml-modules/pfff/default.nix
@@ -1,0 +1,90 @@
+{ buildDunePackage
+, lib
+, fetchFromGitHub
+, ocaml
+, opam
+, perl
+, dune_2
+, ocamlgraph
+, yojson
+, menhir
+, grain_dypgen
+, ppx_deriving
+, ppx_hash
+, ppxlib
+, uutf
+, uucp
+, alcotest
+, ansiterminal
+, easy_logging
+, easy_logging_yojson
+}:
+
+buildDunePackage rec {
+  pname = "pfff";
+  version = "2021-12-14";
+
+  src = fetchFromGitHub {
+    owner = "returntocorp";
+    repo = "pfff";
+    rev = "0a3be7857551b69c430dc081575f9daef8ac85a0";
+    sha256 = "YA/BN6AFXLyeT3SxCixqtzKgd4LfrDNqw1IEEsHDs+c=";
+  };
+
+  nativeBuildInputs = [
+    ocaml
+    opam
+    perl
+    dune_2
+    menhir
+    grain_dypgen
+  ];
+
+  propagatedBuildInputs = [
+    ocamlgraph
+    yojson
+    grain_dypgen
+    ppx_deriving
+    ppx_hash
+    ppxlib
+    uutf
+    uucp
+    alcotest
+    ansiterminal
+    easy_logging
+    easy_logging_yojson
+  ];
+
+  useDune2 = true;
+  strictDeps = true;
+
+  postPatch = ''
+    patchShebangs ./configure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    dune build ''${enableParallelBuilding:+-j $NIX_BUILD_CORES}
+    runHook postBuild
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    dune runtest ''${enableParallelBuilding:+-j $NIX_BUILD_CORES}
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    dune install --prefix $out --libdir $OCAMLFIND_DESTDIR
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Tools and APIs for program analysis, code visualization, refactoring";
+    homepage = "https://github.com/returntocorp/pfff/wiki";
+    license = licenses.lgpl21Only;
+    maintainers = [ ];
+    platforms = ocaml.meta.platforms or [];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -500,6 +500,8 @@ let
 
     gmetadom = callPackage ../development/ocaml-modules/gmetadom { };
 
+    grain_dypgen = callPackage ../development/ocaml-modules/grain_dypgen { };
+
     graphics =
     if lib.versionOlder "4.09" ocaml.version
     then callPackage ../development/ocaml-modules/graphics { }

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -581,6 +581,8 @@ let
 
     json-data-encoding-bson = callPackage ../development/ocaml-modules/json-data-encoding/bson.nix { };
 
+    json-wheel = callPackage ../development/ocaml-modules/json-wheel { };
+
     junit = callPackage ../development/ocaml-modules/junit { };
     junit_ounit = callPackage ../development/ocaml-modules/junit/ounit.nix { };
     junit_alcotest = callPackage ../development/ocaml-modules/junit/alcotest.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -918,6 +918,8 @@ let
 
     pgocaml = callPackage ../development/ocaml-modules/pgocaml {};
 
+    pfff = callPackage ../development/ocaml-modules/pfff {};
+
     pgocaml_ppx = callPackage ../development/ocaml-modules/pgocaml/ppx.nix {};
 
     ocaml-r = callPackage ../development/ocaml-modules/ocaml-r { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -327,6 +327,10 @@ let
 
     earlybird = callPackage ../development/ocaml-modules/earlybird { };
 
+    easy_logging = callPackage ../development/ocaml-modules/easy_logging { };
+
+    easy_logging_yojson = callPackage ../development/ocaml-modules/easy_logging_yojson { };
+
     easy-format = callPackage ../development/ocaml-modules/easy-format { };
 
     eigen = callPackage ../development/ocaml-modules/eigen { };


### PR DESCRIPTION
> [pfff](https://github.com/returntocorp/pfff/) is a set of tools and APIs to perform static analysis, code visualizations, code navigations, or style-preserving source-to-source transformations such as refactorings on source code. There is good support for Javascript, Python, C, Java, Go, and PHP. There is also preliminary support for other languages such as C++, Ruby, Rust, C#, Html, CSS, Erlang, Lisp, Haskell, Skip, and SQL. There is also very good support for OCaml code so that the framework can be used on the code of pfff itself.

Unfortunately it looks like it has been quite gutted.
