### PR TITLE
python3Packages.scikitimage: 0.18.3 -> 0.19.3 + broken packages

### DIFF
--- a/pkgs/development/python-modules/scikit-image/default.nix
+++ b/pkgs/development/python-modules/scikit-image/default.nix
@@ -4,6 +4,7 @@
 , buildPythonPackage
 , python
 , cython
+, pythran
 , numpy
 , scipy
 , matplotlib
@@ -22,18 +23,19 @@ let
   installedPackageRoot = "${builtins.placeholder "out"}/${python.sitePackages}";
 in buildPythonPackage rec {
   pname = "scikit-image";
-  version = "0.18.3";
+  version = "0.19.1";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "0a2h3bw5rkk23k4r04qc9maccg00nddssd7lfsps8nhp5agk1vyh";
+    sha256 = "09wy21zcq03grb0lj35pp46l44qp08a9q9ijkglqa428f3wp7nma";
   };
 
   patches = [ ./add-testing-data.patch ];
 
-  nativeBuildInputs = [ cython ];
+  # pythran isn't necessary for building but is imported in `setup.py`.
+  nativeBuildInputs = [ cython pythran ];
 
   propagatedBuildInputs = [
     cloudpickle


### PR DESCRIPTION
###### Motivation for this change

Scikit-image update to 0.19.3 ([changelog for 0.19.0](https://github.com/scikit-image/scikit-image/releases/tag/v0.19.0), see also [this](https://github.com/scikit-image/scikit-image/issues/6093)). It breaks some packages:

- [ ] `batchgenerators`: ~~tests ok on the version from master~~ ok on the latest 0.24;
- [ ] `imgaug`: needs major fixes in upstream;
- [ ] `mask-rcnn`: depends on `imgaug`;
- [x] `sunpy`: ~~needs major upstream fixes, [in progress there](https://github.com/sunpy/sunpy/pull/5742)~~ dropping of `scikit-image` dependency is [in progress](https://github.com/sunpy/sunpy/pull/5867).

Seems like we'd need to leave 0.18.3 specifically for `imgaug`/`mask-rcnn`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
