### PR TITLE
kodi.packages.orftvthek: init at 0.12.3-1

### DIFF
--- a/pkgs/applications/video/kodi/addons/future/default.nix
+++ b/pkgs/applications/video/kodi/addons/future/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildKodiAddon, fetchzip, addonUpdateScript }:
+
+buildKodiAddon rec {
+  pname = "future";
+  namespace = "script.module.future";
+  version = "0.18.2+matrix.1";
+
+  src = fetchzip {
+    url = "https://mirrors.kodi.tv/addons/matrix/${namespace}/${namespace}-${version}.zip";
+    sha256 = "sha256-QBG7V70Dwmfq8ISILxGNvtmQT9fJp2e5gs2C9skRwIw=";
+  };
+
+  passthru = {
+    pythonPath = "lib";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.future";
+    };
+  };
+
+  meta = with lib; {
+    homepage = "http://python-future.org";
+    description = "The missing compatibility layer between Python 2 and Python 3";
+    license = licenses.mit;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/applications/video/kodi/addons/orftvthek/default.nix
+++ b/pkgs/applications/video/kodi/addons/orftvthek/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildKodiAddon, fetchFromGitHub, future, kodi-six, simplejson, inputstreamhelper }:
+
+buildKodiAddon rec {
+  pname = "orftvthek";
+  namespace = "plugin.video.orftvthek";
+  version = "0.12.3-1";
+
+  src = fetchFromGitHub {
+    owner = "s0faking";
+    repo = namespace;
+    rev = version;
+    sha256 = "sha256-+J1NtmjbDWtS8d4nO9P/lR5GNmvtc1YjTW+bulGaU2Q=";
+  };
+
+  propagatedBuildInputs = [
+    future
+    kodi-six
+    simplejson
+    inputstreamhelper
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/s0faking/plugin.video.orftvthek";
+    description = "An addon that gives you access to the ORF TVthek Video Platform";
+    license = licenses.gpl2Only;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/applications/video/kodi/addons/simplejson/default.nix
+++ b/pkgs/applications/video/kodi/addons/simplejson/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildKodiAddon, fetchzip, addonUpdateScript }:
+
+buildKodiAddon rec {
+  pname = "simplejson";
+  namespace = "script.module.simplejson";
+  version = "3.17.0+matrix.2";
+
+  src = fetchzip {
+    url = "https://mirrors.kodi.tv/addons/matrix/${namespace}/${namespace}-${version}.zip";
+    sha256 = "sha256-XLE4x0qr3CFwWqh1BfSg9q+w6pWgFBXG7TyVJWeGQIs=";
+  };
+
+  passthru = {
+    pythonPath = "lib";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.simplejson";
+    };
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/simplejson/simplejson";
+    description = "Simple, fast, extensible JSON encoder/decoder for Python";
+    license = licenses.mit;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -126,6 +126,8 @@ let self = rec {
 
   defusedxml = callPackage ../applications/video/kodi/addons/defusedxml { };
 
+  future = callPackage ../applications/video/kodi/addons/future { };
+
   idna = callPackage ../applications/video/kodi/addons/idna { };
 
   inputstream-adaptive = callPackage ../applications/video/kodi/addons/inputstream-adaptive { };

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -150,6 +150,8 @@ let self = rec {
 
   signals = callPackage ../applications/video/kodi/addons/signals { };
 
+  simplejson = callPackage ../applications/video/kodi/addons/simplejson { };
+
   six = callPackage ../applications/video/kodi/addons/six { };
 
   urllib3 = callPackage ../applications/video/kodi/addons/urllib3 { };

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -90,6 +90,8 @@ let self = rec {
 
   netflix = callPackage ../applications/video/kodi/addons/netflix { };
 
+  orftvthek = callPackage ../applications/video/kodi/addons/orftvthek { };
+
   svtplay = callPackage ../applications/video/kodi/addons/svtplay { };
 
   steam-controller = callPackage ../applications/video/kodi/addons/steam-controller { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
~~dependencies for `plugin.video.orftvthek`~~ meh i just ended up packaging it for you... happy new year :partying_face: 

ping @dschrempf for testing

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
