### PR TITLE
fltk*: Bump

### DIFF
--- a/pkgs/applications/radio/fldigi/default.nix
+++ b/pkgs/applications/radio/fldigi/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , fetchurl
 , hamlib
-, fltk14
+, fltk13
 , libjpeg
 , libpng
 , portaudio
@@ -31,13 +31,15 @@ stdenv.mkDerivation rec {
     libXinerama
     gettext
     hamlib
-    fltk14
+    fltk13
     libjpeg
     libpng
     portaudio
     libsndfile
     libsamplerate
   ] ++ lib.optionals (stdenv.isLinux) [ libpulseaudio alsa-lib udev ];
+
+  enableParallelBuilding = true;
 
   meta = with lib; {
     description = "Digital modem program";

--- a/pkgs/applications/radio/fldigi/default.nix
+++ b/pkgs/applications/radio/fldigi/default.nix
@@ -47,5 +47,8 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ relrod ftrvxmtrx ];
     platforms = platforms.unix;
+    # unable to execute command: posix_spawn failed: Argument list too long
+    # Builds fine on aarch64-darwin
+    broken = stdenv.system == "x86_64-darwin";
   };
 }

--- a/pkgs/development/libraries/fltk/1.4.nix
+++ b/pkgs/development/libraries/fltk/1.4.nix
@@ -1,5 +1,5 @@
 import ./common.nix rec {
-  version = "1.4.x-2021-07-04";
-  rev = "1008cdfab27609a6f6a0e82dadad9fd9cbd8a66d";
-  sha256 = "1h057dyhd04b9bjci952b2l7brxv183l9jw9i50mn9qjfljmvqim";
+  version = "1.4.x-2021-12-21";
+  rev = "c8bb2a35850be7c6eaec5ad5a2936a77f7913de2";
+  sha256 = "1fwfg1hp1ajqh2b4ra4phi96854q9i8c0gbyi7pr35ljyv848295";
 }

--- a/pkgs/development/libraries/fltk/default.nix
+++ b/pkgs/development/libraries/fltk/default.nix
@@ -1,5 +1,5 @@
 import ./common.nix rec {
-  version = "1.3.6";
+  version = "1.3.8";
   rev = "release-${version}";
-  sha256 = "0vzk4d6j927v7dxywr5xlqlf70myal1xikkdfvd11p94rcdf9bsv";
+  sha256 = "1pw4ndwn9rr1cxw5qiw32r9la2z9zbjphgsqq1hj2yy4blwv419r";
 }

--- a/pkgs/development/libraries/librsb/default.nix
+++ b/pkgs/development/libraries/librsb/default.nix
@@ -82,5 +82,7 @@ stdenv.mkDerivation rec {
     license = with licenses; [ lgpl3Plus ];
     maintainers = with maintainers; [ KarlJoad ];
     platforms = platforms.all;
+    # ./rsb_common.h:56:10: fatal error: 'omp.h' file not found
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/octave-modules/gsl/default.nix
+++ b/pkgs/development/octave-modules/gsl/default.nix
@@ -1,4 +1,5 @@
 { buildOctavePackage
+, stdenv
 , lib
 , fetchurl
 , gsl
@@ -22,5 +23,8 @@ buildOctavePackage rec {
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ KarlJoad ];
     description = "Octave bindings to the GNU Scientific Library";
+    # error: use of undeclared identifier 'feval'; did you mean 'octave::feval'?
+    # error: no member named 'is_real_type' in 'octave_value'
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/octave-modules/level-set/default.nix
+++ b/pkgs/development/octave-modules/level-set/default.nix
@@ -1,4 +1,5 @@
 { buildOctavePackage
+, stdenv
 , lib
 , fetchgit
 , automake
@@ -50,5 +51,7 @@ buildOctavePackage rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ KarlJoad ];
     description = "Routines for calculating the time-evolution of the level-set equation and extracting geometric information from the level-set function";
+    # /build/level-set-2019-04-13.tar.gz: Cannot open: No such file or directory
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/octave-modules/ocl/default.nix
+++ b/pkgs/development/octave-modules/ocl/default.nix
@@ -1,4 +1,5 @@
 { buildOctavePackage
+, stdenv
 , lib
 , fetchurl
 }:
@@ -22,5 +23,7 @@ buildOctavePackage rec {
        Single-Instruction-Multiple-Data (SIMD) computations, selectively
        using available OpenCL hardware and drivers.
     '';
+    # error: structure has no member 'dir'
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/octave-modules/strings/default.nix
+++ b/pkgs/development/octave-modules/strings/default.nix
@@ -1,4 +1,5 @@
 { buildOctavePackage
+, stdenv
 , lib
 , fetchurl
 , pcre
@@ -33,5 +34,7 @@ buildOctavePackage rec {
     # Claims to have a freebsd license, but I found none.
     maintainers = with maintainers; [ KarlJoad ];
     description = "Additional functions for manipulation and analysis of strings";
+    # Some pcre symbols claimed to be missing
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/octave-modules/tisean/default.nix
+++ b/pkgs/development/octave-modules/tisean/default.nix
@@ -1,4 +1,5 @@
 { buildOctavePackage
+, stdenv
 , lib
 , fetchurl
 # Octave dependencies
@@ -29,5 +30,7 @@ buildOctavePackage rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ KarlJoad ];
     description = "Port of TISEAN 3.0.1";
+    # Some gfortran symbols claimed to be missing
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/octave-modules/video/default.nix
+++ b/pkgs/development/octave-modules/video/default.nix
@@ -1,4 +1,5 @@
 { buildOctavePackage
+, stdenv
 , lib
 , fetchurl
 , pkg-config
@@ -27,5 +28,7 @@ buildOctavePackage rec {
     license = with licenses; [ gpl3Plus bsd3 ];
     maintainers = with maintainers; [ KarlJoad ];
     description = "Wrapper for OpenCV's CvCapture_FFMPEG and CvVideoWriter_FFMPEG";
+    # error: declaration of 'panic' has a different language linkage
+    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Bumping fltk versions.

WIPs:
- [x] [1.3.8 was released a month ago](https://www.fltk.org/articles.php?L1782) but didn't get a tag on the GitHub repo. I'll open an issue about it
- [x] Test if it & reverse dependencies build & work on all platforms (I can test x86_64-{linux,darwin} and aarch64-linux)
- [ ] Test if any patches/workarounds can be removed

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
