### PR TITLE
sagetex: init at 3.6

### DIFF
--- a/pkgs/misc/sagetex/default.nix
+++ b/pkgs/misc/sagetex/default.nix
@@ -5,8 +5,8 @@
 }:
 
 stdenv.mkDerivation rec {
+  pname = "sagetex"; 
   version = "3.6";
-  pname = "sagetex";
   passthru.tlType = "run";
 
   src = fetchFromGitHub {

--- a/pkgs/misc/sagetex/default.nix
+++ b/pkgs/misc/sagetex/default.nix
@@ -5,7 +5,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "sagetex"; 
+  pname = "sagetex";
   version = "3.6";
   passthru.tlType = "run";
 

--- a/pkgs/misc/sagetex/default.nix
+++ b/pkgs/misc/sagetex/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, texlive
+}:
+
+stdenv.mkDerivation rec {
+  version = "3.6";
+  pname = "sagetex";
+  passthru.tlType = "run";
+
+  src = fetchFromGitHub {
+    owner = "sagemath";
+    repo = "sagetex";
+    rev = "v${version}";
+    sha256 = "8iHcJbaY/dh0vmvYyd6zj1ZbuJRaJGb6bUBK1v4gXWU=";
+  };
+
+  buildInputs = [
+    texlive.combined.scheme-basic
+  ];
+
+  buildPhase = ''
+    make sagetex.sty
+  '';
+
+  installPhase = ''
+    path="$out/tex/latex/sagetex"
+    mkdir -p "$path"
+    cp -va *.sty *.cfg *.def "$path/"
+  '';
+
+  meta = with lib; {
+    description = "Embed code, results of computations, and plots from Sage into LaTeX documents";
+    homepage = "https://github.com/sagemath/sagetex";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ alexnortung ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31676,6 +31676,8 @@ with pkgs;
   sage = callPackage ../applications/science/math/sage { };
   sageWithDoc = sage.override { withDoc = true; };
 
+  sagetex = callPackage ../misc/sagetex { };
+
   subread = callPackage ../applications/science/biology/subread { };
 
   suitesparse_4_2 = callPackage ../development/libraries/science/math/suitesparse/4.2.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I want to add the sagetex latex package to nixpkgs. This package works and makes `sagetx.sty` know to latex, however since sage is not packaged as a python module, it is not possible to build the outputs of the `.sagetex.sage` file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
