### PR TITLE
space-cadet-pinball: unstable-2021-12-02 -> 2.0.1

### DIFF
--- a/pkgs/games/space-cadet-pinball/default.nix
+++ b/pkgs/games/space-cadet-pinball/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, fetchFromGitHub, fetchzip
 , cmake, SDL2, SDL2_mixer
 , unrar-wrapper, makeWrapper
+, fetchpatch
 }:
 
 let
@@ -14,14 +15,23 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "SpaceCadetPinball";
-  version = "unstable-2021-12-02";
+  version = "2.0.1";
 
   src = fetchFromGitHub {
     owner = "k4zmu2a";
     repo = pname;
-    rev = "de13d4e326b2dfa8e6dfb59815c0a8b9657f942d";
-    sha256 = "sha256-/nk4kNsmL1z2rKgV1dh9gcVjp8xJwovhE6/u2aNl/fA=";
+    rev = "Release_${version}";
+    sha256 = "sha256-LmYplJr1Mg4yNg9eP02FXf9mL1FnzNBhpted3GpmlQ0=";
   };
+
+  patches = [
+    # remove when updating past 2.0.1
+    (fetchpatch {
+      name = "fix-install-directories";
+      url = "https://github.com/k4zmu2a/SpaceCadetPinball/commit/d8ee1b9bfeee21d3981a40e735411393392bc1f6.patch";
+      sha256 = "sha256-BtCDJ+a9AFaOM8nyId0eU9GN/gUQT2kFCO4RIVTzZlE=";
+    })
+  ];
 
   buildInputs = [
     SDL2


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Version bump

~In release 2.0.1, the two lines in the cmakelists.txt file contained absolute paths. This was fixed in https://github.com/k4zmu2a/SpaceCadetPinball/pull/115. Alternatively we could stay on release 2.0.1 and just patch the file using `substituteInPlace`. I am unsure which is preferred.~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
