### PR TITLE
gg-scm: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13434,6 +13434,12 @@
     github = "zeri42";
     githubId = 68825133;
   };
+  zombiezen = {
+    name = "Ross Light";
+    email = "ross@zombiezen.com";
+    github = "zombiezen";
+    githubId = 181535;
+  };
   zseri = {
     name = "zseri";
     email = "zseri.devel@ytrizja.de";

--- a/pkgs/applications/version-management/git-and-tools/gg/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gg/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+, makeWrapper
+, git
+, pandoc
+}:
+
+buildGoModule rec {
+  pname = "gg-scm";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "gg-scm";
+    repo = "gg";
+    rev = "v${version}";
+    sha256 = "sha256-kLmu4h/EBbSFHrffvusKq38X3/ID9bOlLMvEUtnFGhk=";
+  };
+  patches = [ ./skip-broken-revert-tests.patch ];
+  subPackages = [ "cmd/gg" ];
+  ldflags = [
+    "-s" "-w"
+    "-X" "main.versionInfo=${version}"
+    "-X" "main.buildCommit=a0b348c9cef33fa46899f5e55e3316f382a09f6a+"
+  ];
+
+  vendorSha256 = "sha256-+ZmNXB+I6vPRbACwEkfl/vVmqoZy67Zn9SBrham5zRk=";
+
+  nativeBuildInputs = [ git pandoc installShellFiles makeWrapper ];
+  buildInputs = [ git ];
+
+  postInstall = ''
+    wrapProgram $out/bin/gg --suffix PATH : ${git}/bin
+    pandoc --standalone --to man misc/gg.1.md -o misc/gg.1
+    installManPage misc/gg.1
+    installShellCompletion --cmd gg \
+      --bash misc/gg.bash \
+      --zsh misc/_gg.zsh
+  '';
+
+  meta = with lib; {
+    mainProgram = "gg";
+    description = "Git with less typing";
+    longDescription = ''
+      gg is an alternative command-line interface for Git heavily inspired by Mercurial.
+      It's designed for less typing in common workflows,
+      making Git easier to use for both novices and advanced users alike.
+    '';
+    homepage = "https://gg-scm.io/";
+    changelog = "https://github.com/gg-scm/gg/blob/v${version}/CHANGELOG.md";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ zombiezen ];
+  };
+}

--- a/pkgs/applications/version-management/git-and-tools/gg/skip-broken-revert-tests.patch
+++ b/pkgs/applications/version-management/git-and-tools/gg/skip-broken-revert-tests.patch
@@ -1,0 +1,12 @@
+diff --git a/cmd/gg/revert_test.go b/cmd/gg/revert_test.go
+index 9420e9b..ff6ca93 100644
+--- a/cmd/gg/revert_test.go
++++ b/cmd/gg/revert_test.go
+@@ -592,6 +592,7 @@ func TestRevert_LocalRename(t *testing.T) {
+ }
+ 
+ func TestRevert_UnknownFile(t *testing.T) {
++	t.Skip("Broken in 1.1.0")
+ 	t.Parallel()
+ 	t.Run("EmptyRepo", func(t *testing.T) {
+ 		t.Parallel()

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25112,6 +25112,8 @@ with pkgs;
 
   fnott = callPackage ../applications/misc/fnott { };
 
+  gg-scm = callPackage ../applications/version-management/git-and-tools/gg { };
+
   gigalixir = with python3Packages; toPythonApplication gigalixir;
 
   go-libp2p-daemon = callPackage ../servers/go-libp2p-daemon { };


### PR DESCRIPTION
###### Motivation for this change

Add packaging for https://gg-scm.io

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
