### PR TITLE
andyetitmoves: deprecate phases and refactor

### DIFF
--- a/pkgs/games/andyetitmoves/default.nix
+++ b/pkgs/games/andyetitmoves/default.nix
@@ -2,37 +2,42 @@
 
 stdenv.mkDerivation rec {
   pname = "andyetitmoves";
-  version   = "1.2.2";
+  version = "1.2.2";
 
-  src = if stdenv.hostPlatform.system == "i686-linux" || stdenv.hostPlatform.system == "x86_64-linux"
+  src =
+    if stdenv.hostPlatform.system == "i686-linux" || stdenv.hostPlatform.system == "x86_64-linux"
     then
-      let postfix        = if stdenv.hostPlatform.system == "i686-linux" then "i386" else "x86_64";
-          commercialName = "${pname}-${version}_${postfix}.tar.gz";
-          demoUrl        = "http://www.andyetitmoves.net/demo/${pname}Demo-${version}_${postfix}.tar.gz";
+      let
+        postfix = if stdenv.hostPlatform.system == "i686-linux" then "i386" else "x86_64";
+        commercialName = "${pname}-${version}_${postfix}.tar.gz";
+        demoUrl = "http://www.andyetitmoves.net/demo/${pname}Demo-${version}_${postfix}.tar.gz";
       in
       if commercialVersion
-        then requireFile {
-               message = ''
-                 We cannot download the commercial version automatically, as you require a license.
-                 Once you bought a license, you need to add your downloaded version to the nix store.
-                 You can do this by using "nix-prefetch-url file:///\$PWD/${commercialName}" in the
-                 directory where yousaved it.
-               '';
-               name = commercialName;
-               sha256 = if stdenv.hostPlatform.system == "i686-linux"
-                          then "15wvzmmidvykwjrbnq70h5jrvnjx1hcrm0357qj85q4aqbzavh01"
-                          else "1v8z16qa9ka8sf7qq45knsxj87s6sipvv3a7xq11pb5xk08fb2ql";
-             }
-        else fetchurl {
-               url = demoUrl;
-               sha256 = if stdenv.hostPlatform.system == "i686-linux"
-                          then "0f14vrrbq05hsbdajrb5y9za65fpng1lc8f0adb4aaz27x7sh525"
-                          else "0mg41ya0b27blq3b5498kwl4rj46dj21rcd7qd0rw1kyvr7sx4v4";
-             }
+      then
+        requireFile
+          {
+            message = ''
+              We cannot download the commercial version automatically, as you require a license.
+              Once you bought a license, you need to add your downloaded version to the nix store.
+              You can do this by using "nix-prefetch-url file:///\$PWD/${commercialName}" in the
+              directory where yousaved it.
+            '';
+            name = commercialName;
+            sha256 =
+              if stdenv.hostPlatform.system == "i686-linux"
+              then "15wvzmmidvykwjrbnq70h5jrvnjx1hcrm0357qj85q4aqbzavh01"
+              else "1v8z16qa9ka8sf7qq45knsxj87s6sipvv3a7xq11pb5xk08fb2ql";
+          }
+      else
+        fetchurl {
+          url = demoUrl;
+          sha256 =
+            if stdenv.hostPlatform.system == "i686-linux"
+            then "0f14vrrbq05hsbdajrb5y9za65fpng1lc8f0adb4aaz27x7sh525"
+            else "0mg41ya0b27blq3b5498kwl4rj46dj21rcd7qd0rw1kyvr7sx4v4";
+        }
     else
       throw "And Yet It Moves nix package only supports linux and intel cpu's.";
-
-  phases = "unpackPhase installPhase";
 
   installPhase = ''
     mkdir -p $out/{opt/andyetitmoves,bin}
@@ -54,19 +59,15 @@ stdenv.mkDerivation rec {
     chmod +x $out/bin/$binName
   '';
 
-  buildInputs = [libvorbis libogg libtheora SDL libXft SDL_image zlib libX11 libpng openal];
+  buildInputs = [ libvorbis libogg libtheora SDL libXft SDL_image zlib libX11 libpng openal ];
 
-  meta = {
+  meta = with lib; {
     description = "Physics/Gravity Platform game";
-
     longDescription = ''
       And Yet It Moves is an award-winning physics-based platform game in which players rotate the game world at will to solve challenging puzzles. Tilting the world turns walls into floors, slides into platforms, and stacks of rocks into dangerous hazards.
     '';
-
     homepage = "http://www.andyetitmoves.net/";
-
-    license = lib.licenses.unfree;
-
-    maintainers = with lib.maintainers; [bluescreen303];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ bluescreen303 ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#28910 with refactoring

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
