### PR TITLE
dmd: made derivation compile when overriding to certain older versions

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3168,6 +3168,12 @@
       fingerprint = "389A 78CB CD88 5E0C 4701  DEB9 FD42 C7D0 D414 94C8";
     }];
   };
+  dukc = {
+    email = "ajieskola@gmail.com";
+    github = "dukc";
+    githubId = 24233408;
+    name = "Ate Eskola";
+  };
   dump_stack = {
     email = "root@dumpstack.io";
     github = "jollheef";

--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -60,24 +60,46 @@ stdenv.mkDerivation rec {
   # Not using patches option to make it easy to patch, for example, dmd and
   # Phobos at same time if that's required
   patchPhase =
-  lib.optionalString (builtins.compareVersions version "2.092.1" <= 0) ''
+
+  # Migrates D1-style operator overloads in DMD source, to allow building with
+  # a newer DMD
+  lib.optionalString (lib.versionOlder version "2.088.0") ''
+    patch -p1 -F3 --directory=dmd -i ${(fetchpatch {
+      url = "https://github.com/dlang/dmd/commit/c4d33e5eb46c123761ac501e8c52f33850483a8a.patch";
+      sha256 = "0rhl9h3hsi6d0qrz24f4zx960cirad1h8mm383q6n21jzcw71cp5";
+    })}
+  ''
+
+  # Fixes C++ tests that compiled on older C++ but not on the current one
+  + lib.optionalString (lib.versionOlder version "2.092.2") ''
     patch -p1 -F3 --directory=druntime -i ${(fetchpatch {
       url = "https://github.com/dlang/druntime/commit/438990def7e377ca1f87b6d28246673bb38022ab.patch";
       sha256 = "0nxzkrd1rzj44l83j7jj90yz2cv01na8vn9d116ijnm85jl007b4";
     })}
+  ''
 
-  '' + postPatch;
+  + postPatch;
+
 
   postPatch =
   ''
     patchShebangs .
+  ''
 
-  '' + lib.optionalString (version == "2.092.1") ''
+  # This one has tested against a hardcoded year, then against a current year on
+  # and off again. It just isn't worth it to patch all the historical versions
+  # of it, so just remove it until the most recent change.
+  + lib.optionalString (lib.versionOlder version "2.091.0") ''
+    rm dmd/test/compilable/ddocYear.d
+  ''
+
+  + lib.optionalString (version == "2.092.1") ''
     rm dmd/test/dshell/test6952.d
-  '' + lib.optionalString (builtins.compareVersions "2.092.1" version < 0) ''
+  '' + lib.optionalString (lib.versionAtLeast version "2.092.2") ''
     substituteInPlace dmd/test/dshell/test6952.d --replace "/usr/bin/env bash" "${bash}/bin/bash"
+  ''
 
-  '' + ''
+  + ''
     rm dmd/test/runnable/gdb1.d
     rm dmd/test/runnable/gdb10311.d
     rm dmd/test/runnable/gdb14225.d
@@ -87,8 +109,9 @@ stdenv.mkDerivation rec {
     rm dmd/test/runnable/gdb15729.sh
     rm dmd/test/runnable/gdb4149.d
     rm dmd/test/runnable/gdb4181.d
+  ''
 
-  '' + lib.optionalString stdenv.isLinux ''
+  + lib.optionalString stdenv.isLinux ''
     substituteInPlace phobos/std/socket.d --replace "assert(ih.addrList[0] == 0x7F_00_00_01);" ""
   '' + lib.optionalString stdenv.isDarwin ''
     substituteInPlace phobos/std/socket.d --replace "foreach (name; names)" "names = []; foreach (name; names)"
@@ -178,7 +201,7 @@ stdenv.mkDerivation rec {
     # Everything is now Boost licensed, even the backend.
     # https://github.com/dlang/dmd/pull/6680
     license = licenses.boost;
-    maintainers = with maintainers; [ ThomasMader lionello ];
+    maintainers = with maintainers; [ ThomasMader lionello dukc ];
     platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
   };
 }


### PR DESCRIPTION
I ported legacy compatibility improvements from [oldDDerivations](https://github.com/dukc/oldDDerivations). These let dmd to build if the user overrides version/hashes to DMD version 2.084.1, 2.087.1 or 2.088.1, and likely some other versions of around that age.

Also added myself as DMD maintainer - if you do not want me, tell and I remove myself again.

###### Motivation for this change

@lionello [mentioned earlier](https://github.com/NixOS/nixpkgs/pull/127932#discussion_r694052350) he wants to make it easy for the user to override the versions/hashes as needed.

###### Things done

I have already tested the derivation on oldDDerivations, using it with the official channels. I also test-built this PR with DMD version 2.084.1. You can test yourself with `nix-build -E 'with import ./default.nix {}; dmd.override {version = "...";dmdSha256 = "...";druntimeSha256 = "...";phobosSha256 = "...";}'` at root directory - the quickest way to get the versions/hashes is oldDDerivations.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
