### PR TITLE
gnu-shepherd: init at 0.8.1

### DIFF
--- a/pkgs/misc/gnu-shepherd/default.nix
+++ b/pkgs/misc/gnu-shepherd/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, fetchurl, guile, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "gnu-shepherd";
+  version = "0.8.1";
+
+  src = fetchurl {
+    url = "https://ftp.gnu.org/gnu/shepherd/shepherd-${version}.tar.gz";
+    sha256 = "sha256-0y/lhpS7U1C1/HKFzwyg2cfSQiGqWWnWxGTuPjrIP3U=";
+  };
+
+  configureFlags = [
+    "--localstatedir=/"
+  ];
+
+  buildInputs = [ guile ];
+  nativeBuildInputs = [ pkg-config guile ];
+
+  meta = with lib; {
+    homepage = "https://www.gnu.org/software/shepherd/";
+    description = "Service manager that looks after the herd of system services";
+    license = with licenses; [ gpl3Plus ];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ kloenk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5927,6 +5927,8 @@ with pkgs;
 
   gnuapl = callPackage ../development/interpreters/gnu-apl { };
 
+  gnu-shepherd = callPackage ../misc/gnu-shepherd { };
+
   dapl = callPackage ../development/interpreters/dzaima-apl {
     buildNativeImage = false;
     stdenv = stdenvNoCC;


### PR DESCRIPTION
###### Motivation for this change


###### Things done


- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
