### PR TITLE
btop: Add darwin support

### DIFF
--- a/pkgs/tools/system/btop/default.nix
+++ b/pkgs/tools/system/btop/default.nix
@@ -1,6 +1,9 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, runCommand
+, darwin
+, gcc11
 }:
 
 stdenv.mkDerivation rec {
@@ -14,6 +17,28 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-uKR1ogQwEoyxyWBiLnW8BsOsYgTpeIpKrKspq0JwYjY=";
   };
 
+  nativeBuildInputs = lib.optionals stdenv.isDarwin [ gcc11 ];
+
+  hardeningDisable = lib.optionals (stdenv.isAarch64 && stdenv.isDarwin) [ "stackprotector" ];
+
+  ADDFLAGS = with darwin.apple_sdk;
+    lib.optional stdenv.isDarwin
+      "-F${frameworks.IOKit}/Library/Frameworks/";
+
+  buildInputs = with darwin.apple_sdk;
+    lib.optionals stdenv.isDarwin [
+      frameworks.CoreFoundation
+      frameworks.IOKit
+    ] ++ lib.optional (stdenv.isDarwin && !stdenv.isAarch64) (
+      # Found this explanation for needing to create a header directory for libproc.h alone.
+      # https://github.com/NixOS/nixpkgs/blob/049e5e93af9bbbe06b4c40fd001a4e138ce1d677/pkgs/development/libraries/webkitgtk/default.nix#L154
+      # TL;DR, the other headers in the include path for the macOS SDK is not compatible with the C++ stdlib and causes issues, so we copy
+      # this to avoid those issues
+      runCommand "${pname}_headers" { } ''
+        install -Dm444 "${lib.getDev sdk}"/include/libproc.h "$out"/include/libproc.h
+      ''
+    );
+
   installFlags = [ "PREFIX=$(out)" ];
 
   meta = with lib; {
@@ -21,7 +46,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/aristocratos/btop";
     changelog = "https://github.com/aristocratos/btop/blob/v${version}/CHANGELOG.md";
     license = licenses.asl20;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ rmcgibbo ];
   };
 }

--- a/pkgs/tools/system/btop/default.nix
+++ b/pkgs/tools/system/btop/default.nix
@@ -3,7 +3,6 @@
 , fetchFromGitHub
 , runCommand
 , darwin
-, gcc11
 }:
 
 stdenv.mkDerivation rec {
@@ -17,13 +16,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-uKR1ogQwEoyxyWBiLnW8BsOsYgTpeIpKrKspq0JwYjY=";
   };
 
-  nativeBuildInputs = lib.optionals stdenv.isDarwin [ gcc11 ];
-
   hardeningDisable = lib.optionals (stdenv.isAarch64 && stdenv.isDarwin) [ "stackprotector" ];
 
-  ADDFLAGS = with darwin.apple_sdk;
+  ADDFLAGS = with darwin.apple_sdk.frameworks;
     lib.optional stdenv.isDarwin
-      "-F${frameworks.IOKit}/Library/Frameworks/";
+      "-F${IOKit}/Library/Frameworks/";
 
   buildInputs = with darwin.apple_sdk;
     lib.optionals stdenv.isDarwin [

--- a/pkgs/tools/system/btop/default.nix
+++ b/pkgs/tools/system/btop/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     lib.optionals stdenv.isDarwin [
       frameworks.CoreFoundation
       frameworks.IOKit
-    ] ++ lib.optional (stdenv.isDarwin && !stdenv.isAarch64) (
+    ] ++ lib.optional (stdenv.isDarwin && stdenv.isx86_64) (
       # Found this explanation for needing to create a header directory for libproc.h alone.
       # https://github.com/NixOS/nixpkgs/blob/049e5e93af9bbbe06b4c40fd001a4e138ce1d677/pkgs/development/libraries/webkitgtk/default.nix#L154
       # TL;DR, the other headers in the include path for the macOS SDK is not compatible with the C++ stdlib and causes issues, so we copy


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adds darwin support for btop

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
