### PR TITLE
symfony-cli: 4.26.9 -> 5.0.7

### DIFF
--- a/pkgs/development/tools/symfony-cli/default.nix
+++ b/pkgs/development/tools/symfony-cli/default.nix
@@ -1,50 +1,24 @@
-{ stdenvNoCC, fetchurl, lib }:
+{ buildGoModule, fetchFromGitHub, lib }:
 
-let
-  version = "4.26.9";
-
-  srcs = {
-    x86_64-linux = fetchurl {
-      url = "https://github.com/symfony/cli/releases/download/v${version}/symfony_linux_amd64.gz";
-      sha256 = "0ivqqrpzbpyzp60bv25scarmvisj401rp7h2s3cxa7d17prja91v";
-    };
-
-    i686-linux = fetchurl {
-      url = "https://github.com/symfony/cli/releases/download/v${version}/symfony_linux_386.gz";
-      sha256 = "0ag5w70bkvj9wgp4yzzy824shj907sa5l20sqcgivi3r5gy0p277";
-    };
-
-    aarch64-linux = fetchurl {
-      url = "https://github.com/symfony/cli/releases/download/v${version}/symfony_linux_arm64.gz";
-      sha256 = "00325xz7xl3bprj5zbg5yhn36jf4n37zlyag10m8zcmq8asa6k51";
-    };
-
-    x86_64-darwin = fetchurl {
-        url = "https://github.com/symfony/cli/releases/download/v${version}/symfony_darwin_amd64.gz";
-        sha256 = "00325xz7xl3bprj5zbg5yhn36jf4n37zlyag10m8zcmq8asa6k51";
-      };
-  };
-in stdenvNoCC.mkDerivation rec {
-  inherit version;
+buildGoModule rec {
   pname = "symfony-cli";
+  version = "5.0.7";
+  vendorSha256 = "sha256-aTC84iA3/z/qhZbXPtOeZwDGn6BFCefCVlkUrbEtxUI=";
 
-  src = srcs.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
+  src = fetchFromGitHub {
+    owner = "symfony-cli";
+    repo = "symfony-cli";
+    rev = "v${version}";
+    sha256 = "sha256-Z3AIlN/s0uPE0OAlgSxbQPRoWPTHjDq4c8RlQ3SuIk8=";
+  };
 
-  dontBuild = true;
-
-  unpackPhase = ''
-    gunzip <$src >symfony
-  '';
-
-  installPhase = ''
-    install -D -t $out/bin symfony
-  '';
+  # Tests requires network access
+  doCheck = false;
 
   meta = with lib; {
     description = "Symfony CLI";
-    homepage = "https://symfony.com/download";
-    license = licenses.unfree;
+    homepage = "https://github.com/symfony-cli/symfony-cli";
+    license = licenses.agpl3Plus;
     maintainers = with maintainers; [ drupol ];
-    platforms = [ "x86_64-linux" "aarch64-linux" "i686-linux" "x86_64-darwin" ];
   };
 }


### PR DESCRIPTION
The Symfony-cli tool has been [open-sourced](https://symfony.com/blog/announcing-the-open-sourcing-of-the-symfony-cli) so it's time to update the derivation.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
