### PR TITLE
bird-lg : add package and create service

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -174,6 +174,13 @@
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://github.com/xddxdd/bird-lg-go">bird-lg</link>,
+          a BGP looking glass for Bird Routing. Available as
+          <link linkend="opt-services.bird-lg.package">services.bird-lg</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://docs.docker.com/engine/security/rootless/">rootless
           Docker</link>, a <literal>systemd --user</literal> Docker
           service which runs without root permissions. Available as

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -59,6 +59,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [aesmd](https://github.com/intel/linux-sgx#install-the-intelr-sgx-psw), the Intel SGX Architectural Enclave Service Manager. Available as [services.aesmd](#opt-services.aesmd.enable).
 
+- [bird-lg](https://github.com/xddxdd/bird-lg-go), a BGP looking glass for Bird Routing. Available as [services.bird-lg](#opt-services.bird-lg.package).
+
 - [rootless Docker](https://docs.docker.com/engine/security/rootless/), a `systemd --user` Docker service which runs without root permissions. Available as [virtualisation.docker.rootless.enable](options.html#opt-virtualisation.docker.rootless.enable).
 
 - [matrix-conduit](https://conduit.rs/), a simple, fast and reliable chat server powered by matrix. Available as [services.matrix-conduit](option.html#opt-services.matrix-conduit.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -733,6 +733,7 @@
   ./services/networking/bitcoind.nix
   ./services/networking/autossh.nix
   ./services/networking/bird.nix
+  ./services/networking/bird-lg.nix
   ./services/networking/bitlbee.nix
   ./services/networking/blockbook-frontend.nix
   ./services/networking/blocky.nix

--- a/nixos/modules/services/networking/bird-lg.nix
+++ b/nixos/modules/services/networking/bird-lg.nix
@@ -1,0 +1,269 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.bird-lg;
+in
+{
+  options = {
+    services.bird-lg = {
+      package = mkOption {
+        type = types.package;
+        default = pkgs.bird-lg;
+        defaultText = literalExpression "pkgs.bird-lg";
+        description = "The Bird Looking Glass package to use.";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "bird-lg";
+        description = "User to run the service.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "bird-lg";
+        description = "Group to run the service.";
+      };
+
+      frontend = {
+        enable = mkEnableOption "Bird Looking Glass Frontend Webserver";
+
+        listenAddress = mkOption {
+          type = types.str;
+          default = "127.0.0.1:5000";
+          description = "Address to listen on.";
+        };
+
+        proxyPort = mkOption {
+          type = types.port;
+          default = 8000;
+          description = "Port bird-lg-proxy is running on.";
+        };
+
+        domain = mkOption {
+          type = types.str;
+          default = "";
+          example = "dn42.lantian.pub";
+          description = "Server name domain suffixes.";
+        };
+
+        servers = mkOption {
+          type = types.listOf types.str;
+          default = [ ];
+          example = [ "gigsgigscloud" "hostdare" ];
+          description = "Server name prefixes.";
+        };
+
+        whois = mkOption {
+          type = types.str;
+          default = "whois.verisign-grs.com";
+          description = "Whois server for queries.";
+        };
+
+        dnsInterface = mkOption {
+          type = types.str;
+          default = "asn.cymru.com";
+          description = "DNS zone to query ASN information.";
+        };
+
+        bgpMapInfo = mkOption {
+          type = types.listOf types.str;
+          default = [ "asn" "as-name" "ASName" "descr" ];
+          description = "Information displayed in bgpmap.";
+        };
+
+        titleBrand = mkOption {
+          type = types.str;
+          default = "Bird-lg Go";
+          description = "Prefix of page titles in browser tabs.";
+        };
+
+        netSpecificMode = mkOption {
+          type = types.str;
+          default = "";
+          example = "dn42";
+          description = "Apply network-specific changes for some networks.";
+        };
+
+        protocolFilter = mkOption {
+          type = types.listOf types.str;
+          default = [ ];
+          example = [ "ospf" ];
+          description = "Information displayed in bgpmap.";
+        };
+
+        nameFilter = mkOption {
+          type = types.str;
+          default = "";
+          example = "^ospf";
+          description = "Protocol names to hide in summary tables (RE2 syntax),";
+        };
+
+        timeout = mkOption {
+          type = types.int;
+          default = 120;
+          description = "Time before request timed out, in seconds.";
+        };
+
+        navbar = {
+          brand = mkOption {
+            type = types.str;
+            default = "Bird-lg Go";
+            description = "Brand to show in the navigation bar .";
+          };
+
+          brandURL = mkOption {
+            type = types.str;
+            default = "/";
+            description = "URL of the brand to show in the navigation bar.";
+          };
+
+          allServers = mkOption {
+            type = types.str;
+            default = "ALL Servers";
+            description = "Text of 'All server' button in the navigation bar.";
+          };
+
+          allServersURL = mkOption {
+            type = types.str;
+            default = "all";
+            description = "URL of 'All servers' button.";
+          };
+        };
+
+        extraArgs = mkOption {
+          type = types.lines;
+          default = "";
+          description = "
+            Extra parameters documented <link xlink:href=\"https://github.com/xddxdd/bird-lg-go#frontend\">here</link>.
+          ";
+        };
+      };
+
+      proxy = {
+        enable = mkEnableOption "Bird Looking Glass Proxy";
+
+        listenAddress = mkOption {
+          type = types.str;
+          default = "127.0.0.1:8000";
+          description = "Address to listen on.";
+        };
+
+        allowedIPs = mkOption {
+          type = types.listOf types.str;
+          default = [ ];
+          example = [ "192.168.25.52" "192.168.25.53" ];
+          description = "List of IPs to allow (default all allowed).";
+        };
+
+        birdSocket = mkOption {
+          type = types.str;
+          default = "/run/bird.ctl";
+          example = "/var/run/bird/bird.ctl";
+          description = "Bird control socket path.";
+        };
+
+        traceroute = {
+          binary = mkOption {
+            type = types.str;
+            default = "${pkgs.traceroute}/bin/traceroute";
+            defaultText = literalExpression ''"''${pkgs.traceroute}/bin/traceroute"'';
+            description = "Traceroute's binary path.";
+          };
+
+          rawOutput = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Display traceroute output in raw format.";
+          };
+        };
+
+        extraArgs = mkOption {
+          type = types.lines;
+          default = "";
+          description = "
+            Extra parameters documented <link xlink:href=\"https://github.com/xddxdd/bird-lg-go#proxy\">here</link>.
+          ";
+        };
+      };
+    };
+  };
+
+  ###### implementation
+
+  config = {
+    systemd.services = {
+      bird-lg-frontend = mkIf cfg.frontend.enable {
+        enable = true;
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+        description = "Bird Looking Glass Frontend Webserver";
+        serviceConfig = {
+          Type = "simple";
+          Restart = "on-failure";
+          ProtectSystem = "full";
+          ProtectHome = "yes";
+          MemoryDenyWriteExecute = "yes";
+          User = cfg.user;
+          Group = cfg.group;
+        };
+        script = ''
+          ${cfg.package}/bin/frontend \
+            --servers ${concatStringsSep "," cfg.frontend.servers } \
+            --domain ${cfg.frontend.domain} \
+            --listen ${cfg.frontend.listenAddress} \
+            --proxy-port ${toString cfg.frontend.proxyPort} \
+            --whois ${cfg.frontend.whois} \
+            --dns-interface ${cfg.frontend.dnsInterface} \
+            --bgpmap-info ${concatStringsSep "," cfg.frontend.bgpMapInfo } \
+            --title-brand ${cfg.frontend.titleBrand} \
+            --navbar-brand ${cfg.frontend.navbar.brand} \
+            --navbar-brand-url ${cfg.frontend.navbar.brandURL} \
+            --navbar-all-servers ${cfg.frontend.navbar.allServers} \
+            --navbar-all-url ${cfg.frontend.navbar.allServersURL} \
+            --net-specific-mode ${cfg.frontend.netSpecificMode} \
+            --protocol-filter ${concatStringsSep "," cfg.frontend.protocolFilter } \
+            --name-filter ${cfg.frontend.nameFilter} \
+            --time-out ${toString cfg.frontend.timeout} \
+            ${cfg.frontend.extraArgs}
+        '';
+      };
+
+      bird-lg-proxy = mkIf cfg.proxy.enable {
+        enable = true;
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+        description = "Bird Looking Glass Proxy";
+        serviceConfig = {
+          Type = "simple";
+          Restart = "on-failure";
+          ProtectSystem = "full";
+          ProtectHome = "yes";
+          MemoryDenyWriteExecute = "yes";
+          User = cfg.user;
+          Group = cfg.group;
+        };
+        script = ''
+          ${cfg.package}/bin/proxy \
+          --allowed ${concatStringsSep "," cfg.proxy.allowedIPs } \
+          --bird ${cfg.proxy.birdSocket} \
+          --listen ${cfg.proxy.listenAddress} \
+          --traceroute_bin ${cfg.proxy.traceroute.binary}
+          --traceroute_raw ${boolToString cfg.proxy.traceroute.rawOutput}
+          ${cfg.proxy.extraArgs}
+        '';
+      };
+    };
+    users = mkIf (cfg.frontend.enable || cfg.proxy.enable) {
+      groups."bird-lg" = mkIf (cfg.group == "bird-lg") { };
+      users."bird-lg" = mkIf (cfg.user == "bird-lg") {
+        description = "Bird Looking Glass user";
+        extraGroups = lib.optionals (config.services.bird2.enable) [ "bird2" ];
+        group = cfg.group;
+        isSystemUser = true;
+      };
+    };
+  };
+}

--- a/pkgs/servers/bird-lg/default.nix
+++ b/pkgs/servers/bird-lg/default.nix
@@ -1,0 +1,43 @@
+{ buildGoModule, fetchFromGitHub, lib, symlinkJoin }:
+let
+  generic = { modRoot, vendorSha256 }:
+    buildGoModule rec {
+      pname = "bird-lg-${modRoot}";
+      version = "2022-05-08";
+
+      doDist = false;
+
+      ldflags = [
+        "-s"
+        "-w"
+      ];
+
+      inherit modRoot;
+      inherit vendorSha256;
+
+      src = fetchFromGitHub {
+        owner = "xddxdd";
+        repo = "bird-lg-go";
+        rev = "348295b9aa954a92df2cf6b1179846a9486dafc0";
+        sha256 = "sha256-2t8ZP9Uc0sJlqWiJMq3MVoARfMKsuTXJkuOid0oWgyY=";
+      };
+
+      meta = with lib; {
+        description = "Bird Looking Glass";
+        homepage = "https://github.com/xddxdd/bird-lg-go";
+        license = licenses.gpl3Plus;
+        maintainers = with maintainers; [ tchekda ];
+      };
+    };
+
+  bird-lg-frontend = generic {
+    modRoot = "frontend";
+    vendorSha256 = "sha256-WKuVGiSV5LZrJ8/672TRN6tZNQxdCktHV6nx0ZxCP4A=";
+  };
+
+  bird-lg-proxy = generic {
+    modRoot = "proxy";
+    vendorSha256 = "sha256-7LZeCY4xSxREsQ+Dc2XSpu2ZI8CLE0mz0yoThP7/OO4=";
+  };
+in
+symlinkJoin { name = "bird-lg"; paths = [ bird-lg-frontend bird-lg-proxy ]; }

--- a/pkgs/servers/bird-lg/default.nix
+++ b/pkgs/servers/bird-lg/default.nix
@@ -3,7 +3,14 @@ let
   generic = { modRoot, vendorSha256 }:
     buildGoModule rec {
       pname = "bird-lg-${modRoot}";
-      version = "2022-05-08";
+      version = "unstable-2022-05-08";
+
+      src = fetchFromGitHub {
+        owner = "xddxdd";
+        repo = "bird-lg-go";
+        rev = "348295b9aa954a92df2cf6b1179846a9486dafc0";
+        sha256 = "sha256-2t8ZP9Uc0sJlqWiJMq3MVoARfMKsuTXJkuOid0oWgyY=";
+      };
 
       doDist = false;
 
@@ -12,15 +19,7 @@ let
         "-w"
       ];
 
-      inherit modRoot;
-      inherit vendorSha256;
-
-      src = fetchFromGitHub {
-        owner = "xddxdd";
-        repo = "bird-lg-go";
-        rev = "348295b9aa954a92df2cf6b1179846a9486dafc0";
-        sha256 = "sha256-2t8ZP9Uc0sJlqWiJMq3MVoARfMKsuTXJkuOid0oWgyY=";
-      };
+      inherit modRoot vendorSha256;
 
       meta = with lib; {
         description = "Bird Looking Glass";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21598,6 +21598,8 @@ with pkgs;
 
   bird = callPackage ../servers/bird { };
 
+  bird-lg = callPackage ../servers/bird-lg { };
+
   bloat = callPackage ../servers/bloat { };
 
   bosun = callPackage ../servers/monitoring/bosun { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Because `bird` was available as package and a service, it seemed to me that having a looking glass available out-of-the-box was a good idea

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
