### PR TITLE
pkgs.path: Avoid copying when used via flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,10 @@
                   system.nixos.versionSuffix =
                     ".${final.substring 0 8 (self.lastModifiedDate or self.lastModified or "19700101")}.${self.shortRev or "dirty"}";
                   system.nixos.revision = final.mkIf (self ? rev) self.rev;
+
+                  # NOTE: This assumes that `nixpkgs.config` is _not_ used when
+                  #       nixpkgs.pkgs is set OR _module.args.pkgs is set.
+                  nixpkgs.config.path = self.outPath;
                 }
               ];
           });

--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,7 @@
         }).nixos.manual.x86_64-linux;
       };
 
-      legacyPackages = forAllSystems (system: import ./. { inherit system; });
+      legacyPackages = forAllSystems (system: import ./. { inherit system; config.path = self.outPath; });
 
       nixosModules = {
         notDetected = import ./nixos/modules/installer/scan/not-detected.nix;

--- a/nixos/modules/misc/documentation.nix
+++ b/nixos/modules/misc/documentation.nix
@@ -61,26 +61,80 @@ let
       in scrubbedEval.options;
     baseOptionsJSON =
       let
-        filter =
+        filterIntoStore =
           builtins.filterSource
             (n: t:
               (t == "directory" -> baseNameOf n != "tests")
               && (t == "file" -> hasSuffix ".nix" n)
             );
-        # When working directly from a checkout,
-        #   produce separate, smaller store paths
-        # When already in the store,
-        #   avoid copying; reuse the whole nixpkgs sources
+
+        # Figure out if Nix runs in pure evaluation mode. May return true in
+        # impure mode, but this is highly unlikely.
+        # We need to know because of https://github.com/NixOS/nix/issues/1888
+        # and https://github.com/NixOS/nix/issues/5868
+        isPureEval = builtins.getEnv "PATH" == "" && builtins.getEnv "_" == "";
+
+        # Return a nixpkgs subpath with minimal copying.
         #
-        # We can only avoid copying when pkgs.path is already a string. A path
-        # value can not be converted to a store path without rehashing it.
-        # builtins.storePath would be a solution but is currently off-limits
-        # because of https://github.com/NixOS/nix/issues/1888
-        #        and https://github.com/NixOS/nix/issues/5868
-        pull = dir:
-          if builtins.typeOf pkgs.path == "string" && isStorePath pkgs.path
-          then "${pkgs.path}/${dir}"
-          else filter "${toString pkgs.path}/${dir}";
+        # The sources for the base options json derivation can come in one of
+        # two forms:
+        #   - single source: a store path with all of nixpkgs, postfix with
+        #     subpaths to access various directories. This has the benefit of
+        #     not creating copies of these subtrees in the Nix store, but
+        #     can cause unnecessary rebuilds if you update the Nixpkgs `pkgs`
+        #     tree often.
+        #   - split sources: multiple store paths with subdirectories of
+        #     nixpkgs that exclude the bulk of the pkgs directory.
+        #     This requires more copying and hashing during evaluation but
+        #     requires fewer files to be copied. This method produces fewer
+        #     unnecessary rebuilds of the base options json.
+        #
+        # Flake
+        #
+        # Flakes always put a copy of the full nixpkgs sources in the store,
+        # so we can use the "single source" method. This method is ideal
+        # for using nixpkgs as a dependency, as the base options json will be
+        # substitutable from cache.nixos.org.
+        #
+        # This requires that the `self.outPath` is wired into `pkgs` correctly,
+        # which is done for you if `pkgs` comes from the `lib.nixosSystem` or
+        # `legacyPackages` flake attributes.
+        #
+        # Other Nixpkgs invocation
+        #
+        # If you do not use the known-correct flake attributes, but rather
+        # invoke Nixpkgs yourself, set `config.path` to the correct path value,
+        # e.g. `import nixpkgs { config.path = nixpkgs; }`.
+        #
+        # Choosing between single or split source paths
+        #
+        # We make assumptions based on the type and contents of `pkgs.path`.
+        # By passing a different `config.path` to Nixpkgs, you can influence
+        # how your documentation cache is evaluated and rebuilt.
+        #
+        # Single source
+        #  - If pkgs.path is a string containing a store path, the code has no
+        #    choice but to create this store path, if it hasn't already been.
+        #    We assume that the "single source" method is most efficient.
+        #  - If pkgs.path is a path value containing that is a store path,
+        #    we try to convert it to a string with context without copying.
+        #    This occurs for example when nixpkgs was fetched and using its
+        #    default `config.path`, which is `./.`.
+        #    Nix currently does not allow this conversion when evaluating in
+        #    pure mode. If the conversion is not possible, we use the
+        #    "split source" method.
+        #
+        # Split source
+        #  - If pkgs.path is a path value that is not a store path, we assume
+        #    that it's unlikely for all of nixpkgs to end up in the store for
+        #    other reasons and try to keep both the copying and rebuilds low.
+        pull =
+          if builtins.typeOf pkgs.path == "string" && isStorePath pkgs.path then
+            dir: "${pkgs.path}/${dir}"
+          else if !isPureEval && isStorePath pkgs.path then
+            dir: "${builtins.storePath pkgs.path}/${dir}"
+          else
+            dir: filterIntoStore "${toString pkgs.path}/${dir}";
       in
         pkgs.runCommand "lazy-options.json" {
           libPath = pull "lib";

--- a/nixos/modules/misc/documentation.nix
+++ b/nixos/modules/misc/documentation.nix
@@ -67,11 +67,19 @@ let
               (t == "directory" -> baseNameOf n != "tests")
               && (t == "file" -> hasSuffix ".nix" n)
             );
+        # When working directly from a checkout,
+        #   produce separate, smaller store paths
+        # When already in the store,
+        #   avoid copying; reuse the whole nixpkgs sources
+        pull = dir:
+          if isStorePath pkgs.path
+          then "${pkgs.path}/${dir}"
+          else filter "${toString pkgs.path}/${dir}";
       in
         pkgs.runCommand "lazy-options.json" {
-          libPath = filter "${toString pkgs.path}/lib";
-          pkgsLibPath = filter "${toString pkgs.path}/pkgs/pkgs-lib";
-          nixosPath = filter "${toString pkgs.path}/nixos";
+          libPath = pull "lib";
+          pkgsLibPath = pull "pkgs/pkgs-lib";
+          nixosPath = pull "nixos";
           modules = map (p: ''"${removePrefix "${modulesPath}/" (toString p)}"'') docModules.lazy;
         } ''
           export NIX_STORE_DIR=$TMPDIR/store

--- a/nixos/modules/misc/documentation.nix
+++ b/nixos/modules/misc/documentation.nix
@@ -71,8 +71,14 @@ let
         #   produce separate, smaller store paths
         # When already in the store,
         #   avoid copying; reuse the whole nixpkgs sources
+        #
+        # We can only avoid copying when pkgs.path is already a string. A path
+        # value can not be converted to a store path without rehashing it.
+        # builtins.storePath would be a solution but is currently off-limits
+        # because of https://github.com/NixOS/nix/issues/1888
+        #        and https://github.com/NixOS/nix/issues/5868
         pull = dir:
-          if isStorePath pkgs.path
+          if builtins.typeOf pkgs.path == "string" && isStorePath pkgs.path
           then "${pkgs.path}/${dir}"
           else filter "${toString pkgs.path}/${dir}";
       in

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -59,6 +59,8 @@ let
     inherit (cfg) config overlays localSystem crossSystem;
   };
 
+  # NOTE: flake.nix assumes that nixpkgs.config is only used with ../../..
+  #       as nixpkgs.config.path should be equivalent to ../../..
   finalPkgs = if opt.pkgs.isDefined then cfg.pkgs.appendOverlays cfg.overlays else defaultPkgs;
 
 in

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -67,7 +67,7 @@ with pkgs;
   clangStdenvNoLibs = mkStdenvNoLibs clangStdenv;
 
   # For convenience, allow callers to get the path to Nixpkgs.
-  path = ../..;
+  path = config.path;
 
 
   ### Helper functions.

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -32,6 +32,20 @@ let
       feature = "run <literal>checkPhase</literal> by default";
     };
 
+    path = mkOption {
+      type = types.path;
+      default = ../..;
+      defaultText = lib.literalDocBook "a path expression";
+      internal = true;
+      description = ''
+        A reference to Nixpkgs' own sources.
+
+        This is overridable in order to avoid copying sources unnecessarily,
+        as a path expression that references a store path will not short-circuit
+        to the store path itself, but copy the store path instead.
+      '';
+    };
+
   };
 
 in {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

 - Avoid unnecessary copies of the nixpkgs sources via `pkgs.path`
 - Fix https://github.com/NixOS/nixpkgs/pull/153592 disk space regression.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
