### PR TITLE
pkgsStatic.libredirect: build empty outputs on static stdenv

### DIFF
--- a/pkgs/build-support/libredirect/default.nix
+++ b/pkgs/build-support/libredirect/default.nix
@@ -8,7 +8,7 @@ then throw ''
   builds, using something like following:
 
     nativeBuildInputs =
-      lib.optional (!stdenv.hostPlatform.isStatic) libredirect;
+      lib.optional (!stdenv.buildPlatform.isStatic) libredirect;
 
   and disable tests as necessary, although fixing tests to work without
   libredirect is even better.

--- a/pkgs/build-support/libredirect/default.nix
+++ b/pkgs/build-support/libredirect/default.nix
@@ -1,6 +1,22 @@
-{ stdenv, lib, coreutils }:
+{ stdenv, runCommand, lib, coreutils }:
 
-stdenv.mkDerivation rec {
+if stdenv.hostPlatform.isStatic
+then throw ''
+  libredirect is not available on static builds.
+
+  Please fix your derivation to not depend on libredirect on static
+  builds, using something like following:
+
+    nativeBuildInputs =
+      lib.optional (!stdenv.hostPlatform.isStatic) libredirect;
+
+  and disable tests as necessary, although fixing tests to work without
+  libredirect is even better.
+
+  libredirect uses LD_PRELOAD feature of dynamic loader and does not
+  work on static builds where dynamic loader is not used.
+  ''
+else stdenv.mkDerivation rec {
   pname = "libredirect";
   version = "0";
 


### PR DESCRIPTION
The whole point of libredirect is manipulation with LD_PRELOAD, which is not
supposed to work on static builds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
