### PR TITLE
blop-plugins: init at 0.2.8

### DIFF
--- a/pkgs/applications/audio/blop-plugins/default.nix
+++ b/pkgs/applications/audio/blop-plugins/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
         building synthesis networks.
     '';
     homepage = "http://blop.sourceforge.net/index.html";
-    license = licenses.gpl3;
+    license = licenses.gpl2Plus;
     maintainers = [ maintainers.fps ];
   };
 }

--- a/pkgs/applications/audio/blop-plugins/default.nix
+++ b/pkgs/applications/audio/blop-plugins/default.nix
@@ -1,11 +1,11 @@
-{ lib, stdenv, fetchurl, ladspa-sdk, pkgs, ... }:
+{ lib, stdenv, fetchurl, ladspa-sdk, ... }:
 
 stdenv.mkDerivation rec {
   pname = "blop-plugins";
   version = "0.2.8";
 
   src = fetchurl {
-    url = "http://prdownloads.sourceforge.net/blop/blop-${version}.tar.gz?download";
+    url = "http://prdownloads.sourceforge.net/blop/blop-${version}.tar.gz";
     sha256 = "sha256-focTT6xCjSw6REIxGeJz0YnvCO419Ic9fYjWRhCvPgo=";
   };
 

--- a/pkgs/applications/audio/blop-plugins/default.nix
+++ b/pkgs/applications/audio/blop-plugins/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchurl, ladspa-sdk, pkgs, ... }:
+
+stdenv.mkDerivation rec {
+  pname = "blop-plugins";
+  version = "0.2.8";
+
+  src = fetchurl {
+    url = "http://prdownloads.sourceforge.net/blop/blop-${version}.tar.gz?download";
+    sha256 = "sha256-focTT6xCjSw6REIxGeJz0YnvCO419Ic9fYjWRhCvPgo=";
+  };
+
+  buildInputs = [ ladspa-sdk ];
+
+  configureFlags = [
+    "--with-ladspa-plugin-dir=$(out)/lib/ladspa"
+    "--with-ladspa-prefix=${ladspa-sdk}"
+  ];
+
+  meta = with lib; {
+    description = "BLOP LADSPA plugins";
+    longDescription = ''
+        BLOP comprises a set of LADSPA plugins that generate bandlimited sawtooth, square,
+        variable pulse and slope-variable triangle waves, principally for use with one of
+        the many modular software synthesisers available. They are wavetable based, and
+        are designed to produce output with harmonic content as high as possible over a
+        wide pitch range. Additionally, there are a few extra plugins to assist in
+        building synthesis networks.
+    '';
+    homepage = "http://blop.sourceforge.net/index.html";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.fps ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28799,6 +28799,8 @@ with pkgs;
 
   tap-plugins = callPackage ../applications/audio/tap-plugins { };
 
+  blop-plugins = callPackage ../applications/audio/blop-plugins { };
+
   taskjuggler = callPackage ../applications/misc/taskjuggler { };
 
   tabula = callPackage ../applications/misc/tabula { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This set of LADSPA plugins is still somewhat useful!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
