### PR TITLE
realesrgan-ncnn-vulkan: init at 0.1.3.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12025,7 +12025,7 @@
     name = "Tiago Castro";
   };
   tilcreator = {
-    name = "Tilman Jackel";
+    name = "TilCreator";
     email = "contact.nixos@tc-j.de";
     matrix = "@tilcreator:matrix.org";
     github = "TilCreator";

--- a/pkgs/development/compilers/glslang/default.nix
+++ b/pkgs/development/compilers/glslang/default.nix
@@ -31,6 +31,11 @@ stdenv.mkDerivation rec {
     ln -s "${spirv-headers.src}" External/spirv-tools/external/spirv-headers
   '';
 
+  # This is a dirty fix for lib/cmake/SPIRVTargets.cmake:51 which includes this directory
+  postInstall = ''
+    mkdir $out/include/External
+  '';
+
   meta = with lib; {
     inherit (src.meta) homepage;
     description = "Khronos reference front-end for GLSL and ESSL";

--- a/pkgs/development/libraries/ncnn/cmakelists.patch
+++ b/pkgs/development/libraries/ncnn/cmakelists.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 98611276..989350bb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -260,6 +260,8 @@ if(NCNN_VULKAN)
+                 include("${GLSLANG_TARGET_DIR}/HLSLTargets.cmake")
+             endif()
+             include("${GLSLANG_TARGET_DIR}/glslangTargets.cmake")
++            include("${GLSLANG_TARGET_DIR}/SPIRV-Tools/SPIRV-ToolsTarget.cmake")
++            include("${GLSLANG_TARGET_DIR}/SPIRV-Tools-opt/SPIRV-Tools-optTargets.cmake")
+             include("${GLSLANG_TARGET_DIR}/SPIRVTargets.cmake")
+ 
+             if (NOT TARGET glslang OR NOT TARGET SPIRV)

--- a/pkgs/development/libraries/ncnn/default.nix
+++ b/pkgs/development/libraries/ncnn/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, vulkan-headers
+, vulkan-loader
+, glslang
+, opencv
+, protobuf
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ncnn";
+  version = "20211208";
+
+  src = fetchFromGitHub {
+    owner = "Tencent";
+    repo = pname;
+    rev = version;
+    sha256 = "1c9axrnafksnks7v5fmi6nzs0qim9n6j5kh5d0vfl3b4r22irhqr";
+  };
+
+  patches = [
+    ./cmakelists.patch
+    ./gpu-include.patch
+  ];
+
+  cmakeFlags = [
+    "-DNCNN_CMAKE_VERBOSE=1" # Only for debugging the build
+    "-DNCNN_SHARED_LIB=1"
+    "-DNCNN_ENABLE_LTO=1"
+    "-DNCNN_VULKAN=1"
+    "-DNCNN_BUILD_EXAMPLES=0"
+    "-DNCNN_BUILD_TOOLS=0"
+    "-DNCNN_SYSTEM_GLSLANG=1"
+    "-DNCNN_PYTHON=0" # Should be an attribute
+
+    "-DGLSLANG_TARGET_DIR=${glslang}/lib/cmake"
+  ];
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ vulkan-headers vulkan-loader glslang opencv protobuf ];
+
+  meta = with lib; {
+    description = "ncnn is a high-performance neural network inference framework optimized for the mobile platform";
+    homepage = "https://github.com/Tencent/ncnn";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ tilcreator ];
+  };
+}

--- a/pkgs/development/libraries/ncnn/gpu-include.patch
+++ b/pkgs/development/libraries/ncnn/gpu-include.patch
@@ -1,0 +1,13 @@
+diff --git a/src/gpu.cpp b/src/gpu.cpp
+index 51cd7f95..bf7ed828 100644
+--- a/src/gpu.cpp
++++ b/src/gpu.cpp
+@@ -21,7 +21,7 @@
+ #include <vulkan/vulkan.h>
+ 
+ #include "glslang/SPIRV/GlslangToSpv.h"
+-#include "glslang/glslang/Public/ShaderLang.h"
++#include "glslang/Public/ShaderLang.h"
+ 
+ #include "command.h"
+ #include "layer.h"

--- a/pkgs/tools/graphics/realesrgan-ncnn-vulkan/cmakelists.patch
+++ b/pkgs/tools/graphics/realesrgan-ncnn-vulkan/cmakelists.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a234caa..cd9d2c5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -114,6 +114,8 @@ if(USE_SYSTEM_NCNN)
+             include("${GLSLANG_TARGET_DIR}/HLSLTargets.cmake")
+         endif()
+         include("${GLSLANG_TARGET_DIR}/glslangTargets.cmake")
++        include("${GLSLANG_TARGET_DIR}/SPIRV-Tools/SPIRV-ToolsTarget.cmake")
++        include("${GLSLANG_TARGET_DIR}/SPIRV-Tools-opt/SPIRV-Tools-optTargets.cmake")
+         include("${GLSLANG_TARGET_DIR}/SPIRVTargets.cmake")
+ 
+         if (NOT TARGET glslang OR NOT TARGET SPIRV)

--- a/pkgs/tools/graphics/realesrgan-ncnn-vulkan/default.nix
+++ b/pkgs/tools/graphics/realesrgan-ncnn-vulkan/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, stdenv
+, fetchzip
+, fetchFromGitHub
+, cmake
+, spirv-headers
+, vulkan-headers
+, vulkan-loader
+, glslang
+, libgcc
+, libwebp
+, ncnn
+}:
+
+stdenv.mkDerivation rec {
+  pname = "Real-ESRGAN-ncnn-vulkan";
+  version = "0.1.3.2";
+
+  src = fetchFromGitHub {
+    owner = "xinntao";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-eLAIlOl1sUxijeVPFG+NscZGxDdtrQqVkMuxhegESHk=";
+  };
+  sourceRoot = "source/src";
+
+  models = fetchzip {
+    # Choose the newst release from https://github.com/xinntao/Real-ESRGAN/releases to update
+    url = "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.3.0/realesrgan-ncnn-vulkan-20211212-ubuntu.zip";
+    stripRoot = false;
+    sha256 = "sha256-17k6fewVEXxx7hi+vPXjHAOq4IIUHLh7WC80CwTeFKI=";
+  };
+
+  patches = [
+    ./cmakelists.patch
+    ./models_path.patch
+  ];
+
+  cmakeFlags = [
+    "-DUSE_SYSTEM_NCNN=1"
+    "-DUSE_SYSTEM_WEBP=1"
+
+    "-DGLSLANG_TARGET_DIR=${glslang}/lib/cmake"
+  ];
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ vulkan-headers vulkan-loader glslang libgcc libwebp ncnn ];
+
+  postPatch = ''
+    substituteInPlace main.cpp --replace REPLACE_MODELS $out/share/models
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share
+    cp realesrgan-ncnn-vulkan $out/bin/
+    cp -r ${models}/models $out/share
+  '';
+
+  meta = with lib; {
+    description = "NCNN implementation of Real-ESRGAN. Real-ESRGAN aims at developing Practical Algorithms for General Image Restoration.";
+    homepage = "https://github.com/xinntao/Real-ESRGAN-ncnn-vulkan";
+    license = licenses.mit;
+    maintainers = with maintainers; [ tilcreator ];
+  };
+}

--- a/pkgs/tools/graphics/realesrgan-ncnn-vulkan/models_path.patch
+++ b/pkgs/tools/graphics/realesrgan-ncnn-vulkan/models_path.patch
@@ -1,0 +1,22 @@
+diff --git a/main.cpp b/main.cpp
+index eb6f6c8..b230bed 100644
+--- a/main.cpp
++++ b/main.cpp
+@@ -110,7 +110,7 @@ static void print_usage()
+     fprintf(stderr, "  -o output-path       output image path (jpg/png/webp) or directory\n");
+     fprintf(stderr, "  -s scale             upscale ratio (can be 2, 4. default=4)\n");
+     fprintf(stderr, "  -t tile-size         tile size (>=32/0=auto, default=0) can be 0,0,0 for multi-gpu\n");
+-    fprintf(stderr, "  -m model-path        folder path to pre-trained models(default=models)\n");
++    fprintf(stderr, "  -m model-path        folder path to pre-trained models(default=REPLACE_MODELS)\n");
+     fprintf(stderr, "  -n model-name        model name (default=realesrgan-x4plus, can be realesrgan-x4plus | realesrgan-x4plus-anime | realesrnet-x4plus | RealESRGANv2-animevideo-xsx2 | RealESRGANv2-animevideo-xsx4 | RealESRGANv2-anime-xsx2 | RealESRGANv2-anime-xsx4)\n");
+     fprintf(stderr, "  -g gpu-id            gpu device to use (default=auto) can be 0,1,2 for multi-gpu\n");
+     fprintf(stderr, "  -j load:proc:save    thread count for load/proc/save (default=1:2:2) can be 1:2,2,2:2 for multi-gpu\n");
+@@ -438,7 +438,7 @@ int main(int argc, char** argv)
+     path_t outputpath;
+     int scale = 4;
+     std::vector<int> tilesize;
+-    path_t model = PATHSTR("models");
++    path_t model = PATHSTR("REPLACE_MODELS");
+     path_t modelname = PATHSTR("realesrgan-x4plus");
+     std::vector<int> gpuid;
+     int jobs_load = 1;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18990,6 +18990,8 @@ with pkgs;
 
   nanovna-saver = libsForQt5.callPackage ../applications/science/electronics/nanovna-saver { };
 
+  ncnn = callPackage ../development/libraries/ncnn { };
+
   ndpi = callPackage ../development/libraries/ndpi { };
 
   nemo-qml-plugin-dbus = libsForQt5.callPackage ../development/libraries/nemo-qml-plugin-dbus { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9156,6 +9156,8 @@ with pkgs;
 
   real_time_config_quick_scan = callPackage ../applications/audio/real_time_config_quick_scan { };
 
+  realesrgan-ncnn-vulkan = callPackage ../tools/graphics/realesrgan-ncnn-vulkan { };
+
   react-native-debugger = callPackage ../development/tools/react-native-debugger { };
 
   read-edid = callPackage ../os-specific/linux/read-edid { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I want to use Real-ESRGAN-ncnn-vulkan

###### Things done
glslang: 11.1.0 -> 11.7.0, also added a workaround
ncnn: init at 20211208
realesrgan-ncnn-vulkan: init at 0.1.3.2

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
