### PR TITLE
wl-mirror: 0.5.0 -> 0.8.1

### DIFF
--- a/pkgs/tools/misc/pipectl/default.nix
+++ b/pkgs/tools/misc/pipectl/default.nix
@@ -1,0 +1,26 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pipectl";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "Ferdi265";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-wa/SKKNXkl8XxE7XORodoAlrMc2QNGXGPE+/yya209Y=";
+  };
+
+  buildInputs = [ cmake ];
+
+  meta = with lib; {
+    homepage = "https://github.com/Ferdi265/pipectl";
+    license = licenses.gpl3;
+    description = "a simple named pipe management utility";
+    maintainers = with maintainers; [ synthetica ];
+  };
+}

--- a/pkgs/tools/misc/pipectl/default.nix
+++ b/pkgs/tools/misc/pipectl/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-wa/SKKNXkl8XxE7XORodoAlrMc2QNGXGPE+/yya209Y=";
   };
 
-  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
 
   meta = with lib; {
     homepage = "https://github.com/Ferdi265/pipectl";

--- a/pkgs/tools/wayland/wl-mirror/default.nix
+++ b/pkgs/tools/wayland/wl-mirror/default.nix
@@ -8,17 +8,31 @@
 , wayland-scanner
 , wlr-protocols
 , libGL
+, installExampleScripts ? true
+, makeWrapper
+, pipectl
+, slurp
+, rofi
 }:
+
+let
+  wl-present-binpath = lib.makeBinPath [
+    pipectl
+    rofi
+    slurp
+    (placeholder "out")
+  ];
+in
 
 stdenv.mkDerivation rec {
   pname = "wl-mirror";
-  version = "0.5.0";
+  version = "0.8.1";
 
   src = fetchFromGitHub {
     owner = "Ferdi265";
     repo = "wl-mirror";
     rev = "v${version}";
-    sha256 = "1wjdjzj6h1q51yg70gdrq2yrgg6ihamcwhizxfrjq8955yy2y6ly";
+    hash = "sha256-P5rvZPpIStlOSGj3PaiXAMPWqgWpkC+4IrixEMwoGJU=";
   };
 
   patchPhase = ''
@@ -27,13 +41,16 @@ stdenv.mkDerivation rec {
       --replace 'WLR_PROTOCOL_DIR "/usr' 'WLR_PROTOCOL_DIR "${wlr-protocols}'
   '';
 
-  nativeBuildInputs = [ cmake pkg-config wayland-scanner ];
-  buildInputs = [
-    libGL
-    wayland
-    wayland-protocols
-    wlr-protocols
+  cmakeFlags = [
+    "-DINSTALL_EXAMPLE_SCRIPTS=${if installExampleScripts then "ON" else "OFF"}"
   ];
+
+  postInstall = lib.optionalString installExampleScripts ''
+    wrapProgram $out/bin/wl-present --prefix PATH ":" ${wl-present-binpath}
+  '';
+
+  nativeBuildInputs = [ cmake pkg-config wayland-scanner makeWrapper ];
+  buildInputs = [ libGL wayland wayland-protocols wlr-protocols ];
 
   meta = with lib; {
     homepage = "https://github.com/Ferdi265/wl-mirror";

--- a/pkgs/tools/wayland/wl-mirror/default.nix
+++ b/pkgs/tools/wayland/wl-mirror/default.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/Ferdi265/wl-mirror";
     description = "Mirrors an output onto a Wayland surface.";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ twitchyliquid64 ];
+    maintainers = with maintainers; [ synthetica twitchyliquid64 ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8627,6 +8627,8 @@ with pkgs;
 
   pipe-rename = callPackage ../tools/misc/pipe-rename { };
 
+  pipectl = callPackage ../tools/misc/pipectl { };
+
   pitivi = callPackage ../applications/video/pitivi { };
 
   prism = callPackage ../applications/video/prism { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
