### PR TITLE
nixos/webhook: init

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -43,6 +43,14 @@
           <link xlink:href="options.html#opt-services.powerdns-admin.enable">services.powerdns-admin</link>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://github.com/adnanh/webhook">webhook</link>,
+          a lightweight incoming webhook server to run shell commands.
+          Available as
+          <link linkend="opt-services.webhook.enable">services.webhook</link>.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-22.05-incompatibilities">

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -14,6 +14,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [PowerDNS-Admin](https://github.com/ngoduykhanh/PowerDNS-Admin), a web interface for the PowerDNS server. Available at [services.powerdns-admin](options.html#opt-services.powerdns-admin.enable).
 
+- [webhook](https://github.com/adnanh/webhook), a lightweight incoming webhook server to run shell commands. Available as [services.webhook](#opt-services.webhook.enable).
+
 ## Backward Incompatibilities {#sec-release-22.05-incompatibilities}
 
 - `pkgs.ghc` now refers to `pkgs.targetPackages.haskellPackages.ghc`.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1071,6 +1071,7 @@
   ./services/web-servers/ttyd.nix
   ./services/web-servers/uwsgi.nix
   ./services/web-servers/varnish/default.nix
+  ./services/web-servers/webhook.nix
   ./services/web-servers/zope2.nix
   ./services/x11/extra-layouts.nix
   ./services/x11/clight.nix

--- a/nixos/modules/services/web-servers/webhook.nix
+++ b/nixos/modules/services/web-servers/webhook.nix
@@ -1,0 +1,91 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.webhook;
+  webhook = pkgs.webhook;
+  user = cfg.user;
+  group = cfg.group;
+  settingsFormat = pkgs.formats.json {};
+  configFile = settingsFormat.generate "webhook.json" cfg.settings;
+
+in {
+  options.services.webhook = {
+
+    enable = mkEnableOption "the webhook service";
+
+    user = mkOption {
+      default = "webhook";
+      description = "User webhook service runs as. Defaults to <literal>webhook</literal>.";
+      type = types.str;
+    };
+
+    group = mkOption {
+      default = "webhook";
+      description = "Group webhook service runs as. Defaults to <literal>webhook</literal>.";
+      type = types.str;
+    };
+
+    settings = mkOption {
+      description = "Webhook service settings.";
+      type = settingsFormat.type;
+      example = literalExpression ''
+        [{
+          id = "redeploy-webhook";
+          execute-command = "/var/scripts/redeploy.sh";
+          command-working-directory = "/var/webhook";
+        }]
+      '';
+    };
+
+    path = mkOption {
+      default = [];
+      description = "Which packages the service can access";
+      example = literalExpression ''
+        with pkgs; [ nixFlakes ]
+      '';
+      type = with types; listOf package;
+    };
+
+    extraOptions = mkOption {
+      default = [ "-verbose" ];
+      description = "Which flags to append to the command";
+      example = literalExpression ''
+        [ "-debug" "-port" 12345" ]
+      '';
+      type = with types; listOf str;
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    systemd.services.webhook = {
+      description = "Webhook service";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      path = cfg.path;
+      serviceConfig = {
+        Type = "simple";
+        User = user;
+        Group = group;
+        WorkingDirectory = "${webhook}";
+        ExecStart = ''
+          ${webhook}/bin/webhook -hooks ${configFile} ${lib.concatMapStringsSep " " builtins.toJSON cfg.extraOptions}
+        '';
+      };
+    };
+
+    users = {
+      users.webhook = mkIf (cfg.user == "webhook") {
+        isSystemUser = true;
+        inherit group;
+      };
+      groups.webhook = mkIf (cfg.group == "webhook") {};
+    };
+
+  };
+
+  meta.maintainers = with maintainers; [ ymarkus ];
+}

--- a/nixos/tests/webhook.nix
+++ b/nixos/tests/webhook.nix
@@ -1,0 +1,35 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "webhook";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ ymarkus ];
+  };
+
+  nodes = {
+    webserver = { pkgs, lib, ... }: {
+      services.webhook =
+      let
+        command = pkgs.writeScript "startDeployTimer" ''
+          #! ${pkgs.runtimeShell}
+          touch /tmp/testWebhook
+        '';
+      in {
+        enable = true;
+        settings = [{
+          id = "testWebhook";
+          execute-command = "${command}";
+        }];
+        user = "root";
+      };
+    };
+  };
+
+  testScript = { ... }: ''
+    url = "http://localhost:9000/hooks/testWebhook"
+    webserver.wait_for_unit("webhook")
+    webserver.wait_for_open_port("9000")
+
+    webserver.succeed("curl -fvvv -s http://localhost:9000/hooks/testWebhook")
+    webserver.succeed("cat /tmp/testWebhook")
+  '';
+
+})


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
add module for webhook package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
