### PR TITLE
Fix loading of libcrypto when using salt-ssh

### DIFF
--- a/pkgs/tools/admin/salt/fix-libcrypto-loading.patch
+++ b/pkgs/tools/admin/salt/fix-libcrypto-loading.patch
@@ -1,13 +1,13 @@
-diff --git a/salt/utils/rsax931.py b/salt/utils/rsax931.py
-index f827cc6db8..b728595186 100644
---- a/salt/utils/rsax931.py
-+++ b/salt/utils/rsax931.py
-@@ -74,7 +74,7 @@
+--- a/salt/utils/rsax931.py	2021-11-24 00:39:57.940790184 +0100
++++ b/salt/utils/rsax931.py	2021-11-24 00:38:35.436728341 +0100
+@@ -85,6 +85,10 @@
      """
      Attempt to load libcrypto.
      """
--    return cdll.LoadLibrary(_find_libcrypto())
-+    return cdll.LoadLibrary('@libcrypto@')
++    try:
++        return cdll.LoadLibrary('@libcrypto@')
++    except OSError:
++        pass
+     return cdll.LoadLibrary(_find_libcrypto())
  
  
- def _init_libcrypto():


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

When using salt-ssh, Salt would copy itself to the target machine. The libcrypto loading patch included in Nix hardcodes the location, but does not provide any fallback for the target machine, making salt-ssh unusable from a nix environment, which is ironically, one of the coolest use-cases of nix: a self contained git repo with a Saltfile and a shell.nix with dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
