### PR TITLE
rtrtr: init at 0.1.2

### DIFF
--- a/pkgs/servers/rtrtr/default.nix
+++ b/pkgs/servers/rtrtr/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, stdenv
+, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rtrtr";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "NLnetLabs";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-8wcmciQ2OcvMNl6gADte40jrP+VfhoKn95ofjyjtRIo=";
+  };
+
+  cargoSha256 = "sha256-Jdu5U56Duqzakvj3rldzch17y1nhJmuxwJtq4Ydx3IY=";
+
+  buildInputs = lib.optional stdenv.isDarwin Security;
+  nativeBuildInputs = [ pkg-config ];
+
+  buildNoDefaultFeatures = true;
+
+  meta = with lib; {
+    description = "RPKI data proxy";
+    longDescription = ''
+      TRTR is an RPKI data proxy, designed to collect Validated ROA Payloads
+      from one or more sources in multiple formats and dispatch it onwards. It
+      provides the means to implement multiple distribution architectures for RPKI
+      such as centralised RPKI validators that dispatch data to local caching RTR
+      servers. RTRTR can read RPKI data from multiple RPKI Relying Party packages via
+      RTR and JSON and, in turn, provide an RTR service for routers to connect to.
+    '';
+    homepage = "https://github.com/NLnetLabs/rtrtr";
+    changelog = "https://github.com/NLnetLabs/rtrtr/blob/v${version}/Changelog.md";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ steamwalker ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3769,6 +3769,10 @@ with pkgs;
     libmaxminddb = null;
   };
 
+  rtrtr = callPackage ../servers/rtrtr {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   xmlbeans = callPackage ../tools/misc/xmlbeans { };
 
   xmlsort = perlPackages.XMLFilterSort;


### PR DESCRIPTION
###### Motivation for this change

New package for this project from the same people that brought us nsd, unbound, krill and routinator (already packaged).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
