### PR TITLE
python3Packages.ormar: init at 0.10.23

### DIFF
--- a/pkgs/development/python-modules/ormar/default.nix
+++ b/pkgs/development/python-modules/ormar/default.nix
@@ -1,0 +1,80 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, poetry-core
+, databases
+, pydantic
+, sqlalchemy
+, asyncpg
+, psycopg2
+, aiomysql
+, aiosqlite
+, cryptography
+, orjson
+, typing-extensions
+, importlib-metadata
+, aiopg
+, mysqlclient
+, pymysql
+, pytestCheckHook
+, pytest-asyncio
+, fastapi
+}:
+
+buildPythonPackage rec {
+  pname = "ormar";
+  version = "0.10.23";
+  format = "pyproject";
+  disabled = pythonOlder "3.7";
+  src = fetchFromGitHub {
+    owner = "collerek";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-ILJvJyd56lqlKq7+mUz26LvusYb5AOOfoA7OgNq2fT0=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    databases
+    pydantic
+    sqlalchemy
+    asyncpg
+    psycopg2
+    aiomysql
+    aiosqlite
+    cryptography
+
+    orjson
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    typing-extensions
+    importlib-metadata
+  ];
+
+  checkInputs = [
+    aiomysql
+    aiosqlite
+    aiopg
+    asyncpg
+
+    psycopg2
+    mysqlclient
+    pymysql
+
+    pytestCheckHook
+    pytest-asyncio
+    fastapi
+  ];
+
+  pythonImportsCheck = [ "ormar" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/collerek/ormar";
+    description = "A simple async ORM with fastapi in mind and pydantic validation.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ andreasfelix ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5566,6 +5566,8 @@ in {
 
   orm = callPackage ../development/python-modules/orm { };
 
+  ormar = callPackage ../development/python-modules/ormar { };
+
   ortools = (toPythonModule (pkgs.or-tools.override { inherit (self) python; })).python;
 
   orvibo = callPackage ../development/python-modules/orvibo { };


### PR DESCRIPTION
###### Motivation for this change

https://github.com/collerek/ormar

A simple async ORM with fastapi in mind and pydantic validation.

Hi, as this is my first contribution of a Python package, maybe someone else wants to add themselves to the maintainers list?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
