### PR TITLE
fq: init at 0.0.2

### DIFF
--- a/pkgs/development/tools/fq/default.nix
+++ b/pkgs/development/tools/fq/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildGo117Module, fetchFromGitHub }:
+
+buildGo117Module rec {
+  pname = "fq";
+  version = "0.0.2";
+
+  src = fetchFromGitHub {
+    owner = "wader";
+    repo = "fq";
+    rev = "v${version}";
+    sha256 = "sha256-ykjt9MPkN5dgTaY2VhApNt5DKh9TFapMpoHwLdpOKcw=";
+  };
+
+  vendorSha256 = "sha256-89rSpxhP35wreo+0AqM+rDICCPchF+yFVvrTtZ2Xwr4=";
+
+  meta = with lib; {
+    description = "jq for binary formats";
+    homepage = "https://github.com/wader/fq";
+    license = licenses.mit;
+    maintainers = with maintainers; [ siraben ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5424,6 +5424,8 @@ with pkgs;
     mkFranzDerivation = callPackage ../applications/networking/instant-messengers/franz/generic.nix { };
   };
 
+  fq = callPackage ../development/tools/fq { };
+
   franz = callPackage ../applications/networking/instant-messengers/franz {
     mkFranzDerivation = callPackage ../applications/networking/instant-messengers/franz/generic.nix { };
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/wader/fq

```ShellSession
❯ nix run github:siraben/nixpkgs/fq#fq -- . <(curl -s https://nixos.org/logo/nixos-hires.png)
      |00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 11|0123456789abcdef01|.{}: /dev/fd/11 (png)
0x0000|89 50 4e 47 0d 0a 1a 0a                              |.PNG....          |  signature: raw bits (valid)
0x0000|                        00 00 00 0d 49 48 44 52 00 00|        ....IHDR..|  chunks[0:12]:
0x0012|05 42 00 00 01 88 08 06 00 00 00 84 07 9a cc 00 00 00|.B................|
*     |until 0xc7da.7 (end) (51155)                         |                  |
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
