### PR TITLE
qcad: 3.26.4.10 -> 3.27.1.0

### DIFF
--- a/pkgs/applications/misc/qcad/default.nix
+++ b/pkgs/applications/misc/qcad/default.nix
@@ -1,28 +1,30 @@
-{ boost
-, fetchFromGitHub
-, libGLU
+{ lib
+, stdenv
 , mkDerivation
-, muparser
+, fetchFromGitHub
+, installShellFiles
 , pkg-config
-, qtbase
 , qmake
+, qttools
+, boost
+, libGLU
+, muparser
+, qtbase
 , qtscript
 , qtsvg
 , qtxmlpatterns
-, qttools
-, lib
-, installShellFiles
+, qtmacextras
 }:
 
 mkDerivation rec {
   pname = "qcad";
-  version = "3.26.4.10";
+  version = "3.27.1.0";
 
   src = fetchFromGitHub {
     owner = "qcad";
     repo = "qcad";
     rev = "v${version}";
-    sha256 = "sha256-dWpItV18lYjdwUsn2wwA//AUHU5ICGfmih2cJWihvn0=";
+    sha256 = "sha256-tydgSfS1MF322sgWULMEZ8P6YIaN1QoeJiia0wbsgjo=";
   };
 
   patches = [
@@ -39,26 +41,56 @@ mkDerivation rec {
     fi
   '';
 
+  nativeBuildInputs = [
+    installShellFiles
+    pkg-config
+    qmake
+    qttools
+  ];
+
+  buildInputs = [
+    boost
+    libGLU
+    muparser
+    qtbase
+    qtscript
+    qtsvg
+    qtxmlpatterns
+  ] ++ lib.optionals stdenv.isDarwin [
+    qtmacextras
+  ];
+
   qmakeFlags = [
     "MUPARSER_DIR=${muparser}"
     "INSTALLROOT=$(out)"
     "BOOST_DIR=${boost.dev}"
   ];
 
+  qtWrapperArgs =
+    lib.optionals stdenv.isLinux [ "--prefix LD_LIBRARY_PATH : ${placeholder "out"}/lib" ]
+    ++
+    lib.optionals stdenv.isDarwin [ "--prefix DYLD_LIBRARY_PATH : ${placeholder "out"}/lib" ];
+
   installPhase = ''
     runHook preInstall
 
-    install -Dm555 -t $out/bin release/qcad-bin
-    install -Dm555 -t $out/lib release/libspatialindexnavel.so
-    install -Dm555 -t $out/lib release/libqcadcore.so
-    install -Dm555 -t $out/lib release/libqcadentity.so
-    install -Dm555 -t $out/lib release/libqcadgrid.so
-    install -Dm555 -t $out/lib release/libqcadsnap.so
-    install -Dm555 -t $out/lib release/libqcadoperations.so
-    install -Dm555 -t $out/lib release/libqcadstemmer.so
-    install -Dm555 -t $out/lib release/libqcadspatialindex.so
-    install -Dm555 -t $out/lib release/libqcadgui.so
-    install -Dm555 -t $out/lib release/libqcadecmaapi.so
+  '' + lib.optionalString stdenv.isLinux ''
+    install -Dm555 release/qcad-bin $out/bin/qcad
+  '' + lib.optionalString stdenv.isDarwin ''
+    install -Dm555 release/QCAD.app/Contents/MacOS/QCAD $out/bin/qcad
+    mkdir -p $out/lib
+  '' +
+  ''
+    install -Dm555 -t $out/lib release/libspatialindexnavel${stdenv.hostPlatform.extensions.sharedLibrary}
+    install -Dm555 -t $out/lib release/libqcadcore${stdenv.hostPlatform.extensions.sharedLibrary}
+    install -Dm555 -t $out/lib release/libqcadentity${stdenv.hostPlatform.extensions.sharedLibrary}
+    install -Dm555 -t $out/lib release/libqcadgrid${stdenv.hostPlatform.extensions.sharedLibrary}
+    install -Dm555 -t $out/lib release/libqcadsnap${stdenv.hostPlatform.extensions.sharedLibrary}
+    install -Dm555 -t $out/lib release/libqcadoperations${stdenv.hostPlatform.extensions.sharedLibrary}
+    install -Dm555 -t $out/lib release/libqcadstemmer${stdenv.hostPlatform.extensions.sharedLibrary}
+    install -Dm555 -t $out/lib release/libqcadspatialindex${stdenv.hostPlatform.extensions.sharedLibrary}
+    install -Dm555 -t $out/lib release/libqcadgui${stdenv.hostPlatform.extensions.sharedLibrary}
+    install -Dm555 -t $out/lib release/libqcadecmaapi${stdenv.hostPlatform.extensions.sharedLibrary}
 
     install -Dm444 -t $out/share/applications qcad.desktop
     install -Dm644 -t $out/share/pixmaps      scripts/qcad_icon.png
@@ -87,23 +119,6 @@ mkDerivation rec {
 
     runHook postInstall
   '';
-
-  buildInputs = [
-    boost
-    muparser
-    libGLU
-    qtbase
-    qtscript
-    qtsvg
-    qtxmlpatterns
-  ];
-
-  nativeBuildInputs = [
-    pkg-config
-    qmake
-    qttools
-    installShellFiles
-  ];
 
   meta = with lib; {
     description = "2D CAD package based on Qt";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- version update
- fix build on darwin (by adding qtmacextras to buildInputs)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
