### PR TITLE
nixos/maddy: Add `listeners` option

### DIFF
--- a/nixos/tests/maddy/tls.nix
+++ b/nixos/tests/maddy/tls.nix
@@ -26,18 +26,9 @@ in {
             keyPath = "${certs.${domain}.key}";
           }];
         };
-        # Enable TLS listeners. Configuring this via the module is not yet
-        # implemented.
-        config = builtins.replaceStrings [
-          "imap tcp://0.0.0.0:143"
-          "submission tcp://0.0.0.0:587"
-        ] [
-          "imap tls://0.0.0.0:993 tcp://0.0.0.0:143"
-          "submission tls://0.0.0.0:465 tcp://0.0.0.0:587"
-        ] options.services.maddy.config.default;
+        submission.tlsEnable = true;
+        imap.tlsEnable = true;
       };
-      # Not covered by openFirewall yet
-      networking.firewall.allowedTCPPorts = [ 993 465 ];
     };
 
     client = { nodes, ... }: {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Support configuring listening addresses and port configuration for Imap, Submission and Smtp.
Configuration interface will look like this:

```
services.maddy = {
  enable = true;
  openFirewall = true;
  tls = {
    loader = "file";
    certificates = [{
      keyPath = "/tmp/key.pem";
      certPath = "/tmp/cert.pem";
    }];
  };
  ensureAccounts = [ "postmaster@localhost" ];
  ensureCredentials = {
    # Do not use this in production. This will make passwords world-readable
    # in the Nix store
    "postmaster@localhost".passwordFile = "${pkgs.writeText "postmaster" "test"}";
  };
  listeners = [
    {
      type = "imap";
      bind_addresses = [
        {
          tls = true;
          port = 993;
          address = "0.0.0.0";
        };
        {
          port = 143;
          address = "0.0.0.0";
        };
      ];
      extraConfig = ''
        auth &local_authdb
        storage &local_mailboxes
      '';
    };
  ];
};
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
