### PR TITLE
Gambit and Gerbil Scheme: fixes for aarch64-darwin, Leveldb: 1.20 -> 1.23

### DIFF
--- a/pkgs/development/compilers/gambit/bootstrap.nix
+++ b/pkgs/development/compilers/gambit/bootstrap.nix
@@ -42,7 +42,7 @@ gccStdenv.mkDerivation {
   '';
 
   installPhase = ''
-    cp -fa ./ $out/gambit/
+    cp -fa ./gsc-boot $out/gambit/
   '';
 
   forceShare = [ "info" ];

--- a/pkgs/development/compilers/gambit/bootstrap.nix
+++ b/pkgs/development/compilers/gambit/bootstrap.nix
@@ -15,6 +15,15 @@ gccStdenv.mkDerivation {
 
   buildInputs = [ autoconf ];
 
+  # disable stackprotector on aarch64-darwin for now
+  # build error:
+  # ```
+  # /private/tmp/nix-build-gambit-bootstrap-4.9.3.drv-0/ccbOVwnF.s:207:15: error: index must be an integer in range [-256, 255].
+  #         ldr     x2, [x2, ___stack_chk_guard];momd
+  #                          ^
+  # ```
+  hardeningDisable = lib.optionals (gccStdenv.isAarch64 && gccStdenv.isDarwin) [ "stackprotector" ];
+
   configurePhase = ''
     export CC=${gcc}/bin/gcc CXX=${gcc}/bin/g++ \
            CPP=${gcc}/bin/cpp CXXCPP=${gcc}/bin/cpp LD=${gcc}/bin/ld \

--- a/pkgs/development/compilers/gambit/build.nix
+++ b/pkgs/development/compilers/gambit/build.nix
@@ -35,6 +35,15 @@ gccStdenv.mkDerivation rec {
   # Or wrap relevant programs to add a suitable PATH ?
   #runtimeDeps = [ gnused gnugrep ];
 
+  # disable stackprotector on aarch64-darwin for now
+  # build error:
+  # ```
+  # /private/tmp/nix-build-gambit-unstable-2020-09-20.drv-0/ccIjyeeb.s:207:15: error: index must be an integer in range [-256, 255].
+  #         ldr     x2, [x2, ___stack_chk_guard];momd
+  #                          ^
+  # ```
+  hardeningDisable = lib.optionals (gccStdenv.isAarch64 && gccStdenv.isDarwin) [ "stackprotector" ];
+
   configureFlags = [
     "--enable-targets=${gambit-params.targets}"
     "--enable-single-host"

--- a/pkgs/development/compilers/gerbil/build.nix
+++ b/pkgs/development/compilers/gerbil/build.nix
@@ -21,6 +21,15 @@ stdenv.mkDerivation rec {
   buildInputs = [ gambit ]
     ++ buildInputs_libraries; # ++ buildInputs_staticLibraries;
 
+  # disable stackprotector on aarch64-darwin for now
+  # build error:
+  # ```
+  # /private/tmp/nix-build-gerbil-unstable-2020-11-05.drv-0/ccjyhWKi.s:326:15: error: index must be an integer in range [-256, 255].
+  #         ldr     x2, [x2, ___stack_chk_guard];momd
+  #                          ^
+  # ```
+  hardeningDisable = lib.optionals (gccStdenv.isAarch64 && gccStdenv.isDarwin) [ "stackprotector" ];
+
   NIX_CFLAGS_COMPILE = "-I${libmysqlclient}/include/mysql -L${libmysqlclient}/lib/mysql";
 
   postPatch = ''

--- a/pkgs/development/libraries/irrlicht/mac_device.patch
+++ b/pkgs/development/libraries/irrlicht/mac_device.patch
@@ -18,3 +18,21 @@
  			[NSBundle loadNibNamed:@"MainMenu" owner:[NSApp delegate]];
  			[NSApp finishLaunching];
  		}
+@@ -642,7 +642,7 @@
+ 						NSOpenGLPFASamples, (NSOpenGLPixelFormatAttribute)CreationParams.AntiAlias,
+ 						NSOpenGLPFAStencilSize, (NSOpenGLPixelFormatAttribute)(CreationParams.Stencilbuffer?1:0),
+ 						NSOpenGLPFADoubleBuffer,
+-						(NSOpenGLPixelFormatAttribute)nil
++						(NSOpenGLPixelFormatAttribute)0
+ 					};
+ 
+ 					if (CreationParams.AntiAlias<2)
+@@ -668,7 +668,7 @@
+ 						{
+ 							// Third try without Doublebuffer
+ 							os::Printer::log("No doublebuffering available.", ELL_WARNING);
+-							windowattribs[14]=(NSOpenGLPixelFormatAttribute)nil;
++							windowattribs[14]=(NSOpenGLPixelFormatAttribute)0;
+ 						}
+ 
+ 						format = [[NSOpenGLPixelFormat alloc] initWithAttributes:windowattribs];

--- a/pkgs/development/libraries/leveldb/default.nix
+++ b/pkgs/development/libraries/leveldb/default.nix
@@ -1,39 +1,50 @@
-{ lib, stdenv, fetchFromGitHub, fixDarwinDylibNames, snappy }:
+{ lib, stdenv, fetchFromGitHub, fixDarwinDylibNames, snappy, cmake
+, static ? stdenv.hostPlatform.isStatic }:
 
 stdenv.mkDerivation rec {
   pname = "leveldb";
-  version = "1.20";
+  version = "1.23";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "leveldb";
-    rev = "v${version}";
-    sha256 = "01kxga1hv4wp94agx5vl3ybxfw5klqrdsrb6p6ywvnjmjxm8322y";
+    rev = "${version}";
+    sha256 = "sha256-RL+dfSFZZzWvUobSqiPbuC4nDiGzjIIukbVJZRacHbI=";
   };
+
+  outputs = [ "out" "dev" ];
 
   buildInputs = [ snappy ];
 
-  nativeBuildInputs = lib.optional stdenv.isDarwin fixDarwinDylibNames;
+  nativeBuildInputs = lib.optional stdenv.isDarwin fixDarwinDylibNames ++ [ cmake ];
 
   doCheck = true;
 
   buildFlags = [ "all" ];
+
+  # NOTE: disabling tests due to gtest issue
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=${if static then "OFF" else "ON"}"
+    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
+    "-DLEVELDB_BUILD_TESTS=OFF"
+  ];
 
   postPatch = lib.optionalString stdenv.hostPlatform.isStatic ''
     # remove shared objects from "all" target
     sed -i '/^all:/ s/$(SHARED_LIBS) $(SHARED_PROGRAMS)//' Makefile
   '';
 
-  installPhase = ''
-    runHook preInstall
-
-    install -D -t $out/include/leveldb include/leveldb/*
-    install -D helpers/memenv/memenv.h $out/include/leveldb/helpers
-
-    install -D -t $out/lib out-{static,shared}/lib*
-    install -D -t $out/bin out-static/{leveldbutil,db_bench}
-
-    runHook postInstall
+  postInstall = ''
+    substituteInPlace "$out"/lib/cmake/leveldb/leveldbTargets.cmake \
+      --replace 'INTERFACE_INCLUDE_DIRECTORIES "''${_IMPORT_PREFIX}/include"' 'INTERFACE_INCLUDE_DIRECTORIES "'$dev'"'
+    mkdir -p $dev/lib/pkgconfig
+    cat <<EOF > $dev/lib/pkgconfig/leveldb.pc
+      Name: leveldb
+      Description: Fast and lightweight key/value database library by Google.
+      Version: ${version}
+      Libs: -L$out/lib -lleveldb
+      Cflags: -I$dev/include
+    EOF
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I have been experiencing build errors on my Mac with the Apple M1 chip such as:
```
/private/tmp/nix-build-gambit-bootstrap-4.9.3.drv-0/ccbOVwnF.s:207:15: error: index must be an integer in range [-256, 255].
        ldr     x2, [x2, ___stack_chk_guard];momd
                         ^
```

Which can be fixed by disabling stackprotector on aarch64-darwin for now in Gambit and Gerbil Scheme.

Also while building Leveldb (necessary for Gerbil Scheme) I got an error probably also related to Apple M1 issues:
```
port/port_posix_sse.cc:58:3: error: use of undeclared identifier '__get_cpuid'
  __get_cpuid(1, &eax, &ebx, &ecx, &edx);
  ^
```
Which is fixed in the new Leveldb version 1.23.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
