### PR TITLE
python3Packages.django_4: init at 4.0.2

### DIFF
--- a/pkgs/development/python-modules/django/4.nix
+++ b/pkgs/development/python-modules/django/4.nix
@@ -1,0 +1,107 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, substituteAll
+
+# patched in
+, geos
+, gdal
+, withGdal ? false
+
+# propagated
+, asgiref
+, backports-zoneinfo
+, sqlparse
+
+# tests
+, aiosmtpd
+, argon2_cffi
+, bcrypt
+, docutils
+, geoip2
+, jinja2
+, memcached
+, numpy
+, pillow
+, pylibmc
+, pymemcache
+, python
+, pytz
+, pywatchman
+, pyyaml
+, redis
+, selenium
+, tblib
+, tzdata
+}:
+
+buildPythonPackage rec {
+  pname = "Django";
+  version = "4.0.2";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-EQ+1j7Euylngcq1Z/ELXcc1kLdei8kFlgqqdp6jvlUo=";
+  };
+
+  patches = lib.optional withGdal
+    (substituteAll {
+      src = ./django_4_set_geos_gdal_lib.patch;
+      geos = geos;
+      gdal = gdal;
+      extension = stdenv.hostPlatform.extensions.sharedLibrary;
+    });
+
+  propagatedBuildInputs = [
+    asgiref
+    sqlparse
+  ] ++ lib.optionals (pythonOlder "3.9") [
+    backports-zoneinfo
+  ];
+
+  # Fails to import asgiref in ~200 tests
+  # ModuleNotFoundError: No module named 'asgiref'
+  doCheck = false;
+
+  checkInputs = [
+    aiosmtpd
+    argon2_cffi
+    asgiref
+    bcrypt
+    docutils
+    geoip2
+    jinja2
+    memcached
+    numpy
+    pillow
+    pylibmc
+    pymemcache
+    pytz
+    pywatchman
+    pyyaml
+    redis
+    selenium
+    tblib
+    tzdata
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    ${python.interpreter} tests/runtests.py
+
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design.";
+    homepage = "https://www.djangoproject.com";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/django/django_4_set_geos_gdal_lib.patch
+++ b/pkgs/development/python-modules/django/django_4_set_geos_gdal_lib.patch
@@ -1,0 +1,26 @@
+diff --git a/django/contrib/gis/gdal/libgdal.py b/django/contrib/gis/gdal/libgdal.py
+index 05b5732..91fafee 100644
+--- a/django/contrib/gis/gdal/libgdal.py
++++ b/django/contrib/gis/gdal/libgdal.py
+@@ -14,7 +14,7 @@ try:
+     from django.conf import settings
+     lib_path = settings.GDAL_LIBRARY_PATH
+ except (AttributeError, ImportError, ImproperlyConfigured, OSError):
+-    lib_path = None
++    lib_path = ""@gdal@/lib/libgdal@extension@"
+ 
+ if lib_path:
+     lib_names = None
+diff --git a/django/contrib/gis/geos/libgeos.py b/django/contrib/gis/geos/libgeos.py
+index 2cdb5d3..fac2d04 100644
+--- a/django/contrib/gis/geos/libgeos.py
++++ b/django/contrib/gis/geos/libgeos.py
+@@ -24,7 +24,7 @@ def load_geos():
+         from django.conf import settings
+         lib_path = settings.GEOS_LIBRARY_PATH
+     except (AttributeError, ImportError, ImproperlyConfigured, OSError):
+-        lib_path = None
++        lib_path = "@geos@/lib/libgeos_c@extension@"
+ 
+     # Setting the appropriate names for the GEOS-C library.
+     if lib_path:

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2162,9 +2162,10 @@ in {
 
   # Current LTS
   django_2 = callPackage ../development/python-modules/django/2.nix { };
+  django_3 = callPackage ../development/python-modules/django/3.nix { };
 
   # Current latest
-  django_3 = callPackage ../development/python-modules/django/3.nix { };
+  django_4 = callPackage ../development/python-modules/django/4.nix { };
 
   django-allauth = callPackage ../development/python-modules/django-allauth { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://docs.djangoproject.com/en/4.0/releases/4.0/
https://docs.djangoproject.com/en/4.0/releases/4.0.1/
https://docs.djangoproject.com/en/4.0/releases/4.0.2/

Tried to get the test suite running, but out of ~14k tests ~200 failed and ~10 errored out.
Tests fail to import `asgiref` which is already propagated, no idea what's happening yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
