### PR TITLE
buildGraalvmNativeImage: fix meta

### DIFF
--- a/pkgs/build-support/build-graalvm-native-image/default.nix
+++ b/pkgs/build-support/build-graalvm-native-image/default.nix
@@ -21,6 +21,7 @@
 , graalvmXmx ? "-J-Xmx6g"
   # The GraalVM to use
 , graalvm ? graalvmCEPackages.graalvm11-ce
+, meta ? { }
 , ...
 } @ args:
 
@@ -47,6 +48,10 @@ stdenv.mkDerivation (args // {
     runHook postInstall
   '';
 
-  meta.platforms = lib.attrByPath [ "meta" "platforms" ] graalvm.meta.platforms args;
-  meta.mainProgram = lib.attrByPath [ "meta" "mainProgram" ] executable args;
+  meta = {
+    # default to graalvm's platforms
+    platforms = graalvm.meta.platforms;
+    # default to executable name
+    mainProgram = executable;
+  } // meta;
 })

--- a/pkgs/development/tools/clj-kondo/default.nix
+++ b/pkgs/development/tools/clj-kondo/default.nix
@@ -18,7 +18,7 @@ buildGraalvmNativeImage rec {
     description = "A linter for Clojure code that sparks joy";
     homepage = "https://github.com/clj-kondo/clj-kondo";
     license = licenses.epl10;
-    changelog = "https://github.com/clj-kondo/clj-kondo/blob/v${versiont}/CHANGELOG.md";
+    changelog = "https://github.com/clj-kondo/clj-kondo/blob/v${version}/CHANGELOG.md";
     maintainers = with maintainers; [ jlesquembre bandresen thiagokokada ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

All packages using this functions is currently missing all meta information except `meta.platforms` and `meta.mainProgram`. This PR fixes it.

Example of the issue: https://github.com/NixOS/nixpkgs/pull/150331

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
