### PR TITLE
CockroachDB: 20.1.8 -> {20.2.18, 21.1.13, 21.2.4}

### DIFF
--- a/nixos/modules/services/databases/cockroachdb.nix
+++ b/nixos/modules/services/databases/cockroachdb.nix
@@ -6,49 +6,47 @@ let
   cfg = config.services.cockroachdb;
   crdb = cfg.package;
 
-  escape    = builtins.replaceStrings ["%"] ["%%"];
+  escape = builtins.replaceStrings [ "%" ] [ "%%" ];
   ifNotNull = v: s: optionalString (v != null) s;
 
-  startupCommand = lib.concatStringsSep " "
-    [ # Basic startup
-      "${crdb}/bin/cockroach start"
-      "--logtostderr"
-      "--store=/var/lib/cockroachdb"
-      (ifNotNull cfg.locality "--locality='${cfg.locality}'")
+  startupCommand = lib.concatStringsSep " " [ # Basic startup
+    "${crdb}/bin/cockroach start"
+    "--logtostderr"
+    "--store=/var/lib/cockroachdb"
+    (ifNotNull cfg.locality "--locality='${cfg.locality}'")
 
-      # WebUI settings
-      "--http-addr='${cfg.http.address}:${toString cfg.http.port}'"
+    # WebUI settings
+    "--http-addr='${cfg.http.address}:${toString cfg.http.port}'"
 
-      # Cluster listen address
-      "--listen-addr='${cfg.listen.address}:${toString cfg.listen.port}'"
+    # Cluster listen address
+    "--listen-addr='${cfg.listen.address}:${toString cfg.listen.port}'"
 
-      # Cluster configuration
-      (ifNotNull cfg.join "--join=${cfg.join}")
+    # Cluster configuration
+    "--join=${cfg.join}"
 
-      # Cache and memory settings. Must be escaped.
-      "--cache='${escape cfg.cache}'"
-      "--max-sql-memory='${escape cfg.maxSqlMemory}'"
+    # Cache and memory settings. Must be escaped.
+    "--cache='${escape cfg.cache}'"
+    "--max-sql-memory='${escape cfg.maxSqlMemory}'"
 
-      # Certificate/security settings.
-      (if cfg.insecure then "--insecure" else "--certs-dir=${cfg.certsDir}")
-    ];
+    # Certificate/security settings.
+    (if cfg.insecure then "--insecure" else "--certs-dir=${cfg.certsDir}")
+  ];
 
-    addressOption = descr: defaultPort: {
-      address = mkOption {
-        type = types.str;
-        default = "localhost";
-        description = "Address to bind to for ${descr}";
-      };
-
-      port = mkOption {
-        type = types.port;
-        default = defaultPort;
-        description = "Port to bind to for ${descr}";
-      };
+  addressOption = descr: defaultPort: {
+    address = mkOption {
+      type = types.str;
+      default = "localhost";
+      description = "Address to bind to for ${descr}";
     };
-in
 
-{
+    port = mkOption {
+      type = types.port;
+      default = defaultPort;
+      description = "Port to bind to for ${descr}";
+    };
+  };
+
+in {
   options = {
     services.cockroachdb = {
       enable = mkEnableOption "CockroachDB Server";
@@ -80,8 +78,8 @@ in
       };
 
       join = mkOption {
-        type = types.nullOr types.str;
-        default = null;
+        type = types.str;
+        default = "localhost";
         description = "The addresses for connecting the node to a cluster.";
       };
 
@@ -112,7 +110,8 @@ in
       openPorts = mkOption {
         type = types.bool;
         default = false;
-        description = "Open firewall ports for cluster communication by default";
+        description =
+          "Open firewall ports for cluster communication by default";
       };
 
       cache = mkOption {
@@ -163,19 +162,19 @@ in
   };
 
   config = mkIf config.services.cockroachdb.enable {
-    assertions = [
-      { assertion = !cfg.insecure -> cfg.certsDir != null;
-        message = "CockroachDB must have a set of SSL certificates (.certsDir), or run in Insecure Mode (.insecure = true)";
-      }
-    ];
+    assertions = [{
+      assertion = !cfg.insecure -> cfg.certsDir != null;
+      message =
+        "CockroachDB must have a set of SSL certificates (.certsDir), or run in Insecure Mode (.insecure = true)";
+    }];
 
     environment.systemPackages = [ crdb ];
 
     users.users = optionalAttrs (cfg.user == "cockroachdb") {
       cockroachdb = {
         description = "CockroachDB Server User";
-        uid         = config.ids.uids.cockroachdb;
-        group       = cfg.group;
+        uid = config.ids.uids.cockroachdb;
+        group = cfg.group;
       };
     };
 
@@ -183,34 +182,34 @@ in
       cockroachdb.gid = config.ids.gids.cockroachdb;
     };
 
-    networking.firewall.allowedTCPPorts = lib.optionals cfg.openPorts
-      [ cfg.http.port cfg.listen.port ];
+    networking.firewall.allowedTCPPorts =
+      lib.optionals cfg.openPorts [ cfg.http.port cfg.listen.port ];
 
-    systemd.services.cockroachdb =
-      { description   = "CockroachDB Server";
-        documentation = [ "man:cockroach(1)" "https://www.cockroachlabs.com" ];
+    systemd.services.cockroachdb = {
+      description = "CockroachDB Server";
+      documentation = [ "man:cockroach(1)" "https://www.cockroachlabs.com" ];
 
-        after    = [ "network.target" "time-sync.target" ];
-        requires = [ "time-sync.target" ];
-        wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" "time-sync.target" ];
+      requires = [ "time-sync.target" ];
+      wantedBy = [ "multi-user.target" ];
 
-        unitConfig.RequiresMountsFor = "/var/lib/cockroachdb";
+      unitConfig.RequiresMountsFor = "/var/lib/cockroachdb";
 
-        serviceConfig =
-          { ExecStart = startupCommand;
-            Type = "notify";
-            User = cfg.user;
-            StateDirectory = "cockroachdb";
-            StateDirectoryMode = "0700";
+      serviceConfig = {
+        ExecStart = startupCommand;
+        Type = "notify";
+        User = cfg.user;
+        StateDirectory = "cockroachdb";
+        StateDirectoryMode = "0700";
 
-            Restart = "always";
+        Restart = "always";
 
-            # A conservative-ish timeout is alright here, because for Type=notify
-            # cockroach will send systemd pings during startup to keep it alive
-            TimeoutStopSec = 60;
-            RestartSec = 10;
-          };
+        # A conservative-ish timeout is alright here, because for Type=notify
+        # cockroach will send systemd pings during startup to keep it alive
+        TimeoutStopSec = 60;
+        RestartSec = 10;
       };
+    };
   };
 
   meta.maintainers = with lib.maintainers; [ thoughtpolice ];

--- a/pkgs/servers/sql/cockroachdb/default.nix
+++ b/pkgs/servers/sql/cockroachdb/default.nix
@@ -1,70 +1,25 @@
-{ lib, stdenv, buildGoPackage, fetchurl
-, cmake, xz, which, autoconf
-, ncurses6, libedit, libunwind
-, installShellFiles
-, removeReferencesTo, go
-}:
+# https://www.cockroachlabs.com/docs/releases/release-support-policy.html
 
-let
-  darwinDeps = [ libunwind libedit ];
-  linuxDeps  = [ ncurses6 ];
-
-  buildInputs = if stdenv.isDarwin then darwinDeps else linuxDeps;
-  nativeBuildInputs = [ installShellFiles cmake xz which autoconf ];
-
-in
-buildGoPackage rec {
-  pname = "cockroach";
-  version = "20.1.8";
-
-  goPackagePath = "github.com/cockroachdb/cockroach";
-
-  src = fetchurl {
-    url = "https://binaries.cockroachdb.com/cockroach-v${version}.src.tgz";
-    sha256 = "0mm3hfr778c7djza8gr1clwa8wca4d3ldh9hlg80avw4x664y5zi";
+{ callPackage }: {
+  # Maintenance Support Ends: 2021-11-10
+  # EOL: 2022-05-10
+  cockroachdb_20_2 = callPackage ./generic.nix {
+    version = "20.2.18";
+    sha256 = "1m850w1lm8x14yj2b6l3yvma0dbr6l4lislhy7d2yl37pgbg6s60";
   };
 
-  NIX_CFLAGS_COMPILE = lib.optionals stdenv.cc.isGNU [ "-Wno-error=deprecated-copy" "-Wno-error=redundant-move" "-Wno-error=pessimizing-move" ];
+  # Maintenance Support Ends: 2022-05-18
+  # EOL: 2022-11-18
+  cockroachdb_21_1 = callPackage ./generic.nix {
+    version = "21.1.13";
+    sha256 = "1npqh75w1x2jjmy512jxqlr4caam96lw74gfs8kdq0iaw6hkh3y2";
+  };
 
-  inherit nativeBuildInputs buildInputs;
-
-  buildPhase = ''
-    runHook preBuild
-    cd $NIX_BUILD_TOP/go/src/${goPackagePath}
-    patchShebangs .
-    make buildoss
-    cd src/${goPackagePath}
-    for asset in man autocomplete; do
-      ./cockroachoss gen $asset
-    done
-    runHook postBuild
-  '';
-
-  installPhase = ''
-    runHook preInstall
-
-    install -D cockroachoss $out/bin/cockroach
-    installShellCompletion cockroach.bash
-
-    mkdir -p $man/share/man
-    cp -r man $man/share/man
-
-    runHook postInstall
-  '';
-
-  outputs = [ "out" "man" ];
-
-  # fails with `GOFLAGS=-trimpath`
-  allowGoReference = true;
-  preFixup = ''
-    find $out -type f -exec ${removeReferencesTo}/bin/remove-references-to -t ${go} '{}' +
-  '';
-
-  meta = with lib; {
-    homepage    = "https://www.cockroachlabs.com";
-    description = "A scalable, survivable, strongly-consistent SQL database";
-    license     = licenses.bsl11;
-    platforms   = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
-    maintainers = with maintainers; [ rushmorem thoughtpolice ];
+  # Maintenance Support Ends: 2022-11-16
+  # EOL: 2023-05-16
+  cockroachdb_21_2 = callPackage ./generic.nix {
+    version = "21.2.4";
+    sha256 = "1zflfn4fszg6b1g2z3pw16gni6aismm35n3d87vchasb1l5gvryx";
+    patches = [ ./redacted.patch ];
   };
 }

--- a/pkgs/servers/sql/cockroachdb/default.nix
+++ b/pkgs/servers/sql/cockroachdb/default.nix
@@ -19,7 +19,7 @@
   # EOL: 2023-05-16
   cockroachdb_21_2 = callPackage ./generic.nix {
     version = "21.2.4";
-    sha256 = "1zflfn4fszg6b1g2z3pw16gni6aismm35n3d87vchasb1l5gvryx";
-    patches = [ ./redacted.patch ];
+    sha256 = "02qhi0hk7yxzx3r0m190piib2582j31mr3as7zpg17igs852xm7k";
+    # patches = [ ./redacted.patch ];
   };
 }

--- a/pkgs/servers/sql/cockroachdb/generic.nix
+++ b/pkgs/servers/sql/cockroachdb/generic.nix
@@ -1,0 +1,66 @@
+{ lib, stdenv, buildGoModule, fetchurl, cmake, xz, which, autoconf, ncurses6
+, libedit, libunwind, installShellFiles, removeReferencesTo, go, version, sha256
+, patches ? [ ] }:
+
+buildGoModule rec {
+  pname = "cockroach";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://binaries.cockroachdb.com/cockroach-v${version}.src.tgz";
+    inherit sha256;
+  };
+  vendorSha256 = null;
+
+  NIX_CFLAGS_COMPILE = lib.optionals stdenv.cc.isGNU [
+    "-Wno-error=deprecated-copy"
+    "-Wno-error=redundant-move"
+    "-Wno-error=pessimizing-move"
+  ];
+
+  nativeBuildInputs = [ installShellFiles cmake xz which autoconf ];
+  buildInputs = if stdenv.isDarwin then [ libunwind libedit ] else [ ncurses6 ];
+
+  inherit patches;
+
+  postPatch = ''
+    patchShebangs .
+  '';
+  buildPhase = ''
+    runHook preBuild
+    export HOME=$TMPDIR
+    make buildoss
+    cd src/github.com/cockroachdb/cockroach
+    for asset in man autocomplete; do
+      ./cockroachoss gen $asset
+    done
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D cockroachoss $out/bin/cockroach
+    installShellCompletion cockroach.bash
+
+    installManPage man/man1/*
+
+    runHook postInstall
+  '';
+
+  outputs = [ "out" "man" ];
+
+  # fails with `GOFLAGS=-trimpath`
+  allowGoReference = true;
+  preFixup = ''
+    find $out -type f -exec ${removeReferencesTo}/bin/remove-references-to -t ${go} '{}' +
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.cockroachlabs.com";
+    description = "A scalable, survivable, strongly-consistent SQL database";
+    license = licenses.bsl11;
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
+    maintainers = with maintainers; [ rushmorem thoughtpolice turion ];
+  };
+}

--- a/pkgs/servers/sql/cockroachdb/generic.nix
+++ b/pkgs/servers/sql/cockroachdb/generic.nix
@@ -1,15 +1,24 @@
-{ lib, stdenv, buildGoModule, fetchurl, cmake, xz, which, autoconf, ncurses6
-, libedit, libunwind, installShellFiles, removeReferencesTo, go, version, sha256
-, patches ? [ ] }:
+{ lib, stdenv, buildGoModule, fetchurl, fetchFromGitHub, cmake, xz, which
+, autoconf, ncurses6, libedit, libunwind, installShellFiles, removeReferencesTo
+, go, version, sha256, patches ? [ ] }:
 
 buildGoModule rec {
   pname = "cockroach";
   inherit version;
 
-  src = fetchurl {
-    url = "https://binaries.cockroachdb.com/cockroach-v${version}.src.tgz";
+  # src = fetchurl {
+  #   url = "https://binaries.cockroachdb.com/cockroach-v${version}.src.tgz";
+  #   inherit sha256;
+  # };
+
+  src = fetchFromGitHub {
+    owner = "cockroachdb";
+    repo = "cockroach";
+    rev = "v${version}";
+    fetchSubmodules = true;
     inherit sha256;
   };
+
   vendorSha256 = null;
 
   NIX_CFLAGS_COMPILE = lib.optionals stdenv.cc.isGNU [

--- a/pkgs/servers/sql/cockroachdb/redacted.patch
+++ b/pkgs/servers/sql/cockroachdb/redacted.patch
@@ -1,0 +1,12 @@
+diff --git a/src/github.com/cockroachdb/cockroach/Makefile b/src/github.com/cockroachdb/cockroach/Makefile
+index f3f3c0ff..e854fffb 100644
+--- a/src/github.com/cockroachdb/cockroach/Makefile
++++ b/src/github.com/cockroachdb/cockroach/Makefile
+@@ -790,7 +790,6 @@ SWAGGER_TARGETS := \
+ DOCGEN_TARGETS := \
+ 	bin/.docgen_bnfs \
+ 	bin/.docgen_functions \
+-	docs/generated/redact_safe.md \
+ 	bin/.docgen_http \
+ 	bin/.docgen_logformats \
+ 	docs/generated/logsinks.md \

--- a/pkgs/servers/sql/cockroachdb/remove_make_flags.patch
+++ b/pkgs/servers/sql/cockroachdb/remove_make_flags.patch
@@ -1,0 +1,18 @@
+diff --git a/src/github.com/cockroachdb/cockroach/Makefile b/src/github.com/cockroachdb/cockroach/Makefile
+index f3f3c0f..4ee109f 100644
+--- a/src/github.com/cockroachdb/cockroach/Makefile
++++ b/src/github.com/cockroachdb/cockroach/Makefile
+@@ -176,13 +176,6 @@ bindir       := $(prefix)/bin
+ # Avoid reusing GOFLAGS as that is overwritten by various release processes.
+ GOMODVENDORFLAGS := -mod=vendor
+ 
+-ifeq "$(findstring -j,$(shell ps -o args= $$PPID))" ""
+-ifdef NCPUS
+-MAKEFLAGS += -j$(NCPUS)
+-$(info Running make with -j$(NCPUS))
+-endif
+-endif
+-
+ help: ## Print help for targets with comments.
+ 	@echo "Usage:"
+ 	@echo "  make [target...] [VAR=foo VAR2=bar...]"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22076,7 +22076,10 @@ with pkgs;
 
   cpustat = callPackage ../os-specific/linux/cpustat { };
 
-  cockroachdb = callPackage ../servers/sql/cockroachdb { };
+  inherit (callPackage ../servers/sql/cockroachdb { })
+    cockroachdb_20_2 cockroachdb_21_1 cockroachdb_21_2;
+
+  cockroachdb = cockroachdb_21_2;
 
   conky = callPackage ../os-specific/linux/conky ({
     lua = lua5_3_compat;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The current version of cockroachdb has reached EOL about a month ago. 

###### Things done

* Removed the EOL version
* Added a generic builder to support multiple versions
* Added the three versions that are still supported in some way

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
