### PR TITLE
python3Packages.pytest-httpx: 0.15.0 -> 0.17.3

### DIFF
--- a/pkgs/development/python-modules/aiocurrencylayer/default.nix
+++ b/pkgs/development/python-modules/aiocurrencylayer/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "aiocurrencylayer";
-  version = "1.0.2";
+  version = "1.0.3";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "home-assistant-ecosystem";
     repo = pname;
     rev = version;
-    sha256 = "EVqnrMatOk2I6hiCkiT5FOWvMY9LEK8LlSHqi0x9kuQ=";
+    sha256 = "sha256-t2Pcoakk25vtUYajIZVITsrEUSdwwiA3fbdswy3n9P8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/denonavr/default.nix
+++ b/pkgs/development/python-modules/denonavr/default.nix
@@ -16,6 +16,8 @@
 buildPythonPackage rec {
   pname = "denonavr";
   version = "0.10.9";
+  format = "setuptools";
+
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
@@ -40,7 +42,14 @@ buildPythonPackage rec {
     pytest-timeout
   ];
 
-  pythonImportsCheck = [ "denonavr" ];
+  disabledTestPaths = [
+    # https://github.com/ol-iver/denonavr/issues/228
+    "tests/test_denonavr.py"
+  ];
+
+  pythonImportsCheck = [
+    "denonavr"
+  ];
 
   meta = with lib; {
     description = "Automation Library for Denon AVR receivers";

--- a/pkgs/development/python-modules/devolo-plc-api/default.nix
+++ b/pkgs/development/python-modules/devolo-plc-api/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "devolo-plc-api";
-  version = "0.7.0";
+  version = "0.7.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.8";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "2Fake";
     repo = "devolo_plc_api";
     rev = "v${version}";
-    sha256 = "sha256-qzjH52bKQ/oSFd580V92uE2/Z2g+2nLh/JXOXYqVfSY=";
+    sha256 = "sha256-XR/daDrnfbLBrUTTMFYtndr6+RxPwnF4qbXAdXsXKHk=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;

--- a/pkgs/development/python-modules/devolo-plc-api/default.nix
+++ b/pkgs/development/python-modules/devolo-plc-api/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , httpx
 , protobuf
 , pytest-asyncio
@@ -38,13 +39,14 @@ buildPythonPackage rec {
     zeroconf
   ];
 
-
   checkInputs = [
     pytest-asyncio
     pytest-httpx
     pytest-mock
     pytestCheckHook
   ];
+
+
 
   pythonImportsCheck = [
     "devolo_plc_api"

--- a/pkgs/development/python-modules/glances-api/default.nix
+++ b/pkgs/development/python-modules/glances-api/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "glances-api";
-  version = "0.3.2";
+  version = "0.3.3";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "home-assistant-ecosystem";
     repo = "python-glances-api";
     rev = version;
-    sha256 = "sha256-zVK63SI8ZeVrY2iEEkgp8pq6RDheKeApb9/RWgZCKGI=";
+    sha256 = "sha256-F3jmYBZNzI4hRmH1J+S5RwxjouZNcUJOnD3QpX1J39s=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/luftdaten/default.nix
+++ b/pkgs/development/python-modules/luftdaten/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "luftdaten";
-  version = "0.7.1";
+  version = "0.7.2";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "home-assistant-ecosystem";
     repo = "python-luftdaten";
     rev = version;
-    sha256 = "sha256-76Y5TJet0WtzYXuK8Og0rmpsUIlXK7b37oesh+MliU8=";
+    sha256 = "sha256-tYaY/F4mdO5k+Oj+RkNFWP8xqh1xuDyoAKBFzAhamkA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/netdata/default.nix
+++ b/pkgs/development/python-modules/netdata/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "netdata";
-  version = "1.0.1";
+  version = "1.0.2";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "home-assistant-ecosystem";
     repo = "python-netdata";
     rev = version;
-    sha256 = "sha256-4+cTIqytHrCPG7lUZv1IhL7Bk5GlTEveQTtuCkFIepo=";
+    sha256 = "sha256-D0W+zOpD2+iynhHMZh4obUSJJKmP3DnzA7blNWi6eHk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/pyrmvtransport/default.nix
+++ b/pkgs/development/python-modules/pyrmvtransport/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , pythonOlder
 , flit
 , async-timeout
@@ -39,6 +40,15 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-asyncio
     pytest-httpx
+  ];
+
+  patches = [
+    # Can be removed with next release, https://github.com/cgtobi/PyRMVtransport/pull/55
+    (fetchpatch {
+      name = "update-tests.patch";
+      url = "https://github.com/cgtobi/PyRMVtransport/commit/fe93b3d9d625f9ccf8eb7b0c39e0ff41c72d2e77.patch";
+      sha256 = "sha256-t+GP5VG1S86vVSsisl85ZHBtOqxIi7QS83DA+HgRet4=";
+    })
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/pytest-httpx/default.nix
+++ b/pkgs/development/python-modules/pytest-httpx/default.nix
@@ -5,20 +5,26 @@
 , pytest
 , pytest-asyncio
 , pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "pytest-httpx";
-  version = "0.15.0";
+  version = "0.17.3";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "Colin-b";
     repo = "pytest_httpx";
     rev = "v${version}";
-    sha256 = "08dxvjkxlnam3r0yp17495d1vksyawzzkpykacjql1gi6hqlfrwg";
+    sha256 = "sha256-cJRzjNIN9Fc8vcjmndW+akjxDSp+wFahY2MEslgXIwM=";
   };
 
-  buildInputs = [ pytest ];
+  buildInputs = [
+    pytest
+  ];
 
   propagatedBuildInputs = [
     httpx
@@ -29,12 +35,14 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "pytest_httpx" ];
+  pythonImportsCheck = [
+    "pytest_httpx"
+  ];
 
   meta = with lib; {
     description = "Send responses to httpx";
     homepage = "https://github.com/Colin-b/pytest_httpx";
     license = licenses.mit;
-    maintainers = with maintainers; [ SuperSandro2000 ];
+    maintainers = with maintainers; [ fab SuperSandro2000 ];
   };
 }

--- a/pkgs/development/python-modules/zeep/default.nix
+++ b/pkgs/development/python-modules/zeep/default.nix
@@ -28,6 +28,7 @@
 buildPythonPackage rec {
   pname = "zeep";
   version = "4.1.0";
+
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
@@ -71,9 +72,15 @@ buildPythonPackage rec {
   disabledTests = [
     # lxml.etree.XMLSyntaxError: Extra content at the end of the document, line 2, column 64
     "test_mime_content_serialize_text_xml"
+    # Tests are outdated
+    "test_load"
+    "test_load_cache"
+    "test_post"
   ];
 
-  pythonImportsCheck = [ "zeep" ];
+  pythonImportsCheck = [
+    "zeep"
+  ];
 
   meta = with lib; {
     description = "Python SOAP client";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/Colin-b/pytest_httpx/releases

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
