### PR TITLE
pipewire: introduce roc-toolkit support

### DIFF
--- a/pkgs/development/libraries/audio/roc-toolkit/default.nix
+++ b/pkgs/development/libraries/audio/roc-toolkit/default.nix
@@ -1,0 +1,63 @@
+{ stdenv,
+  lib,
+  fetchFromGitHub,
+  sconsPackages,
+  ragel,
+  gengetopt,
+  pkg-config,
+  libuv,
+  openfecSupport ? true,
+  openfec,
+  libunwindSupport ? true,
+  libunwind,
+  pulseaudioSupport ? true,
+  libpulseaudio
+}:
+
+stdenv.mkDerivation rec {
+  pname = "roc-toolkit";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "roc-streaming";
+    repo = "roc-toolkit";
+    rev = "v${version}";
+    sha256 = "sha256:1pld340zfch4p3qaf5anrspq7vmxrgf9ddsdsq92pk49axaaz19w";
+  };
+
+  nativeBuildInputs = [
+    sconsPackages.scons_3_0_1
+    ragel
+    gengetopt
+    pkg-config
+  ];
+
+  buildInputs = [
+    libuv
+    libunwind
+    openfec
+    libpulseaudio
+  ];
+
+  sconsFlags =
+    [ "--disable-sox"
+      "--disable-tests" ] ++
+    lib.optional (!libunwindSupport) "--disable-libunwind" ++
+    lib.optional (!pulseaudioSupport) "--disable-pulseaudio" ++
+    (if (!openfecSupport)
+       then ["--disable-openfec"]
+       else [ "--with-libraries=${openfec}/lib"
+              "--with-openfec-includes=${openfec.dev}/include" ]);
+
+  preConfigure = ''
+    sconsFlags+=" --prefix=$out"
+  '';
+
+  meta = with lib; {
+    description = "Roc is a toolkit for real-time audio streaming over the network";
+    homepage = "https://github.com/roc-streaming/roc-toolkit";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ bgamari ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/openfec/default.nix
+++ b/pkgs/development/libraries/openfec/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, lib, fetchzip, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "openfec";
+  version = "1.4.2";
+
+  src = fetchzip {
+    url = "http://openfec.org/files/openfec_v1_4_2.tgz";
+    sha256 = "sha256:0c2lg8afr7lqpzrsi0g44a6h6s7nq4vz7yc9vm2k57ph2y6r86la";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  cmakeFlags = [ "-DDEBUG:STRING=OFF" ];
+
+  installPhase =
+    let so = stdenv.hostPlatform.extensions.sharedLibrary;
+    in ''
+      # This is pretty horrible but sadly there is not installation procedure
+      # provided.
+      mkdir -p $dev/include
+      cp -R ../src/* $dev/include
+      find $dev/include -type f -a ! -iname '*.h' -delete
+
+      install -D -m755 -t $out/lib ../bin/Release/libopenfec${so}
+      ln -s libopenfec${so} $out/lib/libopenfec${so}.1
+    '';
+
+  meta = with lib; {
+    description = "Application-level Forward Erasure Correction codes";
+    homepage = "https://github.com/roc-streaming/openfec";
+    license = licenses.cecill-c;
+    maintainers = with maintainers; [ bgamari ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -25,6 +25,8 @@
 , webrtc-audio-processing
 , ncurses
 , readline81 # meson can't find <7 as those versions don't have a .pc file
+, lilv
+, openssl
 , makeFontsConf
 , callPackage
 , nixosTests
@@ -64,7 +66,7 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "pipewire";
-    version = "0.3.40";
+    version = "0.3.42";
 
     outputs = [
       "out"
@@ -82,7 +84,7 @@ let
       owner = "pipewire";
       repo = "pipewire";
       rev = version;
-      sha256 = "sha256-eY6uQa4+sC6yUWhF4IpAgRoppwhHO4s5fIMXOkS0z7A=";
+      sha256 = "sha256-Iyd5snOt+iCT7W0+FlfvhMUZo/gF+zr9JX4HIGVdHto=";
     };
 
     patches = [
@@ -117,7 +119,9 @@ let
       libjack2
       libusb1
       libsndfile
+      lilv
       ncurses
+      openssl
       readline81
       udev
       vulkan-headers

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -54,6 +54,8 @@
 , libpulseaudio
 , zeroconfSupport ? true
 , avahi
+, rocSupport ? true
+, roc-toolkit
 }:
 
 let
@@ -134,7 +136,8 @@ let
     ++ lib.optional ffmpegSupport ffmpeg
     ++ lib.optionals bluezSupport [ bluez libfreeaptx ldacbt sbc fdk_aac ]
     ++ lib.optional pulseTunnelSupport libpulseaudio
-    ++ lib.optional zeroconfSupport avahi;
+    ++ lib.optional zeroconfSupport avahi
+    ++ lib.optional rocSupport roc-toolkit;
 
     # Valgrind binary is required for running one optional test.
     checkInputs = lib.optional withValgrind valgrind;
@@ -147,7 +150,7 @@ let
       "-Dpipewire_pulse_prefix=${placeholder "pulse"}"
       "-Dlibjack-path=${placeholder "jack"}/lib"
       "-Dlibcamera=${mesonEnable libcameraSupport}"
-      "-Droc=disabled"
+      "-Droc=${mesonEnable rocSupport}"
       "-Dlibpulse=${mesonEnable pulseTunnelSupport}"
       "-Davahi=${mesonEnable zeroconfSupport}"
       "-Dgstreamer=${mesonEnable gstreamerSupport}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9313,6 +9313,8 @@ with pkgs;
 
   rmtrash = callPackage ../tools/misc/rmtrash { };
 
+  roc-toolkit = callPackage ../development/libraries/audio/roc-toolkit { };
+
   rockbox_utility = libsForQt5.callPackage ../tools/misc/rockbox-utility { };
 
   rosegarden = libsForQt514.callPackage ../applications/audio/rosegarden { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8366,6 +8366,8 @@ with pkgs;
     opendylan-bootstrap = opendylan_bin;
   };
 
+  openfec = callPackage ../development/libraries/openfec { };
+
   ophis = python3Packages.callPackage ../development/compilers/ophis { };
 
   opendylan_bin = callPackage ../development/compilers/opendylan/bin.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`roc-streaming` is a library for robust streaming of audio data over (unreliable) networks. `pipewire` has support for it via the `libpipewire-module-roc-{sink,source}` modules. Here I add derivations for the `openfec` and `roc-toolkit` libraries, as well as introduce support for the latter in the `pipewire` derivation.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
