### PR TITLE
maintainers: update personal details

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3320,12 +3320,6 @@
     github = "edlimerkaj";
     githubId = 71988351;
   };
-  edibopp = {
-    email = "eduard.bopp@aepsil0n.de";
-    github = "edibopp";
-    githubId = 3098430;
-    name = "Eduard Bopp";
-  };
   emantor = {
     email = "rouven+nixos@czerwinskis.de";
     github = "emantor";
@@ -7820,6 +7814,12 @@
     github = "milesbreslin";
     githubId = 38543128;
     name = "Miles Breslin";
+  };
+  milibopp = {
+    email = "contact@ebopp.de";
+    github = "milibopp";
+    githubId = 3098430;
+    name = "Emilia Bopp";
   };
   millerjason = {
     email = "mailings-github@millerjason.com";

--- a/pkgs/development/python-modules/alot/default.nix
+++ b/pkgs/development/python-modules/alot/default.nix
@@ -66,6 +66,6 @@ buildPythonPackage rec {
     description = "Terminal MUA using notmuch mail";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ edibopp ];
+    maintainers = with maintainers; [ milibopp ];
   };
 }

--- a/pkgs/development/python-modules/parsy/default.nix
+++ b/pkgs/development/python-modules/parsy/default.nix
@@ -21,6 +21,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/python-parsy/parsy";
     description = "Easy-to-use parser combinators, for parsing in pure Python";
     license = [ licenses.mit ];
-    maintainers = with maintainers; [ edibopp ];
+    maintainers = with maintainers; [ milibopp ];
   };
 }

--- a/pkgs/os-specific/linux/firmware/rtl8761b-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/rtl8761b-firmware/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Firmware for Realtek RTL8761b";
     license = licenses.unfreeRedistributableFirmware;
-    maintainers = with maintainers; [ edibopp ];
+    maintainers = with maintainers; [ milibopp ];
     platforms = with platforms; linux;
   };
 }

--- a/pkgs/tools/networking/oneshot/default.nix
+++ b/pkgs/tools/networking/oneshot/default.nix
@@ -21,6 +21,6 @@ buildGoModule rec {
     description = "A first-come-first-serve single-fire HTTP server";
     homepage = "https://github.com/raphaelreyna/oneshot";
     license = licenses.mit;
-    maintainers = with maintainers; [ edibopp ];
+    maintainers = with maintainers; [ milibopp ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I changed my name and thus GitHub username and email address.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
