### PR TITLE
widelands: fix building with boost 1.77

### DIFF
--- a/pkgs/games/widelands/default.nix
+++ b/pkgs/games/widelands/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , SDL2
 , SDL2_image
 , SDL2_mixer
@@ -32,7 +33,14 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-gNumYoeKePaxiAzrqEPKibMxFwv9vyBrCSoua+MKhcM=";
   };
 
-  patches = [ ./bincmake.patch ];
+  patches = [
+    ./bincmake.patch
+    # fix for building with Boost 1.77, https://github.com/widelands/widelands/pull/5025
+    (fetchpatch {
+      url = "https://github.com/widelands/widelands/commit/33981fda8c319c9feafc958f5f0b1670c48666ef.patch";
+      sha256 = "sha256-FjxxCTPpg/Zp01XpNfgRXMMLJBfxAptkLpsLmnFXm2Q=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace xdg/org.widelands.Widelands.desktop \


### PR DESCRIPTION
###### Motivation for this change
Widelands 1.0 does not build with Boost 1.77, which means that it doesn't build with current master in Nixpkgs. This pulls in a patch to fix that. 

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
