### PR TITLE
python3Packages.dm-haiku: init at 0.0.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13432,4 +13432,14 @@
     github = "PhilippWoelfel";
     githubId = 19400064;
   };
+  harwiltz = {
+    name = "Harley Wiltzer";
+    email = "harley.wiltzer@mail.mcgill.ca";
+    github = "harwiltz";
+    githubId = 56648659;
+    keys = [{
+      longkeyid = "rsa2048/0xC1F6F58AAF3AB8E1";
+      fingerprint = "B405 F8E3 7504 8BB7 4456  88F9 C1F6 F58A AF3A B8E1";
+    }];
+  };
 }

--- a/pkgs/development/python-modules/chex/default.nix
+++ b/pkgs/development/python-modules/chex/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, fetchpatch
+, numpy
+, absl-py
+, toolz
+, dm-tree
+, jax
+, jaxlib
+}:
+
+buildPythonPackage rec {
+  pname = "chex";
+  version = "0.1.0";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "deepmind";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-V8zQ9PWLvW+sG1K6893uX62XFx8l+pB7AOqBFZd+Y0Q=";
+  };
+
+  propagatedBuildInputs = [
+    absl-py
+    jax
+    jaxlib
+    dm-tree
+    toolz
+  ];
+
+  patches = [
+    (fetchpatch {
+      name = "fix-restrict-backends-tests.patch";
+      url = "https://github.com/deepmind/chex/commit/4b4b79ff028bfedc0f8e25ef2617998d81a90918.patch";
+      sha256 = "sha256-Lz2cD9z1CEq57uZqMpQhHb7mJeHd8sxA02DX/Rlor/Q=";
+    })
+  ];
+
+  pythonImportsCheck = [ "chex" ];
+
+  meta = with lib; {
+    description = "Chex is a library of utilities for helping to write JAX code.";
+    homepage = "https://chex.readthedocs.io";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ harwiltz ];
+  };
+}

--- a/pkgs/development/python-modules/dm-haiku/default.nix
+++ b/pkgs/development/python-modules/dm-haiku/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, tabulate
+, absl-py
+, jmp
+, optax
+}:
+
+buildPythonPackage rec {
+  pname = "dm-haiku";
+  version = "0.0.5";
+
+  src = fetchFromGitHub {
+    owner = "deepmind";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-ihMh0mHz1dsDthV3BAMjLZL0EUdqPTvMji1UoCaTuNU=";
+  };
+
+  propagatedBuildInputs = [
+    tabulate
+    absl-py
+    jmp
+    optax
+  ];
+
+  # Tests require huge dependencies (tensorflow for one)
+  doCheck = false;
+
+  pythonImportsCheck = [ "haiku" ];
+
+  meta = with lib; {
+    description = "JAX-based neural network library";
+    homepage = "https://dm-haiku.readthedocs.io";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ harwiltz ];
+  };
+}

--- a/pkgs/development/python-modules/jmp/default.nix
+++ b/pkgs/development/python-modules/jmp/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, numpy
+, jax
+, jaxlib
+}:
+
+buildPythonPackage rec {
+  pname = "jmp";
+  version = "0.0.2";
+
+  src = fetchFromGitHub {
+    owner = "deepmind";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-t78zg6H17l/yBPxYygFjPRdclr88BoTDhPUhsEcNUM0=";
+  };
+
+  propagatedBuildInputs = [
+    jax
+    jaxlib
+  ];
+
+  # Test uses unsupported pytest
+  doCheck = false;
+
+  pythonImportsCheck = [ "jmp" ];
+
+  meta = with lib; {
+    description = "Mixed Precision library for JAX";
+    homepage = "https://github.com/deepmind/jmp";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ harwiltz ];
+  };
+}

--- a/pkgs/development/python-modules/optax/default.nix
+++ b/pkgs/development/python-modules/optax/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, jax
+, jaxlib
+, chex
+}:
+
+buildPythonPackage rec {
+  pname = "optax";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "deepmind";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-uZ65DSPjt5tmAGjpOMDHBXYW6tpjPKN8f5fyP2FC1Wc=";
+  };
+
+  propagatedBuildInputs = [
+    jax
+    jaxlib
+    chex
+  ];
+
+  # Test requires flax and haiku
+  doCheck = false;
+
+  postPatch = ''
+    # These dirs are not packaged correctly
+    rm -rf docs examples
+  '';
+
+  pythonImportsCheck = [ "optax" ];
+
+  meta = with lib; {
+    description = "Gradient processing and optimization library for JAX";
+    homepage = "https://optax.readthedocs.io";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ harwiltz ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1531,6 +1531,8 @@ in {
 
   chevron = callPackage ../development/python-modules/chevron { };
 
+  chex = callPackage ../development/python-modules/chex { };
+
   chiabip158 = callPackage ../development/python-modules/chiabip158 { };
 
   chiapos = callPackage ../development/python-modules/chiapos { };
@@ -2298,6 +2300,8 @@ in {
   dlx = callPackage ../development/python-modules/dlx { };
 
   dmenu-python = callPackage ../development/python-modules/dmenu { };
+
+  dm-haiku = callPackage ../development/python-modules/dm-haiku { };
 
   dm-sonnet = callPackage ../development/python-modules/dm-sonnet { };
 
@@ -4075,6 +4079,8 @@ in {
 
   jmespath = callPackage ../development/python-modules/jmespath { };
 
+  jmp = callPackage ../development/python-modules/jmp { };
+
   joblib = callPackage ../development/python-modules/joblib { };
 
   johnnycanencrypt = callPackage ../development/python-modules/johnnycanencrypt {
@@ -5525,6 +5531,8 @@ in {
   opsdroid_get_image_size = callPackage ../development/python-modules/opsdroid_get_image_size { };
 
   opt-einsum = callPackage ../development/python-modules/opt-einsum { };
+
+  optax = callPackage ../development/python-modules/optax { };
 
   optuna = callPackage ../development/python-modules/optuna { };
 


### PR DESCRIPTION
```
python3Packages.dm-haiku : init at 0.0.5
python3Packages.optax    : init at 0.1.0
python3Packages.jmp      : init at 0.0.2
python3Packages.chex     : init at 0.1.0
```
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adds support for Google Deepmind's popular open-source `haiku` and `optax` frameworks for optimization and ML in JAX.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
