### PR TITLE
bcc: fix aarch64 test 

### DIFF
--- a/pkgs/os-specific/linux/bcc/absolute-ausyscall.patch
+++ b/pkgs/os-specific/linux/bcc/absolute-ausyscall.patch
@@ -1,0 +1,43 @@
+From 01e793163231c5085afced37471df32b94a313f5 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
+Date: Thu, 30 Dec 2021 06:34:41 +0100
+Subject: [PATCH] absolute ausyscall
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
+---
+ libbpf-tools/syscall_helpers.c | 2 +-
+ src/python/bcc/syscall.py      | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libbpf-tools/syscall_helpers.c b/libbpf-tools/syscall_helpers.c
+index e114a08f..62adea78 100644
+--- a/libbpf-tools/syscall_helpers.c
++++ b/libbpf-tools/syscall_helpers.c
+@@ -47,7 +47,7 @@ void init_syscall_names(void)
+ 	int err;
+ 	FILE *f;
+ 
+-	f = popen("ausyscall --dump 2>/dev/null", "r");
++	f = popen("@ausyscall@ --dump 2>/dev/null", "r");
+ 	if (!f) {
+ 		warn("popen: ausyscall --dump: %s\n", strerror(errno));
+ 		return;
+diff --git a/src/python/bcc/syscall.py b/src/python/bcc/syscall.py
+index 1346b4e8..e7e29a11 100644
+--- a/src/python/bcc/syscall.py
++++ b/src/python/bcc/syscall.py
+@@ -376,7 +376,7 @@ def _parse_syscall(line):
+ try:
+     # Skip the first line, which is a header. The rest of the lines are simply
+     # SYSCALL_NUM\tSYSCALL_NAME pairs.
+-    out = subprocess.check_output(['ausyscall', '--dump'], stderr=subprocess.STDOUT)
++    out = subprocess.check_output(['@ausyscall@', '--dump'], stderr=subprocess.STDOUT)
+     # remove the first line of expected output
+     out = out.split(b'\n',1)[1]
+     syscalls = dict(map(_parse_syscall, out.strip().split(b'\n')))
+-- 
+2.34.0
+

--- a/pkgs/os-specific/linux/bcc/default.nix
+++ b/pkgs/os-specific/linux/bcc/default.nix
@@ -2,6 +2,7 @@
 , makeWrapper, cmake, llvmPackages
 , flex, bison, elfutils, python, luajit, netperf, iperf, libelf
 , bash, libbpf, nixosTests
+, audit
 }:
 
 python.pkgs.buildPythonApplication rec {
@@ -41,9 +42,16 @@ python.pkgs.buildPythonApplication rec {
     "-DCMAKE_USE_LIBBPF_PACKAGE=ON"
   ];
 
+  # to replace this executable path:
+  # https://github.com/iovisor/bcc/blob/master/src/python/bcc/syscall.py#L384
+  ausyscall = "${audit}/bin/ausyscall";
+
   postPatch = ''
     substituteAll ${./libbcc-path.patch} ./libbcc-path.patch
     patch -p1 < libbcc-path.patch
+
+    substituteAll ${./absolute-ausyscall.patch} ./absolute-ausyscall.patch
+    patch -p1 < absolute-ausyscall.patch
   '';
 
   postInstall = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

cc @andir


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).