### PR TITLE
pipewire_0_2: remove unused valgrind

### DIFF
--- a/pkgs/development/libraries/pipewire/0.2.nix
+++ b/pkgs/development/libraries/pipewire/0.2.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, doxygen, graphviz, valgrind
+{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, doxygen, graphviz
 , glib, dbus, gst_all_1, alsa-lib, ffmpeg_4, libjack2, udev, libva, xorg
 , sbc, SDL2, makeFontsConf
 }:
@@ -21,7 +21,7 @@ in stdenv.mkDerivation rec {
   outputs = [ "out" "lib" "dev" "doc" ];
 
   nativeBuildInputs = [
-    meson ninja pkg-config doxygen graphviz valgrind
+    meson ninja pkg-config doxygen graphviz
   ];
   buildInputs = [
     glib dbus gst_all_1.gst-plugins-base gst_all_1.gstreamer


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`valgrind` is not used in `pipewire` 0.2. Building without it produced bit-by-bit same result except for contained self-referenced store paths.

I tested building `weston` which depends on `pipewire_0_2` and it builds.

BTW: This should be part of #147997, but I totally missed it.

<details>
<summary>diff -r ("result" for before, "result2" for after)</summary>

```
> diff -r result{,2}-3-doc

> diff -r result{,2}-2-dev
diff -r result-2-dev/lib/pkgconfig/libpipewire-0.2.pc result2-2-dev/lib/pkgconfig/libpipewire-0.2.pc
1,3c1,3
< prefix=/nix/store/vgw9s62nb02w64dp61v5x79inychnbzn-pipewire-0.2.7
< libdir=/nix/store/6dvg4qq2xfjrrzn5k1xbfxcj4ssd8xgy-pipewire-0.2.7-lib/lib
< includedir=/nix/store/2yqrz4fvpj7ifqkmirrih8jpq7a93f7g-pipewire-0.2.7-dev/include
---
> prefix=/nix/store/5iraggz4v0f8wgrkvr5cnfrb28s14d8h-pipewire-0.2.7
> libdir=/nix/store/586a7v2kmv9ic0q2k00dyiyhk9g5cjc6-pipewire-0.2.7-lib/lib
> includedir=/nix/store/yydv3gxxyf4a89sjn2i3v16hbsm9iayh-pipewire-0.2.7-dev/include
diff -r result-2-dev/lib/pkgconfig/libspa-0.1.pc result2-2-dev/lib/pkgconfig/libspa-0.1.pc
1,3c1,3
< prefix=/nix/store/vgw9s62nb02w64dp61v5x79inychnbzn-pipewire-0.2.7
< libdir=/nix/store/6dvg4qq2xfjrrzn5k1xbfxcj4ssd8xgy-pipewire-0.2.7-lib/lib
< includedir=/nix/store/2yqrz4fvpj7ifqkmirrih8jpq7a93f7g-pipewire-0.2.7-dev/include
---
> prefix=/nix/store/5iraggz4v0f8wgrkvr5cnfrb28s14d8h-pipewire-0.2.7
> libdir=/nix/store/586a7v2kmv9ic0q2k00dyiyhk9g5cjc6-pipewire-0.2.7-lib/lib
> includedir=/nix/store/yydv3gxxyf4a89sjn2i3v16hbsm9iayh-pipewire-0.2.7-dev/include
diff -r result-2-dev/nix-support/propagated-build-inputs result2-2-dev/nix-support/propagated-build-inputs
1c1
<  /nix/store/6dvg4qq2xfjrrzn5k1xbfxcj4ssd8xgy-pipewire-0.2.7-lib /nix/store/vgw9s62nb02w64dp61v5x79inychnbzn-pipewire-0.2.7
\ No newline at end of file
---
>  /nix/store/586a7v2kmv9ic0q2k00dyiyhk9g5cjc6-pipewire-0.2.7-lib /nix/store/5iraggz4v0f8wgrkvr5cnfrb28s14d8h-pipewire-0.2.7
\ No newline at end of file

> diff -r result{,2}-1-lib
Binary files result-1-lib/lib/gstreamer-1.0/libgstpipewire.so and result2-1-lib/lib/gstreamer-1.0/libgstpipewire.so differ
Binary files result-1-lib/lib/libpipewire-0.2.so and result2-1-lib/lib/libpipewire-0.2.so differ
Binary files result-1-lib/lib/libpipewire-0.2.so.1 and result2-1-lib/lib/libpipewire-0.2.so.1 differ
Binary files result-1-lib/lib/libpipewire-0.2.so.1.207.0 and result2-1-lib/lib/libpipewire-0.2.so.1.207.0 differ
Binary files result-1-lib/lib/pipewire-0.2/libpipewire-module-audio-dsp.so and result2-1-lib/lib/pipewire-0.2/libpipewire-module-audio-dsp.so differ
Binary files result-1-lib/lib/pipewire-0.2/libpipewire-module-autolink.so and result2-1-lib/lib/pipewire-0.2/libpipewire-module-autolink.so differ
Binary files result-1-lib/lib/pipewire-0.2/libpipewire-module-client-node.so and result2-1-lib/lib/pipewire-0.2/libpipewire-module-client-node.so differ
Binary files result-1-lib/lib/pipewire-0.2/libpipewire-module-link-factory.so and result2-1-lib/lib/pipewire-0.2/libpipewire-module-link-factory.so differ
Binary files result-1-lib/lib/pipewire-0.2/libpipewire-module-mixer.so and result2-1-lib/lib/pipewire-0.2/libpipewire-module-mixer.so differ
Binary files result-1-lib/lib/pipewire-0.2/libpipewire-module-portal.so and result2-1-lib/lib/pipewire-0.2/libpipewire-module-portal.so differ
Binary files result-1-lib/lib/pipewire-0.2/libpipewire-module-protocol-native.so and result2-1-lib/lib/pipewire-0.2/libpipewire-module-protocol-native.so differ
Binary files result-1-lib/lib/pipewire-0.2/libpipewire-module-rtkit.so and result2-1-lib/lib/pipewire-0.2/libpipewire-module-rtkit.so differ
Binary files result-1-lib/lib/pipewire-0.2/libpipewire-module-spa-monitor.so and result2-1-lib/lib/pipewire-0.2/libpipewire-module-spa-monitor.so differ
Binary files result-1-lib/lib/pipewire-0.2/libpipewire-module-spa-node-factory.so and result2-1-lib/lib/pipewire-0.2/libpipewire-module-spa-node-factory.so differ
Binary files result-1-lib/lib/pipewire-0.2/libpipewire-module-spa-node.so and result2-1-lib/lib/pipewire-0.2/libpipewire-module-spa-node.so differ
Binary files result-1-lib/lib/pipewire-0.2/libpipewire-module-suspend-on-idle.so and result2-1-lib/lib/pipewire-0.2/libpipewire-module-suspend-on-idle.so differ

> diff -r result{,2}
Binary files result/bin/pipewire and result2/bin/pipewire differ
Binary files result/bin/pipewire-cli and result2/bin/pipewire-cli differ
Binary files result/bin/pipewire-monitor and result2/bin/pipewire-monitor differ
diff -r result/lib/systemd/user/pipewire.service result2/lib/systemd/user/pipewire.service
20c20
< ExecStart=/nix/store/vgw9s62nb02w64dp61v5x79inychnbzn-pipewire-0.2.7/bin/pipewire
---
> ExecStart=/nix/store/5iraggz4v0f8wgrkvr5cnfrb28s14d8h-pipewire-0.2.7/bin/pipewire
diff -r result/share/systemd/user/pipewire.service result2/share/systemd/user/pipewire.service
20c20
< ExecStart=/nix/store/vgw9s62nb02w64dp61v5x79inychnbzn-pipewire-0.2.7/bin/pipewire
---
> ExecStart=/nix/store/5iraggz4v0f8wgrkvr5cnfrb28s14d8h-pipewire-0.2.7/bin/pipewire
```

</details>

<details>
<summary>hexdump diff of binaries ("result" for before, "result2" for after)</summary>

```
> while read -r file; do diff <(hexdump -C $file) <(hexdump -C ${file/result/result2}); done < <(find result/ result-1-lib/ -type f)                
161,163c161,163
< 00000a00  73 74 6f 72 65 2f 36 64  76 67 34 71 71 32 78 66  |store/6dvg4qq2xf|
< 00000a10  6a 72 72 7a 6e 35 6b 31  78 62 66 78 63 6a 34 73  |jrrzn5k1xbfxcj4s|
< 00000a20  73 64 38 78 67 79 2d 70  69 70 65 77 69 72 65 2d  |sd8xgy-pipewire-|
---
> 00000a00  73 74 6f 72 65 2f 35 38  36 61 37 76 32 6b 6d 76  |store/586a7v2kmv|
> 00000a10  39 69 63 30 71 32 6b 30  30 64 79 69 79 68 6b 39  |9ic0q2k00dyiyhk9|
> 00000a20  67 35 63 6a 63 36 2d 70  69 70 65 77 69 72 65 2d  |g5cjc6-pipewire-|
449,451c449,451
< 00002270  72 65 2f 76 67 77 39 73  36 32 6e 62 30 32 77 36  |re/vgw9s62nb02w6|
< 00002280  34 64 70 36 31 76 35 78  37 39 69 6e 79 63 68 6e  |4dp61v5x79inychn|
< 00002290  62 7a 6e 2d 70 69 70 65  77 69 72 65 2d 30 2e 32  |bzn-pipewire-0.2|
---
> 00002270  72 65 2f 35 69 72 61 67  67 7a 34 76 30 66 38 77  |re/5iraggz4v0f8w|
> 00002280  67 72 6b 76 72 35 63 6e  66 72 62 32 38 73 31 34  |grkvr5cnfrb28s14|
> 00002290  64 38 68 2d 70 69 70 65  77 69 72 65 2d 30 2e 32  |d8h-pipewire-0.2|
297,299c297,299
< 00001290  00 2f 6e 69 78 2f 73 74  6f 72 65 2f 36 64 76 67  |./nix/store/6dvg|
< 000012a0  34 71 71 32 78 66 6a 72  72 7a 6e 35 6b 31 78 62  |4qq2xfjrrzn5k1xb|
< 000012b0  66 78 63 6a 34 73 73 64  38 78 67 79 2d 70 69 70  |fxcj4ssd8xgy-pip|
---
> 00001290  00 2f 6e 69 78 2f 73 74  6f 72 65 2f 35 38 36 61  |./nix/store/586a|
> 000012a0  37 76 32 6b 6d 76 39 69  63 30 71 32 6b 30 30 64  |7v2kmv9ic0q2k00d|
> 000012b0  79 69 79 68 6b 39 67 35  63 6a 63 36 2d 70 69 70  |yiyhk9g5cjc6-pip|
224,226c224,226
< 00000df0  69 78 2f 73 74 6f 72 65  2f 36 64 76 67 34 71 71  |ix/store/6dvg4qq|
< 00000e00  32 78 66 6a 72 72 7a 6e  35 6b 31 78 62 66 78 63  |2xfjrrzn5k1xbfxc|
< 00000e10  6a 34 73 73 64 38 78 67  79 2d 70 69 70 65 77 69  |j4ssd8xgy-pipewi|
---
> 00000df0  69 78 2f 73 74 6f 72 65  2f 35 38 36 61 37 76 32  |ix/store/586a7v2|
> 00000e00  6b 6d 76 39 69 63 30 71  32 6b 30 30 64 79 69 79  |kmv9ic0q2k00dyiy|
> 00000e10  68 6b 39 67 35 63 6a 63  36 2d 70 69 70 65 77 69  |hk9g5cjc6-pipewi|
47,49c47,49
< 000002e0  2f 76 67 77 39 73 36 32  6e 62 30 32 77 36 34 64  |/vgw9s62nb02w64d|
< 000002f0  70 36 31 76 35 78 37 39  69 6e 79 63 68 6e 62 7a  |p61v5x79inychnbz|
< 00000300  6e 2d 70 69 70 65 77 69  72 65 2d 30 2e 32 2e 37  |n-pipewire-0.2.7|
---
> 000002e0  2f 35 69 72 61 67 67 7a  34 76 30 66 38 77 67 72  |/5iraggz4v0f8wgr|
> 000002f0  6b 76 72 35 63 6e 66 72  62 32 38 73 31 34 64 38  |kvr5cnfrb28s14d8|
> 00000300  68 2d 70 69 70 65 77 69  72 65 2d 30 2e 32 2e 37  |h-pipewire-0.2.7|
944,946c944,946
< 00003b20  00 2f 6e 69 78 2f 73 74  6f 72 65 2f 36 64 76 67  |./nix/store/6dvg|
< 00003b30  34 71 71 32 78 66 6a 72  72 7a 6e 35 6b 31 78 62  |4qq2xfjrrzn5k1xb|
< 00003b40  66 78 63 6a 34 73 73 64  38 78 67 79 2d 70 69 70  |fxcj4ssd8xgy-pip|
---
> 00003b20  00 2f 6e 69 78 2f 73 74  6f 72 65 2f 35 38 36 61  |./nix/store/586a|
> 00003b30  37 76 32 6b 6d 76 39 69  63 30 71 32 6b 30 30 64  |7v2kmv9ic0q2k00d|
> 00003b40  79 69 79 68 6b 39 67 35  63 6a 63 36 2d 70 69 70  |yiyhk9g5cjc6-pip|
11406,11408c11406,11408
< 0002dbf0  72 65 2f 36 64 76 67 34  71 71 32 78 66 6a 72 72  |re/6dvg4qq2xfjrr|
< 0002dc00  7a 6e 35 6b 31 78 62 66  78 63 6a 34 73 73 64 38  |zn5k1xbfxcj4ssd8|
< 0002dc10  78 67 79 2d 70 69 70 65  77 69 72 65 2d 30 2e 32  |xgy-pipewire-0.2|
---
> 0002dbf0  72 65 2f 35 38 36 61 37  76 32 6b 6d 76 39 69 63  |re/586a7v2kmv9ic|
> 0002dc00  30 71 32 6b 30 30 64 79  69 79 68 6b 39 67 35 63  |0q2k00dyiyhk9g5c|
> 0002dc10  6a 63 36 2d 70 69 70 65  77 69 72 65 2d 30 2e 32  |jc6-pipewire-0.2|
11550,11552c11550,11552
< 0002e4f0  72 65 2f 36 64 76 67 34  71 71 32 78 66 6a 72 72  |re/6dvg4qq2xfjrr|
< 0002e500  7a 6e 35 6b 31 78 62 66  78 63 6a 34 73 73 64 38  |zn5k1xbfxcj4ssd8|
< 0002e510  78 67 79 2d 70 69 70 65  77 69 72 65 2d 30 2e 32  |xgy-pipewire-0.2|
---
> 0002e4f0  72 65 2f 35 38 36 61 37  76 32 6b 6d 76 39 69 63  |re/586a7v2kmv9ic|
> 0002e500  30 71 32 6b 30 30 64 79  69 79 68 6b 39 67 35 63  |0q2k00dyiyhk9g5c|
> 0002e510  6a 63 36 2d 70 69 70 65  77 69 72 65 2d 30 2e 32  |jc6-pipewire-0.2|
225,226c225,226
< 00000e00  36 64 76 67 34 71 71 32  78 66 6a 72 72 7a 6e 35  |6dvg4qq2xfjrrzn5|
< 00000e10  6b 31 78 62 66 78 63 6a  34 73 73 64 38 78 67 79  |k1xbfxcj4ssd8xgy|
---
> 00000e00  35 38 36 61 37 76 32 6b  6d 76 39 69 63 30 71 32  |586a7v2kmv9ic0q2|
> 00000e10  6b 30 30 64 79 69 79 68  6b 39 67 35 63 6a 63 36  |k00dyiyhk9g5cjc6|
3149,3151c3149,3151
< 0000d350  72 65 2f 36 64 76 67 34  71 71 32 78 66 6a 72 72  |re/6dvg4qq2xfjrr|
< 0000d360  7a 6e 35 6b 31 78 62 66  78 63 6a 34 73 73 64 38  |zn5k1xbfxcj4ssd8|
< 0000d370  78 67 79 2d 70 69 70 65  77 69 72 65 2d 30 2e 32  |xgy-pipewire-0.2|
---
> 0000d350  72 65 2f 35 38 36 61 37  76 32 6b 6d 76 39 69 63  |re/586a7v2kmv9ic|
> 0000d360  30 71 32 6b 30 30 64 79  69 79 68 6b 39 67 35 63  |0q2k00dyiyhk9g5c|
> 0000d370  6a 63 36 2d 70 69 70 65  77 69 72 65 2d 30 2e 32  |jc6-pipewire-0.2|
161,163c161,163
< 00000a00  32 2e 35 00 2f 6e 69 78  2f 73 74 6f 72 65 2f 36  |2.5./nix/store/6|
< 00000a10  64 76 67 34 71 71 32 78  66 6a 72 72 7a 6e 35 6b  |dvg4qq2xfjrrzn5k|
< 00000a20  31 78 62 66 78 63 6a 34  73 73 64 38 78 67 79 2d  |1xbfxcj4ssd8xgy-|
---
> 00000a00  32 2e 35 00 2f 6e 69 78  2f 73 74 6f 72 65 2f 35  |2.5./nix/store/5|
> 00000a10  38 36 61 37 76 32 6b 6d  76 39 69 63 30 71 32 6b  |86a7v2kmv9ic0q2k|
> 00000a20  30 30 64 79 69 79 68 6b  39 67 35 63 6a 63 36 2d  |00dyiyhk9g5cjc6-|
389,391c389,391
< 00001840  69 78 2f 73 74 6f 72 65  2f 36 64 76 67 34 71 71  |ix/store/6dvg4qq|
< 00001850  32 78 66 6a 72 72 7a 6e  35 6b 31 78 62 66 78 63  |2xfjrrzn5k1xbfxc|
< 00001860  6a 34 73 73 64 38 78 67  79 2d 70 69 70 65 77 69  |j4ssd8xgy-pipewi|
---
> 00001840  69 78 2f 73 74 6f 72 65  2f 35 38 36 61 37 76 32  |ix/store/586a7v2|
> 00001850  6b 6d 76 39 69 63 30 71  32 6b 30 30 64 79 69 79  |kmv9ic0q2k00dyiy|
> 00001860  68 6b 39 67 35 63 6a 63  36 2d 70 69 70 65 77 69  |hk9g5cjc6-pipewi|
5082,5084c5082,5084
< 00015600  72 65 2f 36 64 76 67 34  71 71 32 78 66 6a 72 72  |re/6dvg4qq2xfjrr|
< 00015610  7a 6e 35 6b 31 78 62 66  78 63 6a 34 73 73 64 38  |zn5k1xbfxcj4ssd8|
< 00015620  78 67 79 2d 70 69 70 65  77 69 72 65 2d 30 2e 32  |xgy-pipewire-0.2|
---
> 00015600  72 65 2f 35 38 36 61 37  76 32 6b 6d 76 39 69 63  |re/586a7v2kmv9ic|
> 00015610  30 71 32 6b 30 30 64 79  69 79 68 6b 39 67 35 63  |0q2k00dyiyhk9g5c|
> 00015620  6a 63 36 2d 70 69 70 65  77 69 72 65 2d 30 2e 32  |jc6-pipewire-0.2|
142,144c142,144
< 000008d0  65 2f 36 64 76 67 34 71  71 32 78 66 6a 72 72 7a  |e/6dvg4qq2xfjrrz|
< 000008e0  6e 35 6b 31 78 62 66 78  63 6a 34 73 73 64 38 78  |n5k1xbfxcj4ssd8x|
< 000008f0  67 79 2d 70 69 70 65 77  69 72 65 2d 30 2e 32 2e  |gy-pipewire-0.2.|
---
> 000008d0  65 2f 35 38 36 61 37 76  32 6b 6d 76 39 69 63 30  |e/586a7v2kmv9ic0|
> 000008e0  71 32 6b 30 30 64 79 69  79 68 6b 39 67 35 63 6a  |q2k00dyiyhk9g5cj|
> 000008f0  63 36 2d 70 69 70 65 77  69 72 65 2d 30 2e 32 2e  |c6-pipewire-0.2.|
191,193c191,193
< 00000be0  6e 69 78 2f 73 74 6f 72  65 2f 36 64 76 67 34 71  |nix/store/6dvg4q|
< 00000bf0  71 32 78 66 6a 72 72 7a  6e 35 6b 31 78 62 66 78  |q2xfjrrzn5k1xbfx|
< 00000c00  63 6a 34 73 73 64 38 78  67 79 2d 70 69 70 65 77  |cj4ssd8xgy-pipew|
---
> 00000be0  6e 69 78 2f 73 74 6f 72  65 2f 35 38 36 61 37 76  |nix/store/586a7v|
> 00000bf0  32 6b 6d 76 39 69 63 30  71 32 6b 30 30 64 79 69  |2kmv9ic0q2k00dyi|
> 00000c00  79 68 6b 39 67 35 63 6a  63 36 2d 70 69 70 65 77  |yhk9g5cjc6-pipew|
652,654c652,654
< 00004130  2f 6e 69 78 2f 73 74 6f  72 65 2f 36 64 76 67 34  |/nix/store/6dvg4|
< 00004140  71 71 32 78 66 6a 72 72  7a 6e 35 6b 31 78 62 66  |qq2xfjrrzn5k1xbf|
< 00004150  78 63 6a 34 73 73 64 38  78 67 79 2d 70 69 70 65  |xcj4ssd8xgy-pipe|
---
> 00004130  2f 6e 69 78 2f 73 74 6f  72 65 2f 35 38 36 61 37  |/nix/store/586a7|
> 00004140  76 32 6b 6d 76 39 69 63  30 71 32 6b 30 30 64 79  |v2kmv9ic0q2k00dy|
> 00004150  69 79 68 6b 39 67 35 63  6a 63 36 2d 70 69 70 65  |iyhk9g5cjc6-pipe|
223,225c223,225
< 00000de0  00 2f 6e 69 78 2f 73 74  6f 72 65 2f 36 64 76 67  |./nix/store/6dvg|
< 00000df0  34 71 71 32 78 66 6a 72  72 7a 6e 35 6b 31 78 62  |4qq2xfjrrzn5k1xb|
< 00000e00  66 78 63 6a 34 73 73 64  38 78 67 79 2d 70 69 70  |fxcj4ssd8xgy-pip|
---
> 00000de0  00 2f 6e 69 78 2f 73 74  6f 72 65 2f 35 38 36 61  |./nix/store/586a|
> 00000df0  37 76 32 6b 6d 76 39 69  63 30 71 32 6b 30 30 64  |7v2kmv9ic0q2k00d|
> 00000e00  79 69 79 68 6b 39 67 35  63 6a 63 36 2d 70 69 70  |yiyhk9g5cjc6-pip|
352,353c352,353
< 000015f0  36 64 76 67 34 71 71 32  78 66 6a 72 72 7a 6e 35  |6dvg4qq2xfjrrzn5|
< 00001600  6b 31 78 62 66 78 63 6a  34 73 73 64 38 78 67 79  |k1xbfxcj4ssd8xgy|
---
> 000015f0  35 38 36 61 37 76 32 6b  6d 76 39 69 63 30 71 32  |586a7v2kmv9ic0q2|
> 00001600  6b 30 30 64 79 69 79 68  6b 39 67 35 63 6a 63 36  |k00dyiyhk9g5cjc6|
202,204c202,204
< 00000c90  65 2f 36 64 76 67 34 71  71 32 78 66 6a 72 72 7a  |e/6dvg4qq2xfjrrz|
< 00000ca0  6e 35 6b 31 78 62 66 78  63 6a 34 73 73 64 38 78  |n5k1xbfxcj4ssd8x|
< 00000cb0  67 79 2d 70 69 70 65 77  69 72 65 2d 30 2e 32 2e  |gy-pipewire-0.2.|
---
> 00000c90  65 2f 35 38 36 61 37 76  32 6b 6d 76 39 69 63 30  |e/586a7v2kmv9ic0|
> 00000ca0  71 32 6b 30 30 64 79 69  79 68 6b 39 67 35 63 6a  |q2k00dyiyhk9g5cj|
> 00000cb0  63 36 2d 70 69 70 65 77  69 72 65 2d 30 2e 32 2e  |c6-pipewire-0.2.|
194,196c194,196
< 00000c10  32 2e 34 00 2f 6e 69 78  2f 73 74 6f 72 65 2f 36  |2.4./nix/store/6|
< 00000c20  64 76 67 34 71 71 32 78  66 6a 72 72 7a 6e 35 6b  |dvg4qq2xfjrrzn5k|
< 00000c30  31 78 62 66 78 63 6a 34  73 73 64 38 78 67 79 2d  |1xbfxcj4ssd8xgy-|
---
> 00000c10  32 2e 34 00 2f 6e 69 78  2f 73 74 6f 72 65 2f 35  |2.4./nix/store/5|
> 00000c20  38 36 61 37 76 32 6b 6d  76 39 69 63 30 71 32 6b  |86a7v2kmv9ic0q2k|
> 00000c30  30 30 64 79 69 79 68 6b  39 67 35 63 6a 63 36 2d  |00dyiyhk9g5cjc6-|
899,901c899,901
< 00005000  2f 6e 69 78 2f 73 74 6f  72 65 2f 36 64 76 67 34  |/nix/store/6dvg4|
< 00005010  71 71 32 78 66 6a 72 72  7a 6e 35 6b 31 78 62 66  |qq2xfjrrzn5k1xbf|
< 00005020  78 63 6a 34 73 73 64 38  78 67 79 2d 70 69 70 65  |xcj4ssd8xgy-pipe|
---
> 00005000  2f 6e 69 78 2f 73 74 6f  72 65 2f 35 38 36 61 37  |/nix/store/586a7|
> 00005010  76 32 6b 6d 76 39 69 63  30 71 32 6b 30 30 64 79  |v2kmv9ic0q2k00dy|
> 00005020  69 79 68 6b 39 67 35 63  6a 63 36 2d 70 69 70 65  |iyhk9g5cjc6-pipe|
199,201c199,201
< 00000c60  65 2f 36 64 76 67 34 71  71 32 78 66 6a 72 72 7a  |e/6dvg4qq2xfjrrz|
< 00000c70  6e 35 6b 31 78 62 66 78  63 6a 34 73 73 64 38 78  |n5k1xbfxcj4ssd8x|
< 00000c80  67 79 2d 70 69 70 65 77  69 72 65 2d 30 2e 32 2e  |gy-pipewire-0.2.|
---
> 00000c60  65 2f 35 38 36 61 37 76  32 6b 6d 76 39 69 63 30  |e/586a7v2kmv9ic0|
> 00000c70  71 32 6b 30 30 64 79 69  79 68 6b 39 67 35 63 6a  |q2k00dyiyhk9g5cj|
> 00000c80  63 36 2d 70 69 70 65 77  69 72 65 2d 30 2e 32 2e  |c6-pipewire-0.2.|
647,649c647,649
< 00004290  72 65 2f 36 64 76 67 34  71 71 32 78 66 6a 72 72  |re/6dvg4qq2xfjrr|
< 000042a0  7a 6e 35 6b 31 78 62 66  78 63 6a 34 73 73 64 38  |zn5k1xbfxcj4ssd8|
< 000042b0  78 67 79 2d 70 69 70 65  77 69 72 65 2d 30 2e 32  |xgy-pipewire-0.2|
---
> 00004290  72 65 2f 35 38 36 61 37  76 32 6b 6d 76 39 69 63  |re/586a7v2kmv9ic|
> 000042a0  30 71 32 6b 30 30 64 79  69 79 68 6b 39 67 35 63  |0q2k00dyiyhk9g5c|
> 000042b0  6a 63 36 2d 70 69 70 65  77 69 72 65 2d 30 2e 32  |jc6-pipewire-0.2|
171,173c171,173
< 00000aa0  65 2f 36 64 76 67 34 71  71 32 78 66 6a 72 72 7a  |e/6dvg4qq2xfjrrz|
< 00000ab0  6e 35 6b 31 78 62 66 78  63 6a 34 73 73 64 38 78  |n5k1xbfxcj4ssd8x|
< 00000ac0  67 79 2d 70 69 70 65 77  69 72 65 2d 30 2e 32 2e  |gy-pipewire-0.2.|
---
> 00000aa0  65 2f 35 38 36 61 37 76  32 6b 6d 76 39 69 63 30  |e/586a7v2kmv9ic0|
> 00000ab0  71 32 6b 30 30 64 79 69  79 68 6b 39 67 35 63 6a  |q2k00dyiyhk9g5cj|
> 00000ac0  63 36 2d 70 69 70 65 77  69 72 65 2d 30 2e 32 2e  |c6-pipewire-0.2.|
552,554c552,554
< 00003220  2f 6e 69 78 2f 73 74 6f  72 65 2f 36 64 76 67 34  |/nix/store/6dvg4|
< 00003230  71 71 32 78 66 6a 72 72  7a 6e 35 6b 31 78 62 66  |qq2xfjrrzn5k1xbf|
< 00003240  78 63 6a 34 73 73 64 38  78 67 79 2d 70 69 70 65  |xcj4ssd8xgy-pipe|
---
> 00003220  2f 6e 69 78 2f 73 74 6f  72 65 2f 35 38 36 61 37  |/nix/store/586a7|
> 00003230  76 32 6b 6d 76 39 69 63  30 71 32 6b 30 30 64 79  |v2kmv9ic0q2k00dy|
> 00003240  69 79 68 6b 39 67 35 63  6a 63 36 2d 70 69 70 65  |iyhk9g5cjc6-pipe|
111,113c111,113
< 000006e0  72 65 2f 36 64 76 67 34  71 71 32 78 66 6a 72 72  |re/6dvg4qq2xfjrr|
< 000006f0  7a 6e 35 6b 31 78 62 66  78 63 6a 34 73 73 64 38  |zn5k1xbfxcj4ssd8|
< 00000700  78 67 79 2d 70 69 70 65  77 69 72 65 2d 30 2e 32  |xgy-pipewire-0.2|
---
> 000006e0  72 65 2f 35 38 36 61 37  76 32 6b 6d 76 39 69 63  |re/586a7v2kmv9ic|
> 000006f0  30 71 32 6b 30 30 64 79  69 79 68 6b 39 67 35 63  |0q2k00dyiyhk9g5c|
> 00000700  6a 63 36 2d 70 69 70 65  77 69 72 65 2d 30 2e 32  |jc6-pipewire-0.2|

```

</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
