### PR TITLE
dbus-python: fix cross compilation

### DIFF
--- a/pkgs/development/python-modules/dbus/default.nix
+++ b/pkgs/development/python-modules/dbus/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   '' else null;
 
   configureFlags = [
-    "PYTHON_VERSION=${lib.versions.major python.version}"
+    "PYTHON=${python.pythonForBuild.interpreter}"
   ];
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
### Problem

During configure it executes `python`, which happens to be the host executable if we're cross compiling.

For example `pkgsCross.aarch64-multiplatform.python3Packages.dbus-python`:

```
checking for a version of Python >= '2.1.0'... ./configure: line 12489: /nix/store/48s7qnqyx693h8b90lj1m591rn5izisx-python3-aarch64-unknown-linux-gnu-3.9.9/bin/python3: cannot execute binary file: Exec format error
no
configure: error: in `/build/dbus-python-1.2.18':
configure: error:
This version of the AC_PYTHON_DEVEL macro
doesn't work properly with versions of Python before
2.1.0. You may need to re-run configure, setting the
variables PYTHON_CPPFLAGS, PYTHON_LIBS, PYTHON_SITE_PKG,
PYTHON_EXTRA_LIBS and PYTHON_EXTRA_LDFLAGS by hand.
Moreover, to disable this check, set PYTHON_NOVERSIONCHECK
to something else than an empty string.

See `config.log' for more details
builder for '/nix/store/mzn8lfjfg46ip70sqsnyqrqfhrqq3ggl-python3.9-dbus-python-1.2.18-aarch64-unknown-linux-gnu.drv' failed with exit code 1
error: build of '/nix/store/mzn8lfjfg46ip70sqsnyqrqfhrqq3ggl-python3.9-dbus-python-1.2.18-aarch64-unknown-linux-gnu.drv' failed
```

### Resolution

There's a `dbus-python` related fix in staging https://github.com/NixOS/nixpkgs/pull/148193 to fix compilation on python 2, but that doesn't help us here as it's just hinting which python version to execute. Setting the interpreter fixes cross compilation and works for python2 builds as well as far as I can tell - which means this PR supersedes #148193.

My sole remaining concern is that the build system is gathering information on the build (instead of host) interpreter in the first place. This fix *works* but it might not be ideal.

### Test

Builds on top of `master` c1792db42df222b0ec570bd774488f48aa0c91b1:

```
with import ~/git/nixpkgs-alt {};
[
  python3Packages.dbus-python
  python2Packages.dbus-python

  pkgsCross.aarch64-multiplatform.python3Packages.dbus-python
  pkgsCross.aarch64-multiplatform.python2Packages.dbus-python

  pkgsCross.riscv64.python3Packages.dbus-python
  pkgsCross.riscv64.python2Packages.dbus-python
]
```

@jtojnar @dadada @FRidh @Artturin 