### PR TITLE
commit format: add optional footer to indicate breaking changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,5 +33,5 @@ Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-
   - [ ] (Module updates) Added a release notes entry if the change is significant
   - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
   - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
-  - [ ] (Breaking change) Added a `breaks things:` footer to each commit that breaks compatibility (see [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#submitting-changes))
+  - [ ] (Breaking change) Added a `breaks things:` footer to each commit that breaks compatibility (see [Submitting changes](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#submitting-changes))
 - [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,4 +33,5 @@ Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-
   - [ ] (Module updates) Added a release notes entry if the change is significant
   - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
   - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
+  - [ ] (Breaking change) Added a `breaks things:` footer to each commit that breaks compatibility (see [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#submitting-changes))
 - [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,8 @@ under the terms of [COPYING](COPYING), which is an MIT-like license.
   (pkg-name | nixos/<module>): (from -> to | init at version | refactor | etc)
 
   (Motivation for change. Additional information.)
+
+  (breaks things: <A brief description of what breakage is introduced.>)
   ```
 
   For consistency, there should not be a period at the end of the commit message's summary line (the first line of the commit message).


### PR DESCRIPTION
###### Motivation for this change
suggested by @joepie91 on matrix,
breaking changes are often unreported
this would give authors of commits, and authors of the release notes
a way to ensure breaking changes don't get missed

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
