### PR TITLE
cudatoolkit: expose compute-sanitizer, nsys utilities

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -206,10 +206,10 @@ stdenv.mkDerivation rec {
       fi
     done < <(find $out $lib $doc -type f -print0)
   '' + lib.optionalString (lib.versionAtLeast version "11") ''
-    while IFS= read -r -d $'\0' i; do
-      echo "patching $i..."
-      patchelf --set-rpath "$rpath:\$ORIGIN" $i
-    done < <(find $out/target-linux-x64 -type f -name '*.so' -print0)
+    for file in $out/target-linux-x64/*.so; do
+      echo "patching $file..."
+      patchelf --set-rpath "$rpath:\$ORIGIN" $file
+    done
   '';
 
   # Set RPATH so that libcuda and other libraries in

--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -214,6 +214,10 @@ stdenv.mkDerivation rec {
   # --force-rpath prevents changing RPATH (set above) to RUNPATH.
   postFixup = ''
     addOpenGLRunpath --force-rpath {$out,$lib}/lib/lib*.so
+    ${lib.optionalString (lib.versionAtLeast version "11") ''
+      addOpenGLRunpath $out/cuda_sanitizer_api/compute-sanitizer/*
+      addOpenGLRunpath $out/cuda_sanitizer_api/compute-sanitizer/x86/*
+    ''}
   '';
 
   # cuda-gdb doesn't run correctly when not using sandboxing, so

--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -205,12 +205,11 @@ stdenv.mkDerivation rec {
         patchelf --set-rpath "$rpath2" --force-rpath $i
       fi
     done < <(find $out $lib $doc -type f -print0)
-    ${lib.optionalString (lib.versionAtLeast version "11") ''
-      while IFS= read -r -d $'\0' i; do
-        echo "patching $i..."
-        patchelf --set-rpath "$rpath:\$ORIGIN" $i
-      done < <(find $out/target-linux-x64 -type f -name '*.so' -print0)
-    ''}
+  '' + lib.optionalString (lib.versionAtLeast version "11") ''
+    while IFS= read -r -d $'\0' i; do
+      echo "patching $i..."
+      patchelf --set-rpath "$rpath:\$ORIGIN" $i
+    done < <(find $out/target-linux-x64 -type f -name '*.so' -print0)
   '';
 
   # Set RPATH so that libcuda and other libraries in
@@ -220,11 +219,10 @@ stdenv.mkDerivation rec {
   # --force-rpath prevents changing RPATH (set above) to RUNPATH.
   postFixup = ''
     addOpenGLRunpath --force-rpath {$out,$lib}/lib/lib*.so
-    ${lib.optionalString (lib.versionAtLeast version "11") ''
-      addOpenGLRunpath $out/cuda_sanitizer_api/compute-sanitizer/*
-      addOpenGLRunpath $out/cuda_sanitizer_api/compute-sanitizer/x86/*
-      addOpenGLRunpath $out/target-linux-x64/*
-    ''}
+  '' + lib.optionalString (lib.versionAtLeast version "11") ''
+    addOpenGLRunpath $out/cuda_sanitizer_api/compute-sanitizer/*
+    addOpenGLRunpath $out/cuda_sanitizer_api/compute-sanitizer/x86/*
+    addOpenGLRunpath $out/target-linux-x64/*
   '';
 
   # cuda-gdb doesn't run correctly when not using sandboxing, so

--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -205,6 +205,12 @@ stdenv.mkDerivation rec {
         patchelf --set-rpath "$rpath2" --force-rpath $i
       fi
     done < <(find $out $lib $doc -type f -print0)
+    ${lib.optionalString (lib.versionAtLeast version "11") ''
+      while IFS= read -r -d $'\0' i; do
+        echo "patching $i..."
+        patchelf --set-rpath "$rpath:$out/target-linux-x64" $i
+      done < <(find $out/target-linux-x64 -type f -name '*.so' -print0)
+    ''}
   '';
 
   # Set RPATH so that libcuda and other libraries in

--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -191,12 +191,12 @@ stdenv.mkDerivation rec {
   '';
 
   preFixup = ''
-    while IFS= read -r -d ''$'\0' i; do
+    while IFS= read -r -d $'\0' i; do
       if ! isELF "$i"; then continue; fi
       echo "patching $i..."
       if [[ ! $i =~ \.so ]]; then
         patchelf \
-          --set-interpreter "''$(cat $NIX_CC/nix-support/dynamic-linker)" $i
+          --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $i
       fi
       if [[ $i =~ libcudart ]]; then
         patchelf --remove-rpath $i

--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -223,6 +223,7 @@ stdenv.mkDerivation rec {
     ${lib.optionalString (lib.versionAtLeast version "11") ''
       addOpenGLRunpath $out/cuda_sanitizer_api/compute-sanitizer/*
       addOpenGLRunpath $out/cuda_sanitizer_api/compute-sanitizer/x86/*
+      addOpenGLRunpath $out/target-linux-x64/*
     ''}
   '';
 

--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -119,6 +119,12 @@ stdenv.mkDerivation rec {
         fi
       done
       mv pkg/builds/cuda_nvcc/nvvm $out/nvvm
+
+      mv pkg/builds/cuda_sanitizer_api $out/cuda_sanitizer_api
+      ln -s $out/cuda_sanitizer_api/compute-sanitizer/compute-sanitizer $out/bin/compute-sanitizer
+
+      mv pkg/builds/nsight_systems/target-linux-x64 $out/target-linux-x64
+      mv pkg/builds/nsight_systems/host-linux-x64 $out/host-linux-x64
     ''}
 
     rm -f $out/tools/CUDA_Occupancy_Calculator.xls # FIXME: why?

--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -214,6 +214,9 @@ stdenv.mkDerivation rec {
   # --force-rpath prevents changing RPATH (set above) to RUNPATH.
   postFixup = ''
     addOpenGLRunpath --force-rpath {$out,$lib}/lib/lib*.so
+    ${lib.optionalString (lib.versionAtLeast version "11") ''
+      addOpenGLRunpath $out/bin/compute-sanitizer
+    ''}
   '';
 
   # cuda-gdb doesn't run correctly when not using sandboxing, so

--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -208,7 +208,7 @@ stdenv.mkDerivation rec {
     ${lib.optionalString (lib.versionAtLeast version "11") ''
       while IFS= read -r -d $'\0' i; do
         echo "patching $i..."
-        patchelf --set-rpath "$rpath:$out/target-linux-x64" $i
+        patchelf --set-rpath "$rpath:\$ORIGIN" $i
       done < <(find $out/target-linux-x64 -type f -name '*.so' -print0)
     ''}
   '';

--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -214,9 +214,6 @@ stdenv.mkDerivation rec {
   # --force-rpath prevents changing RPATH (set above) to RUNPATH.
   postFixup = ''
     addOpenGLRunpath --force-rpath {$out,$lib}/lib/lib*.so
-    ${lib.optionalString (lib.versionAtLeast version "11") ''
-      addOpenGLRunpath $out/bin/compute-sanitizer
-    ''}
   '';
 
   # cuda-gdb doesn't run correctly when not using sandboxing, so


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Exposes commands included in the CUDA Toolkit that are not installed by the current deriviation:

- [`nsys`](https://docs.nvidia.com/nsight-systems/UserGuide/index.html) (note that I couldn't get `nsys-ui` to work; it is a QT app and seems a little more complex to package)
- [`compute-sanitizer`](https://docs.nvidia.com/cuda/compute-sanitizer/index.html) (supersedes `cuda-memcheck`)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
