### PR TITLE
python3Packages.pytest-socket: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/development/python-modules/pytest-socket/default.nix
+++ b/pkgs/development/python-modules/pytest-socket/default.nix
@@ -1,23 +1,24 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , poetry-core
 , pytest
 , pythonOlder
+, setuptoolsBuildHook
 }:
 
 buildPythonPackage rec {
   pname = "pytest-socket";
-  version = "0.4.0";
-  disabled = pythonOlder "3.6";
+  version = "0.5.0";
   format = "pyproject";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "miketheman";
     repo = pname;
     rev = version;
-    sha256 = "sha256-cFYtJqZ/RjFbn9XlEy6ffxZ2djisajQAwjV/YR2f59Q=";
+    hash = "sha256-HdGkpIHFsoAG2+8UyL9jSb3Dm8bWkYzREdY3i15ls/Q=";
   };
 
   nativeBuildInputs = [
@@ -28,23 +29,12 @@ buildPythonPackage rec {
     pytest
   ];
 
-  checkInputs = [
-    pytest
-  ];
-
-  patches = [
-    # Switch to poetry-core, https://github.com/miketheman/pytest-socket/pull/74
-    (fetchpatch {
-      name = "switch-to-poetry-core.patch";
-      url = "https://github.com/miketheman/pytest-socket/commit/32519170e656e731d24b81770a170333d3efa6a8.patch";
-      sha256 = "19ksgx77rsa6ijcbml74alwc5052mdqr4rmvqhlzvfcvv3676ig2";
-    })
-  ];
-
   # pytest-socket require network for majority of tests
   doCheck = false;
 
-  pythonImportsCheck = [ "pytest_socket" ];
+  pythonImportsCheck = [
+    "pytest_socket"
+  ];
 
   meta = with lib; {
     description = "Pytest Plugin to disable socket calls during tests";

--- a/pkgs/development/python-modules/url-normalize/default.nix
+++ b/pkgs/development/python-modules/url-normalize/default.nix
@@ -1,8 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, poetry
-, pytest-cov
+, fetchpatch
+, poetry-core
 , pytest-flakes
 , pytest-mock
 , pytest-socket
@@ -19,22 +19,41 @@ buildPythonPackage rec {
     owner = "niksite";
     repo = pname;
     rev = version;
-    sha256 = "09nac5nh94x0n4bfazjfxk96b20mfsx6r1fnvqv85gkzs0rwqkaq";
+    hash = "sha256-WE3MM9B/voI23taFbLp2FYhl0uxOfuUWsaCTBG1hyiY=";
   };
 
-  nativeBuildInputs = [ poetry ];
+  nativeBuildInputs = [
+    poetry-core
+  ];
 
-  propagatedBuildInputs = [ six ];
+  propagatedBuildInputs = [
+    six
+  ];
 
   checkInputs = [
-    pytest-cov
     pytest-flakes
     pytest-mock
     pytest-socket
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "url_normalize" ];
+  patches = [
+    # Switch to poetry-core, https://github.com/niksite/url-normalize/pull/28
+    (fetchpatch {
+      name = "switch-to-poetry-core.patch";
+      url = "https://github.com/niksite/url-normalize/commit/b8557b10c977b191cc9d37e6337afe874a24ad08.patch";
+      sha256 = "sha256-SVCQATV9V6HbLmjOHs7V7eBagO0PuqZLubIJghBYfQQ=";
+    })
+  ];
+
+  postPatch = ''
+    sed -i "/--cov/d" tox.ini
+    sed -i "/--flakes/d" tox.ini
+  '';
+
+  pythonImportsCheck = [
+    "url_normalize"
+  ];
 
   meta = with lib; {
     description = "URL normalization for Python";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/miketheman/pytest-socket/releases/tag/0.5.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
