### PR TITLE
integrity-scrub: init at 0.6.5

### DIFF
--- a/pkgs/by-name/in/integrity-scrub/package.nix
+++ b/pkgs/by-name/in/integrity-scrub/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "integrity-scrub";
+  version = "0.6.5";
+
+  src = fetchFromGitHub {
+    owner = "illdefined";
+    repo = "integrity-scrub";
+    tag = version;
+    hash = "sha256-oWS6HxdZ8tGeIRGpfHHkNhNdepBjhhdgTjKmxElNPbk=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-3LC3eZNmHG6OFIvQzmvs4BCSX0CVpwaYhZM2H2YoY4M=";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  doInstallCheck = true;
+
+  # Requires unstable features
+  env.RUSTC_BOOTSTRAP = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/illdefined/integrity-scrub";
+    description = "Scrub dm-integrity devices";
+    license = lib.licenses.cc0;
+    maintainers = with lib.maintainers; [ mvs ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

This introduces integrity-scrub, a tool to restore Linux dm-integrity volumes with invalid (corrupted) integrity tags.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
