### PR TITLE
gramps: fix map view

### DIFF
--- a/pkgs/applications/misc/gramps/default.nix
+++ b/pkgs/applications/misc/gramps/default.nix
@@ -1,7 +1,7 @@
 { lib, fetchFromGitHub, gtk3, pythonPackages, intltool, gexiv2,
   pango, gobject-introspection, wrapGAppsHook, gettext,
 # Optional packages:
- enableOSM ? true, osm-gps-map,
+ enableOSM ? true, osm-gps-map, glib-networking,
  enableGraphviz ? true, graphviz,
  enableGhostscript ? true, ghostscript
  }:
@@ -15,7 +15,7 @@ in buildPythonApplication rec {
   nativeBuildInputs = [ wrapGAppsHook intltool gettext ];
   buildInputs = [ gtk3 gobject-introspection pango gexiv2 ]
     # Map support
-    ++ lib.optional enableOSM osm-gps-map
+    ++ lib.optionals enableOSM [ osm-gps-map glib-networking ]
     # Graphviz support
     ++ lib.optional enableGraphviz graphviz
     # Ghostscript support


### PR DESCRIPTION
###### Motivation for this change

The OSM map view in `gramps` does not work due to  missing dependency.

To reproduce: start `gramps`, do not load a family tree, select the "Geography" panel, try to load new places on the map (it might use tiles from cache). No (new) tiles are loaded and `gramps` outputs a warning message to the terminal:

```
(.gramps-wrapped:1042320): OsmGpsMap-WARNING **: 00:07:59.851: Error downloading tile: 6 - TLS/SSL support not available; install glib-networking
```

Fix in this PR: conditionally add a `glib-networking` dependency if OSM map support is enabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
