### PR TITLE
PageEdit: init at 1.7.0

### DIFF
--- a/pkgs/applications/office/PageEdit/default.nix
+++ b/pkgs/applications/office/PageEdit/default.nix
@@ -1,8 +1,9 @@
 { lib, mkDerivation, fetchFromGitHub, cmake, qtsvg, qtwebengine, qttranslations }:
 
-mkDerivation rec{
+mkDerivation rec {
   pname = "PageEdit";
   version = "1.7.0";
+
   src = fetchFromGitHub {
     owner = "Sigil-Ebook";
     repo = pname;

--- a/pkgs/applications/office/PageEdit/default.nix
+++ b/pkgs/applications/office/PageEdit/default.nix
@@ -1,0 +1,24 @@
+{ lib, mkDerivation, fetchFromGitHub, cmake, qtsvg, qtwebengine, qttranslations }:
+
+mkDerivation rec{
+  pname = "PageEdit";
+  version = "1.7.0";
+  src = fetchFromGitHub {
+    owner = "Sigil-Ebook";
+    repo = pname;
+    rev = version;
+    hash = "sha256-/t08ZS2iYWIDkco0nhACBQs1X+X77SJ/g+ow7KemfRY=";
+  };
+
+  nativeBuildInputs = [ cmake qttranslations ];
+  propagatedBuildInputs = [ qtsvg qtwebengine ];
+  cmakeFlags = "-DINSTALL_BUNDLED_DICTS=0";
+
+  meta = with lib; {
+    description = "ePub XHTML Visual Editor";
+    homepage = "https://sigil-ebook.com/pageedit/";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.pasqui23 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8548,6 +8548,8 @@ with pkgs;
 
   page = callPackage ../tools/misc/page { };
 
+  PageEdit = libsForQt5.callPackage ../applications/office/PageEdit { };
+
   pagmo2 = callPackage ../development/libraries/pagmo2 { };
 
   pakcs = callPackage ../development/compilers/pakcs { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
