### PR TITLE
python3Packages.datafusion: init at 0.4.0

### DIFF
--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -208,11 +208,6 @@ stdenv.mkDerivation rec {
     in
     lib.optionalString doInstallCheck "-${builtins.concatStringsSep ":" filteredTests}";
 
-  preInstallCheck = ''
-    export HOME
-    HOME="$(mktemp -d)"
-  '';
-
   installCheckInputs = [ perl which ] ++ lib.optional enableS3 minio;
   installCheckPhase =
     let

--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -207,6 +207,12 @@ stdenv.mkDerivation rec {
       ];
     in
     lib.optionalString doInstallCheck "-${builtins.concatStringsSep ":" filteredTests}";
+
+  preInstallCheck = ''
+    export HOME
+    HOME="$(mktemp -d)"
+  '';
+
   installCheckInputs = [ perl which ] ++ lib.optional enableS3 minio;
   installCheckPhase =
     let

--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -207,7 +207,6 @@ stdenv.mkDerivation rec {
       ];
     in
     lib.optionalString doInstallCheck "-${builtins.concatStringsSep ":" filteredTests}";
-
   installCheckInputs = [ perl which ] ++ lib.optional enableS3 minio;
   installCheckPhase =
     let

--- a/pkgs/development/python-modules/datafusion/Cargo.lock.patch
+++ b/pkgs/development/python-modules/datafusion/Cargo.lock.patch
@@ -1,0 +1,78 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index fa84a54c..3d790e1c 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -57,9 +57,9 @@ checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
+ 
+ [[package]]
+ name = "arrow"
+-version = "6.0.0"
++version = "6.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "337e668497751234149fd607f5cb41a6ae7b286b6329589126fe67f0ac55d637"
++checksum = "216c6846a292bdd93c2b93c1baab58c32ff50e2ab5e8d50db333ab518535dd8b"
+ dependencies = [
+  "bitflags",
+  "chrono",
+@@ -212,9 +212,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "comfy-table"
+-version = "4.1.1"
++version = "5.0.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "11e95a3e867422fd8d04049041f5671f94d53c32a9dcd82e2be268714942f3f3"
++checksum = "c42350b81f044f576ff88ac750419f914abb46a03831bb1747134344ee7a4e64"
+ dependencies = [
+  "strum",
+  "strum_macros",
+@@ -279,7 +279,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "datafusion"
+-version = "5.1.0"
++version = "6.0.0"
+ dependencies = [
+  "ahash",
+  "arrow",
+@@ -310,7 +310,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "datafusion-python"
+-version = "0.3.0"
++version = "0.4.0"
+ dependencies = [
+  "datafusion",
+  "pyo3",
+@@ -877,9 +877,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "parquet"
+-version = "6.0.0"
++version = "6.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d263b9b59ba260518de9e57bd65931c3f765fea0fabacfe84f40d6fde38e841a"
++checksum = "788d9953f4cfbe9db1beff7bebd54299d105e34680d78b82b1ddc85d432cac9d"
+ dependencies = [
+  "arrow",
+  "base64",
+@@ -1228,15 +1228,15 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+ 
+ [[package]]
+ name = "strum"
+-version = "0.21.0"
++version = "0.22.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
++checksum = "f7ac893c7d471c8a21f31cfe213ec4f6d9afeed25537c772e08ef3f005f8729e"
+ 
+ [[package]]
+ name = "strum_macros"
+-version = "0.21.1"
++version = "0.22.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
++checksum = "339f799d8b549e3744c7ac7feb216383e4005d94bdb22561b3ab8f3b808ae9fb"
+ dependencies = [
+  "heck",
+  "proc-macro2",

--- a/pkgs/development/python-modules/datafusion/default.nix
+++ b/pkgs/development/python-modules/datafusion/default.nix
@@ -1,0 +1,75 @@
+{ lib
+, stdenv
+, fetchurl
+, buildPythonPackage
+, fetchPypi
+, fetchFromGitHub
+, rustPlatform
+, maturin
+, pytestCheckHook
+, libiconv
+, numpy
+, pandas
+, pyarrow
+}:
+
+let
+
+  # le sigh, the perils of unrelated versions of software living in the
+  # same repo: there's no obvious way to map the top level source repo
+  # (arrow-datafusion) version to the version of contained repo
+  # (arrow-datafusion/python)
+  #
+  # A commit hash will do in a pinch, and ultimately the sha256 has
+  # the final say of what the content is when building
+  cargoLock = fetchurl {
+    url = "https://raw.githubusercontent.com/apache/arrow-datafusion/6.0.0/python/Cargo.lock";
+    sha256 = "sha256-xiv3drEU5jOGsEIh0U01ZQ1NBKobxO2ctp4mxy9iigw=";
+  };
+
+  postUnpack = ''
+    # TODO: apache/arrow-datafusion should ship the Cargo.lock file in the Python package
+    cp "${cargoLock}" $sourceRoot/Cargo.lock
+    chmod u+w $sourceRoot/Cargo.lock
+  '';
+in
+
+buildPythonPackage rec {
+  pname = "datafusion";
+  version = "0.4.0";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-+YqogteKfNhtI2QbVXv/5CIWm3PcOH653dwONm5ZcL8=";
+  };
+
+  inherit postUnpack;
+
+  # the lock file isn't up to date as of 6.0.0 so we need to patch the source
+  # lockfile and the vendored cargo deps lockfile :(
+  patches = [ ./Cargo.lock.patch ];
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src pname version postUnpack;
+    sha256 = "sha256-JGyDxpfBXzduJaMF1sbmRm7KJajHYdVSj+WbiSETiY0=";
+    patches = [ ./Cargo.lock.patch ];
+  };
+
+  nativeBuildInputs = with rustPlatform; [ cargoSetupHook maturinBuildHook ];
+
+  buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
+  propagatedBuildInputs = [ numpy pandas pyarrow ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "Extensible query execution framework";
+    longDescription = ''
+      DataFusion is an extensible query execution framework, written in Rust,
+      that uses Apache Arrow as its in-memory format.
+    '';
+    homepage = "https://arrow.apache.org/datafusion/";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ cpcloud ];
+  };
+}

--- a/pkgs/development/python-modules/datafusion/default.nix
+++ b/pkgs/development/python-modules/datafusion/default.nix
@@ -13,27 +13,24 @@
 , pyarrow
 , pytest
 }:
-
 let
-  # le sigh, the perils of unrelated versions of software living in the
-  # same repo: there's no obvious way to map the top level source repo
+  # le sigh, the perils of unrelated versions of software living in the same
+  # repo: there's no obvious way to map the top level source repo
   # (arrow-datafusion) version to the version of contained repo
   # (arrow-datafusion/python)
   #
-  # A commit hash will do in a pinch, and ultimately the sha256 has
-  # the final say of what the content is when building
+  # A commit hash will do in a pinch, and ultimately the sha256 has the final
+  # say of what the content is when building
   cargoLock = fetchurl {
     url = "https://raw.githubusercontent.com/apache/arrow-datafusion/6.0.0/python/Cargo.lock";
     sha256 = "sha256-xiv3drEU5jOGsEIh0U01ZQ1NBKobxO2ctp4mxy9iigw=";
   };
 
   postUnpack = ''
-    # TODO: apache/arrow-datafusion should ship the Cargo.lock file in the Python package
     cp "${cargoLock}" $sourceRoot/Cargo.lock
     chmod u+w $sourceRoot/Cargo.lock
   '';
 in
-
 buildPythonPackage rec {
   pname = "datafusion";
   version = "0.4.0";
@@ -46,8 +43,11 @@ buildPythonPackage rec {
 
   inherit postUnpack;
 
+  # TODO: remove the patch hacking and postUnpack hooks after
+  # https://github.com/apache/arrow-datafusion/pull/1508 is merged
+  #
   # the lock file isn't up to date as of 6.0.0 so we need to patch the source
-  # lockfile and the vendored cargo deps lockfile :(
+  # lockfile and the vendored cargo deps lockfile
   patches = [ ./Cargo.lock.patch ];
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src pname version postUnpack;

--- a/pkgs/development/python-modules/datafusion/default.nix
+++ b/pkgs/development/python-modules/datafusion/default.nix
@@ -11,10 +11,10 @@
 , numpy
 , pandas
 , pyarrow
+, pytest
 }:
 
 let
-
   # le sigh, the perils of unrelated versions of software living in the
   # same repo: there's no obvious way to map the top level source repo
   # (arrow-datafusion) version to the version of contained repo
@@ -60,7 +60,14 @@ buildPythonPackage rec {
   buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
   propagatedBuildInputs = [ numpy pandas pyarrow ];
 
-  checkInputs = [ pytestCheckHook ];
+  checkInputs = [ pytest ];
+  pythonImportsCheck = [ "datafusion" ];
+
+  checkPhase = ''
+    runHook preCheck
+    pytest --pyargs "${pname}"
+    runHook postCheck
+  '';
 
   meta = with lib; {
     description = "Extensible query execution framework";

--- a/pkgs/development/python-modules/datafusion/default.nix
+++ b/pkgs/development/python-modules/datafusion/default.nix
@@ -55,10 +55,18 @@ buildPythonPackage rec {
     patches = [ ./Cargo.lock.patch ];
   };
 
-  nativeBuildInputs = with rustPlatform; [ cargoSetupHook maturinBuildHook ];
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ];
 
   buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
-  propagatedBuildInputs = [ numpy pandas pyarrow ];
+
+  propagatedBuildInputs = [
+    numpy
+    pandas
+    pyarrow
+  ];
 
   checkInputs = [ pytest ];
   pythonImportsCheck = [ "datafusion" ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1994,6 +1994,8 @@ in {
 
   datadog = callPackage ../development/python-modules/datadog { };
 
+  datafusion = callPackage ../development/python-modules/datafusion { };
+
   datamodeldict = callPackage ../development/python-modules/datamodeldict { };
 
   dataset = callPackage ../development/python-modules/dataset { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add `datafusion` to nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
