### PR TITLE
modules/nix-daemon: rename substituters related options

### DIFF
--- a/nixos/tests/containers-imperative.nix
+++ b/nixos/tests/containers-imperative.nix
@@ -11,7 +11,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
       # XXX: Sandbox setup fails while trying to hardlink files from the host's
       #      store file system into the prepared chroot directory.
       nix.useSandbox = false;
-      nix.binaryCaches = []; # don't try to access cache.nixos.org
+      nix.substituters = lib.mkForce []; # don't try to access cache.nixos.org
 
       virtualisation.writableStore = true;
       # Make sure we always have all the required dependencies for creating a

--- a/nixos/tests/hibernate.nix
+++ b/nixos/tests/hibernate.nix
@@ -45,7 +45,7 @@ in makeTest {
         ../modules/profiles/base.nix
       ];
 
-      nix.binaryCaches = mkForce [ ];
+      nix.substituters = mkForce [ ];
       nix.extraOptions = ''
         hashed-mirrors =
         connect-timeout = 1

--- a/nixos/tests/hydra/common.nix
+++ b/nixos/tests/hydra/common.nix
@@ -42,7 +42,7 @@
         hostName = "localhost";
         systems = [ system ];
       }];
-      binaryCaches = [];
+      substituters = [];
     };
   };
 }

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -334,7 +334,7 @@ let
             (pkgs.grub2_efi.override { inherit zfsSupport; })
           ]);
 
-          nix.binaryCaches = mkForce [ ];
+          nix.substituters = mkForce [ ];
           nix.extraOptions = ''
             hashed-mirrors =
             connect-timeout = 1

--- a/nixos/tests/iscsi-multipath-root.nix
+++ b/nixos/tests/iscsi-multipath-root.nix
@@ -111,7 +111,7 @@ import ./make-test-python.nix (
 
         environment.etc."initiator-root-disk-closure".source = nodes.initiatorRootDisk.config.system.build.toplevel;
 
-        nix.binaryCaches = lib.mkForce [ ];
+        nix.substituters = lib.mkForce [ ];
         nix.extraOptions = ''
           hashed-mirrors =
           connect-timeout = 1
@@ -263,5 +263,3 @@ import ./make-test-python.nix (
     '';
   }
 )
-
-

--- a/nixos/tests/iscsi-root.nix
+++ b/nixos/tests/iscsi-root.nix
@@ -95,7 +95,7 @@ import ./make-test-python.nix (
 
             system.extraDependencies = [ nodes.initiatorRootDisk.config.system.build.toplevel ];
 
-            nix.binaryCaches = lib.mkForce [];
+            nix.substituters = lib.mkForce [];
             nix.extraOptions = ''
               hashed-mirrors =
               connect-timeout = 1

--- a/nixos/tests/nixops/default.nix
+++ b/nixos/tests/nixops/default.nix
@@ -23,7 +23,7 @@ let
       deployer = { config, lib, nodes, pkgs, ... }: {
         imports = [ ../../modules/installer/cd-dvd/channel.nix ];
         environment.systemPackages = [ nixopsPkg ];
-        nix.binaryCaches = lib.mkForce [ ];
+        nix.substituters = lib.mkForce [ ];
         users.users.person.isNormalUser = true;
         virtualisation.writableStore = true;
         virtualisation.additionalPaths = [

--- a/nixos/tests/nixops/legacy/base-configuration.nix
+++ b/nixos/tests/nixops/legacy/base-configuration.nix
@@ -16,7 +16,7 @@ in
     (modulesPath + "/testing/test-instrumentation.nix")
   ];
   virtualisation.writableStore = true;
-  nix.binaryCaches = lib.mkForce [ ];
+  nix.substituters = lib.mkForce [ ];
   virtualisation.graphics = false;
   documentation.enable = false;
   services.qemuGuest.enable = true;

--- a/nixos/tests/os-prober.nix
+++ b/nixos/tests/os-prober.nix
@@ -43,7 +43,7 @@ let
       # vda is a filesystem without partition table
       forceInstall = true;
     };
-    nix.binaryCaches = lib.mkForce [ ];
+    nix.substituters = lib.mkForce [ ];
     nix.extraOptions = ''
       hashed-mirrors =
       connect-timeout = 1

--- a/pkgs/build-support/trivial-builders/test/references.nix
+++ b/pkgs/build-support/trivial-builders/test/references.nix
@@ -28,7 +28,7 @@ nixosTest {
     virtualisation.writableStore = true;
 
     # Test runs without network, so we don't substitute and prepare our deps
-    nix.binaryCaches = lib.mkForce [];
+    nix.substituters = lib.mkForce [];
     environment.etc."pre-built-paths".source = writeText "pre-built-paths" (
       builtins.toJSON [hello figlet stdenvNoCC]
     );


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Match new naming of latest nix releases and replace "binary cache" name with "substituter".

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
