### PR TITLE
seahub: init at 8.0.8

### DIFF
--- a/pkgs/applications/networking/seahub/default.nix
+++ b/pkgs/applications/networking/seahub/default.nix
@@ -1,0 +1,74 @@
+{ lib, fetchFromGitHub, python3, makeWrapper }:
+let
+  # Seahub 8.x.x does not support django-webpack-loader >=1.x.x
+  python = python3.override {
+    packageOverrides = self: super: {
+      django-webpack-loader = super.django-webpack-loader.overridePythonAttrs (old: rec {
+        version = "0.7.0";
+        src = old.src.override {
+          inherit version;
+          sha256 = "0izl6bibhz3v538ad5hl13lfr6kvprf62rcl77wq2i5538h8hg3s";
+        };
+      });
+    };
+  };
+in
+python.pkgs.buildPythonApplication rec {
+  pname = "seahub";
+  version = "8.0.8";
+
+  src = fetchFromGitHub {
+    owner = "haiwen";
+    repo = "seahub";
+    rev = "c51346155b2f31e038c3a2a12e69dcc6665502e2"; # using a fixed revision because upstream may re-tag releases :/
+    sha256 = "0dagiifxllfk73xdzfw2g378jccpzplhdrmkwbaakbhgbvvkg92k";
+  };
+
+  dontBuild = true;
+  doCheck = false; # disabled because it requires a ccnet environment
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  propagatedBuildInputs = with python.pkgs; [
+    django
+    future
+    django-statici18n
+    django-webpack-loader
+    django-simple-captcha
+    django-picklefield
+    django-formtools
+    mysqlclient
+    pillow
+    python-dateutil
+    django_compressor
+    djangorestframework
+    openpyxl
+    requests
+    requests_oauthlib
+    pyjwt
+    pycryptodome
+    qrcode
+    pysearpc
+    seaserv
+    gunicorn
+  ];
+
+  installPhase = ''
+    cp -dr --no-preserve='ownership' . $out/
+    wrapProgram $out/manage.py \
+      --prefix PYTHONPATH : "$PYTHONPATH:$out/thirdpart:"
+  '';
+
+  passthru = {
+    inherit python;
+    pythonPath = python3.pkgs.makePythonPath propagatedBuildInputs;
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/haiwen/seahub";
+    description = "The web end of seafile server";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ greizgh schmittlauch ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28407,6 +28407,8 @@ with pkgs;
 
   seafile-client = libsForQt5.callPackage ../applications/networking/seafile-client { };
 
+  seahub = callPackage ../applications/networking/seahub { };
+
   seatd = callPackage ../applications/misc/seatd { };
 
   secretscanner = callPackage ../tools/security/secretscanner { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This fixes the seafile module by re-introducing a seahub application (removed in #152912) in a hopefully more compliant way.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
