### PR TITLE
solana: testnet cli init at 1.9.2

### DIFF
--- a/pkgs/applications/blockchains/solana/default.nix
+++ b/pkgs/applications/blockchains/solana/default.nix
@@ -1,0 +1,56 @@
+{ stdenv
+, fetchFromGitHub
+, lib
+, rustPlatform
+, IOKit
+, Security
+, AppKit
+, pkg-config
+, udev
+, zlib
+, protobuf
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "solana-testnet-cli";
+  version = "1.9.2";
+
+  src = fetchFromGitHub {
+    owner = "solana-labs";
+    repo = "solana";
+    rev = "v${version}";
+    sha256 = "sha256-wrv35vBohLztMZPb6gfZdCaXcjj/Y7vnQqINaI6dBM4=";
+  };
+
+  cargoSha256 = "sha256-A5uVa+cRmrkVyw7MFH4QAr0VIFi18wcc2VPFvQyT9EM=";
+
+  buildAndTestSubdir = "cli";
+
+  nativeBuildInputs = lib.optionals stdenv.isLinux [ protobuf pkg-config ];
+  buildInputs = lib.optionals stdenv.isLinux [ udev zlib ] ++ lib.optionals stdenv.isDarwin [ IOKit Security AppKit ];
+
+  # check phase fails
+  # on darwin with missing framework System. This framework is not available in nixpkgs
+  # on linux with some librocksdb-sys compilation error
+  doCheck = false;
+
+  # all the following are needed for the checkphase
+  # checkInputs = lib.optionals stdenv.isDarwin [ pkg-config rustfmt ];
+  # Needed to get openssl-sys to use pkg-config.
+  # OPENSSL_NO_VENDOR = 1;
+  # OPENSSL_LIB_DIR = "${openssl.out}/lib";
+  # OPENSSL_DIR="${lib.getDev openssl}";
+  # LLVM_CONFIG_PATH="${llvm}/bin/llvm-config";
+  # LIBCLANG_PATH="${llvmPackages.libclang.lib}/lib";
+  # Used by build.rs in the rocksdb-sys crate. If we don't set these, it would
+  # try to build RocksDB from source.
+  # ROCKSDB_INCLUDE_DIR="${rocksdb}/include";
+  # ROCKSDB_LIB_DIR="${rocksdb}/lib";
+
+  meta = with lib; {
+    description = "Web-Scale Blockchain for fast, secure, scalable, decentralized apps and marketplaces. ";
+    homepage = "https://solana.com";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ happysalada ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30042,6 +30042,10 @@ with pkgs;
 
   sumokoin = callPackage ../applications/blockchains/sumokoin { boost = boost165; };
 
+  solana-testnet = callPackage ../applications/blockchains/solana {
+    inherit (darwin.apple_sdk.frameworks) IOKit Security AppKit;
+  };
+
   tessera = callPackage ../applications/blockchains/tessera { };
 
   vertcoin  = libsForQt514.callPackage ../applications/blockchains/vertcoin {


### PR DESCRIPTION
###### Motivation for this change

I've had some troubles running the tests. I'm leaving things commented out just for when I get more time to investigate.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
