### PR TITLE
doublecmd: init at 1.0.2

### DIFF
--- a/pkgs/applications/misc/double-commander/default.nix
+++ b/pkgs/applications/misc/double-commander/default.nix
@@ -1,0 +1,98 @@
+{ lib
+, stdenv
+, autoPatchelfHook
+, fetchFromGitHub
+, lazarus
+, fpc
+, libX11
+, glib
+, dbus
+
+  # GTK2
+, gtk2
+, atk
+, pango
+, gdk-pixbuf
+, cairo
+
+  # Qt5
+, libqt5pas
+, qt5
+, widgetset ? "qt5"
+}:
+
+stdenv.mkDerivation rec {
+  pname = "doublecmd";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "doublecmd";
+    repo = "doublecmd";
+    rev = "v${version}";
+    sha256 = "sha256-DVEFflk+gEcqWbAvCri4v1O3oOOXUMBYFKRifDpX1y4=";
+  };
+
+  nativeBuildInputs = [ lazarus fpc autoPatchelfHook ]
+    ++ lib.optional (widgetset == "qt5") qt5.wrapQtAppsHook;
+
+  buildInputs = [ libX11 glib dbus ]
+    ++ lib.optionals (widgetset == "gtk2") [ gtk2 atk pango gdk-pixbuf cairo ]
+    ++ lib.optional (widgetset == "qt5") libqt5pas;
+
+  buildPhase = ''
+   lazbuild --lazarusdir=${lazarus}/share/lazarus --pcp=./lazarus --widgetset=${widgetset} \
+      components/chsdet/chsdet.lpk \
+      components/CmdLine/cmdbox.lpk \
+      components/multithreadprocs/multithreadprocslaz.lpk \
+      components/dcpcrypt/dcpcrypt.lpk \
+      components/doublecmd/doublecmd_common.lpk \
+      components/KASToolBar/kascomp.lpk \
+      components/viewer/viewerpackage.lpk \
+      components/gifanim/pkg_gifanim.lpk \
+      components/synunihighlighter/synuni.lpk \
+      src/doublecmd.lpi
+
+    # TODO build plugins
+    # build plugins
+    # WCX plugins
+    # lazbuild plugins/wcx/cpio/src/cpio.lpi
+    # lazbuild plugins/wcx/deb/src/deb.lpi
+    # lazbuild plugins/wcx/rpm/src/rpm.lpi
+    # lazbuild plugins/wcx/unrar/src/unrar.lpi
+    # lazbuild plugins/wcx/zip/src/Zip.lpi
+
+    # # WDX plugins
+    # lazbuild plugins/wdx/rpm_wdx/src/rpm_wdx.lpi
+    # lazbuild plugins/wdx/deb_wdx/src/deb_wdx.lpi
+    # lazbuild plugins/wdx/xpi_wdx/src/xpi_wdx.lpi
+    # lazbuild plugins/wdx/audioinfo/src/AudioInfo.lpi
+
+    # # WFX plugins
+    # lazbuild plugins/wfx/ftp/src/ftp.lpi
+    # lazbuild plugins/wfx/samba/src/samba.lpi
+    # lazbuild plugins/wlx/WlxMplayer/src/wlxMplayer.lpi
+
+    # # DSX plugins
+    # lazbuild plugins/dsx/DSXLocate/src/DSXLocate.lpi
+  '';
+
+  installPhase = ''
+    install -Dt $out/bin doublecmd
+    install -Dm644 install/linux/doublecmd.desktop -t $out/share/applications
+    install -Dm644 doublecmd.png -t $out/share/pixmaps
+    install -Dm644 install/linux/*.1 -t $out/share/man/man1
+
+    # TODO pixmaps don't seem to work
+    install -Dt $out/share pixmaps.txt
+    mkdir -p $out/share/pixmaps
+    cp -R pixmaps/* $out/share/pixmaps/
+  '';
+
+  meta = with lib; {
+    description = "File manager with two panels side by side";
+    homepage = "https://doublecmd.sourceforge.io/";
+    license = licenses.gpl2Plus;
+    platforms = [ "x86_64-linux" ]; # TODO other platforms/arch
+    maintainers = with maintainers; [ mausch ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16234,6 +16234,10 @@ with pkgs;
 
   double-conversion = callPackage ../development/libraries/double-conversion { };
 
+  doublecmd-qt = callPackage ../applications/misc/double-commander { widgetset = "qt5"; };
+  doublecmd-gtk = callPackage ../applications/misc/double-commander { widgetset = "gtk2"; };
+  doublecmd = doublecmd-gtk;
+
   dclib = callPackage ../development/libraries/dclib { };
 
   dillo = callPackage ../applications/networking/browsers/dillo {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Addresses #144305

Base program works, but there are currently some issues:

- No pixmaps / icons. I think it's just a matter of placing them in the right directory.
- Zip / other plugins don't work. Again I think it's just a matter of placing them in the right directory, plus maybe they need to be patchelf'd?
- Only built for Linux+x86_64, though this should also build on Darwin and i386 and aarch64.

I'm hoping someone else will put in some time to help with those issues.
Regardless I think this is worth merging as it is.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
