### PR TITLE
gnuradio3_8: Fix build with boost177

### DIFF
--- a/pkgs/applications/radio/gnuradio/3.8.nix
+++ b/pkgs/applications/radio/gnuradio/3.8.nix
@@ -248,6 +248,11 @@ stdenv.mkDerivation rec {
       url = "https://github.com/gnuradio/gnuradio/commit/9d7343526dd793120b6425cd9a6969416ed32503.patch";
       sha256 = "sha256-usSoRDDuClUfdX4yFbQNu8wDzve6UEhZYTFj1oZbFic=";
     })
+    # Fix compilation with boost 177
+    (fetchpatch {
+      url = "https://github.com/gnuradio/gnuradio/commit/2c767bb260a25b415e8c9c4b3ea37280b2127cec.patch";
+      sha256 = "sha256-l4dSzkXb5s3vcCeuKMMwiKfv83hFI9Yg+EMEX+sl+Uo=";
+    })
   ];
   passthru = shared.passthru // {
     # Deps that are potentially overriden and are used inside GR plugins - the same version must

--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -6,14 +6,13 @@
 , pkg-config
 # See https://files.ettus.com/manual_archive/v3.15.0.0/html/page_build_guide.html for dependencies explanations
 , boost
-, enableLibuhd_C_api ? true
+, enableCApi ? true
 # requires numpy
-, enableLibuhd_Python_api ? false
+, enablePythonApi ? false
 , python3
 , enableExamples ? false
 , enableUtils ? false
-, enableLiberio ? false
-, liberio
+, enableSim ? false
 , libusb1
 , enableDpdk ? false
 , dpdk
@@ -25,7 +24,6 @@
 , enableUsrp1 ? true
 , enableUsrp2 ? true
 , enableX300 ? true
-, enableN230 ? true
 , enableN300 ? true
 , enableN320 ? true
 , enableE300 ? true
@@ -41,18 +39,18 @@ stdenv.mkDerivation rec {
   pname = "uhd";
   # UHD seems to use three different version number styles: x.y.z, xxx_yyy_zzz
   # and xxx.yyy.zzz. Hrmpf... style keeps changing
-  version = "4.0.0.0";
+  version = "4.1.0.5";
 
   src = fetchFromGitHub {
     owner = "EttusResearch";
     repo = "uhd";
     rev = "v${version}";
-    sha256 = "NCyiI4pIPw0nBRFdUGpgZ/x2mWz+Qm78ZGACUnSbGSs=";
+    sha256 = "sha256-XBq4GkLRR2SFunFRvpPOMiIbTuUkMYf8tPAoHCoveRA=";
   };
   # Firmware images are downloaded (pre-built) from the respective release on Github
   uhdImagesSrc = fetchurl {
     url = "https://github.com/EttusResearch/uhd/releases/download/v${version}/uhd-images_${version}.tar.xz";
-    sha256 = "Xfx0bsHUQ5+Dp+xk0sVWWP83oyXQcUH5AX4PNEE7fY4=";
+    sha256 = "HctHB90ikOMkrYNyWmjGE/2HvA7xXKCUezdtiqzN+1A=";
   };
 
   cmakeFlags = [
@@ -61,9 +59,8 @@ stdenv.mkDerivation rec {
     "-DENABLE_TESTS=ON" # This installs tests as well so we delete them via postPhases
     "-DENABLE_EXAMPLES=${onOffBool enableExamples}"
     "-DENABLE_UTILS=${onOffBool enableUtils}"
-    "-DENABLE_LIBUHD_C_API=${onOffBool enableLibuhd_C_api}"
-    "-DENABLE_LIBUHD_PYTHON_API=${onOffBool enableLibuhd_Python_api}"
-    "-DENABLE_LIBERIO=${onOffBool enableLiberio}"
+    "-DENABLE_C_API=${onOffBool enableCApi}"
+    "-DENABLE_PYTHON_API=${onOffBool enablePythonApi}"
     "-DENABLE_DPDK=${onOffBool enableDpdk}"
     # Devices
     "-DENABLE_OCTOCLOCK=${onOffBool enableOctoClock}"
@@ -73,7 +70,6 @@ stdenv.mkDerivation rec {
     "-DENABLE_USRP1=${onOffBool enableUsrp1}"
     "-DENABLE_USRP2=${onOffBool enableUsrp2}"
     "-DENABLE_X300=${onOffBool enableX300}"
-    "-DENABLE_N230=${onOffBool enableN230}"
     "-DENABLE_N300=${onOffBool enableN300}"
     "-DENABLE_N320=${onOffBool enableN320}"
     "-DENABLE_E300=${onOffBool enableE300}"
@@ -87,7 +83,7 @@ stdenv.mkDerivation rec {
 
   # Python + Mako are always required for the build itself but not necessary for runtime.
   pythonEnv = python3.withPackages (ps: with ps; [ Mako ]
-    ++ optionals (enableLibuhd_Python_api) [ numpy setuptools ]
+    ++ optionals (enablePythonApi) [ numpy setuptools ]
     ++ optionals (enableUtils) [ requests six ]
   );
 
@@ -98,7 +94,7 @@ stdenv.mkDerivation rec {
     # If both enableLibuhd_Python_api and enableUtils are off, we don't need
     # pythonEnv in buildInputs as it's a 'build' dependency and not a runtime
     # dependency
-    ++ optionals (!enableLibuhd_Python_api && !enableUtils) [ pythonEnv ]
+    ++ optionals (!enablePythonApi && !enableUtils) [ pythonEnv ]
   ;
   buildInputs = [
     boost
@@ -107,8 +103,7 @@ stdenv.mkDerivation rec {
     # However, if enableLibuhd_Python_api *or* enableUtils is on, we need
     # pythonEnv for runtime as well. The utilities' runtime dependencies are
     # handled at the environment
-    ++ optionals (enableLibuhd_Python_api || enableUtils) [ pythonEnv ]
-    ++ optionals (enableLiberio) [ liberio ]
+    ++ optionals (enablePythonApi || enableUtils) [ pythonEnv ]
     ++ optionals (enableDpdk) [ dpdk ]
   ;
 
@@ -154,6 +149,6 @@ stdenv.mkDerivation rec {
     homepage = "https://uhd.ettus.com/";
     license = licenses.gpl3Plus;
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ bjornfor fpletz tomberek ];
+    maintainers = with maintainers; [ bjornfor fpletz tomberek doronbehar ];
   };
 }

--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -107,7 +107,8 @@ stdenv.mkDerivation rec {
     ++ optionals (enableDpdk) [ dpdk ]
   ;
 
-  doCheck = true;
+  # many tests fails on darwin, according to ofborg
+  doCheck = !stdenv.isDarwin;
 
   # Build only the host software
   preConfigure = "cd host";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15546,9 +15546,7 @@ with pkgs;
   uefi-firmware-parser = callPackage ../development/tools/analysis/uefi-firmware-parser { };
 
   uhd3_5 = callPackage ../applications/radio/uhd/3.5.nix { };
-  uhd = callPackage ../applications/radio/uhd {
-    boost = boost175;
-  };
+  uhd = callPackage ../applications/radio/uhd { };
 
   uisp = callPackage ../development/embedded/uisp { };
 


### PR DESCRIPTION
- gnuradio3_8: Fix build with boost177
- uhd: 4.0.0.0 -> 4.1.0.5

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#151469

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
