### PR TITLE
libjxl: Fix tests on darwin

### DIFF
--- a/pkgs/development/libraries/libjxl/default.nix
+++ b/pkgs/development/libraries/libjxl/default.nix
@@ -108,7 +108,9 @@ stdenv.mkDerivation rec {
   # LD_LIBRARY_PATH setting errors with:
   #     /build/source/build/tools/tests/libjxl_test: error while loading shared libraries: libjxl.so.0
   # The required file is in the build directory (`$PWD`).
-  preCheck = ''
+  preCheck = if stdenv.isDarwin then ''
+    export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH''${DYLD_LIBRARY_PATH:+:}$PWD
+  '' else ''
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$PWD
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

On my intel macbook running 12.0.1, building libjxl fails while running its LibraryCLinkageTest - 

```
1122/1129 Test #1128: LibraryCLinkageTest .......................................................................................................Subprocess aborted***Exception:   0.32 sec
dyld[53579]: Library not loaded: @rpath/libjxl.0.dylib
  Referenced from: /private/tmp/nix-build-libjxl-0.5.drv-1/source/build/tools/tests/libjxl_test
  Reason: tried: '/nix/store/82d092jfk2sckailcp5hpb29xsxhk4h2-swift-corefoundation/Library/Frameworks/libjxl.0.dylib' (no such file), '/nix/store/82d092jfk2sckailcp5hpb29xsxhk4h2-swift-corefoundation/Library/Frameworks/libjxl.0.dylib' (no
```

I _think_ this is an appropriate fix, and does solve the problem for my local builds. However, it seems like hydra is already [successfully building the job](https://hydra.nixos.org/job/nixpkgs/nixpkgs-21.11-darwin/libjxl.x86_64-darwin) without this fix - I'm not sure how. Anyone know if it's due to differences in macos versions or something else?


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
