### PR TITLE
spice-gtk: 0.37 -> 0.39

### DIFF
--- a/pkgs/development/libraries/spice-gtk/default.nix
+++ b/pkgs/development/libraries/spice-gtk/default.nix
@@ -9,8 +9,10 @@
 , gst_all_1
 , gtk-doc
 , gtk3
+, hwdata
 , json-glib
 , libcacard
+, libcap_ng
 , libdrm
 , libjpeg_turbo
 , libopus
@@ -28,8 +30,8 @@
 , python3
 , spice-protocol
 , usbredir
-, usbutils
 , vala
+, wayland-protocols
 , zlib
 , withPolkit ? true
 }:
@@ -57,19 +59,22 @@
 
 stdenv.mkDerivation rec {
   pname = "spice-gtk";
-  version = "0.37";
+  version = "0.39";
 
   outputs = [ "out" "dev" "devdoc" "man" ];
 
   src = fetchurl {
-    url = "https://www.spice-space.org/download/gtk/${pname}-${version}.tar.bz2";
-    sha256 = "1drvj8y35gnxbnrxsipwi15yh0vs9ixzv4wslz6r3lra8w3bfa0z";
+    url = "https://www.spice-space.org/download/gtk/${pname}-${version}.tar.xz";
+    sha256 = "sha256-I6y+4Zfqrsm85ua/2IW9j3lwgzJjkkP/BIMwIIZXE80=";
   };
 
   postPatch = ''
     # get rid of absolute path to helper in store so we can use a setuid wrapper
     substituteInPlace src/usb-acl-helper.c \
       --replace 'ACL_HELPER_PATH"/' '"'
+    # don't try to setcap/suid in a nix builder
+    substituteInPlace src/meson.build \
+      --replace "meson.add_install_script('../build-aux/setcap-or-suid'" "#"
   '';
 
   nativeBuildInputs = [
@@ -98,6 +103,7 @@ stdenv.mkDerivation rec {
     gtk3
     json-glib
     libcacard
+    libcap_ng
     libdrm
     libjpeg_turbo
     libopus
@@ -108,14 +114,15 @@ stdenv.mkDerivation rec {
     pixman
     spice-protocol
     usbredir
+    wayland-protocols
     zlib
-  ] ++ lib.optionals withPolkit [ polkit acl usbutils ] ;
+  ] ++ lib.optionals withPolkit [ polkit acl ] ;
 
   PKG_CONFIG_POLKIT_GOBJECT_1_POLICYDIR = "${placeholder "out"}/share/polkit-1/actions";
 
   mesonFlags = [
-    "-Dcelt051=disabled"
-    "-Dpulse=disabled" # is deprecated upstream
+    "-Dusb-acl-helper-dir=${placeholder "out"}/bin"
+    "-Dusb-ids-path=${hwdata}/share/hwdata/usb.ids"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This update fixes issues I've had with display scaling.i

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
