### PR TITLE
matrix-nio: pyproject.toml aiohttp-socks "^0.6.0" -> "*"

### DIFF
--- a/pkgs/development/python-modules/matrix-nio/default.nix
+++ b/pkgs/development/python-modules/matrix-nio/default.nix
@@ -41,6 +41,8 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace 'aiofiles = "^0.6.0"' 'aiofiles = "*"'
+    substituteInPlace pyproject.toml \
+      --replace 'aiohttp-socks = "^0.6.0"' 'aiohttp-socks = "*"'
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

as of https://github.com/NixOS/nixpkgs/pull/147426 `matrix-nio` doesn't build:
```
error: builder for '/nix/store/hzh7d9l414csy1b6s8wqr627qfw3d8gf-python3.9-matrix-nio-0.18.7.drv' failed with exit code 4;
       last 10 log lines:
       >     from .client import *
       > nio/client/__init__.py:6: in <module>
       >     from .async_client import AsyncClient, AsyncClientConfig, DataProvider
       > nio/client/async_client.py:56: in <module>
       >     from aiohttp_socks import ProxyConnector
       > /nix/store/5q1a73pdngqj4xcfylzg4yggjg0dd5d1-python3.9-aiohttp-socks-0.6.0/lib/python3.9/site-packages/aiohttp_socks/__init__.py:11: in <module>
       >     from .connector import (
       > /nix/store/5q1a73pdngqj4xcfylzg4yggjg0dd5d1-python3.9-aiohttp-socks-0.6.0/lib/python3.9/site-packages/aiohttp_socks/connector.py:9: in <module>
       >     from python_socks.async_.asyncio.ext import Proxy
       > E   ModuleNotFoundError: No module named 'python_socks.async_.asyncio.ext'
```

in tandem with https://github.com/NixOS/nixpkgs/pull/152582 it now builds.

tested with `weechatScripts.weechat-matrix`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
