### PR TITLE
nymphcast: init at 0.1-rc0

### DIFF
--- a/pkgs/development/libraries/libnymphcast/default.nix
+++ b/pkgs/development/libraries/libnymphcast/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, fetchFromGitHub, nymphrpc, poco }:
+
+stdenv.mkDerivation rec {
+  pname = "libnymphcast";
+  version = "0.1-beta0";
+
+  src = fetchFromGitHub {
+    owner = "MayaPosch";
+    repo = "libnymphcast";
+    rev = "v${version}";
+    sha256 = "sha256-+3V5ujwamh9SQSBY+P1WHldatsbGzqBwJ6xY6ZN4FJc=";
+  };
+
+  installFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  buildInputs = [ nymphrpc poco ];
+
+  meta = with lib; {
+    description = "A library containing the core functionality for a NymphCast client";
+    homepage = "https://github.com/MayaPosch/libnymphcast";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ aanderse ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/nymphrpc/default.nix
+++ b/pkgs/development/libraries/nymphrpc/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, fetchFromGitHub, poco }:
+
+stdenv.mkDerivation rec {
+  pname = "NymphRPC";
+  version = "0.1-alpha1";
+
+  src = fetchFromGitHub {
+    owner = "MayaPosch";
+    repo = "NymphRPC";
+    rev = "v${version}";
+    sha256 = "sha256-UkCO/dPJBero/RLGs3CAuwasLhql1g3mVwKpmPkIXQY=";
+  };
+
+  installFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  buildInputs = [ poco ];
+
+  meta = with lib; {
+    description = "A compact, C++-based Remote Procedure Call (RPC) library";
+    homepage = "https://github.com/MayaPosch/NymphRPC";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ aanderse ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/servers/nymphcast/default.nix
+++ b/pkgs/servers/nymphcast/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, lib, fetchFromGitHub, nymphrpc, libnymphcast, ffmpeg, SDL2, SDL2_image, poco, freetype, freeimage, rapidjson, pkg-config, libvlc, curl, alsa-lib }:
+
+stdenv.mkDerivation rec {
+  pname = "NymphCast";
+  version = "0.1-rc0";
+
+  src = fetchFromGitHub {
+    owner = "MayaPosch";
+    repo = "NymphCast";
+    rev = "v${version}";
+    sha256 = "sha256-zvJXl4fHM9vHJWYFP97+7I30gOuKZPwNZVnJhQMhh14=";
+  };
+
+  sourceRoot = "source/src/server";
+
+  installFlags = [ "CONFDIR=${placeholder "out"}/etc" "PREFIX=${placeholder "out"}" ];
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    alsa-lib
+    nymphrpc
+    libnymphcast
+    ffmpeg
+    SDL2
+    SDL2_image
+    poco
+    freetype
+    freeimage
+    rapidjson
+    libvlc
+    curl
+  ];
+
+  meta = with lib; {
+    description = "A software solution which turns your choice of Linux-capable hardware into an audio and video source for a television or powered speakers";
+    homepage = "http://nyanko.ws/nymphcast.php";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ aanderse ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27402,6 +27402,8 @@ with pkgs;
 
   nwg-wrapper = callPackage ../applications/misc/nwg-wrapper { };
 
+  nymphrpc = callPackage ../development/libraries/nymphrpc { };
+
   ocenaudio = callPackage ../applications/audio/ocenaudio { };
 
   onlyoffice-bin = callPackage ../applications/office/onlyoffice-bin { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26860,6 +26860,8 @@ with pkgs;
 
   liblinphone = callPackage ../development/libraries/liblinphone { };
 
+  libnymphcast = callPackage ../development/libraries/libnymphcast { };
+
   links2 = callPackage ../applications/networking/browsers/links2 { };
 
   linphone = libsForQt5.callPackage ../applications/networking/instant-messengers/linphone { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7304,6 +7304,8 @@ with pkgs;
 
   np2kai = callPackage ../misc/emulators/np2kai { };
 
+  nymphcast = callPackage ../servers/nymphcast { };
+
   openipmi = callPackage ../tools/system/openipmi { };
 
   ox = callPackage ../applications/editors/ox { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
[NymphCast](https://github.com/MayaPosch/NymphCast) looks like it might solve some problems for me in the future, so I want to keep an eye on it waiting for a stable release. A NixOS module can be added at some point in the future.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
