### PR TITLE
python3Packages.{django-redis,redis,hiredis,packaging,lz4}: update and refactor

### DIFF
--- a/pkgs/development/python-modules/django-redis/default.nix
+++ b/pkgs/development/python-modules/django-redis/default.nix
@@ -19,7 +19,7 @@
 
 let
   pname = "django-redis";
-  version = "5.1.0";
+  version = "5.2.0";
 in
 buildPythonPackage {
   inherit pname version;
@@ -30,7 +30,7 @@ buildPythonPackage {
     owner = "jazzband";
     repo = "django-redis";
     rev = version;
-    sha256 = "sha256-S94qH2W5e65yzGfPxpwBUKhvvVS0Uc/zSyo66bnvzf4=";
+    sha256 = "sha256-e8wCgfxBT+WKFY4H83CTMirTpQym3QAoeWnXbRCDO90=";
   };
 
   postPatch = ''
@@ -53,6 +53,11 @@ buildPythonPackage {
 
   preCheck = ''
     ${pkgs.redis}/bin/redis-server &
+    REDIS_PID=$!
+  '';
+
+  postCheck = ''
+    kill $REDIS_PID
   '';
 
   checkInputs = [

--- a/pkgs/development/python-modules/hiredis/default.nix
+++ b/pkgs/development/python-modules/hiredis/default.nix
@@ -1,25 +1,30 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, redis
+, pythonOlder
+
+# tested using
 , python
 }:
 
 buildPythonPackage rec {
   pname = "hiredis";
   version = "2.0.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "81d6d8e39695f2c37954d1011c0480ef7cf444d4e3ae24bc5e89ee5de360139a";
   };
-  propagatedBuildInputs = [ redis ];
+
+  pythonImportsCheck = [ "hiredis" ];
 
   checkPhase = ''
     mv hiredis _hiredis
     ${python.interpreter} test.py
   '';
-  pythonImportsCheck = [ "hiredis" ];
 
   meta = with lib; {
     description = "Wraps protocol parsing code in hiredis, speeds up parsing of multi bulk replies";

--- a/pkgs/development/python-modules/lz4/default.nix
+++ b/pkgs/development/python-modules/lz4/default.nix
@@ -1,41 +1,68 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, future
-, isPy3k
+, pythonOlder
+
+# native inputs
 , pkgconfig
-, psutil
-, pytest
-, pytest-cov
-, pytest-runner
 , setuptools-scm
+
+# tests
+, psutil
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "python-lz4";
-  version = "3.1.10";
+  version = "3.1.12";
+  format = "setuptools";
 
-  # get full repository inorder to run tests
+  disabled = pythonOlder "3.5";
+
+  # get full repository in order to run tests
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    rev = version;
-    sha256 = "0a4gic8xh3simkk5k8302rxwf765pr6y63k3js79mkl983vpxcim";
+    rev = "v${version}";
+    sha256 = "sha256-fqt9aJGqZpfbiYtU8cmm7UQaixZwbTKFBwRfR1B/qic=";
   };
 
-  nativeBuildInputs = [ setuptools-scm pkgconfig pytest-runner ];
-  checkInputs = [ pytest pytest-cov psutil ];
-  propagatedBuildInputs = lib.optionals (!isPy3k) [ future ];
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
-  # give a hint to setuptools-scm on package version
-  preBuild = ''
-    export SETUPTOOLS_SCM_PRETEND_VERSION="v${version}"
+  postPatch = ''
+    sed -i '/pytest-cov/d' setup.py
   '';
 
-  meta = {
-     description = "LZ4 Bindings for Python";
-     homepage = "https://github.com/python-lz4/python-lz4";
-     license = lib.licenses.bsd3;
-     maintainers = with lib.maintainers; [ costrouc ];
+  nativeBuildInputs = [
+    setuptools-scm
+    pkgconfig
+  ];
+
+  pythonImportsCheck = [
+    "lz4"
+    "lz4.block"
+    "lz4.frame"
+    "lz4.stream"
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    psutil
+  ];
+
+  # leave build directory, so the installed library gets imported
+  preCheck = ''
+    pushd tests
+  '';
+
+  postCheck = ''
+    popd
+  '';
+
+  meta = with lib; {
+    description = "LZ4 Bindings for Python";
+    homepage = "https://github.com/python-lz4/python-lz4";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ costrouc ];
   };
 }

--- a/pkgs/development/python-modules/packaging/default.nix
+++ b/pkgs/development/python-modules/packaging/default.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage rec {
   pname = "packaging";
-  version = "20.9";
+  version = "21.3";
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-WzJ6wTINyGPcpy9FFOzAhvMRhnRLhKIwN0zB/Xdv6uU=";
+    sha256 = "sha256-3UfEKSfYmrkR5gZRiQfMLTofOLvQJjhZcGQ/nFuOz+s=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/redis/default.nix
+++ b/pkgs/development/python-modules/redis/default.nix
@@ -1,13 +1,48 @@
-{ lib, fetchPypi, buildPythonPackage }:
+{ lib
+, fetchPypi
+, buildPythonPackage
+, pythonOlder
+
+# propagates
+, cryptography
+, deprecated
+, hiredis
+, importlib-metadata
+, packaging
+, requests
+}:
 
 buildPythonPackage rec {
   pname = "redis";
-  version = "3.5.3";
+  version = "4.1.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0e7e0cfca8660dea8b7d5cd8c4f6c5e29e11f31158c0b0ae91a397f00e5a05a2";
+    sha256 = "sha256-IfCiO85weQkHbmuizgdsulm/9g0qsily4GR/32IP/kc=";
   };
+
+  propagatedBuildInputs = [
+    cryptography
+    deprecated
+    hiredis
+    packaging
+    requests
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    importlib-metadata
+  ];
+
+  pythonImportsCheck = [
+    "redis"
+    "redis.client"
+    "redis.cluster"
+    "redis.connection"
+    "redis.exceptions"
+    "redis.sentinel"
+    "redis.utils"
+  ];
 
   # tests require a running redis
   doCheck = false;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
django-redis
- https://github.com/jazzband/django-redis/releases/tag/5.2.0

packaging
- https://github.com/pypa/packaging/releases/tag/21.3
- https://github.com/pypa/packaging/releases/tag/21.2
- https://github.com/pypa/packaging/releases/tag/21.1
- https://github.com/pypa/packaging/releases/tag/21.0

hiredis
- does not depend on redis anymore, but redis optionally depends on hiredis, removing redis dependency solves infinite recursion

redis
- https://github.com/redis/redis-py/releases/tag/v4.1.0
- https://github.com/redis/redis-py/releases/tag/v4.0.2
- https://github.com/redis/redis-py/releases/tag/v4.0.1
- https://github.com/redis/redis-py/releases/tag/v4.0.0

lz4
- https://github.com/python-lz4/python-lz4/releases/tag/v3.1.12
- https://github.com/python-lz4/python-lz4/releases/tag/v3.1.11

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
