### PR TITLE
webp-pixbuf-loader: init at 0.0.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2877,6 +2877,12 @@
     githubId = 1382175;
     name = "Oliver Matthews";
   };
+  cwyc = {
+    email = "hello@cwyc.page";
+    github = "cwyc";
+    githubId = 16950437;
+    name = "cwyc";
+  };
   cyounkins = {
     name = "Craig Younkins";
     email = "cyounkins@gmail.com";

--- a/pkgs/development/libraries/webp-pixbuf-loader/default.nix
+++ b/pkgs/development/libraries/webp-pixbuf-loader/default.nix
@@ -1,0 +1,59 @@
+{ lib, stdenv, fetchFromGitHub
+, meson, ninja, pkg-config, makeWrapper
+, gdk-pixbuf, libwebp
+}:
+let
+  moduleDir = gdk-pixbuf.moduleDir;
+
+  # turning lib/gdk-pixbuf-#.#/#.#.#/loaders into lib/gdk-pixbuf-#.#/#.#.#/loaders.cache
+  # removeSuffix is just in case moduleDir gets a trailing slash
+  loadersPath = (lib.strings.removeSuffix "/" gdk-pixbuf.moduleDir) + ".cache";
+in
+stdenv.mkDerivation rec {
+  pname = "webp-pixbuf-loader";
+  version = "0.0.6";
+
+  src = fetchFromGitHub {
+    owner = "aruiz";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-dcdydWYrXZJjo4FxJtvzGzrQLOs87/BmxshFZwsT2ws=";
+  };
+
+  # It looks for gdk-pixbuf-thumbnailer in this package's bin rather than the gdk-pixbuf bin. We need to patch that.
+  postPatch = ''
+    substituteInPlace webp-pixbuf.thumbnailer.in --replace @bindir@/gdk-pixbuf-thumbnailer $out/bin/webp-thumbnailer
+  '';
+
+  nativeBuildInputs = [ gdk-pixbuf meson ninja pkg-config makeWrapper ];
+  buildInputs = [ gdk-pixbuf libwebp ];
+
+  mesonFlags = [
+    "-Dgdk_pixbuf_query_loaders_path=${gdk-pixbuf.dev}/bin/gdk-pixbuf-query-loaders"
+    "-Dgdk_pixbuf_moduledir=${placeholder "out"}/${moduleDir}"
+  ];
+
+  # It assumes gdk-pixbuf-thumbnailer can find the webp loader in the loaders.cache referenced by environment variable, breaking containment.
+  # So we replace it with a wrapped executable.
+  postInstall = ''
+    mkdir -p $out/bin
+    makeWrapper ${gdk-pixbuf}/bin/gdk-pixbuf-thumbnailer $out/bin/webp-thumbnailer \
+      --set GDK_PIXBUF_MODULE_FILE $out/${loadersPath}
+  '';
+
+  # environment variables controlling loaders.cache generation by gdk-pixbuf-query-loaders
+  preInstall = ''
+    export GDK_PIXBUF_MODULE_FILE=$out/${loadersPath}
+    export GDK_PIXBUF_MODULEDIR=$out/${moduleDir}
+  '';
+
+  meta = with lib; {
+    description = "WebP GDK Pixbuf Loader library";
+    homepage = "https://github.com/aruiz/webp-pixbuf-loader";
+    license = licenses.lgpl2Plus;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.cwyc ];
+    # meson.build:16:0: ERROR: Program or command 'gcc' not found or not executable
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22366,6 +22366,8 @@ with pkgs;
     gtk3 = gtk4;
   };
 
+  webp-pixbuf-loader = callPackage ../development/libraries/webp-pixbuf-loader {};
+
   websocketpp = callPackage ../development/libraries/websocket++ { };
 
   webrtc-audio-processing_1 = callPackage ../development/libraries/webrtc-audio-processing { stdenv = gcc10StdenvCompat; };


### PR DESCRIPTION
###### Motivation for this change
Packaging https://github.com/aruiz/webp-pixbuf-loader , which allows programs using gdk-pixbuf to load webp images.

At this time this package isn't much use. The only programs making use of gdk-pixbuf are GTK apps, and `wrapGAppsHook` puts them in a wrapper that overrides the `$GDK_PIXBUF_MODULE_FILE` environment variable. See https://github.com/NixOS/nixpkgs/pull/42562#issuecomment-486647822

Still, it works with `eog` and `ristretto`:
- configure this package in your configuration.nix
`services.xserver.gdk-pixbuf.modulePackages = [pkgs.webp-pixbuf-loader];`
alternatively, you can find this package in `nur.repos.cwyc.webp-pixbuf-loader`
- copy the wrapper script to your working directory and remove the line setting `$GDK_PIXBUF_MODULE_FILE`
`cat $(which eog) | sed -e "s/export GDK_PIXBUF_MODULE_FILE=.*//" > ./wrapper.sh`
- get a sample file if you have none
`curl https://www.gstatic.com/webp/gallery/1.webp -o sample.webp`
- launch it
`./wrapper.sh sample.webp`
(If your terminal program also launches through the GTK wrapper, then `$GDK_PIXBUF_MODULE_FILE` might have already been overwritten. In that case you'd have to find what it would have been using `nixos-option environment.variables`, and set it manually before running.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
