### PR TITLE
xalanc: 1.11 -> 1.12

### DIFF
--- a/pkgs/development/libraries/xalanc/default.nix
+++ b/pkgs/development/libraries/xalanc/default.nix
@@ -1,35 +1,17 @@
-{ lib, stdenv, fetchurl, xercesc, getopt }:
+{ lib, stdenv, fetchFromGitHub, xercesc, getopt, cmake }:
 
-let
-  platform = if stdenv.isLinux then "linux" else
-             if stdenv.isDarwin then "macosx" else
-             throw "Unsupported platform";
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "xalan-c";
-  version = "1.11";
+  version = "1.12.0";
 
-  src = fetchurl {
-    url = "mirror://apache/xalan/xalan-c/sources/xalan_c-${version}-src.tar.gz";
-    sha256 = "0a3a2b15vpacnqgpp6fiy1pwyc8q6ywzvyb5445f6wixfdspypjg";
+  src = fetchFromGitHub {
+    owner = "apache";
+    repo = "xalan-c";
+    rev = "Xalan-C_1_12_0";
+    sha256 = "sha256:0q1204qk97i9h14vxxq7phcfpyiin0i1zzk74ixvg4wqy87b62s8";
   };
 
-  configurePhase = ''
-    export XALANCROOT=`pwd`/c
-    cd `pwd`/c
-    mkdir -p $out
-    ./runConfigure -p ${platform} -c cc -x c++ -P$out
-  '';
-
-  buildInputs = [ xercesc getopt ];
-
-  # Parallel build fails as:
-  #   c++ ... -c ... ExecutionContext.cpp
-  #   ProblemListenerBase.hpp:28:10: fatal error: LocalMsgIndex.hpp: No such file or directory
-  # The build failure happens due to missing intra-project dependencies
-  # against generated headers. Future 1.12 version dropped
-  # autotools-based build system. Let's disable parallel builds until
-  # next release.
-  enableParallelBuilding = false;
+  buildInputs = [ xercesc getopt cmake ];
 
   meta = {
     homepage = "http://xalan.apache.org/";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
