### PR TITLE
wapiti: 3.0.7 -> 3.0.9

### DIFF
--- a/pkgs/development/python-modules/humanize/default.nix
+++ b/pkgs/development/python-modules/humanize/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
-, fetchPypi
-, isPy27
+, fetchFromGitHub
+, pythonOlder
 , setuptools-scm
 , setuptools
 , pytestCheckHook
@@ -9,18 +9,33 @@
 }:
 
 buildPythonPackage rec {
-  version = "3.12.0";
+  version = "3.13.1";
   pname = "humanize";
-  disabled = isPy27; # setup.py no longer compatible
+  format = "pyproject";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "5ec1a66e230a3e31fb3f184aab9436ea13d4e37c168e0ffc345ae5bb57e58be6";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "jmoiron";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-lgGBvYb3ciqETBOR31gxQVD7YyopTtmr++nCwvm63Zs=";
   };
 
-  nativeBuildInputs = [ setuptools-scm ];
-  propagatedBuildInputs = [ setuptools ];
-  checkInputs = [ pytestCheckHook freezegun ];
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    setuptools
+  ];
+
+  checkInputs = [
+    freezegun
+    pytestCheckHook
+  ];
 
   meta = with lib; {
     description = "Python humanize utilities";

--- a/pkgs/tools/security/wapiti/default.nix
+++ b/pkgs/tools/security/wapiti/default.nix
@@ -5,13 +5,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "wapiti";
-  version = "3.0.7";
+  version = "3.0.9";
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "wapiti-scanner";
     repo = pname;
     rev = version;
-    sha256 = "0kya9a2zs1c518z4p34pfjx2sms6843gh3c9qc9zvk4lr4g7hw3x";
+    sha256 = "sha256-olqPM8EQ8LxQQM7kqcjbT9RMdBeYdhfn6Qp6BUu8K5Q=";
   };
 
   nativeBuildInputs = with python3.pkgs; [
@@ -22,17 +23,20 @@ python3.pkgs.buildPythonApplication rec {
     aiocache
     aiosqlite
     beautifulsoup4
+    brotli
     browser-cookie3
     cryptography
     dnspython
     httpx
     httpx-ntlm
     httpx-socks
+    humanize
     loguru
     Mako
     markupsafe
     pysocks
     six
+    sslyze
     sqlalchemy
     tld
     yaswfp
@@ -49,16 +53,8 @@ python3.pkgs.buildPythonApplication rec {
   postPatch = ''
     # Ignore pinned versions
     substituteInPlace setup.py \
-      --replace "httpx-socks[asyncio] == 0.5.1" "httpx-socks[asyncio]" \
-      --replace "markupsafe==1.1.1" "markupsafe" \
-      --replace "importlib_metadata==3.7.2" "importlib_metadata" \
-      --replace "browser-cookie3==0.11.4" "browser-cookie3" \
-      --replace "cryptography==3.3.2" "cryptography" \
-      --replace "httpx[brotli]==0.20.0" "httpx" \
-      --replace "sqlalchemy>=1.4.26" "sqlalchemy" \
-      --replace "aiocache==0.11.1" "aiocache" \
-      --replace "aiosqlite==0.17.0" "aiosqlite" \
-      --replace "dnspython==2.1.0" "dnspython"
+      --replace "httpx-socks[asyncio] == 0.6.0" "httpx-socks[asyncio]"
+    sed -i -e "s/==[0-9.]*//" setup.py
     substituteInPlace setup.cfg \
       --replace " --cov --cov-report=xml" ""
   '';
@@ -103,6 +99,7 @@ python3.pkgs.buildPythonApplication rec {
     "test_request_object"
     "test_script"
     "test_ssrf"
+    "test_merge_with_and_without_redirection"
     "test_tag_name_escape"
     "test_timeout"
     "test_title_false_positive"
@@ -121,7 +118,7 @@ python3.pkgs.buildPythonApplication rec {
     # Requires a PHP installation
     "test_timesql"
     "test_cookies"
-    # E           TypeError: Expected bytes or bytes-like object got: <class 'str'>
+    # TypeError: Expected bytes or bytes-like object got: <class 'str'>
     "test_persister_upload"
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/wapiti-scanner/wapiti/blob/master/doc/ChangeLog_Wapiti

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
