### PR TITLE
honggfuzz: 2.4 -> 2.5

### DIFF
--- a/pkgs/tools/security/honggfuzz/default.nix
+++ b/pkgs/tools/security/honggfuzz/default.nix
@@ -1,17 +1,16 @@
-{ lib, stdenv, fetchFromGitHub, callPackage, makeWrapper
-, clang, llvm, libbfd, libopcodes, libunwind, libblocksruntime
-}:
+{ lib, stdenv, fetchFromGitHub, callPackage, makeWrapper, clang, llvm, libbfd
+, libopcodes, libunwind, libblocksruntime }:
 
 let
   honggfuzz = stdenv.mkDerivation rec {
     pname = "honggfuzz";
-    version = "2.4";
+    version = "2.5";
 
     src = fetchFromGitHub {
       owner = "google";
       repo = pname;
       rev = version;
-      sha256 = "sha256-sU5lmlfmvVWo4K96sI+xQsPfTMd1wsLbihcKI4aTj6g=";
+      sha256 = "sha256-TkyUKmiiSAfCnfQhSOUxuce6+dRyMmHy7vFK59jPIxM=";
     };
 
     postPatch = ''
@@ -28,7 +27,8 @@ let
     makeFlags = [ "PREFIX=$(out)" ];
 
     meta = {
-      description = "A security oriented, feedback-driven, evolutionary, easy-to-use fuzzer";
+      description =
+        "A security oriented, feedback-driven, evolutionary, easy-to-use fuzzer";
       longDescription = ''
         Honggfuzz is a security oriented, feedback-driven, evolutionary,
         easy-to-use fuzzer with interesting analysis options. It is
@@ -42,9 +42,9 @@ let
         fuzzing), and it will work its way up, expanding it by utilizing
         feedback-based coverage metrics.
       '';
-      homepage    = "https://honggfuzz.dev/";
-      license     = lib.licenses.asl20;
-      platforms   = ["x86_64-linux"];
+      homepage = "https://honggfuzz.dev/";
+      license = lib.licenses.asl20;
+      platforms = [ "x86_64-linux" ];
       maintainers = with lib.maintainers; [ cpu ];
     };
   };


### PR DESCRIPTION
###### Motivation for this change

Updates the Honggfuzz derivation under `pkgs/tools/security/` to build the newly released [version 2.5](https://github.com/google/honggfuzz/releases/tag/2.5) instead of 2.4.

Changelog from upstream:
> fixed build for Android NDK >= 23
> fixed build for CygWin
> improved hfuzz-cc, so it supports -x correctly
> error returned if unknown cmd-line parameters are provided
> support for thread CPU pinning
> various fixes for *BSD
> increased number of dictionary entries (to 8192)

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
