### PR TITLE
pango,gtk3,gtk4,libadwaita: update

### DIFF
--- a/pkgs/applications/audio/shortwave/default.nix
+++ b/pkgs/applications/audio/shortwave/default.nix
@@ -80,6 +80,7 @@ stdenv.mkDerivation rec {
       desktop. It is the successor to the older Gradio application.
     '';
     maintainers = with maintainers; [ lasandell ];
+    broken = true; # incompatible with latest libadwaita
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
   };

--- a/pkgs/applications/video/kooha/default.nix
+++ b/pkgs/applications/video/kooha/default.nix
@@ -68,6 +68,7 @@ stdenv.mkDerivation rec {
   # Fixes https://github.com/NixOS/nixpkgs/issues/31168
   postPatch = ''
     patchShebangs build-aux/meson_post_install.py
+    substituteInPlace meson.build --replace '>= 1.0.0-alpha.1' '>= 1.0.0'
   '';
 
   installCheckPhase = ''

--- a/pkgs/desktops/gnome/apps/gnome-todo/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-todo/default.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, fetchurl
+, fetchFromGitLab
 , fetchpatch
 , meson
 , ninja
@@ -16,21 +16,25 @@
 , libpeas
 , gnome-online-accounts
 , gsettings-desktop-schemas
-, libportal
+, libportal-gtk4
 , evolution-data-server
 , libical
 , librest
 , json-glib
 , itstool
+, unstableGitUpdater
 }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-todo";
-  version = "41.0";
+  version = "unstable-2022-01-01";
 
-  src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "1r94880d4khbjhhfnhaba3y3d4hv2bri82rzfzxn27s5iybpqras";
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = "gnome-todo";
+    rev = "4a6be8c38510d909a9f94ec34c4da1f31ac9f1ab";
+    sha256 = "5UGo9vMb8scPWK91gftYOjqkJs9tGMiH1lqyEqedF2A=";
   };
 
   patches = [
@@ -64,7 +68,7 @@ stdenv.mkDerivation rec {
     gnome.adwaita-icon-theme
 
     # Plug-ins
-    libportal # background
+    libportal-gtk4 # background
     evolution-data-server # eds
     libical
     librest # todoist
@@ -77,9 +81,8 @@ stdenv.mkDerivation rec {
   '';
 
   passthru = {
-    updateScript = gnome.updateScript {
-      packageName = pname;
-      attrPath = "gnome.${pname}";
+    updateScript = unstableGitUpdater {
+      url = "https://gitlab.gnome.org/GNOME/gnome-todo.git";
     };
   };
 

--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -59,7 +59,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "gtk+3";
-  version = "3.24.30";
+  version = "3.24.31";
 
   outputs = [ "out" "dev" ] ++ lib.optional withGtkDoc "devdoc";
   outputBin = "dev";
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gtk+/${lib.versions.majorMinor version}/gtk+-${version}.tar.xz";
-    sha256 = "sha256-unW//zIK0fTPvukrqBPsM2MizDxmDUBqrQFLBwh6O6k=";
+    sha256 = "sha256-Qjw+f9tMRZ7oieNf1Ncf0mI1YlQcEEGxHAflrR/xC/k=";
   };
 
   patches = [

--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -6,7 +6,7 @@
 , gettext
 , graphene
 , gi-docgen
-, meson
+, meson_0_60
 , ninja
 , python3
 , makeWrapper
@@ -23,6 +23,9 @@
 , xorg
 , libepoxy
 , libxkbcommon
+, libpng
+, libtiff
+, libjpeg
 , libxml2
 , gnome
 , gsettings-desktop-schemas
@@ -59,7 +62,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "gtk4";
-  version = "4.4.1";
+  version = "4.6.0";
 
   outputs = [ "out" "dev" ] ++ lib.optionals x11Support [ "devdoc" ];
   outputBin = "dev";
@@ -71,14 +74,14 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gtk/${lib.versions.majorMinor version}/gtk-${version}.tar.xz";
-    sha256 = "D6ramD3GsLxAnLNMFxPB8yZ+Z8CT+GseOxfbYQCj3fQ=";
+    sha256 = "eC1ZUfv9WF/J7HbAnQfijmAUxy2wAftWf/8hf7luTYw=";
   };
 
   nativeBuildInputs = [
     gettext
     gobject-introspection
     makeWrapper
-    meson
+    meson_0_60
     ninja
     pkg-config
     python3
@@ -89,6 +92,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libxkbcommon
+    libpng
+    libtiff
+    libjpeg
     libepoxy
     isocodes
   ] ++ lib.optionals vulkanSupport [
@@ -130,6 +136,8 @@ stdenv.mkDerivation rec {
     glib
     graphene
     pango
+  ] ++ lib.optionals waylandSupport [
+    wayland
   ] ++ lib.optionals vulkanSupport [
     vulkan-loader
   ] ++ [

--- a/pkgs/development/libraries/libadwaita/default.nix
+++ b/pkgs/development/libraries/libadwaita/default.nix
@@ -21,7 +21,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libadwaita";
-  version = "1.0.0.alpha.4";
+  version = "1.0.0";
 
   outputs = [ "out" "dev" "devdoc" ];
   outputBin = "devdoc"; # demo app
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     owner = "GNOME";
     repo = "libadwaita";
     rev = version;
-    sha256 = "sha256-3aVeBaKSl6SaPQLodsyJHwnNOlXlWfIaLnbbl3+mlDA=";
+    sha256 = "sha256-ngHCYOmQ6qn55/QOjM+GSpDt3Qvyb/hTrwcTE+Kr0LY=";
   };
 
   nativeBuildInputs = [
@@ -92,7 +92,7 @@ stdenv.mkDerivation rec {
     description = "Library to help with developing UI for mobile devices using GTK/GNOME";
     homepage = "https://gitlab.gnome.org/GNOME/libadwaita";
     license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ dotlambda ];
+    maintainers = teams.gnome.members ++ (with maintainers; [ dotlambda ]);
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/libportal/default.nix
+++ b/pkgs/development/libraries/libportal/default.nix
@@ -4,42 +4,66 @@
 , meson
 , ninja
 , pkg-config
-, gtk-doc
-, docbook-xsl-nons
-, docbook_xml_dtd_45
+, gobject-introspection
+, vala
+, gi-docgen
 , glib
+, gtk3
+, gtk4
+, libsForQt5
+, variant ? null
 }:
 
+assert variant == null || variant == "gtk3" || variant == "gtk4" || variant == "qt5";
+
 stdenv.mkDerivation rec {
-  pname = "libportal";
-  version = "0.4";
+  pname = "libportal" + lib.optionalString (variant != null) "-${variant}";
+  version = "0.5";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchFromGitHub {
     owner = "flatpak";
-    repo = pname;
+    repo = "libportal";
     rev = version;
-    sha256 = "fuYZWGkdazq6H0rThqpF6KIcvwgc17o+CiISb1LjBso=";
+    sha256 = "oPPO2f6NNeok0SGh4jELkkOP6VUxXZiwPM/n6CUHm0Q=";
   };
 
   nativeBuildInputs = [
     meson
     ninja
     pkg-config
-    gtk-doc
-    docbook-xsl-nons
-    docbook_xml_dtd_45
+    gi-docgen
+  ] ++ lib.optionals (variant != "qt5") [
+    gobject-introspection
+    vala
   ];
 
   propagatedBuildInputs = [
     glib
+  ] ++ lib.optionals (variant == "gtk3") [
+    gtk3
+  ] ++ lib.optionals (variant == "gtk4") [
+    gtk4
+  ] ++ lib.optionals (variant == "qt5") [
+    libsForQt5.qtbase
   ];
+
+  mesonFlags = [
+    "-Dbackends=${lib.optionalString (variant != null) variant}"
+    "-Dvapi=${if variant != "qt5" then "true" else "false"}"
+    "-Dintrospection=${if variant != "qt5" then "true" else "false"}"
+  ];
+
+  postFixup = ''
+    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
+    moveToOutput "share/doc" "$devdoc"
+  '';
 
   meta = with lib; {
     description = "Flatpak portal library";
     homepage = "https://github.com/flatpak/libportal";
-    license = licenses.lgpl2Plus;
+    license = licenses.lgpl3Plus;
     maintainers = with maintainers; [ jtojnar ];
     platforms = platforms.linux;
   };

--- a/pkgs/development/libraries/pango/default.nix
+++ b/pkgs/development/libraries/pango/default.nix
@@ -24,14 +24,14 @@
 
 stdenv.mkDerivation rec {
   pname = "pango";
-  version = "1.50.0";
+  version = "1.50.3";
 
   outputs = [ "bin" "out" "dev" ]
     ++ lib.optionals withDocs [ "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "26i2Ld+G4Q9z+Tw9Ila3MjiyvK+HA3yiKbQL3AQOs/M=";
+    sha256 = "St0F7fUcH7N1oczedJiRQSDiPLKA3XOVsa60QfGDikw=";
   };
 
   strictDeps = !withIntrospection;

--- a/pkgs/development/tools/ashpd-demo/default.nix
+++ b/pkgs/development/tools/ashpd-demo/default.nix
@@ -86,6 +86,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Tool for playing with XDG desktop portals";
     homepage = "https://github.com/bilelmoussaoui/ashpd/tree/master/ashpd-demo";
+    broken = true; # requires older libadwaita
     license = licenses.mit;
     maintainers = with maintainers; [ jtojnar ];
     platforms = platforms.linux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7452,6 +7452,9 @@ with pkgs;
   libpointmatcher = callPackage ../development/libraries/libpointmatcher { };
 
   libportal = callPackage ../development/libraries/libportal { };
+  libportal-gtk3 = libportal.override { variant = "gtk3"; };
+  libportal-gtk4 = libportal.override { variant = "gtk4"; };
+  libportal-qt5 = libportal.override { variant = "qt5"; };
 
   libmicrodns = callPackage ../development/libraries/libmicrodns { };
 


### PR DESCRIPTION
###### Motivation for this change

- [x] authenticator – already broken
- [x] metadata-cleaner – works
- [x] notejot ­– #153022
- [x] kooha – fixed dep lookup, works
- [x] clapper – no warnings but crashes when playing
- [x] khronos – works
- [x] mousai – works
- [x] spot – works
- [x] shortwave – marked as broken
- [x] gnome-todo – updated to master
- [x] xdg-desktop-portal-gnome – works
- [x] ashpd-demo – marked as broken


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
