### PR TITLE
wireshark: 3.4.10 -> 3.6.1

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -10,7 +10,7 @@ assert withQt  -> qt5  != null;
 with lib;
 
 let
-  version = "3.4.10";
+  version = "3.6.1";
   variant = if withQt then "qt" else "cli";
 
 in stdenv.mkDerivation {
@@ -20,7 +20,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.wireshark.org/download/src/all-versions/wireshark-${version}.tar.xz";
-    sha256 = "sha256-iqfvSkSuYruNtGPPdh4swDuXMF4Od+1b5T+oNykYfO8=";
+    sha256 = "sha256-BDTtqPtr+I4rQqZ+tdHeJUpn1QW+w7tR/unXyteSWjg=";
   };
 
   cmakeFlags = [
@@ -67,18 +67,18 @@ in stdenv.mkDerivation {
         done
     done
   '' else optionalString withQt ''
-    install -Dm644 -t $out/share/applications ../wireshark.desktop
+    install -Dm644 -t $out/share/applications ../org.wireshark.Wireshark.desktop
 
     install -Dm644 ../image/wsicon.svg $out/share/icons/wireshark.svg
-    mkdir $dev/include/{epan/{wmem,ftypes,dfilter},wsutil,wiretap} -pv
+    mkdir $dev/include/{epan/{wmem,ftypes,dfilter},wsutil/wmem,wiretap} -pv
 
     cp config.h $dev/include/wireshark/
     cp ../ws_*.h $dev/include
     cp ../epan/*.h $dev/include/epan/
-    cp ../epan/wmem/*.h $dev/include/epan/wmem/
     cp ../epan/ftypes/*.h $dev/include/epan/ftypes/
     cp ../epan/dfilter/*.h $dev/include/epan/dfilter/
     cp ../wsutil/*.h $dev/include/wsutil/
+    cp ../wsutil/wmem/*.h $dev/include/wsutil/wmem/
     cp ../wiretap/*.h $dev/include/wiretap
   '');
 

--- a/pkgs/applications/networking/sniffers/wireshark/wireshark-lookup-dumpcap-in-path.patch
+++ b/pkgs/applications/networking/sniffers/wireshark/wireshark-lookup-dumpcap-in-path.patch
@@ -11,16 +11,18 @@ Also change execv() to execvp() because we've set argv[0] to "dumpcap"
 and have to enable PATH lookup. Wireshark is not a setuid program, so
 looking in PATH is not a security issue.
 
+EDITED by teto for wireshark 3.6
+
 Signed-off-by: Franz Pletz <fpletz@fnordicwalking.de>
 ---
  capchild/capture_sync.c | 17 ++++++++++++++---
  1 file changed, 14 insertions(+), 3 deletions(-)
 
 diff --git a/capchild/capture_sync.c b/capchild/capture_sync.c
-index 970688e..49914d5 100644
---- a/capchild/capture_sync.c
-+++ b/capchild/capture_sync.c
-@@ -332,7 +332,18 @@ init_pipe_args(int *argc) {
+index f31914886a..df29b6f0ab 100644
+--- a/capture/capture_sync.c
++++ b/capture/capture_sync.c
+@@ -187,7 +187,18 @@ init_pipe_args(int *argc) {
  #ifdef _WIN32
      exename = g_strdup_printf("%s\\dumpcap.exe", progfile_dir);
  #else
@@ -40,7 +42,7 @@ index 970688e..49914d5 100644
  #endif
  
      /* Make that the first argument in the argument list (argv[0]). */
-@@ -729,7 +740,7 @@ sync_pipe_start(capture_options *capture_opts, capture_session *cap_session, voi
+@@ -572,7 +583,7 @@ sync_pipe_start(capture_options *capture_opts, capture_session *cap_session, inf
           */
          dup2(sync_pipe[PIPE_WRITE], 2);
          ws_close(sync_pipe[PIPE_READ]);
@@ -49,7 +51,7 @@ index 970688e..49914d5 100644
          g_snprintf(errmsg, sizeof errmsg, "Couldn't run %s in child process: %s",
                     argv[0], g_strerror(errno));
          sync_pipe_errmsg_to_parent(2, errmsg, "");
-@@ -997,7 +1008,7 @@ sync_pipe_open_command(char** argv, int *data_read_fd,
+@@ -811,7 +822,7 @@ sync_pipe_open_command(char* const argv[], int *data_read_fd,
          dup2(sync_pipe[PIPE_WRITE], 2);
          ws_close(sync_pipe[PIPE_READ]);
          ws_close(sync_pipe[PIPE_WRITE]);
@@ -58,6 +60,3 @@ index 970688e..49914d5 100644
          g_snprintf(errmsg, sizeof errmsg, "Couldn't run %s in child process: %s",
                     argv[0], g_strerror(errno));
          sync_pipe_errmsg_to_parent(2, errmsg, "");
--- 
-2.6.3
-


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
failing with
```
-- Installing: /nix/store/lni3w6zx01zp9qbfh1xyhcc2gjbz0k7j-wireshark-qt-3.6.0/lib/wireshark/plugins/3.6/codecs/l16mono.so
mkdir: created directory '/nix/store/xmmf68wmzy3mmhf967mbwavlnw5bb1gs-wireshark-qt-3.6.0-dev/include/epan'
mkdir: created directory '/nix/store/xmmf68wmzy3mmhf967mbwavlnw5bb1gs-wireshark-qt-3.6.0-dev/include/epan/wmem'
mkdir: created directory '/nix/store/xmmf68wmzy3mmhf967mbwavlnw5bb1gs-wireshark-qt-3.6.0-dev/include/epan/ftypes'
mkdir: created directory '/nix/store/xmmf68wmzy3mmhf967mbwavlnw5bb1gs-wireshark-qt-3.6.0-dev/include/epan/dfilter'
mkdir: created directory '/nix/store/xmmf68wmzy3mmhf967mbwavlnw5bb1gs-wireshark-qt-3.6.0-dev/include/wsutil'
mkdir: created directory '/nix/store/xmmf68wmzy3mmhf967mbwavlnw5bb1gs-wireshark-qt-3.6.0-dev/include/wiretap'
cp: missing destination file operand after '/nix/store/xmmf68wmzy3mmhf967mbwavlnw5bb1gs-wireshark-qt-3.6.0-dev/include/epan/wmem/'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
