### PR TITLE
python3Packages.tensorly: 0.4.5 -> 0.7.0

### DIFF
--- a/pkgs/development/python-modules/tensorly/default.nix
+++ b/pkgs/development/python-modules/tensorly/default.nix
@@ -1,44 +1,35 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pytest
-, nose
+, pytestCheckHook
 , isPy27
 , numpy
 , scipy
 , sparse
-, pytorch
 }:
 
 buildPythonPackage rec {
   pname = "tensorly";
-  version = "0.4.5";
+  version = "0.7.0";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "1ml91yaxwx4msisxbm92yf22qfrscvk58f3z2r1jhi96pw2k4i7x";
+    sha256 = "VcX3pCczZQUYZaD7xrrkOcj0QPJt28cYTwpZm5D/X3c=";
   };
 
-  propagatedBuildInputs = [ numpy scipy sparse ]
-    ++ lib.optionals (!doCheck) [ nose ]; # upstream added nose to install_requires
-
-  checkInputs = [ pytest nose pytorch ];
-  # also has a cupy backend, but the tests are currently broken
-  # (e.g. attempts to access cupy.qr instead of cupy.linalg.qr)
-  # and this backend also adds a non-optional CUDA dependence,
-  # as well as tensorflow and mxnet backends, but the tests don't
-  # seem to exercise these backend by default
-
-  # uses >= 140GB of ram to test
-  doCheck = false;
-  checkPhase = ''
-    runHook preCheck
-    nosetests -e "test_cupy"
-    runHook postCheck
+  # nose is not actually required for anything
+  # (including testing with the minimal dependencies)
+  postPatch = ''
+    substituteInPlace setup.py --replace ", 'nose'" ""
   '';
+
+  propagatedBuildInputs = [ numpy scipy sparse ];
+
+  checkInputs = [ pytestCheckHook ];
+  pytestFlagsArray = [ "tensorly" ];
 
   pythonImportsCheck = [ "tensorly" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Routine update; clean up dependencies; re-enable tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [NA] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [NA] (Module updates) Added a release notes entry if the change is significant
  - [NA] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
