### PR TITLE
very WIP solo5: 0.6.9 -> 0.7.0

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -38,6 +38,7 @@ rec {
         else if final.isAndroid             then "bionic"
         else if final.isLinux /* default */ then "glibc"
         else if final.isAvr                 then "avrlibc"
+        else if final.isSolo5               then "none" # XXX
         else if final.isNone                then "newlib"
         else if final.isNetBSD              then "nblibc"
         # TODO(@Ericson2314) think more about other operating systems
@@ -89,7 +90,7 @@ rec {
          # uname -r
          release = null;
       };
-      isStatic = final.isWasm || final.isRedox;
+      isStatic = final.isWasm || final.isRedox || final.isSolo5;
 
       # Just a guess, based on `system`
       inherit

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -211,6 +211,22 @@ rec {
   };
 
   #
+  # Solo5
+  #
+
+  aarch64-solo5 = {
+    config = "aarch64-solo5-none";
+    linker = "lld";
+    useLLVM = true;
+  };
+
+  x86_64-linux-solo5 = {
+    config = "aarch64-solo5-none";
+    linker = "lld";
+    useLLVM = true;
+  };
+
+  #
   # Darwin
   #
 

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -53,6 +53,7 @@ rec {
     isRedox        = { kernel = kernels.redox; };
     isGhcjs        = { kernel = kernels.ghcjs; };
     isGenode       = { kernel = kernels.genode; };
+    isSolo5        = { vendor = vendors.solo5; };
     isNone         = { kernel = kernels.none; };
 
     isAndroid      = [ { abi = abis.android; } { abi = abis.androideabi; } ];

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -236,6 +236,7 @@ rec {
     # Actually matters, unlocking some MinGW-w64-specific options in GCC. See
     # bottom of https://sourceforge.net/p/mingw-w64/wiki2/Unicode%20apps/
     w64 = {};
+    solo5 = {};
 
     none = {};
     unknown = {};
@@ -426,6 +427,8 @@ rec {
       else if (elemAt l 2 == "ghcjs")
         then { cpu = elemAt l 0; vendor = "unknown"; kernel = elemAt l 2; }
       else if hasPrefix "genode" (elemAt l 2)
+        then { cpu = elemAt l 0; vendor = elemAt l 1; kernel = elemAt l 2; }
+      else if elemAt l 1 == "solo5"
         then { cpu = elemAt l 0; vendor = elemAt l 1; kernel = elemAt l 2; }
       else throw "Target specification with 3 components is ambiguous";
     "4" =    { cpu = elemAt l 0; vendor = elemAt l 1; kernel = elemAt l 2; abi = elemAt l 3; };

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -17,6 +17,12 @@
 , isGNU ? false, isClang ? cc.isClang or false, gnugrep ? null
 , buildPackages ? {}
 , libcxx ? null
+  # Prefix for binaries. Customarily ends with a dash separator.
+  #
+  # TODO(@Ericson2314) Make unconditional, or optional but always true by
+  # default.
+, targetPrefix ? with stdenvNoCC;
+    lib.optionalString (targetPlatform != hostPlatform) (targetPlatform.config + "-")
 }:
 
 with lib;
@@ -30,13 +36,6 @@ assert (noLibc || nativeLibc) == (libc == null);
 let
   stdenv = stdenvNoCC;
   inherit (stdenv) hostPlatform targetPlatform;
-
-  # Prefix for binaries. Customarily ends with a dash separator.
-  #
-  # TODO(@Ericson2314) Make unconditional, or optional but always true by
-  # default.
-  targetPrefix = lib.optionalString (targetPlatform != hostPlatform)
-                                           (targetPlatform.config + "-");
 
   ccVersion = lib.getVersion cc;
   ccName = lib.removePrefix targetPrefix (lib.getName cc);

--- a/pkgs/os-specific/solo5/default.nix
+++ b/pkgs/os-specific/solo5/default.nix
@@ -1,74 +1,134 @@
-{ lib, stdenv, fetchurl, pkg-config, libseccomp, util-linux, qemu }:
+{ lib, stdenv, fetchurl, pkg-config, libseccomp, util-linux, qemu, coreutils
+, writeShellScriptBin
+, pkgsHostTarget
+, pkgsBuildTarget
+, enableToolchain ? stdenv.targetPlatform.isSolo5
+}:
 
 let
-  version = "0.6.9";
-  # list of all theoretically available targets
-  targets = [
-    "genode"
-    "hvt"
-    "muen"
-    "spt"
-    "virtio"
-    "xen"
-  ];
-in stdenv.mkDerivation {
-  pname = "solo5";
+  version = "0.7.0";
+
+  hostTargetBintools = pkgsHostTarget.bintools;
+
+  # gcc is theoretical, since we can't compile it with libc == null atm
+  hostTargetCC =
+    if stdenv.targetPlatform.useLLVM or false
+    then pkgsHostTarget.llvmPackages.clang-unwrapped
+    else pkgsHostTarget.gcc-unwrapped;
+
+  unwrappedCompiler =
+    /**/ if hostTargetCC.isClang or false then "clang"
+    else if hostTargetCC.isGNU or false then "${targetPrefix}gcc"
+    else "${targetPrefix}cc";
+
+  # build->target uses wrapped ones, so stuff compiles properly
+  buildTargetCC =
+    if stdenv.targetPlatform.useLLVM or false
+    then pkgsBuildTarget.llvmPackages.clangNoLibcxx
+    else pkgsBuildTarget.gcc;
+
+  targetPrefix = "${stdenv.targetPlatform.config}-";
+in
+
+if !(enableToolchain -> (with stdenv.targetPlatform; isx86_64 || isAarch64))
+then throw "solo5 only supports aarch64 and x86_64 as targets"
+else
+
+stdenv.mkDerivation {
+  pname =
+    lib.optionalString enableToolchain targetPrefix
+    + "solo5"
+    + lib.optionalString (!enableToolchain) "-tools";
   inherit version;
 
+  depsBuildTarget = [ buildTargetCC ];
   nativeBuildInputs = [ pkg-config ];
   buildInputs = lib.optional (stdenv.hostPlatform.isLinux) libseccomp;
 
   src = fetchurl {
     url = "https://github.com/Solo5/solo5/releases/download/v${version}/solo5-v${version}.tar.gz";
-    sha256 = "03lvk9mab3yxrmi73wrvvhykqcydjrsda0wj6aasnjm5lx9jycpr";
+    sha256 = "132hjmwy0sh2ghx9gd8cbd5p9g7vx00afqcyd6snniw6ig9sxc1r";
   };
 
   hardeningEnable = [ "pie" ];
+  # -fPIC is passed after -fPIE and removes the __PIE__ CPP macro, stopping
+  # configure.sh from detecting PIE support.
+  hardeningDisable = [ "pic" ];
 
-  configurePhase = ''
-    runHook preConfigure
-    sh configure.sh
-    runHook postConfigure
+  patches = [
+    ./pkg-config-env.patch
+  ];
+
+  preConfigure = ''
+    export HOST_CC=$CC
+    export HOST_AR=$AR
+    export HOST_PKG_CONFIG=$PKG_CONFIG
+
+    makeFlagsArray+=(
+      "SUBDIRS=elftool bindings tenders toolchain"
+    )
+  ''
+  + lib.optionalString enableToolchain ''
+    export TARGET_CC=$CC_FOR_TARGET
+    export TARGET_LD=$LD_FOR_TARGET
+    export TARGET_OBJCOPY=$OBJCOPY_FOR_TARGET
   '';
 
-  enableParallelBuilding = true;
+  configureScript = "./configure.sh";
+  configurePlatforms = [ ]; # configure.sh doesn't know about these flags
+  configureFlags = lib.optionals (!enableToolchain) [ "--disable-toolchain" ];
 
-  installPhase = ''
-    runHook preInstall
-    export DESTDIR=$out
-    export PREFIX=$out
-    make install-tools
+  makeFlags = [
+    "HOSTAR=$(HOST_AR)" # TODO patch in HOST_AR for configure.sh
+    #"V=1"
+  ];
 
-    # get CONFIG_* vars from Makeconf which also parse in sh
-    grep '^CONFIG_' Makeconf > nix_tmp_targetconf
-    source nix_tmp_targetconf
-    # install opam / pkg-config files for all enabled targets
-    ${lib.concatMapStrings (bind: ''
-      [ -n "$CONFIG_${lib.toUpper bind}" ] && make install-opam-${bind}
-    '') targets}
+  enableParallelBuilding = false; # TODO
 
-    runHook postInstall
-  '';
-
-  doCheck = stdenv.hostPlatform.isLinux;
+  doCheck = enableToolchain
+    && stdenv.hostPlatform.isLinux
+    && !stdenv.hostPlatform.isAarch64
+    && false;
   checkInputs = [ util-linux qemu ];
   checkPhase = ''
     runHook preCheck
+    make $makeFlags tests
     patchShebangs tests
     ./tests/bats-core/bats ./tests/tests.bats
     runHook postCheck
   '';
+
+      #sed -i '2i export PATH=${
+      #  lib.makeBinPath [ hostTargetCC hostTargetBintools coreutils ]
+      #}' "$toolPath"
+  postInstall = ''
+    ls $out/bin
+    for tool in cc ld objcopy; do
+      toolPath="$out/bin/${stdenv.targetPlatform.parsed.cpu.name}-solo5-none-static-$tool"
+
+      substituteInPlace "$toolPath" \
+        --replace "exec $CC_FOR_TARGET" "exec ${hostTargetCC}/bin/${unwrappedCompiler}"
+
+      ln -s "$toolPath" "$out/bin/${targetPrefix}$tool"
+    done
+
+    ln -sL "$out/bin/${targetPrefix}cc" "$out/bin/${unwrappedCompiler}"
+  '';
+
+  passthru = {
+    isClang = hostTargetCC.isClang or false;
+    isGNU = hostTargetCC.isGNU or false;
+
+    bintools = hostTargetBintools;
+
+    inherit targetPrefix;
+  };
 
   meta = with lib; {
     description = "Sandboxed execution environment";
     homepage = "https://github.com/solo5/solo5";
     license = licenses.isc;
     maintainers = [ maintainers.ehmry ];
-    platforms = builtins.map ({arch, os}: "${arch}-${os}")
-      (cartesianProductOfSets {
-        arch = [ "aarch64" "x86_64" ];
-        os = [ "freebsd" "genode" "linux" "openbsd" ];
-      });
+    platforms = platforms.freebsd ++ platforms.linux ++ platforms.openbsd;
   };
-
 }

--- a/pkgs/os-specific/solo5/pkg-config-env.patch
+++ b/pkgs/os-specific/solo5/pkg-config-env.patch
@@ -1,0 +1,45 @@
+diff --git a/configure.sh b/configure.sh
+index a7b0949..2761b23 100755
+--- a/configure.sh
++++ b/configure.sh
+@@ -281,6 +281,8 @@ case ${HOST_CC_MACHINE} in
+         ;;
+ esac
+ 
++HOST_PKG_CONFIG=${HOST_PKG_CONFIG:-pkg-config}
++
+ CONFIG_SPT_TENDER_NO_PIE=
+ CONFIG_SPT_TENDER_LIBSECCOMP_CFLAGS=
+ CONFIG_SPT_TENDER_LIBSECCOMP_LDFLAGS=
+@@ -295,24 +297,24 @@ if [ -n "${CONFIG_SPT_TENDER}" ]; then
+         CONFIG_SPT_TENDER_NO_PIE=1
+     fi
+ 
+-    if ! command -v pkg-config >/dev/null; then
+-        die "pkg-config is required"
++    if ! command -v $HOST_PKG_CONFIG >/dev/null; then
++        die "pkg-config is required: $HOST_PKG_CONFIG not in PATH"
+     fi
+-    if ! pkg-config libseccomp; then
++    if ! $HOST_PKG_CONFIG libseccomp; then
+         die "libseccomp development headers are required"
+     else
+-        if ! pkg-config --atleast-version=2.3.3 libseccomp; then
++        if ! $HOST_PKG_CONFIG --atleast-version=2.3.3 libseccomp; then
+             # TODO Make this a hard error once there are no distros with
+             # libseccomp < 2.3.3 in the various CIs.
+             warn "libseccomp >= 2.3.3 is required" \
+                 "for correct spt tender operation"
+             warn "Proceeding anyway, expect tests to fail"
+-        elif ! pkg-config --atleast-version=2.4.1 libseccomp; then
++        elif ! $HOST_PKG_CONFIG --atleast-version=2.4.1 libseccomp; then
+             warn "libseccomp < 2.4.1 has known vulnerabilities"
+             warn "Proceeding anyway, but consider upgrading"
+         fi
+-        CONFIG_SPT_TENDER_LIBSECCOMP_CFLAGS="$(pkg-config --cflags libseccomp)"
+-        CONFIG_SPT_TENDER_LIBSECCOMP_LDLIBS="$(pkg-config --libs libseccomp)"
++        CONFIG_SPT_TENDER_LIBSECCOMP_CFLAGS="$($HOST_PKG_CONFIG --cflags libseccomp)"
++        CONFIG_SPT_TENDER_LIBSECCOMP_LDLIBS="$($HOST_PKG_CONFIG --libs libseccomp)"
+     fi
+     if ! CC="${HOST_CC}" PKG_CFLAGS="${CONFIG_SPT_TENDER_LIBSECCOMP_CFLAGS}" \
+         cc_check_header seccomp.h; then

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -71,6 +71,8 @@ in lib.init bootStages ++ [
              then throw "no C compiler provided for this platform"
            else if crossSystem.isDarwin
              then buildPackages.llvmPackages.clang
+           else if crossSystem.isSolo5
+             then buildPackages.solo5-toolchain
            else if crossSystem.useLLVM or false
              then buildPackages.llvmPackages.clangUseLLVM
            else buildPackages.gcc;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22912,7 +22912,26 @@ with pkgs;
 
   smimesign = callPackage ../os-specific/darwin/smimesign { };
 
-  solo5 = callPackage ../os-specific/solo5 { };
+  solo5 = callPackage ../os-specific/solo5 { }; # XXX
+  solo5-tools = callPackage ../os-specific/solo5 {
+    enableToolchain = false;
+  };
+
+  solo5-toolchain-unwrapped = callPackage ../os-specific/solo5 {
+    enableToolchain = true;
+  };
+
+  solo5-toolchain = wrapCCWith rec {
+    cc = solo5-toolchain-unwrapped;
+    inherit (solo5-toolchain-unwrapped) targetPrefix;
+    bintools = wrapBintoolsWith {
+      bintools = solo5-toolchain-unwrapped;
+    };
+    # XXX lol
+    extraBuildCommands = ''
+      echo "-target aarch64-unknown-linux" >> "$out/nix-support/cc-cflags"
+    '';
+  };
 
   speedometer = callPackage ../os-specific/linux/speedometer { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16702,6 +16702,7 @@ with pkgs;
     else if name == "wasilibc" then targetPackages.wasilibc or wasilibc
     else if name == "relibc" then targetPackages.relibc or relibc
     else if stdenv.targetPlatform.isGhcjs then null
+    else if stdenv.targetPlatform.isSolo5 then null
     else throw "Unknown libc ${name}";
 
   libcCross = assert stdenv.targetPlatform != stdenv.buildPlatform; libcCrossChooser stdenv.targetPlatform.libc;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Mainly opening this, so we don't duplicate the effort accidentally. My goal is to have `pkgsCross.{aarch64,x86_64}-solo5` in the end which just work™ for packages that support it. Specifically, the ocaml compiler in these sets could then automatically switch to `ocaml-freestanding` and we may even be able to have a proper package sets for MirageOS unikernels…

However, there are currently a few problems:

* Configuring the package set with a consistent platform config seems extremely difficult. `solo5` has chosen `{aarch64,x86_64}-solo5-none-static` as its configuration which we would translate to `{aarch64,x86_64}-solo5-none` since the link type is stored independently from the platform string for us (Alternatively `{aarch64,x86_64}-solo5-none-elf` would be more in line with our other "embedded" platforms, however autotools does not like this string at all and I am relatively sure that the embedded `config`s we pass currently work more by accident). The vendor is enough to throw binutils off and stop it from compiling (I have no clue about gcc as it's not possible to compile without a target libc atm). LLVM swallows the target, but behaves weirdly, insisting on using `gcc` for linking despite `-fuse-ld` being passed. Since solo5's toolchain is intended as a bunch of wrapper scripts around a normal linux toolchain you already have, there seems little interest from their side to upstream this into autotools, binutils, LLVM, ... which is annoying, because it means, in order to build the toolchain, we have to configure parts of it with different triples than `targetPlatform.config`.
  A related problem is that the config string is not configurable in solo5's configure script, so we'll have to patch that in eventually.
* Upstream seems to mostly have tested `build == host == target`, but supports `build == host != target` *theoretically*. The later case is more or less broken with `clang` however which is the only real option for us atm (it basically ignores that clang is multi target and will never pass `-target` to it).
* Since this is a wrapper script around a toolchain, we are faced with the choice what to wrap: the wrapped compiler (and reimplement the API / setup hooks of `cc-wrapper`) or the unwrapped compiler. The latter is the better choice in general (I think at least), but unfortunately quite tricky to implement, because everything mashed together into a single build: solo5 specific bintools, solo5 toolchain wrappers, solo5 runtime libs etc. Untangling this will probably require quite a bit of patching.

These are just a few notes and may be out of date quite quickly when I continue working on this. The current state is *quite* hacky, but sort of works: the "native" toolchain `pkgs.solo5-toolchain` works from what I can tell, the cross one `pkgsCross.aarch64-solo5` works but chokes on linking which I currently would attribute to some flags getting passed to `lld` which shouldn't, but I still need to confirm this theory.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
