### PR TITLE
citrix_workspace: 21.09.0.25 -> 21.12.0.18

### DIFF
--- a/pkgs/applications/networking/remote/citrix-workspace/generic.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/generic.nix
@@ -120,10 +120,11 @@ stdenv.mkDerivation rec {
   installPhase = let
     icaFlag = program:
       if (builtins.match "selfservice(.*)" program) != null then "--icaroot"
+      else if (lib.versionAtLeast version "21.12" && builtins.match "wfica(.*)" program != null) then null
       else "-icaroot";
     wrap = program: ''
       wrapProgram $out/opt/citrix-icaclient/${program} \
-        --add-flags "${icaFlag program} $ICAInstDir" \
+        ${lib.optionalString (icaFlag program != null) ''--add-flags "${icaFlag program} $ICAInstDir"''} \
         --set ICAROOT "$ICAInstDir" \
         --prefix LD_LIBRARY_PATH : "$ICAInstDir:$ICAInstDir/lib" \
         --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \

--- a/pkgs/applications/networking/remote/citrix-workspace/generic.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/generic.nix
@@ -3,7 +3,7 @@
 , heimdal, krb5, libsoup, libvorbis, speex, openssl, zlib, xorg, pango, gtk2
 , gnome2, mesa, nss, nspr, gtk_engines, freetype, dconf, libpng12, libxml2
 , libjpeg, libredirect, tzdata, cacert, systemd, libcxxabi, libcxx, e2fsprogs, symlinkJoin
-, libpulseaudio, pcsclite, glib-networking
+, libpulseaudio, pcsclite, glib-networking, llvmPackages_12
 
 , homepage, version, prefix, hash
 
@@ -98,7 +98,8 @@ stdenv.mkDerivation rec {
     xorg.libXtst
     zlib
   ] ++ lib.optional (lib.versionOlder version "20.04") e2fsprogs
-    ++ lib.optional (lib.versionAtLeast version "20.10") libpulseaudio;
+    ++ lib.optional (lib.versionAtLeast version "20.10") libpulseaudio
+    ++ lib.optional (lib.versionAtLeast version "21.12") llvmPackages_12.libunwind;
 
   runtimeDependencies = [
     glib

--- a/pkgs/applications/networking/remote/citrix-workspace/sources.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/sources.nix
@@ -122,6 +122,17 @@ let
       x86suffix = "25";
       homepage  = "https://www.citrix.com/downloads/workspace-app/linux/workspace-app-for-linux-latest.html";
     };
+
+    "21.12.0" = {
+      major     = "21";
+      minor     = "12";
+      patch     = "0";
+      x64hash   = "de81deab648e1ebe0ddb12aa9591c8014d7fad4eba0db768f25eb156330bb34d";
+      x86hash   = "3746cdbe26727f7f6fb85fbe5f3e6df0322d79bb66e3a70158b22cb4f6b6b292";
+      x64suffix = "18";
+      x86suffix = "18";
+      homepage  = "https://www.citrix.com/downloads/workspace-app/linux/workspace-app-for-linux-latest.html";
+    };
   };
 
   # Retain attribute-names for abandoned versions of Citrix workspace to

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4087,7 +4087,7 @@ with pkgs;
 
   circus = callPackage ../tools/networking/circus { };
 
-  citrix_workspace = citrix_workspace_21_09_0;
+  citrix_workspace = citrix_workspace_21_12_0;
 
   inherit (callPackage ../applications/networking/remote/citrix-workspace { })
     citrix_workspace_20_04_0
@@ -4100,6 +4100,7 @@ with pkgs;
     citrix_workspace_21_06_0
     citrix_workspace_21_08_0
     citrix_workspace_21_09_0
+    citrix_workspace_21_12_0
   ;
 
   citra = libsForQt5.callPackage ../misc/emulators/citra { };


### PR DESCRIPTION
###### Motivation for this change
* Updated to most recent version
* Fixing #151885

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
```
✘ asbachb@nixos-t14s  ~/dev/src/nix/nixpkgs   update/citrix-workspace  nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
Auto packing the repository in background for optimum performance.
See "git help gc" for manual housekeeping.
warning: The last gc run reported the following. Please correct the root cause
and remove .git/gc.log
Automatic cleanup will not be performed until the file is removed.

fatal: bad object worktrees/nixpkgs1/HEAD
fatal: failed to run repack

$ git worktree add /home/asbachb/.cache/nixpkgs-review/rev-a157a5de1b07b7af930d4eae12a3d70cf4f35d96/nixpkgs e976a7e860c35f3dbfec62ea9adc97f2a7956c47
Preparing worktree (detached HEAD e976a7e860c)
Updating files: 100% (29374/29374), done.
HEAD is now at e976a7e860c Merge pull request #152024 from Stunkymonkey/angelscript_2_22-refactor
$ nix-env --option system x86_64-linux -f /home/asbachb/.cache/nixpkgs-review/rev-a157a5de1b07b7af930d4eae12a3d70cf4f35d96/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit --no-ff a157a5de1b07b7af930d4eae12a3d70cf4f35d96
Auto-merging pkgs/top-level/all-packages.nix
Automatic merge went well; stopped before committing as requested
$ nix-env --option system x86_64-linux -f /home/asbachb/.cache/nixpkgs-review/rev-a157a5de1b07b7af930d4eae12a3d70cf4f35d96/nixpkgs -qaP --xml --out-path --show-trace --meta
1 package added:
citrix_workspace_21_09_0 (init at 21.9.0.25)

1 package updated:
citrix_workspace (21.9.0.25 → 21.12.0.18)

$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /home/asbachb/.cache/nixpkgs-review/rev-a157a5de1b07b7af930d4eae12a3d70cf4f35d96/build.nix
2 packages built:
citrix_workspace citrix_workspace_21_09_0

$ nix-shell /home/asbachb/.cache/nixpkgs-review/rev-a157a5de1b07b7af930d4eae12a3d70cf4f35d96/shell.nix

[nix-shell:~/.cache/nixpkgs-review/rev-a157a5de1b07b7af930d4eae12a3d70cf4f35d96]
```
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
