### PR TITLE
libretro.citra: remove nix-prefetch-github hack 

### DIFF
--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -306,13 +306,6 @@ in
 
   citra = mkLibRetroCore {
     core = "citra";
-    # `nix-prefetch-github` doesn't support `deepClone`, necessary for citra
-    # https://github.com/seppeljordan/nix-prefetch-github/issues/41
-    src = fetchFromGitHub {
-      inherit (hashesFile.citra) owner repo rev fetchSubmodules;
-      deepClone = true;
-      sha256 = "sha256-bwnYkMvbtRF5bGZRYVtMWxnCu9P45qeX4+ntOj9eRds=";
-    };
     description = "Port of Citra to libretro";
     license = lib.licenses.gpl2Plus;
     extraNativeBuildInputs = [ cmake pkg-config ];

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -54,7 +54,7 @@ let
     , description
       # Check https://github.com/libretro/libretro-core-info for license information
     , license
-    , src ? null
+    , src ? (getCoreSrc core)
     , broken ? false
     , version ? "unstable-2021-12-06"
     , platforms ? retroarch.meta.platforms
@@ -63,15 +63,13 @@ let
     , normalizeCore ? true
     , ...
     }@args:
-    lib.makeOverridable stdenv.mkDerivation (
+    stdenv.mkDerivation (
       let
         d2u = if normalizeCore then (lib.replaceChars [ "-" ] [ "_" ]) else (x: x);
-        finalSrc = if src == null then getCoreSrc core else src;
       in
       (rec {
         pname = "libretro-${core}";
-        inherit version;
-        src = finalSrc;
+        inherit version src;
 
         buildInputs = [ zlib ] ++ args.extraBuildInputs or [ ];
         nativeBuildInputs = [ makeWrapper ] ++ args.extraNativeBuildInputs or [ ];

--- a/pkgs/misc/emulators/retroarch/hashes.json
+++ b/pkgs/misc/emulators/retroarch/hashes.json
@@ -122,8 +122,10 @@
         "owner": "libretro",
         "repo": "citra",
         "rev": "b1959d07a340bfd9af65ad464fd19eb6799a96ef",
-        "sha256": "Tw6Niba9gsZOMKGaXF9AZ5gdigB0mmFyqoRTMElM/Ps=",
-        "fetchSubmodules": true
+        "sha256": "bwnYkMvbtRF5bGZRYVtMWxnCu9P45qeX4+ntOj9eRds=",
+        "fetchSubmodules": true,
+        "leaveDotGit": true,
+        "deepClone": true
     },
     "desmume": {
         "owner": "libretro",

--- a/pkgs/misc/emulators/retroarch/update.py
+++ b/pkgs/misc/emulators/retroarch/update.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i python3 -p "python3.withPackages (ps: with ps; [ requests nix-prefetch-github ])" -p "git"
+#!nix-shell -I nixpkgs=../../../../ -i python3 -p "python3.withPackages (ps: with ps; [ requests nix-prefetch-github ])" -p "git"
 
 import json
 import sys
+import subprocess
 from pathlib import Path
-
-from nix_prefetch_github import nix_prefetch_github
 
 SCRIPT_PATH = Path(__file__).absolute().parent
 HASHES_PATH = SCRIPT_PATH / "hashes.json"
@@ -27,7 +26,7 @@ CORES = {
     "bsnes": {"repo": "bsnes-libretro"},
     "bsnes-hd": {"repo": "bsnes-hd", "owner": "DerKoun"},
     "bsnes-mercury": {"repo": "bsnes-mercury"},
-    "citra": {"repo": "citra", "fetch_submodules": True},
+    "citra": {"repo": "citra", "fetch_submodules": True, "deep_clone": True, "leave_dot_git": True},
     "desmume": {"repo": "desmume"},
     "desmume2015": {"repo": "desmume2015"},
     "dolphin": {"repo": "dolphin"},
@@ -97,19 +96,27 @@ def info(*msg):
     print(*msg, file=sys.stderr)
 
 
-def get_repo_hash_fetchFromGitHub(repo, owner="libretro", fetch_submodules=False):
-    assert repo is not None, "Parameter 'repo' can't be None."
-
-    repo_hash = nix_prefetch_github(
-        owner=owner, repo=repo, fetch_submodules=fetch_submodules
+def get_repo_hash_fetchFromGitHub(
+    repo,
+    owner="libretro",
+    deep_clone=False,
+    fetch_submodules=False,
+    leave_dot_git=False,
+):
+    extra_args = []
+    if deep_clone:
+        extra_args.append("--deep-clone")
+    if fetch_submodules:
+        extra_args.append("--fetch-submodules")
+    if leave_dot_git:
+        extra_args.append("--leave-dot-git")
+    result = subprocess.run(
+        ["nix-prefetch-github", owner, repo, *extra_args],
+        check=True,
+        capture_output=True,
+        text=True,
     )
-    return {
-        "owner": repo_hash.repository.owner,
-        "repo": repo_hash.repository.name,
-        "rev": repo_hash.rev,
-        "sha256": repo_hash.sha256,
-        "fetchSubmodules": repo_hash.fetch_submodules,
-    }
+    return json.loads(result.stdout)
 
 
 def get_repo_hash(fetcher="fetchFromGitHub", **kwargs):


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

After merging #153227, `update.py` is broken and also the `libretro.citra` hack is not necessary anymore. So this PR fixes it, and also does some minor refactors.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
