### PR TITLE
nixos/tracker: Define env var so it can find miners’ subcommands

### DIFF
--- a/nixos/modules/services/desktops/gnome/tracker-miners.nix
+++ b/nixos/modules/services/desktops/gnome/tracker-miners.nix
@@ -47,6 +47,8 @@ with lib;
 
     systemd.packages = [ pkgs.tracker-miners ];
 
+    services.gnome.tracker.subcommandPackages = [ pkgs.tracker-miners ];
+
   };
 
 }

--- a/nixos/modules/services/desktops/gnome/tracker.nix
+++ b/nixos/modules/services/desktops/gnome/tracker.nix
@@ -4,6 +4,9 @@
 
 with lib;
 
+let
+  cfg = config.services.gnome.tracker;
+in
 {
 
   meta = {
@@ -33,6 +36,15 @@ with lib;
         '';
       };
 
+      subcommandPackages = mkOption {
+        type = types.listOf types.package;
+        default = [ ];
+        internal = true;
+        description = ''
+          List of packages containing tracker3 subcommands.
+        '';
+      };
+
     };
 
   };
@@ -40,13 +52,24 @@ with lib;
 
   ###### implementation
 
-  config = mkIf config.services.gnome.tracker.enable {
+  config = mkIf cfg.enable {
 
     environment.systemPackages = [ pkgs.tracker ];
 
     services.dbus.packages = [ pkgs.tracker ];
 
     systemd.packages = [ pkgs.tracker ];
+
+    environment.variables = {
+      TRACKER_CLI_SUBCOMMANDS_DIR =
+        let
+          subcommandPackagesTree = pkgs.symlinkJoin {
+            name = "tracker-with-subcommands-${pkgs.tracker.version}";
+            paths = [ pkgs.tracker ] ++ cfg.subcommandPackages;
+          };
+        in
+        "${subcommandPackagesTree}/libexec/tracker3";
+    };
 
   };
 


### PR DESCRIPTION
tracker looks in its directory tree for executable files to make available as subcommands. Users expect to find subcommands from tracker-miners package but that fails as they are in different tree. We also cannot change the lookup path since tracker-miners also depends on a library from tracker package.

Until we can break the dependency cycle on package level:

   tracker -> tracker-miners -> tracker-sparql (tracker)

we need to work around it. I chose to set an environment variable that overrides the subcommands lookup to a tree symlinking files from both packages in GNOME NixOS module.

https://gitlab.gnome.org/GNOME/tracker/-/issues/341
Fixes: https://github.com/NixOS/nixpkgs/issues/153378

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
