### PR TITLE
[WIP] vtune: init at 2022.1.0-98

### DIFF
--- a/pkgs/development/tools/profiling/vtune/default.nix
+++ b/pkgs/development/tools/profiling/vtune/default.nix
@@ -1,0 +1,116 @@
+{ stdenv, lib, fetchurl, autoPatchelfHook, wrapGAppsHook
+, libarchive
+
+, hwloc
+, libndctl
+, gdbm
+, ncurses5
+, readline
+, fontconfig
+, libxkbcommon
+, openssl
+, libkrb5
+, gtk3
+, glib
+, gdk-pixbuf
+, cairo
+, pango
+, icu67
+, atk
+, nss
+, cups
+, alsa-lib
+, mesa
+, libglvnd
+, kmod
+, systemdMinimal
+, xorg
+}:
+
+let
+  version = "2022.1.0-98";
+  baseVersion = lib.head (lib.splitString "-" version);
+
+  # See the build output for a list of components and their versions
+  components = [
+    { id = "intel.oneapi.lin.oneapi-common.licensing"; version = "2022.0.0-59"; }
+    { id = "intel.oneapi.lin.vtune"; version = "2022.1.0-98"; }
+  ];
+in stdenv.mkDerivation {
+  pname = "vtune";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://registrationcenter-download.intel.com/akdlm/irc_nas/18447/l_oneapi_vtune_p_2022.1.0.98_offline.sh";
+    sha256 = "sha256-Ox0MYhUNhYXegTRMeCk6keXfG49XsdgPXoSkq/yNQ4I=";
+  };
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+
+    hwloc
+    libndctl
+    gdbm
+    ncurses5
+    readline
+    fontconfig
+    libxkbcommon
+    openssl
+    libkrb5
+    gtk3
+    glib
+    gdk-pixbuf
+    cairo
+    pango
+    icu67
+    atk
+    nss
+    cups
+    alsa-lib
+    mesa
+    libglvnd
+    kmod
+    systemdMinimal
+  ] ++ (with xorg; [
+    libXrandr
+    libxcb
+    libxshmfence
+    xcbutilimage
+    xcbutilkeysyms
+    xcbutilrenderutil
+    xcbutilwm
+  ]);
+
+  autoPatchelfIgnoreMissingDeps = true;
+
+  nativeBuildInputs = [
+    libarchive autoPatchelfHook
+  ];
+
+  unpackPhase = ''
+    bash $src -x
+    cd l_oneapi_*
+
+    >&2 echo "All components in the archive:"
+    >&2 find packages -type d -maxdepth 1
+  '';
+
+  installPhase = let
+    commands = map (component: "bsdtar xf packages/${component.id},v=${component.version}/cupPayload.cup --strip-components=1 -C $out/opt/intel") components;
+  in ''
+    mkdir -p $out/opt/intel $out/bin
+
+    ${builtins.concatStringsSep "\n" commands}
+
+    for executable in "vtune" "vtune-gui" "vtune-agent" "vtune-backend" "vtune-worker"; do
+      ln -s $out/opt/intel/vtune/${baseVersion}/bin64/$executable $out/bin/$executable
+    done
+  '';
+
+  meta = with lib; {
+    description = "Performance analysis tool for x86-based machines";
+    license = licenses.unfreeRedistributable;
+    maintainers = with maintainers; [ zhaofengli ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10607,6 +10607,8 @@ with pkgs;
     SDL = SDL_sixel;
   };
 
+  vtune = callPackage ../development/tools/profiling/vtune { };
+
   openconnect = openconnect_gnutls;
 
   openconnect_openssl = callPackage ../tools/networking/openconnect {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

WIP because `vtune-gui` crashes with a SIGTRAP inside libcef, but starting a recording with the `vtune` CLI seems to work fine.

The `vtune-gui` crash seems to be from a debug assertion in CEF which is embedded into the executable, and it's annoying to track down the cause without symbols.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
