### PR TITLE
xnotify: unstable-2021-12-22

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13432,4 +13432,10 @@
     github = "PhilippWoelfel";
     githubId = 19400064;
   };
+  CarlosLoboxyz = {
+    name = "Carlos Lobo";
+    email = "86011416+CarlosLoboxyz@users.noreply.github.com";
+    github = "CarlosLoboxyz";
+    githubId = 86011416;
+  };
 }

--- a/pkgs/applications/misc/xnotify/default.nix
+++ b/pkgs/applications/misc/xnotify/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, fetchFromGitHub, libX11, libXinerama, libXft, imlib2 }:
+
+stdenv.mkDerivation {
+  pname = "xnotify";
+  version = "unstable-2021-12-22";
+
+  src = fetchFromGitHub {
+    owner = "phillbush";
+    repo = "xnotify";
+    rev = "cacfb959effd61f932faf87c4e5bf37c9d2ef2ea";
+    sha256 = "1hvgfrcpzp7q6jn808f7jj824360mlfhym60w02ylh99p582hc3c";
+  };
+
+  buildInputs = [
+    libX11 libXinerama libXft imlib2
+  ];
+  makeFlags = [
+    "PREFIX=$(out)"
+  ];
+
+  meta = with lib; {
+    description = "xnotify - popup a notification on the screen";
+    longDescription = ''
+      xnotify is a notification launcher for X, it receives a notification
+      specification from standard input and shows a notification on the screen.
+      The notification disappears automatically after a given number of seconds 
+      or after a mouse click is operated on it.
+    '';
+    homepage = "https://github.com/phillbush/xnotify";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ CarlosLoboxyz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34064,4 +34064,6 @@ with pkgs;
   };
 
   zthrottle = callPackage ../tools/misc/zthrottle { };
+
+  xnotify = callPackage ../applications/misc/xnotify {};
 }


### PR DESCRIPTION
###### Motivation for this change

to complement #151360 xnotify provide full desktop notification

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
