### PR TITLE
terraform-providers: update-provider scripts - misc fixes 

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/update-all-providers
+++ b/pkgs/applications/networking/cluster/terraform-providers/update-all-providers
@@ -14,9 +14,9 @@ providers=$(
 )
 
 echo "Will update providers:"
-echo "$providers"
+echo "${providers}"
 
-for provider in $providers; do
-  echo "Updating $provider"
-  ./update-provider "$provider"
+for provider in ${providers}; do
+  echo "Updating ${provider}"
+  ./update-provider "${provider}"
 done

--- a/pkgs/applications/networking/cluster/terraform-providers/update-all-providers
+++ b/pkgs/applications/networking/cluster/terraform-providers/update-all-providers
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -i bash -p jq
+#! nix-shell -I nixpkgs=../../../../.. -i bash -p jq
 # shellcheck shell=bash
 
 # Update all providers which have specified provider source address

--- a/pkgs/applications/networking/cluster/terraform-providers/update-provider
+++ b/pkgs/applications/networking/cluster/terraform-providers/update-provider
@@ -7,6 +7,7 @@
 # provider source address.
 #
 set -euo pipefail
+shopt -s inherit_errexit
 
 show_usage() {
   cat <<DOC
@@ -57,36 +58,37 @@ while [[ $# -gt 0 ]]; do
     shift 2
     ;;
   *)
-    if [[ -n "$provider" ]]; then
-      echo "ERROR: provider name was passed two times: '$provider' and '$1'"
+    if [[ -n ${provider} ]]; then
+      echo "ERROR: provider name was passed two times: '${provider}' and '$1'"
       echo "Use --help for more info"
       exit 1
     fi
     provider=$1
     shift
+    ;;
   esac
 done
 
-if [[ -z "$provider" ]]; then
+if [[ -z ${provider} ]]; then
   echo "ERROR: No providers specified!"
   echo
   show_usage
   exit 1
 fi
 
-provider_name=$(basename "$provider")
+provider_name=$(basename "${provider}")
 
 # Usage: read_attr <key>
 read_attr() {
-  jq -r ".\"$provider_name\".\"$1\"" providers.json
+  jq -r ".\"${provider_name}\".\"$1\"" providers.json
 }
 
 # Usage: update_attr <key> <value>
 update_attr() {
-  if [[ "$2" == "null" ]]; then
-    jq -S ".\"$provider_name\".\"$1\" = null" providers.json | sponge providers.json
+  if [[ $2 == "null" ]]; then
+    jq -S ".\"${provider_name}\".\"$1\" = null" providers.json | sponge providers.json
   else
-    jq -S ".\"$provider_name\".\"$1\" = \"$2\"" providers.json | sponge providers.json
+    jq -S ".\"${provider_name}\".\"$1\" = \"$2\"" providers.json | sponge providers.json
   fi
 }
 
@@ -96,23 +98,23 @@ prefetch_github() {
   local owner=$1
   local repo=$2
   local rev=$3
-  nix-prefetch-url --unpack "https://github.com/$owner/$repo/archive/$rev.tar.gz"
+  nix-prefetch-url --unpack "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"
 }
 
 old_source_address="$(read_attr provider-source-address)"
 old_vendor_sha256=$(read_attr vendorSha256)
 old_version=$(read_attr version)
 
-if [[ $provider =~ ^[^/]+/[^/]+$ ]]; then
-  source_address=registry.terraform.io/$provider
+if [[ ${provider} =~ ^[^/]+/[^/]+$ ]]; then
+  source_address=registry.terraform.io/${provider}
 else
-  source_address=$old_source_address
+  source_address=${old_source_address}
 fi
-if [[ "$source_address" == "null" ]]; then
-  echo "Could not find the source address for provider: $provider"
+if [[ ${source_address} == "null" ]]; then
+  echo "Could not find the source address for provider: ${provider}"
   exit 1
 fi
-update_attr "provider-source-address" "$source_address"
+update_attr "provider-source-address" "${source_address}"
 
 # The provider source address (used inside Terraform `required_providers` block) is
 # used to compute the registry API endpoint
@@ -122,39 +124,39 @@ update_attr "provider-source-address" "$source_address"
 # registry.terraform.io/v1/providers/hashicorp/aws (provider URL for the JSON API)
 registry_response=$(curl -s https://"${source_address/\///v1/providers/}")
 
-version="$(jq -r '.version' <<< "$registry_response")"
-if [[ "$old_version" = "$version" && "$force" != 1 && -z "$vendorSha256" && "$old_vendor_sha256" != "$vendorSha256" ]]; then
-  echo "$provider_name is already at version $version"
+version="$(jq -r '.version' <<<"${registry_response}")"
+if [[ ${old_version} == "${version}" && ${force} != 1 && -z ${vendorSha256} && ${old_vendor_sha256} != "${vendorSha256}" ]]; then
+  echo "${provider_name} is already at version ${version}"
   exit
 fi
-update_attr version "$version"
+update_attr version "${version}"
 
-provider_source_url="$(jq -r '.source' <<< "$registry_response")"
+provider_source_url="$(jq -r '.source' <<<"${registry_response}")"
 
-org="$(echo "$provider_source_url" | cut -d '/' -f 4)"
-update_attr owner "$org"
-repo="$(echo "$provider_source_url" | cut -d '/' -f 5)"
-update_attr repo "$repo"
-rev="$(jq -r '.tag' <<< "$registry_response")"
-update_attr rev "$rev"
-sha256=$(prefetch_github "$org" "$repo" "$rev")
-update_attr sha256 "$sha256"
+org="$(echo "${provider_source_url}" | cut -d '/' -f 4)"
+update_attr owner "${org}"
+repo="$(echo "${provider_source_url}" | cut -d '/' -f 5)"
+update_attr repo "${repo}"
+rev="$(jq -r '.tag' <<<"${registry_response}")"
+update_attr rev "${rev}"
+sha256=$(prefetch_github "${org}" "${repo}" "${rev}")
+update_attr sha256 "${sha256}"
 
 repo_root=$(git rev-parse --show-toplevel)
 
-if [[ -z "$vendorSha256" ]]; then
-  if [[ "$old_vendor_sha256" == null ]]; then
+if [[ -z ${vendorSha256} ]]; then
+  if [[ ${old_vendor_sha256} == null ]]; then
     vendorSha256=null
-  elif [[ -n "$old_vendor_sha256" || "$vendor" = 1 ]]; then
+  elif [[ -n ${old_vendor_sha256} || ${vendor} == 1 ]]; then
     echo "=== Calculating vendorSha256 ==="
     update_attr vendorSha256 "0000000000000000000000000000000000000000000000000000000000000000"
     # Hackish way to find out the desired sha256. First build, then extract the
     # error message from the logs.
     set +e
-    nix-build --no-out-link "$repo_root" -A "terraform-providers.$provider_name.go-modules" 2>vendor_log.txt
+    nix-build --no-out-link "${repo_root}" -A "terraform-providers.${provider_name}.go-modules" 2>vendor_log.txt
     set -e
-    logs=$(< vendor_log.txt)
-    if ! [[ $logs =~ got:\ +([^\ ]+) ]]; then
+    logs=$(<vendor_log.txt)
+    if ! [[ ${logs} =~ got:\ +([^\ ]+) ]]; then
       echo "ERROR: could not find new hash in output:"
       cat vendor_log.txt
       rm -f vendor_log.txt
@@ -164,16 +166,16 @@ if [[ -z "$vendorSha256" ]]; then
     # trim the results in case it they have a sha256: prefix or contain more than one line
     vendorSha256=$(echo "${BASH_REMATCH[1]#sha256:}" | head -n 1)
     # Deal with nix unstable
-    if [[ $vendorSha256 = sha256-* ]]; then
-      vendorSha256=$(nix --extra-experimental-features nix-command hash to-base32 "$vendorSha256")
+    if [[ ${vendorSha256} == sha256-* ]]; then
+      vendorSha256=$(nix --extra-experimental-features nix-command hash to-base32 "${vendorSha256}")
     fi
   fi
 fi
 
-if [[ -n "$vendorSha256" ]]; then
-  update_attr vendorSha256 "$vendorSha256"
+if [[ -n ${vendorSha256} ]]; then
+  update_attr vendorSha256 "${vendorSha256}"
 fi
 
 # Check that the provider builds
-echo "=== Building terraform-providers.$provider_name ==="
-nix-build "$repo_root" -A "terraform-providers.$provider_name"
+echo "=== Building terraform-providers.${provider_name} ==="
+nix-build "${repo_root}" -A "terraform-providers.${provider_name}"

--- a/pkgs/applications/networking/cluster/terraform-providers/update-provider
+++ b/pkgs/applications/networking/cluster/terraform-providers/update-provider
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -I nixpkgs=../../../../.. -i bash -p coreutils curl jq moreutils nix
+#! nix-shell -I nixpkgs=../../../../.. -i bash -p coreutils curl jq moreutils nix nix-prefetch
 # shellcheck shell=bash
 # vim: ft=sh
 #
@@ -149,22 +149,7 @@ if [[ -z ${vendorSha256} ]]; then
     vendorSha256=null
   elif [[ -n ${old_vendor_sha256} || ${vendor} == 1 ]]; then
     echo "=== Calculating vendorSha256 ==="
-    update_attr vendorSha256 "0000000000000000000000000000000000000000000000000000000000000000"
-    # Hackish way to find out the desired sha256. First build, then extract the
-    # error message from the logs.
-    set +e
-    nix-build --no-out-link "${repo_root}" -A "terraform-providers.${provider_name}.go-modules" 2>vendor_log.txt
-    set -e
-    logs=$(<vendor_log.txt)
-    if ! [[ ${logs} =~ got:\ +([^\ ]+) ]]; then
-      echo "ERROR: could not find new hash in output:"
-      cat vendor_log.txt
-      rm -f vendor_log.txt
-      exit 1
-    fi
-    rm -f vendor_log.txt
-    # trim the results in case it they have a sha256: prefix or contain more than one line
-    vendorSha256=$(echo "${BASH_REMATCH[1]#sha256:}" | head -n 1)
+    vendorSha256=$(nix-prefetch "{ sha256 }: (import ../../../../.. {}).terraform-providers.${provider_name}.go-modules.overrideAttrs (_: { vendorSha256 = sha256; })")
     # Deal with nix unstable
     if [[ ${vendorSha256} == sha256-* ]]; then
       vendorSha256=$(nix --extra-experimental-features nix-command hash to-base32 "${vendorSha256}")
@@ -178,4 +163,4 @@ fi
 
 # Check that the provider builds
 echo "=== Building terraform-providers.${provider_name} ==="
-nix-build "${repo_root}" -A "terraform-providers.${provider_name}"
+nix-build --no-out-link "${repo_root}" -A "terraform-providers.${provider_name}"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I'll likely rewrite these scripts but for now just minor fixes and making linters happy.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


cc @zimbatm 