### PR TITLE
mkShell: make it buildable

### DIFF
--- a/doc/builders/special/mkshell.section.md
+++ b/doc/builders/special/mkshell.section.md
@@ -25,7 +25,7 @@ pkgs.mkShell {
 * `name` (default: `nix-shell`). Set the name of the derivation.
 * `packages` (default: `[]`). Add executable packages to the `nix-shell` environment.
 * `inputsFrom` (default: `[]`). Add build dependencies of the listed derivations to the `nix-shell` environment.
-* `shellHook` (default: `""`). Bash script that is executed by `nix-shell`.
+* `shellHook` (default: `""`). Bash statements that are executed by `nix-shell`.
 
 ... all the attributes of `stdenv.mkDerivation`.
 

--- a/doc/builders/special/mkshell.section.md
+++ b/doc/builders/special/mkshell.section.md
@@ -24,7 +24,7 @@ pkgs.mkShell {
 
 * `name` (default: `nix-shell`). Set the name of the derivation.
 * `packages` (default: `[]`). Add build dependencies to the `nix-shell` environment.
-* `inputsFrom` (default: `[]`). Add build dependencies of the dependencies to the `nix-shell` environment.
+* `inputsFrom` (default: `[]`). Add build dependencies of the listed derivations to the `nix-shell` environment.
 * `shellHook` (default: `""`). Bash script that is executed by `nix-shell`.
 
 ... all the attributes of `stdenv.mkDerivation`.

--- a/doc/builders/special/mkshell.section.md
+++ b/doc/builders/special/mkshell.section.md
@@ -23,7 +23,7 @@ pkgs.mkShell {
 ## Attributes
 
 * `name` (default: `nix-shell`). Set the name of the derivation.
-* `packages` (default: `[]`). Add build dependencies to the `nix-shell` environment.
+* `packages` (default: `[]`). Add executable packages to the `nix-shell` environment.
 * `inputsFrom` (default: `[]`). Add build dependencies of the listed derivations to the `nix-shell` environment.
 * `shellHook` (default: `""`). Bash script that is executed by `nix-shell`.
 

--- a/doc/builders/special/mkshell.section.md
+++ b/doc/builders/special/mkshell.section.md
@@ -1,17 +1,37 @@
 # pkgs.mkShell {#sec-pkgs-mkShell}
 
-`pkgs.mkShell` is a special kind of derivation that is only useful when using
-it combined with `nix-shell`. It will in fact fail to instantiate when invoked
-with `nix-build`.
+`pkgs.mkShell` is a specialized `stdenv.mkDerivation` that removes some
+repetition when using it with `nix-shell` (or `nix develop`).
 
 ## Usage {#sec-pkgs-mkShell-usage}
+
+Here is a common usage example:
 
 ```nix
 { pkgs ? import <nixpkgs> {} }:
 pkgs.mkShell {
-  # specify which packages to add to the shell environment
   packages = [ pkgs.gnumake ];
-  # add all the dependencies, of the given packages, to the shell environment
-  inputsFrom = with pkgs; [ hello gnutar ];
+
+  inputsFrom = [ pkgs.hello pkgs.gnutar ];
+
+  shellHook = ''
+    export DEBUG=1
+  '';
 }
 ```
+
+## Attributes
+
+* `name` (default: `nix-shell`). Set the name of the derivation.
+* `packages` (default: `[]`). Add build dependencies to the `nix-shell` environment.
+* `inputsFrom` (default: `[]`). Add build dependencies of the dependencies to the `nix-shell` environment.
+* `shellHook` (default: `""`). Bash script that is executed by `nix-shell`.
+
+... all the attributes of `stdenv.mkDerivation`.
+
+## Building the shell
+
+This derivation output will contain a text file that contains a reference to
+all the build inputs. This is useful in CI where we want to make sure that
+every derivation, and its dependencies, build properly. Or when creating a GC
+root so that the build dependencies don't get garbage-collected.

--- a/pkgs/build-support/mkshell/default.nix
+++ b/pkgs/build-support/mkshell/default.nix
@@ -1,9 +1,9 @@
-{ lib, stdenv }:
+{ lib, stdenv, buildEnv }:
 
 # A special kind of derivation that is only meant to be consumed by the
 # nix-shell.
-{
-  # a list of packages to add to the shell environment
+{ name ? "nix-shell"
+, # a list of packages to add to the shell environment
   packages ? [ ]
 , # propagate all the inputs from the given derivations
   inputsFrom ? [ ]
@@ -15,10 +15,11 @@
 }@attrs:
 let
   mergeInputs = name:
-    (attrs.${name} or []) ++
+    (attrs.${name} or [ ]) ++
     (lib.subtractLists inputsFrom (lib.flatten (lib.catAttrs name inputsFrom)));
 
   rest = builtins.removeAttrs attrs [
+    "name"
     "packages"
     "inputsFrom"
     "buildInputs"
@@ -30,8 +31,7 @@ let
 in
 
 stdenv.mkDerivation ({
-  name = "nix-shell";
-  phases = [ "nobuildPhase" ];
+  inherit name;
 
   buildInputs = mergeInputs "buildInputs";
   nativeBuildInputs = packages ++ (mergeInputs "nativeBuildInputs");
@@ -41,10 +41,14 @@ stdenv.mkDerivation ({
   shellHook = lib.concatStringsSep "\n" (lib.catAttrs "shellHook"
     (lib.reverseList inputsFrom ++ [ attrs ]));
 
-  nobuildPhase = ''
-    echo
-    echo "This derivation is not meant to be built, aborting";
-    echo
-    exit 1
+  phases = [ "buildPhase" ];
+
+  buildPhase = ''
+    echo "-------------------------------------------" >> $out
+    echo " Do not use this file. See the mkShell doc." >>$out
+    echo "-------------------------------------------" >> $out
+    echo >> $out
+    # Record all build inputs as runtime dependencies
+    export >> $out
   '';
 } // rest)

--- a/pkgs/build-support/mkshell/default.nix
+++ b/pkgs/build-support/mkshell/default.nix
@@ -44,9 +44,10 @@ stdenv.mkDerivation ({
   phases = [ "buildPhase" ];
 
   buildPhase = ''
-    echo "-------------------------------------------" >> $out
-    echo " Do not use this file. See the mkShell doc." >>$out
-    echo "-------------------------------------------" >> $out
+    echo "------------------------------------------------------------" >>$out
+    echo " WARNING: this file existence or location is not guaranteed." >>$out
+    echo " It is an internal implementation detail for pkgs.mkShell."   >>$out
+    echo "------------------------------------------------------------" >>$out
     echo >> $out
     # Record all build inputs as runtime dependencies
     export >> $out

--- a/pkgs/build-support/mkshell/default.nix
+++ b/pkgs/build-support/mkshell/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation ({
 
   buildPhase = ''
     echo "------------------------------------------------------------" >>$out
-    echo " WARNING: this file existence or location is not guaranteed." >>$out
+    echo " WARNING: the existence of this path is not guaranteed." >>$out
     echo " It is an internal implementation detail for pkgs.mkShell."   >>$out
     echo "------------------------------------------------------------" >>$out
     echo >> $out


### PR DESCRIPTION
When I designed `mkShell`, I didn't have a good idea of what the output
should look like and so decided to make the build fail. In practice,
this causes quite a bit of confusion and complications because now the
shell cannot be part of a normal package set without failing the CI as
well.

This commit changes that build phase to record all the build inputs in a
file. That way it becomes possible to build it, makes sure that all the
build inputs get built as well, and also can be used as a GC root.
(by applying the same trick as #95536).

The documentation has also been improved to better describe what mkShell
does and how to use it.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
