### PR TITLE
vlc: quick fix issue with newer libcaca

### DIFF
--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -233,6 +233,7 @@ stdenv.mkDerivation rec {
     description = "Cross-platform media player and streaming server";
     homepage = "http://www.videolan.org/vlc/";
     license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ AndersonTorres ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -62,6 +62,7 @@ stdenv.mkDerivation rec {
   BUILDCC = "${stdenv.cc}/bin/gcc";
 
   patches = [
+    # Required in order to run newer srt plugin. Remove it when next release arrives
     (fetchpatch {
       url = "https://raw.githubusercontent.com/archlinux/svntogit-packages/4250fe8f28c220d883db454cec2b2c76a07473eb/trunk/vlc-3.0.11.1-srt_1.4.2.patch";
       sha256 = "53poWjZfwq/6l316sqiCp0AtcGweyXBntcLDFPSokHQ=";

--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -1,28 +1,87 @@
-{ lib, stdenv, fetchurl, autoreconfHook, fetchpatch
-, libarchive, perl, xorg, libdvdnav, libbluray
-, zlib, a52dec, libmad, faad2, ffmpeg, alsa-lib
-, pkg-config, dbus, fribidi, freefont_ttf, libebml, libmatroska
-, libvorbis, libtheora, speex, lua5, libgcrypt, libgpg-error, libupnp
-, libcaca, libpulseaudio, flac, schroedinger, libxml2, librsvg
-, mpeg2dec, systemd, gnutls, avahi, libcddb, libjack2, SDL, SDL_image
-, libmtp, unzip, taglib, libkate, libtiger, libv4l, samba, libssh2, liboggz
-, libass, libva, libdvbpsi, libdc1394, libraw1394, libopus
-, libvdpau, libsamplerate, libspatialaudio, live555, fluidsynth
-, wayland, wayland-protocols, ncurses, srt
-, onlyLibVLC ? false
-, withQt5 ? true, qtbase, qtsvg, qtx11extras, wrapQtAppsHook
-, jackSupport ? false
-, skins2Support ? !onlyLibVLC, freetype
+{ lib
+, stdenv
+, fetchurl
+, fetchpatch
+, SDL
+, SDL_image
+, a52dec
+, alsa-lib
+, autoreconfHook
+, avahi
+, dbus
+, faad2
+, ffmpeg
+, flac
+, fluidsynth
+, freefont_ttf
+, fribidi
+, gnutls
+, libarchive
+, libass
+, libbluray
+, libcaca
+, libcddb
+, libdc1394
+, libdvbpsi
+, libdvdnav
+, libebml
+, libgcrypt
+, libgpg-error
+, libjack2
+, libkate
+, libmad
+, libmatroska
+, libmtp
+, liboggz
+, libopus
+, libpulseaudio
+, libraw1394
+, librsvg
+, libsamplerate
+, libspatialaudio
+, libssh2
+, libtheora
+, libtiger
+, libupnp
+, libv4l
+, libva
+, libvdpau
+, libvorbis
+, libxml2
+, live555
+, lua5
+, mpeg2dec
+, ncurses
+, perl
+, pkg-config
 , removeReferencesTo
-, chromecastSupport ? true, protobuf, libmicrodns
+, samba
+, schroedinger
+, speex
+, srt
+, systemd
+, taglib
+, unzip
+, wayland
+, wayland-protocols
+, xorg
+, zlib
+
+, chromecastSupport ? true, libmicrodns, protobuf
+, jackSupport ? false
+, onlyLibVLC ? false
+, skins2Support ? !onlyLibVLC, freetype
+, withQt5 ? true, qtbase, qtsvg, qtx11extras, wrapQtAppsHook
 }:
 
 # chromecastSupport requires TCP port 8010 to be open for it to work.
 # If your firewall is enabled, make sure to have something like:
 #   networking.firewall.allowedTCPPorts = [ 8010 ];
 
-with lib;
-
+let
+  inherit (lib) optionalString optional optionals;
+  hostIsAarch = stdenv.hostPlatform.isAarch32 || stdenv.hostPlatform.isAarch64;
+in
 stdenv.mkDerivation rec {
   pname = "${optionalString onlyLibVLC "lib"}vlc";
   version = "3.0.16";
@@ -36,26 +95,88 @@ stdenv.mkDerivation rec {
   # which are not included here for no other reason that nobody has mentioned
   # needing them
   buildInputs = [
-    zlib a52dec libmad faad2 ffmpeg alsa-lib libdvdnav libdvdnav.libdvdread
-    libbluray dbus fribidi libvorbis libtheora speex lua5 libgcrypt libgpg-error
-    libupnp libcaca libpulseaudio flac schroedinger libxml2 librsvg mpeg2dec
-    systemd gnutls avahi libcddb SDL SDL_image libmtp taglib libarchive
-    libkate libtiger libv4l samba libssh2 liboggz libass libdvbpsi libva
-    xorg.xlibsWrapper xorg.libXv xorg.libXvMC xorg.libXpm xorg.xcbutilkeysyms
-    libdc1394 libraw1394 libopus libebml libmatroska libvdpau libsamplerate
-    libspatialaudio fluidsynth wayland wayland-protocols ncurses srt
-  ] ++ optional (!stdenv.hostPlatform.isAarch64 && !stdenv.hostPlatform.isAarch32) live555
-    ++ optionals withQt5    [ qtbase qtsvg qtx11extras ]
-    ++ optionals skins2Support (with xorg; [ libXpm freetype libXext libXinerama ])
-    ++ optional jackSupport libjack2
-    ++ optionals chromecastSupport [ protobuf libmicrodns ];
+    SDL
+    SDL_image
+    a52dec
+    alsa-lib
+    avahi
+    dbus
+    faad2
+    ffmpeg
+    flac
+    fluidsynth
+    fribidi
+    gnutls
+    libarchive
+    libass
+    libbluray
+    libcaca
+    libcddb
+    libdc1394
+    libdvbpsi
+    libdvdnav
+    libdvdnav.libdvdread
+    libebml
+    libgcrypt
+    libgpg-error
+    libkate
+    libmad
+    libmatroska
+    libmtp
+    liboggz
+    libopus
+    libpulseaudio
+    libraw1394
+    librsvg
+    libsamplerate
+    libspatialaudio
+    libssh2
+    libtheora
+    libtiger
+    libupnp
+    libv4l
+    libva
+    libvdpau
+    libvorbis
+    libxml2
+    lua5
+    mpeg2dec
+    ncurses
+    samba
+    schroedinger
+    speex
+    srt
+    systemd
+    taglib
+    wayland
+    wayland-protocols
+    zlib
+  ]
+  ++ (with xorg; [
+    libXpm
+    libXv
+    libXvMC
+    xcbutilkeysyms
+    xlibsWrapper
+  ])
+  ++ optional (!hostIsAarch) live555
+  ++ optional jackSupport libjack2
+  ++ optionals chromecastSupport [ libmicrodns protobuf ]
+  ++ optionals skins2Support (with xorg; [ freetype libXext libXinerama libXpm ])
+  ++ optionals withQt5 [ qtbase qtsvg qtx11extras ];
 
-  nativeBuildInputs = [ autoreconfHook perl pkg-config removeReferencesTo unzip ]
-    ++ optionals withQt5 [ wrapQtAppsHook ];
+  nativeBuildInputs = [
+    autoreconfHook
+    perl
+    pkg-config
+    removeReferencesTo
+    unzip
+  ]
+  ++ optionals withQt5 [ wrapQtAppsHook ];
 
   enableParallelBuilding = true;
 
-  LIVE555_PREFIX = if (!stdenv.hostPlatform.isAarch64 && !stdenv.hostPlatform.isAarch32) then live555 else null;
+  LIVE555_PREFIX = if hostIsAarch then null else live555;
 
   # vlc depends on a c11-gcc wrapper script which we don't have so we need to
   # set the path to the compiler
@@ -87,8 +208,8 @@ stdenv.mkDerivation rec {
   # Most of the libraries are auto-detected so we don't need to set a bunch of
   # "--enable-foo" flags here
   configureFlags = [
-    "--with-kde-solid=$out/share/apps/solid/actions"
     "--enable-srt" # Explicit enable srt to ensure the patch is applied.
+    "--with-kde-solid=$out/share/apps/solid/actions"
   ] ++ optional onlyLibVLC "--disable-vlc"
     ++ optional skins2Support "--enable-skins2"
     ++ optionals chromecastSupport [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29275,7 +29275,12 @@ with pkgs;
 
   vkeybd = callPackage ../applications/audio/vkeybd {};
 
-  vlc = libsForQt5.callPackage ../applications/video/vlc {};
+  vlc = libsForQt5.callPackage ../applications/video/vlc {
+    # Newest libcaca changed the API, and libvlc didn't catch it. Until next
+    # version arrives, it is safer to disable it.
+    # Upstream thread: https://code.videolan.org/videolan/vlc/-/issues/26389
+    libcaca = null;
+  };
 
   vlc_qt5 = vlc;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Newest libcaca changed the API, and libvlc didn't catch it. Until next version of VLC arrives, it is safer to disable it.

Fixes https://github.com/NixOS/nixpkgs/issues/153284

Related: https://github.com/NixOS/nixpkgs/pull/153140

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
