### PR TITLE
mattermost: 5.37.5 -> 6.2.1

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -30,6 +30,14 @@
           PHP 8.1 is now available
         </para>
       </listitem>
+      <listitem>
+        <para>
+          Mattermost has been updated to version 6.2. Migrations may
+          take a while, see the
+          <link xlink:href="https://docs.mattermost.com/install/self-managed-changelog.html#release-v6.2-feature-release">upgrade
+          notes</link>.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-22.05-new-services">

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -13,6 +13,9 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - PHP 8.1 is now available
 
+- Mattermost has been updated to version 6.2. Migrations may take a while,
+  see the [upgrade notes](https://docs.mattermost.com/install/self-managed-changelog.html#release-v6.2-feature-release).
+
 ## New Services {#sec-release-22.05-new-services}
 
 - [aesmd](https://github.com/intel/linux-sgx#install-the-intelr-sgx-psw), the Intel SGX Architectural Enclave Service Manager. Available as [services.aesmd](#opt-services.aesmd.enable).

--- a/pkgs/servers/mattermost/default.nix
+++ b/pkgs/servers/mattermost/default.nix
@@ -1,27 +1,63 @@
-{ lib, stdenv, fetchurl, fetchFromGitHub, buildGoModule, buildEnv }:
+{ lib, stdenv, fetchurl, fetchFromGitHub, buildGo117Package, buildEnv
+
+# The suffix for the Mattermost version.
+, versionSuffix ? "nixpkgs"
+
+# The constant build date.
+, buildDate ? "1970-01-01"
+
+# Set to true to set the build hash to the Nix store path.
+, storePathAsBuildHash ? false }:
 
 let
-  version = "5.37.5";
+  version = "6.2.1";
 
-  mattermost-server = buildGoModule rec {
+  goPackagePath = "github.com/mattermost/mattermost-server";
+
+  mattermost-server-build = buildGo117Package rec {
     pname = "mattermost-server";
-    inherit version;
+    inherit version goPackagePath;
 
     src = fetchFromGitHub {
       owner = "mattermost";
-      repo = pname;
+      repo = "mattermost-server";
       rev = "v${version}";
-      sha256 = "sha256-ddK7gxWl1arCtW2vqmon28AAeyZQPYlbGj3QtOlqtiU=";
+      sha256 = "WjBsbW7aEI+MX2I1LrEJh8JgNQ4Do7PpeshXgaQAk1s=";
     };
 
-    vendorSha256 = null;
-    doCheck = false;
-
     ldflags = [
-      "-s" "-w" "-X github.com/mattermost/mattermost-server/v${lib.versions.major version}/model.BuildNumber=${version}"
+      "-s" "-w"
+      "-X ${goPackagePath}/model.BuildNumber=${version}${lib.optionalString (versionSuffix != null) "-${versionSuffix}"}"
+      "-X ${goPackagePath}/model.BuildDate=${buildDate}"
+      "-X ${goPackagePath}/model.BuildEnterpriseReady=false"
     ];
-
   };
+
+  mattermost-server = if storePathAsBuildHash then mattermost-server-build.overrideAttrs (orig: {
+    buildPhase = ''
+      origGo="$(type -p go)"
+
+      # Override the Go binary to set the build hash in -ldflags to $out.
+      # Technically this is more accurate than a Git hash!
+      # nixpkgs does not appear to support environment variables in ldflags
+      # for go packages, so we have to rewrite -ldflags before calling go.
+      go() {
+        local args=()
+        local ldflags="-X ${goPackagePath}/model.BuildHash=$out"
+        local found=0
+        for arg in "$@"; do
+          if [[ "$arg" == -ldflags=* ]] && [ $found -eq 0 ]; then
+            arg="-ldflags=''${ldflags} ''${arg#-ldflags=}"
+            found=1
+          fi
+          args+=("$arg")
+        done
+        "$origGo" "''${args[@]}"
+      }
+
+      ${orig.buildPhase}
+    '';
+  }) else mattermost-server-build;
 
   mattermost-webapp = stdenv.mkDerivation {
     pname = "mattermost-webapp";
@@ -29,7 +65,7 @@ let
 
     src = fetchurl {
       url = "https://releases.mattermost.com/${version}/mattermost-${version}-linux-amd64.tar.gz";
-      sha256 = "sha256-G6L8Ct6PtARg2LKxcoFyg9vrDJXIKGByxovquMc6p00=";
+      sha256 = "pV/MwMCK8vMzASXuM1+ePcarIgrcNAkFLEdmPya911E=";
     };
 
     installPhase = ''
@@ -52,7 +88,7 @@ in
       description = "Open-source, self-hosted Slack-alternative";
       homepage = "https://www.mattermost.org";
       license = with licenses; [ agpl3 asl20 ];
-      maintainers = with maintainers; [ fpletz ryantm ];
+      maintainers = with maintainers; [ fpletz ryantm numinit ];
       platforms = platforms.unix;
     };
   }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to latest.

Add overridable arguments:
- versionSuffix (default: nixpkgs)
- buildDate (default: 1970-01-01)
- storePathAsBuildHash (default: false)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
