### PR TITLE
libcaca: 0.99.beta19 -> 0.99.beta20

### DIFF
--- a/pkgs/development/libraries/libcaca/default.nix
+++ b/pkgs/development/libraries/libcaca/default.nix
@@ -1,40 +1,32 @@
 { lib
 , stdenv
-, fetchurl
+, fetchFromGitHub
+, autoreconfHook
 , imlib2
 , libX11
 , libXext
 , ncurses
 , pkg-config
-, x11Support ? !stdenv.isDarwin
 , zlib
+, x11Support ? !stdenv.isDarwin
 }:
 
 stdenv.mkDerivation rec {
   pname = "libcaca";
-  version = "0.99.beta19";
+  version = "0.99.beta20";
 
-  src = fetchurl {
-    urls = [
-      "http://fossies.org/linux/privat/${pname}-${version}.tar.gz"
-      "http://caca.zoy.org/files/libcaca/${pname}-${version}.tar.gz"
-    ];
-    hash = "sha256-EotGfE7QMmTBh0BRcqToMEk0LMjML2VfU6LQ7p03cvQ=";
+  src = fetchFromGitHub {
+    owner = "cacalabs";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-N0Lfi0d4kjxirEbIjdeearYWvStkKMyV6lgeyNKXcVw=";
   };
 
-  outputs = [ "bin" "dev" "out" "man" ];
-
-  configureFlags = [
-    (if x11Support then "--enable-x11" else "--disable-x11")
-  ];
-
-  NIX_CFLAGS_COMPILE = lib.optionalString (!x11Support) "-DX_DISPLAY_MISSING";
-
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [
+    autoreconfHook
     pkg-config
   ];
+
   buildInputs = [
     ncurses
     zlib
@@ -43,6 +35,14 @@ stdenv.mkDerivation rec {
     libX11
     libXext
   ];
+
+  outputs = [ "bin" "dev" "out" "man" ];
+
+  configureFlags = [
+    (if x11Support then "--enable-x11" else "--disable-x11")
+  ];
+
+  NIX_CFLAGS_COMPILE = lib.optionalString (!x11Support) "-DX_DISPLAY_MISSING";
 
   postInstall = ''
     mkdir -p $dev/bin


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
