### PR TITLE
Fix ghc c++ exceptions

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -212,6 +212,10 @@ stdenv.mkDerivation (rec {
       url = "https://gitlab.haskell.org/ghc/ghc/-/commit/97d0b0a367e4c6a52a17c3299439ac7de129da24.patch";
       sha256 = "0r4zjj0bv1x1m2dgxp3adsf2xkr94fjnyj1igsivd9ilbs5ja0b5";
     })
+
+    # Add flag to fix C++ exceptions on darwin
+    # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/7247
+    ./add-fcompact-unwind.patch
   ];
 
   postPatch = "patchShebangs .";

--- a/pkgs/development/compilers/ghc/add-fcompact-unwind.patch
+++ b/pkgs/development/compilers/ghc/add-fcompact-unwind.patch
@@ -1,0 +1,68 @@
+commit e11f194f6765756df19e39e501bdc420d278848a
+Author: Robert Hensing <robert@roberthensing.nl>
+Date:   Fri Dec 24 14:52:35 2021 +0100
+
+    Add -fcompact-unwind
+
+diff --git a/compiler/main/DriverPipeline.hs b/compiler/main/DriverPipeline.hs
+index 1bc08779cc..b85a2f87d7 100644
+--- a/compiler/main/DriverPipeline.hs
++++ b/compiler/main/DriverPipeline.hs
+@@ -1850,7 +1850,8 @@ linkBinary' staticLink dflags o_files dep_packages = do
+                       -- like
+                       --     ld: warning: could not create compact unwind for .LFB3: non-standard register 5 being saved in prolog
+                       -- on x86.
+-                      ++ (if toolSettings_ldSupportsCompactUnwind toolSettings' &&
++                      ++ (if not (gopt Opt_CompactUnwind dflags) &&
++                             toolSettings_ldSupportsCompactUnwind toolSettings' &&
+                              not staticLink &&
+                              (platformOS platform == OSDarwin) &&
+                              case platformArch platform of
+diff --git a/compiler/main/DynFlags.hs b/compiler/main/DynFlags.hs
+index d222b3b6de..e8c766f6e1 100644
+--- a/compiler/main/DynFlags.hs
++++ b/compiler/main/DynFlags.hs
+@@ -644,6 +644,7 @@ data GeneralFlag
+    | Opt_Ticky_Dyn_Thunk
+    | Opt_RPath
+    | Opt_RelativeDynlibPaths
++   | Opt_CompactUnwind               -- ^ @-fcompact-unwind@
+    | Opt_Hpc
+    | Opt_FlatCache
+    | Opt_ExternalInterpreter
+@@ -3145,6 +3146,13 @@ dynamic_flags_deps = [
+                   return dflags
+           else return (gopt_set dflags Opt_SplitSections)))
+ 
++  , make_ord_flag defGhcFlag "fcompact-unwind"
++      (noArgM (\dflags -> do
++        if platformOS (targetPlatform dflags) == OSDarwin
++          then return (gopt_set dflags Opt_CompactUnwind)
++          else do addWarn "-compact-unwind is only implemented by the darwin platform. Ignoring."
++                  return dflags))
++
+         -------- ghc -M -----------------------------------------------------
+   , make_ord_flag defGhcFlag "dep-suffix"              (hasArg addDepSuffix)
+   , make_ord_flag defGhcFlag "dep-makefile"            (hasArg setDepMakefile)
+diff --git a/docs/users_guide/phases.rst b/docs/users_guide/phases.rst
+index e6dcb1dbd0..926591bac9 100644
+--- a/docs/users_guide/phases.rst
++++ b/docs/users_guide/phases.rst
+@@ -1264,3 +1264,17 @@ for example).
+     that do runtime dynamic linking, where code dynamically linked in
+     the future might require the value of a CAF that would otherwise
+     be garbage-collected.
++
++.. ghc-flag:: -fcompact-unwind
++    :shortdesc: Instruct the linker to produce a `__compact_unwind` section.
++    :type: dynamic
++    :category: linking
++
++    :since: 8.10
++
++    This instructs the linker to produce an executable that supports Apple's
++    compact unwinding sections. These are used by C++ and Objective-C code
++    to unwind the stack when an exception occurs.
++
++    In theory, the older `__eh_frame` section should also be usable for this
++    purpose, but this does not always work.

--- a/pkgs/development/haskell-modules/configuration-darwin.nix
+++ b/pkgs/development/haskell-modules/configuration-darwin.nix
@@ -256,11 +256,11 @@ self: super: ({
     ] ++ (drv.libraryFrameworkDepends or []);
   }) super.streamly_0_8_1_1;
 
+  inline-c-cpp = appendPatch ./patches/inline-c-cpp-fcompact-unwind.patch super.inline-c-cpp;
+
 } // lib.optionalAttrs pkgs.stdenv.isAarch64 {  # aarch64-darwin
 
   # https://github.com/fpco/unliftio/issues/87
   unliftio = dontCheck super.unliftio;
 
-  # https://github.com/fpco/inline-c/issues/127
-  inline-c-cpp = dontCheck super.inline-c-cpp;
 })

--- a/pkgs/development/haskell-modules/patches/inline-c-cpp-fcompact-unwind.patch
+++ b/pkgs/development/haskell-modules/patches/inline-c-cpp-fcompact-unwind.patch
@@ -1,0 +1,15 @@
+diff --git a/inline-c-cpp/inline-c-cpp.cabal b/inline-c-cpp/inline-c-cpp.cabal
+index 9645dd7..6ab7b32 100644
+--- a/inline-c-cpp/inline-c-cpp.cabal
++++ b/inline-c-cpp/inline-c-cpp.cabal
+@@ -47,6 +47,10 @@ common cxx-opts
+     ghc-options:
+       -optcxx-std=c++11
+       -optcxx-Wall
++
++    if os(darwin)
++      ghc-options:
++        -fcompact-unwind
+   else
+     -- On GHC < 8.10, we have to emulate -optcxx by making the C compiler compile
+     -- C++. GCC accepts this via -std, whereas Clang requires us to change the


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix C++ exception handling in darwin executables linked by GHC.

`-fcompact-unwind` should probably be applied to all test suites and executables that interface with C++.
Perhaps, after a decade of `__compact_unwind` existing, it should become the default, but I don't know if the ecosystem is ready for it, so it's opt-in for now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
