### PR TITLE
pythonPackages.pylibdmtx: init at 0.1.9

### DIFF
--- a/pkgs/development/python-modules/pylibdmtx/default.nix
+++ b/pkgs/development/python-modules/pylibdmtx/default.nix
@@ -1,0 +1,47 @@
+{ fetchFromGitHub
+, buildPythonPackage
+, pillow
+, numpy
+, libdmtx
+, lib
+}:
+
+buildPythonPackage rec {
+  pname = "pylibdmtx";
+  version = "0.1.10";
+
+  src = fetchFromGitHub {
+    owner = "NaturalHistoryMuseum";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-vNWzhO4V0mj4eItZ0Z5UG9RBCqprIcgMGNyIe1+mXWY=";
+  };
+
+  # Change:
+  # def load():
+  #     """Loads the libdmtx shared library.
+  #
+  # To:
+  # def load():
+  #     return cdll.LoadLibrary("/nix/store/.../lib/libdmtx.so")
+  #     """Loads the libdmtx shared library.
+  postPatch = ''
+    sed -i '\#def load.*#a\    return cdll.LoadLibrary("${libdmtx}/lib/libdmtx.so")' \
+        pylibdmtx/dmtx_library.py
+
+    # Checks that the loader works in various scenarios, but we just
+    # forced it to only work one way.
+    rm pylibdmtx/tests/test_dmtx_library.py
+  '';
+
+  propagatedBuildInputs = [ pillow numpy ];
+
+  pythonImportsCheck = [ "pylibdmtx" ];
+
+  meta = with lib; {
+    description = "Read and write Data Matrix barcodes from Python 2 and 3 using the libdmtx library";
+    homepage = "https://github.com/NaturalHistoryMuseum/pylibdmtx/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ grahamc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7257,6 +7257,8 @@ in {
 
   pylibconfig2 = callPackage ../development/python-modules/pylibconfig2 { };
 
+  pylibdmtx = callPackage ../development/python-modules/pylibdmtx { };
+
   pylibftdi = callPackage ../development/python-modules/pylibftdi {
     inherit (pkgs) libusb1;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
