### PR TITLE
helix: reenable haskell syntax highlighting support

### DIFF
--- a/pkgs/applications/editors/helix/default.nix
+++ b/pkgs/applications/editors/helix/default.nix
@@ -16,6 +16,10 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
+  patches = [
+    ./patches/reenable-haskell.patch
+  ];
+
   postInstall = ''
     mkdir -p $out/lib
     cp -r runtime $out/lib

--- a/pkgs/applications/editors/helix/patches/reenable-haskell.patch
+++ b/pkgs/applications/editors/helix/patches/reenable-haskell.patch
@@ -1,0 +1,13 @@
+diff --git a/helix-syntax/build.rs b/helix-syntax/build.rs
+index 28f85e7..bad1c6b 100644
+--- a/helix-syntax/build.rs
++++ b/helix-syntax/build.rs
+@@ -175,7 +175,7 @@ fn build_dir(dir: &str, language: &str) {
+ fn main() {
+     let ignore = vec![
+         "tree-sitter-typescript".to_string(),
+-        "tree-sitter-haskell".to_string(), // aarch64 failures: https://github.com/tree-sitter/tree-sitter-haskell/issues/34
++        // "tree-sitter-haskell".to_string(), // aarch64 failures: https://github.com/tree-sitter/tree-sitter-haskell/issues/34
+         "tree-sitter-ocaml".to_string(),
+     ];
+     let dirs = collect_tree_sitter_dirs(&ignore).unwrap();


### PR DESCRIPTION
Haskell syntax highlighting is disabled in `helix-editor` by default.
This is because of an issue compiling tree-sitter-haskell on M1 macs,
as its default compilier doesn't support c++14.
As we're using a nix-derived toolchain, we shouldn't be subject to
this problem.

See [this comment](https://github.com/helix-editor/helix/issues/1384#issuecomment-1001240194) for more info.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
