### PR TITLE
spike: do not re-evaluate nixpkgs

### DIFF
--- a/pkgs/applications/virtualization/spike/default.nix
+++ b/pkgs/applications/virtualization/spike/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchgit, dtc, fetchpatch }:
+{ lib, stdenv, fetchgit, dtc, fetchpatch, pkgsCross }:
 
 stdenv.mkDerivation rec {
   pname = "spike";
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   doInstallCheck = true;
   installCheckPhase =
     let
-      riscvPkgs = import ../../../.. { crossSystem = lib.systems.examples.riscv64-embedded; };
+      riscvPkgs = pkgsCross.riscv64-embedded;
     in
     ''
       runHook preInstallCheck


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Evaluating the spike output from the nixpkgs flake results in:

```
error: attribute 'currentSystem' missing

       at /nix/store/jd9nimiq4c3vbgdi40ld75bz3jl27ln8-source/pkgs/top-level/impure.nix:17:43:

           16|   # (build, in GNU Autotools parlance) platform.
           17|   localSystem ? { system = args.system or builtins.currentSystem; }
             |                                           ^
           18|
(use '--show-trace' to show detailed location information)
```

Avoid breaking flakes pure evaluation by using pkgsCross to get RISC-V
test binaries.

See https://github.com/NixOS/nixpkgs/pull/143832#issuecomment-1001553370 for context. 

Ping @dramforever.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
