### PR TITLE
amazon-s3-plugin-for-pytorch: init at 0.0.1-38284c8

### DIFF
--- a/pkgs/development/python-modules/amazon-s3-plugin-for-pytorch/default.nix
+++ b/pkgs/development/python-modules/amazon-s3-plugin-for-pytorch/default.nix
@@ -1,0 +1,66 @@
+{ buildPythonPackage
+, aws-sdk-cpp
+, cmake
+, curl
+, fetchFromGitHub
+, lib
+, pybind11
+, pytorch
+, zlib
+}:
+
+let
+  aws-sdk-cpp-s3-transfer = (aws-sdk-cpp.override {
+    apis = ["s3" "transfer"];
+    customMemoryManagement = false;
+  }).overrideAttrs (oldAttrs: {
+
+    # Fixes downstream issue with dependent CMake configuration
+    # See https://github.com/NixOS/nixpkgs/issues/70075#issuecomment-1019328864
+    postPatch = oldAttrs.postPatch + ''
+      substituteInPlace cmake/AWSSDKConfig.cmake \
+        --replace "\''${AWSSDK_DEFAULT_ROOT_DIR}/\''${AWSSDK_INSTALL_INCLUDEDIR}" "\''${AWSSDK_INSTALL_INCLUDEDIR}"
+    '';
+
+});
+in
+buildPythonPackage rec {
+  pname = "amazon-s3-plugin-for-pytorch";
+
+  version = "0.0.1-38284c8"; # No official release published yet
+
+  src = fetchFromGitHub {
+    owner = "aws";
+    repo = pname;
+    rev = "38284c8a5e92be3bbf47b08e8c90d94be0cb79e7";
+    sha256 = "0lww4y3mq854za95hi4y441as4r3h3q0nyrpgj4j6kjk58gijbx9";
+  };
+
+  dontUseCmakeConfigure = true; # Allow setup.py to take care of building _pywrap_s3_io via build_ext
+
+  nativeBuildInputs = [
+    cmake
+    zlib
+  ];
+
+  buildInputs = [
+    aws-sdk-cpp-s3-transfer
+    pybind11
+    curl
+  ];
+
+  propagatedBuildInputs = [
+    pytorch
+  ];
+
+  pythonImportsCheck = [ "awsio.python.lib.io.s3.s3dataset" ];
+
+  doCheck = false; # More or less every test requires a network connection
+
+  meta = with lib; {
+    description = "S3-plugin is a high performance PyTorch dataset library to efficiently access datasets stored in S3 buckets.";
+    homepage = "https://github.com/aws/amazon-s3-plugin-for-pytorch";
+    license = licenses.asl20;
+    maintainers = with maintainers; [];
+  };
+}


### PR DESCRIPTION
~Unfortunately I ran out of steam trying to package this python library, but I thought I'd leave a draft PR for posterity in case someone wants to pick it up in future.~

**UPDATE:** This basically works now, but https://github.com/NixOS/nixpkgs/pull/152465/files#r790173854 probably needs to be addressed directly in `aws-sdk-cpp`.

References:
* https://aws.amazon.com/blogs/machine-learning/announcing-the-amazon-s3-plugin-for-pytorch/
* [jeffwang0516's installation guide](https://gist.github.com/jeffwang0516/770b5513ee2a05bce7545352237118a2)


###### Things done


- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
