### PR TITLE
python3Packages.emv: 1.0.13 -> 1.0.14

### DIFF
--- a/pkgs/development/python-modules/emv/default.nix
+++ b/pkgs/development/python-modules/emv/default.nix
@@ -1,31 +1,29 @@
-{ lib, buildPythonPackage, fetchFromGitHub
-, click, enum-compat, pyscard, pycountry, terminaltables
-, pytestCheckHook, pythonOlder
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, click
+, pyscard
+, pycountry
+, terminaltables
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "emv";
-  version = "1.0.13";
+  version = "1.0.14";
+  format = "setuptools";
+
   disabled = pythonOlder "3.4";
 
   src = fetchFromGitHub {
     owner = "russss";
     repo = "python-emv";
     rev = "v${version}";
-    hash = "sha256-Jobw8OyKMaLfVsvMadrUrg5BijFo9G6kjgjhGIV8H1M=";
+    hash = "sha256-MnaeQZ0rA3i0CoUA6HgJQpwk5yo4rm9e+pc5XzRd1eg=";
   };
 
-  postPatch = ''
-    # argparse is part of the standard libary since python 2.7/3.2
-    sed -i '/argparse==1.4.0/d' setup.py
-
-    substituteInPlace setup.py \
-      --replace "click==7.1.2" "click" \
-      --replace "pyscard==2.0.0" "pyscard"
-  '';
-
   propagatedBuildInputs = [
-    enum-compat
     click
     pyscard
     pycountry
@@ -36,9 +34,21 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace '"enum-compat==0.0.3",' "" \
+      --replace '"argparse==1.4.0",' "" \
+      --replace "click==7.1.2" "click" \
+      --replace "pyscard==2.0.0" "pyscard"
+  '';
+
+  pythonImportsCheck = [
+    "emv"
+  ];
+
   meta = with lib; {
-    homepage = "https://github.com/russss/python-emv";
     description = "Implementation of the EMV chip-and-pin smartcard protocol";
+    homepage = "https://github.com/russss/python-emv";
     license = licenses.mit;
     maintainers = with maintainers; [ lukegb ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/russss/python-emv/releases/tag/v1.0.14

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
