### PR TITLE
nixos/wireless: disable SAE by default

### DIFF
--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -254,10 +254,10 @@ in {
 
             authProtocols = mkOption {
               default = [
-                # WPA2 and WPA3
-                "WPA-PSK" "WPA-EAP" "SAE"
+                # WPA2
+                "WPA-PSK" "WPA-EAP"
                 # 802.11r variants of the above
-                "FT-PSK" "FT-EAP" "FT-SAE"
+                "FT-PSK" "FT-EAP"
               ];
               # The list can be obtained by running this command
               # awk '


### PR DESCRIPTION
###### Motivation for this change

Unfortunately this is not working as expected and results in
authentication failures in some cases. See issue #151729.

###### Things done

- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
