### PR TITLE
Submit/newm

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5380,6 +5380,12 @@
     githubId = 221929;
     name = "Jean-Baptiste Giraudeau";
   };
+  jbuchermn = {
+    email = "j.bucher.mn@gmail.com";
+    github = "jbuchermn";
+    githubId = 23573451;
+    name = "Jonas Bucher";
+  };
   jceb = {
     name = "jceb";
     email = "jceb@e-jc.de";

--- a/pkgs/applications/window-managers/newm/default.nix
+++ b/pkgs/applications/window-managers/newm/default.nix
@@ -1,11 +1,18 @@
 { lib,
 fetchFromGitHub,
-python3Packages,
+buildPythonApplication,
 bash,
+
 pywm,
+pycairo,
+psutil,
+websockets,
+python-pam,
+pyfiglet,
+fuzzywuzzy
 }:
 
-python3Packages.buildPythonApplication rec {
+buildPythonApplication rec {
   pname = "newm";
   version = "0.2";
 
@@ -16,7 +23,7 @@ python3Packages.buildPythonApplication rec {
     sha256 = "sha256-0nAjQxcZIuenFddpXqfatEvekwTnGIQUzAyhziMJLR4=";
   };
 
-  propagatedBuildInputs = with python3Packages; [
+  propagatedBuildInputs = [
     pywm
     pycairo
     psutil

--- a/pkgs/applications/window-managers/newm/default.nix
+++ b/pkgs/applications/window-managers/newm/default.nix
@@ -1,0 +1,44 @@
+{ lib,
+fetchFromGitHub,
+python3Packages,
+bash,
+pywm,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "newm";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner = "jbuchermn";
+    repo = "newm";
+    rev = "b6ef102";
+    sha256 = "sha256-0nAjQxcZIuenFddpXqfatEvekwTnGIQUzAyhziMJLR4=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    pywm
+    pycairo
+    psutil
+    websockets
+    python-pam
+    pyfiglet
+    fuzzywuzzy
+  ];
+
+  # Skip this as it tries to start the compositor
+  setuptoolsCheckPhase = "true";
+
+  LC_ALL = "en_US.UTF-8";
+
+  meta =  with lib; {
+    description = "Wayland compositor";
+    longDescription = ''
+      Tiling Wayland compositor written with touchpads and laptops in mind.
+    '';
+    homepage = "https://github.com/jbuchermn/newm";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jbuchermn ];
+  };
+}

--- a/pkgs/development/python-modules/pywm/default.nix
+++ b/pkgs/development/python-modules/pywm/default.nix
@@ -1,6 +1,7 @@
 { lib,
+pkgs,
+buildPythonPackage,
 fetchFromGitHub,
-python3Packages,
 meson_0_60,
 ninja,
 pkg-config,
@@ -11,7 +12,6 @@ wayland,
 wayland-protocols,
 libinput,
 libxkbcommon,
-mesa,
 pixman,
 seatd,
 vulkan-loader,
@@ -19,10 +19,16 @@ xorg,
 libpng,
 libcap,
 ffmpeg,
-xwayland
+xwayland,
+
+imageio,
+numpy,
+pycairo,
+evdev,
+matplotlib
 }:
 
-python3Packages.buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "pywm";
   version = "0.2";
 
@@ -56,10 +62,10 @@ python3Packages.buildPythonPackage rec {
     xorg.xcbutilerrors
     xorg.xcbutilimage
     xorg.libX11
-    mesa
     seatd
     xwayland
     vulkan-loader
+    pkgs.mesa # Prevent clash with python module mesa
 
     libpng
     ffmpeg
@@ -67,11 +73,11 @@ python3Packages.buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    python3Packages.imageio
-    python3Packages.numpy
-    python3Packages.pycairo
-    python3Packages.evdev
-    python3Packages.matplotlib
+    imageio
+    numpy
+    pycairo
+    evdev
+    matplotlib
   ];
 
   LC_ALL = "en_US.UTF-8";

--- a/pkgs/development/python-modules/pywm/default.nix
+++ b/pkgs/development/python-modules/pywm/default.nix
@@ -1,0 +1,90 @@
+{ lib,
+fetchFromGitHub,
+python3Packages,
+meson_0_60,
+ninja,
+pkg-config,
+wayland-scanner,
+glslang,
+libGL,
+wayland,
+wayland-protocols,
+libinput,
+libxkbcommon,
+mesa,
+pixman,
+seatd,
+vulkan-loader,
+xorg,
+libpng,
+libcap,
+ffmpeg,
+xwayland
+}:
+
+python3Packages.buildPythonPackage rec {
+  pname = "pywm";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner = "jbuchermn";
+    repo = "pywm";
+    fetchSubmodules = true;
+    rev = "89f8de6";
+    sha256= "sha256-UOBlV/I3f9XLHeKnF9EOYN7XpcHDpNC01mvRHOWJ4TQ=";
+  };
+
+  nativeBuildInputs = [
+    meson_0_60
+    ninja
+    pkg-config
+    wayland-scanner
+    glslang
+  ];
+
+  preBuild = "cd ..";
+
+  buildInputs = [
+    libGL
+    wayland
+    wayland-protocols
+    libinput
+    libxkbcommon
+    pixman
+    xorg.xcbutilwm
+    xorg.xcbutilrenderutil
+    xorg.xcbutilerrors
+    xorg.xcbutilimage
+    xorg.libX11
+    mesa
+    seatd
+    xwayland
+    vulkan-loader
+
+    libpng
+    ffmpeg
+    libcap
+  ];
+
+  propagatedBuildInputs = [
+    python3Packages.imageio
+    python3Packages.numpy
+    python3Packages.pycairo
+    python3Packages.evdev
+    python3Packages.matplotlib
+  ];
+
+  LC_ALL = "en_US.UTF-8";
+
+  meta =  with lib; {
+    description = "Wayland compositor core";
+    longDescription = ''
+      Python based Wayland compositor library based on wlroots.
+      Backend for the compositor newm.
+    '';
+    homepage = "https://github.com/jbuchermn/pywm";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jbuchermn ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34214,4 +34214,5 @@ with pkgs;
   zthrottle = callPackage ../tools/misc/zthrottle { };
 
   pywm = callPackage ../development/python-modules/pywm {};
+  newm = callPackage ../applications/window-managers/newm {};
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9020,6 +9020,8 @@ with pkgs;
 
   pystring = callPackage ../development/libraries/pystring {};
 
+  pywm = python3Packages.callPackage ../development/python-modules/pywm {};
+
   rbw = callPackage ../tools/security/rbw {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
@@ -18998,6 +19000,8 @@ with pkgs;
   };
 
   nettle = import ../development/libraries/nettle { inherit callPackage fetchurl; };
+
+  newm = python3Packages.callPackage ../applications/window-managers/newm {};
 
   newman = callPackage ../development/web/newman {};
 
@@ -34213,6 +34217,4 @@ with pkgs;
 
   zthrottle = callPackage ../tools/misc/zthrottle { };
 
-  pywm = callPackage ../development/python-modules/pywm {};
-  newm = callPackage ../applications/window-managers/newm {};
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34212,4 +34212,6 @@ with pkgs;
   };
 
   zthrottle = callPackage ../tools/misc/zthrottle { };
+
+  pywm = callPackage ../development/python-modules/pywm {};
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Initially package the Wayland compositor newm and its abstraction layer pywm

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
