### PR TITLE
gourmand: init at 1.0.0, +dependency 

### DIFF
--- a/pkgs/applications/misc/gourmand/default.nix
+++ b/pkgs/applications/misc/gourmand/default.nix
@@ -1,0 +1,117 @@
+{ lib
+, stdenv
+, python3Packages
+, fetchFromGitHub
+, fetchpatch
+, intltool
+, gtk3
+, gobject-introspection
+, gst_all_1
+, wrapGAppsHook
+, xvfb-run
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "gourmand";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "GourmandRecipeManager";
+    repo = "gourmand";
+    rev = version;
+    sha256 = "sha256-QNcVfsAxcqtM7VGuoCQL7ZD26+PwxwFW3EkA7FAE0Z0=";
+  };
+
+  # https://github.com/NixOS/nixpkgs/issues/56943
+  strictDeps = false;
+
+  patches = [
+    # Fix compatibility with Sqlalchemy 1.4, https://github.com/GourmandRecipeManager/gourmand/pull/80. This does not fix failing db tests.
+    (fetchpatch {
+      name = "fix-sqlalchemy-1.4-compat";
+      url = "https://github.com/GourmandRecipeManager/gourmand/commit/533bd247a0fd6a08c527bc27d1a303487c6ad144.patch";
+      sha256 = "sha256-C0joinwhy6pjmD2qlTm1wT7m4wXAvHbDMxw115kDDeU=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "beautifulsoup4==4.9.3" "beautifulsoup4" \
+      --replace "lxml==4.6.3" "lxml" \
+      --replace "pillow==8.2.0" "pillow" \
+      --replace "pygobject==3.40.1" "pygobject" \
+      --replace "requests==2.25.1"  "requests" \
+      --replace "sqlalchemy==1.3.22" "sqlalchemy" \
+      --replace "toml==0.10.2" "toml"
+  '';
+
+  nativeBuildInputs = [
+    intltool
+  ];
+
+  buildInputs = [
+    gtk3
+    gobject-introspection
+    gst_all_1.gstreamer
+    wrapGAppsHook
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    beautifulsoup4
+    lxml
+    pillow
+    pygobject3
+    requests
+    sqlalchemy
+    toml
+    setuptools
+    reportlab
+    ebooklib
+    pyenchant
+    pygtkspellcheck
+  ];
+
+  checkInputs = [
+    xvfb-run
+  ] ++  (with python3Packages; [
+    pytest
+  ]);
+
+  postInstall = ''
+    install -D data/io.github.GourmandRecipeManager.Gourmand.desktop -t $out/share/applications/
+    install -D data/io.github.GourmandRecipeManager.Gourmand.svg -t $out/share/icons/hicolor/scalable/apps/
+    install -D data/io.github.GourmandRecipeManager.Gourmand.appdata.xml -t $out/share/appdata/
+
+    substituteInPlace $out/share/applications/io.github.GourmandRecipeManager.Gourmand.desktop \
+      --replace "Exec=gourmand" "Exec=$out/bin/gourmand"
+  '';
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  # we skip anything upstream ci doesn't run, and also the web scraping plugin
+  # tests, since we do not enable the optional web scrape feature
+  checkPhase = ''
+    export HOME=$(mktemp -d)
+    LANGUAGE=de_DE xvfb-run -a pytest -vv \
+      --ignore-glob='tests/test_*_plugin.py' \
+      --ignore=tests/broken \
+      --ignore=tests/dogtail \
+      --ignore=tests/old_databases \
+      --ignore=tests/recipe_files \
+      --ignore tests/test_db.py \
+      tests/
+  '';
+
+  meta = with lib; {
+    description = "Desktop recipe manager";
+    longDescription = ''
+      Gourmand Recipe Manager is a desktop cookbook application for editing and organizing recipes. It is a fork of the Gourmet Recipe Manager.
+    '';
+    homepage = "https://github.com/GourmandRecipeManager/gourmand";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ DeeUnderscore ];
+  };
+}

--- a/pkgs/development/python-modules/ebooklib/default.nix
+++ b/pkgs/development/python-modules/ebooklib/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, lxml
+, six
+}:
+buildPythonPackage rec {
+  pname = "ebooklib";
+  version = "0.17.1";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "EbookLib";
+    sha256 = "sha256-/iPiLCgFAZbGjbPnsTsle/OUJtknyzlcbyzBOsETJ/E=";
+  };
+
+  propagatedBuildInputs = [ lxml six ];
+
+  pythonImportsCheck = [ "ebooklib" ];
+
+  meta = with lib; {
+    description = "A library for handling EPUB and Kindle files";
+    homepage = "https://github.com/aerkalov/ebooklib";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ DeeUnderscore ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7434,6 +7434,8 @@ with pkgs;
 
   gource = callPackage ../applications/version-management/gource { };
 
+  gourmand = callPackage ../applications/misc/gourmand { };
+
   govc = callPackage ../tools/virtualization/govc { };
 
   goverlay = callPackage ../tools/graphics/goverlay {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2838,6 +2838,8 @@ self: super: with self; {
 
   ebaysdk = callPackage ../development/python-modules/ebaysdk { };
 
+  ebooklib = callPackage ../development/python-modules/ebooklib { };
+
   ec2instanceconnectcli = callPackage ../tools/virtualization/ec2instanceconnectcli { };
 
   eccodes = toPythonModule (pkgs.eccodes.override {


### PR DESCRIPTION
###### Motivation for this change
Gourmand is a fork of the Gourmet Recipe Manager, a desktop cookbook/recipe manager. It is actively maintained, and runs under Python 3 (Gourmet used Python 2).

pythonPackages.ebooklib, also in this PR, is the library that Gourmet uses for exporting recipes to epub.
 
Website scraping plugins do not work in this derivation, as they'd need another dependency not currently in Nixpkgs, and they are gone in the latest release candidate for the next version of Gourmand, replaced instead by the recipe-scrapers library (which I managed to build, but omitted from this PR). 

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
