### PR TITLE
pythonPackages.{brother-ql,packbits}: init

### DIFF
--- a/pkgs/development/python-modules/brother-ql/default.nix
+++ b/pkgs/development/python-modules/brother-ql/default.nix
@@ -1,0 +1,37 @@
+{ stdenv
+, fetchPypi
+, buildPythonPackage
+, future
+, packbits
+, pillow
+, pyusb
+, pytest
+, mock
+, click
+, attrs
+, lib
+}:
+
+buildPythonPackage rec {
+  pname = "brother-ql";
+  version = "0.9.4";
+
+  src = fetchPypi {
+    pname = "brother_ql";
+    inherit version;
+    sha256 = "sha256-H1xXoDnwEsnCBDl/RwAB9267dINCHr3phdDLPGFOhmA=";
+  };
+
+  propagatedBuildInputs = [ future packbits pillow pyusb click attrs ];
+
+  meta = with lib; {
+    description = "Python package for the raster language protocol of the Brother QL series label printers";
+    longDescription = ''
+      Python package for the raster language protocol of the Brother QL series label printers
+      (QL-500, QL-550, QL-570, QL-700, QL-710W, QL-720NW, QL-800, QL-820NWB, QL-1050 and more)
+    '';
+    homepage = "https://github.com/pklaus/brother_ql";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ grahamc ];
+  };
+}

--- a/pkgs/development/python-modules/packbits/default.nix
+++ b/pkgs/development/python-modules/packbits/default.nix
@@ -1,0 +1,26 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pyparsing
+, six
+, pytest
+, pretend
+, lib
+}:
+
+buildPythonPackage rec {
+  pname = "packbits";
+  version = "0.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "bc6b370bb34e04ac8cfa835e06c0484380affc6d593adb8009dd6c0f7bfff034";
+  };
+
+  meta = with lib; {
+    description = "PackBits encoder/decoder for Python";
+    homepage = "https://github.com/psd-tools/packbits";
+    license = [ licenses.mit ];
+    maintainers = with maintainers; [ grahamc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1320,6 +1320,8 @@ in {
 
   brother = callPackage ../development/python-modules/brother { };
 
+  brother-ql = callPackage ../development/python-modules/brother-ql { };
+
   brotli = callPackage ../development/python-modules/brotli { };
 
   brotlicffi = callPackage ../development/python-modules/brotlicffi {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5640,6 +5640,8 @@ in {
 
   packaging = callPackage ../development/python-modules/packaging { };
 
+  packbits = callPackage ../development/python-modules/packbits { };
+
   packet-python = callPackage ../development/python-modules/packet-python { };
 
   pafy = callPackage ../development/python-modules/pafy { };


### PR DESCRIPTION
###### Motivation for this change

Wanted brother_ql to print to a QL-800 without CUPS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
