### PR TITLE
pinta: 1.7.1 -> 2.0

### DIFF
--- a/pkgs/applications/graphics/pinta/default.nix
+++ b/pkgs/applications/graphics/pinta/default.nix
@@ -1,91 +1,86 @@
 { lib
+, buildDotnetModule
+, dotnetCorePackages
 , fetchFromGitHub
-, buildDotnetPackage
-, dotnetPackages
-, gtksharp
-, gettext
+, gtk3
+, installShellFiles
+, librsvg
+, makeDesktopItem
+, wrapGAppsHook
 }:
 
-let
-  mono-addins = dotnetPackages.MonoAddins;
-in
-buildDotnetPackage rec {
+buildDotnetModule rec {
   pname = "Pinta";
-  version = "1.7.1";
+  version = "2.0";
 
-  outputFiles = [ "bin/*" ];
-  buildInputs = [ gtksharp mono-addins gettext ];
-  xBuildFiles = [ "Pinta.sln" ];
+  nativeBuildInputs = [
+    installShellFiles
+    wrapGAppsHook
+  ];
+
+  runtimeDeps = [ gtk3 ];
+
+  dotnet-sdk = dotnetCorePackages.sdk_6_0;
+  dotnet-runtime = dotnetCorePackages.runtime_6_0;
+
+  # How-to update deps:
+  # $ nix-build -A pinta.fetch-deps
+  # $ ./result
+  # $ cp /tmp/Pinta-deps.nix ./pkgs/applications/graphics/pinta/default.nix
+  # TODO: create update script
+  nugetDeps = ./deps.nix;
+
+  projectFile = "Pinta";
 
   src = fetchFromGitHub {
     owner = "PintaProject";
     repo = "Pinta";
     rev = version;
-    sha256 = "sha256-yRp/dpJ9T4DieqHTj3vhyuASPGe4vjHw0rSXFrTNZVc=";
+    sha256 = "sha256-wqqNPyy5h/hTDm2u5MDZx1ds5qWAxy1/BY/fX4PeA88=";
   };
 
-  # Remove version information from nodes <Reference Include="... Version=... ">
-  postPatch = with lib; let
-    csprojFiles = [
-      "Pinta/Pinta.csproj"
-      "Pinta.Core/Pinta.Core.csproj"
-      "Pinta.Effects/Pinta.Effects.csproj"
-      "Pinta.Gui.Widgets/Pinta.Gui.Widgets.csproj"
-      "Pinta.Resources/Pinta.Resources.csproj"
-      "Pinta.Tools/Pinta.Tools.csproj"
-    ];
-    versionedNames = [
-      "Mono\\.Addins"
-      "Mono\\.Posix"
-      "Mono\\.Addins\\.Gui"
-      "Mono\\.Addins\\.Setup"
-    ];
-
-    stripVersion = name: file:
-      let
-        match = ''<Reference Include="${name}([ ,][^"]*)?"'';
-        replace = ''<Reference Include="${name}"'';
-      in
-      "sed -i -re 's/${match}/${replace}/g' ${file}\n";
-
-    # Map all possible pairs of two lists
-    map2 = f: listA: listB: concatMap (a: map (f a) listB) listA;
-    concatMap2Strings = f: listA: listB: concatStrings (map2 f listA listB);
-  in
-  concatMap2Strings stripVersion versionedNames csprojFiles
-  + ''
-    # For some reason there is no Microsoft.Common.tasks file
-    # in ''${mono}/lib/mono/3.5 .
-    substituteInPlace Pinta.Install.proj \
-      --replace 'ToolsVersion="3.5"' 'ToolsVersion="4.0"' \
-      --replace "/usr/local" "$out"
+  # FIXME: this should be propagated by wrapGAppsHook already, however for some
+  # reason it is not working. Maybe a bug in buildDotnetModule?
+  preInstall = ''
+    gappsWrapperArgs+=(
+      --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}"
+      --set GDK_PIXBUF_MODULE_FILE ${librsvg}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache
+    )
   '';
 
-  makeWrapperArgs = [
-    "--prefix MONO_GAC_PREFIX : ${gtksharp}"
-    "--prefix LD_LIBRARY_PATH : ${gtksharp}/lib"
-    "--prefix LD_LIBRARY_PATH : ${gtksharp.gtk.out}/lib"
-  ];
-
   postInstall = ''
-    # Do automake's job manually
-    substitute xdg/pinta.desktop.in xdg/pinta.desktop \
+    # Rename the binary
+    mv $out/bin/Pinta $out/bin/pinta
+
+    # Copy desktop icons
+    for size in 16x16 22x22 24x24 32x32 96x96 scalable; do
+      mkdir -p $out/share/icons/hicolor/$size/apps
+      cp xdg/$size/* $out/share/icons/hicolor/$size/apps/
+    done
+
+    # Copy runtime icons
+    cp -r Pinta.Resources/icons/hicolor/16x16/* $out/share/icons/hicolor/16x16/
+
+    # Install manpage
+    installManPage xdg/pinta.1
+
+    # Fix and copy desktop file
+    # TODO: fix this propely by using the autoreconf+pkg-config build system
+    # from upstream
+    mkdir -p $out/share/applications
+    substitute xdg/pinta.desktop.in $out/share/applications/Pinta.desktop \
       --replace _Name Name \
       --replace _Comment Comment \
       --replace _GenericName GenericName \
-      --replace _X-GNOME-FullName X-GNOME-FullName
-    substitute xdg/pinta.appdata.xml.in xdg/pinta.appdata.xml \
-      --replace _p p
-
-    xbuild /target:CompileTranslations Pinta.Install.proj
-    xbuild /target:Install Pinta.Install.proj
+      --replace _X-GNOME-FullName X-GNOME-FullName \
+      --replace _Keywords Keywords
   '';
 
   meta = {
     homepage = "https://www.pinta-project.com/";
     description = "Drawing/editing program modeled after Paint.NET";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ thiagokokada ];
     platforms = with lib.platforms; linux;
   };
 }

--- a/pkgs/applications/graphics/pinta/deps.nix
+++ b/pkgs/applications/graphics/pinta/deps.nix
@@ -1,0 +1,12 @@
+{ fetchNuGet }: [
+  (fetchNuGet { pname = "AtkSharp"; version = "3.24.24.34"; sha256 = "1jn1vgi9xm0jp7769k6sbdi8d273kigjrsh93i6s4c03hqxv7cqs"; })
+  (fetchNuGet { pname = "CairoSharp"; version = "3.24.24.34"; sha256 = "0pydn1k0cam1gclg9sc1sbnmbyzh28qlc5qanyxcylwghink3kgz"; })
+  (fetchNuGet { pname = "GdkSharp"; version = "3.24.24.34"; sha256 = "0r0x0yib7chwsyrbpvicrfwldwqx5lyqq4p86zaxpmzd6zdaj0x5"; })
+  (fetchNuGet { pname = "GioSharp"; version = "3.24.24.34"; sha256 = "02hxvgjd4w9jpzbkk7qf9q9bkvyp5hfzwxfqp10vg5lpl9yl3xpx"; })
+  (fetchNuGet { pname = "GLibSharp"; version = "3.24.24.34"; sha256 = "0kvp033fgdwc8p2abfp5z9pzq66cvwbnjfvr4v4bkpy5s5h181kq"; })
+  (fetchNuGet { pname = "GtkSharp"; version = "3.24.24.34"; sha256 = "0028hzmmqyfx87qqmaf9cgb5psn7gkbmqvixcid67x1d6mzxjicb"; })
+  (fetchNuGet { pname = "NGettext"; version = "0.6.7"; sha256 = "1lnq1lgd80xqn80qwq5ipfjnd7nl1ghinjc3krnd546r0c7hwqky"; })
+  (fetchNuGet { pname = "PangoSharp"; version = "3.24.24.34"; sha256 = "1r0h14cklglfpv1lhv93cxmzi2w7d5s03gzpq3j5dmrz43flg9zw"; })
+  (fetchNuGet { pname = "ParagonClipper"; version = "6.4.2"; sha256 = "0pam44f7iayqjz8nh1x29gxdd4dj00i7m5883cpa64i192pgl94c"; })
+  (fetchNuGet { pname = "SharpZipLib"; version = "1.3.3"; sha256 = "1gij11wfj1mqm10631cjpnhzw882bnzx699jzwhdqakxm1610q8x"; })
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27951,9 +27951,7 @@ with pkgs;
 
   pinpoint = callPackage ../applications/office/pinpoint { };
 
-  pinta = callPackage ../applications/graphics/pinta {
-    gtksharp = gtk-sharp-2_0;
-  };
+  pinta = callPackage ../applications/graphics/pinta { };
 
   pistol = callPackage ../tools/misc/pistol { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Pinta now uses dotnet 6.0 + GTK3 instead of old mono + gtk-sharp (GTK2) library. So build it with the new buildDotnetModule introduced sometime ago.

This does causes some small issues. For example, there is no translations since this is build using autoreconf + intltool + pkg-config. There is no way to build just translations using this build system AFAIK. Shouldn't be too much of an issue considering that we also didn't had translations before (or it was incomplete).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
