### PR TITLE
kodi: copy web assets instead of symlinking

### DIFF
--- a/pkgs/applications/video/kodi/wrapper.nix
+++ b/pkgs/applications/video/kodi/wrapper.nix
@@ -35,5 +35,11 @@ buildEnv {
           (lib.concatMap
             (plugin: plugin.extraRuntimeDependencies or []) addons)}"
     done
+
+    # makeWrapper just created webinterface.default as a symlink. However,
+    # kodi's webserver carefully refuses to follow symlinks, so we need to copy
+    # these assets instead.
+    rm $out/share/kodi/addons/webinterface.default
+    cp -r ${kodi}/share/kodi/addons/webinterface.default/ $out/share/kodi/addons/webinterface.default
   '';
 }


### PR DESCRIPTION
Kodi refuses to follow symlinks that lead outside of a small whitelist
of allowed directories. See
[`CFileUtils::CheckFileAccessAllowed`](https://github.com/xbmc/xbmc/blob/4ac445c4a9f3080895bfcc34e7115e2de5b66d22/xbmc/utils/FileUtils.cpp#L252)
for the relevant code.

This feels like a pretty brittle workaround, but I can't think of a
better solution, so I'm going to say that this fixes
https://github.com/NixOS/nixpkgs/issues/145116.

###### Motivation for this change

I ran into https://github.com/NixOS/nixpkgs/issues/145116 and wanted to fix it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
