### PR TITLE
jade: explicitly disable parallel builds

### DIFF
--- a/pkgs/tools/text/sgml/jade/default.nix
+++ b/pkgs/tools/text/sgml/jade/default.nix
@@ -21,6 +21,11 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-Wno-deprecated";
 
+  # Makefile is missing intra-library depends, fails build as:
+  # ld: cannot find -lsp
+  # ld: cannot find -lspgrove
+  enableParallelBuilding = false;
+
   preInstall = ''
     install -d -m755 "$out"/lib
   '';


### PR DESCRIPTION
Without the change enabling parallel builds fails as:

    ld: cannot find -lsp
    ld: cannot find -lspgrove
