### PR TITLE
Check link type based on expanded parameters

### DIFF
--- a/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
@@ -30,7 +30,7 @@ expandResponseParams "$@"
 if [[ -n "${NIX_LINK_TYPE_@suffixSalt@:-}" ]]; then
     linkType=$NIX_LINK_TYPE_@suffixSalt@
 else
-    linkType=$(checkLinkType "$@")
+    linkType=$(checkLinkType "${params[@]}")
 fi
 
 if [[ "${NIX_ENFORCE_PURITY:-}" = 1 && -n "${NIX_STORE:-}"

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -31,7 +31,7 @@ cxxLibrary=1
 cInclude=1
 
 expandResponseParams "$@"
-linkType=$(checkLinkType "$@")
+linkType=$(checkLinkType "${params[@]}")
 
 declare -i n=0
 nParams=${#params[@]}


### PR DESCRIPTION
So far we've ignored response files in arguments, and did not
check linkType against expanded parameters.  This means if
we have `-static` in a @reponse-file, linkType will not be
set to `-static` as we never check against the expanded arguments
from response files.