### PR TITLE
python3Packages.dm-haiku: init at 0.0.5

### DIFF
--- a/pkgs/development/python-modules/dm-haiku/default.nix
+++ b/pkgs/development/python-modules/dm-haiku/default.nix
@@ -1,0 +1,59 @@
+{ buildPythonPackage
+, chex
+, cloudpickle
+, dill
+, dm-tree
+, fetchFromGitHub
+, jmp
+, lib
+, pytestCheckHook
+, tabulate
+, tensorflow
+}:
+
+buildPythonPackage rec {
+  pname = "dm-haiku";
+  version = "0.0.5";
+
+  src = fetchFromGitHub {
+    owner = "deepmind";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1mdqjcka0m1div63ngba8w8z94id4c1h8xqmnq1xpmgkc79224wa";
+  };
+
+  propagatedBuildInputs = [
+    jmp
+    tabulate
+  ];
+
+  checkInputs = [
+    chex
+    cloudpickle
+    dm-tree
+    pytestCheckHook
+    tensorflow
+  ];
+
+  pythonImportsCheck = [
+    "haiku"
+  ];
+
+  disabledTestPaths = [
+    # These tests require `bsuite` which isn't packaged in `nixpkgs`.
+    "examples/impala_lite_test.py"
+    "examples/impala/actor_test.py"
+    "examples/impala/learner_test.py"
+    # This test breaks on multiple cases with TF-related errors,
+    # likely that's the reason the upstream uses TF-nightly for tests?
+    # `nixpkgs` doesn't have the corresponding TF version packaged.
+    "haiku/_src/integration/jax2tf_test.py"
+  ];
+
+  meta = with lib; {
+    description = "Haiku is a simple neural network library for JAX developed by some of the authors of Sonnet.";
+    homepage = "https://github.com/deepmind/dm-haiku";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ndl ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2325,6 +2325,8 @@ in {
 
   dmenu-python = callPackage ../development/python-modules/dmenu { };
 
+  dm-haiku = callPackage ../development/python-modules/dm-haiku { };
+
   dm-sonnet = callPackage ../development/python-modules/dm-sonnet { };
 
   dm-tree = callPackage ../development/python-modules/dm-tree { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Part of "extra JAX libraries / frameworks" implementation, see the discussion in #152754

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
