### PR TITLE
adrgen: init at 0.4.0-beta

### DIFF
--- a/pkgs/tools/misc/adrgen/default.nix
+++ b/pkgs/tools/misc/adrgen/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, testVersion
+, adrgen
+}:
+
+buildGoModule rec {
+  pname = "adrgen";
+  version = "0.4.0-beta";
+
+  src = fetchFromGitHub {
+    owner = "asiermarques";
+    repo = "adrgen";
+    rev = "v${version}";
+    sha256 = "sha256-2ZE/orsfwL59Io09c4yfXt2enVmpSM/QHlUMgyd9RYQ=";
+  };
+
+  vendorSha256 = "sha256-aDtUD+KKKSE0TpSi4+6HXSBMqF/TROZZhT0ox3a8Idk=";
+
+  passthru.tests.version = testVersion {
+    package = adrgen;
+    command = "adrgen version";
+    version = "v${version}";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/asiermarques/adrgen";
+    description = "A command-line tool for generating and managing Architecture Decision Records";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.ivar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -909,6 +909,8 @@ with pkgs;
 
   acme-client = callPackage ../tools/networking/acme-client { stdenv = gccStdenv; };
 
+  adrgen = callPackage ../tools/misc/adrgen { };
+
   adriconf = callPackage ../tools/graphics/adriconf { };
 
   amass = callPackage ../tools/networking/amass { };


### PR DESCRIPTION
###### Motivation for this change
Closes: #152638

Unit tests succeed, and the binary seems to function as expected from my basic testing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
