### PR TITLE
gnupg23: add unreleased patch for mac.

### DIFF
--- a/pkgs/tools/security/gnupg/23.nix
+++ b/pkgs/tools/security/gnupg/23.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation rec {
     ./tests-add-test-cases-for-import-without-uid.patch
     ./allow-import-of-previously-known-keys-even-without-UI.patch
     ./accept-subkeys-with-a-good-revocation-but-no-self-sig.patch
+    ./silence-warning-from-unix_rootdir-on-systems.patch
   ];
   postPatch = ''
     sed -i 's,hkps://hkps.pool.sks-keyservers.net,hkps://keys.openpgp.org,g' configure doc/dirmngr.texi doc/gnupg.info-1

--- a/pkgs/tools/security/gnupg/silence-warning-from-unix_rootdir-on-systems.patch
+++ b/pkgs/tools/security/gnupg/silence-warning-from-unix_rootdir-on-systems.patch
@@ -1,0 +1,48 @@
+From: Werner Koch <wk@gnupg.org>
+Date: Wed, 20 Oct 2021 14:39:23 +0000 (+0200)
+Subject: common: Silence warning from unix_rootdir on systems w/o /proc
+X-Git-Tag: gnupg-2.3.4~52
+X-Git-Url: http://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=commitdiff_plain;h=4cb44914b57a8db9d2f0d24e11d2b5e6fedc0a87
+
+common: Silence warning from unix_rootdir on systems w/o /proc
+
+* common/homedir.c (unix_rootdir): Silence diagnostic in the common
+case.
+(MYPROC_SELF_EXE): Support NetBSD.
+--
+
+GnuPG-bug-id: 5656
+---
+
+diff --git a/common/homedir.c b/common/homedir.c
+index 455c188c9..2877101e3 100644
+--- a/common/homedir.c
++++ b/common/homedir.c
+@@ -68,7 +68,9 @@
+  * text was read.  */
+ #if __linux__
+ # define MYPROC_SELF_EXE "/proc/self/exe"
+-#else /* Assume *BSD*/
++#elif defined(__NetBSD__)
++# define MYPROC_SELF_EXE "/proc/curproc/exe"
++#else /* Assume other BSDs */
+ # define MYPROC_SELF_EXE "/proc/curproc/file"
+ #endif
+ 
+@@ -495,13 +497,13 @@ unix_rootdir (int want_sysconfdir)
+           if (nread < 0)
+             {
+               err = gpg_error_from_syserror ();
+-              log_info ("error reading symlink '%s': %s\n",
+-                        MYPROC_SELF_EXE, gpg_strerror (err));
+               buffer[0] = 0;
+               if ((name = getenv ("GNUPG_BUILD_ROOT")) && *name == '/')
+                 {
+                   /* Try a fallback for systems w/o a supported /proc
+-                   * file system.  */
++                   * file system if we are running a regression test.  */
++                  log_info ("error reading symlink '%s': %s\n",
++                            MYPROC_SELF_EXE, gpg_strerror (err));
+                   xfree  (buffer);
+                   buffer = xstrconcat (name, "/bin/gpgconf", NULL);
+                   log_info ("trying fallback '%s'\n", buffer);


### PR DESCRIPTION
###### Motivation for this change
Here is related [discussion](https://stackoverflow.com/questions/69699986/gpg-error-reading-symlink-proc-curproc-file-no-such-file-or-directory).
Here is upstream [patch](http://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=commitdiff_plain;h=4cb44914b57a8db9d2f0d24e11d2b5e6fedc0a87).

###### Things done
backport upstream patch to 2.3

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
