### PR TITLE
eudev: 3.2.10 -> 3.2.11

### DIFF
--- a/pkgs/os-specific/linux/eudev/default.nix
+++ b/pkgs/os-specific/linux/eudev/default.nix
@@ -1,60 +1,68 @@
-{lib, stdenv, fetchurl, pkg-config, glib, gperf, util-linux, kmod}:
-let
-  s = # Generated upstream information
-  rec {
-    baseName="eudev";
-    version = "3.2.10";
-    name="${baseName}-${version}";
-    url="http://dev.gentoo.org/~blueness/eudev/eudev-${version}.tar.gz";
-    sha256 = "sha256-h7sCjUcP0bhRaTSbRMVdW3M3M9wtUN3xGW4CZyXq0DQ=";
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, glib
+, gperf
+, kmod
+, pkg-config
+, util-linux
+}:
+
+stdenv.mkDerivation rec {
+  pname = "eudev";
+  version = "3.2.11";
+
+  src = fetchFromGitHub {
+    owner = "eudev-project";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-W5nL4hicQ4fxz5rqoP+hhkE1tVn8lJZjMq4UaiXH6jc=";
   };
 
-  nativeBuildInputs = [ pkg-config gperf ];
-  buildInputs = [
-    glib util-linux kmod
+  nativeBuildInputs = [
+    autoreconfHook
+    gperf
+    pkg-config
   ];
-in
-stdenv.mkDerivation {
-  inherit (s) name version;
-  inherit nativeBuildInputs buildInputs;
-  src = fetchurl {
-    inherit (s) url sha256;
-  };
-  patches = [
+
+  buildInputs = [
+    glib
+    kmod
+    util-linux
   ];
 
   configureFlags = [
     "--localstatedir=/var"
     "--sysconfdir=/etc"
   ];
+
   makeFlags = [
     "hwdb_bin=/var/lib/udev/hwdb.bin"
     "udevrulesdir=/etc/udev/rules.d"
     ];
 
   preInstall = ''
-    # Disable install-exec-hook target as it conflicts with our move-sbin setup-hook
+    # Disable install-exec-hook target,
+    # as it conflicts with our move-sbin setup-hook
+
     sed -i 's;$(MAKE) $(AM_MAKEFLAGS) install-exec-hook;$(MAKE) $(AM_MAKEFLAGS);g' src/udev/Makefile
   '';
 
-  installFlags =
-    [
+  installFlags = [
     "localstatedir=$(TMPDIR)/var"
     "sysconfdir=$(out)/etc"
     "udevconfdir=$(out)/etc/udev"
     "udevhwdbbin=$(out)/var/lib/udev/hwdb.bin"
     "udevhwdbdir=$(out)/var/lib/udev/hwdb.d"
     "udevrulesdir=$(out)/var/lib/udev/rules.d"
-    ];
-  enableParallelBuilding = true;
-  meta = {
-    inherit (s) version;
-    description = "An udev fork by Gentoo";
-    license = lib.licenses.gpl2Plus ;
-    maintainers = [lib.maintainers.raskin];
-    platforms = lib.platforms.linux;
-    homepage = "https://wiki.gentoo.org/wiki/Project:Eudev";
-    downloadPage = "http://dev.gentoo.org/~blueness/eudev/";
-    updateWalker = true;
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/eudev-project/eudev";
+    description = "A fork of udev with the aim of isolating it from init";
+    license = licenses.gpl2Plus ;
+    maintainers = with maintainers; [ raskin AndersonTorres ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
From GitHub.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

bump

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
