### PR TITLE
appflowy: init at 0.0.2

### DIFF
--- a/pkgs/applications/office/appflowy/default.nix
+++ b/pkgs/applications/office/appflowy/default.nix
@@ -1,0 +1,76 @@
+{ stdenv,
+  lib,
+  fetchzip,
+  autoPatchelfHook,
+  makeWrapper,
+  copyDesktopItems,
+  makeDesktopItem,
+  gtk3,
+  openssl,
+  xdg-user-dirs
+}:
+
+stdenv.mkDerivation rec {
+  pname = "appflowy";
+  version = "0.0.2";
+
+  src = fetchzip {
+    url = "https://github.com/AppFlowy-IO/appflowy/releases/download/${version}/AppFlowy-linux-x86.tar.gz";
+    sha256 = "1fvv4mlgf0vqcq5zh0zl2xr44saz0sm47r8whcywwrmcm0l66iv6";
+  };
+
+  nativeBuildInputs = [
+      autoPatchelfHook
+      makeWrapper
+      copyDesktopItems
+  ];
+
+  buildInputs = [
+      gtk3
+      openssl
+  ];
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/opt/
+    mkdir -p $out/bin/
+
+    # Copy archive contents to the outpout directory
+    cp -r ./* $out/opt/
+
+    runHook postInstall
+  '';
+
+  preFixup = let
+    libPath = lib.makeLibraryPath [
+      xdg-user-dirs
+    ];
+  in ''
+    # Add missing libraries to appflowy using the ones it comes with
+    makeWrapper $out/opt/app_flowy $out/bin/appflowy \
+          --set LD_LIBRARY_PATH "$out/opt/lib/:${libPath}"
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      desktopName = "AppFlowy";
+      comment = meta.description;
+      exec = "appflowy";
+      categories = "Office;";
+    })
+  ];
+
+  meta = with lib; {
+    description = "An open-source alternative to Notion";
+    homepage = "https://www.appflowy.io/";
+    license = licenses.agpl3Only;
+    changelog = "https://github.com/AppFlowy-IO/appflowy/releases/tag/${version}";
+    maintainers = with maintainers; [ darkonion0 ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -147,6 +147,8 @@ with pkgs;
     { name = "auto-patchelf-hook"; deps = [ bintools ]; }
     ../build-support/setup-hooks/auto-patchelf.sh;
 
+  appflowy = callPackage ../applications/office/appflowy { };
+
   appimageTools = callPackage ../build-support/appimage {
     buildFHSUserEnv = buildFHSUserEnvBubblewrap;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add AppFlowy to nixpkgs according to this packaging request #146724

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
