### PR TITLE
klee: init at 2.2

### DIFF
--- a/pkgs/applications/science/logic/klee/default.nix
+++ b/pkgs/applications/science/logic/klee/default.nix
@@ -1,0 +1,110 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, llvmPackages_9
+, clang_9
+, python3
+, zlib
+, z3
+, stp
+, cryptominisat
+, gperftools
+, sqlite
+, gtest
+, lit
+, debug ? false
+}:
+
+let
+  kleePython = python3.withPackages (ps: with ps; [ tabulate ]);
+in
+stdenv.mkDerivation rec {
+  pname = "klee";
+  version = "2.2";
+  src = fetchFromGitHub {
+    owner = "klee";
+    repo = "klee";
+    rev = "v${version}";
+    sha256 = "Ar3BKfADjJvvP0dI9+x/l3RDs8ncx4jmO7ol4MgOr4M=";
+  };
+  buildInputs = [
+    llvmPackages_9.llvm clang_9 z3 stp cryptominisat
+    gperftools sqlite
+  ];
+  nativeBuildInputs = [
+    cmake
+  ];
+  checkInputs = [
+    gtest
+
+    # Should appear BEFORE lit, since lit passes through python rather
+    # than the python environment we make.
+    kleePython
+    (lit.override { python3 = kleePython; })
+  ];
+
+  cmakeFlags = let
+    buildType = if debug then "Debug" else "Release";
+  in
+  [
+    "-DCMAKE_BUILD_TYPE=${buildType}"
+    "-DKLEE_RUNTIME_BUILD_TYPE=${buildType}"
+    "-DENABLE_POSIX_RUNTIME=ON"
+    "-DENABLE_UNIT_TESTS=ON"
+    "-DENABLE_SYSTEM_TESTS=ON"
+    "-DGTEST_SRC_DIR=${gtest.src}"
+    "-DGTEST_INCLUDE_DIR=${gtest.src}/googletest/include"
+    "-Wno-dev"
+  ];
+
+  # Silence various warnings during the compilation of fortified bitcode.
+  NIX_CFLAGS_COMPILE = ["-Wno-macro-redefined"];
+
+  prePatch = ''
+    patchShebangs .
+  '';
+
+  /* This patch is currently necessary for the unit test suite to run correctly.
+   * See https://www.mail-archive.com/klee-dev@imperial.ac.uk/msg03136.html
+   * and https://github.com/klee/klee/pull/1458 for more information.
+   */
+  patches = map fetchpatch [
+    {
+      name = "fix-gtest";
+      sha256 = "F+/6videwJZz4sDF9lnV4B8lMx6W11KFJ0Q8t1qUDf4=";
+      url = "https://github.com/klee/klee/pull/1458.patch";
+    }
+  ];
+
+  doCheck = true;
+  checkTarget = "check";
+
+  meta = with lib; {
+    description = "A symbolic virtual machine built on top of LLVM";
+    longDescription = ''
+      KLEE is a symbolic virtual machine built on top of the LLVM compiler
+      infrastructure. Currently, there are two primary components:
+
+      1. The core symbolic virtual machine engine; this is responsible for
+         executing LLVM bitcode modules with support for symbolic values. This
+         is comprised of the code in lib/.
+
+      2. A POSIX/Linux emulation layer oriented towards supporting uClibc, with
+         additional support for making parts of the operating system environment
+         symbolic.
+
+      Additionally, there is a simple library for replaying computed inputs on
+      native code (for closed programs). There is also a more complicated
+      infrastructure for replaying the inputs generated for the POSIX/Linux
+      emulation layer, which handles running native programs in an environment
+      that matches a computed test input, including setting up files, pipes,
+      environment variables, and passing command line arguments.
+    '';
+    homepage = "https://klee.github.io/";
+    license = licenses.ncsa;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ numinit ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26574,6 +26574,8 @@ with pkgs;
 
   klayout = libsForQt5.callPackage ../applications/misc/klayout { };
 
+  klee = callPackage ../applications/science/logic/klee { };
+
   kmetronome = libsForQt5.callPackage ../applications/audio/kmetronome { };
 
   kmplayer = libsForQt5.callPackage ../applications/video/kmplayer { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adding Klee, another fairly popular SMT solver that can symbolically execute LLVM bytecode.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
