### PR TITLE
[staging-next] boehmgc: revert "8.0.6 -> 8.2.0", experimental release

### DIFF
--- a/pkgs/development/libraries/boehm-gc/default.nix
+++ b/pkgs/development/libraries/boehm-gc/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl
 , autoreconfHook
-, enableLargeConfig ? false # doc: https://github.com/ivmai/bdwgc/blob/v8.2.0/doc/README.macros (LARGE_CONFIG)
+, enableLargeConfig ? false # doc: https://github.com/ivmai/bdwgc/blob/v8.0.6/doc/README.macros (LARGE_CONFIG)
 , nix
 , nix_2_3
 , nixUnstable
@@ -8,14 +8,14 @@
 
 stdenv.mkDerivation rec {
   pname = "boehm-gc";
-  version = "8.2.0";
+  version = "8.0.6";
 
   src = fetchurl {
     urls = [
       "https://github.com/ivmai/bdwgc/releases/download/v${version}/gc-${version}.tar.gz"
       "https://www.hboehm.info/gc/gc_source/gc-${version}.tar.gz"
     ];
-    sha256 = "sha256-JUD3NWy3T2xbdTJsbTigZu3XljYf19TtJuSU2YVv7Y8=";
+    sha256 = "3b4914abc9fa76593596773e4da671d7ed4d5390e3d46fbf2e5f155e121bea11";
   };
 
   outputs = [ "out" "dev" "doc" ];


### PR DESCRIPTION
Revert also fixes build guile-3. Without it the build fails as:

    error: builder for '/nix/store/v3vkr9vaxg278mdi6cv2a0jaqw8mn3xp-guile-3.0.7.drv' failed with exit code 2;
       last 10 log lines:
       >                  from alist.c:31:
       > /nix/store/2dzi3ls093ffivpp6ykhb3wh33ngyaww-boehm-gc-8.2.0-dev/include/gc/gc.h:1784:11: fatal error: gc_pthread_redirects.h: No such file or directory
       >  1784 | # include "gc_pthread_redirects.h"
       >       |           ^~~~~~~~~~~~~~~~~~~~~~~~

Upstream fixed it in master only.