### PR TITLE
libredirect: build fat library for x86_64, arm64, arm64e on darwin

### DIFF
--- a/pkgs/build-support/libredirect/default.nix
+++ b/pkgs/build-support/libredirect/default.nix
@@ -1,5 +1,4 @@
-{ stdenv, lib, coreutils }:
-
+{ lib, stdenv, bintools-unwrapped, llvmPackages_13, coreutils }:
 stdenv.mkDerivation rec {
   pname = "libredirect";
   version = "0";
@@ -9,17 +8,36 @@ stdenv.mkDerivation rec {
     cp ${./test.c} test.c
   '';
 
-  libName = "libredirect" + stdenv.targetPlatform.extensions.sharedLibrary;
-
   outputs = ["out" "hook"];
+
+  libName = "libredirect" + stdenv.targetPlatform.extensions.sharedLibrary;
 
   buildPhase = ''
     runHook preBuild
 
-    $CC -Wall -std=c99 -O3 -fPIC -ldl -shared \
-      ${lib.optionalString stdenv.isDarwin "-Wl,-install_name,$out/lib/$libName"} \
-      -o "$libName" \
-      libredirect.c
+    ${if stdenv.isDarwin && stdenv.isAarch64 then ''
+    # We need the unwrapped binutils and clang:
+    # We also want to build a fat library with x86_64, arm64, arm64e in there.
+    # Because we use the unwrapped tools, we need to provide -isystem for headers
+    # and the library search directory for libdl.
+    # We can't build this on x86_64, because the libSystem we point to doesn't
+    # like arm64(e).
+    PATH=${bintools-unwrapped}/bin:${llvmPackages_13.clang-unwrapped}/bin:$PATH \
+      clang -arch x86_64 -arch arm64 -arch arm64e \
+      -isystem ${llvmPackages_13.clang.libc}/include \
+      -isystem ${llvmPackages_13.libclang.lib}/lib/clang/*/include \
+      -L${llvmPackages_13.clang.libc}/lib \
+      -Wl,-install_name,$out/lib/$libName \
+      -Wall -std=c99 -O3 -fPIC libredirect.c \
+      -ldl -shared -o "$libName"
+    '' else if stdenv.isDarwin then ''
+    $CC -Wall -std=c99 -O3 -fPIC libredirect.c \
+      -Wl,-install_name,$out/lib/$libName \
+      -ldl -shared -o "$libName"
+    '' else ''
+    $CC -Wall -std=c99 -O3 -fPIC libredirect.c \
+      -ldl -shared -o "$libName"
+    ''}
 
     if [ -n "$doInstallCheck" ]; then
       $CC -Wall -std=c99 -O3 test.c -o test


### PR DESCRIPTION
`libredirect` currently fails to build on macOS machines. I've tried various combinations of BigSur and Monotery, it fails everywhere.

Our llvmPackages_13.clang doesn't seem to like being forced to create tiple arch files. So we'll resort to the system clang on darwin for now. This item is so fundamentally intwined with the impure state of the host system (dyld) over which we have no control, that I find this "hack" to be acceptable, while ugly.

/cc @thefloweringash @Ericson2314 