### PR TITLE
kafdrop: init at 3.28.0

### DIFF
--- a/pkgs/development/tools/misc/kafdrop/default.nix
+++ b/pkgs/development/tools/misc/kafdrop/default.nix
@@ -1,0 +1,55 @@
+{ stdenv, maven, fetchgit, makeWrapper, jre, lib }:
+let
+  version = "3.28.0";
+
+  src = fetchgit {
+    url = "https://github.com/obsidiandynamics/kafdrop.git";
+    rev = "d2f0bf10cce8e842dab7b8bcca27ac00b2752abb";
+    sha256 = "0jnkkchc2hqvsn7hhq9ayhnbl8wqby9mhmr7yrxakddy2rlwbgh1";
+  };
+
+  deps = stdenv.mkDerivation {
+    name = "kafdrop-${version}-deps";
+    inherit src;
+    buildInputs = [ maven ];
+    buildPhase = ''
+       mvn package -Dmaven.repo.local=$out
+    '';
+    installPhase = ''
+    find $out -type f \
+      -name \*.lastUpdated -or \
+      -name resolver-status.properties -or \
+      -name _remote.repositories \
+      -delete
+  '';
+    dontFixup = true;
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "sha256-X67wCwxC1Z7H+vDUKPsjx8PGSm7O5JVA7/f9tvKobyA=";
+  };
+  
+in
+stdenv.mkDerivation rec {
+  pname = "kafdrop";
+  inherit version;
+  inherit src;
+  buildInputs = [ maven makeWrapper ];
+  buildPhase = ''
+    echo "Using repository ${deps}"
+    mvn --offline -Dmaven.repo.local=${deps} package;
+  '';
+  installPhase =''
+    mkdir -p $out/bin
+    mkdir -p $out/share/java           
+    mv target/${pname}-${version}-SNAPSHOT.jar $out/share/java/           
+    makeWrapper ${jre}/bin/java $out/bin/${pname} \
+        --add-flags "-jar $out/share/java/${pname}-${version}-SNAPSHOT.jar"
+                '';
+
+  meta = with lib; {
+    homepage = "https://github.com/obsidiandynamics/kafdrop";
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ heph2 ];
+  };
+}

--- a/pkgs/development/tools/misc/kafdrop/default.nix
+++ b/pkgs/development/tools/misc/kafdrop/default.nix
@@ -27,7 +27,7 @@ let
     outputHashMode = "recursive";
     outputHash = "sha256-X67wCwxC1Z7H+vDUKPsjx8PGSm7O5JVA7/f9tvKobyA=";
   };
-  
+
 in
 stdenv.mkDerivation rec {
   pname = "kafdrop";
@@ -40,8 +40,8 @@ stdenv.mkDerivation rec {
   '';
   installPhase =''
     mkdir -p $out/bin
-    mkdir -p $out/share/java           
-    mv target/${pname}-${version}-SNAPSHOT.jar $out/share/java/           
+    mkdir -p $out/share/java
+    mv target/${pname}-${version}-SNAPSHOT.jar $out/share/java/
     makeWrapper ${jre}/bin/java $out/bin/${pname} \
         --add-flags "-jar $out/share/java/${pname}-${version}-SNAPSHOT.jar"
                 '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Kafdrop is a web UI for viewing Kafka topics and browsing consumer groups

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
