### PR TITLE
popsicle: init at unstable-2021-12-20

### DIFF
--- a/pkgs/tools/misc/popsicle/default.nix
+++ b/pkgs/tools/misc/popsicle/default.nix
@@ -1,0 +1,73 @@
+{ stdenv
+, fetchFromGitHub
+, rustc
+, cargo
+, rustPlatform
+, pkg-config
+, dbus
+, glib
+, cairo
+, pango
+, atk
+, lib
+, gdk-pixbuf
+, gtk3
+}:
+
+rustPlatform.buildRustPackage.override { stdenv = stdenv; } rec {
+  pname = "popsicle";
+  version = "unstable-2021-12-20";
+
+  src = fetchFromGitHub {
+    owner = "pop-os";
+    repo = pname;
+    rev = "b02ebf5f2e6c18777453ca9a144d69689a6fa901";
+    sha256 = "03ilhvnr4mwy7b8bipp616h16m2ilxzxz2zjpkzy3afwvh9bz1mx";
+  };
+
+  cargoSha256 = "1c54wxyrfxk5chnjhxw6vaznm7ff9dkx1rxlgp417jfygiwijjs4";
+
+  nativeBuildInputs = [ gtk3 pkg-config ];
+
+  buildInputs = [
+    gtk3
+    dbus
+    glib
+    cairo
+    pango
+    atk
+    gdk-pixbuf
+  ];
+
+  # Use the stdenv default phases (./configure; make) instead of the
+  # ones from buildRustPackage.
+  configurePhase = "configurePhase";
+  buildPhase = "buildPhase";
+  checkPhase = "checkPhase";
+  installPhase = "installPhase";
+
+  postPatch = ''
+    # Have to do this here instead of in preConfigure because
+    # cargoDepsCopy gets unset after postPatch.
+    configureFlagsArray+=("RUST_VENDORED_SOURCES=$NIX_BUILD_TOP/$cargoDepsCopy")
+  '';
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "DESTDIR=${placeholder "out"}"
+  ];
+
+  postInstall = ''
+    # install man page, icon, etc...
+    mv $out/usr/local/* $out
+    rm -rf $out/usr
+  '';
+
+  meta = with lib; {
+    description = "Multiple USB File Flasher";
+    homepage = "https://github.com/pop-os/popsicle";
+    maintainers = with maintainers; [ _13r0ck ];
+    license = licenses.mit;
+    platforms = [ "aarch64-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1142,6 +1142,8 @@ with pkgs;
 
   pikchr = callPackage ../tools/graphics/pikchr { };
 
+  popsicle = callPackage ../tools/misc/popsicle { };
+
   roxterm = callPackage ../applications/terminal-emulators/roxterm { };
 
   rxvt = callPackage ../applications/terminal-emulators/rxvt { };


### PR DESCRIPTION
Package working version of popsicle for nix

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
