### PR TITLE
pythonPackages.pysimplegui: init at 4.55.1

### DIFF
--- a/pkgs/development/python-modules/pysimplegui/default.nix
+++ b/pkgs/development/python-modules/pysimplegui/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, tkinter
+}:
+buildPythonPackage rec {
+  pname = "PySimpleGUI";
+  version = "4.55.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-nUDAoMK0w9Luk1hU5I1yT1CK5oEj9LrIByYS3Z5wfew=";
+  };
+
+  pythonImportsCheck = [ "PySimpleGUI" ];
+
+  propagatedBuildInputs = [
+    tkinter
+  ];
+
+  meta = with lib; {
+    description = "Python GUIs for Humans.";
+    homepage = "https://github.com/PySimpleGUI/PySimpleGUI";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ lucasew ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7359,6 +7359,8 @@ in {
 
   pysigset = callPackage ../development/python-modules/pysigset { };
 
+  pysimplegui = callPackage ../development/python-modules/pysimplegui { };
+
   pysingleton = callPackage ../development/python-modules/pysingleton { };
 
   pyslurm = callPackage ../development/python-modules/pyslurm {


### PR DESCRIPTION
Signed-off-by: lucasew <lucas59356@gmail.com>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- This lib provides a way to make GUIs easily in Python, thing that will be useful for NixOS mass adoption

###### Things done
- Package PySimpleGUI

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
