### PR TITLE
python3Packages.dm-tree: refactor to build from sources

### DIFF
--- a/pkgs/development/python-modules/dm-tree/cmake.patch
+++ b/pkgs/development/python-modules/dm-tree/cmake.patch
@@ -1,8 +1,8 @@
 diff --git a/tree/CMakeLists.txt b/tree/CMakeLists.txt
-index 5e7eb43..7ad6d1a 100644
+index 8f9946c..b9d6e9b 100644
 --- a/tree/CMakeLists.txt
 +++ b/tree/CMakeLists.txt
-@@ -50,62 +50,18 @@ if(APPLE)
+@@ -50,70 +50,80 @@ if(APPLE)
    set (CMAKE_FIND_FRAMEWORK LAST)
  endif()
  
@@ -19,43 +19,114 @@ index 5e7eb43..7ad6d1a 100644
 -    add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
 -    include_directories(${pybind11_INCLUDE_DIR})
 -endif()
-+find_package(pybind11 CONFIG REQUIRED)
- 
- # Needed to disable Abseil tests.
- set (BUILD_TESTING OFF)
- 
- # Include abseil-cpp.
+-
+-# Needed to disable Abseil tests.
+-set (BUILD_TESTING OFF)
+-
+-# Include abseil-cpp.
 -set(ABSEIL_VER 20210324.2)
 -include(ExternalProject)
+-set(ABSEIL_CMAKE_ARGS
+-    "-DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR}/abseil-cpp"
+-    "-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}"
+-    "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
+-    "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"
+-    "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+-    "-DCMAKE_POSITION_INDEPENDENT_CODE=${CMAKE_POSITION_INDEPENDENT_CODE}"
+-    "-DLIBRARY_OUTPUT_PATH=${CMAKE_SOURCE_DIR}/abseil-cpp/lib")
+-if(DEFINED CMAKE_OSX_ARCHITECTURES)
+-    set(ABSEIL_CMAKE_ARGS
+-        ${ABSEIL_CMAKE_ARGS}
+-        "-DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}")
++find_package(pybind11 CONFIG)
++
++if (NOT pybind11_FOUND)
++  # Fetch pybind to be able to use pybind11_add_module symbol.
++  set(PYBIND_VER v2.6.2)
++  include(FetchContent)
++  FetchContent_Declare(
++    pybind11
++    GIT_REPOSITORY https://github.com/pybind/pybind11
++    GIT_TAG        ${PYBIND_VER}
++  )
++  if(NOT pybind11_POPULATED)
++      FetchContent_Populate(pybind11)
++      add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
++      include_directories(${pybind11_INCLUDE_DIR})
++  endif()
+ endif()
 -ExternalProject_Add(abseil-cpp
 -  GIT_REPOSITORY    https://github.com/abseil/abseil-cpp.git
 -  GIT_TAG           ${ABSEIL_VER}
 -  PREFIX            ${CMAKE_SOURCE_DIR}/abseil-cpp
--  CMAKE_ARGS       -DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR}/abseil-cpp
--                   -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
--                   -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
--                   -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
--                   -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
--                   -DCMAKE_POSITION_INDEPENDENT_CODE=${CMAKE_POSITION_INDEPENDENT_CODE}
--                   -DLIBRARY_OUTPUT_PATH=${CMAKE_SOURCE_DIR}/abseil-cpp/lib
+-  CMAKE_ARGS        ${ABSEIL_CMAKE_ARGS}
 -)
 -ExternalProject_Get_Property(abseil-cpp install_dir)
 -set(abseil_install_dir ${install_dir})
 -include_directories (${abseil_install_dir}/include)
 -
-+find_package(absl REQUIRED)
  
  # Define pybind11 tree module.
  pybind11_add_module(_tree tree.h tree.cc)
 -add_dependencies(_tree abseil-cpp)
--
+ 
 -if (WIN32 OR MSVC)
 -    set(ABSEIL_LIB_PREF "absl")
 -    set(LIB_SUFF "lib")
--else()
++find_package(absl)
++
++if (NOT absl_FOUND)
++  # Needed to disable Abseil tests.
++  set (BUILD_TESTING OFF)
++
++  # Include abseil-cpp.
++  set(ABSEIL_VER 20210324.2)
++  include(ExternalProject)
++  set(ABSEIL_CMAKE_ARGS
++      "-DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR}/abseil-cpp"
++      "-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}"
++      "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
++      "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"
++      "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
++      "-DCMAKE_POSITION_INDEPENDENT_CODE=${CMAKE_POSITION_INDEPENDENT_CODE}"
++      "-DLIBRARY_OUTPUT_PATH=${CMAKE_SOURCE_DIR}/abseil-cpp/lib")
++  if(DEFINED CMAKE_OSX_ARCHITECTURES)
++      set(ABSEIL_CMAKE_ARGS
++          ${ABSEIL_CMAKE_ARGS}
++          "-DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}")
++  endif()
++  ExternalProject_Add(abseil-cpp
++    GIT_REPOSITORY    https://github.com/abseil/abseil-cpp.git
++    GIT_TAG           ${ABSEIL_VER}
++    PREFIX            ${CMAKE_SOURCE_DIR}/abseil-cpp
++    CMAKE_ARGS        ${ABSEIL_CMAKE_ARGS}
++  )
++  ExternalProject_Get_Property(abseil-cpp install_dir)
++  set(abseil_install_dir ${install_dir})
++  include_directories (${abseil_install_dir}/include)
++
++  add_dependencies(_tree abseil-cpp)
++
++  if (WIN32 OR MSVC)
++      set(ABSEIL_LIB_PREF "absl")
++      set(LIB_SUFF "lib")
++  else()
++      set(ABSEIL_LIB_PREF "libabsl")
++      set(LIB_SUFF "a")
++  endif()
++
++  # Link abseil static libs.
++  # We don't use find_library here to force cmake to build abseil before linking.
++  set(ABSEIL_LIBS int128 raw_hash_set raw_logging_internal strings throw_delegate)
++  foreach(ABSEIL_LIB IN LISTS ABSEIL_LIBS)
++    target_link_libraries(_tree PRIVATE
++        "${abseil_install_dir}/lib/${ABSEIL_LIB_PREF}_${ABSEIL_LIB}.${LIB_SUFF}")
++  endforeach()
+ else()
 -    set(ABSEIL_LIB_PREF "libabsl")
 -    set(LIB_SUFF "a")
--endif()
++  target_link_libraries(_tree PRIVATE absl::int128 absl::raw_hash_set absl::raw_logging_internal absl::strings absl::throw_delegate)
+ endif()
  
 -# Link abseil static libs.
 -# We don't use find_library here to force cmake to build abseil before linking.
@@ -64,7 +135,7 @@ index 5e7eb43..7ad6d1a 100644
 -  target_link_libraries(_tree PRIVATE
 -      "${abseil_install_dir}/lib/${ABSEIL_LIB_PREF}_${ABSEIL_LIB}.${LIB_SUFF}")
 -endforeach()
-+target_link_libraries(_tree PRIVATE absl::int128 absl::raw_hash_set absl::raw_logging_internal absl::strings absl::throw_delegate)
- 
+-
  # Make the module private to tree package.
  set_target_properties(_tree PROPERTIES OUTPUT_NAME tree/_tree)
+ 

--- a/pkgs/development/python-modules/dm-tree/cmake.patch
+++ b/pkgs/development/python-modules/dm-tree/cmake.patch
@@ -1,0 +1,70 @@
+diff --git a/tree/CMakeLists.txt b/tree/CMakeLists.txt
+index 5e7eb43..7ad6d1a 100644
+--- a/tree/CMakeLists.txt
++++ b/tree/CMakeLists.txt
+@@ -50,62 +50,18 @@ if(APPLE)
+   set (CMAKE_FIND_FRAMEWORK LAST)
+ endif()
+ 
+-# Fetch pybind to be able to use pybind11_add_module symbol.
+-set(PYBIND_VER v2.6.2)
+-include(FetchContent)
+-FetchContent_Declare(
+-  pybind11
+-  GIT_REPOSITORY https://github.com/pybind/pybind11
+-  GIT_TAG        ${PYBIND_VER}
+-)
+-if(NOT pybind11_POPULATED)
+-    FetchContent_Populate(pybind11)
+-    add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
+-    include_directories(${pybind11_INCLUDE_DIR})
+-endif()
++find_package(pybind11 CONFIG REQUIRED)
+ 
+ # Needed to disable Abseil tests.
+ set (BUILD_TESTING OFF)
+ 
+ # Include abseil-cpp.
+-set(ABSEIL_VER 20210324.2)
+-include(ExternalProject)
+-ExternalProject_Add(abseil-cpp
+-  GIT_REPOSITORY    https://github.com/abseil/abseil-cpp.git
+-  GIT_TAG           ${ABSEIL_VER}
+-  PREFIX            ${CMAKE_SOURCE_DIR}/abseil-cpp
+-  CMAKE_ARGS       -DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR}/abseil-cpp
+-                   -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
+-                   -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+-                   -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+-                   -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+-                   -DCMAKE_POSITION_INDEPENDENT_CODE=${CMAKE_POSITION_INDEPENDENT_CODE}
+-                   -DLIBRARY_OUTPUT_PATH=${CMAKE_SOURCE_DIR}/abseil-cpp/lib
+-)
+-ExternalProject_Get_Property(abseil-cpp install_dir)
+-set(abseil_install_dir ${install_dir})
+-include_directories (${abseil_install_dir}/include)
+-
++find_package(absl REQUIRED)
+ 
+ # Define pybind11 tree module.
+ pybind11_add_module(_tree tree.h tree.cc)
+-add_dependencies(_tree abseil-cpp)
+-
+-if (WIN32 OR MSVC)
+-    set(ABSEIL_LIB_PREF "absl")
+-    set(LIB_SUFF "lib")
+-else()
+-    set(ABSEIL_LIB_PREF "libabsl")
+-    set(LIB_SUFF "a")
+-endif()
+ 
+-# Link abseil static libs.
+-# We don't use find_library here to force cmake to build abseil before linking.
+-set(ABSEIL_LIBS int128 raw_hash_set raw_logging_internal strings throw_delegate)
+-foreach(ABSEIL_LIB IN LISTS ABSEIL_LIBS)
+-  target_link_libraries(_tree PRIVATE
+-      "${abseil_install_dir}/lib/${ABSEIL_LIB_PREF}_${ABSEIL_LIB}.${LIB_SUFF}")
+-endforeach()
++target_link_libraries(_tree PRIVATE absl::int128 absl::raw_hash_set absl::raw_logging_internal absl::strings absl::throw_delegate)
+ 
+ # Make the module private to tree package.
+ set_target_properties(_tree PROPERTIES OUTPUT_NAME tree/_tree)

--- a/pkgs/development/python-modules/dm-tree/default.nix
+++ b/pkgs/development/python-modules/dm-tree/default.nix
@@ -1,47 +1,56 @@
-{ autoPatchelfHook
+{ lib
+, cmake
+, fetchFromGitHub
 , buildPythonPackage
-, fetchPypi
-, isPy39
-, lib
-, six
-, stdenv
+, abseil-cpp
+, absl-py
+, attrs
+, numpy
+, pybind11
+, wrapt
 }:
 
 buildPythonPackage rec {
   pname = "dm-tree";
-  version = "0.1.6";
-  format = "wheel";
+  # As of 2021-12-29, the latest stable version still builds with Bazel.
+  version = "42e87fda83278e2eb32bb55225e1d1511e77c10c";
 
-  # At the time of writing (8/19/21), there are releases for 3.6-3.9. Supporting
-  # all of them is a pain, so we focus on 3.9, the current nixpkgs python3
-  # version.
-  disabled = !isPy39;
-
-  src = fetchPypi {
-    inherit version format;
-    sha256 = "1f71dy5xa5ywa5chbdhpdf8k0w1v9cvpn3qyk8nnjm79j90la9c4";
-    pname = "dm_tree";
-    dist = "cp39";
-    python = "cp39";
-    abi = "cp39";
-    platform = "manylinux_2_24_x86_64";
+  src = fetchFromGitHub {
+    owner = "deepmind";
+    repo = "tree";
+    rev = "${version}";
+    sha256 = "0bnvnn6m54jp5sr7lbvakdmhbrh2myv79ffmrgl7yjp13mz03lqi";
   };
 
-  # Prebuilt wheels are dynamically linked against things that nix can't find.
-  # Run `autoPatchelfHook` to automagically fix them.
-  nativeBuildInputs = [ autoPatchelfHook ];
-  # Dynamic link dependencies
-  buildInputs = [ stdenv.cc.cc ];
+  patches = [
+    ./cmake.patch
+  ];
 
-  propagatedBuildInputs = [ six ];
+  dontUseCmakeConfigure = true;
+
+  nativeBuildInputs = [
+    cmake
+    pybind11
+  ];
+
+  buildInputs = [
+    abseil-cpp
+    pybind11
+  ];
+
+  checkInputs = [
+    absl-py
+    attrs
+    numpy
+    wrapt
+  ];
 
   pythonImportsCheck = [ "tree" ];
 
   meta = with lib; {
     description = "Tree is a library for working with nested data structures.";
-    homepage    = "https://github.com/deepmind/tree";
-    license     = licenses.asl20;
-    maintainers = with maintainers; [ samuela ];
-    platforms = [ "x86_64-linux" ];
+    homepage = "https://github.com/deepmind/tree";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ samuela ndl ];
   };
 }

--- a/pkgs/development/python-modules/dm-tree/default.nix
+++ b/pkgs/development/python-modules/dm-tree/default.nix
@@ -1,10 +1,10 @@
-{ lib
-, cmake
-, fetchFromGitHub
-, buildPythonPackage
-, abseil-cpp
+{ abseil-cpp
 , absl-py
 , attrs
+, buildPythonPackage
+, cmake
+, fetchFromGitHub
+, lib
 , numpy
 , pybind11
 , wrapt
@@ -13,13 +13,13 @@
 buildPythonPackage rec {
   pname = "dm-tree";
   # As of 2021-12-29, the latest stable version still builds with Bazel.
-  version = "42e87fda83278e2eb32bb55225e1d1511e77c10c";
+  version = "unstable-2021-12-20";
 
   src = fetchFromGitHub {
     owner = "deepmind";
     repo = "tree";
-    rev = "${version}";
-    sha256 = "0bnvnn6m54jp5sr7lbvakdmhbrh2myv79ffmrgl7yjp13mz03lqi";
+    rev = "b452e5c2743e7489b4ba7f16ecd51c516d7cd8e3";
+    sha256 = "1r187xwpvnnj98lyasngcv3lbxz0ziihpl5dbnjbfbjr0kh6z0j9";
   };
 
   patches = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Part of "extra JAX libraries / frameworks" implementation, see the discussion in https://github.com/NixOS/nixpkgs/pull/152754

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
