### PR TITLE
obb: init at 0.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12671,6 +12671,12 @@
     email = "tim.williams.public@gmail.com";
     name = "Tim Philip Williams";
   };
+  willcohen = {
+    email = "willcohen@users.noreply.github.com";
+    github = "willcohen";
+    githubId = 5185341;
+    name = "Will Cohen";
+  };
   winden = {
     email = "windenntw@gmail.com";
     name = "Antonio Vargas Gonzalez";

--- a/pkgs/development/interpreters/clojure/obb.nix
+++ b/pkgs/development/interpreters/clojure/obb.nix
@@ -1,0 +1,79 @@
+{ lib
+, stdenv
+, fetchurl
+, babashka
+, cacert
+, clojure
+, git
+, jdk
+, callPackage
+, makeWrapper
+, runCommand }:
+
+stdenv.mkDerivation rec {
+  pname = "obb";
+  version = "0.0.1";
+
+  src = fetchurl {
+    url = "https://github.com/babashka/${pname}/archive/refs/tags/v${version}.tar.gz";
+    sha256 = "sha256-ZVd3VCJ7vdQGQ7iY5v2b+gRX/Ni0/03hzqBElqpPvpI=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ babashka cacert git jdk ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    mkdir -p .m2
+    substituteInPlace deps.edn --replace ':paths' ':mvn/local-repo "./.m2" :paths'
+    substituteInPlace bb.edn --replace ':paths' ':mvn/local-repo "./.m2" :paths'
+    echo deps.edn
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    export DEPS_CLJ_TOOLS_DIR=${clojure}
+    export DEPS_CLJ_TOOLS_VERSION=${clojure.version}
+    mkdir -p .gitlibs
+    mkdir -p .cpcache
+    export GITLIBS=.gitlibs
+    export CLJ_CACHE=.cpcache
+
+    bb build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    ln -s /usr/bin/osascript $out/bin/osascript
+
+    install -Dm755 "out/bin/obb" "$out/bin/obb"
+    wrapProgram $out/bin/obb --prefix PATH : $out/bin
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    [ $($out/bin/obb -e '(+ 1 2)') = '3' ]
+  '';
+
+
+  meta = with lib; {
+    description = "Ad-hoc ClojureScript scripting of Mac applications via Apple's Open Scripting Architecture";
+    homepage = "https://github.com/babashka/obb";
+    license = licenses.epl10;
+    maintainers = with maintainers; [
+      willcohen
+    ];
+    platforms = platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13578,6 +13578,8 @@ with pkgs;
 
   ngn-k = callPackage ../development/interpreters/ngn-k { };
 
+  obb = callPackage ../development/interpreters/clojure/obb.nix { };
+
   octave = callPackage ../development/interpreters/octave {
     python = python3;
     mkDerivation = stdenv.mkDerivation;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add initial release of [obb](https://github.com/babashka/obb), a Mac scripting tool built off of [babashka](https://babashka.org/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
