### PR TITLE
ghidra: init at 10.1.1

### DIFF
--- a/pkgs/tools/security/ghidra/0001-Use-protobuf-gradle-plugin.patch
+++ b/pkgs/tools/security/ghidra/0001-Use-protobuf-gradle-plugin.patch
@@ -1,0 +1,130 @@
+From 913e74b8682f77da94ed7b7d459482b9b23a5d88 Mon Sep 17 00:00:00 2001
+From: roblabla <unfiltered@roblab.la>
+Date: Tue, 28 Dec 2021 14:20:30 +0100
+Subject: [PATCH] Use protobuf gradle plugin
+
+---
+ Ghidra/Debug/Debugger-gadp/build.gradle | 76 +++----------------------
+ build.gradle                            |  6 ++
+ 2 files changed, 15 insertions(+), 67 deletions(-)
+
+diff --git a/Ghidra/Debug/Debugger-gadp/build.gradle b/Ghidra/Debug/Debugger-gadp/build.gradle
+index 1b4922f66..3d2ef8856 100644
+--- a/Ghidra/Debug/Debugger-gadp/build.gradle
++++ b/Ghidra/Debug/Debugger-gadp/build.gradle
+@@ -23,42 +23,19 @@ apply from: "${rootProject.projectDir}/gradle/javaTestProject.gradle"
+ apply from: "${rootProject.projectDir}/gradle/distributableGhidraModule.gradle"
+ 
+ apply plugin: 'eclipse'
+-eclipse.project.name = 'Debug Debugger-gadp'
++apply plugin: 'com.google.protobuf'
+ 
+-configurations {
+-	allProtocArtifacts
+-	protocArtifact
+-}
++eclipse.project.name = 'Debug Debugger-gadp'
+ 
+ def platform = getCurrentPlatformName()
+ 
+-dependencies {
+-	allProtocArtifacts 'com.google.protobuf:protoc:3.17.3:windows-x86_64@exe'
+-	allProtocArtifacts 'com.google.protobuf:protoc:3.17.3:linux-x86_64@exe'
+-	allProtocArtifacts 'com.google.protobuf:protoc:3.17.3:linux-aarch_64@exe'
+-	allProtocArtifacts 'com.google.protobuf:protoc:3.17.3:osx-x86_64@exe'
+-	allProtocArtifacts 'com.google.protobuf:protoc:3.17.3:osx-aarch_64@exe'
+-
+-	if (isCurrentWindows()) {
+-		protocArtifact 'com.google.protobuf:protoc:3.17.3:windows-x86_64@exe'
+-	}
+-	if (isCurrentLinux()) {
+-		if (platform.endsWith("x86_64")) {
+-			protocArtifact 'com.google.protobuf:protoc:3.17.3:linux-x86_64@exe'
+-		}
+-		else {
+-			protocArtifact 'com.google.protobuf:protoc:3.17.3:linux-aarch_64@exe'
+-		}
+-	}
+-	if (isCurrentMac()) {
+-		if (platform.endsWith("x86_64")) {
+-			protocArtifact 'com.google.protobuf:protoc:3.17.3:osx-x86_64@exe'
+-		}
+-		else {
+-			protocArtifact 'com.google.protobuf:protoc:3.17.3:osx-aarch_64@exe'
+-		}
+-	}
++buildscript {
++  dependencies {
++    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.18'
++  }
++}
+ 
++dependencies {
+ 	api 'com.google.protobuf:protobuf-java:3.17.3'
+ 	api project(':Framework-AsyncComm')
+ 	api project(':Framework-Debugging')
+@@ -68,43 +45,8 @@ dependencies {
+ 	testImplementation project(path: ':Framework-Debugging', configuration: 'testArtifacts')
+ }
+ 
+-/*protobuf {
++protobuf {
+ 	protoc {
+ 		artifact = 'com.google.protobuf:protoc:3.17.3'
+ 	}
+-}*/
+-
+-task generateProto {
+-	ext.srcdir = file("src/main/proto")
+-	ext.src = fileTree(srcdir) {
+-		include "**/*.proto"
+-	}
+-	ext.outdir = file("build/generated/source/proto/main/java")
+-	outputs.dir(outdir)
+-	inputs.files(src)
+-	dependsOn(configurations.protocArtifact)
+-	doLast {
+-		def exe = configurations.protocArtifact.first()
+-		if (!isCurrentWindows()) {
+-			exe.setExecutable(true)
+-		}
+-		exec {
+-			commandLine exe, "--java_out=$outdir", "-I$srcdir"
+-			args src
+-		}
+-	}
+ }
+-
+-tasks.compileJava.dependsOn(tasks.generateProto)
+-tasks.eclipse.dependsOn(tasks.generateProto)
+-rootProject.tasks.prepDev.dependsOn(tasks.generateProto)
+-
+-sourceSets {
+-	main {
+-		java {
+-			srcDir tasks.generateProto.outdir
+-		}
+-	}
+-}
+-zipSourceSubproject.dependsOn generateProto
+-
+diff --git a/build.gradle b/build.gradle
+index dce3a5149..7a2e637ce 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -76,6 +76,12 @@ if (flatRepo.isDirectory()) {
+ 			jcenter()
+ 			flatDir name: "flat", dirs:["$flatRepo"]
+ 		}
++		buildscript {
++			repositories {
++				mavenLocal()
++				mavenCentral()
++			}
++		}
+ 	}
+ }
+ else {	
+-- 
+2.33.1
+

--- a/pkgs/tools/security/ghidra/build.nix
+++ b/pkgs/tools/security/ghidra/build.nix
@@ -1,0 +1,150 @@
+{ stdenv
+, fetchzip
+, fetchurl
+, fetchFromGitHub
+, lib
+, gradle
+, perl
+, makeWrapper
+, openjdk11
+, unzip
+, makeDesktopItem
+, autoPatchelfHook
+, icoutils
+}:
+
+let
+  pkg_path = "$out/lib/ghidra";
+  pname = "ghidra";
+  version = "10.1.1";
+
+  src = fetchFromGitHub {
+    owner = "NationalSecurityAgency";
+    repo = "Ghidra";
+    rev = "Ghidra_${version}_build";
+    sha256 = "sha256-0hj9IVvTxgStCbfnTzqeKD+Q5GnGowDsIkMvk2GqJqY=";
+  };
+
+  desktopItem = makeDesktopItem {
+    name = "ghidra";
+    exec = "ghidra";
+    icon = "ghidra";
+    desktopName = "Ghidra";
+    genericName = "Ghidra Software Reverse Engineering Suite";
+    categories = "Development;";
+  };
+
+  # fake build to pre-download deps into fixed-output derivation
+  # Taken from mindustry derivation.
+  deps = stdenv.mkDerivation {
+    pname = "${pname}-deps";
+    inherit version src;
+
+    nativeBuildInputs = [ gradle perl ];
+    buildPhase = ''
+    cat >>build.gradle <<HERE
+task resolveDependencies {
+  doLast {
+    project.rootProject.allprojects.each { subProject ->
+      subProject.buildscript.configurations.each { configuration ->
+        resolveConfiguration(subProject, configuration, "buildscript config \''${configuration.name}")
+      }
+      subProject.configurations.each { configuration ->
+        resolveConfiguration(subProject, configuration, "config \''${configuration.name}")
+      }
+    }
+  }
+}
+void resolveConfiguration(subProject, configuration, name) {
+  if (configuration.canBeResolved) {
+    logger.info("Resolving project {} {}", subProject.name, name)
+    configuration.resolve()
+  }
+}
+HERE
+      export GRADLE_USER_HOME=$(mktemp -d)
+
+      # First, fetch the static dependencies.
+      gradle --no-daemon --info -Dorg.gradle.java.home=${openjdk11} -I gradle/support/fetchDependencies.gradle init
+
+      # Then, fetch the maven dependencies.
+      gradle --no-daemon --info -Dorg.gradle.java.home=${openjdk11} resolveDependencies
+    '';
+    # perl code mavenizes pathes (com.squareup.okio/okio/1.13.0/a9283170b7305c8d92d25aff02a6ab7e45d06cbe/okio-1.13.0.jar -> com/squareup/okio/okio/1.13.0/okio-1.13.0.jar)
+    installPhase = ''
+      find $GRADLE_USER_HOME/caches/modules-2 -type f -regex '.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/maven/$x/$3/$4/$5" #e' \
+        | sh
+      find $GRADLE_USER_HOME/caches/modules-2 -type f -regex '.*\.exe' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm555 $1 \$out/maven/$x/$3/$4/$5" #e' \
+        | sh
+      cp -r dependencies $out/dependencies
+    '';
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "sha256-tiJpctga2ddPJbO9qvYQBpDmpEn6ncCjfDIxg8YWs5U=";
+  };
+
+  fixedDeps = stdenv.mkDerivation {
+    pname = "${pname}-fixeddeps";
+    inherit version;
+
+    nativeBuildInputs = [ autoPatchelfHook ];
+    src = deps;
+    installPhase = ''
+    cp -r . $out
+    '';
+  };
+
+in stdenv.mkDerivation rec {
+  inherit pname version src;
+
+  nativeBuildInputs = [
+    gradle unzip makeWrapper icoutils
+  ];
+
+  dontStrip = true;
+
+  buildPhase = ''
+    ln -s ${fixedDeps}/dependencies dependencies
+
+    sed -ie "s#mavenLocal()#mavenLocal(); maven { url '${fixedDeps}/maven' }#g" build.gradle
+    gradle --offline --no-daemon --info -Dorg.gradle.java.home=${openjdk11} buildGhidra
+  '';
+
+  installPhase = ''
+    mkdir -p "${pkg_path}" "$out/share/applications"
+
+    ZIP=build/dist/$(ls build/dist)
+    echo $ZIP
+    unzip $ZIP -d ${pkg_path}
+    f=("${pkg_path}"/*)
+    mv "${pkg_path}"/*/* "${pkg_path}"
+    rmdir "''${f[@]}"
+
+    ln -s ${desktopItem}/share/applications/* $out/share/applications
+
+    icotool -x "Ghidra/RuntimeScripts/Windows/support/ghidra.ico"
+    rm ghidra_4_40x40x32.png
+    for f in ghidra_*.png; do
+      res=$(basename "$f" ".png" | cut -d"_" -f3 | cut -d"x" -f1-2)
+      mkdir -pv "$out/share/icons/hicolor/$res/apps"
+      mv "$f" "$out/share/icons/hicolor/$res/apps/ghidra.png"
+    done;
+  '';
+
+  postFixup = ''
+    mkdir -p "$out/bin"
+    ln -s "${pkg_path}/ghidraRun" "$out/bin/ghidra"
+    wrapProgram "${pkg_path}/support/launch.sh" \
+      --prefix PATH : ${lib.makeBinPath [ openjdk11 ]}
+  '';
+
+  meta = with lib; {
+    description = "A software reverse engineering (SRE) suite of tools developed by NSA's Research Directorate in support of the Cybersecurity mission";
+    homepage = "https://ghidra-sre.org/";
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    license = licenses.asl20;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3111,6 +3111,8 @@ with pkgs;
 
   ghdorker = callPackage ../tools/security/ghdorker { };
 
+  ghidra = callPackage ../tools/security/ghidra/build.nix { };
+
   ghidra-bin = callPackage ../tools/security/ghidra { };
 
   gif-for-cli = callPackage ../tools/misc/gif-for-cli { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

A proper ghidra package that's actually built by us instead of using upstream's binary artifacts. This would allow patching the sources with overrideAttrs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
