### PR TITLE
torrent7z: init at 1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2134,6 +2134,12 @@
     githubId = 3956062;
     name = "Simon Lackerbauer";
   };
+  cirno-999 = {
+    email = "reverene@protonmail.com";
+    github = "cirno-999";
+    githubId = 73712874;
+    name = "cirno-999";
+  };
   citadelcore = {
     email = "alex@arctarus.co.uk";
     github = "citadelcore";

--- a/pkgs/tools/archivers/torrent7z/default.nix
+++ b/pkgs/tools/archivers/torrent7z/default.nix
@@ -1,0 +1,53 @@
+{ lib, stdenv, fetchFromGitHub, fetchpatch, ncurses }:
+
+stdenv.mkDerivation rec {
+  pname = "torrent7z";
+  version = "1.3";
+
+  src = fetchFromGitHub {
+    owner = "BubblesInTheTub";
+    repo = pname;
+    rev = version;
+    sha256 = "Y2tr0+z9uij4Ifi6FfWRN24BwcDXUZKVLkLtKUiVjU4=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-gcc10-compilation.patch"; # Fix compilation on GCC 10. This patch is included on the latest commit
+      url =
+        "https://github.com/paulyc/torrent7z/commit/5958f42a364c430b3ed4ac68911bbbea1f967fc4.patch";
+      sha256 = "vJOv1sG9XwTvvxQiWew0H5ALoUb9wIAouzTsTvKHuPI=";
+    })
+  ];
+
+  buildInputs = [ ncurses ];
+
+  hardeningDisable = [ "format" ];
+
+  postPatch = ''
+    # Remove non-free RAR source code
+    # (see DOC/License.txt, https://fedoraproject.org/wiki/Licensing:Unrar)
+    rm -r linux_src/p7zip_4.65/CPP/7zip/Compress/Rar*
+    find . -name makefile'*' -exec sed -i '/Rar/d' {} +
+  '';
+
+  preConfigure = ''
+    mkdir linux_src/p7zip_4.65/bin
+    cd linux_src/p7zip_4.65/CPP/7zip/Bundles/Alone
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ../../../../bin/t7z $out/bin
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/BubblesInTheTub/torrent7z";
+    description = "A fork of torrent7z, viz a derivative of 7zip that produces invariant .7z archives for torrenting";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ cirno-999 ];
+    mainProgram = "t7z";
+    # RAR code is under non-free UnRAR license, but we remove it
+    license = licenses.gpl3Only;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10264,6 +10264,8 @@ with pkgs;
 
   touchegg = callPackage ../tools/inputmethods/touchegg { };
 
+  torrent7z = callPackage ../tools/archivers/torrent7z { };
+
   torsocks = callPackage ../tools/security/tor/torsocks.nix { };
 
   toss = callPackage ../tools/networking/toss { };


### PR DESCRIPTION
###### Motivation for this change
Getting this useful archival tool into nixpkgs. (A fork of torrent7z, viz a derivative of 7zip that produces invariant .7z archives for torrenting. https://github.com/BubblesInTheTub/torrent7z)

###### Things done
Built initial derivation. Added myself as the maintainer for this package.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
