### PR TITLE
t-rex: init at 0.14.2

### DIFF
--- a/pkgs/servers/t-rex/default.nix
+++ b/pkgs/servers/t-rex/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, rustPlatform, fetchFromGitHub, pkg-config, gdal, openssl, Security }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "t-rex";
+  version = "0.14.2";
+
+  src = fetchFromGitHub {
+    owner = "t-rex-tileserver";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-QNowkQzEYLOgJ2h0yq+gShmW5WgqPF3iiSejqwrOrHo=";
+  };
+
+  cargoHash = "sha256-k10DjLJCJLqjmtEED5pwQDt3mOiey89UYC36lG+3AmM=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ gdal openssl ] ++ lib.optional stdenv.isDarwin Security;
+
+  meta = with lib; {
+    description = "Vector tile server specialized on publishing MVT tiles";
+    homepage = "https://t-rex.tileserver.ch/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12308,6 +12308,10 @@ with pkgs;
 
   remarkable2-toolchain = callPackage ../development/tools/misc/remarkable/remarkable2-toolchain { };
 
+  t-rex = callPackage ../servers/t-rex {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   tacacsplus = callPackage ../servers/tacacsplus { };
 
   tamarin-prover =


### PR DESCRIPTION
###### Motivation for this change
[**t-rex**](https://t-rex.tileserver.ch/) is a vector tile server specialized on publishing MVT tiles from your own data.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
