### PR TITLE
Easier kodi addon patching + fix bug in youtube kodi addon

### DIFF
--- a/pkgs/applications/video/kodi/addons/youtube/default.nix
+++ b/pkgs/applications/video/kodi/addons/youtube/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildKodiAddon, fetchzip, addonUpdateScript, six, requests, inputstreamhelper }:
+{ lib, buildKodiAddon, fetchpatch, fetchzip, addonUpdateScript, six, requests, inputstreamhelper }:
 
 buildKodiAddon rec {
   pname = "youtube";
@@ -22,6 +22,15 @@ buildKodiAddon rec {
       attrPath = "kodi.packages.youtube";
     };
   };
+
+  patches = [
+    # This patch can be removed once https://github.com/anxdpanic/plugin.video.youtube/pull/260 has been merged.
+    (fetchpatch {
+      name = "fix-addon-path";
+      url = "https://patch-diff.githubusercontent.com/raw/anxdpanic/plugin.video.youtube/pull/260.patch";
+      sha256 = "11c9sfwl5kvfll2jws5b4i46s60v6gkfns4al13p4m5ch9rk06hs";
+    })
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/anxdpanic/plugin.video.youtube";

--- a/pkgs/applications/video/kodi/build-kodi-addon.nix
+++ b/pkgs/applications/video/kodi/build-kodi-addon.nix
@@ -13,7 +13,7 @@ toKodiAddon (stdenv.mkDerivation ({
   installPhase = ''
     runHook preInstall
 
-    cd $src/$sourceDir
+    cd ./$sourceDir
     d=$out${addonDir}/${namespace}
     mkdir -p $d
     sauce="."


### PR DESCRIPTION
(There are 2 commits here: this PR might make more sense if you read them separately.)

###### Motivation for this change

I saw some errors when using the youtube kodi addon, which I fixed upstream: https://github.com/anxdpanic/plugin.video.youtube/pull/260, but also thought it would be nice to patch over here in the meantime.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
