### PR TITLE
python3Packages.paramiko: 2.8.1 -> 2.9.1

### DIFF
--- a/pkgs/development/python-modules/paramiko/default.nix
+++ b/pkgs/development/python-modules/paramiko/default.nix
@@ -1,48 +1,65 @@
-{ pkgs
-, buildPythonPackage
-, fetchPypi
-, cryptography
+{ lib
 , bcrypt
+, buildPythonPackage
+, cryptography
+, fetchPypi
 , invoke
-, pynacl
-, pyasn1
-, pytestCheckHook
-, pytest-relaxed
 , mock
+, pyasn1
+, pynacl
+, pytest-relaxed
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "paramiko";
-  version = "2.8.1";
+  version = "2.9.1";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "85b1245054e5d7592b9088cc6d08da22445417912d3a3e48138675c7a8616438";
+    hash = "sha256-of3e07VfYdIzieT+UtmuQolgrJWNLt9QNz+qXYkm7dA=";
   };
 
-  propagatedBuildInputs = [ bcrypt cryptography pynacl pyasn1 ];
+  propagatedBuildInputs = [
+    bcrypt
+    cryptography
+    pyasn1
+    pynacl
+  ];
+
+  checkInputs = [
+    invoke
+    mock
+    pytest-relaxed
+    pytestCheckHook
+  ];
 
   # with python 3.9.6+, the deprecation warnings will fail the test suite
   # see: https://github.com/pyinvoke/invoke/issues/829
   doCheck = false;
-  checkInputs = [ invoke pytestCheckHook pytest-relaxed mock ];
 
   disabledTestPaths = [
     "tests/test_sftp.py"
     "tests/test_config.py"
   ];
 
+  pythonImportsCheck = [
+    "paramiko"
+  ];
+
   __darwinAllowLocalNetworking = true;
 
-  meta = with pkgs.lib; {
+  meta = with lib; {
     homepage = "https://github.com/paramiko/paramiko/";
     description = "Native Python SSHv2 protocol library";
     license = licenses.lgpl21Plus;
     longDescription = ''
-      This is a library for making SSH2 connections (client or server).
-      Emphasis is on using SSH2 as an alternative to SSL for making secure
-      connections between python scripts. All major ciphers and hash methods
-      are supported. SFTP client and server mode are both supported too.
+      Library for making SSH2 connections (client or server). Emphasis is
+      on using SSH2 as an alternative to SSL for making secure connections
+      between python scripts. All major ciphers and hash methods are
+      supported. SFTP client and server mode are both supported too.
     '';
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
No changelog for 2.9.1
https://github.com/paramiko/paramiko/tree/2.9.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
