### PR TITLE
graphite-gtk-theme: init at unstable-2022-01-04

### DIFF
--- a/pkgs/data/themes/graphite/default.nix
+++ b/pkgs/data/themes/graphite/default.nix
@@ -1,0 +1,87 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, gnome-themes-extra
+, gtk-engine-murrine
+, jdupes
+, sassc
+, themeVariants ? [] # default: blue
+, colorVariants ? [] # default: all
+, sizeVariants ? [] # default: standard
+, tweaks ? []
+, wallpapers ? false
+}:
+
+let
+  pname = "graphite-gtk-theme";
+
+  throwIfNotSubList = name: given: valid:
+    let
+      unexpected = lib.subtractLists valid given;
+    in
+      lib.throwIfNot (unexpected == [])
+        "${name}: ${builtins.concatStringsSep ", " (builtins.map builtins.toString unexpected)} unexpected; valid ones: ${builtins.concatStringsSep ", " (builtins.map builtins.toString valid)}";
+
+in
+throwIfNotSubList "${pname}: theme variants" themeVariants [ "default" "purple" "pink" "red" "orange" "yellow" "green" "teal" "blue" "all" ]
+throwIfNotSubList "${pname}: color variants" colorVariants [ "standard" "light" "dark" ]
+throwIfNotSubList "${pname}: size variants" sizeVariants [ "standard" "compact" ]
+throwIfNotSubList "${pname}: tweaks" tweaks [ "nord" "black" "midblack" "rimless" "normal" ]
+
+stdenvNoCC.mkDerivation {
+  inherit pname;
+  version = "unstable-2022-01-04";
+
+  src = fetchFromGitHub {
+    owner = "vinceliuice";
+    repo = pname;
+    rev = "947cac4966377d8f5b5a4e2966ec2b9a6041d205";
+    sha256 = "11pl8hzk4fwniqdib0ffvjilpspr1n5pg1gw39kal13wxh4sdg28";
+  };
+
+  nativeBuildInputs = [
+    jdupes
+    sassc
+  ];
+
+  buildInputs = [
+    gnome-themes-extra
+  ];
+
+  propagatedUserEnvPkgs = [
+    gtk-engine-murrine
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    patchShebangs install.sh
+
+    name= ./install.sh \
+      ${lib.optionalString (themeVariants != []) "--theme " + builtins.toString themeVariants} \
+      ${lib.optionalString (colorVariants != []) "--color " + builtins.toString colorVariants} \
+      ${lib.optionalString (sizeVariants != []) "--size " + builtins.toString sizeVariants} \
+      ${lib.optionalString (tweaks != []) "--tweaks " + builtins.toString tweaks} \
+      --dest $out/share/themes
+
+    ${lib.optionalString wallpapers ''
+      mkdir -p $out/share/backgrounds
+      cp -a wallpaper/Graphite-normal/*.png $out/share/backgrounds/
+      ${lib.optionalString (builtins.elem "nord" tweaks) ''
+        cp -a wallpaper/Graphite-nord/*.png $out/share/backgrounds/
+      ''}
+    ''}
+
+    jdupes -L -r $out/share
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Flat Gtk+ theme based on Elegant Design";
+    homepage = "https://github.com/vinceliuice/Graphite-gtk-theme";
+    license = licenses.gpl3Only;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23463,6 +23463,8 @@ with pkgs;
 
   go-font = callPackage ../data/fonts/go-font { };
 
+  graphite-gtk-theme = callPackage ../data/themes/graphite { };
+
   greybird = callPackage ../data/themes/greybird { };
 
   gruvbox-dark-gtk = callPackage ../data/themes/gruvbox-dark-gtk { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add [graphite-gtk-theme](https://github.com/vinceliuice/Graphite-gtk-theme).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
