### PR TITLE
CuboCore.packages: 4.2.0 -> 4.3.0

### DIFF
--- a/pkgs/applications/misc/cubocore-packages/coreaction/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/coreaction/default.nix
@@ -1,23 +1,15 @@
-{ mkDerivation, lib, fetchFromGitLab, fetchpatch, qtsvg, qtbase, cmake, ninja, libcprime, libcsys }:
+{ mkDerivation, lib, fetchFromGitLab, qtsvg, qtbase, cmake, ninja, libcprime, libcsys }:
 
 mkDerivation rec {
   pname = "coreaction";
-  version = "4.2.0";
+  version = "4.3.0";
 
   src = fetchFromGitLab {
     owner = "cubocore/coreapps";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-5qEZNLvbgLoAOXij0wXoVw2iyvytsYZikSJDm6F6ddc=";
+    sha256 = "sha256-XQ/GcSjGSe+3d0dJxjmmcBFoDzrmM6zsHMfbDdzmpPs=";
   };
-
-  patches = [
-    ## Fix Plugin Error: "The shared library was not found." "libbatery.so"
-    (fetchpatch {
-      url = "https://gitlab.com/cubocore/coreapps/coreaction/-/commit/1d1307363614a117978723eaad2332e6e8c05b28.patch";
-      sha256 = "039x19rsm23l9vxd5mnbl6gvc3is0igahf47kv54v6apz2q72l3f";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/applications/misc/cubocore-packages/corearchiver/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/corearchiver/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "corearchiver";
-  version = "4.2.0";
+  version = "4.3.0";
 
   src = fetchFromGitLab {
     owner = "cubocore/coreapps";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-FJGsQp1lbsrvlzKPiTv/FC9RH2+JRwwIvkLDTFW8t5s=";
+    sha256 = "sha256-EUcUivUuuUApIC9daS6BFA1YoE4yO3Kc8jG0VIks/Y0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/cubocore-packages/corefm/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/corefm/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "corefm";
-  version = "4.2.0";
+  version = "4.3.0";
 
   src = fetchFromGitLab {
     owner = "cubocore/coreapps";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-PczKIKY9uCD+cAzAC6Gkb+g+cn9KKCQYd3epoZK8bvA=";
+    sha256 = "sha256-uScM6cVRwYopZ6NY3PSAAyxNNyX3hVnFs6hkAyF29PA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/cubocore-packages/coregarage/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/coregarage/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "coregarage";
-  version = "4.2.0";
+  version = "4.3.0";
 
   src = fetchFromGitLab {
     owner = "cubocore/coreapps";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-2pOQwSj+QKwpHVJp7VCyq6QpVW5wLUf/BE7ReXrJ78s=";
+    sha256 = "sha256-Jq0lIXfw/1Ixd+QIY7D1ErBCOSKmwkWBupcDxUUEliM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/cubocore-packages/corehunt/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/corehunt/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "corehunt";
-  version = "4.2.0";
+  version = "4.3.0";
 
   src = fetchFromGitLab {
     owner = "cubocore/coreapps";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-KnIqLI8MtLirFycW2YNHAjS7EDfU3dpqb6vVq9Tl6Ow=";
+    sha256 = "sha256-zhJadrdOXpl0bXxEPWjQ59Pzjg4MfIZXtYzCnJbh+pI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/cubocore-packages/coreimage/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/coreimage/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "coreimage";
-  version = "4.2.0";
+  version = "4.3.0";
 
   src = fetchFromGitLab {
     owner = "cubocore/coreapps";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-dxRHzSG5ea1MhpTjgZbFztV9mElEaeOK4NsmieSgf5Q";
+    sha256 = "sha256-uG9/8sQK0G3f7O59OHEHqNHP8cUC73hmjsfpOnj0kFM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/cubocore-packages/coreinfo/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/coreinfo/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "coreinfo";
-  version = "4.2.0";
+  version = "4.3.0";
 
   src = fetchFromGitLab {
     owner = "cubocore/coreapps";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-kLBOvvulHE1+4TyZVEVZwEA+Id7+w8fI3ll+QL2ukr0=";
+    sha256 = "sha256-KoX2U07giVF2xZR1diM6teiNfKYRiqjowTJgnsMlaN0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/cubocore-packages/corekeyboard/0001-fix-installPhase.patch
+++ b/pkgs/applications/misc/cubocore-packages/corekeyboard/0001-fix-installPhase.patch
@@ -1,0 +1,8 @@
+--- a/corekeyboard/CMakeLists.txt	2022-01-29 14:03:28.149607341 +0700
++++ b/CMakeLists.txt	2022-01-29 14:04:00.178733700 +0700
+@@ -55,5 +55,4 @@
+ 
+ install( TARGETS corekeyboard DESTINATION bin )
+ install( FILES org.cubocore.CoreKeyboard.desktop DESTINATION share/applications )
+-install( FILES org.cubocore.CoreKeyboard-Tray.desktop DESTINATION /etc/xdg/autostart )
+ install( FILES org.cubocore.CoreKeyboard.svg DESTINATION share/icons/hicolor/scalable/apps/ )

--- a/pkgs/applications/misc/cubocore-packages/corekeyboard/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/corekeyboard/default.nix
@@ -2,14 +2,19 @@
 
 mkDerivation rec {
   pname = "corekeyboard";
-  version = "4.2.0";
+  version = "4.3.0";
 
   src = fetchFromGitLab {
     owner = "cubocore/coreapps";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-0CbQ43BN4ORvtxs6FwNkgk/0jcVdFJq/tqvjUGYanM4=";
+    sha256 = "sha256-yJOcuE6HknDhXCr1qW/NJkerjvBABYntXos0owDDwcw=";
   };
+
+  patches = [
+    # Remove autostart
+    ./0001-fix-installPhase.patch
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/applications/misc/cubocore-packages/corepad/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/corepad/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "corepad";
-  version = "4.2.0";
+  version = "4.3.0";
 
   src = fetchFromGitLab {
     owner = "cubocore/coreapps";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-2bGHVv0+0NlkIqnvWm014Kr20uARWnOS5xSuNmCt/bQ=";
+    sha256 = "sha256-19qR08QhWeeXnJAQHe1SJjT0xnQLlbkXlzmd9uiMp14=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/cubocore-packages/corepaint/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/corepaint/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "corepaint";
-  version = "4.2.0";
+  version = "4.3.0";
 
   src = fetchFromGitLab {
     owner = "cubocore/coreapps";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-nATraYm7FZEXoNWgXt1G86KdrAvRgM358F+YdfWcnkg=";
+    sha256 = "sha256-uAFV3NKtgNri8GQLD+MRacl9WYMfkMVZcoVML+oSX78=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/cubocore-packages/corepdf/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/corepdf/default.nix
@@ -1,14 +1,14 @@
-{ mkDerivation, lib, fetchFromGitLab, qtbase, poppler, cmake, ninja, libcprime, libcsys }:
+{ mkDerivation, lib, fetchFromGitLab, qtbase, poppler, qtwebengine, cmake, ninja, libcprime, libcsys }:
 
 mkDerivation rec {
   pname = "corepdf";
-  version = "4.2.0";
+  version = "4.3.0";
 
   src = fetchFromGitLab {
     owner = "cubocore/coreapps";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-HeOklgCwJ5h3DeelJOZqasG+eC9DGG3R0Cqg2yPKYhM=";
+    sha256 = "sha256-VwJ3H/jNP3u5C+LATPUSftiWm89upx77fN3NqzTnU7Y=";
   };
 
   nativeBuildInputs = [
@@ -19,6 +19,7 @@ mkDerivation rec {
   buildInputs = [
     qtbase
     poppler
+    qtwebengine
     libcprime
     libcsys
   ];

--- a/pkgs/applications/misc/cubocore-packages/corepins/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/corepins/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "corepins";
-  version = "4.2.0";
+  version = "4.3.0";
 
   src = fetchFromGitLab {
     owner = "cubocore/coreapps";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-H/l/MHHrTmkfznVKUHFAhim8b/arT5SNK5fxTvjsTE4=";
+    sha256 = "sha256-CVToPF8/Tw+n31/A0bzyBbwF7xPBVirsqVOUsM8QtH0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/cubocore-packages/corerenamer/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/corerenamer/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "corerenamer";
-  version = "4.2.0";
+  version = "4.3.0";
 
   src = fetchFromGitLab {
     owner = "cubocore/coreapps";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-OI7M7vV0CA42J5cWCqgGKEzUUHSgIJCWRTXmKRD6Jb0=";
+    sha256 = "sha256-WrMyz8Noq0EeBIxL4mSl6e+8wrivmwfoa1yKBrSgrRI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/cubocore-packages/coreshot/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/coreshot/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "coreshot";
-  version = "4.2.0";
+  version = "4.3.0";
 
   src = fetchFromGitLab {
     owner = "cubocore/coreapps";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-HKgGeuM3CKGXwnFwSw6a0AB0klZKY5YS9C4q2UT6TN8=";
+    sha256 = "sha256-wEpo/YINtKAYHqlGYytUPh9ndkvQBw3tRIlyjnKJaf8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/cubocore-packages/corestats/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/corestats/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "corestats";
-  version = "4.2.0";
+  version = "4.3.0";
 
   src = fetchFromGitLab {
     owner = "cubocore/coreapps";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-/WBetvbd8e4v+j6e2xbGtSLwNMdLlaahSIks6r889B4=";
+    sha256 = "sha256-154BZIKb6QDrTC4DXh4dbFtN/Lq0ok/qOrqTkXa+rAo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/cubocore-packages/corestuff/0001-fix-installPhase.patch
+++ b/pkgs/applications/misc/cubocore-packages/corestuff/0001-fix-installPhase.patch
@@ -1,0 +1,11 @@
+--- a/corestuff/CMakeLists.txt	2022-01-29 14:09:02.699700817 +0700
++++ b/CMakeLists.txt	2022-01-29 14:09:23.211754633 +0700
+@@ -120,8 +120,3 @@
+ install( FILES org.cubocore.CoreStuff.desktop DESTINATION share/applications )
+ install( FILES org.cubocore.CoreStuff.svg DESTINATION share/icons/hicolor/scalable/apps/ )
+ install( FILES background/default.svg DESTINATION share/coreapps/background )
+-
+-if ( DEFINED ADD_AUTOSTART )
+-	message("INSTALLING TO AUTOSTART LOCATION")
+-	install( FILES org.cubocore.CoreStuff.desktop DESTINATION /etc/xdg/autostart )
+-endif()

--- a/pkgs/applications/misc/cubocore-packages/corestuff/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/corestuff/default.nix
@@ -2,14 +2,19 @@
 
 mkDerivation rec {
   pname = "corestuff";
-  version = "4.2.0";
+  version = "4.3.0";
 
   src = fetchFromGitLab {
     owner = "cubocore/coreapps";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-/mmCIHZXn/Jpjr37neI6owWuU1VO6o7wmRj6ZH8tUbo=";
+    sha256 = "sha256-snzW6cqxIyiXJLOD5MoEqmzen1aZN4IALESaIWIOMro=";
   };
+
+  patches = [
+    # Remove autostart
+    ./0001-fix-installPhase.patch
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/applications/misc/cubocore-packages/coreterminal/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/coreterminal/default.nix
@@ -12,13 +12,13 @@
 
 mkDerivation rec {
   pname = "coreterminal";
-  version = "4.2.0";
+  version = "4.3.0";
 
   src = fetchFromGitLab {
     owner = "cubocore/coreapps";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-YXs6VTem3AaK4n1DYwKP/jqNuf09Srn2THHyJJnArlc=";
+    sha256 = "sha256-0gxcbfDD43BnkxYWSdViK3hjzfgPGFruwzF4hCxFZ7c=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/cubocore-packages/coretime/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/coretime/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "coretime";
-  version = "4.2.0";
+  version = "4.3.0";
 
   src = fetchFromGitLab {
     owner = "cubocore/coreapps";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-b7oqHhsuHsy96IAXPUtw+WqneEHgn/nUDgHiJt2aXXM=";
+    sha256 = "sha256-MIcmgBfgyjEyJxXCq6IbQ/i6IdtL5cWVGpV2YZbzK58=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/cubocore-packages/coretoppings/0001-fix-install-phase.patch
+++ b/pkgs/applications/misc/cubocore-packages/coretoppings/0001-fix-install-phase.patch
@@ -1,8 +1,8 @@
---- a/corepkit/CMakeLists.txt
-+++ b/corepkit/Cmakelists.txt
+--- a/corepkit/CMakeLists.txt	2021-12-25 17:52:20.000000000 +0700
++++ b/corepkit/CMakeLists.txt	2021-12-29 17:58:09.298024297 +0700
 @@ -32,4 +32,4 @@
  target_link_libraries( corepkit  Qt5::Core )
  
  install( TARGETS corepkit DESTINATION libexec/coreapps/ )
--install( FILES org.cubocore.coreapps.policy DESTINATION /usr/share/polkit-1/actions/ )
+-install( FILES org.cubocore.coreapps.policy DESTINATION share/polkit-1/actions/ )
 +install( FILES org.cubocore.coreapps.policy DESTINATION ${CMAKE_INSTALL_PREFIX}/usr/share/polkit-1/actions/ )

--- a/pkgs/applications/misc/cubocore-packages/coretoppings/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/coretoppings/default.nix
@@ -30,13 +30,13 @@
 
 mkDerivation rec {
   pname = "coretoppings";
-  version = "4.2.0";
+  version = "4.3.0";
 
   src = fetchFromGitLab {
     owner = "cubocore/coreapps";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-DpmzGqjW1swLirRLzd5nblAb40LHAmf8nL+VykQNL3E=";
+    sha256 = "sha256-Yq57dY1zIuQN2Gj9haxJMomafL32B+/9v3lWlY9fvcc=";
   };
 
   patches = [

--- a/pkgs/applications/misc/cubocore-packages/coreuniverse/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/coreuniverse/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "coreuniverse";
-  version = "4.2.0";
+  version = "4.3.0";
 
   src = fetchFromGitLab {
     owner = "cubocore/coreapps";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-YZCMyYMAvd/xQYNUnURIvmQwaM+X+Ql93OS4ZIyAZLY=";
+    sha256 = "sha256-KNjXrsm4OfBxida8mcAlKgomcpg0xJg51ZxEdhaiL84=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/cubocore-packages/libcprime/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/libcprime/default.nix
@@ -10,13 +10,13 @@
 
 mkDerivation rec {
   pname = "libcprime";
-  version = "4.2.2";
+  version = "4.3.0";
 
   src = fetchFromGitLab {
     owner = "cubocore";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-RywvFATA/+fDP/TR5QRWaJlDgy3EID//iVmrJcj3GXI=";
+    sha256 = "sha256-+z5dXKaV2anN6OLMycEz87kDqQScgHHEKwGhDAdHSd4=";
   };
 
   patches = [

--- a/pkgs/applications/misc/cubocore-packages/libcsys/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/libcsys/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "libcsys";
-  version = "4.2.0";
+  version = "4.3.0";
 
   src = fetchFromGitLab {
     owner = "cubocore";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-9LH95uJJIn4FHfnikGi5UCI6nUNW+1cSZnJ/KpZDI5Y=";
+    sha256 = "sha256-/iRFppe08+rMQNFjWSyxo3Noy0iNaelg0JAczg/BYBs=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
