### PR TITLE
vigra: python2 -> python3

### DIFF
--- a/pkgs/development/libraries/vigra/default.nix
+++ b/pkgs/development/libraries/vigra/default.nix
@@ -12,13 +12,9 @@
 , libpng
 , libtiff
 , openexr
-, python2Packages
+, python3
 }:
 
-let
-  inherit (python2Packages) python numpy;
-  # Might want to use `python2.withPackages(ps: [ps.numpy]);` here...
-in
 stdenv.mkDerivation rec {
   pname = "vigra";
   version = "1.11.1";
@@ -50,12 +46,9 @@ stdenv.mkDerivation rec {
     libjpeg
     libpng
     libtiff
-    numpy
     openexr
-    python
+    python3
   ];
-
-  preConfigure = "cmakeFlags+=\" -DVIGRANUMPY_INSTALL_DIR=$out/lib/${python.libPrefix}/site-packages\"";
 
   cmakeFlags = [ "-DWITH_OPENEXR=1" ]
     ++ lib.optionals (stdenv.hostPlatform.system == "x86_64-linux")


### PR DESCRIPTION
This derivation already doesn't build vigra's python bindings; the only use of python is the `bin/vigra-config` script that dependent packages can use to get compiler flags. I confirmed that this script works correctly on python3. Without building the python bindings, the numpy dependency is not used, so was removed.

A `diff` between the old and new output directories shows that the only changes are in `bin/vigra-config`: the `#!` path to python and the absolute paths to the output directory that would change on any rebuild.

###### Motivation for this change

Remove python2: https://github.com/NixOS/nixpkgs/issues/148779

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
