### PR TITLE
krill: init at 0.9.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11163,6 +11163,12 @@
     githubId = 7512804;
     name = "Martin Langlotz";
   };
+  steamwalker = {
+    email = "steamwalker@xs4all.nl";
+    github = "steamwalker";
+    githubId = 94006354;
+    name = "steamwalker";
+  };
   steell = {
     email = "steve@steellworks.com";
     github = "Steell";

--- a/pkgs/servers/krill/default.nix
+++ b/pkgs/servers/krill/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, openssl
+, pkg-config
+, stdenv
+, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "krill";
+  version = "0.9.4";
+
+  src = fetchFromGitHub {
+    owner = "NLnetLabs";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256:1w5s4vmr126k5lnxsv3hfxx1yz2c1gp3hmwfz5jn4lar78r5kidy";
+  };
+
+  cargoSha256 = "sha256:0ksh68giq3yd8k7vynxdl13ccysl6i5ag2nz9nknbnrvpv201c88";
+
+  buildInputs = [ openssl ] ++ lib.optional stdenv.isDarwin Security;
+  nativeBuildInputs = [ pkg-config ];
+
+  # Needed to get openssl-sys to use pkgconfig.
+  OPENSSL_NO_VENDOR = 1;
+
+  meta = with lib; {
+    description = "RPKI Certificate Authority and Publication Server written in Rust";
+    longDescription = ''
+      Krill is a free, open source RPKI Certificate Authority that lets you run
+      delegated RPKI under one or multiple Regional Internet Registries (RIRs).
+      Through its built-in publication server, Krill can publish Route Origin
+      Authorisations (ROAs) on your own servers or with a third party.
+    '';
+    homepage = "https://github.com/NLnetLabs/krill";
+    changelog = "https://github.com/NLnetLabs/krill/blob/v${version}/Changelog.md";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ steamwalker ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3303,6 +3303,10 @@ with pkgs;
 
   krapslog = callPackage ../tools/misc/krapslog { };
 
+  krill = callPackage ../servers/krill {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   lcdproc = callPackage ../servers/monitoring/lcdproc { };
 
   languagetool = callPackage ../tools/text/languagetool {  };


### PR DESCRIPTION
###### Motivation for this change

New package for this project from the same people that brought us nsd, unbound and routinator (already packaged). Added myself to the maintainer list in a seperate commit.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
