### PR TITLE
secp256k1: bump revision

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -151,6 +151,16 @@
       </listitem>
       <listitem>
         <para>
+          <literal>secp256k1</literal> has been upgraded to the latest
+          upstream commit. It includes some backwards-incompatible
+          changes in the schnorr signatures module; code that depends on
+          it will need to be updated to either use
+          <literal>secp256k1_schnorr_sign_custom</literal> or not pass a
+          <literal>noncefp</literal> parameter.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           For <literal>pkgs.python3.pkgs.ipython</literal>, its direct
           dependency
           <literal>pkgs.python3.pkgs.matplotlib-inline</literal> (which

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -53,6 +53,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The `autorestic` package has been upgraded from 1.3.0 to 1.5.0 which introduces breaking changes in config file, check [their migration guide](https://autorestic.vercel.app/migration/1.4_1.5) for more details.
 
+- `secp256k1` has been upgraded to the latest upstream commit. It includes some backwards-incompatible changes in the schnorr signatures module; code that depends on it will need to be updated to either use `secp256k1_schnorr_sign_custom` or not pass a `noncefp` parameter.
+
 - For `pkgs.python3.pkgs.ipython`, its direct dependency `pkgs.python3.pkgs.matplotlib-inline`
   (which is really an adapter to integrate matplotlib in ipython if it is installed) does
   not depend on `pkgs.python3.pkgs.matplotlib` anymore.

--- a/pkgs/tools/security/secp256k1/default.nix
+++ b/pkgs/tools/security/secp256k1/default.nix
@@ -9,13 +9,13 @@ stdenv.mkDerivation {
 
   # I can't find any version numbers, so we're just using the date of the
   # last commit.
-  version = "unstable-2021-06-06";
+  version = "unstable-2021-12-25";
 
   src = fetchFromGitHub {
     owner = "bitcoin-core";
     repo = "secp256k1";
-    rev = "7973576f6e3ab27d036a09397152b124d747f4ae";
-    sha256 = "0vjk55dv0mkph4k6bqgkykmxn05ngzvhc4rzjnvn33xzi8dzlvah";
+    rev = "39a36db94a6f733398d4eefd4e89bcaaeb063551";
+    sha256 = "1xss16608cvjaivlz7y4wzj229f1411hcbfw0lnrznl4rz4r4ah1";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
There have been some API changes; in particular
secp256k1_schnorrsig_sign no longer takes a noncefp argument, and
secp256k1_schnorrsig_sign_custom has been added to support taking a
noncefp argument.

The specified revision is the latest upstream commit as of this commit's
date.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I'm building a wrapper for Schnorr sigs in a different project; I wanted to use the latest upstream API.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
