### PR TITLE
 fcitx5*: update

### DIFF
--- a/pkgs/development/libraries/libime/default.nix
+++ b/pkgs/development/libraries/libime/default.nix
@@ -26,13 +26,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "libime";
-  version = "1.0.10";
+  version = "1.0.11";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "libime";
     rev = version;
-    sha256 = "sha256-dHlya2vC3ugslP0K2oIHadcZQTmzt+tzNMkLy8V5M1Q=";
+    sha256 = "sha256-0yo0D9Yxn7tx1HtEaQvWCDwpWxnRVa1rIGK/mC4G8CI=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/tools/inputmethods/fcitx5/default.nix
+++ b/pkgs/tools/inputmethods/fcitx5/default.nix
@@ -41,13 +41,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "fcitx5";
-  version = "5.0.11";
+  version = "5.0.12";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = pname;
     rev = version;
-    sha256 = "sha256-81FuV6wBDQcOG5TLEJBqSG09BRgLekAo3tqZA40AQYo=";
+    sha256 = "sha256-v+K4rlUOBWoRXh7lNeETBbgtu5IJqYKXwSznIRzrrwE=";
   };
 
   prePatch = ''

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix
@@ -31,13 +31,13 @@ in
 
 mkDerivation rec {
   pname = "fcitx5-chinese-addons";
-  version = "5.0.9";
+  version = "5.0.10";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "fcitx5-chinese-addons";
     rev = version;
-    sha256 = "sha256-GnFIbvbLkL8YkLA3ziS8gBia9juDOkQWRcrXIPJAjLc=";
+    sha256 = "sha256-8h2cHjxcn1swm2TsH9pZu+ojOB6xlspdd4IIXYxZM/8=";
   };
 
   cmakeFlags = [

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-configtool.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-configtool.nix
@@ -19,13 +19,13 @@
 
 mkDerivation rec {
   pname = "fcitx5-configtool";
-  version = "5.0.9";
+  version = "5.0.10";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = pname;
     rev = version;
-    sha256 = "sha256-QPRaATx6TaysfZrFCR/Itc+4hx3sx7kLbahacQGrccE=";
+    sha256 = "sha256-PrzMKATv//LNGXl82J8dirNOjl6EDvlzGiarkMLaQqs=";
   };
 
   cmakeFlags = [

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-gtk.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-gtk.nix
@@ -26,13 +26,13 @@
 
 stdenv.mkDerivation rec {
   pname = "fcitx5-gtk";
-  version = "5.0.10";
+  version = "5.0.11";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = pname;
     rev = version;
-    sha256 = "sha256-QR2ZHP6dP7XcOCJw2BE1ak+mnRL0njV2T1+iBeMA+do=";
+    sha256 = "sha256-x2sOPybbAUM0/es9JM/F7A1+01HQPVwb9SCBpJ+ueRk=";
   };
 
   cmakeFlags = [

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-qt.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-qt.nix
@@ -12,13 +12,13 @@
 
 mkDerivation rec {
   pname = "fcitx5-qt";
-  version = "5.0.8";
+  version = "5.0.9";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "fcitx5-qt";
     rev = version;
-    sha256 = "sha256-S7hbcAyoS+gagqoL+C3YgcyjODnE+ZvHEFIoAqAmOxo=";
+    sha256 = "sha256-IXO1mRtkg4Tt9ZRuICdNWhK1UYYFNMbKGdGlUcdmsJY=";
   };
 
   preConfigure = ''

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-rime.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-rime.nix
@@ -6,22 +6,21 @@
 , gettext
 , fcitx5
 , librime
-, brise
 }:
 
 stdenv.mkDerivation rec {
   pname = "fcitx5-rime";
-  version = "5.0.9";
+  version = "5.0.10";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = pname;
     rev = version;
-    sha256 = "sha256-DRT4e59sMgS1xOIVx4t8I4aJGPprvRS6CYcNssIU2iY=";
+    sha256 = "sha256-cossoo/S1AzB5sHA+b2C49a6Uv8iVMYJAd32i9Y1is4=";
   };
 
   cmakeFlags = [
-    "-DRIME_DATA_DIR=${brise}/share/rime-data"
+    "-DRIME_DATA_DIR=${placeholder "out"}/share/rime-data"
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
Update. 

Brise is deprecated in fcitx5-rime and replaced by plum which can be used out of nix store. Furthermore, the old fcitx5-rime packing copied a file into brise causing an error, "premission denied".

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
