### PR TITLE
enlightenment.enlightenment: 0.24.2 -> 0.25.0

### DIFF
--- a/pkgs/desktops/enlightenment/efl/default.nix
+++ b/pkgs/desktops/enlightenment/efl/default.nix
@@ -56,11 +56,11 @@
 
 stdenv.mkDerivation rec {
   pname = "efl";
-  version = "1.25.1";
+  version = "1.26.0";
 
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/libs/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "0svybbrvpf6q955y6fclxh3md64z0dgmh0x54x2j60503hhs071m";
+    sha256 = "0k10mwpdjn57r2kflbzpybhvwl25yqqa2i2fhx0qazyjbzjbrad4";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/enlightenment/enlightenment/0001-wrapped-setuid-executables.patch
+++ b/pkgs/desktops/enlightenment/enlightenment/0001-wrapped-setuid-executables.patch
@@ -1,4 +1,4 @@
-From a1e54ae0097a3b6a0dabf4639fe8bc594c4f602d Mon Sep 17 00:00:00 2001
+From 2c563889fcad37df4ee4251bf0a63316d8b7b612 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jos=C3=A9=20Romildo=20Malaquias?= <malaquias@gmail.com>
 Date: Thu, 14 May 2020 16:36:34 -0300
 Subject: [PATCH] wrapped setuid executables
@@ -11,9 +11,9 @@ instead.
  meson/meson_inst.sh           | 4 ++--
  src/bin/e_auth.c              | 6 ++----
  src/bin/e_fm/e_fm_main_eeze.c | 6 +++---
- src/bin/e_start_main.c        | 2 +-
+ src/bin/e_start_main.c        | 3 +--
  src/bin/e_system.c            | 2 +-
- 5 files changed, 9 insertions(+), 11 deletions(-)
+ 5 files changed, 9 insertions(+), 12 deletions(-)
 
 diff --git a/meson/meson_inst.sh b/meson/meson_inst.sh
 index 321143e40..cd2399306 100755
@@ -29,11 +29,11 @@ index 321143e40..cd2399306 100755
 +	echo TODO: chmod a=rx,u+xs "$DESTDIR/$x"
  done
 diff --git a/src/bin/e_auth.c b/src/bin/e_auth.c
-index 8b0aa6641..63c68c4bc 100644
+index 6d07a0ac3..d519f0649 100644
 --- a/src/bin/e_auth.c
 +++ b/src/bin/e_auth.c
-@@ -12,8 +12,7 @@ e_auth_begin(char *passwd)
-    if (pwlen == 0) goto out;
+@@ -38,8 +38,7 @@ e_auth_begin(char *passwd)
+    pwlen = strlen(passwd);
  
     snprintf(buf, sizeof(buf),
 -            "%s/enlightenment/utils/enlightenment_ckpasswd pw",
@@ -41,9 +41,9 @@ index 8b0aa6641..63c68c4bc 100644
 +            "/run/wrappers/bin/enlightenment_ckpasswd pw");
     exe = ecore_exe_pipe_run(buf, ECORE_EXE_PIPE_WRITE, NULL);
     if (!exe) goto out;
-    if (ecore_exe_send(exe, passwd, pwlen) != EINA_TRUE) goto out;
-@@ -47,8 +46,7 @@ e_auth_polkit_begin(char *passwd, const char *cookie, unsigned int uid)
-    if (pwlen == 0) goto out;
+    snprintf(buf, sizeof(buf), "pw %s", passwd);
+@@ -75,8 +74,7 @@ e_auth_polkit_begin(char *passwd, const char *cookie, unsigned int uid)
+    pwlen = strlen(passwd);
  
     snprintf(buf, sizeof(buf),
 -            "%s/enlightenment/utils/enlightenment_ckpasswd pk",
@@ -84,23 +84,24 @@ index 9b10b3117..0f0aa5b53 100644
       }
     v->guard = ecore_timer_loop_add(E_FM_MOUNT_TIMEOUT, (Ecore_Task_Cb)_e_fm_main_eeze_vol_mount_timeout, v);
 diff --git a/src/bin/e_start_main.c b/src/bin/e_start_main.c
-index 8534a7a8e..f0f0061a4 100644
+index 722063339..ee85aa9f1 100644
 --- a/src/bin/e_start_main.c
 +++ b/src/bin/e_start_main.c
-@@ -709,7 +709,7 @@ main(int argc, char **argv)
-             "E_ALERT_FONT_DIR=%s/data/fonts", eina_prefix_data_get(pfx));
+@@ -596,8 +596,7 @@ main(int argc, char **argv)
+               eina_prefix_data_get(pfx));
     putenv(buf2);
-    snprintf(buf3, sizeof(buf3),
--            "E_ALERT_SYSTEM_BIN=%s/enlightenment/utils/enlightenment_system", eina_prefix_lib_get(pfx));
-+            "E_ALERT_SYSTEM_BIN=/run/wrappers/bin/enlightenment_system");
+    myasprintf(&buf3,
+-              "E_ALERT_SYSTEM_BIN=%s/enlightenment/utils/enlightenment_system",
+-              eina_prefix_lib_get(pfx));
++              "E_ALERT_SYSTEM_BIN=/run/wrappers/bin/enlightenment_system");
     putenv(buf3);
  
-    if ((valgrind_mode || valgrind_tool) &&
+    home = getenv("HOME");
 diff --git a/src/bin/e_system.c b/src/bin/e_system.c
-index 1e7aabb64..5084933a1 100644
+index bfd43e7e2..6bf48e31f 100644
 --- a/src/bin/e_system.c
 +++ b/src/bin/e_system.c
-@@ -132,7 +132,7 @@ _system_spawn(void)
+@@ -133,7 +133,7 @@ _system_spawn(void)
     else _respawn_count = 0;
     if (_respawn_count > 5) return;
     snprintf(buf, sizeof(buf),
@@ -110,5 +111,5 @@ index 1e7aabb64..5084933a1 100644
       (buf, ECORE_EXE_NOT_LEADER | ECORE_EXE_TERM_WITH_PARENT |
        ECORE_EXE_PIPE_READ | ECORE_EXE_PIPE_WRITE, NULL);
 -- 
-2.26.2
+2.34.0
 

--- a/pkgs/desktops/enlightenment/enlightenment/default.nix
+++ b/pkgs/desktops/enlightenment/enlightenment/default.nix
@@ -9,6 +9,7 @@
 , bc
 , ddcutil
 , efl
+, libexif
 , pam
 , xkeyboard_config
 , udisks2
@@ -20,11 +21,11 @@
 
 stdenv.mkDerivation rec {
   pname = "enlightenment";
-  version = "0.24.2";
+  version = "0.25.0";
 
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/apps/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "1wfz0rwwsx7c1mkswn4hc9xw1i6bsdirhxiycf7ha2vcipqy465y";
+    sha256 = "01nzyvjy06043m01fdb1309xx3wxxg0s3hj9g9di7jjsxp774vkx";
   };
 
   nativeBuildInputs = [
@@ -40,6 +41,7 @@ stdenv.mkDerivation rec {
     bc # for the Everything module calculator mode
     ddcutil # specifically libddcutil.so.2 for backlight control
     efl
+    libexif
     pam
     xkeyboard_config
     udisks2 # for removable storage mounting/unmounting

--- a/pkgs/desktops/enlightenment/ephoto/default.nix
+++ b/pkgs/desktops/enlightenment/ephoto/default.nix
@@ -1,30 +1,36 @@
-{ lib, stdenv, fetchurl, pkg-config, efl, pcre, mesa, makeWrapper }:
+{ lib
+, stdenv
+, fetchurl
+, meson
+, ninja
+, pkg-config
+, efl
+}:
 
 stdenv.mkDerivation rec {
   pname = "ephoto";
-  version = "1.5";
+  version = "1.6.0";
 
   src = fetchurl {
-    url = "http://www.smhouston.us/stuff/${pname}-${version}.tar.gz";
-    sha256 = "09kraa5zz45728h2dw1ssh23b87j01bkfzf977m48y1r507sy3vb";
+    url = "http://download.enlightenment.org/rel/apps/${pname}/${pname}-${version}.tar.xz";
+    sha256 = "1lvhcs4ba8h3z78nyycbww8mj4cscb8k200dcc3cdy8vrvrp7g1n";
   };
 
   nativeBuildInputs = [
+    meson
+    ninja
     pkg-config
-    mesa.dev # otherwise pkg-config does not find gbm
-    makeWrapper
   ];
 
   buildInputs = [
     efl
-    pcre
   ];
 
-  meta = {
+  meta = with lib; {
     description = "Image viewer and editor written using the Enlightenment Foundation Libraries";
-    homepage = "https://smhouston.us/projects/ephoto/";
-    license = lib.licenses.bsd2;
-    platforms = lib.platforms.linux;
-    maintainers = [ lib.maintainers.romildo ];
+    homepage = "https://www.smhouston.us/ephoto/";
+    license = licenses.bsd2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
   };
 }

--- a/pkgs/desktops/enlightenment/evisum/default.nix
+++ b/pkgs/desktops/enlightenment/evisum/default.nix
@@ -1,12 +1,19 @@
-{ lib, stdenv, fetchurl, meson, ninja, pkg-config, efl }:
+{ lib
+, stdenv
+, fetchurl
+, meson
+, ninja
+, pkg-config
+, efl
+}:
 
 stdenv.mkDerivation rec {
   pname = "evisum";
-  version = "0.5.13";
+  version = "0.6.0";
 
   src = fetchurl {
     url = "https://download.enlightenment.org/rel/apps/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-TMVxx7D9wdujyN6PcbIxC8M6zby5myvxO9AqolrcWOY=";
+    sha256 = "1ip3rmp0hcn0pk6lv089cayx18p1b2wycgvwpnf7ghbdxg7n4q15";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/enlightenment/rage/default.nix
+++ b/pkgs/desktops/enlightenment/rage/default.nix
@@ -1,19 +1,27 @@
-{ lib, stdenv, fetchurl, meson, ninja, pkg-config, efl, gst_all_1, pcre, mesa, wrapGAppsHook }:
+{ lib
+, stdenv
+, fetchurl
+, meson
+, ninja
+, pkg-config
+, efl
+, gst_all_1
+, wrapGAppsHook
+}:
 
 stdenv.mkDerivation rec {
   pname = "rage";
-  version = "0.3.1";
+  version = "0.4.0";
 
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/apps/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "04fdk23bbgvni212zrfy4ndg7vmshbsjgicrhckdvhay87pk9i75";
+    sha256 = "03yal7ajh57x2jhmygc6msf3gzvqkpmzkqzj6dnam5sim8cq9rbw";
   };
 
   nativeBuildInputs = [
     meson
     ninja
     pkg-config
-    mesa.dev
     wrapGAppsHook
   ];
 
@@ -24,14 +32,13 @@ stdenv.mkDerivation rec {
     gst_all_1.gst-plugins-good
     gst_all_1.gst-plugins-bad
     gst_all_1.gst-libav
-    pcre
   ];
 
-  meta = {
-    description = "Video + Audio player along the lines of mplayer";
+  meta = with lib; {
+    description = "Video and audio player along the lines of mplayer";
     homepage = "https://enlightenment.org/";
-    maintainers = with lib.maintainers; [ matejc ftrvxmtrx romildo ];
-    platforms = lib.platforms.linux;
-    license = lib.licenses.bsd2;
+    license = licenses.bsd2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ matejc ftrvxmtrx romildo ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- enlightenment.enlightenment: 0.24.2 -> [0.25.0](https://www.enlightenment.org/news/2021-12-26-enlightenment-0.25.0)
- enlightenment.evisum: 0.5.13 -> [0.6.0](https://www.enlightenment.org/news/2021-12-26-evisum-0.6.0)
- enlightenment.rage: 0.3.1 -> [0.4.0](https://www.enlightenment.org/news/2021-12-26-rage-0.4.0)
- enlightenment.ephoto: 1.5 -> [1.6.0](https://www.enlightenment.org/news/2021-12-26-ephoto-1.6.0)
- enlightenment.efl: 1.25.1 -> [1.26.0](https://www.enlightenment.org/news/2021-12-26-efl-1.26.0)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
