### PR TITLE
polkit: disable gtkdocs when cross compiling

### DIFF
--- a/pkgs/development/libraries/polkit/default.nix
+++ b/pkgs/development/libraries/polkit/default.nix
@@ -25,6 +25,8 @@
 , elogind
 # needed until gobject-introspection does cross-compile (https://github.com/NixOS/nixpkgs/pull/88222)
 , withIntrospection ? (stdenv.buildPlatform == stdenv.hostPlatform)
+# cross build fails on polkit-1-scan (https://github.com/NixOS/nixpkgs/pull/152704)
+, withGtkDoc ? (stdenv.buildPlatform == stdenv.hostPlatform)
 # A few tests currently fail on musl (polkitunixusertest, polkitunixgrouptest, polkitidentitytest segfault).
 # Not yet investigated; it may be due to the "Make netgroup support optional"
 # patch not updating the tests correctly yet, or doing something wrong,
@@ -119,7 +121,7 @@ stdenv.mkDerivation rec {
     "-Dos_type=redhat" # only affects PAM includes
     "-Dintrospection=${lib.boolToString withIntrospection}"
     "-Dtests=${lib.boolToString doCheck}"
-    "-Dgtk_doc=${lib.boolToString true}"
+    "-Dgtk_doc=${lib.boolToString withGtkDoc}"
     "-Dman=true"
   ] ++ lib.optionals stdenv.isLinux [
     "-Dsession_tracking=${if useSystemd then "libsystemd-login" else "libelogind"}"


### PR DESCRIPTION
###### Motivation for this change

Polkit fails to build its gtk (?) documentation when cross compiling:

```
Building documentation for polkit-1
ERROR: Error in gtkdoc helper script:

ERROR: ['/nix/store/dn1iqlp90ppxacn12zz8kc6xhcqrp8rh-gtk-doc-1.33.2/bin/gtkdoc-scangobj', '--types=/build/source/docs/polkit/polkit-1.types', '--module=polkit-1', '--run=', '--cflags=-I/build/source/build/src/polkitagent/. -I/build/source/src/polkitagent/. -I/nix/store/gvilicflmvqisy4qlb60sxz92h43mr0g-expat-aarch64-unknown-linux-gnu-2.4.1-dev/include -I/nix/store/k3f480hw0bvl42k9cbyv3nlr03jp8kj8-glib-aarch64-unknown-linux-gnu-2.70.1-dev/include/gio-unix-2.0 -I/nix/store/k3f480hw0bvl42k9cbyv3nlr03jp8kj8-glib-aarch64-unknown-linux-gnu-2.70.1-dev/include -I/nix/store/k3f480hw0bvl42k9cbyv3nlr03jp8kj8-glib-aarch64-unknown-linux-gnu-2.70.1-dev/include/glib-2.0 -I/nix/store/51darv8hc3iivbp7ivakvpqcxfwfsz54-glib-aarch64-unknown-linux-gnu-2.70.1/lib/glib-2.0/include -I/build/source/build/src/. -I/build/source/src/. -I/nix/store/j5g7cjv0547hgvd8122vd4ppcnpw0xv3-systemd-aarch64-unknown-linux-gnu-249.5-dev/include -std=c99 -DHAVE_CONFIG_H', '--ldflags=-L/build/source/build/src/polkitagent -Wl,-rpath,/build/source/build/src/polkitagent -L/build/source/build/src/polkit -Wl,-rpath,/build/source/build/src/polkit -lpolkit-agent-1 -lpolkit-gobject-1 -L/nix/store/gz71iwc85p3a4ym9jnc621sj21rpgb61-expat-aarch64-unknown-linux-gnu-2.4.1/lib -lexpat -L/nix/store/51darv8hc3iivbp7ivakvpqcxfwfsz54-glib-aarch64-unknown-linux-gnu-2.70.1/lib -lgio-2.0 -lgobject-2.0 -lglib-2.0 -L/nix/store/7niir8dbk9a3x7sphlf6vgbsq5zfj116-systemd-aarch64-unknown-linux-gnu-249.5/lib -lsystemd', '--cc=aarch64-unknown-linux-gnu-gcc', '--ld=aarch64-unknown-linux-gnu-gcc', '--output-dir=/build/source/build/docs/polkit'] failed with status 1
2021-12-30 01:00:16,055:scangobj.py:execute_command:1293:WARNING:Running scanner failed: [Errno 8] Exec format error: './polkit-1-scan', command: ./polkit-1-scan
```

###### Fix

[This](https://mail.gnome.org/archives/gtk-doc-list/2018-October/msg00005.html) mailing list post leads me to believe building documentation when cross compiling might be a lost cause, so I did not investigate further and decided to just disable these docs altogether. If anyone has a better idea: shoot.

Edit: we seem to have applied the same fix in other places.

###### Checklist

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
