### PR TITLE
nitter: unstable-2021-07-18 -> unstable-2021-12-31

### DIFF
--- a/pkgs/development/nim-packages/flatty/default.nix
+++ b/pkgs/development/nim-packages/flatty/default.nix
@@ -2,6 +2,6 @@
 
 fetchNimble {
   pname = "flatty";
-  version = "0.2.1";
-  hash = "sha256-TqNnRh2+i6n98ktLRVQxt9CVw17FGLNYq29rJoMus/0=";
+  version = "0.2.3";
+  hash = "sha256-1tPLtnlGtE4SF5/ti/2svvYHpEy/0Za5N4YAOHFOyjA=";
 }

--- a/pkgs/development/nim-packages/packedjson/default.nix
+++ b/pkgs/development/nim-packages/packedjson/default.nix
@@ -3,6 +3,6 @@
 fetchFromGitHub {
   owner = "Araq";
   repo = "packedjson";
-  rev = "7198cc8";
-  sha256 = "1ay2zd88q8hvpvigsg8h0y5vc65hk3lk0d48fy9hwg4lcng19mp1";
+  rev = "d11d167";
+  sha256 = "1302rn58277c3ic5sfq89c4mkn0d66bhilifh5xjf40x74ahir5x";
 }

--- a/pkgs/development/nim-packages/redis/default.nix
+++ b/pkgs/development/nim-packages/redis/default.nix
@@ -3,6 +3,6 @@
 fetchFromGitHub {
   owner = "zedeus";
   repo = "redis";
-  rev = "94bcbf1";
-  sha256 = "1p9zv4f4lqrjqa8fk98cb89b9fzlf866jc584ll9sws14904i80j";
+  rev = "d0a0e6f";
+  sha256 = "166kzflb3wgwvqnv9flyynp8b35xby617lxmk0yas8i4m6vjl00f";
 }

--- a/pkgs/development/nim-packages/redpool/default.nix
+++ b/pkgs/development/nim-packages/redpool/default.nix
@@ -3,6 +3,6 @@
 fetchFromGitHub {
   owner = "zedeus";
   repo = "redpool";
-  rev = "57aeb25";
-  sha256 = "0fph7qlia6fvya1zqzbgvww2hk5pd0vq1wlf9ij9jyn655mg0w3q";
+  rev = "f880f49";
+  sha256 = "01n73bpgfdz2a3qvcfxsq4a6gxbhabf2n5np1ilzgdqkzcd4jf9b";
 }

--- a/pkgs/development/nim-packages/regex/default.nix
+++ b/pkgs/development/nim-packages/regex/default.nix
@@ -3,6 +3,6 @@
 fetchFromGitHub {
   owner = "nitely";
   repo = "nim-regex";
-  rev = "2e32fdc";
-  sha256 = "1hrl40mwql7nh4wc7sdhmk8bj5728b93v5a93j49v660l0rn4qx8";
+  rev = "eeefb4f";
+  sha256 = "13gn0qhnxz07474kv94br5qlac9j8pz2555fk83538fiq83vgbm5";
 }

--- a/pkgs/development/nim-packages/zippy/default.nix
+++ b/pkgs/development/nim-packages/zippy/default.nix
@@ -2,6 +2,6 @@
 
 fetchNimble {
   pname = "zippy";
-  version = "0.5.6";
-  hash = "sha256-axp4t9+8TFSpvnATlRKZyuOGLA0e/XKfvrVSwreXpC4=";
+  version = "0.7.3";
+  hash = "sha256-w64ENRyP3mNTtESSt7CDDxUkjYSfziNVVedkO4HIuJ8=";
 }

--- a/pkgs/servers/nitter/default.nix
+++ b/pkgs/servers/nitter/default.nix
@@ -2,14 +2,14 @@
 
 nimPackages.buildNimPackage rec {
   pname = "nitter";
-  version = "unstable-2021-07-18";
+  version = "unstable-2021-12-31";
   nimBinOnly = true;
 
   src = fetchFromGitHub {
     owner = "zedeus";
     repo = "nitter";
-    rev = "6c5cb01b294d4f6e3b438fc47683359eb0fe5057";
-    sha256 = "1dl8ndyv8m1hnydrp5xilcpp2cfbp02d5jap3y42i4nazc9ar6p4";
+    rev = "9d117aa15b3c3238cee79acd45d655eeb0e46293";
+    sha256 = "06hd3r1kgxx83sl5ss90r39v815xp2ki72fc8p64kid34mcn57cz";
   };
 
   buildInputs = with nimPackages; [
@@ -25,7 +25,8 @@ nimPackages.buildNimPackage rec {
     packedjson
     supersnappy
     redpool
-    frosty
+    flatty
+    zippy
     redis
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
