### PR TITLE
multipath-tools: pull upstream fix for -fno-cmmon toolchains

### DIFF
--- a/pkgs/os-specific/linux/multipath-tools/default.nix
+++ b/pkgs/os-specific/linux/multipath-tools/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pkg-config, perl, lvm2, libaio, gzip, readline, systemd, liburcu, json_c, kmod }:
+{ lib, stdenv, fetchurl, fetchpatch, pkg-config, perl, lvm2, libaio, gzip, readline, systemd, liburcu, json_c, kmod }:
 
 stdenv.mkDerivation rec {
   pname = "multipath-tools";
@@ -13,6 +13,13 @@ stdenv.mkDerivation rec {
   patches = [
     # fix build with json-c 0.14 https://www.redhat.com/archives/dm-devel/2020-May/msg00261.html
     ./json-c-0.14.patch
+
+    # pull upstream fix for -fno-common toolchains like clang-12
+    (fetchpatch {
+        name = "fno-common.patch";
+        url = "https://github.com/opensvc/multipath-tools/commit/23a9247fa89cd0c84fe7e0f32468fd698b1caa48.patch";
+        sha256 = "10hq0g2jfkfbmwhm4x4q5cgsswj30lm34ib153alqzjzsxc1hqjk";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
Without the change build on clang-12 (and upstream gcc-10+) fails as:

    $ nix build -L --impure --expr 'with import ./. {}; multipath-tools.override { stdenv = clang12Stdenv; }'
    ...
    multipath-tools> ld: callout.o:libmultipath/./structs.h:109:
      multiple definition of `___error1___'; devmapper.o:structs.h:109: first defined here
