### PR TITLE
spectral-compressor: init at unstable-2021-12-30

### DIFF
--- a/pkgs/applications/audio/spectral-compressor/default.nix
+++ b/pkgs/applications/audio/spectral-compressor/default.nix
@@ -1,0 +1,76 @@
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config
+, libjack2, alsa-lib, freetype, libX11, libXrandr, libXinerama, libXext, libXcursor, fftwFloat
+}:
+
+let
+
+  # Derived from subprojects/function2.wrap
+  function2 = rec {
+    version = "4.1.0";
+    src = fetchFromGitHub {
+      owner = "Naios";
+      repo = "function2";
+      rev = version;
+      hash = "sha256-JceZU8ZvtYhFheh8BjMvjjZty4hcYxHEK+IIo5X4eSk=";
+    };
+  };
+
+  juce = rec {
+    version = "unstable-2021-04-07";
+    src = fetchFromGitHub {
+      owner = "juce-framework";
+      repo = "JUCE";
+      rev = "1a5fb5992a1a4e28e998708ed8dce2cc864a30d7";
+      sha256= "1ri7w4sz3sy5xilibg53ls9526fx7jwbv8rc54ccrqfhxqyin308";
+    };
+  };
+
+
+in  stdenv.mkDerivation rec {
+  pname = "spectral-compressor";
+  version = "unstable-2021-12-30";
+
+  src = fetchFromGitHub {
+    owner = "robbert-vdh";
+    repo = pname;
+    fetchSubmodules = true;
+    rev = "97bf23bef83a76057d808971627ce2e7f4859f2f";
+    sha256 = "sha256-YbcIWcyePbYA/3b4l69q3juJLj/H6Uxoi/Ew/4Q0xJA=";
+  };
+
+  postUnpack = ''
+  (
+  cd "$sourceRoot"
+  cp -R --no-preserve=mode,ownership ${juce.src} JUCE
+  cp -R --no-preserve=mode,ownership ${function2.src} function2
+  sed -i 's@CPMAddPackage("gh:juce-framework/JUCE.*@add_subdirectory(JUCE)@g' CMakeLists.txt
+  sed -i 's@CPMAddPackage("gh:Naios/function2.*@add_subdirectory(function2)@g' CMakeLists.txt
+  patchShebangs .
+  )
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib/vst3
+    cp -r SpectralCompressor_artefacts/Release/VST3/Spectral\ Compressor.vst3 $out/lib/vst3
+  '';
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [
+    libjack2 alsa-lib freetype libX11 libXrandr libXinerama libXext
+    libXcursor fftwFloat
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_AR=${stdenv.cc.cc}/bin/gcc-ar"
+    "-DCMAKE_RANLIB=${stdenv.cc.cc}/bin/gcc-ranlib"
+  ];
+
+  meta = with lib; {
+    description = "Everything can be pink noise if you try hard enough!";
+    homepage = "https://github.com/robbert-vdh/spectral-compressor";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ magnetophon ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26134,6 +26134,8 @@ with pkgs;
 
   singularity = callPackage ../applications/virtualization/singularity { };
 
+  spectral-compressor = callPackage ../applications/audio/spectral-compressor  { };
+
   spectmorph = callPackage ../applications/audio/spectmorph { };
 
   smallwm = callPackage ../applications/window-managers/smallwm { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
