### PR TITLE
nixos/test-driver: also passthru driverInteractive

### DIFF
--- a/nixos/doc/manual/development/running-nixos-tests-interactively.section.md
+++ b/nixos/doc/manual/development/running-nixos-tests-interactively.section.md
@@ -4,19 +4,19 @@ The test itself can be run interactively. This is particularly useful
 when developing or debugging a test:
 
 ```ShellSession
-$ nix-build nixos/tests/login.nix -A driverInteractive
+$ nix-build . -A nixosTests.login.driverInteractive
 $ ./result/bin/nixos-test-driver --interactive
-starting VDE switch for network 1
->
+[...]
+>>>
 ```
 
 You can then take any Python statement, e.g.
 
 ```py
-> start_all()
-> test_script()
-> machine.succeed("touch /tmp/foo")
-> print(machine.succeed("pwd")) # Show stdout of command
+>>> start_all()
+>>> test_script()
+>>> machine.succeed("touch /tmp/foo")
+>>> print(machine.succeed("pwd")) # Show stdout of command
 ```
 
 The function `test_script` executes the entire test script and drops you

--- a/nixos/doc/manual/from_md/development/running-nixos-tests-interactively.section.xml
+++ b/nixos/doc/manual/from_md/development/running-nixos-tests-interactively.section.xml
@@ -5,19 +5,19 @@
     useful when developing or debugging a test:
   </para>
   <programlisting>
-$ nix-build nixos/tests/login.nix -A driverInteractive
+$ nix-build . -A nixosTests.login.driverInteractive
 $ ./result/bin/nixos-test-driver --interactive
-starting VDE switch for network 1
-&gt;
+[...]
+&gt;&gt;&gt;
 </programlisting>
   <para>
     You can then take any Python statement, e.g.
   </para>
   <programlisting language="python">
-&gt; start_all()
-&gt; test_script()
-&gt; machine.succeed(&quot;touch /tmp/foo&quot;)
-&gt; print(machine.succeed(&quot;pwd&quot;)) # Show stdout of command
+&gt;&gt;&gt; start_all()
+&gt;&gt;&gt; test_script()
+&gt;&gt;&gt; machine.succeed(&quot;touch /tmp/foo&quot;)
+&gt;&gt;&gt; print(machine.succeed(&quot;pwd&quot;)) # Show stdout of command
 </programlisting>
   <para>
     The function <literal>test_script</literal> executes the entire test

--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -17,7 +17,7 @@ rec {
   inherit pkgs;
 
   # Run an automated test suite in the given virtual network.
-  runTests = { driver, pos }:
+  runTests = { driver, driverInteractive, pos }:
     stdenv.mkDerivation {
       name = "vm-test-run-${driver.testName}";
 
@@ -34,7 +34,7 @@ rec {
         '';
 
       passthru = driver.passthru // {
-        inherit driver;
+        inherit driver driverInteractive;
       };
 
       inherit pos; # for better debugging
@@ -224,7 +224,7 @@ rec {
           passMeta = drv: drv // lib.optionalAttrs (t ? meta) {
             meta = (drv.meta or { }) // t.meta;
           };
-        in passMeta (runTests { inherit driver pos; });
+        in passMeta (runTests { inherit driver pos driverInteractive; });
 
     in
       test // {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

To make `driverInteractive` more easily accessible, instead of having to type out the name of the file you can now type `nixosTests.<test>.driverInteractive`, consistent with `nixosTests.<test>.driver`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
