### PR TITLE
python3Packages.formbox: init at 0.1.0

### DIFF
--- a/pkgs/development/python-modules/formbox/default.nix
+++ b/pkgs/development/python-modules/formbox/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, pythonOlder, fetchFromSourcehut, bleach, markdown }:
+
+buildPythonPackage rec {
+  pname = "formbox";
+  version = "0.1.0";
+  format = "flit";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromSourcehut {
+    owner = "~cnx";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-6OzmYqUC3mmrAMeMExI4rdVGUoWrxRuBfjKFYbHUlgE=";
+  };
+
+  propagatedBuildInputs = [ bleach markdown ];
+  doCheck = false; # there's no test
+  pythonImportsCheck = [ "formbox" ];
+
+  meta = with lib; {
+    description = "A script to format mbox as HTML/XML";
+    homepage = "https://sr.ht/~cnx/formbox";
+    license = licenses.agpl3Plus;
+    maintainers = [ maintainers.McSinyx ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2980,6 +2980,8 @@ in {
 
   forecast-solar = callPackage ../development/python-modules/forecast-solar { };
 
+  formbox = callPackage ../development/python-modules/formbox { };
+
   fortiosapi = callPackage ../development/python-modules/fortiosapi { };
 
   FormEncode = callPackage ../development/python-modules/FormEncode { };


### PR DESCRIPTION
###### Motivation for this change

I am using this to embed comments to my personal web log.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
