### PR TITLE
kitty-themes: init at unstable-2022-01-01

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8559,6 +8559,12 @@
     githubId = 3747396;
     name = "Nathan Isom";
   };
+  nelsonjeppesen = {
+    email = "nix@jeppesen.io";
+    github = "NelsonJeppesen";
+    githubId = 50854675;
+    name = "Nelson Jeppesen";
+  };
   neonfuz = {
     email = "neonfuz@gmail.com";
     github = "neonfuz";

--- a/pkgs/misc/kitty-themes/default.nix
+++ b/pkgs/misc/kitty-themes/default.nix
@@ -1,0 +1,27 @@
+{ fetchFromGitHub, lib, stdenv }:
+
+stdenv.mkDerivation rec {
+  pname = "kitty-themes";
+  version = "unstable-2022-02-03";
+
+  src = fetchFromGitHub {
+    owner = "kovidgoyal";
+    repo = pname;
+    rev = "337d6fcb3ad7e38544edfb8d0f6447894b7e5f58";
+    sha256 = "ZP5GrT2QCdXtC5swqI0SXzIlqIcQNsxBlzEplj/hpz4=";
+  };
+
+  installPhase = ''
+    mkdir -p $out/themes
+    mv themes.json $out
+    mv themes/*.conf $out/themes
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/kovidgoyal/kitty-themes";
+    description = "Themes for the kitty terminal emulator";
+    license = licenses.gpl3Only;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ nelsonjeppesen ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1140,6 +1140,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Cocoa CoreGraphics Foundation IOKit Kernel OpenGL;
   };
 
+  kitty-themes  = callPackage ../misc/kitty-themes {};
+
   lxterminal = callPackage ../applications/terminal-emulators/lxterminal { };
 
   microcom = callPackage ../applications/terminal-emulators/microcom { };


### PR DESCRIPTION
###### Motivation for this change
Closes https://github.com/NixOS/nixpkgs/issues/153504

Add kitty-themes to the Nix store. Once there, I can use them with `home-manager`. Once merged, I plan to add a themes option to home-managers kitty module

###### Things done
This is very basic; copy all the `*.conf` theme files and manifest to Nix store from GitHub
```
❯ find /nix/store/0r0v51dyd905n7n2drzxhg3xk0jdyjkf-kitty-themes-unstable-2022-02-03 | head -n 5
/nix/store/0r0v51dyd905n7n2drzxhg3xk0jdyjkf-kitty-themes-unstable-2022-02-03
/nix/store/0r0v51dyd905n7n2drzxhg3xk0jdyjkf-kitty-themes-unstable-2022-02-03/themes.json
/nix/store/0r0v51dyd905n7n2drzxhg3xk0jdyjkf-kitty-themes-unstable-2022-02-03/themes
/nix/store/0r0v51dyd905n7n2drzxhg3xk0jdyjkf-kitty-themes-unstable-2022-02-03/themes/1984_dark.conf
/nix/store/0r0v51dyd905n7n2drzxhg3xk0jdyjkf-kitty-themes-unstable-2022-02-03/themes/1984_light.conf
...
```
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
