### PR TITLE
home-manager: 2021-03-21 -> 2021-12-25

### DIFF
--- a/pkgs/tools/package-management/home-manager/default.nix
+++ b/pkgs/tools/package-management/home-manager/default.nix
@@ -1,18 +1,18 @@
 #Adapted from
 #https://github.com/rycee/home-manager/blob/2c07829be2bcae55e04997b19719ff902a44016d/home-manager/default.nix
 
-{ bash, coreutils, findutils, gnused, less, lib, stdenv, makeWrapper, fetchFromGitHub }:
+{ bash, coreutils, findutils, gnused, less, gettext, nixos-option, lib, stdenv, makeWrapper, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
 
   pname = "home-manager";
-  version = "2021-03-21";
+  version = "2021-12-25";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "home-manager";
-    rev = "ddcd476603dfd3388b1dc8234fa9d550156a51f5";
-    sha256 = "sha256-E6ABXtzw6bHmrIirB1sJL6S2MEa3sfcvRLzRa92frCo=";
+    rev = "48f2b381dd397ec88040d3354ac9c036739ba139";
+    sha256 = "1i9v94brh9vhyhzcqyfj64nzhaibdj0sw74pxgk4bcsp0hqawgcd";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -23,14 +23,29 @@ stdenv.mkDerivation rec {
 
     substituteInPlace $out/bin/home-manager \
       --subst-var-by bash "${bash}" \
-      --subst-var-by coreutils "${coreutils}" \
-      --subst-var-by findutils "${findutils}" \
-      --subst-var-by gnused "${gnused}" \
-      --subst-var-by less "${less}" \
-      --subst-var-by HOME_MANAGER_PATH '${src}'
+      --subst-var-by DEP_PATH "${
+        lib.makeBinPath [ coreutils findutils gettext gnused less nixos-option ]
+      }" \
+      --subst-var-by HOME_MANAGER_LIB '${src}/lib/bash/home-manager.sh' \
+      --subst-var-by HOME_MANAGER_PATH '${src}' \
+      --subst-var-by OUT "$out"
 
-    install -D -m755 home-manager/completion.bash \
-      "$out/share/bash-completion/completions/home-manager"
+    install -D -m755 ${src}/home-manager/completion.bash \
+      $out/share/bash-completion/completions/home-manager
+    install -D -m755 ${src}/home-manager/completion.zsh \
+      $out/share/zsh/site-functions/_home-manager
+    install -D -m755 ${src}/home-manager/completion.fish \
+      $out/share/fish/vendor_completions.d/home-manager.fish
+
+    install -D -m755 ${src}/lib/bash/home-manager.sh \
+      "$out/share/bash/home-manager.sh"
+
+    for path in ${src}/home-manager/po/*.po; do
+      lang="''${path##*/}"
+      lang="''${lang%%.*}"
+      mkdir -p "$out/share/locale/$lang/LC_MESSAGES"
+      ${gettext}/bin/msgfmt -o "$out/share/locale/$lang/LC_MESSAGES/home-manager.mo" "$path"
+    done
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this 

bump `home-manager` version to last one.

A pull request already exist but was never merge and is now outdated #139980.

this use home-manager `master` to not depend on nixos version. as suggested by https://github.com/NixOS/nixpkgs/pull/139980#issuecomment-931493774 in the previous merge request.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
