### PR TITLE
skawarePackages: Winter 2021-2022 release

### DIFF
--- a/pkgs/development/libraries/nsss/default.nix
+++ b/pkgs/development/libraries/nsss/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "nsss";
-  version = "0.2.0.0";
-  sha256 = "0zg0lwkvx9ch4a6h9ryc73nqfz733v2pv4gbf65qzpz7ccniwagi";
+  version = "0.2.0.1";
+  sha256 = "0nqjnfqvzzn4i45h849b3n8qwcrzd5wlrwlvkmjdga5k4yk4x63x";
 
   description = "An implementation of a subset of the pwd.h, group.h and shadow.h family of functions.";
 

--- a/pkgs/development/libraries/skalibs/default.nix
+++ b/pkgs/development/libraries/skalibs/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "skalibs";
-  version = "2.11.0.0";
-  sha256 = "1n9l7mb54dlb0iijjaf446jba6nmq1ql9n39s095ngrk5ahcipwq";
+  version = "2.11.1.0";
+  sha256 = "1fga2kmzcp2llqv5nzrmgm33p1jz7y9pnaghzbxf8ldnsns800a0";
 
   description = "A set of general-purpose C programming libraries";
 

--- a/pkgs/development/libraries/utmps/default.nix
+++ b/pkgs/development/libraries/utmps/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "utmps";
-  version = "0.1.0.3";
-  sha256 = "0npgg90lzxmhld6hp296gbnrsixip28s7axirc2g6yjpjz2bvcan";
+  version = "0.1.1.0";
+  sha256 = "0vsx5b99fwmp05l4wsw744gg79hbfb4wlzyfip3k0g76fcs49nil";
 
   description = "A secure utmpx and wtmp implementation";
 

--- a/pkgs/os-specific/linux/mdevd/default.nix
+++ b/pkgs/os-specific/linux/mdevd/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "mdevd";
-  version = "0.1.5.0";
-  sha256 = "01ykxgnbm53wijdrbld10664xy2wkvyzbbs98mfnqnf4h1y064n0";
+  version = "0.1.5.1";
+  sha256 = "1xch9sk3hklf2v9z3qlw0rfhhmikqp85zkij7qzwbs09g039bkll";
 
   description = "mdev-compatible Linux hotplug manager daemon";
   platforms = lib.platforms.linux;

--- a/pkgs/os-specific/linux/s6-linux-init/default.nix
+++ b/pkgs/os-specific/linux/s6-linux-init/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "s6-linux-init";
-  version = "1.0.6.4";
-  sha256 = "0grqk111d6aqym1c4l9j26fdqcgra1hvwb9vdgylrfbvn1c3hlpb";
+  version = "1.0.7.0";
+  sha256 = "16bzijmzxi91ycayhpn398yjgag3c5pnlghs6sqdmzlf2fiirif5";
 
   description = "A set of minimalistic tools used to create a s6-based init system, including a /sbin/init binary, on a Linux kernel";
   platforms = lib.platforms.linux;

--- a/pkgs/os-specific/linux/s6-linux-utils/default.nix
+++ b/pkgs/os-specific/linux/s6-linux-utils/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "s6-linux-utils";
-  version = "2.5.1.6";
-  sha256 = "0hr49nl0d7a6i5w8cfg43xzvzayb8kpqij9xg7bmw2fyvc2z338z";
+  version = "2.5.1.7";
+  sha256 = "1n6zmnczbybwcchkhg5zqixz8mdk5bfn0sxq0kxifgpi9ggw5a46";
 
   description = "A set of minimalistic Linux-specific system utilities";
   platforms = lib.platforms.linux;

--- a/pkgs/tools/misc/execline/default.nix
+++ b/pkgs/tools/misc/execline/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "execline";
-  version = "2.8.1.0";
-  sha256 = "0msmzf5zwjcsgjlvvq28rd2i0fkdb2skmv8ii0ix8dhyckwwjmav";
+  version = "2.8.2.0";
+  sha256 = "0h9kb3cx8dw05md6smvs56i4lr8g5n3ljaxy5vj4zs86yc3pdprg";
 
   description = "A small scripting language, to be used in place of a shell in non-interactive scripts";
 

--- a/pkgs/tools/misc/s6-portable-utils/default.nix
+++ b/pkgs/tools/misc/s6-portable-utils/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "s6-portable-utils";
-  version = "2.2.3.3";
-  sha256 = "132jj5qk8x40kw6lrrn7jiqhvqj9d2h6g6mhl8zma1sp37bg0i84";
+  version = "2.2.3.4";
+  sha256 = "04n9i9ydaa3cb3pip9d02dm24k26v3djvwrafjzq5qx94zvrifip";
 
   description = "A set of tiny general Unix utilities optimized for simplicity and small size";
 

--- a/pkgs/tools/networking/s6-dns/default.nix
+++ b/pkgs/tools/networking/s6-dns/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "s6-dns";
-  version = "2.3.5.2";
-  sha256 = "0nczzjprvp6wirzycgf5h32dlgx4r8grzkqhif27n3ii6f5g78yw";
+  version = "2.3.5.3";
+  sha256 = "1nknkh2rw7ggf5ncspb11wyp6ldyqc9lf3nmnklwb5fcf5kjzi1a";
 
   description = "A suite of DNS client programs and libraries for Unix systems";
 

--- a/pkgs/tools/networking/s6-networking/default.nix
+++ b/pkgs/tools/networking/s6-networking/default.nix
@@ -19,8 +19,8 @@ assert sslSupportEnabled -> sslLibs ? ${sslSupport};
 
 buildPackage {
   pname = "s6-networking";
-  version = "2.5.0.0";
-  sha256 = "1fn3g9gkwgmnxallhk82f5rly81pnkilj7n49g5fbfmaalsq96mh";
+  version = "2.5.1.0";
+  sha256 = "0hgzj68bk17r1gr32ld1dm5s1x1a5x8ac03klykhfbasx8gwa1r5";
 
   description = "A suite of small networking utilities for Unix systems";
 

--- a/pkgs/tools/system/s6-rc/default.nix
+++ b/pkgs/tools/system/s6-rc/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "s6-rc";
-  version = "0.5.2.3";
-  sha256 = "1xyaplwzvqnb53mg59a7jklakzwsiqivp6qggsry3sbaw4hf3d5j";
+  version = "0.5.3.0";
+  sha256 = "09rznjlz988fk9pff6mxc3dknwh2mibbawr9g62gcscmscmiv8wk";
 
   description = "A service manager for s6-based systems";
   platforms = lib.platforms.unix;

--- a/pkgs/tools/system/s6/default.nix
+++ b/pkgs/tools/system/s6/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "s6";
-  version = "2.11.0.0";
-  sha256 = "1a3lj0xfhn1w3a4ygqsxy8q4dr3n48hnwml4xzdpz3nrikhy8if5";
+  version = "2.11.0.1";
+  sha256 = "02pr4q4cr9wc8i8ad8s6184a6fyndpmpnylgxwhfnkk3hx2j0zxd";
 
   description = "skarnet.org's small & secure supervision software suite";
 


### PR DESCRIPTION
I bumped all versions of all packages that we packaged so far (I
hope). We might want to build an update script at some point, there is
a lot of potential for copy & paste errors in these updates.

Laurent’s notes below:

  Hello,

  New versions of all the skarnet.org packages are available.

  The changes are, for the most part, minimal: essentially, the new
versions fix a bug in the build system that made cross-building under
slashpackage more difficult than intended. Very few people should
have been impacted by this bug.
  Some packages had a few more bugfixes; and some packages have
additional functionality. No major update; no compatibility break.

  The new versions are the following:

skalibs-2.11.1.0 (minor)
nsss-0.2.0.1 (release)
utmps-0.1.1.0 (minor)
execline-2.8.2.0 (minor)
s6-2.11.0.1 (release)
s6-rc-0.5.3.0 (minor)
s6-portable-utils-2.2.3.4 (release)
s6-linux-utils-2.5.1.7 (release)
s6-linux-init-1.0.7.0 (minor)
s6-dns-2.3.5.3 (release)
s6-networking-2.5.1.0 (minor)
mdevd-0.1.5.1 (release)
bcnm-0.0.1.5 (release)
dnsfunnel-0.0.1.3 (release)
smtpd-starttls-proxy-0.0.1.1 (release)

  Dependencies have all been updated to the latest versions. They are not
strict: libraries and binaries may build with older releases of their
dependencies, although this is not guaranteed.

  You do not need to recompile your s6-rc service databases. To make use
of the new s6-linux-init functionality, however, you will have to
recreate your run-image.
  You do not need to restart your supervision tree, unless you're
deleting
your old s6 binaries.

  Details of minor package changes follow.

* skalibs-2.11.1.0
   ----------------

  - New function: opendir_at()

* utmps-0.1.1.0
   ------------

  - New binary: utmps-write, a generic utmp client that can write
user-crafted records to the utmp and/or wtmp databases.

* execline-2.8.2.0
   ----------------

  - New -s option to the case binary, enabling fnmatch() (shell)
expression matching instead of regular expression matching.

* s6-rc-0.5.3.0
   -------------

  - Bundle contents are now read in a "contents.d/" subdirectory, one
file per content, instead of one per line in a "contents" file. In
the same way, service dependencies are now read in a "dependencies.d/"
subdirectory, one file per dependency. Old "contents" and "dependencies"
files are still supported, but deprecated. This change allows better
integration of s6-rc service definitions with package managers.

* s6-linux-init-1.0.7.0
   ---------------------

  - New -S option to s6-linux-init-maker, forcing a sync on halt even
in a container.

* s6-networking-2.5.1.0
   ---------------------

  - SNI wildcarding is implemented, as well as a workaround for a
bearssl bug causing errors on certificate signatures in certain cases.

  Enjoy,
  Bug-reports welcome.
  And happy holidays to you all!

--
  Laurent

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
