### PR TITLE
Treewide: fix wrong declaration of Apache License 2.0

### DIFF
--- a/pkgs/applications/networking/cluster/helm/plugins/helm-diff.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/helm-diff.nix
@@ -28,7 +28,7 @@ buildGoModule rec {
   meta = with lib; {
     description = "A Helm plugin that shows a diff";
     inherit (src.meta) homepage;
-    license = licenses.apsl20;
+    license = licenses.asl20;
     maintainers = with maintainers; [ yurrriq ];
   };
 }

--- a/pkgs/applications/networking/cluster/helm/plugins/helm-s3.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/helm-s3.nix
@@ -31,7 +31,7 @@ buildGoModule rec {
   meta = with lib; {
     description = "A Helm plugin that shows a diff";
     inherit (src.meta) homepage;
-    license = licenses.apsl20;
+    license = licenses.mit;
     maintainers = with maintainers; [ yurrriq ];
   };
 }

--- a/pkgs/applications/networking/cluster/helm/plugins/helm-secrets.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/helm-secrets.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A Helm plugin that helps manage secrets";
     inherit (src.meta) homepage;
-    license = licenses.apsl20;
+    license = licenses.asl20;
     maintainers = with maintainers; [ yurrriq ];
     platforms = platforms.all;
   };

--- a/pkgs/applications/networking/cluster/kbst/default.nix
+++ b/pkgs/applications/networking/cluster/kbst/default.nix
@@ -34,7 +34,7 @@ buildGoModule rec {
   meta = with lib; {
     description = "Kubestack framework CLI";
     homepage = "https://www.kubestack.com/";
-    license = licenses.apsl20;
+    license = licenses.asl20;
     maintainers = with maintainers; [ mtrsk ];
   };
 }

--- a/pkgs/development/libraries/xed/default.nix
+++ b/pkgs/development/libraries/xed/default.nix
@@ -39,7 +39,7 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Intel X86 Encoder Decoder (Intel XED)";
     homepage    = "https://intelxed.github.io/";
-    license     = licenses.apsl20;
+    license     = licenses.asl20;
     platforms   = platforms.unix;
     maintainers = with maintainers; [ arturcygan ];
   };

--- a/pkgs/development/tools/go-containerregistry/default.nix
+++ b/pkgs/development/tools/go-containerregistry/default.nix
@@ -37,7 +37,7 @@ buildGoModule rec {
   meta = with lib; {
     description = "Tools for interacting with remote images and registries including crane and gcrane";
     homepage = "https://github.com/google/go-containerregistry";
-    license = licenses.apsl20;
+    license = licenses.asl20;
     maintainers = with maintainers; [ yurrriq ];
   };
 }

--- a/pkgs/tools/admin/synapse-admin/default.nix
+++ b/pkgs/tools/admin/synapse-admin/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Admin UI for Synapse Homeservers";
     homepage = "https://github.com/Awesome-Technologies/synapse-admin";
-    license = licenses.apsl20;
+    license = licenses.asl20;
     platforms = platforms.all;
     maintainers = with maintainers; [ mkg20001 ];
   };

--- a/pkgs/tools/security/snow/default.nix
+++ b/pkgs/tools/security/snow/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Conceal messages in ASCII text by appending whitespace to the end of lines";
     homepage = "http://www.darkside.com.au/snow/";
-    license = licenses.apsl20;
+    license = licenses.asl20;
     maintainers = with maintainers; [ siraben ];
     platforms = platforms.unix;
   };

--- a/pkgs/tools/system/bpytop/default.nix
+++ b/pkgs/tools/system/bpytop/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A resource monitor; python port of bashtop";
     homepage = src.meta.homepage;
-    license = licenses.apsl20;
+    license = licenses.asl20;
     maintainers = with maintainers; [ aw ];
     platforms = with platforms; linux ++ freebsd ++ darwin;
 

--- a/pkgs/tools/virtualization/ec2instanceconnectcli/default.nix
+++ b/pkgs/tools/virtualization/ec2instanceconnectcli/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Command Line Interface for AWS EC2 Instance Connect";
     homepage = "https://github.com/aws/aws-ec2-instance-connect-cli";
-    license = licenses.apsl20;
+    license = licenses.asl20;
     maintainers = with maintainers; [ yurrriq ];
   };
 }

--- a/pkgs/tools/virtualization/lxd-image-server/default.nix
+++ b/pkgs/tools/virtualization/lxd-image-server/default.nix
@@ -40,7 +40,7 @@ python3.pkgs.buildPythonApplication rec {
   meta = with lib; {
     description = "Creates and manages a simplestreams lxd image server on top of nginx";
     homepage = "https://github.com/Avature/lxd-image-server";
-    license = licenses.apsl20;
+    license = licenses.asl20;
     platforms = platforms.unix;
     maintainers = with maintainers; [ mkg20001 ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

These packages were announced as published under Apple Public Source
License 2.0 (`apsl20` short handle) but they are actually published
under the Apache License 2.0 (`asl20` short handle)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
