### PR TITLE
micromamba: 0.15.0 -> 0.18.1

### DIFF
--- a/pkgs/tools/package-management/micromamba/default.nix
+++ b/pkgs/tools/package-management/micromamba/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch, cmake
-, cli11, nlohmann_json, curl, libarchive, libyamlcpp, libsolv, reproc
+, cli11, nlohmann_json, curl, libarchive, libyamlcpp, libsolv, reproc, spdlog, termcolor, ghc_filesystem
 }:
 
 let
@@ -11,51 +11,26 @@ let
     patches = [
       # Patch added by the mamba team
       (fetchpatch {
-        url = "https://raw.githubusercontent.com/mamba-org/boa-forge/f766da0cc18701c4d107a41de22417a65b53cc2d/libsolv/add_strict_repo_prio_rule.patch";
+        url = "https://raw.githubusercontent.com/mamba-org/boa-forge/20530f80e2e15012078d058803b6e2c75ed54224/libsolv/add_strict_repo_prio_rule.patch";
         sha256 = "19c47i5cpyy88nxskf7k6q6r43i55w61jvnz7fc2r84hpjkcrv7r";
       })
       # Patch added by the mamba team
       (fetchpatch {
-        url = "https://raw.githubusercontent.com/mamba-org/boa-forge/f766da0cc18701c4d107a41de22417a65b53cc2d/libsolv/conda_variant_priorization.patch";
+        url = "https://raw.githubusercontent.com/mamba-org/boa-forge/20530f80e2e15012078d058803b6e2c75ed54224/libsolv/conda_variant_priorization.patch";
         sha256 = "1iic0yx7h8s662hi2jqx68w5kpyrab4fr017vxd4wyxb6wyk35dd";
-      })
-      # Patch added by the mamba team
-      (fetchpatch {
-        url = "https://raw.githubusercontent.com/mamba-org/boa-forge/f766da0cc18701c4d107a41de22417a65b53cc2d/libsolv/memcpy_to_memmove.patch";
-        sha256 = "1c9ir40l6crcxllj5zwhzbrbgibwqaizyykd0vip61gywlfzss64";
-      })
-    ];
-  });
-
-  # fails linking with yaml-cpp 0.7.x
-  libyamlcpp' = libyamlcpp.overrideAttrs (oldAttrs: rec {
-
-    version = "0.6.3";
-
-    src = fetchFromGitHub {
-      owner = "jbeder";
-      repo = "yaml-cpp";
-      rev = "yaml-cpp-${version}";
-      sha256 = "0ykkxzxcwwiv8l8r697gyqh1nl582krpvi7m7l6b40ijnk4pw30s";
-    };
-
-    patches = [
-      (fetchpatch {
-        url = "https://github.com/jbeder/yaml-cpp/commit/4f48727b365962e31451cd91027bd797bc7d2ee7.patch";
-        sha256 = "sha256-jarZAh7NgwL3xXzxijDiAQmC/EC2WYfNMkYHEIQBPhM=";
       })
     ];
   });
 in
 stdenv.mkDerivation rec {
   pname = "micromamba";
-  version = "0.15.0";
+  version = "0.18.1";
 
   src = fetchFromGitHub {
     owner = "mamba-org";
     repo = "mamba";
     rev = version;
-    sha256 = "1zksp4zqj4wn9p9jb1qx1acajaz20k9xnm80yi7bab2d37y18hcw";
+    sha256 = "1gr9r257l300hafp8zm61bn58rysdk9i4wv1879q96b6n6v8hwa6";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -65,23 +40,32 @@ stdenv.mkDerivation rec {
     nlohmann_json
     curl
     libarchive
-    libyamlcpp'
+    libyamlcpp
     libsolv'
     reproc
-    # python3Packages.pybind11 # Would be necessary if someone wants to build with bindings I guess.
+    spdlog
+    termcolor
+    ghc_filesystem
   ];
+
+  postPatch = ''
+    # See https://github.com/gabime/spdlog/issues/1897
+    sed -i '1a add_compile_definitions(SPDLOG_FMT_EXTERNAL)' CMakeLists.txt
+    echo 'target_link_libraries(micromamba PRIVATE -lspdlog -lfmt)' >> micromamba/CMakeLists.txt
+  '';
 
   cmakeFlags = [
-    "-DBUILD_BINDINGS=OFF" # Fails to build, I don't think it's necessary for now.
-    "-DBUILD_EXE=ON"
+    "-DBUILD_LIBMAMBA=ON"
+    "-DBUILD_SHARED=ON"
+    "-DBUILD_MICROMAMBA=ON"
+    # "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
   ];
-
-  CXXFLAGS = "-DMAMBA_USE_STD_FS";
 
   meta = with lib; {
     description = "Reimplementation of the conda package manager";
     homepage = "https://github.com/mamba-org/mamba";
     license = licenses.bsd3;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ mausch ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
