### PR TITLE
kdiff3: usable on darwin

### DIFF
--- a/pkgs/tools/text/kdiff3/default.nix
+++ b/pkgs/tools/text/kdiff3/default.nix
@@ -1,27 +1,73 @@
-{
-  mkDerivation, lib, fetchurl,
-  extra-cmake-modules, kdoctools, wrapGAppsHook,
-  kcrash, kconfig, kinit, kparts, kiconthemes
+{ stdenv
+, mkDerivation
+, lib
+, fetchurl
+, extra-cmake-modules
+, kdoctools
+, wrapGAppsHook
+, kcrash
+, kconfig
+, kinit
+, kparts
+, kiconthemes
+, undmg
 }:
 
-mkDerivation rec {
+let
   pname = "kdiff3";
   version = "1.8.5";
 
-  src = fetchurl {
-    url = "https://download.kde.org/stable/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-vJL30E6xI/nFbb4wR69nv3FSQPqZSHrB0czypF4IVME=";
+  srcs = {
+    x86_64-linux = fetchurl {
+      url = "https://download.kde.org/stable/${pname}/${pname}-${version}.tar.xz";
+      sha256 = "sha256-vJL30E6xI/nFbb4wR69nv3FSQPqZSHrB0czypF4IVME=";
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://download.kde.org/stable/${pname}/${pname}-${version}-macos-64.dmg";
+      name = "${pname}-${version}.dmg"; # required due to "No such file or directory" error otherwise
+      hash = "sha256-Fe7fbWjM0b6Kd7SLjtjrDm9/PIER8b5wkH1bwAATw18=";
+    };
   };
-
-  nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook ];
-
-  propagatedBuildInputs = [ kconfig kcrash kinit kparts kiconthemes ];
+  src = srcs.${stdenv.hostPlatform.system};
 
   meta = with lib; {
     homepage = "https://invent.kde.org/sdk/kdiff3";
     license = licenses.gpl2Plus;
     description = "Compares and merges 2 or 3 files or directories";
-    maintainers = with maintainers; [ peterhoeg ];
-    platforms = with platforms; linux;
+    maintainers = with maintainers; [ peterhoeg aaschmid ];
+    platforms = builtins.attrNames srcs;
   };
-}
+
+  linux = mkDerivation {
+    inherit pname version src meta;
+
+    nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook ];
+
+    propagatedBuildInputs = [ kconfig kcrash kinit kparts kiconthemes ];
+  };
+
+  darwin = mkDerivation rec {
+    inherit pname version src meta;
+
+    sourceRoot = "${pname}.app"; # The image contains the .app and a symlink to /Applications.
+
+    depsBuildBuild = [ undmg ];
+
+    dontBuild = true;
+    dontWrapQtApps = true;
+    dontFixup = true; # fixes als `dylib` files which breaks kdiff3
+
+    passthru = {
+      binaryPath = "Applications/${sourceRoot}/Contents/MacOS/${pname}";
+    };
+
+    installPhase = ''
+      mkdir -p "$out/Applications/${sourceRoot}"
+      cp -ar . "$out/Applications/${sourceRoot}"
+      chmod a+x "$out/${passthru.binaryPath}"
+    '';
+ };
+in
+if stdenv.isLinux
+then linux
+else darwin


### PR DESCRIPTION
###### Motivation for this change

Make kdiff3 available for darwin as well using a dedicated pre-built `dmg` package as source. I already use it on my environment as a derivation just added to the `gitconfig`s `mergetool` section

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
