### PR TITLE
cubiomes-viewer: init at 1.12.1

### DIFF
--- a/pkgs/applications/misc/cubiomes-viewer/default.nix
+++ b/pkgs/applications/misc/cubiomes-viewer/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, qtbase
+, qmake
+, wrapQtAppsHook
+, copyDesktopItems
+, makeDesktopItem
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cubiomes-viewer";
+  version = "1.12.1";
+
+  src = fetchFromGitHub {
+    owner = "Cubitect";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-F0c6gMQKu35iBNRw+wpoxSUOhRUbPRKIXSNDDNZsfPE=";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [
+    qtbase
+  ];
+
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+    copyDesktopItems
+  ];
+
+  desktopItems = [ (makeDesktopItem {
+    name = pname;
+    desktopName = "Cubiomes Viewer";
+    exec = pname;
+    icon = pname;
+    categories = "Game";
+    comment = meta.description;
+  }) ];
+
+  preBuild = ''
+    # QMAKE_PRE_LINK is not executed (I dont know why)
+    make -C ./cubiomes libcubiomes CFLAGS="-DSTRUCT_CONFIG_OVERRIDE=1" all
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp cubiomes-viewer $out/bin
+
+    mkdir -p $out/share/pixmaps
+    cp icons/map.png $out/share/pixmaps/cubiomes-viewer.png
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/Cubitect/cubiomes-viewer";
+    description = "A graphical Minecraft seed finder and map viewer";
+    longDescription = ''
+      Cubiomes Viewer provides a graphical interface for the efficient and flexible seed-finding
+      utilities provided by cubiomes and a map viewer for the Minecraft biomes and structure generation.
+    '';
+    platforms = platforms.all;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ hqurve ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14440,6 +14440,8 @@ with pkgs;
 
   ctodo = callPackage ../applications/misc/ctodo { };
 
+  cubiomes-viewer = libsForQt5.callPackage ../applications/misc/cubiomes-viewer { };
+
   ctmg = callPackage ../tools/security/ctmg { };
 
   cmake_2_8 = callPackage ../development/tools/build-managers/cmake/2.8.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/152346

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
