### PR TITLE
HentaiAtHome: init at 1.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11634,6 +11634,12 @@
     githubId = 280235;
     name = "Terje Larsen";
   };
+  terrorjack = {
+    email = "astrohavoc@gmail.com";
+    github = "TerrorJack";
+    githubId = 3889585;
+    name = "Cheng Shao";
+  };
   tesq0 = {
     email = "mikolaj.galkowski@gmail.com";
     github = "tesq0";

--- a/pkgs/applications/misc/HentaiAtHome/default.nix
+++ b/pkgs/applications/misc/HentaiAtHome/default.nix
@@ -1,0 +1,37 @@
+{ buildGraalvmNativeImage, fetchzip, graalvm17-ce, lib }:
+
+buildGraalvmNativeImage rec {
+  pname = "HentaiAtHome";
+  version = "1.6.1";
+  src = fetchzip {
+    url = "https://repo.e-hentai.org/hath/HentaiAtHome_${version}.zip";
+    hash =
+      "sha512-nGGCuVovj4NJGrihKKYXnh0Ic9YD36o7r6wv9zSivZn22zm8lBYVXP85LnOw2z9DiJARivOctQGl48YFD7vxOQ==";
+    stripRoot = false;
+  };
+
+  jar = "${src}/HentaiAtHome.jar";
+  dontUnpack = true;
+
+  graalvm = graalvm17-ce;
+  extraNativeImageBuildArgs = [
+    "--enable-url-protocols=http,https"
+    "--install-exit-handlers"
+    "--no-fallback"
+  ];
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    pushd $(mktemp -d)
+    $out/bin/HentaiAtHome
+    popd
+  '';
+
+  meta = with lib; {
+    homepage = "https://ehwiki.org/wiki/Hentai@Home";
+    description =
+      "Hentai@Home is an open-source P2P gallery distribution system which reduces the load on the E-Hentai Galleries";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ terrorjack ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32715,6 +32715,8 @@ with pkgs;
 
   velero = callPackage ../applications/networking/cluster/velero { };
 
+  HentaiAtHome = callPackage ../applications/misc/HentaiAtHome { };
+
   hplip = callPackage ../misc/drivers/hplip { };
 
   hplipWithPlugin = hplip.override { withPlugin = true; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Make it easy for nix users to opt-in the Hentai@Home network by adding the H@H client into nixpkgs. At least one person is using this derivation right now, and there should be more.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
