### PR TITLE
Speedcrunch fixups

### DIFF
--- a/pkgs/applications/science/math/speedcrunch/default.nix
+++ b/pkgs/applications/science/math/speedcrunch/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "speedcrunch";
-  version = "0.12.0";
+  version = "unstable-2021-10-09";
 
   src = fetchFromBitbucket {
     owner = "heldercorreia";
     repo = pname;
-    rev = "release-${version}";
-    sha256 = "0vh7cd1915bjqzkdp3sk25ngy8cq624mkh8c53c5bnzk357kb0fk";
+    rev = "74756f3438149c01e9edc3259b0f411fa319a22f";
+    sha256 = "sha256-XxQv+A5SfYXFIRK7yacxGHHne1Q93pwCGeHhchIKizU=";
   };
 
   buildInputs = [ qtbase qttools ];

--- a/pkgs/applications/science/math/speedcrunch/default.nix
+++ b/pkgs/applications/science/math/speedcrunch/default.nix
@@ -1,13 +1,13 @@
-{ mkDerivation, lib, fetchgit, cmake, qtbase, qttools }:
+{ mkDerivation, lib, fetchFromBitbucket, cmake, qtbase, qttools }:
 
 mkDerivation rec {
   pname = "speedcrunch";
   version = "0.12.0";
 
-  src = fetchgit {
-    # the tagging is not standard, so you probably need to check this when updating
-    rev = "refs/tags/release-${version}";
-    url = "https://bitbucket.org/heldercorreia/speedcrunch";
+  src = fetchFromBitbucket {
+    owner = "heldercorreia";
+    repo = pname;
+    rev = "release-${version}";
     sha256 = "0vh7cd1915bjqzkdp3sk25ngy8cq624mkh8c53c5bnzk357kb0fk";
   };
 
@@ -29,7 +29,7 @@ mkDerivation rec {
       precisions, unlimited variable storage, intelligent automatic completion
       full keyboard-friendly and more than 15 built-in math function.
     '';
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ gebner j0hax ];
     inherit (qtbase.meta) platforms;
     # works with qt 5.6 and qt 5.8
     broken = builtins.compareVersions qtbase.version "5.7.0" == 0;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Small improvements to SpeedCrunch

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
