### PR TITLE
md2gemini: 1.8.1 → 1.9.0

### DIFF
--- a/pkgs/development/python-modules/md2gemini/default.nix
+++ b/pkgs/development/python-modules/md2gemini/default.nix
@@ -3,7 +3,7 @@
 
 buildPythonPackage rec {
   pname = "md2gemini";
-  version = "1.8.1";
+  version = "1.9.0";
 
   propagatedBuildInputs = [ mistune_2_0 cjkwrap wcwidth ];
   checkInputs = [ pytestCheckHook ];
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0mfa0f0m762168fbsxjr1cx9yhj82dr8z1d28jl6hj9bkqnvvwiy";
+    sha256 = "sha256-d1zuK+NqoPS36ihh8qx9gOET94tApY+SGStsc/bITnU=";
   };
 
   meta = with lib; {

--- a/pkgs/development/python-modules/mistune/common.nix
+++ b/pkgs/development/python-modules/mistune/common.nix
@@ -1,7 +1,7 @@
-{ lib, buildPythonPackage, fetchPypi, nose, version, sha256 }:
+{ lib, buildPythonPackage, fetchPypi, nose, version, sha256, format ? "setuptools" }:
 
 buildPythonPackage rec {
-  inherit version;
+  inherit version format;
   pname = "mistune";
 
   src = fetchPypi {

--- a/pkgs/development/python-modules/mistune/default.nix
+++ b/pkgs/development/python-modules/mistune/default.nix
@@ -4,8 +4,9 @@ self: rec {
     sha256 = "59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e";
   };
   mistune_2_0 = self.callPackage ./common.nix {
-    version = "2.0.0rc1";
-    sha256 = "1nd7iav1ixh9hlj4hxn6lmpava88d86ys8rqm30wgvr7gjlxnas5";
+    version = "2.0.2";
+    sha256 = "sha256-b8iMPLSduosWaHtBcl5mHPhXhMEuiXSim50zbdWWw6E=";
+    format = "pyproject";
   };
   mistune = mistune_0_8;
 }

--- a/pkgs/servers/mail/mailman/hyperkitty.nix
+++ b/pkgs/servers/mail/mailman/hyperkitty.nix
@@ -43,6 +43,9 @@ buildPythonPackage rec {
   postPatch = ''
     # isort is a development dependency
     sed -i '/isort/d' setup.py
+    # Fix mistune imports for mistune >= 2.0.0
+    # https://gitlab.com/mailman/hyperkitty/-/merge_requests/379
+    sed -i 's/mistune.scanner/mistune.util/' hyperkitty/lib/renderer.py
   '';
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/makeworld-the-better-one/md2gemini/releases/tag/v1.9.0)
mistune >= 2.0.0 required.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
