### PR TITLE
 python3Packages.pydicom: 2.1.2 -> 2.2.2, python3Packages.pynetdicom: 2.0.0 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/pydicom/default.nix
+++ b/pkgs/development/python-modules/pydicom/default.nix
@@ -11,13 +11,13 @@
 
 let
   pname = "pydicom";
-  version = "2.1.2";
+  version = "2.2.2";
 
   src = fetchFromGitHub {
     owner = "${pname}";
     repo = "${pname}";
     rev = "v${version}";
-    sha256 = "sha256-iExy+mUs1uqs/u9N6btlqyP6/TvoPVsuOuzs56zZAS8=";
+    sha256 = "sha256-p5hJAUsactv6UEvbVaF+zk4iapx98eYkC9Zo+lzFATA=";
   };
 
   # Pydicom needs pydicom-data to run some tests. If these files aren't downloaded
@@ -34,9 +34,15 @@ buildPythonPackage {
   inherit pname version src;
   disabled = pythonOlder "3.6";
 
-  propagatedBuildInputs = [ numpy pillow setuptools ];
+  propagatedBuildInputs = [
+    numpy
+    pillow
+    setuptools
+  ];
 
-  checkInputs = [ pytestCheckHook ];
+  checkInputs = [
+    pytestCheckHook
+  ];
 
   # Setting $HOME to prevent pytest to try to create a folder inside
   # /homeless-shelter which is read-only.
@@ -58,9 +64,13 @@ buildPythonPackage {
     "test_time_check"
   ];
 
+  pythonImportsCheck = [
+    "pydicom"
+  ];
+
   meta = with lib; {
+    description = "Python package for working with DICOM files";
     homepage = "https://pydicom.github.io";
-    description = "Pure-Python package for working with DICOM files";
     license = licenses.mit;
     maintainers = with maintainers; [ bcdarwin ];
   };

--- a/pkgs/development/python-modules/pynetdicom/default.nix
+++ b/pkgs/development/python-modules/pynetdicom/default.nix
@@ -6,17 +6,21 @@
 , pyfakefs
 , pytestCheckHook
 , sqlalchemy
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "pynetdicom";
-  version = "1.5.7";
+  version = "2.0.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "pydicom";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0wr6nh0xrhzwf05gnf3dwg5r3lhn9nfwch3l16zkbj6fli871brc";
+    sha256 = "sha256-Kfcfk76au2ymbX+nl0PhuuCd+t6dYRbTurGlW6msv3Y=";
   };
 
   propagatedBuildInputs = [
@@ -33,6 +37,7 @@ buildPythonPackage rec {
     # Some tests needs network capabilities
     "test_str_types_empty"
     "test_associate_reject"
+    "TestAEGoodAssociation"
     "TestEchoSCP"
     "TestEchoSCPCLI"
     "TestFindSCP"
@@ -50,7 +55,9 @@ buildPythonPackage rec {
     "TestState"
   ];
 
-  pythonImportsCheck = [ "pynetdicom" ];
+  pythonImportsCheck = [
+    "pynetdicom"
+  ];
 
   meta = with lib; {
     description = "Python implementation of the DICOM networking protocol";

--- a/pkgs/tools/security/expliot/default.nix
+++ b/pkgs/tools/security/expliot/default.nix
@@ -22,8 +22,6 @@ buildPythonApplication rec {
   pname = "expliot";
   version = "0.9.8";
 
-  disabled = python3.pythonOlder "3.7";
-
   src = fetchFromGitLab {
     owner = "expliot_framework";
     repo = pname;
@@ -50,10 +48,18 @@ buildPythonApplication rec {
     zeroconf
   ];
 
+  postPatch = ''
+    # https://gitlab.com/expliot_framework/expliot/-/merge_requests/113
+    substituteInPlace setup.py \
+      --replace "pynetdicom>=1.5.1,<2" "pynetdicom>=2,<3"
+  '';
+
   # Project has no tests
   doCheck = false;
 
-  pythonImportsCheck = [ "expliot" ];
+  pythonImportsCheck = [
+    "expliot"
+  ];
 
   meta = with lib; {
     description = "IoT security testing and exploitation framework";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/pydicom/pydicom/releases/tag/v2.2.2

https://github.com/pydicom/pynetdicom/releases/tag/v2.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
