### PR TITLE
obb: switch to fetchFromGitHub and passthru.tests

### DIFF
--- a/pkgs/development/interpreters/clojure/obb.nix
+++ b/pkgs/development/interpreters/clojure/obb.nix
@@ -7,6 +7,7 @@
 , git
 , jdk
 , callPackage
+, fetchFromGitHub
 , makeWrapper
 , runCommand }:
 
@@ -14,9 +15,11 @@ stdenv.mkDerivation rec {
   pname = "obb";
   version = "0.0.1";
 
-  src = fetchurl {
-    url = "https://github.com/babashka/${pname}/archive/refs/tags/v${version}.tar.gz";
-    sha256 = "sha256-ZVd3VCJ7vdQGQ7iY5v2b+gRX/Ni0/03hzqBElqpPvpI=";
+  src = fetchFromGitHub {
+    owner = "babashka";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-WxQjBg6el6XMiHTurmSo1GgZnTdaJjRmcV3+3X4yohc=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/development/interpreters/clojure/obb.nix
+++ b/pkgs/development/interpreters/clojure/obb.nix
@@ -6,7 +6,7 @@
 , clojure
 , git
 , jdk
-, callPackage
+, obb
 , fetchFromGitHub
 , makeWrapper
 , runCommand }:
@@ -64,11 +64,12 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  doInstallCheck = true;
-  installCheckPhase = ''
-    [ $($out/bin/obb -e '(+ 1 2)') = '3' ]
-  '';
-
+  passthru.tests = {
+    simple = runCommand "${pname}-test" {} ''
+      [ $(${obb}/bin/obb -e '(+ 1 2)') = '3' ]
+      touch $out
+    '';
+  };
 
   meta = with lib; {
     description = "Ad-hoc ClojureScript scripting of Mac applications via Apple's Open Scripting Architecture";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Followup to #153496 discussion.

Now uses `fetchFromGitHub` instead of `fetchurl`.

Also, per [package docs](https://github.com/NixOS/nixpkgs/blob/master/doc/stdenv/meta.chapter.md#package-tests), the reason to prefer package tests over the install check, in this case, is because the test is being introduced in `nixpkgs` itself and this encourages speedier builds (acknowledging in this case that the speed difference is trivial, but I don't mind trying to use current best practices on a new package).

@thiagokokada @legendofmiracles 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
