### PR TITLE
Check nixpkgs overlays argument types

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -66,7 +66,8 @@ let
       stringLength sub substring tail trace;
     inherit (self.trivial) id const pipe concat or and bitAnd bitOr bitXor
       bitNot boolToString mergeAttrs flip mapNullable inNixShell isFloat min max
-      importJSON importTOML warn warnIf info showWarnings nixpkgsVersion version
+      importJSON importTOML warn warnIf throwIfNot
+      info showWarnings nixpkgsVersion version
       mod compare splitByAndCompare functionArgs setFunctionArgs isFunction
       toHexString toBaseDigits;
     inherit (self.fixedPoints) fix fix' converge extends composeExtensions

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -325,6 +325,28 @@ rec {
   */
   warnIf = cond: msg: if cond then warn msg else id;
 
+  /*
+    Like the `assert b; e` expression, but with a custom error message and
+    without the semicolon.
+
+    If true, return the identity function, `r: r`.
+
+    If false, throw the error message.
+
+    Calls can be juxtaposed using function application, as `(r: r) a = a`, so
+    `(r: r) (r: r) a = a`, and so forth.
+
+    Type: bool -> string -> a -> a
+
+    Example:
+
+        throwIfNot (lib.isList overlays) "The overlays argument to nixpkgs must be a list."
+        lib.foldr (x: throwIfNot (lib.isFunction x) "All overlays passed to nixpkgs must be functions.") (r: r) overlays
+        pkgs
+
+  */
+  throwIfNot = cond: msg: if cond then x: x else throw msg;
+
   info = msg: builtins.trace "INFO: ${msg}";
 
   showWarnings = warnings: res: lib.foldr (w: x: warn w x) res warnings;

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -49,6 +49,15 @@ let # Rename the function arguments
 in let
   lib = import ../../lib;
 
+  throwIfNot = b: msg: if b then x: x else throw msg;
+
+  checked =
+    throwIfNot (lib.isList overlays) "The overlays argument to nixpkgs must be a list."
+    lib.foldr (x: throwIfNot (lib.isFunction x) "All overlays passed to nixpkgs must be functions.") (r: r) overlays
+    throwIfNot (lib.isList crossOverlays) "The crossOverlays argument to nixpkgs must be a list."
+    lib.foldr (x: throwIfNot (lib.isFunction x) "All crossOverlays passed to nixpkgs must be functions.") (r: r) crossOverlays
+    ;
+
   localSystem = lib.systems.elaborate args.localSystem;
 
   # Condition preserves sharing which in turn affects equality.
@@ -121,4 +130,4 @@ in let
 
   pkgs = boot stages;
 
-in pkgs
+in checked pkgs

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -49,7 +49,7 @@ let # Rename the function arguments
 in let
   lib = import ../../lib;
 
-  throwIfNot = b: msg: if b then x: x else throw msg;
+  inherit (lib) throwIfNot;
 
   checked =
     throwIfNot (lib.isList overlays) "The overlays argument to nixpkgs must be a list."


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Improve UX.

Not feasible to do everywhere, but we can do this in a few key places.

Before:

```
nix-repl> import ./. { overlays = [ { overlays = []; } ]; }
error: attempt to call something which is not a function but a set

       at /home/user/h/nixpkgs/lib/fixed-points.nix:69:67:

           68|   #
           69|   extends = f: rattrs: self: let super = rattrs self; in super // f self super;
             |                                                                   ^
           70|

nix-repl> import ./. { overlays = self: super: { }; }       
error: value is a function while a list was expected

       at /home/user/h/nixpkgs/pkgs/top-level/stage.nix:271:8:

          270|     configOverrides
          271|   ] ++ overlays ++ [
             |        ^
          272|     stdenvOverrides ]);
```

After:

```
nix-repl> import ./. { overlays = [ { overlays = []; } ]; }
error: All overlays passed to nixpkgs must be functions.

nix-repl> import ./. { overlays = self: super: { }; }       
error: The overlays argument to nixpkgs must be a list.

```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
