### PR TITLE
tuhi: init at 0.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6573,6 +6573,12 @@
     githubId = 55911173;
     name = "Gwendolyn Quasebarth";
   };
+  lammermann = {
+    email = "k.o.b.e.r@web.de";
+    github = "lammermann";
+    githubId = 695526;
+    name = "Benjamin Kober";
+  };
   larsr = {
     email = "Lars.Rasmusson@gmail.com";
     github = "larsr";

--- a/pkgs/applications/misc/tuhi/default.nix
+++ b/pkgs/applications/misc/tuhi/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, pkg-config
+, python3Packages
+, meson
+, ninja
+, appstream-glib
+, desktop-file-utils
+, glib
+, gtk3
+, gobject-introspection
+, wrapGAppsHook
+, fetchFromGitHub
+}:
+
+python3Packages.buildPythonApplication rec {
+  name = "tuhi";
+  version = "0.5";
+
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "tuhiproject";
+    repo = name;
+    rev = "${version}";
+    sha256 = "17kggm9c423vj7irxx248fjc8sxvkp9w1mgawlx1snrii817p3db";
+  };
+
+  dontWrapGApps = true;
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  nativeBuildInputs = [
+    pkg-config meson ninja
+    appstream-glib desktop-file-utils
+    wrapGAppsHook
+  ];
+  buildInputs = [
+    gtk3 gobject-introspection
+    glib
+  ];
+  checkInputs = with python3Packages; [ flake8 pytest ];
+  propagatedBuildInputs = with python3Packages; [
+    svgwrite pyxdg pycairo pygobject3 setuptools-scm
+  ];
+
+  strictDeps = false;
+  preConfigure = ''
+    substituteInPlace meson_install.sh \
+      --replace "/usr/bin/env sh" "sh"
+  '';
+  postFixup = ''
+    wrapPythonProgramsIn $out/libexec "$out $pythonPath"
+  '';
+
+  meta = with lib; {
+    description = "DBus daemon to access Wacom SmartPad devices";
+    homepage = "https://github.com/tuhiproject/tuhi";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ lammermann ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10393,6 +10393,8 @@ with pkgs;
 
   ipbt = callPackage ../tools/misc/ipbt { };
 
+  tuhi = callPackage ../applications/misc/tuhi { };
+
   tuir = callPackage ../applications/misc/tuir { };
 
   tunnelto = callPackage ../tools/networking/tunnelto {


### PR DESCRIPTION
###### Motivation for this change

package tuhi application to export sketches from wacom tablets.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
