### PR TITLE
nixos/nginx: Revert "disable rejectSSL activation when https is disabled"

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -317,7 +317,7 @@ let
           ${optionalString (hasSSL && vhost.sslTrustedCertificate != null) ''
             ssl_trusted_certificate ${vhost.sslTrustedCertificate};
           ''}
-          ${optionalString (hasSSL && vhost.rejectSSL) ''
+          ${optionalString vhost.rejectSSL ''
             ssl_reject_handshake on;
           ''}
           ${optionalString (hasSSL && vhost.kTLS) ''


### PR DESCRIPTION
This reverts commit 2f66ac01e91d70837377c4356e5c99843b71f105. See https://github.com/NixOS/nixpkgs/pull/147027#issuecomment-1003766945.
