### PR TITLE
libsForQt5.plasmaMobileGear: 21.08 -> 22.04

### DIFF
--- a/pkgs/applications/plasma-mobile/angelfish.nix
+++ b/pkgs/applications/plasma-mobile/angelfish.nix
@@ -4,6 +4,7 @@
 , cmake
 , corrosion
 , extra-cmake-modules
+, gcc11
 , kconfig
 , kcoreaddons
 , kdbusaddons
@@ -19,8 +20,8 @@
 , srcs
 
 # These must be updated in tandem with package updates.
-, cargoShaForVersion ? "21.12"
-, cargoSha256 ? "lEqaLwXC30YBWZieEh84O8GUDvnsBSh0HaMWJWHaZJI="
+, cargoShaForVersion ? "22.04"
+, cargoSha256 ? "RtdZMBKixC3mdHeFXY9u0pHyDv93Z8p4EVY+lz1aISM="
 }:
 
 # Guard against incomplete updates.
@@ -45,6 +46,7 @@ mkDerivation rec {
     cmake
     corrosion
     extra-cmake-modules
+    gcc11 # doesn't build with GCC 9 from stdenv on aarch64
   ] ++ (with rustPlatform; [
     cargoSetupHook
     rust.cargo

--- a/pkgs/applications/plasma-mobile/angelfish.nix
+++ b/pkgs/applications/plasma-mobile/angelfish.nix
@@ -19,8 +19,8 @@
 , srcs
 
 # These must be updated in tandem with package updates.
-, cargoShaForVersion ? "21.08"
-, cargoSha256 ? "1pbvw9hdzn3i97mahdy9y6jnjsmwmjs3lxfz7q6r9r10i8swbkak"
+, cargoShaForVersion ? "21.12"
+, cargoSha256 ? "lEqaLwXC30YBWZieEh84O8GUDvnsBSh0HaMWJWHaZJI="
 }:
 
 # Guard against incomplete updates.

--- a/pkgs/applications/plasma-mobile/audiotube.nix
+++ b/pkgs/applications/plasma-mobile/audiotube.nix
@@ -1,6 +1,5 @@
 { lib
 , mkDerivation
-, fetchpatch
 
 , extra-cmake-modules
 
@@ -16,14 +15,6 @@
 mkDerivation rec {
   pname = "audiotube";
 
-  patches = [
-    # Fix compatibility with ytmusicapi 0.19.1
-    (fetchpatch {
-      url = "https://invent.kde.org/plasma-mobile/audiotube/-/commit/734caa02805988200f923b88d1590b3f7dac8ac2.patch";
-      sha256 = "0zq4f0w84dv0630bpvmqkfmhxbvibr2fxhzy6d2mnf098028gzyd";
-    })
-  ];
-
   nativeBuildInputs = [
     extra-cmake-modules
     python3Packages.wrapPython
@@ -37,13 +28,11 @@ mkDerivation rec {
     kirigami2
     qtmultimedia
     qtquickcontrols2
-    python3Packages.youtube-dl
-    python3Packages.ytmusicapi
-  ];
+  ] ++ pythonPath;
 
-  pythonPath = [
-    python3Packages.youtube-dl
-    python3Packages.ytmusicapi
+  pythonPath = with python3Packages; [
+    yt-dlp
+    ytmusicapi
   ];
 
   preFixup = ''

--- a/pkgs/applications/plasma-mobile/audiotube.nix
+++ b/pkgs/applications/plasma-mobile/audiotube.nix
@@ -2,6 +2,7 @@
 , mkDerivation
 
 , extra-cmake-modules
+, gcc11
 
 , kcoreaddons
 , kcrash
@@ -17,6 +18,7 @@ mkDerivation rec {
 
   nativeBuildInputs = [
     extra-cmake-modules
+    gcc11 # doesn't build with GCC 9 from stdenv on aarch64
     python3Packages.wrapPython
     python3Packages.pybind11
   ];

--- a/pkgs/applications/plasma-mobile/default.nix
+++ b/pkgs/applications/plasma-mobile/default.nix
@@ -77,6 +77,7 @@ let
       plasma-dialer = callPackage ./plasma-dialer.nix {};
       plasma-phonebook = callPackage ./plasma-phonebook.nix {};
       plasma-settings = callPackage ./plasma-settings.nix {};
+      plasmatube = callPackage ./plasmatube.nix {};
       spacebar = callPackage ./spacebar.nix {};
     };
 

--- a/pkgs/applications/plasma-mobile/default.nix
+++ b/pkgs/applications/plasma-mobile/default.nix
@@ -73,6 +73,7 @@ let
       krecorder = callPackage ./krecorder.nix {};
       ktrip = callPackage ./ktrip.nix {};
       kweather = callPackage ./kweather.nix {};
+      neochat = callPackage ./neochat.nix {};
       plasma-dialer = callPackage ./plasma-dialer.nix {};
       plasma-phonebook = callPackage ./plasma-phonebook.nix {};
       plasma-settings = callPackage ./plasma-settings.nix {};

--- a/pkgs/applications/plasma-mobile/fetch.sh
+++ b/pkgs/applications/plasma-mobile/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/plasma-mobile/21.08/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/plasma-mobile/21.12/ -A '*.tar.xz' )

--- a/pkgs/applications/plasma-mobile/fetch.sh
+++ b/pkgs/applications/plasma-mobile/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/plasma-mobile/21.12/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/plasma-mobile/22.04/ -A '*.tar.xz' )

--- a/pkgs/applications/plasma-mobile/kasts.nix
+++ b/pkgs/applications/plasma-mobile/kasts.nix
@@ -10,9 +10,12 @@
 , kcoreaddons
 , ki18n
 , kirigami2
+, networkmanager-qt
+, qtkeychain
 , qtmultimedia
 , qtquickcontrols2
 , syndication
+, taglib
 }:
 
 let
@@ -37,9 +40,12 @@ mkDerivation rec {
     kcoreaddons
     ki18n
     kirigami2
-    qtquickcontrols2
+    networkmanager-qt
+    qtkeychain
     qtmultimedia
+    qtquickcontrols2
     syndication
+    taglib
   ];
 
   preFixup = ''

--- a/pkgs/applications/plasma-mobile/krecorder.nix
+++ b/pkgs/applications/plasma-mobile/krecorder.nix
@@ -5,6 +5,7 @@
 , extra-cmake-modules
 
 , kconfig
+, kcoreaddons
 , ki18n
 , kirigami2
 , qtmultimedia
@@ -21,6 +22,7 @@ mkDerivation rec {
 
   buildInputs = [
     kconfig
+    kcoreaddons
     ki18n
     kirigami2
     qtmultimedia

--- a/pkgs/applications/plasma-mobile/neochat.nix
+++ b/pkgs/applications/plasma-mobile/neochat.nix
@@ -1,6 +1,5 @@
 { mkDerivation
 , lib
-, fetchFromGitLab
 , pkg-config
 , cmake
 , cmark
@@ -28,15 +27,6 @@
 
 mkDerivation rec {
   pname = "neochat";
-  version = "22.02";
-
-  src = fetchFromGitLab {
-    domain = "invent.kde.org";
-    owner = "network";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-7EBnHuwpyJ/bGrCldZHWOwcnJWDIDaNWZXHkCYkOTjs=";
-  };
 
   nativeBuildInputs = [ cmake extra-cmake-modules pkg-config ];
 
@@ -64,7 +54,7 @@ mkDerivation rec {
   ];
 
   meta = with lib; {
-    description = "A client for matrix, the decentralized communication protocol.";
+    description = "A client for matrix, the decentralized communication protocol";
     homepage = "https://apps.kde.org/en/neochat";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ peterhoeg ];

--- a/pkgs/applications/plasma-mobile/plasma-dialer.nix
+++ b/pkgs/applications/plasma-mobile/plasma-dialer.nix
@@ -4,6 +4,7 @@
 , cmake
 , extra-cmake-modules
 
+, callaudiod
 , kcontacts
 , kcoreaddons
 , kdbusaddons
@@ -12,11 +13,10 @@
 , knotifications
 , kpeople
 , libphonenumber
-, libpulseaudio
 , modemmanager-qt
 , protobuf
-, pulseaudio-qt
 , qtfeedback
+, qtmpris
 , qtquickcontrols2
 }:
 
@@ -29,6 +29,7 @@ mkDerivation rec {
   ];
 
   buildInputs = [
+    callaudiod
     kcontacts
     kcoreaddons
     kdbusaddons
@@ -37,11 +38,10 @@ mkDerivation rec {
     knotifications
     kpeople
     libphonenumber
-    libpulseaudio
     modemmanager-qt
     protobuf # Needed by libphonenumber
-    pulseaudio-qt
     qtfeedback
+    qtmpris
     qtquickcontrols2
   ];
 

--- a/pkgs/applications/plasma-mobile/plasma-dialer.nix
+++ b/pkgs/applications/plasma-mobile/plasma-dialer.nix
@@ -13,11 +13,11 @@
 , kpeople
 , libphonenumber
 , libpulseaudio
-, libqofono
+, modemmanager-qt
 , protobuf
 , pulseaudio-qt
+, qtfeedback
 , qtquickcontrols2
-, telepathy
 }:
 
 mkDerivation rec {
@@ -38,11 +38,11 @@ mkDerivation rec {
     kpeople
     libphonenumber
     libpulseaudio
-    libqofono
+    modemmanager-qt
     protobuf # Needed by libphonenumber
     pulseaudio-qt
+    qtfeedback
     qtquickcontrols2
-    telepathy
   ];
 
   meta = with lib; {

--- a/pkgs/applications/plasma-mobile/plasma-settings.nix
+++ b/pkgs/applications/plasma-mobile/plasma-settings.nix
@@ -11,6 +11,8 @@
 , kdbusaddons
 , ki18n
 , kitemmodels
+, modemmanager-qt
+, networkmanager-qt
 , plasma-framework
 }:
 
@@ -29,6 +31,8 @@ mkDerivation rec {
     kdbusaddons
     ki18n
     kitemmodels
+    modemmanager-qt
+    networkmanager-qt
     plasma-framework
   ];
 

--- a/pkgs/applications/plasma-mobile/plasmatube.nix
+++ b/pkgs/applications/plasma-mobile/plasmatube.nix
@@ -1,0 +1,41 @@
+{ lib
+, mkDerivation
+, cmake
+, extra-cmake-modules
+, gst_all_1
+, kcoreaddons
+, kdeclarative
+, ki18n
+, kirigami2
+, qtmultimedia
+, qtquickcontrols2
+}:
+
+mkDerivation {
+  pname = "plasmatube";
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    kcoreaddons
+    kdeclarative
+    ki18n
+    kirigami2
+    qtmultimedia
+    qtquickcontrols2
+  ] ++ (with gst_all_1; [
+    gst-plugins-bad
+    gst-plugins-base
+    gst-plugins-good
+    gstreamer
+  ]);
+
+  meta = {
+    description = "Youtube player powered by an invidious server";
+    homepage = "https://invent.kde.org/plasma-mobile/plasmatube";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/applications/plasma-mobile/spacebar.nix
+++ b/pkgs/applications/plasma-mobile/spacebar.nix
@@ -11,8 +11,10 @@
 , kpeople
 , libphonenumber
 , libqofono
+, modemmanager-qt
 , protobuf
-, telepathy
+, qcoro
+, qtquickcontrols2
 }:
 
 mkDerivation rec {
@@ -30,9 +32,10 @@ mkDerivation rec {
     knotifications
     kpeople
     libphonenumber
-    libqofono
+    modemmanager-qt
     protobuf # Needed by libphonenumber
-    telepathy
+    qcoro
+    qtquickcontrols2
   ];
 
   meta = with lib; {

--- a/pkgs/applications/plasma-mobile/srcs.nix
+++ b/pkgs/applications/plasma-mobile/srcs.nix
@@ -4,187 +4,187 @@
 
 {
   alligator = {
-    version = "21.12";
+    version = "22.04";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.12/alligator-21.12.tar.xz";
-      sha256 = "0g4fp9b5n1dn27yn5ynk9yiqq2841cfa33ba9dvvmh21y82qsnkw";
-      name = "alligator-21.12.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.04/alligator-22.04.tar.xz";
+      sha256 = "1f2s0ay4qr7ylqnx8d1fawwi4h15gza2d4dsvrww1gm8ar1miqwc";
+      name = "alligator-22.04.tar.xz";
     };
   };
   angelfish = {
-    version = "21.12";
+    version = "22.04";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.12/angelfish-21.12.tar.xz";
-      sha256 = "19wv68g9637zlgpnvf1jp60pdbakfgdh0z6jpzsaxqh70vlgmiba";
-      name = "angelfish-21.12.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.04/angelfish-22.04.tar.xz";
+      sha256 = "169bhkymfxcs93injzp86cvcdhv78pl4dfsscjahlh9c1g5lsbqa";
+      name = "angelfish-22.04.tar.xz";
     };
   };
   audiotube = {
-    version = "21.12";
+    version = "22.04";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.12/audiotube-21.12.tar.xz";
-      sha256 = "1q7zraa9z7vdfyg3r3mkigk2x15sskwnhaz06zmprxim0bky44qp";
-      name = "audiotube-21.12.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.04/audiotube-22.04.tar.xz";
+      sha256 = "0x9xmlfz39ac15c4rbg33sl1bbjmglxgz39flmrvrrw9h2m62s2x";
+      name = "audiotube-22.04.tar.xz";
     };
   };
   calindori = {
-    version = "21.12";
+    version = "22.04";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.12/calindori-21.12.tar.xz";
-      sha256 = "1rm9gdb0hp5w7wzb8km0fr0affbng9jy6vcc86qsz6b4v4j2pirb";
-      name = "calindori-21.12.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.04/calindori-22.04.tar.xz";
+      sha256 = "1zinhlflrx230yymlfxvm98dvvq1yig3r49bq61fmyrzq6fdfv60";
+      name = "calindori-22.04.tar.xz";
     };
   };
   kalk = {
-    version = "21.12";
+    version = "22.04";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.12/kalk-21.12.tar.xz";
-      sha256 = "109q95kyrxp8m7zfmdmpgz4kzlqrkhz90gnrcclg1vcj272nbcyj";
-      name = "kalk-21.12.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.04/kalk-22.04.tar.xz";
+      sha256 = "0aaqcb7jkkqypawfkzjnqglzyni17064d0mhch8g7q0qm5izvap8";
+      name = "kalk-22.04.tar.xz";
     };
   };
   kasts = {
-    version = "21.12";
+    version = "22.04";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.12/kasts-21.12.tar.xz";
-      sha256 = "1rnmhpxjjq9p2kpbhdpd9v5hwk47jn1x8v0krbw5761v1sc1j5v0";
-      name = "kasts-21.12.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.04/kasts-22.04.tar.xz";
+      sha256 = "0c60wp0i6l7ji13ap69lh21vpdq09h2nmqpzjlrwlbjqbhhx7lsh";
+      name = "kasts-22.04.tar.xz";
     };
   };
   kclock = {
-    version = "21.12";
+    version = "22.04";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.12/kclock-21.12.tar.xz";
-      sha256 = "15069139zvxw1766gckqzb01ka55pd5idzbv8nd7n24kbls90xqj";
-      name = "kclock-21.12.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.04/kclock-22.04.tar.xz";
+      sha256 = "1ycln85ydd3qmzfadgg80zf7jlwx5yijxs1mbfmx7f1rr427qdk6";
+      name = "kclock-22.04.tar.xz";
     };
   };
   keysmith = {
-    version = "21.12";
+    version = "22.04";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.12/keysmith-21.12.tar.xz";
-      sha256 = "05k2v3bd2szb1h47jwfvshbhx1ifmx1m8lv76i8jmn8kpwla0fzy";
-      name = "keysmith-21.12.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.04/keysmith-22.04.tar.xz";
+      sha256 = "0cx14r820mnlh75l3blc0ywxwmlinn2wakdnwl75w6i8l46k48li";
+      name = "keysmith-22.04.tar.xz";
     };
   };
   khealthcertificate = {
-    version = "21.12";
+    version = "22.04";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.12/khealthcertificate-21.12.tar.xz";
-      sha256 = "065nc1mswpqz2lrxqamm5jf5f6nx3xhf3h7rw313crf175xq1vi3";
-      name = "khealthcertificate-21.12.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.04/khealthcertificate-22.04.tar.xz";
+      sha256 = "0sr90ki42m3cbjy63rl2ay02wm089wyka0lc4ik7jaic6wb47y5d";
+      name = "khealthcertificate-22.04.tar.xz";
     };
   };
   koko = {
-    version = "21.12";
+    version = "22.04";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.12/koko-21.12.tar.xz";
-      sha256 = "18gxhngjzrg6ngprcal309kk42ls7xvaf311iybxfqsjxzc63hml";
-      name = "koko-21.12.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.04/koko-22.04.tar.xz";
+      sha256 = "0i4h2brc5dqwdmj2bs7nywrz7cgqcf7nmm6yl03047vj9aah01cw";
+      name = "koko-22.04.tar.xz";
     };
   };
   kongress = {
-    version = "21.12";
+    version = "22.04";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.12/kongress-21.12.tar.xz";
-      sha256 = "1b85pq25grrcl3y5d0npay1f8jajr9iqqrpvvqh7i56bsxh6vwzw";
-      name = "kongress-21.12.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.04/kongress-22.04.tar.xz";
+      sha256 = "07yb8hddxl7m1wl0z7rcwdls3k9q89zl1d271n15j1rwrsbwiyxd";
+      name = "kongress-22.04.tar.xz";
     };
   };
   krecorder = {
-    version = "21.12";
+    version = "22.04";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.12/krecorder-21.12.tar.xz";
-      sha256 = "02di8py29ah60cqanggjyf5jlcz0qixl8jgb0hm89jjqsqndd14w";
-      name = "krecorder-21.12.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.04/krecorder-22.04.tar.xz";
+      sha256 = "0d7nvq87avw4gj6whjrlmxs361r9cvzfmfsrca5f536jlazp95pg";
+      name = "krecorder-22.04.tar.xz";
     };
   };
   ktrip = {
-    version = "21.12";
+    version = "22.04";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.12/ktrip-21.12.tar.xz";
-      sha256 = "1i31j1hf6c4h86vprl3gyv05dvg6dvzls6im71kqx1ynm1xjr6gr";
-      name = "ktrip-21.12.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.04/ktrip-22.04.tar.xz";
+      sha256 = "1ijy19axc492l4naayr3d8qdjznc286105qnki8vmcaw93p48n9x";
+      name = "ktrip-22.04.tar.xz";
     };
   };
   kweather = {
-    version = "21.12";
+    version = "22.04";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.12/kweather-21.12.tar.xz";
-      sha256 = "101virkh7sbrzm2022axnnb5k3gw3hk4gr2v0w0i8xfl6d4dpr7j";
-      name = "kweather-21.12.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.04/kweather-22.04.tar.xz";
+      sha256 = "0080l00dya34d35sf6z2j3ra6lls0nafr045a9jmxv09763ydb5d";
+      name = "kweather-22.04.tar.xz";
     };
   };
   neochat = {
-    version = "21.12";
+    version = "22.04";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.12/neochat-21.12.tar.xz";
-      sha256 = "12mb518chd4psb9gbxgnbjl8n7grsmr2wk03k7f238pxjmxi94w3";
-      name = "neochat-21.12.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.04/neochat-22.04.tar.xz";
+      sha256 = "04i1kn52w9jjaaw8x53mksw2vzrpsq1xrq13h158c1s3q1g9jdm8";
+      name = "neochat-22.04.tar.xz";
     };
   };
   plasma-dialer = {
-    version = "21.12";
+    version = "22.04";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.12/plasma-dialer-21.12.tar.xz";
-      sha256 = "0pvyz4f9fmm5iahndps9mgnhbvh35ajgmnzkmmknny0pr5b3x01d";
-      name = "plasma-dialer-21.12.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.04/plasma-dialer-22.04.tar.xz";
+      sha256 = "0hnxasj6psplwykahhisipyvy67hfr820azixw5p820fzy11x2g4";
+      name = "plasma-dialer-22.04.tar.xz";
     };
   };
   plasma-phonebook = {
-    version = "21.12";
+    version = "22.04";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.12/plasma-phonebook-21.12.tar.xz";
-      sha256 = "1qh7hqr6sbxrf92sa1pzsdp59fgc3s3b8vh42vyfww7p1v9gf4aq";
-      name = "plasma-phonebook-21.12.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.04/plasma-phonebook-22.04.tar.xz";
+      sha256 = "14nd2yx9cf6gabb10kcaqkdn7kb96n2209qrib7daq2ldva8c9i9";
+      name = "plasma-phonebook-22.04.tar.xz";
     };
   };
   plasma-settings = {
-    version = "21.12";
+    version = "22.04";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.12/plasma-settings-21.12.tar.xz";
-      sha256 = "1gr6wb4jsdizxg3zc0vynfa7fwpiz5ah2s1qpcdir80fjyxhxld7";
-      name = "plasma-settings-21.12.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.04/plasma-settings-22.04.tar.xz";
+      sha256 = "1k40mviikpij1srar1hkg732qg14ld0176g1mpza0ysr3yr21vny";
+      name = "plasma-settings-22.04.tar.xz";
     };
   };
   plasmatube = {
-    version = "21.12";
+    version = "22.04";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.12/plasmatube-21.12.tar.xz";
-      sha256 = "15jyffv4q11sklh7wwivdny58ia09yyrjdj2r6wqjclrdb8n9ni7";
-      name = "plasmatube-21.12.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.04/plasmatube-22.04.tar.xz";
+      sha256 = "01bmxdh0aclm184j5s0kddjc7a14225bdnbkr8jlk21g9wlw8cyx";
+      name = "plasmatube-22.04.tar.xz";
     };
   };
   qmlkonsole = {
-    version = "21.12";
+    version = "22.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.12/qmlkonsole-21.12.tar.xz";
-      sha256 = "0ywdrz00i40hwhci3l4p8f0z4bjnn9vvsz0p154p1cdn7cz9ydca";
-      name = "qmlkonsole-21.12.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.04/qmlkonsole-22.04.1.tar.xz";
+      sha256 = "06zfrqaag9sgihs5k93nssgm4smrs2ymh7q0fx35z7fcphngjpaw";
+      name = "qmlkonsole-22.04.1.tar.xz";
     };
   };
   spacebar = {
-    version = "21.12";
+    version = "22.04";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.12/spacebar-21.12.tar.xz";
-      sha256 = "062vcba6krp3ksskd2v8szvdblmbzdw580blzy767iac4fx6zybf";
-      name = "spacebar-21.12.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.04/spacebar-22.04.tar.xz";
+      sha256 = "0ga3symavdrq5aim924bd889b9cmv09dyplz9gcspk46w49vx3s5";
+      name = "spacebar-22.04.tar.xz";
     };
   };
   tokodon = {
-    version = "21.12";
+    version = "22.04";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.12/tokodon-21.12.tar.xz";
-      sha256 = "0wd41f7xza26lmznj3qisn9islhwnp6kzqsbm66j0vppb35sbfb3";
-      name = "tokodon-21.12.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.04/tokodon-22.04.tar.xz";
+      sha256 = "0c9q2ax0h047xm3g5r5cn6sxfyv2lb93dahd5z3nw67bfrzwvnw2";
+      name = "tokodon-22.04.tar.xz";
     };
   };
   vakzination = {
-    version = "21.12";
+    version = "22.04";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.12/vakzination-21.12.tar.xz";
-      sha256 = "191g6j7s01khg5vbxzbx8d6729vxvgbw3di1bprgm26ahxl430l4";
-      name = "vakzination-21.12.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.04/vakzination-22.04.tar.xz";
+      sha256 = "0zadygzw4xzpwbdnb6dwjjjls1h915gp9xaf59kbfbmzwb6m4mf8";
+      name = "vakzination-22.04.tar.xz";
     };
   };
 }

--- a/pkgs/applications/plasma-mobile/srcs.nix
+++ b/pkgs/applications/plasma-mobile/srcs.nix
@@ -4,155 +4,187 @@
 
 {
   alligator = {
-    version = "21.08";
+    version = "21.12";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.08/alligator-21.08.tar.xz";
-      sha256 = "1dhwfwd1v5wmx3sldpygb79kz87j13wd0arhlkm94z1whsixan0q";
-      name = "alligator-21.08.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/21.12/alligator-21.12.tar.xz";
+      sha256 = "0g4fp9b5n1dn27yn5ynk9yiqq2841cfa33ba9dvvmh21y82qsnkw";
+      name = "alligator-21.12.tar.xz";
     };
   };
   angelfish = {
-    version = "21.08";
+    version = "21.12";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.08/angelfish-21.08.tar.xz";
-      sha256 = "1gzvlha159bw767mj8lisn89592j4j4dazzfws3v4anddjh60xnh";
-      name = "angelfish-21.08.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/21.12/angelfish-21.12.tar.xz";
+      sha256 = "19wv68g9637zlgpnvf1jp60pdbakfgdh0z6jpzsaxqh70vlgmiba";
+      name = "angelfish-21.12.tar.xz";
     };
   };
   audiotube = {
-    version = "21.08";
+    version = "21.12";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.08/audiotube-21.08.tar.xz";
-      sha256 = "14h4xna9v70lmp7cfpvdnz0f5a4gwgj0q3byccmawm38xsv15v8c";
-      name = "audiotube-21.08.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/21.12/audiotube-21.12.tar.xz";
+      sha256 = "1q7zraa9z7vdfyg3r3mkigk2x15sskwnhaz06zmprxim0bky44qp";
+      name = "audiotube-21.12.tar.xz";
     };
   };
   calindori = {
-    version = "21.08";
+    version = "21.12";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.08/calindori-21.08.tar.xz";
-      sha256 = "08s16a8skh02n8ygqwryxpzczj5aqr5k58aijaz2gzx45m7ym31b";
-      name = "calindori-21.08.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/21.12/calindori-21.12.tar.xz";
+      sha256 = "1rm9gdb0hp5w7wzb8km0fr0affbng9jy6vcc86qsz6b4v4j2pirb";
+      name = "calindori-21.12.tar.xz";
     };
   };
   kalk = {
-    version = "21.08";
+    version = "21.12";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.08/kalk-21.08.tar.xz";
-      sha256 = "0xzrahpz47yajalsfmpzmavxjwmr4bgljwyz2dhxdg40ryjxdy23";
-      name = "kalk-21.08.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/21.12/kalk-21.12.tar.xz";
+      sha256 = "109q95kyrxp8m7zfmdmpgz4kzlqrkhz90gnrcclg1vcj272nbcyj";
+      name = "kalk-21.12.tar.xz";
     };
   };
   kasts = {
-    version = "21.08";
+    version = "21.12";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.08/kasts-21.08.tar.xz";
-      sha256 = "10v6icxwv46nihzbdi0n2w71bsg7l166z7jf9rb7vf2mjh1gqavn";
-      name = "kasts-21.08.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/21.12/kasts-21.12.tar.xz";
+      sha256 = "1rnmhpxjjq9p2kpbhdpd9v5hwk47jn1x8v0krbw5761v1sc1j5v0";
+      name = "kasts-21.12.tar.xz";
     };
   };
   kclock = {
-    version = "21.08";
+    version = "21.12";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.08/kclock-21.08.tar.xz";
-      sha256 = "1zq0fxlwd7l3b6dgfqsmv1x4wvhmrjz5r0a38hbd7j7pzgyix47d";
-      name = "kclock-21.08.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/21.12/kclock-21.12.tar.xz";
+      sha256 = "15069139zvxw1766gckqzb01ka55pd5idzbv8nd7n24kbls90xqj";
+      name = "kclock-21.12.tar.xz";
     };
   };
   keysmith = {
-    version = "21.08";
+    version = "21.12";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.08/keysmith-21.08.tar.xz";
-      sha256 = "0fa8inli7cwmb75af0mr2cflng0r6k3pd6ckih6ph7szqbpg2x90";
-      name = "keysmith-21.08.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/21.12/keysmith-21.12.tar.xz";
+      sha256 = "05k2v3bd2szb1h47jwfvshbhx1ifmx1m8lv76i8jmn8kpwla0fzy";
+      name = "keysmith-21.12.tar.xz";
+    };
+  };
+  khealthcertificate = {
+    version = "21.12";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma-mobile/21.12/khealthcertificate-21.12.tar.xz";
+      sha256 = "065nc1mswpqz2lrxqamm5jf5f6nx3xhf3h7rw313crf175xq1vi3";
+      name = "khealthcertificate-21.12.tar.xz";
     };
   };
   koko = {
-    version = "21.08";
+    version = "21.12";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.08/koko-21.08.tar.xz";
-      sha256 = "1sqlcl871m6dlrnkkhqa3xfwix01d74d7jf94r1a3p32hqljv76p";
-      name = "koko-21.08.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/21.12/koko-21.12.tar.xz";
+      sha256 = "18gxhngjzrg6ngprcal309kk42ls7xvaf311iybxfqsjxzc63hml";
+      name = "koko-21.12.tar.xz";
     };
   };
   kongress = {
-    version = "21.08";
+    version = "21.12";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.08/kongress-21.08.tar.xz";
-      sha256 = "099ds4bv4ngx21f28hxcvc17wd2nk786kydwf2h5n3mdd2mgz3ka";
-      name = "kongress-21.08.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/21.12/kongress-21.12.tar.xz";
+      sha256 = "1b85pq25grrcl3y5d0npay1f8jajr9iqqrpvvqh7i56bsxh6vwzw";
+      name = "kongress-21.12.tar.xz";
     };
   };
   krecorder = {
-    version = "21.08";
+    version = "21.12";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.08/krecorder-21.08.tar.xz";
-      sha256 = "1381x889h37saf6k875iqhwz5vbixrp7650smxp31r56ycrqq26i";
-      name = "krecorder-21.08.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/21.12/krecorder-21.12.tar.xz";
+      sha256 = "02di8py29ah60cqanggjyf5jlcz0qixl8jgb0hm89jjqsqndd14w";
+      name = "krecorder-21.12.tar.xz";
     };
   };
   ktrip = {
-    version = "21.08";
+    version = "21.12";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.08/ktrip-21.08.tar.xz";
-      sha256 = "0ipxi3pqd7mznq3qjf9j9w3wyck85lxnr81ay6b3ricfb08ry68x";
-      name = "ktrip-21.08.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/21.12/ktrip-21.12.tar.xz";
+      sha256 = "1i31j1hf6c4h86vprl3gyv05dvg6dvzls6im71kqx1ynm1xjr6gr";
+      name = "ktrip-21.12.tar.xz";
     };
   };
   kweather = {
-    version = "21.08";
+    version = "21.12";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.08/kweather-21.08.tar.xz";
-      sha256 = "0b1zjwsakwsnh6827zjhypvb04c78gwwygr7k1cy2x3finrp5if5";
-      name = "kweather-21.08.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/21.12/kweather-21.12.tar.xz";
+      sha256 = "101virkh7sbrzm2022axnnb5k3gw3hk4gr2v0w0i8xfl6d4dpr7j";
+      name = "kweather-21.12.tar.xz";
+    };
+  };
+  neochat = {
+    version = "21.12";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma-mobile/21.12/neochat-21.12.tar.xz";
+      sha256 = "12mb518chd4psb9gbxgnbjl8n7grsmr2wk03k7f238pxjmxi94w3";
+      name = "neochat-21.12.tar.xz";
     };
   };
   plasma-dialer = {
-    version = "21.08";
+    version = "21.12";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.08/plasma-dialer-21.08.tar.xz";
-      sha256 = "14vgjg0nihhm446cfrrld1l43r50dlah5xs2ypdnm68618bdc7p1";
-      name = "plasma-dialer-21.08.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/21.12/plasma-dialer-21.12.tar.xz";
+      sha256 = "0pvyz4f9fmm5iahndps9mgnhbvh35ajgmnzkmmknny0pr5b3x01d";
+      name = "plasma-dialer-21.12.tar.xz";
     };
   };
   plasma-phonebook = {
-    version = "21.08";
+    version = "21.12";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.08/plasma-phonebook-21.08.tar.xz";
-      sha256 = "09gr5mkwhayx6k6bhm29bmcvdlqqw8jj7gydh5fz40g9z98c84km";
-      name = "plasma-phonebook-21.08.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/21.12/plasma-phonebook-21.12.tar.xz";
+      sha256 = "1qh7hqr6sbxrf92sa1pzsdp59fgc3s3b8vh42vyfww7p1v9gf4aq";
+      name = "plasma-phonebook-21.12.tar.xz";
     };
   };
   plasma-settings = {
-    version = "21.08";
+    version = "21.12";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.08/plasma-settings-21.08.tar.xz";
-      sha256 = "005v1gyrzl9b0k875p2wipja3l8l4awp8nl2d1jx7c28lqaspz2j";
-      name = "plasma-settings-21.08.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/21.12/plasma-settings-21.12.tar.xz";
+      sha256 = "1gr6wb4jsdizxg3zc0vynfa7fwpiz5ah2s1qpcdir80fjyxhxld7";
+      name = "plasma-settings-21.12.tar.xz";
+    };
+  };
+  plasmatube = {
+    version = "21.12";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma-mobile/21.12/plasmatube-21.12.tar.xz";
+      sha256 = "15jyffv4q11sklh7wwivdny58ia09yyrjdj2r6wqjclrdb8n9ni7";
+      name = "plasmatube-21.12.tar.xz";
     };
   };
   qmlkonsole = {
-    version = "21.08";
+    version = "21.12";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.08/qmlkonsole-21.08.tar.xz";
-      sha256 = "1p3ysf6sgiji86400523hm67rvw3znj3a7k6g6s83dxynxdh2faq";
-      name = "qmlkonsole-21.08.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/21.12/qmlkonsole-21.12.tar.xz";
+      sha256 = "0ywdrz00i40hwhci3l4p8f0z4bjnn9vvsz0p154p1cdn7cz9ydca";
+      name = "qmlkonsole-21.12.tar.xz";
     };
   };
   spacebar = {
-    version = "21.08";
+    version = "21.12";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.08/spacebar-21.08.tar.xz";
-      sha256 = "1cg36iys4x7p97ywilnp2lzz1ry5a1m7jz38yh2yiw6m8wvzfqff";
-      name = "spacebar-21.08.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/21.12/spacebar-21.12.tar.xz";
+      sha256 = "062vcba6krp3ksskd2v8szvdblmbzdw580blzy767iac4fx6zybf";
+      name = "spacebar-21.12.tar.xz";
     };
   };
   tokodon = {
-    version = "21.08";
+    version = "21.12";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/21.08/tokodon-21.08.tar.xz";
-      sha256 = "0j9zfcdss1872hv8xxrmy0jjmcz3y5kdz8gdrd6qmig5scrzjvnf";
-      name = "tokodon-21.08.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/21.12/tokodon-21.12.tar.xz";
+      sha256 = "0wd41f7xza26lmznj3qisn9islhwnp6kzqsbm66j0vppb35sbfb3";
+      name = "tokodon-21.12.tar.xz";
+    };
+  };
+  vakzination = {
+    version = "21.12";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma-mobile/21.12/vakzination-21.12.tar.xz";
+      sha256 = "191g6j7s01khg5vbxzbx8d6729vxvgbw3di1bprgm26ahxl430l4";
+      name = "vakzination-21.12.tar.xz";
     };
   };
 }

--- a/pkgs/development/libraries/qtmpris/default.nix
+++ b/pkgs/development/libraries/qtmpris/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, qmake
+, qtbase
+}:
+
+mkDerivation rec {
+  pname = "qtmpris";
+  version = "1.0.6";
+
+  src = fetchFromGitHub {
+    owner = "sailfishos";
+    repo = "qtmpris";
+    rev = version;
+    hash = "sha256-kuM8hUdsa7N+eLDbwYw3ay+PWxg35zcTBOvGow1NlzI=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/src.pro \
+      --replace '$$[QT_INSTALL_LIBS]'    "$out/lib" \
+      --replace '$$[QT_INSTALL_HEADERS]' "$out/include" \
+      --replace '$$[QMAKE_MKSPECS]'      "$out/mkspecs"
+  '';
+
+  nativeBuildInputs = [
+    qmake
+  ];
+
+  buildInputs = [
+    qtbase
+  ];
+
+  meta = {
+    description = "Qt and QML MPRIS interface and adaptor";
+    homepage = "https://github.com/sailfishos/qtmpris";
+    license = lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/tools/build-managers/corrosion/default.nix
+++ b/pkgs/development/tools/build-managers/corrosion/default.nix
@@ -8,19 +8,14 @@
 
 stdenv.mkDerivation rec {
   pname = "corrosion";
-  version = "unstable-2021-11-23";
+  version = "unstable-2022-01-03";
 
   src = fetchFromGitHub {
     owner = "AndrewGaspar";
     repo = "corrosion";
-    rev = "f679545a63a8b214a415e086f910126ab66714fa";
-    sha256 = "sha256-K+QdhWc5n5mH6yxiQa/v5HsrqnWJ5SM93IprVpyCVO0=";
+    rev = "ba253b381e99bd87b514db9cee299b849c7625b5";
+    hash = "sha256-r1chLXvWbHtUYSRJis8RNvjDdWERSkqeM4ik30vlfHQ=";
   };
-
-  patches = [
-    # https://github.com/AndrewGaspar/corrosion/issues/84
-    ./cmake-install-full-dir.patch
-  ];
 
   cargoRoot = "generator";
 
@@ -28,7 +23,7 @@ stdenv.mkDerivation rec {
     inherit src;
     sourceRoot = "${src.name}/${cargoRoot}";
     name = "${pname}-${version}";
-    sha256 = "sha256-ZvCRgXv+ASMIL00oc3luegV1qVNDieU9J7mbIhfayGk=";
+    hash = "sha256-xUDmUj73ja8feEh0yyjgkjm7alPaYxucG6sL59mSECg=";
   };
 
   buildInputs = lib.optional stdenv.isDarwin libiconv;

--- a/pkgs/development/tools/build-managers/corrosion/default.nix
+++ b/pkgs/development/tools/build-managers/corrosion/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "corrosion";
-  version = "unstable-2022-01-03";
+  version = "0.2.1";
 
   src = fetchFromGitHub {
-    owner = "AndrewGaspar";
+    owner = "corrosion-rs";
     repo = "corrosion";
-    rev = "ba253b381e99bd87b514db9cee299b849c7625b5";
-    hash = "sha256-r1chLXvWbHtUYSRJis8RNvjDdWERSkqeM4ik30vlfHQ=";
+    rev = "v${version}";
+    hash = "sha256-nJ4ercNykECDBqecuL8cdCl4DHgbgIUmbiFBG/jiOaA=";
   };
 
   cargoRoot = "generator";
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     inherit src;
     sourceRoot = "${src.name}/${cargoRoot}";
     name = "${pname}-${version}";
-    hash = "sha256-xUDmUj73ja8feEh0yyjgkjm7alPaYxucG6sL59mSECg=";
+    hash = "sha256-4JVbHYlMOKztWPYW7tXQdvdNh/ygfpi0CY6Ly93VxsI=";
   };
 
   buildInputs = lib.optional stdenv.isDarwin libiconv;
@@ -45,7 +45,8 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Tool for integrating Rust into an existing CMake project";
-    homepage = "https://github.com/AndrewGaspar/corrosion";
+    homepage = "https://github.com/corrosion-rs/corrosion";
+    changelog = "https://github.com/corrosion-rs/corrosion/blob/${src.rev}/RELEASES.md";
     license = licenses.mit;
     maintainers = with maintainers; [ dotlambda ];
   };

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -855,6 +855,7 @@ mapAliases ({
   navit = throw "navit has been removed from nixpkgs, due to being unmaintained"; # Added 2021-06-07
   ncat = throw "'ncat' has been renamed to/replaced by 'nmap'"; # Converted to throw 2022-02-22
   neap = throw "neap was removed from nixpkgs, as it relies on python2"; # Added 2022-01-12
+  neochat = libsForQt5.plasmaMobileGear.neochat; # added 2022-05-10
   netease-cloud-music = throw "netease-cloud-music has been removed together with deepin"; # Added 2020-08-31
   networkmanager_fortisslvpn = throw "'networkmanager_fortisslvpn' has been renamed to/replaced by 'networkmanager-fortisslvpn'"; # Converted to throw 2022-02-22
   networkmanager_iodine = throw "'networkmanager_iodine' has been renamed to/replaced by 'networkmanager-iodine'"; # Converted to throw 2022-02-22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8497,8 +8497,6 @@ with pkgs;
 
   neo-cowsay = callPackage ../tools/misc/neo-cowsay { };
 
-  neochat = libsForQt5.callPackage ../applications/networking/instant-messengers/neochat { };
-
   neofetch = callPackage ../tools/misc/neofetch { };
 
   nerdfonts = callPackage ../data/fonts/nerdfonts { };

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -205,6 +205,8 @@ in (kdeFrameworks // plasmaMobileGear // plasma5 // plasma5.thirdParty // kdeGea
     inherit (pkgs.darwin.apple_sdk.frameworks) CoreFoundation Security;
   };
 
+  qtmpris = callPackage ../development/libraries/qtmpris { };
+
   qtpbfimageplugin = callPackage ../development/libraries/qtpbfimageplugin { };
 
   qtstyleplugins = callPackage ../development/libraries/qtstyleplugins { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://plasma-mobile.org/2021/12/07/plasma-mobile-gear-21-12/
https://plasma-mobile.org/2022/02/09/plasma-mobile-gear-22-02/
https://plasma-mobile.org/2022/04/26/plasma-mobile-gear-22-04/


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @NixOS/qt-kde 