### PR TITLE
element-{web,desktop}: 1.9.7 -> 1.9.8

### DIFF
--- a/pkgs/applications/networking/instant-messengers/element/element-desktop-package.json
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop-package.json
@@ -2,7 +2,7 @@
   "name": "element-desktop",
   "productName": "Element",
   "main": "lib/electron-main.js",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "description": "A feature-rich client for Matrix.org",
   "author": "Element",
   "repository": {
@@ -52,9 +52,10 @@
     "@types/auto-launch": "^5.0.1",
     "@types/counterpart": "^0.18.1",
     "@types/minimist": "^1.2.1",
-    "@typescript-eslint/eslint-plugin": "^4.17.0",
-    "@typescript-eslint/parser": "^4.17.0",
+    "@typescript-eslint/eslint-plugin": "^5.6.0",
+    "@typescript-eslint/parser": "^5.6.0",
     "allchange": "^1.0.6",
+    "app-builder-lib": "^22.14.10",
     "asar": "^2.0.1",
     "chokidar": "^3.5.2",
     "electron": "13.5",
@@ -75,7 +76,7 @@
     "pacote": "^11.3.5",
     "rimraf": "^3.0.2",
     "tar": "^6.1.2",
-    "typescript": "^4.1.3"
+    "typescript": "^4.5.3"
   },
   "hakDependencies": {
     "matrix-seshat": "^2.3.0",
@@ -83,7 +84,6 @@
   },
   "build": {
     "appId": "im.riot.app",
-    "electronVersion": "13.5.2",
     "files": [
       "package.json",
       {

--- a/pkgs/applications/networking/instant-messengers/element/pin.json
+++ b/pkgs/applications/networking/instant-messengers/element/pin.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.9.7",
-  "desktopSrcHash": "bUzIIPNVgK2whQJoEZOaoa+jsJx4No+xji6hXK6wxFY=",
-  "desktopYarnHash": "1n9dqpvq31k94mx5s1dgqavaxdd0jrzcwdx106c5dnq6xnxs941p",
-  "webHash": "1fx1nznqbwvs84kpc239ms9kpzy9p72hrz3qqbzay8p9x4gc1ws3"
+  "version": "1.9.8",
+  "desktopSrcHash": "o6SICu7QDdBv9WXDconkypQRj3TbrU4ZAxayO9yemvc=",
+  "desktopYarnHash": "176ih0nzzx2yds6kp3lzdsrlp0glb9nqw146z0s1az7pjp6nrf18",
+  "webHash": "141fqvh4d5lwm692yc8mfwrlvqnfixvc7vlbfis86qi557vq6ljq"
 }


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
ChangeLog: https://github.com/vector-im/element-desktop/releases/tag/v1.9.8
ChangeLog: https://github.com/vector-im/element-web/releases/tag/v1.9.8


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
