### PR TITLE
jetbrains: add Gateway product

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -117,6 +117,28 @@ let
       };
     });
 
+  buildGateway = { name, version, src, license, description, wmClass, ... }:
+    (mkJetBrainsProduct {
+      inherit name version src wmClass jdk;
+      product = "Gateway";
+      extraLdPath = [ zlib ];
+      extraWrapperArgs = [
+        ''--set M2_HOME "${maven}/maven"''
+        ''--set M2 "${maven}/maven/bin"''
+      ];
+      meta = with lib; {
+        homepage = "https://www.jetbrains.com/remote-development/gateway/";
+        inherit description license;
+        longDescription = ''
+          JetBrains Gateway is a compact desktop app that allows
+          you to work remotely with a JetBrains IDE without even
+          downloading one.
+        '';
+        maintainers = with maintainers; [ edwtjo gytis-ivaskevicius ];
+        platforms = [ "x86_64-darwin" "i686-darwin" "i686-linux" "x86_64-linux" ];
+      };
+    });
+
   buildMps = { name, version, src, license, description, wmClass, ... }:
     (mkJetBrainsProduct rec {
       inherit name version src wmClass jdk;
@@ -308,6 +330,19 @@ in
     };
     wmClass = "jetbrains-idea";
     update-channel = "IntelliJ IDEA RELEASE";
+  };
+
+  gateway = buildGateway rec {
+    name = "gateway-${version}";
+    version = "213.6461.21"; /* updated by script */
+    description = "Remote Development Gateway by JetBrains";
+    license = lib.licenses.unfree;
+    src = fetchurl {
+      url = "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-${version}.tar.gz";
+      sha256 = "1m90fm9gmxz7igxskw7h15hpm4fz8rd8c0kpjcv09x8a4axdcgmd"; /* updated by script */
+    };
+    wmClass = "jetbrains-gateway";
+    update-channel = "JetBrains Gateway RELEASE";
   };
 
   mps = buildMps rec {


### PR DESCRIPTION
Introduces a build for the new Gateway product: https://www.jetbrains.com/remote-development/gateway

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

JetBrains have released their new Gateway product which facilitates connecting to remote machines for development. 

###### Things done

Based upon the existing builds for other JetBrains product, a new build has been added for Gateway following existing patterns and best practices already present. 

NOTE: since the product is still in beta, it's versioning does not appear to follow `${year}.{major}.{minor}` like the other products. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
