### PR TITLE
punes: unstable-2021-09-11 -> 0.108

### DIFF
--- a/pkgs/misc/emulators/punes/default.nix
+++ b/pkgs/misc/emulators/punes/default.nix
@@ -2,7 +2,8 @@
 , stdenv
 , lib
 , fetchFromGitHub
-, unstableGitUpdater
+, fetchpatch
+, nix-update-script
 , qtbase
 , qtsvg
 , qttools
@@ -19,14 +20,24 @@
 
 mkDerivation rec {
   pname = "punes";
-  version = "unstable-2021-09-11";
+  version = "0.108";
 
   src = fetchFromGitHub {
     owner = "punesemu";
     repo = "puNES";
-    rev = "60ca36fcb066c41d0b3f2b550ca94dc7d12d84d6";
-    sha256 = "JOi6AE1bpAc/wj9fQqHrUNc6vceeUyP0phT2f9kcJTY=";
+    rev = "v${version}";
+    sha256 = "0inkwmvbr2w4addmgk9r4f13yismang9ylfgflhh9352lf0lirv8";
   };
+
+  patches = [
+    # Drop when version > 0.108
+    # https://github.com/punesemu/puNES/issues/185
+    (fetchpatch {
+      name = "0001-punes-Fixed-make-install.patch";
+      url = "https://github.com/punesemu/puNES/commit/902434f50398ebcda0786ade4b28a0496084810e.patch";
+      sha256 = "1a3052n3n1qipi4bd7f7gq4zl5jjjzzzpbijdisis2vxvhnfvcim";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace configure.ac \
@@ -49,8 +60,8 @@ mkDerivation rec {
     "--with-ffmpeg"
   ];
 
-  passthru.updateScript = unstableGitUpdater {
-    url = "https://github.com/punesemu/puNES.git";
+  passthru.updateScript = nix-update-script {
+    attrPath = pname;
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
New stable release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
