### PR TITLE
prometheus-node-exporter: Remove backslashes in ExecStart script

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters/node.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/node.nix
@@ -29,11 +29,12 @@ in
     serviceConfig = {
       DynamicUser = false;
       RuntimeDirectory = "prometheus-node-exporter";
-      ExecStart = ''
-        ${pkgs.prometheus-node-exporter}/bin/node_exporter \
-          ${concatMapStringsSep " " (x: "--collector." + x) cfg.enabledCollectors} \
-          ${concatMapStringsSep " " (x: "--no-collector." + x) cfg.disabledCollectors} \
-          --web.listen-address ${cfg.listenAddress}:${toString cfg.port} ${concatStringsSep " " cfg.extraFlags}
+      ExecStart = let
+        enabledCollectors = concatMapStringsSep " " (x: "--collector." + x) cfg.enabledCollectors;
+        disabledCollectors = concatMapStringsSep " " (x: "--no-collector." + x) cfg.disabledCollectors;
+        listenAddr = "--web.listen-address ${cfg.listenAddress}:${toString cfg.port} ${concatStringsSep " " cfg.extraFlags}";
+      in ''
+        ${pkgs.prometheus-node-exporter}/bin/node_exporter ${enabledCollectors} ${disabledCollectors} ${listenAddr}
       '';
       RestrictAddressFamilies = optionals (any (collector: (collector == "logind" || collector == "systemd")) cfg.enabledCollectors) [
         # needs access to dbus via unix sockets (logind/systemd)


### PR DESCRIPTION
According to 41c6d7adfcad4ed4fc6f22140ab6c4285348d89c and
https://github.com/NixOS/nixpkgs/issues/63533 having backslashes
prevents systemd from successfully parsing the unit file and therefore
results in prometheus-node-exporter not starting.

This patch removes the backslashes from the ExecStart script.
