### PR TITLE
buildGoModule: use proxyVendor instead of runVend

### DIFF
--- a/doc/languages-frameworks/go.section.md
+++ b/doc/languages-frameworks/go.section.md
@@ -12,8 +12,7 @@ The function `buildGoModule` builds Go programs managed with Go modules. It buil
 In the following is an example expression using `buildGoModule`, the following arguments are of special significance to the function:
 
 - `vendorSha256`: is the hash of the output of the intermediate fetcher derivation. `vendorSha256` can also take `null` as an input. When `null` is used as a value, rather than fetching the dependencies and vendoring them, we use the vendoring included within the source repo. If you'd like to not have to update this field on dependency changes, run `go mod vendor` in your source repo and set `vendorSha256 = null;`
-- `runVend`: runs the vend command to generate the vendor directory. This is useful if your code depends on c code and go mod tidy does not include the needed sources to build.
-- `proxyVendor`: Fetches (go mod download) and proxies the vendor directory. This is useful if any dependency has case-insensitive conflicts which will produce platform dependant `vendorSha256` checksums.
+- `proxyVendor`: Fetches (go mod download) and proxies the vendor directory. This is useful if your code depends on c code and go mod tidy does not include the needed sources to build or if any dependency has case-insensitive conflicts which will produce platform dependant `vendorSha256` checksums.
 
 ```nix
 pet = buildGoModule rec {

--- a/pkgs/applications/blockchains/erigon.nix
+++ b/pkgs/applications/blockchains/erigon.nix
@@ -11,8 +11,8 @@ buildGoModule rec {
     sha256 = "0l0w1badhvlh1rgqzvlmy5k7xhb1nf4f5dmhkl935a5ila08aak3";
   };
 
-  vendorSha256 = "1hbfmq76zm50zwmlh3jblriwq2k1mp99d8lg8xzxwy56hncgfj8k";
-  runVend = true;
+  vendorSha256 = "sha256-kA7pOSP4wkzKuFmUqhZmjXJ0ao64cIgZMrQtQ0bQ++U=";
+  proxyVendor = true;
 
   # Build errors in mdbx when format hardening is enabled:
   #   cc1: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]

--- a/pkgs/applications/misc/hugo/default.nix
+++ b/pkgs/applications/misc/hugo/default.nix
@@ -11,11 +11,11 @@ buildGoModule rec {
     sha256 = "sha256-6bqtw0hUrRBhTwEDURaTjgl3aVVCbfxjoPRfhSd3LK8=";
   };
 
-  vendorSha256 = "sha256-CO+7WgoTsFCd9vkcALKcJP6Kj3CIWr5FF75/WgbK04g=";
+  vendorSha256 = "sha256-M4pKAxNd8rqluVm+c+X+nxC/vcaVclebo9HP17yEpfo=";
 
   doCheck = false;
 
-  runVend = true;
+  proxyVendor = true;
 
   tags = [ "extended" ];
 

--- a/pkgs/applications/networking/mailreaders/aerc/default.nix
+++ b/pkgs/applications/networking/mailreaders/aerc/default.nix
@@ -14,8 +14,8 @@ buildGoModule rec {
     sha256 = "sha256-RaHigTp1YGkjQ46gFLhKcJuajekcCgfozu0ndCNq5Ac=";
   };
 
-  runVend = true;
-  vendorSha256 = "sha256-A2MZzTYzGuZLFENn9OBIBBreJan+b3RKOEu5bQcDwS8=";
+  proxyVendor = true;
+  vendorSha256 = "sha256-ZFs2CXmNZpGae7bD15yTh3w6b00C7AgOwGuz72d2wHs=";
 
   doCheck = false;
 

--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -26,12 +26,10 @@
 , vendorSha256
 # Whether to delete the vendor folder supplied with the source.
 , deleteVendor ? false
-# Whether to run the vend tool to regenerate the vendor directory.
-# This is useful if any dependency contain C files.
-, runVend ? false
 # Whether to fetch (go mod download) and proxy the vendor directory.
-# This is useful if any dependency has case-insensitive conflicts
-# which will produce platform dependant `vendorSha256` checksums.
+# This is useful if your code depends on c code and go mod tidy does not
+# include the needed sources to build or if any dependency has case-insensitive
+# conflicts which will produce platform dependant `vendorSha256` checksums.
 , proxyVendor ? false
 
 # We want parallel builds by default
@@ -42,6 +40,9 @@
 , allowGoReference ? false
 
 , meta ? {}
+
+# disabled
+, runVend ? false
 
 # Not needed with buildGoModule
 , goPackagePath ? ""
@@ -54,7 +55,7 @@
 
 with builtins;
 
-assert (runVend == true && proxyVendor == true) -> throw "can't use `runVend` and `proxyVendor` together";
+assert runVend != false -> throw "`runVend` has been replaced by `proxyVendor`";
 
 assert goPackagePath != "" -> throw "`goPackagePath` is not needed with `buildGoModule`";
 

--- a/pkgs/servers/hydron/default.nix
+++ b/pkgs/servers/hydron/default.nix
@@ -13,8 +13,8 @@ buildGoModule rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  vendorSha256 = "1ngig5zw0gf1mkjjsfvvn09rncb36rg274cbi3glp8wzfcr8aip3";
-  runVend = true;
+  vendorSha256 = "sha256-TxeHfO5IUVsKmKZ1e0/KXi+6dk2nn6AoNG0eB3jyGkY=";
+  proxyVendor = true;
 
   buildInputs = [ ffmpeg ];
 

--- a/pkgs/servers/livepeer/default.nix
+++ b/pkgs/servers/livepeer/default.nix
@@ -6,8 +6,8 @@ buildGoModule rec {
   pname = "livepeer";
   version = "0.5.20";
 
-  runVend = true;
-  vendorSha256 = "sha256-iFVScV3arPkBjMi8sCHIja4G2QeQDb2sgBrbTFyxKyw=";
+  proxyVendor = true;
+  vendorSha256 = "sha256-pyPxONcWniJoA0qYusHktF3/taYda2StaMiMhyRYEm4=";
 
   src = fetchFromGitHub {
     owner = "livepeer";

--- a/pkgs/tools/system/gotop/default.nix
+++ b/pkgs/tools/system/gotop/default.nix
@@ -11,8 +11,8 @@ buildGoModule rec {
     sha256 = "15bsxaxqxp17wsr0p9fkpvgfyqnhhwm3j8jxkvcs4cdw73qaxdsy";
   };
 
-  runVend = true;
-  vendorSha256 = "06hl1npwmy9dvpf4kljvw8lwwiigm52wf106lmf9k6k2gi5ikprz";
+  proxyVendor = true;
+  vendorSha256 = "sha256-c+9IZEKiW95JIh6krs9NhdBohUatTTEIYBU13kj9zB8=";
 
   ldflags = [ "-s" "-w" "-X main.Version=v${version}" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`proxyVendor` provides the same functionality (with sightly worse performance) as `runVend` while also addressing another edge case (vendoring with case sensitivity problems). As there is currently only ~10 packages that use either of them there isn't much point in keeping both.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
