### PR TITLE
prometheus: build with node 14

### DIFF
--- a/pkgs/servers/monitoring/prometheus/default.nix
+++ b/pkgs/servers/monitoring/prometheus/default.nix
@@ -2,7 +2,7 @@
 , lib
 , go
 , pkgs
-, nodejs
+, nodejs-14_x
 , nodePackages
 , buildGoModule
 , fetchFromGitHub
@@ -24,11 +24,13 @@ let
   goPackagePath = "github.com/prometheus/prometheus";
 
   codemirrorNode = import ./webui/codemirror-promql {
-    inherit pkgs nodejs;
+    inherit pkgs;
+    nodejs = nodejs-14_x;
     inherit (stdenv.hostPlatform) system;
   };
   webuiNode = import ./webui/webui {
-    inherit pkgs nodejs;
+    inherit pkgs;
+    nodejs = nodejs-14_x;
     inherit (stdenv.hostPlatform) system;
   };
 
@@ -36,7 +38,7 @@ let
     name = "prometheus-webui-codemirror-promql";
     src = "${src}/web/ui/module/codemirror-promql";
 
-    buildInputs = [ nodejs nodePackages.typescript codemirrorNode.nodeDependencies ];
+    buildInputs = [ nodejs-14_x nodePackages.typescript codemirrorNode.nodeDependencies ];
 
     configurePhase = ''
       ln -s ${codemirrorNode.nodeDependencies}/lib/node_modules node_modules
@@ -56,7 +58,7 @@ let
     name = "prometheus-webui";
     src = "${src}/web/ui/react-app";
 
-    buildInputs = [ nodejs webuiNode.nodeDependencies ];
+    buildInputs = [ nodejs-14_x webuiNode.nodeDependencies ];
 
     # create `node_modules/.cache` dir (we need writeable .cache)
     # and then copy the rest over.
@@ -77,7 +79,7 @@ buildGoModule rec {
 
   excludedPackages = [ "documentation/prometheus-mixin" ];
 
-  nativeBuildInputs = [ nodejs ];
+  nativeBuildInputs = [ nodejs-14_x ];
 
   postPatch = ''
     # we don't want this anyways, as we


### PR DESCRIPTION
###### Motivation for this change
node2nix is still broken on 16.

see: https://github.com/NixOS/nixpkgs/commit/4c60ee3da1e3a9c2441ebeb1c755049555624924

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
