### PR TITLE
factorio-experimental: 1.1.48 -> 1.1.50

### DIFF
--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -2,48 +2,48 @@
   "x86_64-linux": {
     "alpha": {
       "experimental": {
-        "name": "factorio_alpha_x64-1.1.48.tar.xz",
+        "name": "factorio_alpha_x64-1.1.50.tar.xz",
         "needsAuth": true,
-        "sha256": "1j26rrllmbk535xspqp3czl19ijbvyglxfa0ivpmw4wj2cm6796n",
+        "sha256": "1sb3kvpj3kikr1bvm4si4f3dmj7873dhbz6zj57kin6d5mbmhq4p",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.48/alpha/linux64",
-        "version": "1.1.48"
+        "url": "https://factorio.com/get-download/1.1.50/alpha/linux64",
+        "version": "1.1.50"
       },
       "stable": {
-        "name": "factorio_alpha_x64-1.1.48.tar.xz",
+        "name": "factorio_alpha_x64-1.1.50.tar.xz",
         "needsAuth": true,
-        "sha256": "1j26rrllmbk535xspqp3czl19ijbvyglxfa0ivpmw4wj2cm6796n",
+        "sha256": "1sb3kvpj3kikr1bvm4si4f3dmj7873dhbz6zj57kin6d5mbmhq4p",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.48/alpha/linux64",
-        "version": "1.1.48"
+        "url": "https://factorio.com/get-download/1.1.50/alpha/linux64",
+        "version": "1.1.50"
       }
     },
     "demo": {
       "stable": {
-        "name": "factorio_demo_x64-1.1.46.tar.xz",
+        "name": "factorio_demo_x64-1.1.50.tar.xz",
         "needsAuth": false,
-        "sha256": "sha256-CJVk1b3GXqs8xV2a7Pa6p6JxEOy86xAnRfz6kphCDHk=",
+        "sha256": "0i3r21i7s4yzjfqrwf82x87pfjg7d3bhkz3zqi0x398j9bykpw43",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.46/demo/linux64",
-        "version": "1.1.46"
+        "url": "https://factorio.com/get-download/1.1.50/demo/linux64",
+        "version": "1.1.50"
       }
     },
     "headless": {
       "experimental": {
-        "name": "factorio_headless_x64-1.1.48.tar.xz",
+        "name": "factorio_headless_x64-1.1.50.tar.xz",
         "needsAuth": false,
-        "sha256": "0hipzxaj322y4g1if44p818f7f5zmhg831xw6ahxnqg5g8kvf19y",
+        "sha256": "0j75wbnszhlmyk655b2h8jd1lvmnplq44blixl959hh3lxvqn50m",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.48/headless/linux64",
-        "version": "1.1.48"
+        "url": "https://factorio.com/get-download/1.1.50/headless/linux64",
+        "version": "1.1.50"
       },
       "stable": {
-        "name": "factorio_headless_x64-1.1.48.tar.xz",
+        "name": "factorio_headless_x64-1.1.50.tar.xz",
         "needsAuth": false,
-        "sha256": "0hipzxaj322y4g1if44p818f7f5zmhg831xw6ahxnqg5g8kvf19y",
+        "sha256": "0j75wbnszhlmyk655b2h8jd1lvmnplq44blixl959hh3lxvqn50m",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.48/headless/linux64",
-        "version": "1.1.48"
+        "url": "https://factorio.com/get-download/1.1.50/headless/linux64",
+        "version": "1.1.50"
       }
     }
   }


### PR DESCRIPTION
###### Motivation for this change

https://wiki.factorio.com/Version_history/1.1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
tes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
