### PR TITLE
rc: fix static build

### DIFF
--- a/pkgs/shells/rc/default.nix
+++ b/pkgs/shells/rc/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, autoreconfHook, byacc
-, ncurses, readline
+, ncurses, readline, pkgsStatic
 , historySupport ? false, readlineSupport ? true }:
 
 stdenv.mkDerivation rec {
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ ncurses ]
     ++ lib.optionals readlineSupport [ readline ];
 
+  CPPFLAGS = ["-DSIGCLD=SIGCHLD"];
+
   configureFlags = [
     "--enable-def-interp=${stdenv.shell}" #183
     ] ++ lib.optionals historySupport [ "--with-history" ]
@@ -31,7 +33,10 @@ stdenv.mkDerivation rec {
       --replace "$(git describe || echo '(git description unavailable)')" "${builtins.substring 0 7 src.rev}"
   '';
 
-  passthru.shellPath = "/bin/rc";
+  passthru = {
+    shellPath = "/bin/rc";
+    tests.static = pkgsStatic.rc;
+  };
 
   meta = with lib; {
     description = "The Plan 9 shell";


### PR DESCRIPTION
- rc: fix static build
- rc: add static build into release.nix

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
