### PR TITLE
ethminer: 0.19.0 -> 0.20.0

### DIFF
--- a/pkgs/tools/misc/ethminer/default.nix
+++ b/pkgs/tools/misc/ethminer/default.nix
@@ -20,14 +20,14 @@
 
 stdenv.mkDerivation rec {
   pname = "ethminer";
-  version = "0.19.0";
+  version = "0.20.0";
 
   src =
     fetchFromGitHub {
       owner = "ethereum-mining";
       repo = "ethminer";
-      rev = "v${version}";
-      sha256 = "1kyff3vx2r4hjpqah9qk99z6dwz7nsnbnhhl6a76mdhjmgp1q646";
+      rev = "e55fbdc2f985b852de61c1b541eb1570ad69dbf0"; # https://github.com/ethereum-mining/ethminer/pull/2377; FIXME change once upstream releases
+      sha256 = "sha256-ugKMuoBqEztCrOltNK+VXTKZjgwjyHr6pLn+xenhCDA=";
       fetchSubmodules = true;
     };
 
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
   ];
 
   preConfigure = ''
-    sed -i 's/_lib_static//' libpoolprotocols/CMakeLists.txt
+    substituteInPlace libpoolprotocols/CMakeLists.txt --replace _static ""
   '';
 
   postInstall = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/ethereum-mining/ethminer/pull/2396

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
