### PR TITLE
astrolog: switches for using optional ephemeris/atlas files

### DIFF
--- a/pkgs/applications/science/astronomy/astrolog/default.nix
+++ b/pkgs/applications/science/astronomy/astrolog/default.nix
@@ -1,4 +1,8 @@
-{ lib, stdenv, fetchzip, fetchurl, xorg, gnused }:
+{ lib, stdenv, fetchzip, fetchurl, xorg, gnused
+, withBigAtlas ? true
+, withEphemeris ? true
+, withMoonsEphemeris ? true
+}:
 stdenv.mkDerivation rec {
   pname = "astrolog";
   version = "7.30";
@@ -23,15 +27,30 @@ stdenv.mkDerivation rec {
       sha256 = "1mwvpvfk3lxjcc79zvwl4ypqzgqzipnc01cjldxrmx56xkc35zn7";
       stripRoot = false;
     };
+    moonsEphemeris = fetchzip {
+      url = "https://www.astrolog.org/ftp/ephem/moons/sepm.zip";
+      sha256 = "0labcidm8mrwvww93nwpp5738m9ff9q48cqzbgd18xny1jf6f8xd";
+      stripRoot = false;
+    };
     atlas = fetchurl {
       url = "http://astrolog.org/ftp/atlas/atlasbig.as";
-      sha256 = "1k8cy8gpcvkwkhyz248qhvrv5xiwp1n1s3b7rlz86krh7vzz01mp";
+      sha256 = "001bmqyldsbk4bdliqfl4a9ydrh1ff13wccvfniwaxlmvkridx2q";
     };
   in ''
     mkdir -p $out/bin $out/astrolog
-    cp -r ${ephemeris}/*.se1 $out/astrolog
     cp *.as $out/astrolog
     install astrolog $out/bin
+    ${lib.optionalString withBigAtlas "cp ${atlas} $out/astrolog/atlas.as"}
+    ${lib.optionalString withEphemeris ''
+      sed -i "/-Yi1/s#\".*\"#\"$out/ephemeris\"#" $out/astrolog/astrolog.as
+      mkdir -p $out/ephemeris
+      cp -r ${ephemeris}/*.se1 $out/ephemeris
+    ''}
+    ${lib.optionalString withMoonsEphemeris ''
+      sed -i "/-Yi1/s#\".*\"#\"$out/ephemeris\"#" $out/astrolog/astrolog.as
+      mkdir -p $out/ephemeris
+      cp -r ${moonsEphemeris}/*.se1 $out/ephemeris
+    ''}
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
