### PR TITLE
Mautrix updates

### DIFF
--- a/nixos/modules/services/misc/mautrix-telegram.nix
+++ b/nixos/modules/services/misc/mautrix-telegram.nix
@@ -145,7 +145,7 @@ in {
             --config='${settingsFile}' \
             --registration='${registrationFile}'
         fi
-
+      '' + lib.optionalString (pkgs.mautrix-telegram ? alembic) ''
         # run automatic database init and migration scripts
         ${pkgs.mautrix-telegram.alembic}/bin/alembic -x config='${settingsFile}' upgrade head
       '';

--- a/pkgs/development/python-modules/mautrix/default.nix
+++ b/pkgs/development/python-modules/mautrix/default.nix
@@ -4,11 +4,11 @@
 
 buildPythonPackage rec {
   pname = "mautrix";
-  version = "0.12.4";
+  version = "0.14.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "c8d226a96e57d52bb532d7e572ba5670d2e2143f720063a4bbd04a77049030d4";
+    sha256 = "5ad04e87bcf31eb3479fdd3cabd5082b257013e5c00f6b369539a2b584afadaf";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/heisenbridge/default.nix
+++ b/pkgs/servers/heisenbridge/default.nix
@@ -1,6 +1,21 @@
-{ lib, fetchFromGitHub, fetchpatch, python3Packages }:
+{ lib, fetchFromGitHub, fetchpatch, python3 }:
 
-python3Packages.buildPythonApplication rec {
+let
+  python = python3.override {
+    packageOverrides = self: super: {
+      mautrix_0_13 = self.mautrix.overridePythonAttrs (oldAttrs: rec {
+        version = "0.13.3";
+        src = oldAttrs.src.override {
+          inherit (oldAttrs) pname;
+          inherit version;
+          sha256 = "1e4a292469f3e200c182aaa5bf693a5c3834b2a0cfb3d29e4c9a1559db7740e3";
+        };
+      });
+    };
+  };
+in
+
+python.pkgs.buildPythonApplication rec {
   pname = "heisenbridge";
   version = "1.8.2";
 
@@ -15,15 +30,15 @@ python3Packages.buildPythonApplication rec {
     echo "${version}" > heisenbridge/version.txt
   '';
 
-  propagatedBuildInputs = with python3Packages; [
+  propagatedBuildInputs = with python.pkgs; [
     aiohttp
     irc
-    mautrix
+    mautrix_0_13
     python-socks
     pyyaml
   ];
 
-  checkInputs = with python3Packages; [
+  checkInputs = with python.pkgs; [
     pytestCheckHook
   ];
 

--- a/pkgs/servers/mautrix-telegram/0001-Re-add-entrypoint.patch
+++ b/pkgs/servers/mautrix-telegram/0001-Re-add-entrypoint.patch
@@ -8,22 +8,20 @@ Subject: [PATCH 1/2] Re-add entrypoint
  1 file changed, 6 insertions(+)
 
 diff --git a/setup.py b/setup.py
-index 068c351..95dbf89 100644
+index ea001e5..e1ca536 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -51,6 +51,12 @@ setuptools.setup(
+@@ -54,6 +54,12 @@ setuptools.setup(
      extras_require=extras_require,
-     python_requires="~=3.6",
- 
+     python_requires="~=3.7",
+
 +    entry_points={
 +        'console_scripts': [
 +            'mautrix-telegram=mautrix_telegram.__main__:main'
 +        ]
 +    },
 +
-     setup_requires=["pytest-runner"],
-     tests_require=["pytest", "pytest-asyncio", "pytest-mock"],
- 
--- 
-2.28.0
+     classifiers=[
+         "Development Status :: 4 - Beta",
+         "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
 

--- a/pkgs/servers/mautrix-telegram/default.nix
+++ b/pkgs/servers/mautrix-telegram/default.nix
@@ -5,20 +5,12 @@
 let
   python = python3.override {
     packageOverrides = self: super: {
-      sqlalchemy = super.sqlalchemy.overridePythonAttrs (oldAttrs: rec {
-        version = "1.3.24";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "ebbb777cbf9312359b897bf81ba00dae0f5cb69fba2a18265dcc18a6f5ef7519";
-        };
-      });
-
       tulir-telethon = self.telethon.overridePythonAttrs (oldAttrs: rec {
-        version = "1.24.0a2";
+        version = "1.25.0a1";
         pname = "tulir-telethon";
         src = oldAttrs.src.override {
           inherit pname version;
-          sha256 = "sha256-Qbx164FwC8nhesoY2fkaKvErN8g0Ph8vGcx+Cc1AqRg=";
+          sha256 = "sha256-TFZRmhCrQ9IccGFcYxwdbD2ReSCWZ2n33S1ank1Bn1k=";
         };
       });
     };
@@ -33,17 +25,17 @@ let
 
 in python.pkgs.buildPythonPackage rec {
   pname = "mautrix-telegram";
-  version = "0.10.2";
+  version = "0.11.0";
   disabled = python.pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "mautrix";
     repo = "telegram";
     rev = "v${version}";
-    sha256 = "sha256-BYsGLyxhdjBVmnZXLC5ZjwDlWcHdUGp+DsNIOXA1/Tc=";
+    sha256 = "sha256-s0UCl0FJWO53hvHJhpeSQVGCBKEH7COFLXFCFitpDjw=";
   };
 
-  patches = [ ./0001-Re-add-entrypoint.patch ./0002-Don-t-depend-on-pytest-runner.patch ];
+  patches = [ ./0001-Re-add-entrypoint.patch ];
   postPatch = ''
     sed -i -e '/alembic>/d' requirements.txt
     substituteInPlace requirements.txt \


### PR DESCRIPTION
###### Motivation for this change

Fixes the build of mautrix-telegram. Might break others, but it should still be an improvement over the current situation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
