### PR TITLE
python3Packages.aiohttp-socks: 0.6.0 -> 0.7.1

### DIFF
--- a/pkgs/development/python-modules/aiohttp-socks/default.nix
+++ b/pkgs/development/python-modules/aiohttp-socks/default.nix
@@ -2,18 +2,19 @@
 
 buildPythonPackage rec {
   pname = "aiohttp-socks";
-  version = "0.6.0";
+  version = "0.7.1";
 
   src = fetchPypi {
     inherit version;
     pname = "aiohttp_socks";
-    sha256 = "04w010bvi719ifpc3sshav95k10hf9nq8czn9yglkj206yxcypdr";
+    sha256 = "sha256-IhXKxIke8/oUt9YA7TQ+0PCmcMI7EOQUKqhis9sgNBo=";
   };
 
   propagatedBuildInputs = [ aiohttp attrs python-socks ];
 
   # Checks needs internet access
   doCheck = false;
+  pythonImportsCheck = [ "aiohttp_socks" ];
 
   disabled = pythonOlder "3.5.3";
 

--- a/pkgs/development/python-modules/matrix-nio/default.nix
+++ b/pkgs/development/python-modules/matrix-nio/default.nix
@@ -41,12 +41,14 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace 'aiofiles = "^0.6.0"' 'aiofiles = "*"'
+    # Remove after https://github.com/poljar/matrix-nio/pull/288
+    substituteInPlace pyproject.toml \
+      --replace 'aiohttp-socks = "^0.6.0"' 'aiohttp-socks = "^0.7.0"'
   '';
 
   nativeBuildInputs = [
     git
     poetry-core
-    pytestCheckHook
   ];
 
   propagatedBuildInputs = [
@@ -73,7 +75,10 @@ buildPythonPackage rec {
     hypothesis
     pytest-aiohttp
     pytest-benchmark
+    pytestCheckHook
   ];
+
+  pytestFlagsArray = [ "--benchmark-disable" ];
 
   disabledTests = [
     # touches network


### PR DESCRIPTION
###### Motivation for this change

Fixes build of `electrum` and `python3Packages.matrix-nio`, probably others.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).