### PR TITLE
nextflow: init at 21.10.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3665,6 +3665,12 @@
     githubId = 222467;
     name = "Dmitry Ivanov";
   };
+  Etjean = {
+    email = "et.jean@outlook.fr";
+    github = "Etjean";
+    githubId = 32169529;
+    name = "Etienne Jean";
+  };
   etu = {
     email = "elis@hirwing.se";
     matrix = "@etu:semi.social";

--- a/pkgs/development/interpreters/nextflow/default.nix
+++ b/pkgs/development/interpreters/nextflow/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, stdenv
+, fetchurl
+, makeWrapper
+, jre
+, wget
+, which
+, gnused
+, gawk
+, coreutils
+}:
+
+stdenv.mkDerivation rec {
+  pname = "nextflow";
+  version = "21.10.6";
+
+  src = fetchurl {
+    url = "https://github.com/nextflow-io/nextflow/releases/download/v${version}/nextflow-${version}-all";
+    sha256 = "0l9hi51vrhvfx3px2pxw7lp4h21n8ks50x4icfk3hbgl2hwf7fvx";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ jre wget which gnused gawk coreutils ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    install -Dm755 $src $out/bin/nextflow
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/nextflow --prefix PATH : ${lib.makeBinPath buildInputs}
+  '';
+
+  meta = with lib; {
+    description = "A DSL for data-driven computational pipelines";
+    longDescription = ''
+      Nextflow is a bioinformatics workflow manager that enables the development of portable and reproducible workflows.
+
+      It supports deploying workflows on a variety of execution platforms including local, HPC schedulers, AWS Batch, Google Cloud Life Sciences, and Kubernetes.
+
+      Additionally, it provides support for manage your workflow dependencies through built-in support for Conda, Docker, Singularity, and Modules.
+    '';
+    homepage = "https://www.nextflow.io/";
+    changelog = "https://github.com/nextflow-io/nextflow/releases";
+    license = licenses.asl20;
+    maintainers = [ maintainers.Etjean ];
+    mainProgram = "nextflow";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13575,6 +13575,8 @@ with pkgs;
 
   mujs = callPackage ../development/interpreters/mujs { };
 
+  nextflow = callPackage ../development/interpreters/nextflow { };
+
   ngn-k = callPackage ../development/interpreters/ngn-k { };
 
   octave = callPackage ../development/interpreters/octave {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Addition of [nextflow](https://github.com/nextflow-io/nextflow).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - => Tested with `nextflow run hello` in a pure nix-shell.
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
