### PR TITLE
terraform-providers.checkly: init at 1.3.0

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -52,7 +52,7 @@ let
   automated-providers = lib.mapAttrs (_: attrs: mkProvider attrs) list;
 
   # These are the providers that don't fall in line with the default model
-  special-providers = let archived = throw "the provider has been archived by upsteam"; in {
+  special-providers = let archived = throw "the provider has been archived by upstream"; in {
     # Packages that don't fit the default model
     gandi = callPackage ./gandi { };
     libvirt = callPackage ./libvirt { };

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -153,6 +153,15 @@
     "vendorSha256": "07mznpp2mr1n9izgk2s8aibfvqsamj533666s46x1k49p0sh7lqx",
     "version": "2.0.6"
   },
+  "checkly": {
+    "owner": "checkly",
+    "provider-source-address": "registry.terraform.io/checkly/checkly",
+    "repo": "terraform-provider-checkly",
+    "rev": "v1.3.0",
+    "sha256": "11vwl983lh983c1x3f7zc8b7i9f4pymk4j1ikf04vz2kgxry49yr",
+    "vendorSha256": "14wp5sa2fm3hlmyacfy4aacx2cz5bxf24r4fjwd6f2hskzjz6825",
+    "version": "1.3.0"
+  },
   "checkpoint": {
     "deleteVendor": true,
     "owner": "CheckPointSW",


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Supersedes https://github.com/NixOS/nixpkgs/pull/107147

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
