### PR TITLE
libfido2: split outputs & remove static archive

### DIFF
--- a/pkgs/development/libraries/libfido2/default.nix
+++ b/pkgs/development/libraries/libfido2/default.nix
@@ -28,12 +28,16 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DUDEV_RULES_DIR=${placeholder "out"}/etc/udev/rules.d"
-    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_LIBDIR=${placeholder "lib"}/lib"
+    "-DBUILD_SHARED=ON"
+    "-DBUILD_STATIC=OFF"
   ] ++ lib.optionals stdenv.isDarwin [
     "-DUSE_HIDAPI=1"
   ] ++ lib.optionals stdenv.isLinux [
     "-DNFC_LINUX=1"
   ];
+
+  outputs = [ "out" "lib" "dev" ];
 
   meta = with lib; {
     description = ''


### PR DESCRIPTION
###### Motivation for this change

This helps cut down the closure of depending programs by a tiny bit. We
don't need the static library or the binaries in every closure of a
program that depends on the library. We can bring back the static
library as-needed (if needed).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)): the `simple` test still works (there is no fido specific test). `libfido2` is being pulled in as part of the systemd package.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
