### PR TITLE
python3Packages.yamlfix: 0.7.2 -> 0.8.0

### DIFF
--- a/pkgs/development/python-modules/yamlfix/default.nix
+++ b/pkgs/development/python-modules/yamlfix/default.nix
@@ -1,34 +1,53 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pytestCheckHook, pytest-xdist
-, pythonOlder, click, ruyaml }:
+{ lib
+, buildPythonPackage
+, click
+, fetchFromGitHub
+, pytest-xdist
+, pytestCheckHook
+, pythonOlder
+, ruyaml
+}:
 
 buildPythonPackage rec {
   pname = "yamlfix";
-  version = "0.7.2";
+  version = "0.8.0";
+  format = "setuptools";
+
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "lyz-code";
     repo = pname;
     rev = version;
-    sha256 = "sha256-qlA6TyLkOuTXCdMnpfkyN/HDIRfB6+0pQ7f0GCsIjL4=";
+    sha256 = "sha256-Gkq80YMeiPy7xxLauA/nloW4znMV2tfE+e24HyZgUaQ=";
   };
 
-  propagatedBuildInputs = [ click ruyaml ];
+  propagatedBuildInputs = [
+    click
+    ruyaml
+  ];
 
-  checkInputs = [ pytestCheckHook pytest-xdist ];
+  checkInputs = [
+    pytest-xdist
+    pytestCheckHook
+  ];
 
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace 'python_paths = "."' ""
   '';
 
-  pytestFlagsArray = [ "-n" "$NIX_BUILD_CORES" ];
+  pytestFlagsArray = [
+    "-n"
+    "$NIX_BUILD_CORES"
+  ];
 
-  pythonImportsCheck = [ "yamlfix" ];
+  pythonImportsCheck = [
+    "yamlfix"
+  ];
 
   meta = with lib; {
-    description =
-      "A simple opinionated yaml formatter that keeps your comments!";
+    description = "Python YAML formatter that keeps your comments";
     homepage = "https://github.com/lyz-code/yamlfix";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ koozz ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/lyz-code/yamlfix/blob/master/CHANGELOG.md#080-2021-12-01

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
