### PR TITLE
gstreamer: backport device discovery fix

### DIFF
--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchurl
+, fetchpatch
 , meson
 , ninja
 , pkg-config
@@ -39,6 +40,20 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./fix_pkgconfig_includedir.patch
+    # Fix device discovery failing without pulseaudio
+    # (Remove once version > 1.19.3)
+    # https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/679
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/41677a526b83bb2493087af1d93b50c297cf97cd.patch";
+      sha256 = "e5SCjRREIQ2Y1/SK8ywW/Q+ejxuWkJ7eMR4M0/wQCFs=";
+    })
+    # https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/1189
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/1912bcbcc42e8ee2c4948511619219f5722631d2.patch";
+      stripLen = 3;
+      extraPrefix = "";
+      sha256 = "a1EcW0phtXjjoC4PaHGrNB9+SVHSTq8bdQbpyspp/zM=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

This is a manual backport of recent changes[1] in gstdevicemonitor.c
that fix the device discovery failing entirely if one provider fails
(eg. if pulseaudio support is enabled but no daemon is running).

The commit couldn't have been simply cherry-picked because it doesn't
directly apply to gstreamer 1.18.4.

[1]: https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/1189

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
