### PR TITLE
[21.11] chromium: Install libvulkan.so.1 and vk_swiftshader_icd.json

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/browser.nix
+++ b/pkgs/applications/networking/browsers/chromium/browser.nix
@@ -17,6 +17,7 @@ mkChromiumDerivation (base: rec {
   installPhase = ''
     mkdir -p "$libExecPath"
     cp -v "$buildPath/"*.so "$buildPath/"*.pak "$buildPath/"*.bin "$libExecPath/"
+    cp -v "$buildPath/libvulkan.so.1" "$libExecPath/"
     cp -v "$buildPath/vk_swiftshader_icd.json" "$libExecPath/"
     cp -v "$buildPath/icudtl.dat" "$libExecPath/"
     cp -vLR "$buildPath/locales" "$buildPath/resources" "$libExecPath/"

--- a/pkgs/applications/networking/browsers/chromium/browser.nix
+++ b/pkgs/applications/networking/browsers/chromium/browser.nix
@@ -17,6 +17,7 @@ mkChromiumDerivation (base: rec {
   installPhase = ''
     mkdir -p "$libExecPath"
     cp -v "$buildPath/"*.so "$buildPath/"*.pak "$buildPath/"*.bin "$libExecPath/"
+    cp -v "$buildPath/vk_swiftshader_icd.json" "$libExecPath/"
     cp -v "$buildPath/icudtl.dat" "$libExecPath/"
     cp -vLR "$buildPath/locales" "$buildPath/resources" "$libExecPath/"
     cp -v "$buildPath/chrome_crashpad_handler" "$libExecPath/"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The upgrade to Chromium 96 on November 15th (https://github.com/NixOS/nixpkgs/pull/146184) caused the ChromeDriver launch of Chromium in Jibri to fail. This regression can be seen in history of Hydra builds of the NixOS test for Jibri, which started to fail on November 16th: https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.jibri.x86_64-linux/all?page=2

At around the time that the launch would fail, the debug log for Chromium included the following errors:
```
[9187:9187:1216/153040.156429:ERROR:angle_platform_impl.cc(44)] Display.cpp:894 (initialize): ANGLE Display::initialize error 0: Internal Vulkan error (-3): Initialization of an object could not be completed for implementation-specific reasons, in ../../third_party/angle/src/libANGLE/renderer/vulkan/RendererVk.cpp, initialize:1048.
[9187:9187:1216/153040.156800:ERROR:gl_surface_egl.cc(782)] EGL Driver message (Critical) eglInitialize: Internal Vulkan error (-3): Initialization of an object could not be completed for implementation-specific reasons, in ../../third_party/angle/src/libANGLE/renderer/vulkan/RendererVk.cpp, initialize:1048.
[9187:9187:1216/153040.156967:ERROR:gl_surface_egl.cc(1382)] eglInitialize SwANGLE failed with error EGL_NOT_INITIALIZED
```
A workaround for the error at this time was to use Google Chrome instead of Chromium.

On December 16th, the file `libvulkan.so.1` was added to the NixOS build of Chromium (https://github.com/NixOS/nixpkgs/pull/151023) and on December 17th Hydra reported a return of successful builds of the NixOS test for Jibri: https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.jibri.x86_64-linux/all?page=1
The PR also mentions that this file is already distributed with Google Chrome, which would explain why using it was a workaround for the regression. 

I have also added a second commit, https://github.com/NixOS/nixpkgs/pull/150417/commits/66352e3ee4b02927a57b708c32b8314b9df0d948 (adding the file `vk_swiftshader_icd.json` to the Chromium build) to this backport PR because it seems closely related to the commit that fixed Jibri and was made only a few days earlier. Since these two related commits are the only changes to Chromium I could find on the master branch that have not already been backported to 21.11, it seemed worth including them both. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

The main testing I have done is to do a Jitsi Meet deployment with the Jibri module enabled, using my fork of the 21.11-release branch with these commits added (https://github.com/cleeyv/deploy-jitsi/tree/backport-chromium). Jibri worked well on this deployment, confirming that backporting these commits resolves the problem that was being seen earlier (as expected based on the test build history on Hydra). 

For any considerations beyond fixing Jibri, @primeos is the one who made these commits, so is probably the one who would best be able to confirm that it makes sense for these to be backported to 21.11. 

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
