### PR TITLE
python3Packages.aocd: init at 1.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -119,6 +119,12 @@
     githubId = 241628;
     name = "Adam Russell";
   };
+  aadibajpai = {
+    email = "hello@aadibajpai.com";
+    github = "aadibajpai";
+    githubId = 27063113;
+    name = "Aadi Bajpai";
+  };
   aanderse = {
     email = "aaron@fosslib.net";
     matrix = "@aanderse:nixos.dev";

--- a/pkgs/development/python-modules/aocd/default.nix
+++ b/pkgs/development/python-modules/aocd/default.nix
@@ -1,0 +1,58 @@
+{ lib, stdenv, buildPythonPackage, fetchFromGitHub, requests
+, pytestCheckHook, tzlocal, pytest-mock, pytest-freezegun, pytest-raisin
+, pytest-socket, requests-mock, pebble, python-dateutil, termcolor
+, beautifulsoup4, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "aocd";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "wimglenn";
+    repo = "advent-of-code-data";
+    rev = "v${version}";
+    sha256 = "sha256-wdg6XUkjnAc9yAP7DP0UT6SlQHfj/ymhqzIGNM3fco4=";
+  };
+
+  propagatedBuildInputs = [
+    python-dateutil
+    requests
+    termcolor
+    beautifulsoup4
+    pebble
+    tzlocal
+    setuptools
+  ];
+
+  # Too many failing tests
+  preCheck = "rm pytest.ini";
+
+  disabledTests = [
+    "test_results"
+    "test_results_xmas"
+    "test_run_error"
+    "test_run_and_autosubmit"
+    "test_run_and_no_autosubmit"
+    "test_load_input_from_file"
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-mock
+    pytest-freezegun
+    pytest-raisin
+    pytest-socket
+    requests-mock
+  ];
+
+  pythonImportsCheck = [ "aocd" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/wimglenn/advent-of-code-data";
+    description = "Get your Advent of Code data with a single import statement";
+    license = licenses.mit;
+    maintainers = with maintainers; [ aadibajpai ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/pebble/default.nix
+++ b/pkgs/development/python-modules/pebble/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, isPy27, fetchPypi, pytestCheckHook }:
+{ lib, stdenv, buildPythonPackage, isPy27, fetchPypi, pytestCheckHook }:
 
 buildPythonPackage rec {
   pname = "pebble";
@@ -10,6 +10,8 @@ buildPythonPackage rec {
     inherit version;
     sha256 = "0a595f7mrf89xlck9b2x83bqybc9zd9jxkl0sa5cf19vax18rg8h";
   };
+
+  doCheck = !stdenv.isDarwin;
 
   checkInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/pytest-raisin/default.nix
+++ b/pkgs/development/python-modules/pytest-raisin/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flit-core
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-raisin";
+  version = "0.3";
+  format = "flit";
+
+  src = fetchFromGitHub {
+    owner = "wimglenn";
+    repo = "pytest-raisin";
+    rev = "v${version}";
+    sha256 = "73cOrsqlE04m6X3a6VwtRzfi24oqkdO3HjKQH61bU88=";
+  };
+
+  nativeBuildInputs = [
+    flit-core
+  ];
+
+  propagatedBuildInputs = [
+    pytest
+  ];
+
+  # tests cause circular pytest-raisin already registered with pytest error
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Plugin enabling the use of exception instances with pytest.raises context";
+    homepage = "https://github.com/wimglenn/pytest-raisin";
+    license = licenses.mit;
+    maintainers = with maintainers; [ aadibajpai ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -186,6 +186,8 @@ with pkgs;
 
   antsimulator = callPackage ../games/antsimulator { };
 
+  aocd = with pythonPackages; toPythonApplication aocd;
+
   astrolog = callPackage ../applications/science/astronomy/astrolog { };
 
   atkinson-hyperlegible = callPackage ../data/fonts/atkinson-hyperlegible { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -535,6 +535,8 @@ in {
     inherit (pkgs) graphviz;
   };
 
+  aocd = callPackage ../development/python-modules/aocd { };
+
   apache-airflow = callPackage ../development/python-modules/apache-airflow { };
 
   apcaccess = callPackage ../development/python-modules/apcaccess { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7605,6 +7605,8 @@ in {
 
   pytest-raisesregexp = callPackage ../development/python-modules/pytest-raisesregexp { };
 
+  pytest-raisin = callPackage ../development/python-modules/pytest-raisin { };
+
   pytest-randomly = callPackage ../development/python-modules/pytest-randomly { };
 
   pytest-random-order = callPackage ../development/python-modules/pytest-random-order { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/wimglenn/advent-of-code-data
![image](https://user-images.githubusercontent.com/27063113/147370377-98382f81-22fe-46d9-beac-ebb41cf93562.png)

pebble builds now which was required for this expression

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin @siraben 
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
