### PR TITLE
openssh_hpn: 8.4p1 -> 8.8p1

### DIFF
--- a/pkgs/tools/networking/openssh/common.nix
+++ b/pkgs/tools/networking/openssh/common.nix
@@ -4,6 +4,7 @@
 , src
 , extraPatches ? []
 , extraNativeBuildInputs ? []
+, extraConfigureFlags ? []
 , extraMeta ? {}
 }:
 
@@ -94,7 +95,8 @@ stdenv.mkDerivation rec {
     ++ optional withFIDO "--with-security-key-builtin=yes"
     ++ optional withKerberos (assert libkrb5 != null; "--with-kerberos5=${libkrb5}")
     ++ optional stdenv.isDarwin "--disable-libutil"
-    ++ optional (!linkOpenssl) "--without-openssl";
+    ++ optional (!linkOpenssl) "--without-openssl"
+    ++ extraConfigureFlags;
 
   buildFlags = [ "SSH_KEYSIGN=ssh-keysign" ];
 

--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -19,29 +19,30 @@ in
 
   openssh_hpn = common rec {
     pname = "openssh-with-hpn";
-    version = "8.4p1";
+    version = "8.8p1";
     extraDesc = " with high performance networking patches";
 
-    src = fetchFromGitHub {
-      owner = "rapier1";
-      repo = "openssh-portable";
-      rev = "hpn-KitchenSink-${builtins.replaceStrings [ "." "p" ] [ "_" "_P" ] version}";
-      hash = "sha256-SYQPDGxZR41m4g603RaZaOYm4vCr9uZnFnZoKhruueY=";
+    src = fetchurl {
+      url = "mirror://openbsd/OpenSSH/portable/openssh-${version}.tar.gz";
+      sha256 = "1s8z6f7mi1pwsl79cqai8cr350m5lf2ifcxff57wx6mvm478k425";
     };
 
     extraPatches = [
-      ./ssh-keysign-8.4.patch
+      ./ssh-keysign-8.5.patch
 
-      # See https://github.com/openssh/openssh-portable/pull/206
-      ./ssh-copy-id-fix-eof.patch
+      # HPN Patch from FreeBSD ports
+      (fetchpatch {
+        name = "ssh-hpn.patch";
+        url = "https://raw.githubusercontent.com/freebsd/freebsd-ports/a981593e/security/openssh-portable/files/extra-patch-hpn";
+        stripLen = 1;
+        sha256 = "sha256-+JvpPxktZAjhxLLK1lF4ijG9VlSWkqbRwotaLe6en64=";
+      })
     ];
 
     extraNativeBuildInputs = [ autoreconfHook ];
 
-    extraMeta.knownVulnerabilities = [
-      "CVE-2021-28041"
-      "CVE-2021-41617"
-    ];
+    extraConfigureFlags = [ "--with-hpn" ];
+    extraMeta.maintainers = with lib.maintainers; [ abbe ];
   };
 
   openssh_gssapi = common rec {


### PR DESCRIPTION
Switch to using patches from the FreeBSD port `security/openssh-portable`
which is regularly maintained

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
