### PR TITLE
ncdu: 1.16 -> 2.0

### DIFF
--- a/pkgs/tools/misc/ncdu_2/c-import-order.patch
+++ b/pkgs/tools/misc/ncdu_2/c-import-order.patch
@@ -1,0 +1,17 @@
+diff --git a/src/ui.zig b/src/ui.zig
+index 8401910..50171a7 100644
+--- a/src/ui.zig
++++ b/src/ui.zig
+@@ -8,11 +8,11 @@ const main = @import("main.zig");
+ const util = @import("util.zig");
+
+ pub const c = @cImport({
++    @cDefine("_XOPEN_SOURCE", "1");
+     @cInclude("stdio.h");
+     @cInclude("string.h");
+     @cInclude("curses.h");
+     @cInclude("time.h");
+-    @cDefine("_X_OPEN_SOURCE", "1");
+     @cInclude("wchar.h");
+     @cInclude("locale.h");
+ });

--- a/pkgs/tools/misc/ncdu_2/default.nix
+++ b/pkgs/tools/misc/ncdu_2/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchurl, fetchpatch, zig, ncurses }:
+
+stdenv.mkDerivation rec {
+  pname = "ncdu";
+  version = "2.0";
+
+  src = fetchurl {
+    url = "https://dev.yorhel.nl/download/${pname}-${version}.tar.gz";
+    sha256 = "sha256-Zs2mgEdnsukbeM/cqCX5/a9qCkxuQAYloBrVWVQYR8w=";
+  };
+
+  patches = [
+    ./c-import-order.patch # https://code.blicky.net/yorhel/ncdu/issues/183
+  ];
+
+  XDG_CACHE_HOME="Cache"; # FIXME This should be set in stdenv
+
+  nativeBuildInputs = [
+    zig
+  ];
+
+  buildInputs = [ ncurses ];
+
+  PREFIX = placeholder "out";
+
+  meta = with lib; {
+    description = "Disk usage analyzer with an ncurses interface";
+    homepage = "https://dev.yorhel.nl/ncdu";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ pSub SuperSandro2000 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28170,6 +28170,7 @@ with pkgs;
   netcoredbg = callPackage ../development/tools/misc/netcoredbg { };
 
   ncdu = callPackage ../tools/misc/ncdu { };
+  ncdu_2 = callPackage ../tools/misc/ncdu_2 { };
 
   ncdc = callPackage ../applications/networking/p2p/ncdc { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Currently broken upstream it seems: https://code.blicky.net/yorhel/ncdu/issues/184

Edit: Depends on https://github.com/NixOS/nixpkgs/pull/152163 but still broken: https://code.blicky.net/yorhel/ncdu/issues/183

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
