### PR TITLE
mbtileserver: 0.7.0 → 0.8.0

### DIFF
--- a/pkgs/servers/mbtileserver/default.nix
+++ b/pkgs/servers/mbtileserver/default.nix
@@ -1,17 +1,23 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, stdenv, buildGoModule, fetchFromGitHub }:
 
 buildGoModule rec {
   pname = "mbtileserver";
-  version = "0.7.0";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "consbio";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-QdirExVv7p7Mnhp8EGdTVRlmEiYpzoXVQbtO8aS9Kas=";
+    sha256 = "sha256-0wSc2DIfK6o3kSiH2sSQcYRR5dHnQbnJC6SX6DwVk1c=";
   };
 
-  vendorSha256 = "sha256-mUUxUZn8out6WNvKJKHoz+R44RDB0oWJb+57w72+E5w=";
+  # https://github.com/consbio/mbtileserver/issues/130
+  postPatch = lib.optionalString stdenv.isAarch64 ''
+    substituteInPlace handlers/tile_test.go \
+      --replace "Test_CalcScaleResolution" "Skip_CalcScaleResolution"
+  '';
+
+  vendorSha256 = "sha256-36tUTZud0hxH9oZlnKxeK/xzoEzfw3xFMnd/r0srw6U=";
 
   meta = with lib; {
     description = "A simple Go-based server for map tiles stored in mbtiles format";


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/consbio/mbtileserver/releases/tag/v0.8.0)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
