### PR TITLE
btop: remove reference to gcc

### DIFF
--- a/pkgs/tools/system/btop/default.nix
+++ b/pkgs/tools/system/btop/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , runCommand
 , darwin
+, removeReferencesTo
 }:
 
 stdenv.mkDerivation rec {
@@ -37,6 +38,10 @@ stdenv.mkDerivation rec {
     );
 
   installFlags = [ "PREFIX=$(out)" ];
+
+  postInstall = ''
+    ${removeReferencesTo}/bin/remove-references-to -t ${stdenv.cc.cc} $(readlink -f $out/bin/btop)
+  '';
 
   meta = with lib; {
     description = "A monitor of resources";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I've noticed that btop pulls in a reference to gcc, increasing the closure size.

```
$ nix why-depends /nix/store/ycrbgpfg3hi7myhsg8d9i7ba14ry3zcw-btop-1.1.3 /nix/store/d23kgmsa6z0dsy9hbkrhnlrmfg2lvzmh-gcc-11.2.0
/nix/store/ycrbgpfg3hi7myhsg8d9i7ba14ry3zcw-btop-1.1.3
└───bin/btop: … unsigned int]......./nix/store/d23kgmsa6z0dsy9hbkrhnlrmfg2lvzmh-gcc-11.2.0/include/c++/11.2.0/b…
    → /nix/store/d23kgmsa6z0dsy9hbkrhnlrmfg2lvzmh-gcc-11.2.0
```

###### Things done
Stripped the reference to gcc in the postInstall hook. Closure size has been reduced successfully by that.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
