### PR TITLE
ghostscript: 9.53.3 -> 9.55.0

### DIFF
--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -30,22 +30,18 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "ghostscript";
-  version = "9.53.3";
+  version = "9.55.0";
 
   src = fetchurl {
     url = "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9${lib.versions.minor version}${lib.versions.patch version}/${pname}-${version}.tar.xz";
-    sha512 = "2vif3vgxa5wma16yxvhhkymk4p309y5204yykarq94r5rk890556d2lj5w7acnaa2ymkym6y0zd4vq9sy9ca2346igg2c6dxqkjr0zb";
+    sha512 = "27g72152mlwlalg232jxdhaf3ykgmqwi2pccbkwfygql1h9iz40plfbwbs1n0fkvm4zwzg5r9cr8g7w2dxih4jldiidv7rflxdy1is2";
   };
 
   patches = [
     (fetchpatch {
-      url = "https://github.com/ArtifexSoftware/ghostpdl/commit/41ef9a0bc36b9db7115fbe9623f989bfb47bbade.patch";
-      sha256 = "1qpc6q1fpxshqc0mqgg36kng47kgljk50bmr8p7wn21jgfkh7m8w";
-    })
-    (fetchpatch {
-      url = "https://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=a9bd3dec9fde";
-      name = "CVE-2021-3781.patch";
-      sha256 = "FvbH7cb3ZDCbNRz9DF0kDmLdF7OWNYk90wv44pimU58=";
+      name = "fix-non-vendored-lcms2-typo.patch";
+      url = "https://github.com/ArtifexSoftware/ghostpdl/commit/830afae5454dea3bff903869d82022306890a96c.patch";
+      sha256 = "1w9yspsgxyabvrw9ld6pv6pb7708c44ihjqvag7qqh9v1lhm48j0";
     })
     ./urw-font-files.patch
     ./doc-no-ref.diff
@@ -88,6 +84,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--with-system-libtiff"
     "--enable-dynamic"
+    "--without-tesseract"
   ]
   ++ lib.optional x11Support "--with-x"
   ++ lib.optionals cupsSupport [


### PR DESCRIPTION
###### Motivation for this change
Marking this as "security" because ~although I haven't yet figured out which (if any) CVEs this bump addresses~ (see below), it looks like ghostscript have had a busy december and there will be a _lot_ of CVEs incoming soon. Let's be ready for them, having got any quirks of the version bump already ironed out in case we need to start patching.

Leaving new tesseract support disabled for now as it doesn't build cleanly on darwin, and it seems like quite a niche feature for the amount of code/dependencies it would add - I suspect we will want to leave it disabled by default anyway.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
