### PR TITLE
frr: init at 8.1; libyang: init at 2.0.112

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -77,6 +77,14 @@
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://frrouting.org/">FRRouting</link>, a
+          popular suite of Internet routing protocol daemons (BGP, BFD,
+          OSPF, IS-IS, VVRP and others). Available as
+          <link linkend="opt-services.ffr.babel.enable">services.frr</link>
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://github.com/hifi/heisenbridge">heisenbridge</link>,
           a bouncer-style Matrix IRC bridge. Available as
           <link xlink:href="options.html#opt-services.heisenbridge.enable">services.heisenbridge</link>.

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -19,11 +19,14 @@ In addition to numerous new and upgraded packages, this release has the followin
 ## New Services {#sec-release-22.05-new-services}
 
 - [aesmd](https://github.com/intel/linux-sgx#install-the-intelr-sgx-psw), the Intel SGX Architectural Enclave Service Manager. Available as [services.aesmd](#opt-services.aesmd.enable).
+
 - [rootless Docker](https://docs.docker.com/engine/security/rootless/), a `systemd --user` Docker service which runs without root permissions. Available as [virtualisation.docker.rootless.enable](options.html#opt-virtualisation.docker.rootless.enable).
 
 - [matrix-conduit](https://conduit.rs/), a simple, fast and reliable chat server powered by matrix. Available as [services.matrix-conduit](option.html#opt-services.matrix-conduit.enable).
 
 - [filebeat](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-overview.html), a lightweight shipper for forwarding and centralizing log data. Available as [services.filebeat](#opt-services.filebeat.enable).
+
+- [FRRouting](https://frrouting.org/), a popular suite of Internet routing protocol daemons (BGP, BFD, OSPF, IS-IS, VVRP and others). Available as [services.frr](#opt-services.ffr.babel.enable)
 
 - [heisenbridge](https://github.com/hifi/heisenbridge), a bouncer-style Matrix IRC bridge. Available as [services.heisenbridge](options.html#opt-services.heisenbridge.enable).
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -744,6 +744,7 @@
   ./services/networking/flannel.nix
   ./services/networking/freenet.nix
   ./services/networking/freeradius.nix
+  ./services/networking/frr.nix
   ./services/networking/gateone.nix
   ./services/networking/gdomap.nix
   ./services/networking/ghostunnel.nix

--- a/nixos/modules/services/networking/frr.nix
+++ b/nixos/modules/services/networking/frr.nix
@@ -1,0 +1,211 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.frr;
+
+  services = [
+    "static"
+    "bgp"
+    "ospf"
+    "ospf6"
+    "rip"
+    "ripng"
+    "isis"
+    "pim"
+    "ldp"
+    "nhrp"
+    "eigrp"
+    "babel"
+    "sharp"
+    "pbr"
+    "bfd"
+    "fabric"
+  ];
+
+  allServices = services ++ [ "zebra" ];
+
+  isEnabled = service: cfg.${service}.enable;
+
+  daemonName = service: if service == "zebra" then service else "${service}d";
+
+  configFile = service:
+    let
+      scfg = cfg.${service};
+    in
+      if scfg.configFile != null then scfg.configFile
+      else pkgs.writeText "${daemonName service}.conf"
+        ''
+          ! FRR ${daemonName service} configuration
+          !
+          hostname ${config.networking.hostName}
+          log syslog
+          service password-encryption
+          !
+          ${scfg.config}
+          !
+          end
+        '';
+
+  serviceOptions = service:
+    {
+      enable = mkEnableOption "the FRR ${toUpper service} routing protocol";
+
+      configFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        example = "/etc/frr/${daemonName service}.conf";
+        description = ''
+          Configuration file to use for FRR ${daemonName service}.
+          By default the NixOS generated files are used.
+        '';
+      };
+
+      config = mkOption {
+        type = types.lines;
+        default = "";
+        example =
+          let
+            examples = {
+              rip = ''
+                router rip
+                  network 10.0.0.0/8
+              '';
+
+              ospf = ''
+                router ospf
+                  network 10.0.0.0/8 area 0
+              '';
+
+              bgp = ''
+                router bgp 65001
+                  neighbor 10.0.0.1 remote-as 65001
+              '';
+            };
+          in
+            examples.${service} or "";
+        description = ''
+          ${daemonName service} configuration statements.
+        '';
+      };
+
+      vtyListenAddress = mkOption {
+        type = types.str;
+        default = "localhost";
+        description = ''
+          Address to bind to for the VTY interface.
+        '';
+      };
+
+      vtyListenPort = mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        description = ''
+          TCP Port to bind to for the VTY interface.
+        '';
+      };
+    };
+
+in
+
+{
+
+  ###### interface
+  imports = [
+    {
+      options.services.frr = {
+        zebra = (serviceOptions "zebra") // {
+          enable = mkOption {
+            type = types.bool;
+            default = any isEnabled services;
+            description = ''
+              Whether to enable the Zebra routing manager.
+
+              The Zebra routing manager is automatically enabled
+              if any routing protocols are configured.
+            '';
+          };
+        };
+      };
+    }
+    { options.services.frr = (genAttrs services serviceOptions); }
+  ];
+
+  ###### implementation
+
+  config = mkIf (any isEnabled allServices) {
+
+    environment.systemPackages = [
+      pkgs.frr # for the vtysh tool
+    ];
+
+    users.users.frr = {
+      description = "FRR daemon user";
+      isSystemUser = true;
+      group = "frr";
+    };
+
+    users.groups = {
+      frr = {};
+      # Members of the frrvty group can use vtysh to inspect the FRR daemons
+      frrvty = { members = [ "frr" ]; };
+    };
+
+    environment.etc = let
+      mkEtcLink = service: {
+        name = "frr/${service}.conf";
+        value.source = configFile service;
+      };
+    in
+      (builtins.listToAttrs
+      (map mkEtcLink (filter isEnabled allServices))) // {
+        "frr/vtysh.conf".text = "";
+      };
+
+    systemd.tmpfiles.rules = [
+      "d /run/frr 0750 frr frr -"
+    ];
+
+    systemd.services =
+      let
+        frrService = service:
+          let
+            scfg = cfg.${service};
+            daemon = daemonName service;
+          in
+            nameValuePair daemon ({
+              wantedBy = [ "multi-user.target" ];
+              after = [ "network-pre.target" "systemd-sysctl.service" ] ++ lib.optionals (service != "zebra") [ "zebra.service" ];
+              bindsTo = lib.optionals (service != "zebra") [ "zebra.service" ];
+              wants = [ "network.target" ];
+
+              description = if service == "zebra" then "FRR Zebra routing manager"
+                else "FRR ${toUpper service} routing daemon";
+
+              unitConfig.Documentation = if service == "zebra" then "man:zebra(8)"
+                else "man:${daemon}(8) man:zebra(8)";
+
+              restartTriggers = [
+                (configFile service)
+              ];
+              reloadIfChanged = true;
+
+              serviceConfig = {
+                PIDFile = "frr/${daemon}.pid";
+                ExecStart = "${pkgs.frr}/libexec/frr/${daemon} -f /etc/frr/${service}.conf"
+                  + optionalString (scfg.vtyListenAddress != "") " -A ${scfg.vtyListenAddress}"
+                  + optionalString (scfg.vtyListenPort != null) " -P ${toString scfg.vtyListenPort}";
+                ExecReload = "${pkgs.python3.interpreter} ${pkgs.frr}/libexec/frr/frr-reload.py --reload --daemon ${daemonName service} --bindir ${pkgs.frr}/bin --rundir /run/frr /etc/frr/${service}.conf";
+                Restart = "on-abnormal";
+              };
+            });
+       in
+         listToAttrs (map frrService (filter isEnabled allServices));
+
+  };
+
+  meta.maintainers = with lib.maintainers; [ woffs ];
+
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -143,6 +143,7 @@ in
   fluidd = handleTest ./fluidd.nix {};
   fontconfig-default-fonts = handleTest ./fontconfig-default-fonts.nix {};
   freeswitch = handleTest ./freeswitch.nix {};
+  frr = handleTest ./frr.nix {};
   fsck = handleTest ./fsck.nix {};
   ft2-clone = handleTest ./ft2-clone.nix {};
   gerrit = handleTest ./gerrit.nix {};

--- a/nixos/tests/frr.nix
+++ b/nixos/tests/frr.nix
@@ -1,0 +1,104 @@
+# This test runs FRR and checks if OSPF routing works.
+#
+# Network topology:
+#   [ client ]--net1--[ router1 ]--net2--[ router2 ]--net3--[ server ]
+#
+# All interfaces are in OSPF Area 0.
+
+import ./make-test-python.nix ({ pkgs, ... }:
+  let
+
+    ifAddr = node: iface: (pkgs.lib.head node.config.networking.interfaces.${iface}.ipv4.addresses).address;
+
+    ospfConf1 = ''
+      router ospf
+        network 192.168.0.0/16 area 0
+    '';
+
+    ospfConf2 = ''
+      interface eth2
+        ip ospf hello-interval 1
+        ip ospf dead-interval 5
+      !
+      router ospf
+        network 192.168.0.0/16 area 0
+    '';
+
+  in
+    {
+      name = "frr";
+
+      meta = with pkgs.lib.maintainers; {
+        maintainers = [ hexa ];
+      };
+
+      nodes = {
+
+        client =
+          { nodes, ... }:
+          {
+            virtualisation.vlans = [ 1 ];
+            networking.defaultGateway = ifAddr nodes.router1 "eth1";
+          };
+
+        router1 =
+          { ... }:
+          {
+            virtualisation.vlans = [ 1 2 ];
+            boot.kernel.sysctl."net.ipv4.ip_forward" = "1";
+            networking.firewall.extraCommands = "iptables -A nixos-fw -i eth2 -p ospfigp -j ACCEPT";
+            services.frr.ospf = {
+              enable = true;
+              config = ospfConf1;
+            };
+
+            specialisation.ospf.configuration = {
+              services.frr.ospf.config = ospfConf2;
+            };
+          };
+
+        router2 =
+          { ... }:
+          {
+            virtualisation.vlans = [ 3 2 ];
+            boot.kernel.sysctl."net.ipv4.ip_forward" = "1";
+            networking.firewall.extraCommands = "iptables -A nixos-fw -i eth2 -p ospfigp -j ACCEPT";
+            services.frr.ospf = {
+              enable = true;
+              config = ospfConf2;
+            };
+          };
+
+        server =
+          { nodes, ... }:
+          {
+            virtualisation.vlans = [ 3 ];
+            networking.defaultGateway = ifAddr nodes.router2 "eth1";
+          };
+      };
+
+      testScript =
+        { nodes, ... }:
+        ''
+          start_all()
+
+          # Wait for the networking to start on all machines
+          for machine in client, router1, router2, server:
+              machine.wait_for_unit("network.target")
+
+          with subtest("Wait for Zebra and OSPFD"):
+              for gw in router1, router2:
+                  gw.wait_for_unit("zebra")
+                  gw.wait_for_unit("ospfd")
+
+          router1.succeed("${nodes.router1.config.system.build.toplevel}/specialisation/ospf/bin/switch-to-configuration test >&2")
+
+          with subtest("Wait for OSPF to form adjacencies"):
+              for gw in router1, router2:
+                  gw.wait_until_succeeds("vtysh -c 'show ip ospf neighbor' | grep Full")
+                  gw.wait_until_succeeds("vtysh -c 'show ip route' | grep '^O>'")
+
+          with subtest("Test ICMP"):
+              client.wait_until_succeeds("ping -c 3 server >&2")
+        '';
+    })

--- a/pkgs/development/libraries/libyang/default.nix
+++ b/pkgs/development/libraries/libyang/default.nix
@@ -1,0 +1,45 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pcre
+, pkg-config
+, genericUpdater
+, common-updater-scripts
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libyang";
+  version = "1.0.240";
+
+  src = fetchFromGitHub {
+    owner = "CESNET";
+    repo = "libyang";
+    rev = "v${version}";
+    sha256 = "12hzwm0jszhnbmn0a03pljpz18dzsrqn91z6y62ghci26qi3xcxn";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ pcre ];
+  cmakeFlags = [ "-DENABLE_LYD_PRIV=ON" "-DCMAKE_BUILD_TYPE:String=Release" ];
+
+  passthru.updateScript = genericUpdater {
+    inherit pname version;
+    versionLister = "${common-updater-scripts}/bin/list-git-tags ${src.meta.homepage}";
+    ignoredVersions = "^2\.";
+    rev-prefix = "v";
+  };
+
+  meta = with lib; {
+    description = "YANG data modelling language parser and toolkit";
+    longDescription = ''
+      libyang is a YANG data modelling language parser and toolkit written (and
+      providing API) in C. The library is used e.g. in libnetconf2, Netopeer2,
+      sysrepo or FRRouting projects.
+    '';
+    homepage = "https://github.com/CESNET/libyang";
+    license = with licenses; [ bsd3 ];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ woffs ];
+  };
+}

--- a/pkgs/development/libraries/libyang/default.nix
+++ b/pkgs/development/libraries/libyang/default.nix
@@ -1,32 +1,48 @@
 { stdenv
 , lib
 , fetchFromGitHub
+
+# build time
 , cmake
-, pcre
 , pkg-config
+
+# run time
+, pcre2
+
+# update script
 , genericUpdater
 , common-updater-scripts
 }:
 
 stdenv.mkDerivation rec {
   pname = "libyang";
-  version = "1.0.240";
+  version = "2.0.112";
 
   src = fetchFromGitHub {
     owner = "CESNET";
     repo = "libyang";
     rev = "v${version}";
-    sha256 = "12hzwm0jszhnbmn0a03pljpz18dzsrqn91z6y62ghci26qi3xcxn";
+    sha256 = "sha256-f8x0tC3XcQ9fnUE987GYw8qEo/B+J759vpCImqG3QWs=";
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [ pcre ];
-  cmakeFlags = [ "-DENABLE_LYD_PRIV=ON" "-DCMAKE_BUILD_TYPE:String=Release" ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    pcre2
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-DCMAKE_BUILD_TYPE:String=Release"
+  ];
 
   passthru.updateScript = genericUpdater {
     inherit pname version;
     versionLister = "${common-updater-scripts}/bin/list-git-tags ${src.meta.homepage}";
-    ignoredVersions = "^2\.";
     rev-prefix = "v";
   };
 

--- a/pkgs/servers/frr/default.nix
+++ b/pkgs/servers/frr/default.nix
@@ -1,0 +1,90 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, libcap
+, json_c
+, readline
+, net-snmp
+, perl
+, texinfo
+, pkg-config
+, c-ares
+, python3
+, python3Packages
+, libyang
+, flex
+, bison
+, openssl
+, czmq
+, nixosTests
+}:
+
+stdenv.mkDerivation rec {
+  pname = "frr";
+  version = "7.5.1";
+
+  src = fetchFromGitHub {
+    owner = "FRRouting";
+    repo = pname;
+    rev = "${pname}-${version}";
+    sha256 = "0lzsvi3kl9zcd4k04vc3363z9v2yrp7wc8bziv6w9h5fznh2vkxp";
+  };
+
+  buildInputs = [ readline net-snmp c-ares json_c python3 libyang openssl czmq ]
+    ++ lib.optionals stdenv.isLinux [ libcap ];
+
+  nativeBuildInputs = [ pkg-config perl texinfo autoreconfHook python3Packages.sphinx python3Packages.pytest flex bison ];
+
+  configureFlags = [
+    "--sysconfdir=/etc/frr"
+    "--localstatedir=/run/frr"
+    "--sbindir=$(out)/libexec/frr"
+    "--disable-exampledir"
+    "--enable-user=frr"
+    "--enable-group=frr"
+    "--enable-configfile-mask=0640"
+    "--enable-logfile-mask=0640"
+    "--enable-vty-group=frrvty"
+    "--enable-snmp"
+    "--enable-multipath=64"
+  ];
+
+  postPatch = ''
+    substituteInPlace tools/frr-reload --replace /usr/lib/frr/ $out/libexec/frr/
+  '';
+
+  enableParallelBuilding = true;
+
+  passthru.tests = { inherit (nixosTests) frr; };
+
+  meta = with lib; {
+    description = "FRR BGP/OSPF/ISIS/RIP/RIPNG routing daemon suite";
+    longDescription = ''
+      FRRouting (FRR) is a free and open source Internet routing protocol suite
+      for Linux and Unix platforms. It implements BGP, OSPF, RIP, IS-IS, PIM,
+      LDP, BFD, Babel, PBR, OpenFabric and VRRP, with alpha support for EIGRP
+      and NHRP.
+
+      FRR’s seamless integration with native Linux/Unix IP networking stacks
+      makes it a general purpose routing stack applicable to a wide variety of
+      use cases including connecting hosts/VMs/containers to the network,
+      advertising network services, LAN switching and routing, Internet access
+      routers, and Internet peering.
+
+      FRR has its roots in the Quagga project. In fact, it was started by many
+      long-time Quagga developers who combined their efforts to improve on
+      Quagga’s well-established foundation in order to create the best routing
+      protocol stack available. We invite you to participate in the FRRouting
+      community and help shape the future of networking.
+
+      Join the ranks of network architects using FRR for ISPs, SaaS
+      infrastructure, web 2.0 businesses, hyperscale services, and Fortune 500
+      private clouds.
+    '';
+    homepage = "https://frrouting.org/";
+    license = with licenses; [ gpl2Plus lgpl21Plus ];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ woffs ];
+  };
+}

--- a/pkgs/servers/frr/default.nix
+++ b/pkgs/servers/frr/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , python3Packages
 
 # build time
@@ -40,6 +41,15 @@ stdenv.mkDerivation rec {
     rev = "${pname}-${version}";
     sha256 = "sha256-hJcgLiPBxOE5QEh0RhtZhM3dOxFqW5H0TUjN+aP4qRk=";
   };
+
+  patches = [
+    (fetchpatch {
+      # Fix clippy build on aarch64-linux
+      # https://github.com/FRRouting/frr/issues/10267
+      url = "https://github.com/FRRouting/frr/commit/3942ee1f7bc754dd0dd9ae79f89d0f2635be334f.patch";
+      sha256 = "1i0acfy5k9fbm9cxchrcvkhyw9704srq4wm2hyjqgdimm2dq7ryf";
+    })
+  ];
 
   nativeBuildInputs = [
     autoreconfHook

--- a/pkgs/servers/frr/default.nix
+++ b/pkgs/servers/frr/default.nix
@@ -1,40 +1,71 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, autoreconfHook
-, libcap
-, json_c
-, readline
-, net-snmp
-, perl
-, texinfo
-, pkg-config
-, c-ares
-, python3
 , python3Packages
-, libyang
+
+# build time
+, autoreconfHook
 , flex
 , bison
+, perl
+, pkg-config
+, texinfo
+
+# runtime
+, c-ares
+, json_c
+, libcap
+, libelf
+, libunwind
+, libyang
+, net-snmp
 , openssl
-, czmq
+, pam
+, pcre2
+, python3
+, readline
+
+# tests
+, nettools
 , nixosTests
 }:
 
 stdenv.mkDerivation rec {
   pname = "frr";
-  version = "7.5.1";
+  version = "8.1";
 
   src = fetchFromGitHub {
     owner = "FRRouting";
     repo = pname;
     rev = "${pname}-${version}";
-    sha256 = "0lzsvi3kl9zcd4k04vc3363z9v2yrp7wc8bziv6w9h5fznh2vkxp";
+    sha256 = "sha256-hJcgLiPBxOE5QEh0RhtZhM3dOxFqW5H0TUjN+aP4qRk=";
   };
 
-  buildInputs = [ readline net-snmp c-ares json_c python3 libyang openssl czmq ]
-    ++ lib.optionals stdenv.isLinux [ libcap ];
+  nativeBuildInputs = [
+    autoreconfHook
+    bison
+    flex
+    perl
+    pkg-config
+    python3Packages.sphinx
+    texinfo
+  ];
 
-  nativeBuildInputs = [ pkg-config perl texinfo autoreconfHook python3Packages.sphinx python3Packages.pytest flex bison ];
+  buildInputs = [
+    c-ares
+    json_c
+    libelf
+    libunwind
+    libyang
+    net-snmp
+    openssl
+    pam
+    pcre2
+    python3
+    readline
+  ] ++ lib.optionals stdenv.isLinux [
+    libcap
+  ];
 
   configureFlags = [
     "--sysconfdir=/etc/frr"
@@ -53,6 +84,12 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace tools/frr-reload --replace /usr/lib/frr/ $out/libexec/frr/
   '';
+
+  doCheck = true;
+  checkInputs = [
+    nettools
+    python3Packages.pytest
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18710,6 +18710,8 @@ with pkgs;
 
   libyamlcpp_0_3 = callPackage ../development/libraries/libyaml-cpp/0.3.0.nix { };
 
+  libyang = callPackage ../development/libraries/libyang { };
+
   libcyaml = callPackage ../development/libraries/libcyaml { };
 
   rang = callPackage ../development/libraries/rang { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5346,6 +5346,8 @@ with pkgs;
 
   flvstreamer = callPackage ../tools/networking/flvstreamer { };
 
+  frr = callPackage ../servers/frr { };
+
   hmetis = pkgsi686Linux.callPackage ../applications/science/math/hmetis { };
 
   libbsd = callPackage ../development/libraries/libbsd { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I need a linux routing daemon that implements BGP-EVPN.

This PR is based on https://github.com/NixOS/nixpkgs/pull/124506 and I really hope we can get a working version in soon.

Updates frr to 8.1 and implements reload using `frr-reload.py`.

TODO:

- ~~Investigate vtysh.conf defaults (`% Can't open configuration file /etc/frr/vtysh.conf due to 'No such file or directory'.`)~~ No sane defaults for us, so I just create an empty file. https://docs.frrouting.org/en/latest/vtysh.html
- ~~Fix firewalling in the test (`firewall-start[1168]: iptables v1.8.7 (nf_tables): unknown protocol "ospf" specified`)~~ The identifier is `ospfigp` via `/etc/protocols`
- ~~Create `/run/frr` using a systemd-tmpfiles rule~~

cc @dminuoso 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
