### PR TITLE
fake-background-webcam: init at unstable-2023-05-15

### DIFF
--- a/pkgs/by-name/fa/fake-background-webcam/package.nix
+++ b/pkgs/by-name/fa/fake-background-webcam/package.nix
@@ -1,0 +1,51 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, python310
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "fake-background-webcam";
+  version = "0-unstable-2023-05-15";
+
+  src = fetchFromGitHub {
+    owner = "fangfufu";
+    repo = "Linux-Fake-Background-Webcam";
+    rev = "6aa175443a6498bfd977e6472a1696911ba821fb";
+    hash = "sha256-EhhrmBoGvmqZ5uBDLCTs3rDwOVKMGq/sxJCH7JVmP+0=";
+  };
+
+  buildInputs = [
+    (python310.withPackages (ps: with ps; [
+      numpy
+      requests
+      requests-unixsocket
+      aiohttp
+      inotify-simple
+      pyfakewebcam
+      configargparse
+      cmapy
+      mediapipe-bin
+    ]))
+  ];
+
+  postPatch = ''
+    export images="$out/share/$pname"
+    substituteInPlace fake.py \
+      --replace-fail '"foreground.jpg"' "'$images/foreground.jpg'" \
+      --replace-fail '"background.jpg"' "'$images/background.jpg'"
+  '';
+
+  installPhase = ''
+    install -Dm0777 fake.py $out/bin/$pname
+    install -Dt $images foreground.jpg background.jpg
+    install -Dt $out/share/systemd/user systemd-user/fakecam.service
+  '';
+
+  meta = with lib;{
+    homepage = "https://github.com/fangfufu/Linux-Fake-Background-Webcam";
+    license = licenses.gpl3Only;
+    description = "Virtual background-replacing camera";
+    mantainers = with mantainers;[ pasqui023 ];
+  };
+}

--- a/pkgs/development/python-modules/cmapy/default.nix
+++ b/pkgs/development/python-modules/cmapy/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, matplotlib, opencv4, numpy }:
+
+buildPythonPackage rec{
+  pname = "cmapy";
+  version = "0.6.6";
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-y1KmswV8SaFG+wlkuDAvL7fWHf5q5t4amLY2qs6AUlU=";
+  };
+
+  propagatedBuildInputs = [ matplotlib opencv4 numpy ];
+  postPatch = ''
+    sed -i 's/opencv-python/opencv/' setup.py
+  '';
+
+  meta = with lib;{
+    homepage = "https://gitlab.com/cvejarano-oss/cmapy";
+    license = licenses.mit;
+    description = "Use Matplotlib colormaps with OpenCV in Python";
+    mantainers = with mantainers;[ pasqui023 ];
+  };
+}

--- a/pkgs/development/python-modules/mediapipe-bin/default.nix
+++ b/pkgs/development/python-modules/mediapipe-bin/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, ffmpeg
+, opencv4
+, numpy
+, cycler
+, fonttools
+, kiwisolver
+, matplotlib
+, pillow
+, protobuf
+, absl-py
+, pythonOlder
+, pythonAtLeast
+, python
+}:
+let
+  abi = "cp310";
+in
+buildPythonPackage rec{
+  pname = "mediapipe-bin";
+  version = "0.10.5";
+  #Wheel has been compiled specifically for cython 3.10
+  disabled = pythonOlder "3.10" || pythonAtLeast "3.11" || python.implementation != "cpython";
+
+  src = fetchPypi {
+    inherit version format abi;
+    pname = "mediapipe";
+    dist = abi;
+    python = abi;
+    platform = "manylinux_2_17_x86_64.manylinux2014_x86_64";
+    hash = "sha256-lBD8mgs00e3QC1/23fVP1JZIUn+n6G25+BdELEwIDV0=";
+  };
+
+  format = "wheel";
+  # otherwise opencv-contrib-python (aka opencv) will be missed
+  #yes, this does mean that every dependency requires the below line
+  pipInstallFlags = [ "--no-deps" ];
+  propagatedBuildInputs = [
+    ffmpeg
+    opencv4
+    numpy
+    cycler
+    fonttools
+    kiwisolver
+    matplotlib
+    pillow
+    protobuf
+    absl-py
+  ];
+
+  meta = with lib;{
+    homepage = "https://github.com/google/mediapipe";
+    license = licenses.asl20;
+    description = "MediaPipe is the simplest way for researchers and developers to build world-class ML solutions";
+    mantainers = with mantainers;[ pasqui023 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7315,6 +7315,8 @@ self: super: with self; {
 
   mediafire-dl = callPackage ../development/python-modules/mediafire-dl { };
 
+  mediapipe-bin =  ../development/python-modules/mediapipe-bin { };
+
   mediapy = callPackage ../development/python-modules/mediapy { };
 
   medpy = callPackage ../development/python-modules/medpy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2300,6 +2300,8 @@ self: super: with self; {
 
   clvm-tools-rs = throw "clvm-tools-rs has been removed. see https://github.com/NixOS/nixpkgs/pull/270254";
 
+  cmapy = callPackage ../development/python-modules/cmapy { };
+
   cma = callPackage ../development/python-modules/cma { };
 
   cmaes = callPackage ../development/python-modules/cmaes { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I want a working implementation of fake background

###### Things done

The build fails with
```
; nix build .#python3Packages.fake-background-webcam
def-matcher: command not found
warning: Git tree '/home/me/src/nixpkgs' is dirty
error: builder for '/nix/store/a2ggdkgzyjjj5pbr8apxnpv28sf6g64z-python3.9-cmapy-0.6.6.drv' failed with exit code 1;
       last 10 log lines:
       > adding 'cmapy-0.6.6.dist-info/top_level.txt'
       > adding 'cmapy-0.6.6.dist-info/RECORD'
       > removing build/bdist.linux-x86_64/wheel
       > Finished executing setuptoolsBuildPhase
       > installing
       > Executing pipInstallPhase
       > /build/cmapy-0.6.6/dist /build/cmapy-0.6.6
       > Processing ./cmapy-0.6.6-py3-none-any.whl
       > ERROR: Could not find a version that satisfies the requirement opencv>=3.3 (from cmapy) (from versions: none)
       > ERROR: No matching distribution found for opencv>=3.3
       For full logs, run 'nix log /nix/store/a2ggdkgzyjjj5pbr8apxnpv28sf6g64z-python3.9-cmapy-0.6.6.drv'.
error: 1 dependencies of derivation '/nix/store/hny98vdm4a7ls2p41v59vn3qs6dlpcrq-fake-background-webcam-unstable-2021-11-28.drv' failed to build
```

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
