### PR TITLE
rescrobbled: init at 0.4.0

### DIFF
--- a/pkgs/tools/audio/rescrobbled/default.nix
+++ b/pkgs/tools/audio/rescrobbled/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, pkg-config
+, dbus
+, openssl
+, runtimeShell
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rescrobbled";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "InputUsername";
+    repo = "rescrobbled";
+    rev = "v${version}";
+    sha256 = "stz0mrXEFDGx+XLxMttb2XXR5n7cpw86USZQiUaagSw=";
+  };
+
+  cargoSha256 = "IxlhLIIHvEFBd+PghLsRq4PIxFwnHBJd0+79pxelzi4=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    dbus
+    openssl
+  ];
+
+  postPatch = ''
+    # Required for tests.
+    substituteInPlace src/filter.rs --replace '#!/usr/bin/bash' '#!${runtimeShell}'
+  '';
+
+  postInstall = ''
+    substituteInPlace rescrobbled.service --replace '%h/.cargo/bin/rescrobbled' "$out/bin/rescrobbled"
+    install -Dm644 rescrobbled.service -t "$out/share/systemd/user"
+  '';
+
+  meta = with lib; {
+    description = "MPRIS music scrobbler daemon";
+    homepage = "https://github.com/InputUsername/rescrobbled";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30842,6 +30842,8 @@ with pkgs;
 
   redeclipse = callPackage ../games/redeclipse { };
 
+  rescrobbled = callPackage ../tools/audio/rescrobbled { };
+
   rftg = callPackage ../games/rftg { };
 
   rigsofrods = callPackage ../games/rigsofrods {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Something like mpris-scrobbler but more configurable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
