### PR TITLE
deadpixi-sam-unstable: 2017-10-27 -> 2020-07-14

### DIFF
--- a/pkgs/applications/editors/deadpixi-sam/default.nix
+++ b/pkgs/applications/editors/deadpixi-sam/default.nix
@@ -1,20 +1,20 @@
 { lib, stdenv, fetchFromGitHub, freetype, libX11, libXi, libXt, libXft }:
 
 stdenv.mkDerivation rec {
-  version = "2017-10-27";
   pname = "deadpixi-sam-unstable";
+  version = "2020-07-14";
 
   src = fetchFromGitHub {
     owner = "deadpixi";
     repo = "sam";
-    rev = "51693780fb1457913389db6634163998f9b775b8";
-    sha256 = "0nfkj93j4bgli4ixbk041nwi14rabk04kqg8krq4mj0044m1qywr";
+    rev = "5d8acb35d78c327d76f00a54857cbd566ed9bc11";
+    sha256 = "sha256-+vRh6nDPc3UnmEdqROHRel5Te0h5m4eiaERs492xciQ=";
   };
 
   postPatch = ''
     substituteInPlace config.mk.def \
       --replace "/usr/include/freetype2" "${freetype.dev}/include/freetype2" \
-      --replace "CC=gcc" ""
+      --replace "CC=gcc" "CC=${stdenv.cc.targetPrefix}cc"
   '';
 
   CFLAGS = "-D_DARWIN_C_SOURCE";
@@ -27,10 +27,10 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/deadpixi/sam";
     description = "Updated version of the sam text editor";
-    license = with licenses; lpl-102;
+    license = licenses.lpl-102;
     maintainers = with maintainers; [ ramkromberg ];
-    platforms = with platforms; unix;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
