### PR TITLE
btcpayserver: 1.3.6 -> 1.3.7

### DIFF
--- a/pkgs/applications/blockchains/btcpayserver/default.nix
+++ b/pkgs/applications/blockchains/btcpayserver/default.nix
@@ -3,13 +3,13 @@
 
 buildDotnetModule rec {
   pname = "btcpayserver";
-  version = "1.3.6";
+  version = "1.3.7";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-8SWbbdPx/cC7EWTkSbB/YqR13jaL76fFIjHPGL4rFyk=";
+    sha256 = "sha256-W8WRw42hMNUaQZlfrl73REGIvLcj6Vso9Axx53ENkx0=";
   };
 
   projectFile = "BTCPayServer/BTCPayServer.csproj";

--- a/pkgs/applications/blockchains/nbxplorer/util/update-common.sh
+++ b/pkgs/applications/blockchains/nbxplorer/util/update-common.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p coreutils curl jq common-updater-scripts dotnet-sdk_3 git gnupg nix
+#!nix-shell -i bash -p coreutils curl jq common-updater-scripts dotnet-sdk_3 git gnupg nixFlakes
 set -euo pipefail
 
 # This script uses the following env vars:
@@ -17,7 +17,7 @@ scriptDir=$(cd "${BASH_SOURCE[0]%/*}" && pwd)
 nixpkgs=$(realpath "$scriptDir"/../../../../..)
 
 evalNixpkgs() {
-  nix eval --raw "(with import \"$nixpkgs\" {}; $1)"
+  nix eval --impure --raw --expr "(with import \"$nixpkgs\" {}; $1)"
 }
 
 getRepo() {


### PR DESCRIPTION
Things done:
- Tested with the [nix-bitcoin VM test](https://gist.github.com/87b3e8b5d00cbfbd634b762b27ac86f9).

Notes for reviewers:
You can verify GPG signatures with `refetch=1 pkgs/applications/blockchains/btcpayserver/update.sh`.

cc @prusnak @nixbitcoin