### PR TITLE
Meson bump

### DIFF
--- a/pkgs/applications/misc/metadata-cleaner/default.nix
+++ b/pkgs/applications/misc/metadata-cleaner/default.nix
@@ -9,7 +9,7 @@
 , itstool
 , libadwaita
 , librsvg
-, meson_0_60
+, meson
 , ninja
 , pkg-config
 , poppler_gi
@@ -35,7 +35,7 @@ python3.pkgs.buildPythonApplication rec {
     glib
     gtk4
     itstool
-    meson_0_60
+    meson
     ninja
     pkg-config
     wrapGAppsHook

--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -6,7 +6,7 @@
 , gettext
 , graphene
 , gi-docgen
-, meson_0_60
+, meson
 , ninja
 , python3
 , makeWrapper
@@ -81,7 +81,7 @@ stdenv.mkDerivation rec {
     gettext
     gobject-introspection
     makeWrapper
-    meson_0_60
+    meson
     ninja
     pkg-config
     python3

--- a/pkgs/development/libraries/libadwaita/default.nix
+++ b/pkgs/development/libraries/libadwaita/default.nix
@@ -5,7 +5,7 @@
 , gi-docgen
 , gtk-doc
 , libxml2
-, meson_0_60
+, meson
 , ninja
 , pkg-config
 , sassc
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     gi-docgen
     gtk-doc
     libxml2 # for xmllint
-    meson_0_60
+    meson
     ninja
     pkg-config
     sassc

--- a/pkgs/development/libraries/wlroots/0.15.nix
+++ b/pkgs/development/libraries/wlroots/0.15.nix
@@ -1,7 +1,28 @@
-{ lib, stdenv, fetchFromGitLab, meson_0_60, ninja, pkg-config, wayland-scanner
-, libGL, wayland, wayland-protocols, libinput, libxkbcommon, pixman
-, xcbutilwm, libX11, libcap, xcbutilimage, xcbutilerrors, mesa
-, libpng, ffmpeg, xcbutilrenderutil, seatd, vulkan-loader, glslang
+{ lib
+, stdenv
+, fetchFromGitLab
+, ffmpeg
+, glslang
+, libGL
+, libX11
+, libcap
+, libinput
+, libpng
+, libxkbcommon
+, mesa
+, meson_0_60
+, ninja
+, pixman
+, pkg-config
+, seatd
+, vulkan-loader
+, wayland
+, wayland-protocols
+, wayland-scanner
+, xcbutilerrors
+, xcbutilimage
+, xcbutilrenderutil
+, xcbutilwm
 
 , enableXWayland ? true, xwayland ? null
 }:
@@ -23,19 +44,35 @@ stdenv.mkDerivation rec {
 
   depsBuildBuild = [ pkg-config ];
 
-  nativeBuildInputs = [ meson_0_60 ninja pkg-config wayland-scanner ];
+  nativeBuildInputs = [
+    meson_0_60
+    ninja
+    pkg-config
+    wayland-scanner
+  ];
 
   buildInputs = [
-    libGL wayland wayland-protocols libinput libxkbcommon pixman
-    xcbutilwm libX11 libcap xcbutilimage xcbutilerrors mesa
-    libpng ffmpeg xcbutilrenderutil seatd vulkan-loader glslang
+    ffmpeg
+    libGL
+    libX11
+    libcap
+    libinput
+    libpng
+    libxkbcommon
+    mesa
+    pixman
+    seatd
+    vulkan-loader glslang
+    wayland
+    wayland-protocols
+    xcbutilerrors
+    xcbutilimage
+    xcbutilrenderutil
+    xcbutilwm
   ]
-    ++ lib.optional enableXWayland xwayland
-  ;
+  ++ lib.optional enableXWayland xwayland;
 
-  mesonFlags =
-    lib.optional (!enableXWayland) "-Dxwayland=disabled"
-  ;
+  mesonFlags = lib.optional (!enableXWayland) "-Dxwayland=disabled";
 
   postFixup = ''
     # Install ALL example programs to $examples:
@@ -50,12 +87,12 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    inherit (src.meta) homepage;
     description = "A modular Wayland compositor library";
     longDescription = ''
       Pluggable, composable, unopinionated modules for building a Wayland
       compositor; or about 50,000 lines of code you were going to write anyway.
     '';
-    inherit (src.meta) homepage;
     changelog = "https://gitlab.freedesktop.org/wlroots/wlroots/-/tags/${version}";
     license     = licenses.mit;
     platforms   = platforms.linux;

--- a/pkgs/development/libraries/wlroots/0.15.nix
+++ b/pkgs/development/libraries/wlroots/0.15.nix
@@ -94,8 +94,8 @@ stdenv.mkDerivation rec {
       compositor; or about 50,000 lines of code you were going to write anyway.
     '';
     changelog = "https://gitlab.freedesktop.org/wlroots/wlroots/-/tags/${version}";
-    license     = licenses.mit;
-    platforms   = platforms.linux;
+    license = licenses.mit;
     maintainers = with maintainers; [ primeos synthetica ];
+    inherit (wayland.meta) platforms;
   };
 }

--- a/pkgs/development/libraries/wlroots/0.15.nix
+++ b/pkgs/development/libraries/wlroots/0.15.nix
@@ -10,7 +10,7 @@
 , libpng
 , libxkbcommon
 , mesa
-, meson_0_60
+, meson
 , ninja
 , pixman
 , pkg-config
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   depsBuildBuild = [ pkg-config ];
 
   nativeBuildInputs = [
-    meson_0_60
+    meson
     ninja
     pkg-config
     wayland-scanner

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3406,8 +3406,8 @@ with pkgs;
   merriweather-sans = callPackage ../data/fonts/merriweather-sans { };
 
   # TODO: call a sprintable to deprecate Meson 0.57 as soon as possible
-  meson = callPackage ../development/tools/build-managers/meson/0.57 { };
-  meson_0_60 = callPackage ../development/tools/build-managers/meson/0.60 { };
+  meson_0_57 = callPackage ../development/tools/build-managers/meson/0.57 { };
+  meson = callPackage ../development/tools/build-managers/meson/0.60 { };
 
   meson-tools = callPackage ../misc/meson-tools { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22943,6 +22943,8 @@ with pkgs;
   sysstat = callPackage ../os-specific/linux/sysstat { };
 
   systemd = callPackage ../os-specific/linux/systemd {
+    # TODO: get rid of this old meson
+    meson = meson_0_57;
     # break some cyclic dependencies
     util-linux = util-linuxMinimal;
     # provide a super minimal gnupg used for systemd-machined


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Get rid of old Meson

https://github.com/NixOS/nixpkgs/pull/144779

As I have said before, the plan is:

- Insert new Meson in parallel with old one, the older being a safe default (done)
- Try to force new Meson as default
- Look at the ofborg logs in order to repair those packages that do not accept new Meson yet
  - Updates should be preferrable

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
