### PR TITLE
Add/fix darwin support for various virt-manager dependencies

### DIFF
--- a/pkgs/data/misc/osinfo-db/default.nix
+++ b/pkgs/data/misc/osinfo-db/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.com/libosinfo/osinfo-db/";
     changelog = "https://gitlab.com/libosinfo/osinfo-db/-/commits/v${version}";
     license = licenses.gpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ maintainers.bjornfor ];
   };
 }

--- a/pkgs/development/libraries/libosinfo/default.nix
+++ b/pkgs/development/libraries/libosinfo/default.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
     homepage = "https://libosinfo.org/";
     changelog = "https://gitlab.com/libosinfo/libosinfo/-/blob/v${version}/NEWS";
     license = licenses.lgpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ maintainers.bjornfor ];
   };
 }

--- a/pkgs/development/libraries/libvirt-glib/default.nix
+++ b/pkgs/development/libraries/libvirt-glib/default.nix
@@ -46,10 +46,11 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    libcap_ng
     libvirt
     libxml2
     gobject-introspection
+  ] ++ lib.optionals stdenv.isLinux [
+    libcap_ng
   ];
 
   strictDeps = true;
@@ -66,6 +67,6 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://libvirt.org/";
     license = licenses.lgpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -140,7 +140,9 @@ stdenv.mkDerivation rec {
     # delete only the first occurrence of this
     sed -i '0,/qemuxml2argvtest/{/qemuxml2argvtest/d;}' tests/meson.build
   '' + optionalString isDarwin ''
-    sed -i '/qemucapabilitiestest/d' tests/meson.build
+    sed -i tests/meson.build \
+      -e '/qemucapabilitiestest/d' \
+      -e '/vircryptotest/d'
   '';
 
 

--- a/pkgs/development/libraries/usbredir/default.nix
+++ b/pkgs/development/libraries/usbredir/default.nix
@@ -48,6 +48,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.spice-space.org/usbredir.html";
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ offline ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/vte/default.nix
+++ b/pkgs/development/libraries/vte/default.nix
@@ -78,6 +78,8 @@ stdenv.mkDerivation rec {
 
   mesonFlags = lib.optionals (!systemdSupport) [
     "-D_systemd=false"
+  ] ++ lib.optionals stdenv.isDarwin [
+    "-D_b_symbolic_functions=false"
   ];
 
   postPatch = ''

--- a/pkgs/servers/pulseaudio/default.nix
+++ b/pkgs/servers/pulseaudio/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, fetchpatch, pkg-config
 , libsndfile, libtool, makeWrapper, perlPackages
 , xorg, libcap, alsa-lib, glib, dconf
-, avahi, libjack2, libasyncns, lirc, dbus
+, avahi, libjack2, libasyncns, lirc, libintl, dbus
 , sbc, bluez5, udev, openssl, fftwFloat
 , soxr, speexdsp, systemd, webrtc-audio-processing
 , check, meson, ninja, m4
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ libtool libsndfile soxr speexdsp fftwFloat check ]
     ++ lib.optionals stdenv.isLinux [ glib dbus ]
-    ++ lib.optionals stdenv.isDarwin [ AudioUnit Cocoa CoreServices ]
+    ++ lib.optionals stdenv.isDarwin [ AudioUnit Cocoa CoreServices libintl ]
     ++ lib.optionals (!libOnly) (
       [ libasyncns webrtc-audio-processing ]
       ++ lib.optional jackaudioSupport libjack2

--- a/pkgs/tools/admin/gtk-vnc/default.nix
+++ b/pkgs/tools/admin/gtk-vnc/default.nix
@@ -67,6 +67,6 @@ stdenv.mkDerivation rec {
     homepage = "https://wiki.gnome.org/Projects/gtk-vnc";
     license = licenses.lgpl2Plus;
     maintainers = with maintainers; [ raskin offline ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/misc/osinfo-db-tools/default.nix
+++ b/pkgs/tools/misc/osinfo-db-tools/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     homepage = "https://libosinfo.org/";
     changelog = "https://gitlab.com/libosinfo/osinfo-db-tools/-/blob/v${version}/NEWS";
     license = licenses.lgpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ maintainers.bjornfor ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I am planning to get virt-manager up and running on Darwin.

Supersedes bunch of changes in stale-ish PRs:
- #113306
- #128767

Depends on:
- #152371 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
