### PR TITLE
Update of all Jitsi Meet components

### DIFF
--- a/nixos/tests/jibri.nix
+++ b/nixos/tests/jibri.nix
@@ -63,7 +63,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
         """sleep 15 && curl -H "Content-Type: application/json" -X POST http://localhost:2222/jibri/api/v1.0/stopService -d '{"sessionId": "RecordTest","callParams":{"callUrlInfo":{"baseUrl": "https://machine","callName": "TestCall"}},"callLoginParams":{"domain": "recorder.machine", "username": "recorder", "password": "'"$(cat /var/lib/jitsi-meet/jibri-recorder-secret)"'" },"sinkType": "file"}'"""
     )
     machine.wait_until_succeeds(
-        "cat /var/log/jitsi/jibri/log.0.txt | grep -q 'Recording finalize script finished with exit value 0'", timeout=36
+        "cat /var/log/jitsi/jibri/log.0.txt | grep -q 'Finalize script finished with exit value 0'", timeout=36
     )
   '';
 })

--- a/pkgs/misc/jitsi-meet-prosody/default.nix
+++ b/pkgs/misc/jitsi-meet-prosody/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   pname = "jitsi-meet-prosody";
-  version = "1.0.5415";
+  version = "1.0.5675";
   src = fetchurl {
     url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
-    sha256 = "XvW+bAuad1IKJPZzVJBkT7vA2BBDFQBvTWtbyK/in6A=";
+    sha256 = "FrafgJcNF3xv985JJ+xOWPtJZFeElIAaIXWdcgheru0=";
   };
 
   dontBuild = true;

--- a/pkgs/servers/jibri/default.nix
+++ b/pkgs/servers/jibri/default.nix
@@ -13,10 +13,10 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "jibri";
-  version = "8.0-93-g51fe7a2";
+  version = "8.0-114-g20e233e";
   src = fetchurl {
     url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
-    sha256 = "1w78aa3rfdc4frb68ymykrbazxqrcv8mcdayqmcb72q1aa854c7j";
+    sha256 = "DD1l7HQLqpPXgSzfKkZ9dYnGhinEoiGhVj4bbWWBnQM=";
   };
 
   dontBuild = true;

--- a/pkgs/servers/jicofo/default.nix
+++ b/pkgs/servers/jicofo/default.nix
@@ -2,10 +2,10 @@
 
 let
   pname = "jicofo";
-  version = "1.0-813";
+  version = "1.0-832";
   src = fetchurl {
     url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
-    sha256 = "MVlGD2l0e1a2AtYPU1fkBoEfdPhjf2nOehAcacQl4Jk=";
+    sha256 = "ZSzxD4RCsIkNtB4agBRZkzbJOi6ttzlc4Qw5n0t5syc=";
   };
 in
 stdenv.mkDerivation {

--- a/pkgs/servers/jitsi-videobridge/default.nix
+++ b/pkgs/servers/jitsi-videobridge/default.nix
@@ -2,10 +2,10 @@
 
 let
   pname = "jitsi-videobridge2";
-  version = "2.1-570-gb802be83";
+  version = "2.1-595-g3637fda4";
   src = fetchurl {
     url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
-    sha256 = "0SLaCIjMN2/+Iushyz8OQpRHHBYVqn6+DpwNGbQEzy4=";
+    sha256 = "vwn9C8M3wwiIqwxAu1MDe2ra2SCQ2Hssco5J/xUFoKM=";
   };
 in
 stdenv.mkDerivation {

--- a/pkgs/servers/web-apps/jitsi-meet/default.nix
+++ b/pkgs/servers/web-apps/jitsi-meet/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "jitsi-meet";
-  version = "1.0.5415";
+  version = "1.0.5675";
 
   src = fetchurl {
     url = "https://download.jitsi.org/jitsi-meet/src/jitsi-meet-${version}.tar.bz2";
-    sha256 = "DJk+2EAADIz3Jck5Tf3AMWq0pZn3q1JQpDm/VdIz7nc=";
+    sha256 = "pwt1R/LkTCUtAi/LhidU6wvhrRCVo5N8EYBT/qnkMew=";
   };
 
   dontBuild = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Two new stable versions of all the Jitsi Meet components were released by upstream in early December: https://download.jitsi.org/stable/

Automatic update PRs were generated for the first of these releases for the packages that are in Nixpkgs (except Jibri): https://github.com/NixOS/nixpkgs/pull/149267, https://github.com/NixOS/nixpkgs/pull/149269, https://github.com/NixOS/nixpkgs/pull/149592, https://github.com/NixOS/nixpkgs/pull/149597. There are not yet PRs for the second release (on December 10th, the latest updates), nor for the new version of Jibri. These are the updates included in this PR, bringing all Jitsi Meet components in Nixpkgs to their latest stable versions.

###### Things done

I deployed Jitsi Meet using the branch for this PR and did basic testing without any problems. I also successfully built `nixos/tests/jitsi-meet.nix` and `nixos/tests/jibri.nix` using the updated components. The jibri test initially failed, and I determined that this was because the wording of a log message used in the test had changed in the newer version. Once the test was updated to reflect the new wording of the log message https://github.com/NixOS/nixpkgs/commit/ea0276523a26f661d7f783f7d036d113cc6e1d5e, it completed successfully.

In reviewing some of the changes that were made to the Jitsi Meet components in these new releases, I noticed that the most significant feature that has been added is support for Breakout Rooms. However, this feature is not enabled by default, and it appears as though to do so will require modifications to the module for Jitsi Meet (and possibly others, I haven't confirmed). Those modifications are not included in this PR, though if anyone is interested more info is available here: https://community.jitsi.org/t/new-feature-breakout-rooms-how-to-enable/108918

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
