### PR TITLE
spamassassin: support for fetching rules over HTTPS

### DIFF
--- a/pkgs/servers/mail/spamassassin/default.nix
+++ b/pkgs/servers/mail/spamassassin/default.nix
@@ -9,11 +9,18 @@ perlPackages.buildPerlPackage rec {
     sha256 = "044ng2aazqy8g0m17q0a4939ck1ca4x230q2q7q7jndvwkrpaj5w";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  # ExtUtil::MakeMaker is bundled with Perl, but the bundled version
+  # causes build errors for aarch64-darwin, so we override it with the
+  # latest version.  We can drop the dependency to go back to the
+  # bundled version when the version that comes with Perl is ≥7.57_02.
+  #
+  # Check the version bundled with Perl like this:
+  #   perl -e 'use ExtUtils::MakeMaker qw($VERSION); print "$VERSION\n"'
+  nativeBuildInputs = [ makeWrapper perlPackages.ExtUtilsMakeMaker ];
   buildInputs = (with perlPackages; [
     HTMLParser NetCIDRLite NetDNS NetAddrIP DBFile HTTPDate MailDKIM LWP
-    IOSocketSSL DBI EncodeDetect IPCountry NetIdent Razor2ClientAgent MailSPF
-    NetDNSResolverProgrammable Socket6
+    LWPProtocolHttps IOSocketSSL DBI EncodeDetect IPCountry NetIdent
+    Razor2ClientAgent MailSPF NetDNSResolverProgrammable Socket6
   ]);
 
   # Enabling 'taint' mode is desirable, but that flag disables support


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

sa-update.service starts by making an HTTP GET request to http://spamassassin.apache.org/updates/MIRRORED.BY, which now redirects to HTTPS.  Since we didn't have the appropriate library available to handle HTTPS, rule updates would fail:

    Jan 03 12:35:03 atuin systemd[1]: Starting sa-update.service...
    Jan 03 12:35:10 atuin sa-update-start[1250]: Update available for channel updates.spamassassin.org: 1895535 -> 1896618
    Jan 03 12:35:10 atuin sa-update-start[1250]: http: (lwp) hotpatching IO::Socket::INET by module IO::Socket::IP
    Jan 03 12:35:11 atuin sa-update-start[1250]: http: (lwp) GET http://spamassassin.apache.org/updates/MIRRORED.BY, 501 Protocol scheme 'https' is not suppor>
    Jan 03 12:35:11 atuin sa-update-start[1250]: error: unable to refresh mirrors file for channel updates.spamassassin.org, using old file
    Jan 03 12:35:11 atuin sa-update-start[1250]: error: no mirror data available for channel updates.spamassassin.org
    Jan 03 12:35:11 atuin sa-update-start[1250]: channel 'updates.spamassassin.org': MIRRORED.BY file contents were missing, channel failed
    Jan 03 12:35:11 atuin sa-update-start[1250]: Update failed, exiting with code 4
    Jan 03 12:35:11 atuin systemd[1]: sa-update.service: Main process exited, code=exited, status=4/NOPERMISSION
    Jan 03 12:35:11 atuin systemd[1]: sa-update.service: Failed with result 'exit-code'.
    Jan 03 12:35:11 atuin systemd[1]: Failed to start sa-update.service.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
