### PR TITLE
[21.05] ghidra: fix CVE-2021-45046, CVE-2021-45105

### DIFF
--- a/pkgs/tools/security/ghidra/default.nix
+++ b/pkgs/tools/security/ghidra/default.nix
@@ -14,15 +14,15 @@ let
   log4j-api = fetchMavenArtifact {
     groupId = "org.apache.logging.log4j";
     artifactId = "log4j-api";
-    version = "2.15.0";
-    sha256 = "0m8admb2sbcjj9p54r516zczyb09qg4al36gd6p6sj85irz3xhy8";
+    version = "2.12.3";
+    sha256 = "0z9snl8h31dkwqisd6sfsh5yvf6fbg6imjc7mryzflnq1dfnk2d8";
   };
 
   log4j-core = fetchMavenArtifact {
     groupId = "org.apache.logging.log4j";
     artifactId = "log4j-core";
-    version = "2.15.0";
-    sha256 = "02r2d95dv7dhfh24p41bap4yam0j6q6n4gpkyjsbfwari498b6j1";
+    version = "2.12.3";
+    sha256 = "16idm7w073cjbk7nzbc4vcnahh9097dgp1nipj99hh6vamai32q4";
   };
 
   pkg_path = "$out/lib/ghidra";
@@ -73,7 +73,7 @@ in stdenv.mkDerivation rec {
       mv "$f" "$out/share/icons/hicolor/$res/apps/ghidra.png"
     done;
 
-    # workaround for CVE-2021-44228
+    # workaround for CVE-2021-44228, CVE-2021-45046, CVE-2021-45105
     rm -f $out/lib/ghidra/Ghidra/Framework/Generic/lib/{log4j-api-2.12.1.jar,log4j-core-2.12.1.jar}
     cp ${log4j-api}/share/java/*.jar ${log4j-core}/share/java/*.jar $out/lib/ghidra/Ghidra/Framework/Generic/lib
   '';


### PR DESCRIPTION
###### Motivation for this change

Fixes remaining log4j issues.

Note: previous PR for CVE-2021-44228 (https://github.com/NixOS/nixpkgs/pull/150159) upgraded log4j to 2.15 - as Ghidra 9.2.4 ships log4j 2.12.1, substituting for 2.12.3 is a better fit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
