### PR TITLE
gt: init at 2021-09-30

### DIFF
--- a/pkgs/development/libraries/libusbgx/default.nix
+++ b/pkgs/development/libraries/libusbgx/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, lib, fetchFromGitHub, cmake, bash-completion, pkg-config, libconfig, autoreconfHook }:
+stdenv.mkDerivation {
+  pname = "libusbgx";
+  version = "unstable-2021-10-31";
+  src = fetchFromGitHub {
+    owner = "linux-usb-gadgets";
+    repo = "libusbgx";
+    rev = "060784424609d5a4e3bce8355f788c93f09802a5";
+    sha256 = "172qh8gva17jr18ldhf9zi960w2bqzmp030w6apxq57c9nv6d8k7";
+  };
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  buildInputs = [ libconfig ];
+  meta = {
+    description = "C library encapsulating the kernel USB gadget-configfs userspace API functionality";
+    license = with lib.licenses; [
+      lgpl21Plus # library
+      gpl2Plus # examples
+    ];
+    maintainers = with lib.maintainers; [ lheckemann ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/gt/default.nix
+++ b/pkgs/os-specific/linux/gt/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, lib, fetchFromGitHub, cmake, bash-completion, pkg-config, libconfig
+, asciidoc
+, libusbgx
+}:
+stdenv.mkDerivation {
+  pname = "gt";
+  version = "unstable-2021-09-30";
+
+  src = fetchFromGitHub {
+    owner = "linux-usb-gadgets";
+    repo = "gt";
+    rev = "7247547a14b2d092dc03fd83218ae65c2f7ff7d6";
+    sha256 = "1has9q2sghd5vyi25l3h2hd4d315vvpld076iwwsg01fx4d9vjmg";
+  };
+  sourceRoot = "source";
+
+  preConfigure = ''
+    cmakeFlagsArray+=("-DBASH_COMPLETION_COMPLETIONSDIR=$out/share/bash-completions/completions")
+  '';
+  nativeBuildInputs = [ cmake pkg-config asciidoc ];
+  buildInputs = [ bash-completion libconfig libusbgx];
+
+  meta = {
+    description = "Linux command line tool for setting up USB gadgets using configfs";
+    license = with lib.licenses; [ asl20 ];
+    maintainers = with lib.maintainers; [ lheckemann ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18561,6 +18561,8 @@ with pkgs;
     udev = systemdMinimal;
   };
 
+  libusbgx = callPackage ../development/libraries/libusbgx { };
+
   libusbmuxd = callPackage ../development/libraries/libusbmuxd { };
 
   libutempter = callPackage ../development/libraries/libutempter { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22249,6 +22249,8 @@ with pkgs;
 
   gradm = callPackage ../os-specific/linux/gradm { };
 
+  gt = callPackage ../os-specific/linux/gt { };
+
   inherit (nodePackages) gtop;
 
   hd-idle = callPackage ../os-specific/linux/hd-idle { };


### PR DESCRIPTION
###### Motivation for this change
Tool for configuring USB gadgets (useful for mobile-nixos)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
