### PR TITLE
edgetx: init at 2.6.0

### DIFF
--- a/pkgs/applications/misc/edgetx/default.nix
+++ b/pkgs/applications/misc/edgetx/default.nix
@@ -1,0 +1,47 @@
+{ lib, mkDerivation, fetchFromGitHub
+, cmake, gcc-arm-embedded, python3Packages
+, qtbase, qtmultimedia, qttranslations, SDL, gtest
+, dfu-util
+}:
+
+mkDerivation rec {
+  pname = "edgetx";
+  version = "2.6.0";
+
+  src = fetchFromGitHub {
+    owner = "EdgeTX";
+    repo = pname;
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "sha256-TffHFgr3g7v4VnNSSlLITz4cYjHM6wE0aI85W1g4IFA=";
+  };
+
+  nativeBuildInputs = [ cmake gcc-arm-embedded python3Packages.pillow ];
+
+  buildInputs = [ qtbase qtmultimedia qttranslations SDL ];
+
+  postPatch = ''
+    sed -i companion/src/burnconfigdialog.cpp \
+      -e 's|/usr/.*bin/dfu-util|${dfu-util}/bin/dfu-util|'
+  '';
+
+  cmakeFlags = [
+    "-DGTEST_ROOT=${gtest.src}/googletest"
+    "-DQT_TRANSLATIONS_DIR=${qttranslations}/translations"
+    "-DDFU_UTIL_PATH=${dfu-util}/bin/dfu-util"
+  ];
+
+  meta = with lib; {
+    description = "EdgeTX Companion transmitter support software";
+    longDescription = ''
+      EdgeTX Companion is used for many different tasks like loading EdgeTX
+      firmware to the radio, backing up model settings, editing settings and
+      running radio simulators.
+    '';
+    homepage = "https://edgetx.org/";
+    license = licenses.gpl2Only;
+    platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" ];
+    maintainers = with maintainers; [ elitak lopsided98 wucke13 ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27097,6 +27097,8 @@ with pkgs;
 
   mozjpeg = callPackage ../applications/graphics/mozjpeg { };
 
+  edgetx = libsForQt5.callPackage ../applications/misc/edgetx { };
+
   easytag = callPackage ../applications/audio/easytag { };
 
   mp3gain = callPackage ../applications/audio/mp3gain { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I use an EdgeTX radio, so I'd like to have the companion at hand

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@elitak @lopsided98 Are you two fine, to also maintain this one?

Also, since I copied mostly everything from the `opentx` package: I now included the `cmakeFlags` for DFU_UTIL and AVRDUDE. It seems to work - but what was the initial issue?