### PR TITLE
pz-server: init at b41

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -662,6 +662,7 @@ in
       webdav = 322;
       pipewire = 323;
       rstudio-server = 324;
+      pzserver = 325;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -408,6 +408,7 @@
   ./services/games/minecraft-server.nix
   ./services/games/minetest-server.nix
   ./services/games/openarena.nix
+  ./services/games/pz-server.nix
   ./services/games/quake3-server.nix
   ./services/games/teeworlds.nix
   ./services/games/terraria.nix

--- a/nixos/modules/services/games/pz-server.nix
+++ b/nixos/modules/services/games/pz-server.nix
@@ -1,0 +1,108 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.pz-server;
+in {
+
+  options.services.pz-server = {
+
+    enable = mkEnableOption "Project Zomboid server";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.pz-server;
+      example = literalExpression "pkgs.pz-server";
+      description = ''
+        Project Zomboid server package to use.
+      '';
+    };
+
+    stateDir = mkOption {
+      type = types.path;
+      default = "/var/lib/Zomboid";
+      description = ''
+        Server state directory.
+      '';
+    };
+
+    adminPasswordFile = mkOption {
+      type = types.path;
+      default = null;
+      example = literalExpression "/var/secrets/pzserver_pw";
+      description = ''
+        Path to admin password in a file.
+      '';
+    };
+
+    openFirewall = mkEnableOption "opening the firewall ports for Project Zomboid";
+
+    jvmOpts = mkOption {
+      type = types.listOf types.str;
+      default = [
+        "-Xms2g"
+        "-Xmx2g"
+      ];
+      description = ''
+        Populate the JAVA_TOOL_OPTIONS environment variable.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    systemd.services.pz-server = {
+      description = "Project Zomboid server";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Sockets = [ "pz-server.socket" ];
+        StandardInput = "socket";
+        StandardOutput = "journal";
+        StandardError = "journal";
+        ExecStart = "${cfg.package}/bin/pz-server -cachedir=${cfg.stateDir} -adminpassword $(cat ${cfg.adminPasswordFile})";
+        ExecStop = pkgs.writeShellScript "pz-server-stop.sh" ''
+          echo "quit" > /run/pzserver.stdin
+          while kill -0 $MAINPID 2>/dev/null; do sleep 1; done
+        '';
+        User = "pzserver";
+        Restart = "always";
+        WorkingDirectory = cfg.stateDir;
+      };
+
+      environment = {
+        JAVA_TOOL_OPTIONS = builtins.concatStringsSep " " cfg.jvmOpts;
+      };
+    };
+
+    systemd.sockets.pz-server = {
+      wantedBy = [ "sockets.target" ];
+      socketConfig = {
+        Service = [ "pz-server.service" ];
+        ListenFIFO = "/run/pzserver.stdin";
+        SocketGroup = "pzserver";
+        SocketMode = "660";
+        RemoveOnStop = true;
+      };
+    };
+
+    users.users.pzserver = {
+      isSystemUser = true;
+      group = "pzserver";
+      home = cfg.stateDir;
+      createHome = true;
+      description = "Project Zomboid server user";
+    };
+    users.groups.pzserver = {};
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedUDPPorts = [ 8766 16261 ];
+    };
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ kritnich ];
+  };
+}

--- a/pkgs/build-support/fetchsteamdepot/default.nix
+++ b/pkgs/build-support/fetchsteamdepot/default.nix
@@ -1,0 +1,21 @@
+{ lib
+, runCommand
+, writeText
+, cacert
+, depotdownloader }:
+
+{ name, appId, depotId, manifestId, branch ? null, sha256, fileList ? [] }:
+
+let fileListFile = writeText "steam-filelist-${name}.txt" (builtins.concatStringsSep "\n" fileList);
+in with lib; runCommand "${name}-src" {
+  buildInputs = [ cacert depotdownloader ];
+  inherit appId depotId manifestId;
+  outputHashAlgo = "sha256";
+  outputHash = sha256;
+  outputHashMode = "recursive";
+} ''
+  HOME=$TMPDIR DepotDownloader -app "$appId" -depot "$depotId" -manifest "$manifestId" \
+    ${optionalString (fileList != []) "-filelist \"${fileListFile}\""} \
+    ${optionalString (branch != null) "-branch \"${branch}\""} -dir "$out"
+  rm -r "$out/.DepotDownloader"
+''

--- a/pkgs/games/pz-server/default.nix
+++ b/pkgs/games/pz-server/default.nix
@@ -1,0 +1,85 @@
+{ stdenv
+, lib
+, callPackage
+, jre
+, makeWrapper
+, fetchSteamDepot
+, symlinkJoin }:
+
+let
+  version = "b41";
+
+  steamworks-sdk = fetchSteamDepot {
+    name = "steamworks-sdk";
+    appId = 380870;
+    depotId = 1006;
+    manifestId = 1145429015527304256;
+    sha256 = "1y4lwxq2flqb7njha0ff0fag9iqd8asd1lgmq5b968bbw6adfx81";
+  };
+
+  pz-media = fetchSteamDepot {
+    name = "pz-media";
+    appId = 380870;
+    depotId = 380871;
+    manifestId = 597018528582984283;
+    sha256 = "1p4606cg5bjh4jxid2ii0fpbij88xsl8yrhgsjzs9gmwa0jivjaz";
+  };
+
+  pz-linux = fetchSteamDepot {
+    name = "pz-linux";
+    appId = 380870;
+    depotId = 380873;
+    manifestId = 7058797271499103796;
+    sha256 = "12d2c7vk9z5nj8lpdjx35amw5c23dgiz4drmjg9gy33jp9g67r0v";
+  };
+
+in stdenv.mkDerivation rec {
+  pname = "pz-server";
+  inherit version;
+
+  src = symlinkJoin {
+    name = "pz-server";
+    paths = [ pz-media pz-linux steamworks-sdk ];
+  };
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  buildInputs = [
+    jre
+  ];
+
+  installPhase = let
+    shareDir = "$out/share/pz-server";
+  in ''
+    mkdir -p ${shareDir}
+    cp -Lr $src/* ${shareDir}
+
+    makeWrapper ${jre}/bin/java $out/bin/pz-server \
+    --run "cd ${shareDir}" \
+    --prefix LD_PRELOAD : libjsig.so \
+    --prefix LD_LIBRARY_PATH : ${shareDir}/linux64 \
+    --add-flags "-Dzomboid.steam=1 -Dzomboid.znetlog=1" \
+    --add-flags "-Djava.awt.headless=true" \
+    --add-flags "-Djava.library.path=${shareDir}/.:${shareDir}/natives:${shareDir}/linux64" \
+    --add-flags "-Djava.security.egd=file:/dev/urandom" \
+    --add-flags "-XX:+UseZGC" \
+    --add-flags "-XX:-OmitStackTraceInFastThrow" \
+    --add-flags "-cp ${shareDir}/java/.:${shareDir}/java/*" \
+    --add-flags "zombie.network.GameServer"
+  '';
+
+  meta = with lib; {
+    description = "The Ultimate Zombie Survival RPG";
+    homepage    = "https://projectzomboid.com/";
+    license     = licenses.unfree;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ kritnich ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30990,6 +30990,8 @@ with pkgs;
 
   pysolfc = python3Packages.callPackage ../games/pysolfc { };
 
+  pz-server = callPackage ../games/pz-server { };
+
   qqwing = callPackage ../games/qqwing { };
 
   quake3wrapper = callPackage ../games/quake3/wrapper { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -503,6 +503,8 @@ with pkgs;
 
   fetchMavenArtifact = callPackage ../build-support/fetchmavenartifact { };
 
+  fetchSteamDepot = callPackage ../build-support/fetchsteamdepot { };
+
   inherit (callPackage ../build-support/node/fetch-yarn-deps { })
     prefetch-yarn-deps
     fetchYarnDeps;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I wrote package definitions and a module for hosting dedicated Project Zomboid servers and want to bring it upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
