### PR TITLE
nixos/seafile: add optional seafdav service

### DIFF
--- a/pkgs/development/python-modules/seafobj/default.nix
+++ b/pkgs/development/python-modules/seafobj/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+}:
+
+buildPythonPackage rec {
+  pname = "seafobj";
+  version = "unstable-2021-07-08";
+
+  src = fetchFromGitHub {
+    owner = "haiwen";
+    repo = "seafobj";
+    rev = "df13a98e7e32c926083ca60bb7fb1bbc4dfcdbd0";
+    sha256 = "0jwgbx083mwwh18x7450igq748bbld9s7zgibwv1cxwrrny1aari";
+  };
+
+  patches = [
+    ./setuptools.patch
+  ];
+
+  doCheck = false; # disabled because it requires a ccnet environment
+
+  meta = with lib; {
+    homepage = "https://github.com/haiwen/seafobj";
+    description = "Python library for accessing seafile data model";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ pacman99 ];
+  };
+}

--- a/pkgs/development/python-modules/seafobj/setuptools.patch
+++ b/pkgs/development/python-modules/seafobj/setuptools.patch
@@ -1,0 +1,24 @@
+diff --git a/setup.py b/setup.py
+new file mode 100644
+index 0000000..898cbe7
+--- /dev/null
++++ b/setup.py
+@@ -0,0 +1,18 @@
++from setuptools import setup, find_packages
++
++__version__ = '7.0.0'
++
++
++setup(name='seafobj',
++      version=__version__,
++      license='ASL2',
++      description='python library for accessing seafile data model',
++      author='Shuai Lin',
++      author_email='linshuai2012@gmail.com',
++      url='http://seafile.com',
++      platforms=['Any'],
++      packages=find_packages(exclude=["test.*", "test"]),
++      classifiers=['Development Status :: 4 - Beta',
++                   'License :: OSI Approved :: Apache Software License',
++                   'Operating System :: OS Independent',
++                   'Programming Language :: Python'])

--- a/pkgs/servers/seafdav/default.nix
+++ b/pkgs/servers/seafdav/default.nix
@@ -1,0 +1,40 @@
+{ lib, fetchFromGitHub, python3 }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "seafdav";
+  version = "unstable-2021-05-09";
+
+  src = fetchFromGitHub {
+    owner = "haiwen";
+    repo = "seafdav";
+    rev = "0f178088879a8d03c22d9a6b55e7e7ddc39a0c0c"; # using a fixed revision because upstream may re-tag releases :/
+    sha256 = "1gpvmfamjbw90gh9njgmba58qnzxji1w1sra46spnhi9k778mds3";
+  };
+
+  doCheck = false; # disabled because it requires a ccnet environment
+
+
+  propagatedBuildInputs = with python3.pkgs; [
+    seaserv
+    seafobj
+    defusedxml
+    pysearpc
+    future
+    gunicorn
+    jinja2
+    json5
+    python-pam
+    pyyaml
+    six
+    lxml
+    sqlalchemy
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/haiwen/seafdav";
+    description = "WebDAV server for seafile";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ pacman99 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33709,6 +33709,8 @@ with pkgs;
 
   seafile-shared = callPackage ../misc/seafile-shared { };
 
+  seafdav = callPackage ../servers/seafdav { };
+
   ser2net = callPackage ../servers/ser2net {};
 
   serviio = callPackage ../servers/serviio {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8863,6 +8863,8 @@ in {
 
   seabreeze = callPackage ../development/python-modules/seabreeze { };
 
+  seafobj = callPackage ../development/python-modules/seafobj { };
+
   seaserv = toPythonModule (pkgs.seafile-server.override {
     python3 = self.python;
   });


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
add webdav support for seafile

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Configuration Example
```nix
{
  services.seafile.seafdavSettings = {
    enabled = true;
    share_name = "/seafdav";
  };
  services.nginx.virtualHosts."files.example.com" = {
    locations."/seafdav".proxyPass = "http://127.0.0.1:6001/seafdav";
  };
}
```
