### PR TITLE
Add minimal NixOS entrypoint

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,9 @@
     in
     {
       lib = lib.extend (final: prev: {
+
+        nixos = import ./nixos/lib { lib = final; };
+
         nixosSystem = { modules, ... } @ args:
           import ./nixos/lib/eval-config.nix (args // {
             modules =

--- a/nixos/lib/default.nix
+++ b/nixos/lib/default.nix
@@ -1,5 +1,25 @@
-{ lib ? import ../../lib, ... }:
 let
+  # The warning is in a top-level let binding so it is only printed once.
+  minimalModulesWarning = warn "lib.nixos.evalModules is experimental and subject to change. See nixos/lib/default.nix" null;
+  inherit (nonExtendedLib) warn;
+  nonExtendedLib = import ../../lib;
+in
+{ # Optional. Allows an extended `lib` to be used instead of the regular Nixpkgs lib.
+  lib ? nonExtendedLib,
+
+  # Feature flags allow you to opt in to unfinished code. These may change some
+  # behavior or disable warnings.
+  featureFlags ? {},
+
+  # This file itself is rather new, so we accept unknown parameters to be forward
+  # compatible. This is generally not recommended, because typos go undetected.
+  ...
+}:
+let
+  seqIf = cond: if cond then builtins.seq else a: b: b;
+  # If cond, force `a` before returning any attr
+  seqAttrsIf = cond: a: lib.mapAttrs (_: v: seqIf cond a v);
+
   eval-config-minimal = import ./eval-config-minimal.nix { inherit lib; };
 in
 /*
@@ -7,7 +27,7 @@ in
   using a binding like `nixosLib = import (nixpkgs + "/nixos/lib") { }`.
 */
 {
-  inherit (eval-config-minimal)
+  inherit (seqAttrsIf (!featureFlags?minimalModules) minimalModulesWarning eval-config-minimal)
     evalModules
     ;
 }

--- a/nixos/lib/default.nix
+++ b/nixos/lib/default.nix
@@ -1,47 +1,13 @@
+{ lib ? import ../../lib, ... }:
 let
-  # The warning is in a top-level let binding so it is only printed once.
-  experimentalWarning = warn "lib.nixos.evalModules is experimental and subject to change. See nixos/lib/default.nix" null;
-  inherit (nonExtendedLib) warn;
-  nonExtendedLib = import ../../lib;
+  eval-config-minimal = import ./eval-config-minimal.nix { inherit lib; };
 in
-{ lib ? nonExtendedLib, ... }:
-let
-
-  /*
-    Invoke NixOS. Unlike traditional NixOS, this does not include all modules.
-    Any such modules have to be explicitly added via the `modules` parameter,
-    or imported using `imports` in a module.
-
-    A minimal module list improves NixOS evaluation performance and allows
-    modules to be independently usable, supporting new use cases.
-
-    Parameters:
-
-      modules:        A list of modules that constitute the configuration.
-
-      specialArgs:    An attribute set of module arguments. Unlike
-                      `config._module.args`, these are available for use in
-                      `imports`.
-                      `config._module.args` should be preferred when possible.
-
-    Return:
-
-      An attribute set containing `config.system.build.toplevel` among other
-      attributes. See `lib.evalModules` in the Nixpkgs library.
-
-   */
-  evalModules = {
-    prefix ? [],
-    modules ? [],
-    specialArgs ? {},
-  }: lib.evalModules {
-    inherit prefix modules;
-    specialArgs = {
-      modulesPath = builtins.toString ../modules;
-    } // specialArgs;
-  };
-
-in
+/*
+  This attribute set appears as lib.nixos in the flake, or can be imported
+  using a binding like `nixosLib = import (nixpkgs + "/nixos/lib") { }`.
+*/
 {
-  evalModules = builtins.seq experimentalWarning evalModules;
+  inherit (eval-config-minimal)
+    evalModules
+    ;
 }

--- a/nixos/lib/default.nix
+++ b/nixos/lib/default.nix
@@ -1,0 +1,47 @@
+let
+  # The warning is in a top-level let binding so it is only printed once.
+  experimentalWarning = warn "lib.nixos.evalModules is experimental and subject to change. See nixos/lib/default.nix" null;
+  inherit (nonExtendedLib) warn;
+  nonExtendedLib = import ../../lib;
+in
+{ lib ? nonExtendedLib, ... }:
+let
+
+  /*
+    Invoke NixOS. Unlike traditional NixOS, this does not include all modules.
+    Any such modules have to be explicitly added via the `modules` parameter,
+    or imported using `imports` in a module.
+
+    A minimal module list improves NixOS evaluation performance and allows
+    modules to be independently usable, supporting new use cases.
+
+    Parameters:
+
+      modules:        A list of modules that constitute the configuration.
+
+      specialArgs:    An attribute set of module arguments. Unlike
+                      `config._module.args`, these are available for use in
+                      `imports`.
+                      `config._module.args` should be preferred when possible.
+
+    Return:
+
+      An attribute set containing `config.system.build.toplevel` among other
+      attributes. See `lib.evalModules` in the Nixpkgs library.
+
+   */
+  evalModules = {
+    prefix ? [],
+    modules ? [],
+    specialArgs ? {},
+  }: lib.evalModules {
+    inherit prefix modules;
+    specialArgs = {
+      modulesPath = builtins.toString ../modules;
+    } // specialArgs;
+  };
+
+in
+{
+  evalModules = builtins.seq experimentalWarning evalModules;
+}

--- a/nixos/lib/eval-config-minimal.nix
+++ b/nixos/lib/eval-config-minimal.nix
@@ -1,10 +1,7 @@
-let
-  # The warning is in a top-level let binding so it is only printed once.
-  experimentalWarning = warn "lib.nixos.evalModules is experimental and subject to change. See nixos/lib/default.nix" null;
-  inherit (nonExtendedLib) warn;
-  nonExtendedLib = import ../../lib;
-in
-{ lib ? nonExtendedLib, bypassEvalModulesWarning ? false, ... }:
+
+# DO NOT IMPORT. Use nixpkgsFlake.lib.nixos, or import (nixpkgs + "/nixos/lib")
+{ lib }: # read -^
+
 let
 
   /*
@@ -43,5 +40,5 @@ let
 
 in
 {
-  evalModules = builtins.seq (if bypassEvalModulesWarning then null else experimentalWarning) evalModules;
+  inherit evalModules;
 }

--- a/nixos/lib/eval-config-minimal.nix
+++ b/nixos/lib/eval-config-minimal.nix
@@ -4,7 +4,7 @@ let
   inherit (nonExtendedLib) warn;
   nonExtendedLib = import ../../lib;
 in
-{ lib ? nonExtendedLib, ... }:
+{ lib ? nonExtendedLib, bypassEvalModulesWarning ? false, ... }:
 let
 
   /*
@@ -43,5 +43,5 @@ let
 
 in
 {
-  evalModules = builtins.seq experimentalWarning evalModules;
+  evalModules = builtins.seq (if bypassEvalModulesWarning then null else experimentalWarning) evalModules;
 }

--- a/nixos/lib/eval-config-minimal.nix
+++ b/nixos/lib/eval-config-minimal.nix
@@ -1,0 +1,47 @@
+let
+  # The warning is in a top-level let binding so it is only printed once.
+  experimentalWarning = warn "lib.nixos.evalModules is experimental and subject to change. See nixos/lib/default.nix" null;
+  inherit (nonExtendedLib) warn;
+  nonExtendedLib = import ../../lib;
+in
+{ lib ? nonExtendedLib, ... }:
+let
+
+  /*
+    Invoke NixOS. Unlike traditional NixOS, this does not include all modules.
+    Any such modules have to be explicitly added via the `modules` parameter,
+    or imported using `imports` in a module.
+
+    A minimal module list improves NixOS evaluation performance and allows
+    modules to be independently usable, supporting new use cases.
+
+    Parameters:
+
+      modules:        A list of modules that constitute the configuration.
+
+      specialArgs:    An attribute set of module arguments. Unlike
+                      `config._module.args`, these are available for use in
+                      `imports`.
+                      `config._module.args` should be preferred when possible.
+
+    Return:
+
+      An attribute set containing `config.system.build.toplevel` among other
+      attributes. See `lib.evalModules` in the Nixpkgs library.
+
+   */
+  evalModules = {
+    prefix ? [],
+    modules ? [],
+    specialArgs ? {},
+  }: lib.evalModules {
+    inherit prefix modules;
+    specialArgs = {
+      modulesPath = builtins.toString ../modules;
+    } // specialArgs;
+  };
+
+in
+{
+  evalModules = builtins.seq experimentalWarning evalModules;
+}

--- a/nixos/lib/eval-config-minimal.nix
+++ b/nixos/lib/eval-config-minimal.nix
@@ -31,7 +31,12 @@ let
     prefix ? [],
     modules ? [],
     specialArgs ? {},
-  }: lib.evalModules {
+  }:
+  # NOTE: Regular NixOS currently does use this function! Don't break it!
+  #       Ideally we don't diverge, unless we learn that we should.
+  #       In other words, only the public interface of nixos.evalModules
+  #       is experimental.
+  lib.evalModules {
     inherit prefix modules;
     specialArgs = {
       modulesPath = builtins.toString ../modules;

--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -33,6 +33,8 @@ let pkgs_ = pkgs;
 in
 
 let
+  evalModulesMinimal = (import ./eval-config-minimal.nix { inherit lib; bypassEvalModulesWarning = true; }).evalModules;
+
   pkgsModule = rec {
     _file = ./eval-config.nix;
     key = _file;
@@ -70,11 +72,9 @@ let
     };
   allUserModules = modules ++ legacyModules;
 
-  noUserModules = lib.evalModules ({
-    inherit prefix;
+  noUserModules = evalModulesMinimal ({
+    inherit prefix specialArgs;
     modules = baseModules ++ extraModules ++ [ pkgsModule modulesModule ];
-    specialArgs =
-      { modulesPath = builtins.toString ../modules; } // specialArgs;
   });
 
   # Extra arguments that are useful for constructing a similar configuration.

--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -33,7 +33,11 @@ let pkgs_ = pkgs;
 in
 
 let
-  evalModulesMinimal = (import ./eval-config-minimal.nix { inherit lib; bypassEvalModulesWarning = true; }).evalModules;
+  evalModulesMinimal = (import ./default.nix {
+    inherit lib;
+    # Implicit use of feature is noted in implementation.
+    featureFlags.minimalModules = { };
+  }).evalModules;
 
   pkgsModule = rec {
     _file = ./eval-config.nix;

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -64,6 +64,11 @@ let
 in
 
 {
+  imports = [
+    ./assertions.nix
+    ./meta.nix
+  ];
+
   options.nixpkgs = {
 
     pkgs = mkOption {

--- a/nixos/modules/misc/nixpkgs/test.nix
+++ b/nixos/modules/misc/nixpkgs/test.nix
@@ -1,0 +1,8 @@
+{ evalMinimalConfig, pkgs, lib, stdenv }:
+lib.recurseIntoAttrs {
+  invokeNixpkgsSimple =
+    (evalMinimalConfig ({ config, modulesPath, ... }: {
+      imports = [ (modulesPath + "/misc/nixpkgs.nix") ];
+      nixpkgs.system = stdenv.hostPlatform.system;
+    }))._module.args.pkgs.hello;
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -20,7 +20,11 @@ let
     if elem system systems then handleTest path args
     else {};
 
-  nixosLib = import ../lib {};
+  nixosLib = import ../lib {
+    # Experimental features need testing too, but there's no point in warning
+    # about it, so we enable the feature flag.
+    featureFlags.minimalModules = {};
+  };
   evalMinimalConfig = module: nixosLib.evalModules { modules = [ module ]; };
 in
 {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -19,6 +19,9 @@ let
   handleTestOn = systems: path: args:
     if elem system systems then handleTest path args
     else {};
+
+  nixosLib = import ../lib {};
+  evalMinimalConfig = module: nixosLib.evalModules { modules = [ module ]; };
 in
 {
   _3proxy = handleTest ./3proxy.nix {};
@@ -327,6 +330,7 @@ in
   nix-serve-ssh = handleTest ./nix-serve-ssh.nix {};
   nixops = handleTest ./nixops/default.nix {};
   nixos-generate-config = handleTest ./nixos-generate-config.nix {};
+  nixpkgs = pkgs.callPackage ../modules/misc/nixpkgs/test.nix { inherit evalMinimalConfig; };
   node-red = handleTest ./node-red.nix {};
   nomad = handleTest ./nomad.nix {};
   novacomd = handleTestOn ["x86_64-linux"] ./novacomd.nix {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

See #148456

In short: improve modularity, enabling new use cases, improving performance. This is just a first step; doing this in reviewable increments.

This adds a new entrypoint, similar to the PoC, but incorporating some feedback, making the entrypoint _itself_ more minimal.
It also marks the new function as experimental, because using a minimal module list may be a little rough at first and I know it to be incomplete. However, in the spirit of minimalism, this is ok and things that can't be made optional can be added later if necessary.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
