### PR TITLE
 hydra-unstable: 2021-08-11 -> 2021-12-17

### DIFF
--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -2,12 +2,12 @@
 
 {
   hydra-unstable = callPackage ./common.nix {
-    version = "2021-08-11";
+    version = "2021-12-17";
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "hydra";
-      rev = "9bce425c3304173548d8e822029644bb51d35263";
-      sha256 = "sha256-tGzwKNW/odtAYcazWA9bPVSmVXMGKfXsqCA1UYaaxmU=";
+      rev = "e1e5fafdff63c1e1595d2edb8c9854710211a0d7";
+      sha256 = "sha256-JPkw3heasqX9iWju7BWjKDsyoS+HmLIKM2ibwHq5+Ko=";
     };
     nix = nixVersions.unstable;
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -18982,6 +18982,21 @@ let
     };
   };
 
+  ReadonlyX = buildPerlModule {
+    pname = "ReadonlyX";
+    version = "1.04";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/S/SA/SANKO/ReadonlyX-1.04.tar.gz";
+      sha256 = "81bb97dba93ac6b5ccbce04a42c3590eb04557d75018773ee18d5a30fcf48188";
+    };
+    buildInputs = [ ModuleBuildTiny TestFatal ];
+    meta = {
+      homepage = "https://github.com/sanko/readonly";
+      description = "Faster facility for creating read-only scalars, arrays, hashes";
+      license = lib.licenses.artistic2;
+    };
+  };
+
   ReadonlyXS = buildPerlPackage {
     pname = "Readonly-XS";
     version = "1.05";


### PR DESCRIPTION
###### Motivation for this change

Replaces https://github.com/NixOS/nixpkgs/pull/143216.
Enables tests and adds all required dependencies to run tests.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`) -> ran hydra for a week
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>hydra-unstable</li>
    <li>perl532Packages.ReadonlyX</li>
    <li>perl534Packages.ReadonlyX</li>
  </ul>
</details>
