### PR TITLE
python3Packages.torchinfo: init at 1.6.2

### DIFF
--- a/pkgs/development/python-modules/torchinfo/default.nix
+++ b/pkgs/development/python-modules/torchinfo/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, fetchPypi
+, python
+, buildPythonPackage
+, pythonOlder
+, pytorch
+, pytestCheckHook
+, torchvision
+}:
+
+buildPythonPackage rec {
+  pname = "torchinfo";
+  version = "1.6.2";
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-vf3TADqIX4RtCU3dN/lBK4aRg3wud/KkK9u5XGnBbO4=";
+  };
+
+  propagatedBuildInputs = [
+    pytorch
+    torchvision
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Skip as it downloads pretrained weights (require network access)
+    "test_eval_order_doesnt_matter"
+  ];
+
+  pythonImportsCheck = [ "torchvision" ];
+
+  meta = {
+    description = "API to visualize pytorch models";
+    homepage = "https://github.com/TylerYep/torchinfo";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ petterstorvik ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9728,6 +9728,8 @@ in {
 
   torchgpipe = callPackage ../development/python-modules/torchgpipe { };
 
+  torchinfo = callPackage ../development/python-modules/torchinfo { };
+
   torchvision = callPackage ../development/python-modules/torchvision { };
 
   torchvision-bin = callPackage ../development/python-modules/torchvision/bin.nix { };


### PR DESCRIPTION
###### Motivation for this change

Add torchinfo python package. 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
