### PR TITLE
python3Packages.dearpygui: init at 1.1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1087,6 +1087,12 @@
     github = "attila-lendvai";
     githubId = 840345;
   };
+  augu5te = {
+    email = "olivier.richard@imag.fr";
+    github = "augu5te";
+    githubId = 2647100;
+    name = "Olivier Richard";
+  };
   auntie = {
     email = "auntieNeo@gmail.com";
     github = "auntieNeo";

--- a/pkgs/development/python-modules/dearpygui/default.nix
+++ b/pkgs/development/python-modules/dearpygui/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, stdenv
+, python
+, cmake
+, glfw3
+, libX11
+}:
+
+let
+  # DearPyGui is not synced with last stable Imgui's version.
+  imgui = fetchFromGitHub {
+    owner = "ocornut";
+    repo = "imgui";
+    rev = "1b435ae3e07ca813eb3ef40aaabe7053f5570fae";
+    sha256 = "sha256-4UqRKgwaERUz2GQdEZbGmWOj8tAaP+thSlaOBRt06Ho=";
+  };
+in
+buildPythonPackage rec {
+  pname = "DearPyGui";
+  version = "v1.1.3";
+
+  src = fetchFromGitHub {
+    owner = "hoffstadt";
+    repo = pname;
+    rev = version;
+    sha256 = "asJAHXg3bsP/6uimSIhfVeDzCEXA9F702YpYUYzsyMw=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ glfw3 libX11 ];
+
+  prePatch = ''
+    sed -i "/add_subdirectory(\"Dependencies\")/d" CMakeLists.txt
+    cp -r ${imgui}/* Dependencies/imgui
+  '';
+
+  # CMake needs to be run by setuptools rather than by its hook
+  dontUseCmakeConfigure = true;
+
+  meta = with lib; {
+    description = "Dear PyGui is an easy-to-use, dynamic, GPU-Accelerated, cross-platform graphical user interface toolkit(GUI) for Python. It is “built with” Dear ImGui.";
+    homepage = "https://github.com/hoffstadt/DearPyGui";
+    license = licenses.mit;
+    maintainers = with maintainers; [ augu5te ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2016,6 +2016,8 @@ in {
 
   deap = callPackage ../development/python-modules/deap { };
 
+  dearpygui = callPackage ../development/python-modules/dearpygui { };
+  
   debian = callPackage ../development/python-modules/debian { };
 
   debian-inspector = callPackage ../development/python-modules/debian-inspector { };


### PR DESCRIPTION
###### Motivation for this change

Add Dear PyGui Python module, an interface toolkit based on Imgui

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
