### PR TITLE
[21.11] ptcollab: Unbreak on Darwin, 0.5.0.1 -> 0.5.0.3

### DIFF
--- a/pkgs/applications/audio/ptcollab/default.nix
+++ b/pkgs/applications/audio/ptcollab/default.nix
@@ -2,6 +2,7 @@
 , lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , qmake
 , pkg-config
@@ -22,9 +23,30 @@ mkDerivation rec {
     sha256 = "10v310smm0df233wlh1kqv8i36lsg1m36v0flrhs2202k50d69ri";
   };
 
+  patches = [
+    # Lifts macOS version restriction
+    # Remove when version > 0.5.0.1
+    (fetchpatch {
+      name = "0001-ptcollab-lift-10.14-deployment-target-limitation.patch";
+      url = "https://github.com/yuxshao/ptcollab/commit/a9664b5953e1046e1f7da3b38744f33a7ff0ea24.patch";
+      sha256 = "0qgpv5hmb4504kamdgxalrhc4zb9rdxln23s7qwc7ikafg54h1fm";
+    })
+  ];
+
   nativeBuildInputs = [ qmake pkg-config ];
 
   buildInputs = [ qtbase qtmultimedia libvorbis rtmidi ];
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # Move appbundles to Applications before wrapping happens
+    mkdir $out/Applications
+    mv $out/{bin,Applications}/ptcollab.app
+  '';
+
+  postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # Link to now-wrapped binary inside appbundle
+    ln -s $out/{Applications/ptcollab.app/Contents/MacOS,bin}/ptcollab
+  '';
 
   passthru = {
     updateScript = nix-update-script {
@@ -38,7 +60,5 @@ mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ OPNA2608 ];
     platforms = platforms.all;
-    # Requires Qt5.15
-    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/applications/audio/ptcollab/default.nix
+++ b/pkgs/applications/audio/ptcollab/default.nix
@@ -2,7 +2,6 @@
 , lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , nix-update-script
 , qmake
 , pkg-config
@@ -14,24 +13,14 @@
 
 mkDerivation rec {
   pname = "ptcollab";
-  version = "0.5.0.1";
+  version = "0.5.0.3";
 
   src = fetchFromGitHub {
     owner = "yuxshao";
     repo = "ptcollab";
     rev = "v${version}";
-    sha256 = "10v310smm0df233wlh1kqv8i36lsg1m36v0flrhs2202k50d69ri";
+    sha256 = "sha256-8bgi621psvUlhiLyZ15tKGmGOs6HTf5/6Ru2Z9l8QIo=";
   };
-
-  patches = [
-    # Lifts macOS version restriction
-    # Remove when version > 0.5.0.1
-    (fetchpatch {
-      name = "0001-ptcollab-lift-10.14-deployment-target-limitation.patch";
-      url = "https://github.com/yuxshao/ptcollab/commit/a9664b5953e1046e1f7da3b38744f33a7ff0ea24.patch";
-      sha256 = "0qgpv5hmb4504kamdgxalrhc4zb9rdxln23s7qwc7ikafg54h1fm";
-    })
-  ];
 
   nativeBuildInputs = [ qmake pkg-config ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24078,7 +24078,7 @@ with pkgs;
 
   milkytracker = callPackage ../applications/audio/milkytracker { };
 
-  ptcollab = libsForQt5.callPackage ../applications/audio/ptcollab { };
+  ptcollab = libsForQt515.callPackage ../applications/audio/ptcollab { };
 
   schismtracker = callPackage ../applications/audio/schismtracker { };
 


### PR DESCRIPTION
###### Motivation for this change
Backports of #151926 & #152274.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
