### PR TITLE
deadbeef/plugins: add the gnome-mmkeys plugin

### DIFF
--- a/pkgs/applications/audio/deadbeef/plugins/gnome-mmkeys.nix
+++ b/pkgs/applications/audio/deadbeef/plugins/gnome-mmkeys.nix
@@ -1,0 +1,24 @@
+{ lib, stdenv, fetchurl, pkg-config, deadbeef, glib }:
+
+stdenv.mkDerivation {
+  pname = "deadbeef-gnome-mmkeys";
+  version = "2019-03-16";
+
+  src = fetchurl {
+    url = "https://github.com/zhanghai/deadbeef-gnome-mmkeys/archive/895deabd56405cdc71a93418ffb101bb5e35dcfe.tar.gz";
+    sha256 = "08vwsriazpwk4dy9p2if217rfwy69cbbaw6a3zky1g3hbvmfplk8";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ deadbeef glib ];
+
+  installPhase = "make install INSTALL_DIR=$out/lib/deadbeef";
+
+  meta = with lib; {
+    description = "DeaDBeeF player GNOME (via DBus) multimedia keys plugin";
+    homepage = "https://github.com/zhanghai/deadbeef-gnome-mmkeys/";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24808,6 +24808,7 @@ with pkgs;
     infobar = callPackage ../applications/audio/deadbeef/plugins/infobar.nix { };
     lyricbar = callPackage ../applications/audio/deadbeef/plugins/lyricbar.nix { };
     mpris2 = callPackage ../applications/audio/deadbeef/plugins/mpris2.nix { };
+    gnome-mmkeys = callPackage ../applications/audio/deadbeef/plugins/gnome-mmkeys.nix { };
     statusnotifier = callPackage ../applications/audio/deadbeef/plugins/statusnotifier.nix { };
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The gnome-mmkeys plugin for Deadbeef is useful and happens to be easy to package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [v ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [v ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
