### PR TITLE
[21.05] unicorn: add patch for CVE-2021-44078

### DIFF
--- a/pkgs/development/libraries/unicorn/1.0.2-CVE-2021-44078.patch
+++ b/pkgs/development/libraries/unicorn/1.0.2-CVE-2021-44078.patch
@@ -1,0 +1,15 @@
+Based on upstream https://github.com/unicorn-engine/unicorn/commit/c733bbada356b0373fa8aa72c044574bb855fd24.patch
+adapted by ris to apply to 1.0.2
+
+--- a/uc.c
++++ b/uc.c
+@@ -864,7 +864,8 @@ static bool split_region(struct uc_struct *uc, MemoryRegion *mr,
+         break;
+ 
+     QTAILQ_FOREACH(block, &uc->ram_list.blocks, next) {
+-        if (block->offset <= mr->addr && block->length >= (mr->end - mr->addr)) {
++        // block->offset is the offset within ram_addr_t, not GPA
++        if (block->mr->addr <= mr->addr && block->length >= (mr->end - mr->addr)) {
+             break;
+         }
+ 

--- a/pkgs/development/libraries/unicorn/default.nix
+++ b/pkgs/development/libraries/unicorn/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
     sha256 = "0jgnyaq6ykpbg5hrwc0p3pargmr9hpzqfsj6ymp4k07pxnqal76j";
   };
 
+  patches = [ ./1.0.2-CVE-2021-44078.patch ];
+
   nativeBuildInputs = [ pkg-config cmake ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-44078

Patch needed some adaptation, but the same misunderstanding of the qemu structures existed here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
