### PR TITLE
python3Packages.requests: 2.26.0 -> 2.27.0

### DIFF
--- a/pkgs/development/python-modules/requests-file/default.nix
+++ b/pkgs/development/python-modules/requests-file/default.nix
@@ -1,22 +1,38 @@
-{ lib, fetchPypi, buildPythonPackage, pytestCheckHook, requests, six }:
+{ lib
+, fetchPypi
+, buildPythonPackage
+, pytestCheckHook
+, requests
+, six
+}:
 
 buildPythonPackage rec {
-  pname   = "requests-file";
+  pname = "requests-file";
   version = "1.5.1";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "07d74208d3389d01c38ab89ef403af0cfec63957d53a0081d8eca738d0247d8e";
+    hash = "sha256-B9dCCNM4nQHDirie9AOvDP7GOVfVOgCB2OynONAkfY4=";
   };
 
-  propagatedBuildInputs = [ requests six ];
+  propagatedBuildInputs = [
+    requests
+    six
+  ];
 
-  checkInputs = [ pytestCheckHook ];
+  checkInputs = [
+    pytestCheckHook
+  ];
 
-  meta = {
-    homepage = "https://github.com/dashea/requests-file";
+  pythonImportsCheck = [
+    "requests_file"
+  ];
+
+  meta = with lib; {
     description = "Transport adapter for fetching file:// URLs with the requests python library";
-    license = lib.licenses.asl20;
+    homepage = "https://github.com/dashea/requests-file";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ];
   };
-
 }

--- a/pkgs/development/python-modules/requests-http-signature/default.nix
+++ b/pkgs/development/python-modules/requests-http-signature/default.nix
@@ -9,13 +9,13 @@
 buildPythonPackage rec {
   pname = "requests-http-signature";
   version = "0.2.0";
+  format = "setuptools";
 
-  # .pem files for tests aren't present on PyPI
   src = fetchFromGitHub {
     owner = "pyauth";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1jsplqrxadjsc86f0kb6dgpblgwplxrpi0ql1a714w8pbbz4z3h7";
+    hash = "sha256-B45P/loXcRKOChSDeHOnlz+67mtmTeAMYlo21TOmV8s=";
   };
 
   propagatedBuildInputs = [
@@ -27,17 +27,21 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "test/test.py" ];
+  pytestFlagsArray = [
+    "test/test.py"
+  ];
 
   disabledTests = [
     # Test require network access
     "test_readme_example"
   ];
 
-  pythonImportsCheck = [ "requests_http_signature" ];
+  pythonImportsCheck = [
+    "requests_http_signature"
+  ];
 
   meta = with lib; {
-    description = "A Requests auth module for HTTP Signature";
+    description = "Requests authentication module for HTTP Signature";
     homepage = "https://github.com/kislyuk/requests-http-signature";
     license = licenses.asl20;
     maintainers = with maintainers; [ mmai ];

--- a/pkgs/development/python-modules/requests-kerberos/default.nix
+++ b/pkgs/development/python-modules/requests-kerberos/default.nix
@@ -1,32 +1,28 @@
 { lib
-, fetchFromGitHub
 , buildPythonPackage
 , cryptography
-, requests
+, fetchFromGitHub
 , pykerberos
 , pyspnego
-, pytestCheckHook
 , pytest-mock
-, mock
+, pytestCheckHook
+, pythonOlder
+, requests
 }:
 
 buildPythonPackage rec {
   pname = "requests-kerberos";
   version = "0.14.0";
+  format = "setuptools";
 
-  # tests are not present in the PyPI version
+  disabled = pythonOlder "3.6";
+
   src = fetchFromGitHub {
     owner = "requests";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0s30pcnlir3j2jmf7yh065f294cf3x0x5i3ldskn8mm0a3657mv3";
+    hash = "sha256-Y9dTzFCgVmSnbnTE0kEfjpEkXDEA+uOqFHLkSC27YGg=";
   };
-
-  # avoid needing to package krb5
-  postPatch = ''
-    substituteInPlace setup.py \
-    --replace "pyspnego[kerberos]" "pyspnego"
-  '';
 
   propagatedBuildInputs = [
     cryptography
@@ -36,12 +32,19 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    mock
     pytestCheckHook
     pytest-mock
   ];
 
-  pythonImportsCheck = [ "requests_kerberos" ];
+  # avoid needing to package krb5
+  postPatch = ''
+    substituteInPlace setup.py \
+    --replace "pyspnego[kerberos]" "pyspnego"
+  '';
+
+  pythonImportsCheck = [
+    "requests_kerberos"
+  ];
 
   meta = with lib; {
     description = "An authentication handler for using Kerberos with Python Requests";

--- a/pkgs/development/python-modules/requests-unixsocket/default.nix
+++ b/pkgs/development/python-modules/requests-unixsocket/default.nix
@@ -9,26 +9,35 @@
 
 buildPythonPackage rec {
   pname = "requests-unixsocket";
-  version = "0.2.0";
+  version = "0.3.0";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "9e5c1a20afc3cf786197ae59c79bcdb0e7565f218f27df5f891307ee8817c1ea";
+    hash = "sha256-KDBCg+qTV9Rf/1itWxHkdwjPv1gGgXqlmyo2Mijulx4=";
   };
 
-  nativeBuildInputs = [ pbr ];
-  propagatedBuildInputs = [ requests ];
+  nativeBuildInputs = [
+    pbr
+  ];
 
-  checkInputs = [ pytestCheckHook waitress ];
+  propagatedBuildInputs = [
+    requests
+  ];
 
-  preCheck = ''
-    rm pytest.ini
-  '';
+  checkInputs = [
+    pytestCheckHook
+    waitress
+  ];
+
+  pythonImportsCheck = [
+    "requests_unixsocket"
+  ];
 
   meta = with lib; {
     description = "Use requests to talk HTTP via a UNIX domain socket";
     homepage = "https://github.com/msabramo/requests-unixsocket";
     license = licenses.asl20;
-    maintainers = [ maintainers.catern ];
+    maintainers = with maintainers; [ catern ];
   };
 }

--- a/pkgs/development/python-modules/requests/default.nix
+++ b/pkgs/development/python-modules/requests/default.nix
@@ -19,11 +19,11 @@
 
 buildPythonPackage rec {
   pname = "requests";
-  version = "2.27.0";
+  version = "2.27.1";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-jlZDkFvyCjCOJeTB3TeRF8CQAL+KguvMxGLPsbNKFrU=";
+    hash = "sha256-aNfFb9WomZiHco7zBKbRLtx7508c+kdxT8i0FFJcmmE=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/requests/default.nix
+++ b/pkgs/development/python-modules/requests/default.nix
@@ -7,22 +7,23 @@
 , charset-normalizer
 , fetchPypi
 , idna
+, isPy27
+, isPy3k
+, pysocks
 , pytest-mock
 , pytest-xdist
 , pytestCheckHook
-, urllib3
-, isPy27
-, isPy3k
 , trustme
+, urllib3
 }:
 
 buildPythonPackage rec {
   pname = "requests";
-  version = "2.26.0";
+  version = "2.27.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-uKpY+M95P/2HgtPYyxnmbvNverpDU+7IWedGeLAbB6c=";
+    hash = "sha256-jlZDkFvyCjCOJeTB3TeRF8CQAL+KguvMxGLPsbNKFrU=";
   };
 
   patches = [
@@ -32,7 +33,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     # Use latest idna
-    substituteInPlace setup.py --replace ",<3" ""
+    substituteInPlace setup.py \
+      --replace ",<3" ""
   '';
 
   propagatedBuildInputs = [
@@ -48,6 +50,7 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
+    pysocks
     pytest-mock
     pytest-xdist
     pytestCheckHook
@@ -73,11 +76,13 @@ buildPythonPackage rec {
     "TestTimeout"
   ];
 
-  pythonImportsCheck = [ "requests" ];
+  pythonImportsCheck = [
+    "requests"
+  ];
 
   meta = with lib; {
-    description = "Simple HTTP library for Python";
-    homepage = "http://docs.python-requests.org/en/latest/";
+    description = "HTTP library for Python";
+    homepage = "http://docs.python-requests.org/";
     license = licenses.asl20;
     maintainers = with maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/weconnect-mqtt/default.nix
+++ b/pkgs/development/python-modules/weconnect-mqtt/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "weconnect-mqtt";
-  version = "0.21.0";
+  version = "0.22.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     owner = "tillsteinbach";
     repo = "WeConnect-mqtt";
     rev = "v${version}";
-    sha256 = "sha256-wagFjVXTjYFryaUiVeqU+T9ya+NzUFMX3uPlRZGe1v0=";
+    sha256 = "sha256-cNEV9PNBv7mL7QG3p8GIwjz0pUhzz55QV6HmCkv6MSg=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/weconnect/default.nix
+++ b/pkgs/development/python-modules/weconnect/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "weconnect";
-  version = "0.28.0";
+  version = "0.29.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "tillsteinbach";
     repo = "WeConnect-python";
     rev = "v${version}";
-    sha256 = "sha256-J7T62L6wT9rkl/Ukf2y5kBbJEdzh2XnGgCgedkxVEmA=";
+    sha256 = "sha256-eAOEl7KBa7wZkoJxGPtK/6W2dq1n2X+APU2mHIlz9K0=";
   };
 
   propagatedBuildInputs = [
@@ -40,6 +40,8 @@ buildPythonPackage rec {
     substituteInPlace setup.py \
       --replace "setup_requires=SETUP_REQUIRED," "setup_requires=[]," \
       --replace "tests_require=TEST_REQUIRED," "tests_require=[],"
+    substituteInPlace requirements.txt \
+      --replace "pillow~=9.0.0" "pillow"
     substituteInPlace pytest.ini \
       --replace "--cov=weconnect --cov-config=.coveragerc --cov-report html" "" \
       --replace "pytest-cov" ""


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://docs.python-requests.org/en/latest/community/updates/#id1

Includes clean-up and changes of other requests-* modules.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
