### PR TITLE
types.attrs: merge non-conflicting values only

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -279,6 +279,10 @@ checkConfigError 'A definition for option .fun.\[function body\]. is not of type
 checkConfigOutput '^"b a"$' config.result ./functionTo/list-order.nix
 checkConfigOutput '^"a c"$' config.result ./functionTo/merging-attrs.nix
 
+## types.attrs
+checkConfigError 'The option .* has conflicting definition values in .*foo.bar.*' config.value.foo.bar ./define-conflicting-attrs.nix
+checkConfigOutput '^42$' config.value.foo.baz ./define-merging-attrs.nix
+
 # moduleType
 checkConfigOutput '^"a b"$' config.resultFoo ./declare-variants.nix ./define-variant.nix
 checkConfigOutput '^"a y z"$' config.resultFooBar ./declare-variants.nix ./define-variant.nix

--- a/lib/tests/modules/declare-attrs.nix
+++ b/lib/tests/modules/declare-attrs.nix
@@ -1,0 +1,5 @@
+{ lib, ... }: {
+  options.value = lib.mkOption {
+    type = lib.types.attrs;
+  };
+}

--- a/lib/tests/modules/define-conflicting-attrs.nix
+++ b/lib/tests/modules/define-conflicting-attrs.nix
@@ -1,0 +1,7 @@
+{
+  imports = [
+    ./declare-attrs.nix
+    { value = { foo = { bar = false; }; }; }
+    { value = { foo = { bar = true; }; }; }
+  ];
+}

--- a/lib/tests/modules/define-merging-attrs.nix
+++ b/lib/tests/modules/define-merging-attrs.nix
@@ -1,0 +1,7 @@
+{
+  imports = [
+    ./declare-attrs.nix
+    { value = { foo = { bar = true; }; }; }
+    { value = { foo = { bar = true; baz = 42; }; }; }
+  ];
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -48,6 +48,7 @@ let
     mergeDefaultOption
     mergeEqualOption
     mergeOneOption
+    mergeAttrSetOptions
     showFiles
     showOption
     ;
@@ -340,7 +341,7 @@ rec {
       name = "attrs";
       description = "attribute set";
       check = isAttrs;
-      merge = loc: foldl' (res: def: res // def.value) {};
+      merge = mergeAttrSetOptions;
       emptyValue = { value = {}; };
     };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Avoid silent conflicting redefinitions of option values.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
