### PR TITLE
ocamlformat: 0.20.0 and 0.20.1

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-version/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-version/default.nix
@@ -2,11 +2,11 @@
 
 buildDunePackage rec {
   pname = "ocaml-version";
-  version = "3.1.0";
+  version = "3.4.0";
 
   src = fetchurl {
     url = "https://github.com/ocurrent/ocaml-version/releases/download/v${version}/ocaml-version-v${version}.tbz";
-    sha256 = "sha256-rHuhagnY9yISdC85NpgPv667aYx7v2JRgq99ayw83l8=";
+    sha256 = "sha256-2MG+tejY67dxC19DTOZqPsi3UrHk1rqHxP4nRSvbiiU=";
   };
 
   minimumOCamlVersion = "4.07";

--- a/pkgs/development/ocaml-modules/odoc-parser/default.nix
+++ b/pkgs/development/ocaml-modules/odoc-parser/default.nix
@@ -2,13 +2,13 @@
 
 buildDunePackage rec {
   pname = "odoc-parser";
-  version = "0.9.0";
+  version = "1.0.0";
 
   minimumOCamlVersion = "4.02";
 
   src = fetchurl {
     url = "https://github.com/ocaml-doc/odoc-parser/releases/download/${version}/odoc-parser-${version}.tbz";
-    sha256 = "0ydxy2sj2w9i4vvyjnxplgmp5gbkp5ilnv36pvk4vgrrmldss3fz";
+    sha256 = "sha256-tqoI6nGp662bK+vE2h7aDXE882dObVfRBFnZNChueqE=";
   };
 
   useDune2 = true;

--- a/pkgs/development/ocaml-modules/odoc-parser/default.nix
+++ b/pkgs/development/ocaml-modules/odoc-parser/default.nix
@@ -1,14 +1,24 @@
-{ lib, fetchurl, buildDunePackage, astring, result }:
+{ lib, fetchurl, buildDunePackage, astring, result , version ? "1.0.0" }:
 
+let param = {
+  "1.0.0" = {
+    sha256 = "sha256-tqoI6nGp662bK+vE2h7aDXE882dObVfRBFnZNChueqE=";
+  };
+  "0.9.0" = {
+    sha256 = "sha256-3w2tG605v03mvmZsS2O5c71y66O3W+n3JjFxIbXwvXk=";
+  };
+}."${version}"; in
+
+let v = version; in
 buildDunePackage rec {
   pname = "odoc-parser";
-  version = "1.0.0";
+  inherit version;
 
   minimumOCamlVersion = "4.02";
 
   src = fetchurl {
     url = "https://github.com/ocaml-doc/odoc-parser/releases/download/${version}/odoc-parser-${version}.tbz";
-    sha256 = "sha256-tqoI6nGp662bK+vE2h7aDXE882dObVfRBFnZNChueqE=";
+    inherit (param) sha256;
   };
 
   useDune2 = true;

--- a/pkgs/development/ocaml-modules/odoc-parser/default.nix
+++ b/pkgs/development/ocaml-modules/odoc-parser/default.nix
@@ -7,7 +7,7 @@ buildDunePackage rec {
   minimumOCamlVersion = "4.02";
 
   src = fetchurl {
-    url = "https://github.com/ocaml-doc/odoc-parser/releases/download/0.9.0/odoc-parser-0.9.0.tbz";
+    url = "https://github.com/ocaml-doc/odoc-parser/releases/download/${version}/odoc-parser-${version}.tbz";
     sha256 = "0ydxy2sj2w9i4vvyjnxplgmp5gbkp5ilnv36pvk4vgrrmldss3fz";
   };
 

--- a/pkgs/development/tools/ocaml/ocamlformat/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat/default.nix
@@ -60,5 +60,9 @@ rec {
     version = "0.19.0";
   };
 
-  ocamlformat = ocamlformat_0_19_0;
+  ocamlformat_0_20_0 = mkOCamlformat {
+    version = "0.20.0";
+  };
+
+  ocamlformat = ocamlformat_0_20_0;
 }

--- a/pkgs/development/tools/ocaml/ocamlformat/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat/default.nix
@@ -64,5 +64,9 @@ rec {
     version = "0.20.0";
   };
 
-  ocamlformat = ocamlformat_0_20_0;
+  ocamlformat_0_20_1 = mkOCamlformat {
+    version = "0.20.1";
+  };
+
+  ocamlformat = ocamlformat_0_20_1;
 }

--- a/pkgs/development/tools/ocaml/ocamlformat/generic.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat/generic.nix
@@ -23,6 +23,7 @@ let src =
       "0.17.0" = "0f1lxp697yq61z8gqxjjaqd2ns8fd1vjfggn55x0gh9dx098p138";
       "0.18.0" = "0571kzmb1h03qj74090n3mg8wfbh29qqrkdjkai6rnl5chll86lq";
       "0.19.0" = "0ihgwl7d489g938m1jvgx8azdgq9f5np5mzqwwya797hx2m4dz32";
+      "0.20.0" = "sha256-JtmNCgwjbCyUE4bWqdH5Nc2YSit+rekwS43DcviIfgk=";
     }."${version}";
   };
   ocamlPackages =
@@ -47,7 +48,26 @@ buildDunePackage {
   useDune2 = true;
 
   buildInputs =
-    if lib.versionAtLeast version "0.19.0"
+    if lib.versionAtLeast version "0.20.0"
+    then [
+      base
+      cmdliner
+      dune-build-info
+      either
+      fix
+      fpath
+      menhir
+      menhirLib
+      menhirSdk
+      ocaml-version
+      ocp-indent
+      odoc-parser
+      re
+      stdio
+      uuseg
+      uutf
+    ]
+    else if lib.versionAtLeast version "0.19.0"
     then [
       base
       cmdliner

--- a/pkgs/development/tools/ocaml/ocamlformat/generic.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat/generic.nix
@@ -24,6 +24,7 @@ let src =
       "0.18.0" = "0571kzmb1h03qj74090n3mg8wfbh29qqrkdjkai6rnl5chll86lq";
       "0.19.0" = "0ihgwl7d489g938m1jvgx8azdgq9f5np5mzqwwya797hx2m4dz32";
       "0.20.0" = "sha256-JtmNCgwjbCyUE4bWqdH5Nc2YSit+rekwS43DcviIfgk=";
+      "0.20.1" = "sha256-fTpRZFQW+ngoc0T6A69reEUAZ6GmHkeQvxspd5zRAjU=";
     }."${version}";
   };
   ocamlPackages =

--- a/pkgs/development/tools/ocaml/ocamlformat/generic.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat/generic.nix
@@ -61,7 +61,7 @@ buildDunePackage {
       menhirSdk
       ocaml-version
       ocp-indent
-      odoc-parser
+      (if version == "0.20.0" then odoc-parser.override { version = "0.9.0"; } else odoc-parser)
       re
       stdio
       uuseg
@@ -82,7 +82,7 @@ buildDunePackage {
       menhirSdk
       ocp-indent
       dune-build-info
-      odoc-parser
+      (odoc-parser.override { version = "0.9.0"; })
     ]
     else if lib.versionAtLeast version "0.18.0"
     then [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12787,7 +12787,7 @@ with pkgs;
     ocamlformat_0_11_0 ocamlformat_0_12 ocamlformat_0_13_0 ocamlformat_0_14_0
     ocamlformat_0_14_1 ocamlformat_0_14_2 ocamlformat_0_14_3 ocamlformat_0_15_0
     ocamlformat_0_15_1 ocamlformat_0_16_0 ocamlformat_0_17_0 ocamlformat_0_18_0
-    ocamlformat_0_19_0;
+    ocamlformat_0_19_0 ocamlformat_0_20_0;
 
   orc = callPackage ../development/compilers/orc { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12787,7 +12787,7 @@ with pkgs;
     ocamlformat_0_11_0 ocamlformat_0_12 ocamlformat_0_13_0 ocamlformat_0_14_0
     ocamlformat_0_14_1 ocamlformat_0_14_2 ocamlformat_0_14_3 ocamlformat_0_15_0
     ocamlformat_0_15_1 ocamlformat_0_16_0 ocamlformat_0_17_0 ocamlformat_0_18_0
-    ocamlformat_0_19_0 ocamlformat_0_20_0;
+    ocamlformat_0_19_0 ocamlformat_0_20_0 ocamlformat_0_20_1;
 
   orc = callPackage ../development/compilers/orc { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

To include ocamlformat 0.20.0 and 0.20.1 in nixpkgs

###### Things done

Added the mentioned packages and upgraded odoc-parser and ocaml-version to allow for this.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
