### PR TITLE
lziprecover: init at 1.22

### DIFF
--- a/pkgs/tools/compression/lzip/default.nix
+++ b/pkgs/tools/compression/lzip/default.nix
@@ -28,10 +28,11 @@ stdenv.mkDerivation rec {
   doCheck = true;
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with lib; {
     homepage = "https://www.nongnu.org/lzip/lzip.html";
     description = "A lossless data compressor based on the LZMA algorithm";
     license = lib.licenses.gpl2Plus;
+    maintainers = with maintainers; [ vlaci ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/tools/compression/lzip/default.nix
+++ b/pkgs/tools/compression/lzip/default.nix
@@ -20,8 +20,8 @@ stdenv.mkDerivation rec {
     "CPPFLAGS=-DNDEBUG"
     "CFLAGS=-O3"
     "CXXFLAGS=-O3"
-  ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform)
-    "CXX=${stdenv.cc.targetPrefix}c++";
+    "CXX=${stdenv.cc.targetPrefix}c++"
+  ];
 
   setupHook = ./lzip-setup-hook.sh;
 

--- a/pkgs/tools/compression/lzip/default.nix
+++ b/pkgs/tools/compression/lzip/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://www.nongnu.org/lzip/lzip.html";
     description = "A lossless data compressor based on the LZMA algorithm";
-    license = lib.licenses.gpl3Plus;
+    license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/tools/compression/lziprecover/default.nix
+++ b/pkgs/tools/compression/lziprecover/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchurl, lzip }:
+
+stdenv.mkDerivation rec {
+  pname = "lziprecover";
+  version = "1.22";
+
+  src = fetchurl {
+    url = "mirror://savannah/lzip/lziprecover/${pname}-${version}.tar.gz";
+    sha256 = "sha256-/ZWKCXX3cpxE87eE5WaJH3NsPcaDdNvSFJ7mkqFtCGI=";
+  };
+
+  configureFlags = [
+    "CPPFLAGS=-DNDEBUG"
+    "CFLAGS=-O3"
+    "CXXFLAGS=-O3"
+    "CXX=${stdenv.cc.targetPrefix}c++"
+  ];
+
+  doCheck = true;
+  checkInputs = [ lzip ];
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    homepage = "https://www.nongnu.org/lzip/lziprecover.html";
+    description = "Data recovery tool for lzip compressed files";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with maintainers; [ vlaci ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7544,6 +7544,8 @@ with pkgs;
 
   lzip = callPackage ../tools/compression/lzip { };
 
+  lziprecover = callPackage ../tools/compression/lziprecover { };
+
   luxcorerender = callPackage ../tools/graphics/luxcorerender {
     openimagedenoise = openimagedenoise_1_2_x;
   };


### PR DESCRIPTION
Maintainer is absent for the original package that's why I haven't put myself in here. I can add myself to both of them if needed

###### Motivation for this change

This is a data recovery tool for `lzip` files. which I am depending on for my current job :)

###### Things done

Tried cross-building to multiple platform successfully but didn't test any of the crossbuilt output. CFLAGS and co. are directly lifted over from the `lzip` defivation.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
