### PR TITLE
colobot: 0.1.12 -> 0.2.0; fixes build

### DIFF
--- a/pkgs/games/colobot/data.nix
+++ b/pkgs/games/colobot/data.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "colobot-data";
-  version = "0.1.12-alpha";
+  version = "0.2.0-alpha";
 
   src = fetchFromGitHub {
     owner = "colobot";
     repo = "colobot-data";
     rev = "colobot-gold-${version}";
-    sha256 = "1vm33s52ymwd03x24i9bqiglw5v3wgd7rlzyx9r5ww0nnqzwbwi6";
+    sha256 = "sha256-yzIbAzrGsDe6hO0GHF9gjnj7IE8B7+5LDbvjZi4Wtms=";
   };
 
   nativeBuildInputs = [ cmake vorbis-tools xmlstarlet doxygen python3 ];

--- a/pkgs/games/colobot/default.nix
+++ b/pkgs/games/colobot/default.nix
@@ -9,23 +9,14 @@ stdenv.mkDerivation rec {
   pname = "colobot";
   # Maybe require an update to package colobot-data as well
   # in file data.nix next to this one
-  version = "0.1.12-alpha";
+  version = "0.2.0-alpha";
 
   src = fetchFromGitHub {
     owner = "colobot";
-    repo = "colobot";
+    repo = pname;
     rev = "colobot-gold-${version}";
-    sha256 = "0viq5s4zqs33an7rdmc3anf74ml7mwwcwf60alhvp9hj5jr547s2";
+    sha256 = "sha256-Nu7NyicNIk5yza9sXfd4KbGdB65guVuGREd6rwRU3lU=";
   };
-
-  patches = [
-    # Fix issue with newer compilers, like used in nixpkgs
-    # https://github.com/colobot/colobot/pull/1291
-    (fetchpatch {
-      url = "https://github.com/colobot/colobot/commit/fc2bd68876ac6302dbc8e91e8ffa33592db14b21.patch";
-      sha256 = "sha256-PKe8jeyHpTT86tprSafQhNqTYBrSonz+r2fL1lVJdfo=";
-    })
-  ];
 
   nativeBuildInputs = [ cmake xmlstarlet doxygen python3 ];
   buildInputs = [ boost SDL2 SDL2_image SDL2_ttf libpng glew gettext libsndfile libvorbis libogg physfs openal ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
