### PR TITLE
seturgent: unstable-2012-08-17 -> 1.5

### DIFF
--- a/pkgs/os-specific/linux/seturgent/default.nix
+++ b/pkgs/os-specific/linux/seturgent/default.nix
@@ -1,15 +1,15 @@
-{ lib, stdenv, fetchurl, libX11, xorgproto, unzip }:
+{ lib, stdenv, fetchgit, libX11, xorgproto }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "seturgent";
-  version = "unstable-2012-08-17";
+  version = "1.5";
 
-  src = fetchurl {
-    url = "https://github.com/hiltjo/seturgent/archive/ada70dcb15865391e5cdcab27a0739a304a17e03.zip";
-    sha256 = "0q1sr6aljkw2jr9b4xxzbc01qvnd5vk3pxrypif9yd8xjw4wqwri";
+  src = fetchgit {
+    url = "git://git.codemadness.org/seturgent";
+    rev = version;
+    sha256 = "sha256-XW7ms0BVCf1/fuL3PJ970t6sHkmMY1iLYXfS9R60JX0=";
   };
 
-  nativeBuildInputs = [ unzip ];
   buildInputs = [
     libX11
     xorgproto
@@ -20,11 +20,11 @@ stdenv.mkDerivation {
     mv seturgent $out/bin
   '';
 
-  meta = {
-    platforms = lib.platforms.linux;
+  meta = with lib; {
+    platforms = platforms.linux;
     description = "Set an application's urgency hint (or not)";
-    maintainers = [ lib.maintainers.yarr ];
-    homepage = "https://github.com/hiltjo/seturgent";
-    license = lib.licenses.mit;
+    maintainers = with maintainers; [ yarr ];
+    homepage = "https://codemadness.org/seturgent-set-urgency-hints-for-x-applications.html";
+    license = licenses.mit;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
@Eternity-Yarr can you approve these changes?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
