### PR TITLE
NixOS modules: Add mkSuperOptionAlias and mkForEachSubModule.

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -119,12 +119,12 @@ let
       mkFixStrictness mkOrder mkBefore mkAfter mkAliasDefinitions
       mkAliasAndWrapDefinitions fixMergeModules mkRemovedOptionModule
       mkRenamedOptionModule mkMergedOptionModule mkChangedOptionModule
-      mkAliasOptionModule mkDerivedConfig doRename;
+      mkAliasOptionModule mkDerivedConfig doRename mkForEachSubModule;
     inherit (self.options) isOption mkEnableOption mkSinkUndeclaredOptions
       mergeDefaultOption mergeOneOption mergeEqualOption getValues
       getFiles optionAttrSetToDocList optionAttrSetToDocList'
       scrubOptionValue literalExpression literalExample literalDocBook
-      showOption showFiles unknownModule mkOption;
+      showOption showFiles unknownModule mkOption mkSuperOptionAlias;
     inherit (self.types) isType setType defaultTypeMerge defaultFunctor
       isOptionType mkOptionType;
     inherit (self.asserts)

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -557,7 +557,16 @@ rec {
          bothHave "apply" ||
          (bothHave "type" && (! typesMergeable))
       then
-        throw "The option `${showOption loc}' in `${opt._file}' is already declared in ${showFiles res.declarations}."
+        let reason =
+          if bothHave "default" then "Both have `default` attribute."
+          else if bothHave "example" then "Both have `example` attribute."
+          else if bothHave "description" then "Both have `description` attribute."
+          else if bothHave "apply" then "Both have `apply` attribute."
+          else if (bothHave "type" && (! typesMergeable))
+          then "Both have `type` attribute which cannot be merged."
+          else ""
+            ;
+        in throw "The option `${showOption loc}' in `${opt._file}' is already declared in ${showFiles res.declarations}: ${reason}"
       else
         let
           /* Add the modules of the current option to the list of modules
@@ -851,6 +860,57 @@ rec {
 
   mkAliasIfDef = option:
     mkIf (isOption option && option.isDefined);
+
+  /* Given a `forEach` function, return the option definitions produced by the
+     `forEach` function after applying it to all submodules definition
+     independently of the wrapping method used to wrap the submodules.
+
+     This function is useful when combined with mkAliasDefinitions to provide a
+     way to let submodules definitions contribute to supermodule definitions,
+     without having to deal with the internals of options nor the module system.
+
+     The following example, show how to use it, combined with mkSuperOptionAlias
+     and mkAliasDefinitions, to have a module definitions inheriting all
+     submodules definitions from a submodule. The `namedAggregates` option
+     declare a submodule where the `aggregate` option of the super module is
+     aliased into using `mkSuperOptionAlias`. The definitions of the `aggregate`
+     option within each submodule is extracted from each submodule using
+     `mkForEachSubModule`, and aliased as-if it was defined in the super-module
+     using `mkAliasDefinition`.
+
+       { config, options, lib, ... }:
+
+       with lib;
+       let superOptions = options; in
+       {
+         options.aggregate = mkOption { .. };
+         options.namedAggregates = mkOption {
+           type = with lib.types; attrsOf submoduleWith {
+             # Expose the eval.options attribute used as argument of `mkAliasDefinition`
+             exportOptionsUnderConfig = true;
+
+             modules = [
+               ({ ... }: {
+                 # Alias super-module option in the submodule.
+                 options.super.aggregate =
+                   mkSuperOptionAlias (superOptions.aggregate or null);
+               })
+             ];
+           };
+         };
+
+         config = {
+           # Collect all options definitions from submodules.
+           aggregate = mkForEachSubModule
+             (eval: mkAliasDefinitions eval.options.super.aggregate)
+             options.namedAggregates;
+         };
+       }
+
+  */
+  mkForEachSubModule = forEach: option:
+    let subValues = option.type.extractSubValues option.value;
+    in mkMerge (map forEach subValues);
 
   /* Compatibility. */
   fixMergeModules = modules: args: evalModules { inherit modules args; check = false; };

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -117,6 +117,31 @@ rec {
     apply = x: throw "Option value is not readable because the option is not declared.";
   } // attrs);
 
+  /* This option alias a definition of an option from another module, most
+     frequently a super module.
+
+     This option is used to expose the definitions, such that super modules can
+     extract and merge the definition in the super module. This is an hidden
+     internal option as is only purpose is to be used for the implementation of
+     a submodule, and not to be used by users of the submodule.
+
+     The option produced here does not yield any value, as the merge and apply
+     functions provided by the type are not guaranteed to be idempotent.
+
+     The option given as argument should be extracted from the super module or
+     null if it does not exists in the super module. This is a feature meant to
+     provide submodules as independent moduels */
+  mkSuperOptionAlias = option:
+    if isNull option
+    then mkSinkUndeclaredOptions {}
+    else mkOption {
+      internal = true;
+      visible = false;
+      description = "Alias for a super module option.";
+      type = option.type;
+      apply = x: throw "Option value is not readable because the option is an alias of a super module option.";
+    };
+
   mergeDefaultOption = loc: defs:
     let list = getValues defs; in
     if length list == 1 then head list

--- a/lib/tests/modules/declare-submoduleWith-exportOptionsUnderConfig.nix
+++ b/lib/tests/modules/declare-submoduleWith-exportOptionsUnderConfig.nix
@@ -1,0 +1,10 @@
+{ lib, ... }:
+
+{
+  options.submodule = lib.mkOption {
+    type = lib.types.submoduleWith {
+      modules = [ ];
+      exportOptionsUnderConfig = true;
+    };
+  };
+}

--- a/lib/tests/modules/declare-submoduleWith-mkSuperOptionAlias.nix
+++ b/lib/tests/modules/declare-submoduleWith-mkSuperOptionAlias.nix
@@ -1,0 +1,15 @@
+{ lib, options, ... }:
+
+let superOptions = options; in
+
+{
+  options.submodule = lib.mkOption {
+    type = lib.types.submoduleWith {
+      modules = [
+        ({ lib, ... }: {
+          options.super.enable = lib.mkSuperOptionAlias (superOptions.enable or null);
+        })
+      ];
+    };
+  };
+}

--- a/lib/tests/modules/define-enable-alias-attrsOfSub-super-enable.nix
+++ b/lib/tests/modules/define-enable-alias-attrsOfSub-super-enable.nix
@@ -1,0 +1,38 @@
+{ lib, options, ... }:
+
+let
+  superOptions = options;
+  submod = { lib, config, ... }: {
+    options = {
+      super.enable = lib.mkSuperOptionAlias (superOptions.enable or null);
+    };
+
+    config = {
+      # Note: This is different than `super.enable = config.enable;`.
+      super.enable = lib.mkIf config.enable true;
+    };
+  };
+in
+
+{
+  imports = [
+    ./declare-enable.nix
+    ./declare-attrsOfSub-any-enable.nix
+  ];
+
+  options = {
+    attrsOfSub = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.submoduleWith {
+        modules = [ submod ];
+        shorthandOnlyDefinesConfig = true;
+        exportOptionsUnderConfig = true;
+      });
+    };
+  };
+
+  config = {
+    enable = lib.mkForEachSubModule
+      (eval: lib.mkAliasDefinitions eval.options.super.enable)
+      options.attrsOfSub;
+  };
+}

--- a/lib/tests/modules/define-enable-alias-submodule-super-enable.nix
+++ b/lib/tests/modules/define-enable-alias-submodule-super-enable.nix
@@ -1,0 +1,7 @@
+{ lib, options, ... }:
+
+{
+  config.enable = lib.mkForEachSubModule
+    (eval: lib.mkAliasDefinitions eval.options.super.enable)
+    options.submodule;
+}

--- a/lib/tests/modules/define-submodule-super-enable.nix
+++ b/lib/tests/modules/define-submodule-super-enable.nix
@@ -1,0 +1,3 @@
+{
+  submodule.super.enable = true;
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -23,6 +23,7 @@ let
   inherit (lib.lists)
     all
     concatLists
+    concatMap
     count
     elemAt
     filter
@@ -36,6 +37,7 @@ let
     ;
   inherit (lib.attrsets)
     attrNames
+    attrValues
     filterAttrs
     hasAttr
     mapAttrs
@@ -131,6 +133,8 @@ rec {
     , # Function for building the same option type with a different list of
       # modules.
       substSubModules ? m: null
+    , # Function used to return a list of all instances of submodules.
+      extractSubValues ? value: []
     , # Function that merge type declarations.
       # internal, takes a functor as argument and returns the merged type.
       # returning null means the type is not mergeable
@@ -153,7 +157,7 @@ rec {
       nestedTypes ? {}
     }:
     { _type = "option-type";
-      inherit name check merge emptyValue getSubOptions getSubModules substSubModules typeMerge functor deprecationMessage nestedTypes;
+      inherit name check merge emptyValue getSubOptions getSubModules substSubModules extractSubValues typeMerge functor deprecationMessage nestedTypes;
       description = if description == null then name else description;
     };
 
@@ -381,6 +385,7 @@ rec {
       getSubOptions = prefix: elemType.getSubOptions (prefix ++ ["*"]);
       getSubModules = elemType.getSubModules;
       substSubModules = m: listOf (elemType.substSubModules m);
+      extractSubValues = value: concatMap elemType.extractSubValues value;
       functor = (defaultFunctor name) // { wrapped = elemType; };
       nestedTypes.elemType = elemType;
     };
@@ -406,6 +411,7 @@ rec {
       getSubOptions = prefix: elemType.getSubOptions (prefix ++ ["<name>"]);
       getSubModules = elemType.getSubModules;
       substSubModules = m: attrsOf (elemType.substSubModules m);
+      extractSubValues = value: concatMap elemType.extractSubValues (attrValues value);
       functor = (defaultFunctor name) // { wrapped = elemType; };
       nestedTypes.elemType = elemType;
     };
@@ -431,6 +437,7 @@ rec {
       getSubOptions = prefix: elemType.getSubOptions (prefix ++ ["<name>"]);
       getSubModules = elemType.getSubModules;
       substSubModules = m: lazyAttrsOf (elemType.substSubModules m);
+      extractSubValues = value: concatMap elemType.extractSubValues (attrValues value);
       functor = (defaultFunctor name) // { wrapped = elemType; };
       nestedTypes.elemType = elemType;
     };
@@ -453,6 +460,7 @@ rec {
       getSubOptions = elemType.getSubOptions;
       getSubModules = elemType.getSubModules;
       substSubModules = m: uniq (elemType.substSubModules m);
+      extractSubValues = elemType.extractSubValues;
       functor = (defaultFunctor name) // { wrapped = elemType; };
       nestedTypes.elemType = elemType;
     };
@@ -472,6 +480,7 @@ rec {
       getSubOptions = elemType.getSubOptions;
       getSubModules = elemType.getSubModules;
       substSubModules = m: nullOr (elemType.substSubModules m);
+      extractSubValues = value: if isNull value then [] else elemType.extractSubValues value;
       functor = (defaultFunctor name) // { wrapped = elemType; };
       nestedTypes.elemType = elemType;
     };
@@ -485,6 +494,7 @@ rec {
       getSubOptions = elemType.getSubOptions;
       getSubModules = elemType.getSubModules;
       substSubModules = m: functionTo (elemType.substSubModules m);
+      extractSubValues = value: throw "Unable to extract definitions from submodule instances of a function.";
     };
 
     # A submodule (like typed attribute set). See NixOS manual.
@@ -497,6 +507,7 @@ rec {
       { modules
       , specialArgs ? {}
       , shorthandOnlyDefinesConfig ? false
+      , exportOptionsUnderConfig ? false
       }@attrs:
       let
         inherit (lib.modules) evalModules;
@@ -534,6 +545,12 @@ rec {
           }] ++ modules;
         };
 
+        extend = loc: defs:
+          base.extendModules {
+            modules = [ { _module.args.name = last loc; } ] ++ allModules defs;
+            prefix = loc;
+          };
+
         freeformType = base._module.freeformType;
 
       in
@@ -542,10 +559,9 @@ rec {
         description = freeformType.description or name;
         check = x: isAttrs x || isFunction x || path.check x;
         merge = loc: defs:
-          (base.extendModules {
-            modules = [ { _module.args.name = last loc; } ] ++ allModules defs;
-            prefix = loc;
-          }).config;
+          let evaled = extend loc defs;
+              maybeOptions = lib.optionalAttrs exportOptionsUnderConfig { inherit (evaled) options; };
+          in maybeOptions // evaled.config;
         emptyValue = { value = {}; };
         getSubOptions = prefix: (base.extendModules
           { inherit prefix; }).options // optionalAttrs (freeformType != null) {
@@ -558,6 +574,7 @@ rec {
         substSubModules = m: submoduleWith (attrs // {
           modules = m;
         });
+        extractSubValues = value: [ value ];
         nestedTypes = lib.optionalAttrs (freeformType != null) {
           freeformType = freeformType;
         };
@@ -567,6 +584,7 @@ rec {
             modules = modules;
             specialArgs = specialArgs;
             shorthandOnlyDefinesConfig = shorthandOnlyDefinesConfig;
+            exportOptionsUnderConfig = exportOptionsUnderConfig;
           };
           binOp = lhs: rhs: {
             modules = lhs.modules ++ rhs.modules;
@@ -579,6 +597,12 @@ rec {
               if lhs.shorthandOnlyDefinesConfig == rhs.shorthandOnlyDefinesConfig
               then lhs.shorthandOnlyDefinesConfig
               else throw "A submoduleWith option is declared multiple times with conflicting shorthandOnlyDefinesConfig values";
+            # When merging 2 submodules, if any need the options attribute set
+            # to be added, then the merged type should have it. At the moment
+            # exportOptionsUnderConfig defaults to false, such that the set of
+            # attributes visible does not change.
+            exportOptionsUnderConfig =
+              lhs.exportOptionsUnderConfig || rhs.exportOptionsUnderConfig;
           };
         };
       };
@@ -663,6 +687,7 @@ rec {
         getSubOptions = finalType.getSubOptions;
         getSubModules = finalType.getSubModules;
         substSubModules = m: coercedTo coercedType coerceFunc (finalType.substSubModules m);
+        extractSubValues = finalType.extractSubValues;
         typeMerge = t1: t2: null;
         functor = (defaultFunctor name) // { wrapped = finalType; };
         nestedTypes.coercedType = coercedType;


### PR DESCRIPTION
Previously, getting values from submodules to modify the super-module options,
required more complex filtering logic which is dependent on the option type
wrapping the submodule, as well as making sure that the types are coherent.

This change makes it possible to easily set super-module options from submodule
aliases. This change adds 2 major functions: `mkSuperOptionAlias` and
`mkForEachSubModule`.

`mkSuperOptionAlias` is made to create an option within a submodule, which
inherit the type of a parent module option, if it exists as well as preventing
any uses of its computed output. Previously, an easy mistake when implementing
such aliases was to use the computed value of the option. Using the computed
value is a problem as the type, which provide a `merge` and `apply` function is
not garanteed to be idempotent. The work-around is to expose the `options` with
the `submoduleWith` argument named `exportOptionsUnderConfig`. This flag, set to
`false` to avoid regressions, when enabled, it will add the `options` attribute
under the configuration produced by each submodule instance. This is mandatorry
to extract option `definitions` using `mkAliasDefinitions`.

`mkForEachSubModule` is made to abstract over the wrapping type of submodules,
and forward definitions with `mkAliasDefinitions` or similar functions, to skip
over complexity induced by the `merge` and `apply` function logic. This works by
adding a new attribute named `extractSubValues` to each option type. This
attribute is a function which is responsible from unpacking any wrapping types
which are wrapping submodules, such as list or attribute sets, and return an
unordered list of submodule instances. Each submodule instance is then iterated
over and given as argument to the first argument, which is in charge of
producing a valid module or option definition. This is best achieved with
`mkAliasDefinitions` followed with the access to the option exported by the
submodule, using `exportOptionsUnderConfig` flag of the `submoduleWith` type.

The following example illustrates how these functions can be used to aggregate
all definitions defined within multiple submodules, into the super-module which
collect all these definitions.

```
{ config, options, lib, ... }:

let superOptions = options; in
{
  # Suppose that the following option exists:
  #   options.aggregate = lib.mkOption { .. };

  # `namedAggregate` is a tiny submodule which exposes `super.aggregate`, and let
  # the use set parts of the aggregated content under a specific name, such as:
  #
  #   namedAggregate.setupEtc.super.aggregate = " .. ";
  #   namedAggregate.setupBin.super.aggregate = " .. ";
  #
  # All of which would be used as a definitions of the `aggregate` option.
  options.namedAggregates = mkOption {
    type = with lib.types; attrsOf submoduleWith {
      # Expose the eval.options attribute used as argument of `mkAliasDefinitions`
      exportOptionsUnderConfig = true;

      modules = [
        # Create a sub-module which aliases the super-module option, if it exists.
        #
        # To explicit the fact that this option is used only by the super-module,
        # it is added under `super.` attribute set, which might be a convention.
        #
        # Using (.. or null) as argument is useful for submodules which can be
        # embedded in various super-modules. As, this will also work if the
        # option does not exists.
        ({ lib, ... }: {
          options.super.aggregate =
            lib.mkSuperOptionAlias (superOptions.aggregate or null);
        })
      ];
    };
  };

  config = {
    # Collect all options definitions from submodules, if they are defined.
    # `mkForEachSubModule` iterate over all submodule instances. Each instance
    # `eval` has an attribute named `options` exposed by `exportOptionsUnderConfig`
    # flag. This `options` attribute is the same as the `options` argument of
    # submodules and contains the hierachy of options declarations and definitions.
    # `mkAliasDefinitions` is then used to extract options definitions if the
    # option is set in the submodule.
    aggregate = lib.mkForEachSubModule
      (eval: lib.mkAliasDefinitions eval.options.super.aggregate)
      options.namedAggregates;
  };
}
```

###### Things done

Tested locally using:

```
  cd <local-nixpkgs>/lib/tests
  NIX_PATH=<local-nixpkgs> ./modules.sh 
```

All changes made here are new functions, or should be backward compatible.
