### PR TITLE
Disable MEMPROF on aarch64+musl

### DIFF
--- a/pkgs/development/compilers/llvm/13/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/13/compiler-rt/default.nix
@@ -33,6 +33,12 @@ stdenv.mkDerivation {
     "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"
     "-DCOMPILER_RT_BUILD_XRAY=OFF"
     "-DCOMPILER_RT_BUILD_PROFILE=OFF"
+  ] ++ lib.optionals (isMusl && isAarch64) [
+    # disable MEMPROF + XRAY + SANITIZERS to prevent building sanitizer_common,
+    # which fails with
+    #    /build/source/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp: In function 'bool __sanitizer::Aarch64GetESR(ucontext_t*, __sanitizer::u64*)':
+    #    /build/source/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp:1814:35: error: cannot convert 'long double*' to '__sanitizer::u8*' {aka 'unsigned char*'} in initialization
+    "-DCOMPILER_RT_BUILD_MEMPROF=OFF"
   ] ++ lib.optionals ((useLLVM || bareMetal) && !haveLibc) [
     "-DCMAKE_C_COMPILER_WORKS=ON"
     "-DCMAKE_CXX_COMPILER_WORKS=ON"


### PR DESCRIPTION
if either of SANITIZER, XRAY or MEMPROF is enabled, we may see
```
[  4%] Building CXX object lib/sanitizer_common/CMakeFiles/RTSanitizerCommonNoHooks.aarch64.dir/sanitizer_linux.cpp.o
/build/source/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp: In function 'bool __sanitizer::Aarch64GetESR(ucontext_t*, __sanitizer::u64*)':
/build/source/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp:1814:35: error: cannot convert 'long double*' to '__sanitizer::u8*' {aka 'unsigned char*'} in initialization
 1814 |   u8 *aux = ucontext->uc_mcontext.__reserved;
      |             ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
      |                                   |
      |                                   long double*
```

during the build as we are trying to build sanitizer_common files.  