### PR TITLE
python3Packages.python-izone: 1.1.8 -> 1.2.3

### DIFF
--- a/pkgs/development/python-modules/pytest-aio/default.nix
+++ b/pkgs/development/python-modules/pytest-aio/default.nix
@@ -1,11 +1,15 @@
 { lib
+, anyio
 , buildPythonPackage
-, fetchPypi
+, curio
+, fetchFromGitHub
+, hypothesis
 , pytest
-, pytest-mypy
 , pytestCheckHook
 , pythonOlder
-, types-setuptools
+, sniffio
+, trio
+, trio-asyncio
 }:
 
 buildPythonPackage rec {
@@ -15,19 +19,29 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.7";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "ZPG6k+ZNi6FQftIVwr/Lux5rJlo284V/mjtYepNScdQ=";
+  src = fetchFromGitHub {
+    owner = "klen";
+    repo = "pytest-aio";
+    rev = version;
+    sha256 = "pLH0yXe/KS9ohI8+hWSprP1OA3Qjki2BPqeApMPMGDs=";
   };
+
+  postPatch = ''
+    sed -i '/addopts/d' setup.cfg
+  '';
 
   buildInputs = [
     pytest
   ];
 
   checkInputs = [
-    pytest-mypy
+    anyio
+    curio
+    hypothesis
     pytestCheckHook
-    types-setuptools
+    sniffio
+    trio
+    trio-asyncio
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/python-izone/default.nix
+++ b/pkgs/development/python-modules/python-izone/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "python-izone";
-  version = "1.1.8";
+  version = "1.2.3";
   format = "setuptools";
 
   disabled = pythonOlder "3.8";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "Swamp-Ig";
     repo = "pizone";
     rev = "v${version}";
-    sha256 = "sha256-/qPWSTO0PV4lEgwWpgcoBnbUtDUrEVItb4NF9TV2QJU=";
+    hash = "sha256-WF37t9vCEIyQMeN3/CWAiiZ5zsMRMFQ5UvMUqfoGM9I=";
   };
 
   propagatedBuildInputs = [
@@ -34,10 +34,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  disabledTestPaths = [
-    # Test are blocking
-    "tests/test_fullstack.py"
-  ];
+  doCheck = false; # most tests access network
 
   pythonImportsCheck = [
     "pizone"

--- a/pkgs/development/python-modules/trio-asyncio/default.nix
+++ b/pkgs/development/python-modules/trio-asyncio/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, trio
+, outcome
+, sniffio
+, pytest-trio
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "trio-asyncio";
+  version = "0.12.0";
+
+  src = fetchPypi {
+    pname = "trio_asyncio";
+    inherit version;
+    sha256 = "824be23b0c678c0df942816cdb57b92a8b94f264fffa89f04626b0ba2d009768";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "'pytest-runner'" ""
+  '';
+
+  propagatedBuildInputs = [
+    trio
+    outcome
+    sniffio
+  ];
+
+  checkInputs = [
+    pytest-trio
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    "tests/python" # tries to import internal API test.test_asyncio
+  ];
+
+  meta = with lib; {
+    description = "Re-implementation of the asyncio mainloop on top of Trio";
+    homepage = "https://github.com/python-trio/trio-asyncio";
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9750,6 +9750,8 @@ in {
 
   trio = callPackage ../development/python-modules/trio { };
 
+  trio-asyncio = callPackage ../development/python-modules/trio-asyncio { };
+
   trueskill = callPackage ../development/python-modules/trueskill { };
 
   trustme = callPackage ../development/python-modules/trustme { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
