### PR TITLE
tlauncher: init at 2.839

### DIFF
--- a/pkgs/games/tlauncher/default.nix
+++ b/pkgs/games/tlauncher/default.nix
@@ -1,0 +1,100 @@
+{ lib
+, stdenv
+, openjdk8
+, buildFHSUserEnv
+, fetchzip
+, fetchurl
+, copyDesktopItems
+, makeDesktopItem
+}:
+let
+  version = "2.839";
+  src = stdenv.mkDerivation {
+    pname = "tlauncher";
+    inherit version;
+    src = fetchzip {
+      name = "tlauncher.zip";
+      url = "https://dl2.tlauncher.org/f.php?f=files%2FTLauncher-${version}.zip";
+      sha256 = "sha256-KphpNuTucpuJhXspKxqDyYQN6vbpY0XCB3GAd5YCGbc=";
+      stripRoot = false;
+    };
+    installPhase = ''
+      cp $src/*.jar $out
+    '';
+  };
+  fhs = buildFHSUserEnv {
+    name = "tlauncher";
+    runScript = ''
+      ${openjdk8}/bin/java -jar "${src}" "$@"
+    '';
+    targetPkgs = pkgs: with pkgs; [
+      alsa-lib
+      cpio
+      cups
+      file
+      fontconfig
+      freetype
+      giflib
+      glib
+      gnome2.GConf
+      gnome2.gnome_vfs
+      gtk2
+      libjpeg
+      libGL
+      openjdk8-bootstrap
+      perl
+      which
+      xorg.libICE
+      xorg.libX11
+      xorg.libXcursor
+      xorg.libXext
+      xorg.libXi
+      xorg.libXinerama
+      xorg.libXrandr
+      xorg.xrandr
+      xorg.libXrender
+      xorg.libXt
+      xorg.libXtst
+      xorg.libXtst
+      xorg.libXxf86vm
+      zip
+      zlib
+    ];
+  };
+  desktopItem = makeDesktopItem {
+    name = "tlauncher";
+    exec = "tlauncher";
+    icon = fetchurl {
+      url = "https://styles.redditmedia.com/t5_2o8oax/styles/communityIcon_gu5r5v8eaiq51.png";
+      sha256 = "sha256-ma8zxaUxdAw5VYfOK8i8s1kjwMgs80Eomq43Cb0HZWw=";
+    };
+    comment = "Minecraft launcher";
+    desktopName = "TLauncher";
+    categories = "Game;";
+  };
+in stdenv.mkDerivation {
+  pname = "tlauncher-wrapper";
+  inherit version;
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out/{bin,share/applications} -p
+    install ${fhs}/bin/tlauncher $out/bin
+
+    runHook postInstall
+  '';
+
+  nativeBuildInputs = [ copyDesktopItems ];
+  desktopItems = [ desktopItem ];
+
+  meta = with lib; {
+    description = "Minecraft launcher that already deal with forge, optifine and mods";
+    homepage = "https://tlauncher.org/";
+    maintainers = with maintainers; [ lucasew ];
+    license = licenses.unfree;
+    platforms = openjdk8.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30761,6 +30761,8 @@ with pkgs;
 
   portmod = callPackage ../games/portmod { };
 
+  tlauncher = callPackage ../games/tlauncher {};
+
   tr-patcher = callPackage ../games/tr-patcher { };
 
   tes3cmd = callPackage ../games/tes3cmd { };


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- Missing package
- Solves #114571 
- Dealing with quirks caused by how TLauncher and Minecraft bootstraps it's JVMs (Shiginima hasn't this problem)

###### Things done
- Packaged the tlauncher Minecraft launcher 
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
