### PR TITLE
lv2 + sratom + lilv: support cross-compilation

### DIFF
--- a/pkgs/development/libraries/audio/lilv/default.nix
+++ b/pkgs/development/libraries/audio/lilv/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config python3 wafHook ];
   buildInputs = [ serd sord sratom ];
   propagatedBuildInputs = [ lv2 ];
+  dontAddWafCrossFlags = true;
 
   passthru.tests = {
     inherit pipewire;

--- a/pkgs/development/libraries/audio/lv2/default.nix
+++ b/pkgs/development/libraries/audio/lv2/default.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkg-config
     wafHook
+    python3
   ];
 
   buildInputs = [
@@ -35,6 +36,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals stdenv.isDarwin [
     "--lv2dir=${placeholder "out"}/lib/lv2"
   ];
+  dontAddWafCrossFlags = true;
 
   passthru.tests = {
     inherit pipewire;

--- a/pkgs/development/libraries/audio/sratom/default.nix
+++ b/pkgs/development/libraries/audio/sratom/default.nix
@@ -11,6 +11,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config wafHook python3 ];
   buildInputs = [ lv2 serd sord ];
+  dontAddWafCrossFlags = true;
 
   meta = with lib; {
     homepage = "http://drobilla.net/software/sratom";

--- a/pkgs/development/tools/build-managers/wafHook/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/wafHook/setup-hook.sh
@@ -10,6 +10,10 @@ wafConfigurePhase() {
         wafConfigureFlags="${prefixKey:---prefix=}$prefix $wafConfigureFlags"
     fi
 
+    if [ -n "${PKG_CONFIG}" ]; then
+      export PKGCONFIG="${PKG_CONFIG}"
+    fi
+
     local flagsArray=(
         "${flagsArray[@]}"
         $wafConfigureFlags "${wafConfigureFlagsArray[@]}"

--- a/pkgs/misc/jackaudio/default.nix
+++ b/pkgs/misc/jackaudio/default.nix
@@ -48,8 +48,6 @@ stdenv.mkDerivation rec {
         --replace /bin/bash ${bash}/bin/bash
   '';
 
-  PKGCONFIG = "${stdenv.cc.targetPrefix}pkg-config";
-
   dontAddWafCrossFlags = "true";
   wafConfigureFlags = [
     "--classic"


### PR DESCRIPTION
###### Motivation for this change

Support cross-compilation for these packages.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux (output tree is equal to old tree)
  - [x] aarch64-linux (cross-compiled)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
