### PR TITLE
jetbrains.jdk-bin: init at 1751.21

### DIFF
--- a/pkgs/development/compilers/jetbrains-jdk/prebuild.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/prebuild.nix
@@ -3,39 +3,26 @@
 openjdk11.overrideAttrs (oldAttrs: rec {
   pname = "jetbrains-jdk";
   version = "1751.21";
-  darwinVersion = if stdenv.isAarch64 then "11_0_13-osx-aarch64-b${version}" else "11_0_13-osx-x64-b${version}"; 
+  darwinVersion = if stdenv.isAarch64 then "11_0_13-osx-aarch64-b${version}" else "11_0_13-osx-x64-b${version}";
   src = fetchurl {
     url = "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-${darwinVersion}.tar.gz";
-    sha256 = "sha256-ZU3TEm5n3oYFp82Uo+vHEzZcwdY6thVt1l8CSbBk43o=";
+    sha256 = if stdenv.isAarch64 then "65807ed92397cd92e1381c49039af443d713874e1ec8efd6e92e370514e56861" else "654dd3126e67de8605a7cd94a3ebc713365cc1d63ab6156dd65f0249b064e37a";
   };
   patches = [];
-  
+
   unpackCmd = "mkdir jdk; pushd jdk; tar -xzf $src; popd";
   installPhase = ''
     cd ..;
     mv $sourceRoot/jbrsdk $out;
-  '';  
-  
+  '';
+
   postFixup = ''
-  '';  
+  '';
 
   meta = with lib; {
-    description = "An OpenJDK fork to better support Jetbrains's products.";
-    longDescription = ''
-      JetBrains Runtime is a runtime environment for running IntelliJ Platform
-      based products on Windows, Mac OS X, and Linux. JetBrains Runtime is
-      based on OpenJDK project with some modifications. These modifications
-      include: Subpixel Anti-Aliasing, enhanced font rendering on Linux, HiDPI
-      support, ligatures, some fixes for native crashes not presented in
-      official build, and other small enhancements.
-
-      JetBrains Runtime is not a certified build of OpenJDK. Please, use at
-      your own risk.
-    '';
-    homepage = "https://confßluence.jetbrains.com/display/JBR/JetBrains+Runtime";
-    inherit (openjdk11.meta) license platforms mainProgram;
-    maintainers = with maintainers; [ edwtjo petabyteboy ];
+    maintainers = with maintainers; [ lutzmor ];
   };
+
   passthru = oldAttrs.passthru // {
     home = "${jetbrains.jdk}/Contents/Home";
   };

--- a/pkgs/development/compilers/jetbrains-jdk/prebuild.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/prebuild.nix
@@ -22,17 +22,17 @@ openjdk11.overrideAttrs (oldAttrs: rec {
   meta = with lib; {
     description = "An OpenJDK fork to better support Jetbrains's products.";
     longDescription = ''
-     JetBrains Runtime is a runtime environment for running IntelliJ Platform
-     based products on Windows, Mac OS X, and Linux. JetBrains Runtime is
-     based on OpenJDK project with some modifications. These modifications
-     include: Subpixel Anti-Aliasing, enhanced font rendering on Linux, HiDPI
-     support, ligatures, some fixes for native crashes not presented in
-     official build, and other small enhancements.
+      JetBrains Runtime is a runtime environment for running IntelliJ Platform
+      based products on Windows, Mac OS X, and Linux. JetBrains Runtime is
+      based on OpenJDK project with some modifications. These modifications
+      include: Subpixel Anti-Aliasing, enhanced font rendering on Linux, HiDPI
+      support, ligatures, some fixes for native crashes not presented in
+      official build, and other small enhancements.
 
-     JetBrains Runtime is not a certified build of OpenJDK. Please, use at
-     your own risk.
+      JetBrains Runtime is not a certified build of OpenJDK. Please, use at
+      your own risk.
     '';
-    homepage = "https://confluence.jetbrains.com/display/JBR/JetBrains+Runtime";
+    homepage = "https://confßluence.jetbrains.com/display/JBR/JetBrains+Runtime";
     inherit (openjdk11.meta) license platforms mainProgram;
     maintainers = with maintainers; [ edwtjo petabyteboy ];
   };

--- a/pkgs/development/compilers/jetbrains-jdk/prebuild.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/prebuild.nix
@@ -1,0 +1,42 @@
+{ lib, openjdk11, fetchurl, jetbrains, stdenv }:
+
+openjdk11.overrideAttrs (oldAttrs: rec {
+  pname = "jetbrains-jdk";
+  version = "1751.21";
+  darwinVersion = if stdenv.isAarch64 then "11_0_13-osx-aarch64-b${version}" else "11_0_13-osx-x64-b${version}"; 
+  src = fetchurl {
+    url = "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-${darwinVersion}.tar.gz";
+    sha256 = "sha256-ZU3TEm5n3oYFp82Uo+vHEzZcwdY6thVt1l8CSbBk43o=";
+  };
+  patches = [];
+  
+  unpackCmd = "mkdir jdk; pushd jdk; tar -xzf $src; popd";
+  installPhase = ''
+    cd ..;
+    mv $sourceRoot/jbrsdk $out;
+  '';  
+  
+  postFixup = ''
+  '';  
+
+  meta = with lib; {
+    description = "An OpenJDK fork to better support Jetbrains's products.";
+    longDescription = ''
+     JetBrains Runtime is a runtime environment for running IntelliJ Platform
+     based products on Windows, Mac OS X, and Linux. JetBrains Runtime is
+     based on OpenJDK project with some modifications. These modifications
+     include: Subpixel Anti-Aliasing, enhanced font rendering on Linux, HiDPI
+     support, ligatures, some fixes for native crashes not presented in
+     official build, and other small enhancements.
+
+     JetBrains Runtime is not a certified build of OpenJDK. Please, use at
+     your own risk.
+    '';
+    homepage = "https://confluence.jetbrains.com/display/JBR/JetBrains+Runtime";
+    inherit (openjdk11.meta) license platforms mainProgram;
+    maintainers = with maintainers; [ edwtjo petabyteboy ];
+  };
+  passthru = oldAttrs.passthru // {
+    home = "${jetbrains.jdk}/Contents/Home";
+  };
+})

--- a/pkgs/development/compilers/jetbrains-jdk/prebuild.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/prebuild.nix
@@ -20,7 +20,21 @@ openjdk11.overrideAttrs (oldAttrs: rec {
   '';
 
   meta = with lib; {
-    maintainers = with maintainers; [ lutzmor ];
+    description = "An OpenJDK fork to better support Jetbrains's products.";
+    longDescription = ''
+     JetBrains Runtime is a runtime environment for running IntelliJ Platform
+     based products on Windows, Mac OS X, and Linux. JetBrains Runtime is
+     based on OpenJDK project with some modifications. These modifications
+     include: Subpixel Anti-Aliasing, enhanced font rendering on Linux, HiDPI
+     support, ligatures, some fixes for native crashes not presented in
+     official build, and other small enhancements.
+
+     JetBrains Runtime is not a certified build of OpenJDK. Please, use at
+     your own risk.
+    '';
+    homepage = "https://confluence.jetbrains.com/display/JBR/JetBrains+Runtime";
+    inherit (openjdk11.meta) license platforms mainProgram;
+    maintainers = with maintainers; [ edwtjo petabyteboy ];
   };
 
   passthru = oldAttrs.passthru // {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1,4 +1,4 @@
-\/* The top-level package collection of nixpkgs.
+/* The top-level package collection of nixpkgs.
  * It is sorted by categories corresponding to the folder names
  * in the /pkgs folder. Inside the categories packages are roughly
  * sorted by alphabet, but strict sorting has been long lost due

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1,4 +1,4 @@
-/* The top-level package collection of nixpkgs.
+\/* The top-level package collection of nixpkgs.
  * It is sorted by categories corresponding to the folder names
  * in the /pkgs folder. Inside the categories packages are roughly
  * sorted by alphabet, but strict sorting has been long lost due
@@ -25769,7 +25769,9 @@ with pkgs;
     vmopts = config.jetbrains.vmopts or null;
     jdk = jetbrains.jdk;
   }) // {
-    jdk = callPackage ../development/compilers/jetbrains-jdk {  };
+    sourcebuild = callPackage ../development/compilers/jetbrains-jdk/default.nix {  };
+    prebuild = callPackage ../development/compilers/jetbrains-jdk/prebuild.nix {  };
+    jdk = if stdenv.isDarwin then jetbrains.prebuild else jetbrains.sourcebuild;
   });
 
   jmusicbot = callPackage ../applications/audio/jmusicbot { };


### PR DESCRIPTION
Update jetbrains.sdk to be workable on darwin as well, the build process of the source variant used on linux is broken. So update to binary one for darwin.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin ( should also work used a binary dependend the arch )
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

This pr should fix the problem described here: https://github.com/NixOS/nixpkgs/issues/84263