### PR TITLE
gitlab-runner: 14.5.2 -> 14.6.0

### DIFF
--- a/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
@@ -1,7 +1,7 @@
 { lib, buildGoPackage, fetchFromGitLab, fetchurl }:
 
 let
-  version = "14.5.2";
+  version = "14.6.0";
 in
 buildGoPackage rec {
   inherit version;
@@ -19,7 +19,7 @@ buildGoPackage rec {
     owner = "gitlab-org";
     repo = "gitlab-runner";
     rev = "v${version}";
-    sha256 = "07mr9w1rp3rnrlixmqziin1gw78s3gncg47b4z9h9zzpy3acy3xd";
+    sha256 = "1sgz8gri51i2pxnzzkcvwx5ncw1rjz7ain82hlcx6f3874qfsniy";
   };
 
   patches = [

--- a/pkgs/development/tools/continuous-integration/gitlab-runner/fix-shell-path.patch
+++ b/pkgs/development/tools/continuous-integration/gitlab-runner/fix-shell-path.patch
@@ -1,28 +1,25 @@
 diff --git a/shells/bash.go b/shells/bash.go
-index 673f4765..a58cc5e2 100644
+index bd99eca1a..9873dff6b 100644
 --- a/shells/bash.go
 +++ b/shells/bash.go
-@@ -5,6 +5,7 @@ import (
+@@ -3,6 +3,7 @@ package shells
+ import (
  	"bytes"
  	"fmt"
- 	"io"
 +	"os/exec"
  	"path"
  	"runtime"
  	"strconv"
-@@ -225,7 +226,11 @@ func (b *BashShell) GetConfiguration(info common.ShellScriptInfo) (script *commo
+@@ -300,7 +301,11 @@ func (b *BashShell) GetConfiguration(info common.ShellScriptInfo) (*common.Shell
  	if info.User != "" {
  		script.Command = "su"
  		if runtime.GOOS == "linux" {
 -			script.Arguments = append(script.Arguments, "-s", "/bin/"+b.Shell)
 +			shellPath, err := exec.LookPath(b.Shell)
 +			if err != nil {
-+				shellPath = "/bin/"+b.Shell
++				shellPath = "/bin/" + b.Shell
 +			}
 +			script.Arguments = append(script.Arguments, "-s", shellPath)
  		}
- 		script.Arguments = append(script.Arguments, info.User)
- 		script.Arguments = append(script.Arguments, "-c", shellCommand)
--- 
-2.18.0
-
+ 		script.Arguments = append(
+ 			script.Arguments,


### PR DESCRIPTION
###### Motivation for this change

https://gitlab.com/gitlab-org/gitlab-runner/blob/v14.6.0/CHANGELOG.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Build this time: 
<img width="986" alt="image" src="https://user-images.githubusercontent.com/6639323/147235032-4ce618c5-cdac-4f23-aa57-10b37bd4b23d.png">

/cc @bachp @zimbatm @globin @dlouzan
