### PR TITLE
matrix-appservice-slack: Slim down dependencies

### DIFF
--- a/pkgs/servers/matrix-synapse/matrix-appservice-slack/default.nix
+++ b/pkgs/servers/matrix-synapse/matrix-appservice-slack/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, nodejs, nodejs-slim, stdenv, fetchFromGitHub, lib, ... }:
+{ pkgs, nodejs, nodejs-slim, stdenv, fetchFromGitHub, lib, runCommand, matrix-appservice-slack }:
 let
   src = fetchFromGitHub {
     owner = "matrix-org";
@@ -12,9 +12,9 @@ let
     inherit (stdenv.hostPlatform) system;
     nodejs = nodejs-slim;
   };
+  pname = "matrix-appservice-slack";
 in
 nodePackages.package.override {
-  pname = "matrix-appservice-slack";
 
   inherit src;
 
@@ -33,6 +33,13 @@ nodePackages.package.override {
     makeWrapper '${nodejs-slim}/bin/node' "$out/bin/matrix-appservice-slack" \
     --add-flags "$out/lib/node_modules/matrix-appservice-slack/lib/app.js"
   '';
+
+  passthru.tests = {
+    simple = runCommand "${pname}-test" {} ''
+      ${matrix-appservice-slack}/bin/matrix-appservice-slack --help > $out
+      [ -s $out ]
+    '';
+  };
 
   meta = with lib; {
     description = "A Matrix <--> Slack bridge";


### PR DESCRIPTION
###### Motivation for this change

Due to the setup of the node env and npm packages in general,
the resulting nix derivations contain a lot of unwanted dependencies.
In the the case of matrix-appservice-slack, this includes a fully
functional gcc which is required to build native bindings but is
unnecessary at runtime, as well as a full nodejs toolchain,
including tooling like npm and the like.

Switching to nodejs-slim and patching over node paths, in addition with
stripping debug symbols from native bindings, mitigates this a lot,
resulting in a massively reduced closure.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
