### PR TITLE
Revert "linuxPackages: bump default 5.10 -> 5.15"

### DIFF
--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -506,7 +506,7 @@ in {
   });
 
   packageAliases = {
-    linux_default = packages.linux_5_15;
+    linux_default = packages.linux_5_10;
     # Update this when adding the newest kernel major version!
     linux_latest = packages.linux_5_15;
     linux_mptcp = packages.linux_mptcp_95;


### PR DESCRIPTION
Reverts NixOS/nixpkgs#152505

Unfortunately, `linuxPackages_5_15.ena` is broken until upstream supports the kernel version. Since amazonImage was added as a constituent, it was causing evaluation failures for the constituent.