### PR TITLE
spidermonkey_91: fix cross compilation

### DIFF
--- a/pkgs/development/interpreters/spidermonkey/68.nix
+++ b/pkgs/development/interpreters/spidermonkey/68.nix
@@ -78,6 +78,8 @@ in stdenv.mkDerivation rec {
     "--target=${stdenv.hostPlatform.config}"
   ];
 
+  # mkDerivation by default appends --build/--host to configureFlags when cross compiling
+  # These defaults are bogus for Spidermonkey - avoid passing them by providing an empty list
   configurePlatforms = [];
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/development/interpreters/spidermonkey/78.nix
+++ b/pkgs/development/interpreters/spidermonkey/78.nix
@@ -92,6 +92,8 @@ stdenv.mkDerivation rec {
     "--target=${stdenv.hostPlatform.config}"
   ];
 
+  # mkDerivation by default appends --build/--host to configureFlags when cross compiling
+  # These defaults are bogus for Spidermonkey - avoid passing them by providing an empty list
   configurePlatforms = [ ];
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/development/interpreters/spidermonkey/91.nix
+++ b/pkgs/development/interpreters/spidermonkey/91.nix
@@ -88,6 +88,10 @@ stdenv.mkDerivation rec {
     "--target=${stdenv.hostPlatform.config}"
   ];
 
+  # mkDerivation by default appends --build/--host to configureFlags when cross compiling
+  # These defaults are bogus for Spidermonkey - avoid passing them by providing an empty list
+  configurePlatforms = [ ];
+
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   # Remove unnecessary static lib


### PR DESCRIPTION
##### Problem

`spidermonkey_91` fails to cross compile

```
configure flags: --prefix=/nix/store/g1ka9v42f381qmwarl2vyrqhz858zx6s-spidermonkey-aarch64-unknown-linux-gnu-91.4.0 --with-intl-api --with-system-icu --with-system-nspr --with-system-zlib --enable-optimize --enable-readline --enable-release --enable-shared-js --disable-debug --disable-jemalloc --disable-strip --disable-tests --host=x86_64-unknown-linux-gnu --target=aarch64-unknown-linux-gnu --build=x86_64-unknown-linux-gnu --host=aarch64-unknown-linux-gnu
Creating Python 3 environment
created virtual environment CPython3.9.9.final.0-64 in 236ms
  creator CPython3Posix(dest=/build/firefox-91.4.0/obj/_virtualenvs/common, clear=False, no_vcs_ignore=False, global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/build/tmp9fr0y9lq)
    added seed packages: pip==20.3.1, setuptools==51.0.0, wheel==0.36.1
  activators BashActivator,CShellActivator,FishActivator,PowerShellActivator,PythonActivator,XonshActivator
Re-executing in the virtualenv
checking for vcs source checkout... no
checking for a shell... /nix/store/iqprjr5k5385bhf1dzj07zwd5p43py1n-bash-5.1-p12/bin/bash
checking for host system type... aarch64-unknown-linux-gnu
checking for target system type... aarch64-unknown-linux-gnu
Traceback (most recent call last):
  File "/build/firefox-91.4.0/obj/../js/src/../../configure.py", line 231, in <module>
    sys.exit(main(sys.argv))
  File "/build/firefox-91.4.0/obj/../js/src/../../configure.py", line 55, in main
    sandbox.run(os.path.join(os.path.dirname(__file__), "moz.configure"))
  File "/build/firefox-91.4.0/python/mozbuild/mozbuild/configure/__init__.py", line 554, in run
    raise InvalidOptionError(msg)
mozbuild.configure.options.InvalidOptionError: Unknown option: --build
```

A closer look at the configure flags:
```
--host=x86_64-unknown-linux-gnu
--target=aarch64-unknown-linux-gnu
--build=x86_64-unknown-linux-gnu
--host=aarch64-unknown-linux-gnu
```

###### Solution

Turns out `mkDerivation` automatically appends the latter two when cross compiling. Usually that's fine, but we're passing them manually for Spidermonkey due to a slightly unusual interpretation of host - which means we also have to inhibit the default flags.

This is done by setting the `configurePlatforms` parameter to an empty list. In fact, the derivation for Spidermonkey 68/78 does this, but it went missing for 91. Probably it was cleaned up by accident.

This PR reintroduces the parameter and adds a comment to all three derivations to explain the purpose of the empty list.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@ajs124 