### PR TITLE
thunderbird-sequoia: init 91.4.1+1.2.1

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird/sequoia.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/sequoia.nix
@@ -1,0 +1,46 @@
+{ lib, thunderbird, sequoia-octopus-librnp }:
+let
+  originalPackage = thunderbird;
+
+  # We use `overrideAttrs` instead of defining a new `mkDerivation` to keep
+  # the original package's `output`, `passthru`, and so on.
+  thunderbird-sequoia = originalPackage.overrideAttrs (old: rec {
+    pname = "thunderbird-sequoia";
+    version = "${old.version}+${sequoia-octopus-librnp.version}";
+
+    meta = with lib; {
+      description = "Thunderbird with the Sequoia OpenPGP backend";
+      homepage = "https://gitlab.com/sequoia-pgp/sequoia-octopus-librnp";
+      license = old.meta.license;
+      maintainers = with maintainers; [ puzzlewolf ];
+    };
+
+    propagatedBuildInputs = [
+      sequoia-octopus-librnp
+    ];
+
+    buildCommand = ''
+      cp -a "${originalPackage}" "$out"
+
+      # Replace librnp.so
+      chmod +w $out/lib/thunderbird
+      rm $out/lib/thunderbird/librnp.so
+      ln -s ${sequoia-octopus-librnp}/lib/libsequoia_octopus_librnp.so \
+        $out/lib/thunderbird/librnp.so
+      chmod -w $out/lib/thunderbird
+
+      # Thunderbird looks for shared libraries in the same directory as its binary,
+      # so we need to fix the wrappers to run the binary from this derivation
+      # so that it actually finds new librnp.so.
+      chmod +w $out/bin
+      for file in \
+        "$out/bin/thunderbird" "$out/bin/.thunderbird-wrapped_" "$out/bin/.thunderbird-old"
+      do
+        substituteInPlace "$file" --replace "${originalPackage}" "$out"
+      done
+      chmod -w $out/bin
+    '';
+
+  });
+in
+thunderbird-sequoia

--- a/pkgs/tools/security/sequoia/octopus-librnp.nix
+++ b/pkgs/tools/security/sequoia/octopus-librnp.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, lib
+, rustPlatform
+, fetchFromGitLab
+, llvmPackages
+, pkg-config
+, openssl
+, sqlite
+, nettle
+, cargo
+, rustc
+, capnproto
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "sequoia-octopus-librnp";
+  version = "1.2.1";
+
+  src = fetchFromGitLab {
+    owner = "sequoia-pgp";
+    repo = "sequoia-octopus-librnp";
+    rev = "v1.2.1";
+    hash = "sha256:1xmijvkgqqq35amjnnpccflqq2nz6w9jcnmyvp1c20wm8prrdkng";
+  };
+
+  cargoSha256 = "sha256:0d6935xgx7iih7k8mdb3mj6x1zcsghwz7klfrrrrqfr44hzs170d";
+
+  # Rust *-sys packages, like nettle-sys, require this to be set.
+  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+
+  buildInputs = [ openssl sqlite nettle ];
+
+  nativeBuildInputs = [ pkg-config cargo rustc llvmPackages.clang capnproto ];
+
+  meta = with lib; {
+    description =
+      "A Sequoia-based OpenPGP Backend for Thunderbird";
+    homepage = "https://gitlab.com/sequoia-pgp/sequoia-octopus-librnp";
+    license = licenses.lgpl2Plus;
+    maintainers = with maintainers; [ puzzlewolf ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9536,6 +9536,8 @@ with pkgs;
     pythonPackages = python3Packages;
   };
 
+  sequoia-octopus-librnp = callPackage ../tools/security/sequoia/octopus-librnp.nix { };
+
   sewer = callPackage ../tools/admin/sewer { };
 
   sfeed = callPackage ../tools/misc/sfeed { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28868,6 +28868,8 @@ with pkgs;
     };
   });
 
+  thunderbird-sequoia = callPackage ../applications/networking/mailreaders/thunderbird/sequoia.nix { };
+
   thunderbird-unwrapped = thunderbirdPackages.thunderbird;
   thunderbird = wrapThunderbird thunderbird-unwrapped { };
   thunderbird-wayland = wrapThunderbird thunderbird-unwrapped { forceWayland = true; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`sequoia-octopus-librnp` is an alternative PGP backend for Thunderbird with a number of improvements over the original included `librnp`.  This PR provides a Thunderbird package `thunderbird-sequoia` with that backend.

The recommended [installation procedure](https://gitlab.com/sequoia-pgp/sequoia-octopus-librnp#using-debians-thunderbird) is replacing the `librnp.so` shipped with Thunderbird (at path/to/thunderbird/librnp.so) with the `librnp.so` built by `sequoia-octopus-librnp`. This package realizes that by copying over the Thunderbird package's files (they are mostly symlinks as the TB package is wrappered), replacing `librnp.so` and adjusting the wrappers. This also avoids rebuilding TB and keeps the closure size small :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>sequoia-octopus-librnp</li>
    <li>thunderbird-sequoia</li>
  </ul>
</details>
