### PR TITLE
libcoap: 4.2.1 -> 4.3.0

### DIFF
--- a/pkgs/applications/networking/libcoap/default.nix
+++ b/pkgs/applications/networking/libcoap/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/obgm/libcoap";
     description = "A CoAP (RFC 7252) implementation in C";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     license = licenses.bsd2;
     maintainers = [ maintainers.kmein ];
   };

--- a/pkgs/applications/networking/libcoap/default.nix
+++ b/pkgs/applications/networking/libcoap/default.nix
@@ -1,13 +1,16 @@
-{ fetchFromGitHub, automake, autoconf, which, pkg-config, libtool, lib, stdenv }:
+{ fetchFromGitHub, automake, autoconf, which, pkg-config, libtool, lib, stdenv, gnutls, asciidoc, doxygen
+, withTLS ? true
+, withDocs ? true
+}:
 stdenv.mkDerivation rec {
   pname = "libcoap";
-  version = "4.2.1";
+  version = "4.3.0";
   src = fetchFromGitHub {
     repo = "libcoap";
     owner = "obgm";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "1jkvha52lic13f13hnppizkl80bb2rciayb5hxici0gj6spphgha";
+    sha256 = "1l031ys833gch600g9g3lvbsr4nysx6glbbj4lwvx3ywl0jr6l9k";
   };
   nativeBuildInputs = [
     automake
@@ -15,12 +18,11 @@ stdenv.mkDerivation rec {
     which
     libtool
     pkg-config
-  ];
+  ] ++ lib.optional withTLS gnutls ++ lib.optionals withDocs [ doxygen asciidoc ] ;
   preConfigure = "./autogen.sh";
-  configureFlags = [
-    "--disable-documentation"
-    "--disable-shared"
-  ];
+  configureFlags = [ "--disable-shared" ]
+    ++ lib.optional (!withDocs) "--disable-documentation"
+    ++ lib.optional withTLS "--enable-dtls";
   meta = with lib; {
     homepage = "https://github.com/obgm/libcoap";
     description = "A CoAP (RFC 7252) implementation in C";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
There is a new version of libcoap which supports TLS (the coaps:// protocol).
This makes it usable for, e.g. the IKEA Trådfri smart lighting zigbee network.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
