### PR TITLE
bugdom: init at 1.3.1

### DIFF
--- a/pkgs/games/bugdom/default.nix
+++ b/pkgs/games/bugdom/default.nix
@@ -1,0 +1,44 @@
+{ lib, stdenv, fetchFromGitHub, SDL2, cmake, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "bugdom";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "jorio";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256:1371inw11rzfrxmc3v4gv5axp56bxjbcr0mhqm4x839401bfq5mf";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [
+    SDL2
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/bugdom
+    mv Data $out/share/bugdom
+    install -Dm755 {.,$out/bin}/Bugdom
+    wrapProgram $out/bin/Bugdom --run "cd $out/share/bugdom"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A port of Bugdom, a 1999 Macintosh game by Pangea Software, for modern operating systems";
+    homepage = "https://github.com/jorio/Bugdom";
+    license = with licenses; [
+      cc-by-sa-40
+    ];
+    maintainers = with maintainers; [ lux ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30262,6 +30262,8 @@ with pkgs;
 
   btanks = callPackage ../games/btanks { };
 
+  bugdom = callPackage ../games/bugdom { };
+
   bzflag = callPackage ../games/bzflag {
     inherit (darwin.apple_sdk.frameworks) Carbon CoreServices;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add [Bugdom](https://github.com/jorio/Bugdom) package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
