### PR TITLE
python38Packages.homeassistant: build homeassistant package (proposal)

### DIFF
--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -20,7 +20,10 @@
 , packageOverrides ? self: super: {}
 
 # Skip pip install of required packages on startup
-, skipPip ? true }:
+, skipPip ? true
+
+# Whether to build a python package instead of an application
+, buildPackage ? false }:
 
 let
   defaultOverrides = [
@@ -254,7 +257,7 @@ let
   # Don't forget to run parse-requirements.py after updating
   hassVersion = "2021.12.4";
 
-in with py.pkgs; buildPythonApplication rec {
+in with py.pkgs; (if buildPackage then buildPythonPackage else buildPythonApplication) rec {
   pname = "homeassistant";
   version = assert (componentPackages.version == hassVersion); hassVersion;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3656,6 +3656,11 @@ in {
 
   holoviews = callPackage ../development/python-modules/holoviews { };
 
+  homeassistant = callPackage ../servers/home-assistant {
+    buildPackage = true;
+    python3 = python;
+  };
+
   homeassistant-pyozw = callPackage ../development/python-modules/homeassistant-pyozw { };
 
   homeconnect = callPackage ../development/python-modules/homeconnect { };


### PR DESCRIPTION
This creates homeassistant as an importable package, to be used outside of the
home-assistant server package (for example in external custom components).

I have something similar in my NUR for building custom components, so I
thought it would be worth trying to upstream it.  I'm not sure if this is the cleanest
way to do it, but I experimented with some alternatives (e.g. using
`toPythonModule`) and this seemed to be the simplest option overall.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
