### PR TITLE
Darktable: 3.6.1 -> 3.8.0

### DIFF
--- a/pkgs/applications/graphics/darktable/default.nix
+++ b/pkgs/applications/graphics/darktable/default.nix
@@ -1,10 +1,59 @@
-{ lib, stdenv, fetchurl, libsoup, graphicsmagick, json-glib, wrapGAppsHook
-, cairo, cmake, ninja, curl, perl, llvm_13, desktop-file-utils, exiv2, glib
-, ilmbase, gtk3, intltool, lcms2, lensfun, libX11, libexif, libgphoto2, libjpeg
-, libpng, librsvg, libtiff, openexr_3, osm-gps-map, pkg-config, sqlite, libxslt
-, openjpeg, pugixml, colord, colord-gtk, libwebp, libsecret, gnome, SDL2
-, ocl-icd, pcre, gtk-mac-integration, isocodes, llvmPackages, gmic, libavif, icu
-, jasper, libheif, libaom, portmidi, fetchpatch, lua5_4, ...
+{ lib
+, stdenv
+, fetchurl
+, libsoup
+, graphicsmagick
+, json-glib
+, wrapGAppsHook
+, cairo
+, cmake
+, ninja
+, curl
+, perl
+, llvm_13
+, desktop-file-utils
+, exiv2
+, glib
+, ilmbase
+, gtk3
+, intltool
+, lcms2
+, lensfun
+, libX11
+, libexif
+, libgphoto2
+, libjpeg
+, libpng
+, librsvg
+, libtiff
+, openexr_3
+, osm-gps-map
+, pkg-config
+, sqlite
+, libxslt
+, openjpeg
+, pugixml
+, colord
+, colord-gtk
+, libwebp
+, libsecret
+, gnome
+, SDL2
+, ocl-icd
+, pcre
+, gtk-mac-integration
+, isocodes
+, llvmPackages
+, gmic
+, libavif
+, icu
+, jasper
+, libheif
+, libaom
+, portmidi
+, fetchpatch
+, lua5_4
+, ...
 }:
 
 stdenv.mkDerivation rec {
@@ -19,15 +68,50 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ninja llvm_13 pkg-config intltool perl desktop-file-utils wrapGAppsHook ];
 
   buildInputs = [
-    cairo curl exiv2 glib gtk3 ilmbase lcms2 lensfun libexif
-    libgphoto2 libjpeg libpng librsvg libtiff openexr_3 sqlite libxslt
-    libsoup graphicsmagick json-glib openjpeg pugixml
-    libwebp libsecret SDL2 gnome.adwaita-icon-theme osm-gps-map pcre isocodes gmic libavif icu
-    jasper libheif libaom portmidi lua5_4
+    cairo
+    curl
+    exiv2
+    glib
+    gtk3
+    ilmbase
+    lcms2
+    lensfun
+    libexif
+    libgphoto2
+    libjpeg
+    libpng
+    librsvg
+    libtiff
+    openexr_3
+    sqlite
+    libxslt
+    libsoup
+    graphicsmagick
+    json-glib
+    openjpeg
+    pugixml
+    libwebp
+    libsecret
+    SDL2
+    gnome.adwaita-icon-theme
+    osm-gps-map
+    pcre
+    isocodes
+    gmic
+    libavif
+    icu
+    jasper
+    libheif
+    libaom
+    portmidi
+    lua5_4
   ] ++ lib.optionals stdenv.isLinux [
-    colord colord-gtk libX11 ocl-icd
+    colord
+    colord-gtk
+    libX11
+    ocl-icd
   ] ++ lib.optional stdenv.isDarwin gtk-mac-integration
-    ++ lib.optional stdenv.cc.isClang llvmPackages.openmp;
+  ++ lib.optional stdenv.cc.isClang llvmPackages.openmp;
 
   cmakeFlags = [
     "-DBUILD_USERMANUAL=False"
@@ -49,18 +133,20 @@ stdenv.mkDerivation rec {
   # 83c70b876af6484506901e6b381304ae0d073d3c and as a result the
   # binaries can't find libdarktable.so, so change LD_LIBRARY_PATH in
   # the wrappers:
-  preFixup = let
-    libPathEnvVar = if stdenv.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH";
-    libPathPrefix = "$out/lib/darktable" + lib.optionalString stdenv.isLinux ":${ocl-icd}/lib";
-  in ''
-    for f in $out/share/darktable/kernels/*.cl; do
-      sed -r "s|#include \"(.*)\"|#include \"$out/share/darktable/kernels/\1\"|g" -i "$f"
-    done
+  preFixup =
+    let
+      libPathEnvVar = if stdenv.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH";
+      libPathPrefix = "$out/lib/darktable" + lib.optionalString stdenv.isLinux ":${ocl-icd}/lib";
+    in
+    ''
+      for f in $out/share/darktable/kernels/*.cl; do
+        sed -r "s|#include \"(.*)\"|#include \"$out/share/darktable/kernels/\1\"|g" -i "$f"
+      done
 
-    gappsWrapperArgs+=(
-      --prefix ${libPathEnvVar} ":" "${libPathPrefix}"
-    )
-  '';
+      gappsWrapperArgs+=(
+        --prefix ${libPathEnvVar} ":" "${libPathPrefix}"
+      )
+    '';
 
   meta = with lib; {
     description = "Virtual lighttable and darkroom for photographers";

--- a/pkgs/applications/graphics/darktable/default.nix
+++ b/pkgs/applications/graphics/darktable/default.nix
@@ -1,27 +1,29 @@
 { lib, stdenv, fetchurl, libsoup, graphicsmagick, json-glib, wrapGAppsHook
-, cairo, cmake, ninja, curl, perl, llvm, desktop-file-utils, exiv2, glib
+, cairo, cmake, ninja, curl, perl, llvm_13, desktop-file-utils, exiv2, glib
 , ilmbase, gtk3, intltool, lcms2, lensfun, libX11, libexif, libgphoto2, libjpeg
-, libpng, librsvg, libtiff, openexr, osm-gps-map, pkg-config, sqlite, libxslt
-, openjpeg, lua, pugixml, colord, colord-gtk, libwebp, libsecret, gnome
+, libpng, librsvg, libtiff, openexr_3, osm-gps-map, pkg-config, sqlite, libxslt
+, openjpeg, pugixml, colord, colord-gtk, libwebp, libsecret, gnome, SDL2
 , ocl-icd, pcre, gtk-mac-integration, isocodes, llvmPackages, gmic, libavif, icu
+, jasper, libheif, libaom, portmidi, fetchpatch, lua5_4, ...
 }:
 
 stdenv.mkDerivation rec {
-  version = "3.6.1";
+  version = "3.8.0";
   pname = "darktable";
 
   src = fetchurl {
     url = "https://github.com/darktable-org/darktable/releases/download/release-${version}/darktable-${version}.tar.xz";
-    sha256 = "sha256-or/HwQO4JJRUV6m/7Z5S8Af6HQMPnbyz/wMnhRvkLRQ=";
+    sha256 = "01gp9dg5wr2rg1k8cqs0l3s7ism8a4q8qypgwccd4jh7ip3wfr9f";
   };
 
-  nativeBuildInputs = [ cmake ninja llvm pkg-config intltool perl desktop-file-utils wrapGAppsHook ];
+  nativeBuildInputs = [ cmake ninja llvm_13 pkg-config intltool perl desktop-file-utils wrapGAppsHook ];
 
   buildInputs = [
     cairo curl exiv2 glib gtk3 ilmbase lcms2 lensfun libexif
-    libgphoto2 libjpeg libpng librsvg libtiff openexr sqlite libxslt
-    libsoup graphicsmagick json-glib openjpeg lua pugixml
-    libwebp libsecret gnome.adwaita-icon-theme osm-gps-map pcre isocodes gmic libavif icu
+    libgphoto2 libjpeg libpng librsvg libtiff openexr_3 sqlite libxslt
+    libsoup graphicsmagick json-glib openjpeg pugixml
+    libwebp libsecret SDL2 gnome.adwaita-icon-theme osm-gps-map pcre isocodes gmic libavif icu
+    jasper libheif libaom portmidi lua5_4
   ] ++ lib.optionals stdenv.isLinux [
     colord colord-gtk libX11 ocl-icd
   ] ++ lib.optional stdenv.isDarwin gtk-mac-integration
@@ -34,6 +36,14 @@ stdenv.mkDerivation rec {
     "-DUSE_KWALLET=OFF"
   ];
 
+  patches = [
+    (fetchpatch {
+      # This is merged in darktable master and will hopefully be in 3.8.1
+      name = "cmake-fix.patch";
+      url = "https://github.com/darktable-org/darktable/commit/58d247f7ebea76c55fa2525beb9f5ce092c6670d.patch";
+      sha256 = "11fn6d2mwlapbf1zbyv6bhgv29kxcwrs7cnbway0rnl9nj8wimf2";
+    })
+  ];
 
   # darktable changed its rpath handling in commit
   # 83c70b876af6484506901e6b381304ae0d073d3c and as a result the
@@ -57,6 +67,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.darktable.org";
     license = licenses.gpl3Plus;
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ goibhniu flosse mrVanDalo ];
+    maintainers = with maintainers; [ goibhniu flosse mrVanDalo paperdigits ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update darktable to the latest version and update dependencies. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
