### PR TITLE
bottles: 2021.7.28-treviso-2 -> 2021.12.14-treviso-4

### DIFF
--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -3,18 +3,18 @@
 , desktop-file-utils, gsettings-desktop-schemas, libnotify, libhandy
 , python3Packages, gettext
 , appstream-glib, gdk-pixbuf, glib, gobject-introspection, gspell, gtk3
-, steam-run, xdg-utils, pciutils, cabextract, wineWowPackages
+, steam-run, xdg-utils, pciutils, cabextract, wineWowPackages, webkitgtk, p7zip
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "bottles";
-  version = "2021.7.28-treviso-2";
+  version = "2021.12.14-treviso-4";
 
   src = fetchFromGitHub {
     owner = "bottlesdevs";
     repo = pname;
     rev = version;
-    sha256 = "0kvwcajm9izvkwfg7ir7bks39bpc665idwa8mc8d536ajyjriysn";
+    hash = "sha256-Lbqw/M37PUmf2af8B+G4IySifoTfBwMXw9UmeymWiNM=";
   };
 
   postPatch = ''
@@ -53,12 +53,15 @@ python3Packages.buildPythonApplication rec {
     gst-python
     liblarch
     patool
+    markdown
   ] ++ [
     steam-run
     xdg-utils
     pciutils
     cabextract
     wineWowPackages.minimal
+    webkitgtk
+    p7zip
   ];
 
   format = "other";
@@ -68,11 +71,12 @@ python3Packages.buildPythonApplication rec {
   preConfigure = ''
     substituteInPlace build-aux/meson/postinstall.py \
       --replace "'update-desktop-database'" "'${desktop-file-utils}/bin/update-desktop-database'"
-    substituteInPlace src/runner.py \
-      --replace " {runner}" " ${steam-run}/bin/steam-run {runner}" \
-      --replace " {dxvk_setup}" " ${steam-run}/bin/steam-run {dxvk_setup}"
-      substituteInPlace src/runner_utilities.py \
-        --replace " {runner}" " ${steam-run}/bin/steam-run {runner}" \
+    substituteInPlace src/backend/runner.py \
+      --replace "{runner} {command}" "${steam-run}/bin/steam-run {runner} {command}"
+    substituteInPlace src/backend/manager_utils.py \
+      --replace "{runner}" " ${steam-run}/bin/steam-run {runner}"
+    substituteInPlace src/backend/manager.py \
+      --replace "{runner}" " ${steam-run}/bin/steam-run {runner}" \
   '';
 
   preFixup = ''


### PR DESCRIPTION
###### Motivation for this change
Update to most recent version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
```
 asbachb@nixos-t14s  ~/dev/src/nix/nixpkgs   update/bottles  nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 124, done.
remote: Counting objects: 100% (101/101), done.
remote: Compressing objects: 100% (27/27), done.
remote: Total 124 (delta 78), reused 93 (delta 74), pack-reused 23
Receiving objects: 100% (124/124), 339.68 KiB | 3.03 MiB/s, done.
Resolving deltas: 100% (83/83), completed with 51 local objects.
From https://github.com/NixOS/nixpkgs
   a4d96cd808f..e976a7e860c  master     -> refs/nixpkgs-review/0
Auto packing the repository in background for optimum performance.
See "git help gc" for manual housekeeping.
$ git worktree add /home/asbachb/.cache/nixpkgs-review/rev-b2876bb1315343c157f43ace50f5ff094365fc9b/nixpkgs e976a7e860c35f3dbfec62ea9adc97f2a7956c47
Preparing worktree (detached HEAD e976a7e860c)
Updating files: 100% (29374/29374), done.
HEAD is now at e976a7e860c Merge pull request #152024 from Stunkymonkey/angelscript_2_22-refactor
$ nix-env --option system x86_64-linux -f /home/asbachb/.cache/nixpkgs-review/rev-b2876bb1315343c157f43ace50f5ff094365fc9b/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit --no-ff b2876bb1315343c157f43ace50f5ff094365fc9b
Automatic merge went well; stopped before committing as requested
$ nix-env --option system x86_64-linux -f /home/asbachb/.cache/nixpkgs-review/rev-b2876bb1315343c157f43ace50f5ff094365fc9b/nixpkgs -qaP --xml --out-path --show-trace --meta
1 package updated:
bottles (2021.7.28-treviso-2 → 2021.12.14-treviso-4)

$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /home/asbachb/.cache/nixpkgs-review/rev-b2876bb1315343c157f43ace50f5ff094365fc9b/build.nix
1 package built:
bottles

$ nix-shell /home/asbachb/.cache/nixpkgs-review/rev-b2876bb1315343c157f43ace50f5ff094365fc9b/shell.nix
```
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
