### PR TITLE
kgx: Update repo URL

### DIFF
--- a/pkgs/applications/terminal-emulators/kgx/default.nix
+++ b/pkgs/applications/terminal-emulators/kgx/default.nix
@@ -26,8 +26,8 @@ stdenv.mkDerivation {
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
-    owner = "ZanderBrown";
-    repo = "kgx";
+    owner = "GNOME";
+    repo = "console";
     rev = "105adb6a8d09418a3ce622442aef6ae623dee787";
     sha256 = "0m34y0nbcfkyicb40iv0iqaq6f9r3f66w43lr803j3351nxqvcz2";
   };
@@ -68,7 +68,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Simple user-friendly terminal emulator for the GNOME desktop";
-    homepage = "https://gitlab.gnome.org/ZanderBrown/kgx";
+    homepage = "https://gitlab.gnome.org/GNOME/console";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ zhaofengli ];
     platforms = platforms.linux;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

KGX has been rebranded to [GNOME Console](https://gitlab.gnome.org/GNOME/console) with the repo moved without a redirect. We aren't changing the name since we are still using an old version before the rebrand, with the update blocked by `vte` (https://github.com/NixOS/nixpkgs/pull/142731#issuecomment-961294830).

This doesn't cause any rebuild.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
