### PR TITLE
Revert "babashka: 0.7.0 -> 0.7.2"

### DIFF
--- a/pkgs/development/interpreters/clojure/babashka.nix
+++ b/pkgs/development/interpreters/clojure/babashka.nix
@@ -2,11 +2,11 @@
 
 buildGraalvmNativeImage rec {
   pname = "babashka";
-  version = "0.7.2";
+  version = "0.7.0";
 
   src = fetchurl {
     url = "https://github.com/babashka/${pname}/releases/download/v${version}/${pname}-${version}-standalone.jar";
-    sha256 = "sha256-e3/tRSszjLt/lt23ofQz9l5fqJRbshboPvX2bo/qMmI=";
+    sha256 = "sha256-zSjiHacetJ68U0GciIbuGET9I/51EM8JnPPUGemDfEI=";
   };
 
   executable = "bb";


### PR DESCRIPTION
Reverts NixOS/nixpkgs#152621

The recent `babashka` 0.7.2 is trying to download `deps.clj` even in cases where it wouldn't before. This is causing issues to use babashka to build other packages (like `clojure-lsp`), since inside the Nix build environment there is no access to the internet.