### PR TITLE
vmTools/test: fix

### DIFF
--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -511,7 +511,6 @@ rec {
 
   buildRPM = attrs: runInLinuxImage (stdenv.mkDerivation ({
     prePhases = [ "prepareImagePhase" "sysInfoPhase" ];
-    dontUnpack = true;
     dontConfigure = true;
 
     outDir = "rpms/${attrs.diskImage.name}";
@@ -536,9 +535,7 @@ rec {
     buildPhase = ''
       eval "$preBuild"
 
-      # Hacky: RPM looks for <basename>.spec inside the tarball, so
-      # strip off the hash.
-      srcName="$(stripHash "$src")"
+      srcName="$(rpmspec --srpm -q --qf '%{source}' *.spec)"
       cp "$src" "$srcName" # `ln' doesn't work always work: RPM requires that the file is owned by root
 
       export HOME=/tmp/home

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -510,7 +510,7 @@ rec {
      tarball must contain an RPM specfile. */
 
   buildRPM = attrs: runInLinuxImage (stdenv.mkDerivation ({
-    prePhases = [ pkgs.prepareImagePhase pkgs.sysInfoPhase ];
+    prePhases = [ "prepareImagePhase" "sysInfoPhase" ];
     dontUnpack = true;
     dontConfigure = true;
 

--- a/pkgs/build-support/vm/test.nix
+++ b/pkgs/build-support/vm/test.nix
@@ -9,8 +9,10 @@ with vmTools;
 
   buildHelloInVM = runInLinuxVM hello;
 
-  buildPanInVM = runInLinuxVM (pan // { memSize = 2048; });
-
+  buildPcmanrmInVM = runInLinuxVM (pcmanfm.overrideAttrs (old: {
+    # goes out-of-memory with many cores
+    enableParallelBuilding = false;
+  }));
 
   testRPMImage = makeImageTestScript diskImages.fedora27x86_64;
 

--- a/pkgs/build-support/vm/test.nix
+++ b/pkgs/build-support/vm/test.nix
@@ -12,17 +12,17 @@ with vmTools;
   buildPanInVM = runInLinuxVM pan;
 
 
-  testRPMImage = makeImageTestScript diskImages.fedora16x86_64;
+  testRPMImage = makeImageTestScript diskImages.fedora27x86_64;
 
 
   buildPatchelfRPM = buildRPM {
     name = "patchelf-rpm";
     src = patchelf.src;
-    diskImage = diskImages.fedora16x86_64;
+    diskImage = diskImages.fedora27x86_64;
   };
 
 
-  testUbuntuImage = makeImageTestScript diskImages.ubuntu810i386;
+  testUbuntuImage = makeImageTestScript diskImages.ubuntu1804i386;
 
 
   buildInDebian = runInLinuxImage (stdenv.mkDerivation {

--- a/pkgs/build-support/vm/test.nix
+++ b/pkgs/build-support/vm/test.nix
@@ -9,7 +9,7 @@ with vmTools;
 
   buildHelloInVM = runInLinuxVM hello;
 
-  buildPanInVM = runInLinuxVM pan;
+  buildPanInVM = runInLinuxVM (pan // { memSize = 2048; });
 
 
   testRPMImage = makeImageTestScript diskImages.fedora27x86_64;

--- a/pkgs/build-support/vm/test.nix
+++ b/pkgs/build-support/vm/test.nix
@@ -19,6 +19,7 @@ with vmTools;
     name = "patchelf-rpm";
     src = patchelf.src;
     diskImage = diskImages.fedora27x86_64;
+    diskImageFormat = "qcow2";
   };
 
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Some of these tests had been pretty neglected, and didn't even eval.  Others were a bit better, but still didn't work.  More detail in commit messages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
