### PR TITLE
python3Packages.picosnitch: init at 0.9.0

### DIFF
--- a/pkgs/tools/networking/picosnitch/default.nix
+++ b/pkgs/tools/networking/picosnitch/default.nix
@@ -1,0 +1,24 @@
+{ lib, python3 }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "picosnitch";
+  version = "0.9.0";
+
+  src = python3.pkgs.fetchPypi {
+    inherit pname version;
+    sha256 = "e56aef62f0f9a48a346f02a96362b0e655cc754ebacaf58cb1632e602463d365";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [ psutil dbus-python requests ];
+
+  pythonImportsCheck = [ "picosnitch" ];
+
+  meta = with lib; {
+    description = "Tool for Linux to help protect your privacy";
+    homepage = "https://github.com/elesiuta/picosnitch";
+    changelog = "https://github.com/elesiuta/picosnitch/releases";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.j0hax ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27890,6 +27890,8 @@ with pkgs;
 
   picoloop = callPackage ../applications/audio/picoloop { };
 
+  picosnitch = callPackage ../tools/networking/picosnitch { };
+
   pidgin = callPackage ../applications/networking/instant-messengers/pidgin {
     withOpenssl = config.pidgin.openssl or true;
     withGnutls = config.pidgin.gnutls or false;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Package [picosnitch](https://github.com/elesiuta/picosnitch) for NixOS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### TODO

This is a **draft**, it needs following work done before being completed:

- [ ] Fix import error `No module named picosnitch` when executing file
- [ ] NixOS Module (`services.picosnitch.enable = ...`)?