### PR TITLE
libvncserver: refactor

### DIFF
--- a/pkgs/development/libraries/libvncserver/default.nix
+++ b/pkgs/development/libraries/libvncserver/default.nix
@@ -1,21 +1,26 @@
-{ lib, stdenv, fetchzip, fetchpatch, cmake
-, libjpeg, openssl, zlib, libgcrypt, libpng
-, systemd, Carbon
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, libjpeg
+, openssl
+, zlib
+, libgcrypt
+, libpng
+, systemd
+, Carbon
 }:
 
-let
-  s = # Generated upstream information
-  rec {
-    pname = "libvncserver";
-    version = "0.9.13";
-    url = "https://github.com/LibVNC/libvncserver/archive/LibVNCServer-${version}.tar.gz";
-    sha256 = "0zz0hslw8b1p3crnfy3xnmrljik359h83dpk64s697dqdcrzy141"; # unpacked archive checksum
-  };
-in
-stdenv.mkDerivation {
-  inherit (s) pname version;
-  src = fetchzip {
-    inherit (s) url sha256;
+stdenv.mkDerivation rec {
+  pname = "libvncserver";
+  version = "0.9.13";
+
+  src = fetchFromGitHub {
+    owner = "LibVNC";
+    repo = "libvncserver";
+    rev = "LibVNCServer-${version}";
+    sha256 = "sha256-gQT/M2u4nWQ0MfO2gWAqY0ZJc7V9eGczGzcsxKmG4H8=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -24,12 +29,11 @@ stdenv.mkDerivation {
     ++ lib.optional stdenv.isDarwin Carbon;
   propagatedBuildInputs = [ zlib ];
 
-  meta = {
-    inherit (s) version;
+  meta = with lib; {
     description = "VNC server library";
     homepage = "https://libvnc.github.io/";
-    license = lib.licenses.gpl2Plus ;
-    maintainers = [lib.maintainers.raskin];
-    platforms = lib.platforms.unix;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ raskin ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
cleanup with no indirections

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
