### PR TITLE
python3Packages.opencv4: fix installation metadata

### DIFF
--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -275,7 +275,12 @@ stdenv.mkDerivation {
   propagatedBuildInputs = lib.optional enablePython pythonPackages.numpy
     ++ lib.optionals enableCuda [ cudatoolkit nvidia-optical-flow-sdk ];
 
-  nativeBuildInputs = [ cmake pkg-config unzip ];
+  nativeBuildInputs = [ cmake pkg-config unzip ]
+  ++ lib.optionals enablePython [
+    pythonPackages.pip
+    pythonPackages.wheel
+    pythonPackages.setuptools
+  ];
 
   NIX_CFLAGS_COMPILE = lib.optionalString enableEXR "-I${ilmbase.dev}/include/OpenEXR";
 
@@ -333,6 +338,21 @@ stdenv.mkDerivation {
   postInstall = ''
     sed -i "s|{exec_prefix}/$out|{exec_prefix}|;s|{prefix}/$out|{prefix}|" \
       "$out/lib/pkgconfig/opencv4.pc"
+  ''
+  # install python distribution information, so other packages can `import opencv`
+  + lib.optionalString enablePython ''
+    pushd $NIX_BUILD_TOP/$sourceRoot/modules/python/package
+    python -m pip wheel --verbose --no-index --no-deps --no-clean --no-build-isolation --wheel-dir dist .
+
+    pushd dist
+    python -m pip install ./*.whl --no-index --no-warn-script-location --prefix="$out" --no-cache
+
+    # the cv2/__init__.py just tries to check provide "nice user feedback" if the installation is bad
+    # however, this also causes infinite recursion when used by other packages
+    rm -r $out/${pythonPackages.python.sitePackages}/cv2
+
+    popd
+    popd
   '';
 
   passthru = lib.optionalAttrs enablePython { pythonPath = [ ]; };


### PR DESCRIPTION
###### Motivation for this change
Also install the installation metadata and other python files, so other modules can correctly import the module.

before:
```
$ tree -L 4 $(nix-build '<nixpkgs>' -A python3Packages.opencv4)/lib/python3.9
/nix/store/dfylw3ppidn6gpbxrkjhmpsazk7cdzdj-opencv-4.5.4/lib/python3.9
└── site-packages
    └── cv2.cpython-39-x86_64-linux-gnu.so

1 directory, 1 file
```

after:
```
$ tree -L 4 $(nix-build ./. -A python3Packages.opencv4)/lib/python3.9
/nix/store/mcpyj0c16xq4kz22hzh34m8zadzs9b6n-opencv-4.5.4/lib/python3.9
└── site-packages
    ├── cv2
    │   ├── __init__.py
    │   ├── load_config_py2.py
    │   ├── load_config_py3.py
    │   └── __pycache__
    │       ├── __init__.cpython-39.pyc
    │       ├── load_config_py2.cpython-39.pyc
    │       └── load_config_py3.cpython-39.pyc
    ├── cv2.cpython-39-x86_64-linux-gnu.so
    └── opencv-4.5.4.dist-info
        ├── direct_url.json
        ├── INSTALLER
        ├── METADATA
        ├── RECORD
        ├── REQUESTED
        ├── top_level.txt
        └── WHEEL
 ```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
