### PR TITLE
python3Packages.pycm: disable failing test

### DIFF
--- a/pkgs/development/python-modules/pycm/default.nix
+++ b/pkgs/development/python-modules/pycm/default.nix
@@ -1,28 +1,55 @@
-{ lib, buildPythonPackage, fetchFromGitHub, isPy3k, matplotlib, numpy, pytestCheckHook, seaborn }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, matplotlib
+, numpy
+, pytestCheckHook
+, pythonOlder
+, seaborn
+}:
 
 buildPythonPackage rec {
   pname = "pycm";
   version = "3.3";
+  format = "setuptools";
 
-  disabled = !isPy3k;
+  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
-    owner  = "sepandhaghighi";
-    repo   = pname;
-    rev    = "v${version}";
+    owner = "sepandhaghighi";
+    repo = pname;
+    rev = "v${version}";
     sha256 = "0i3qpb20mnc22qny1ar3yvxb1dac7njwi8bvi5sy5kywz10c5dkw";
   };
 
-  # remove a trivial dependency on the author's `art` Python ASCII art library
+  propagatedBuildInputs = [
+    matplotlib
+    numpy
+    seaborn
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
   postPatch = ''
+    # Remove a trivial dependency on the author's `art` Python ASCII art library
     rm pycm/__main__.py
-    rm Otherfiles/notebook_check.py  # also depends on python3Packages.notebook
-    substituteInPlace setup.py --replace '=get_requires()' '=[]'
+    # Also depends on python3Packages.notebook
+    rm Otherfiles/notebook_check.py
+    substituteInPlace setup.py \
+      --replace '=get_requires()' '=[]'
   '';
 
-  checkInputs = [ pytestCheckHook ];
-  disabledTests = [ "pycm.pycm_compare.Compare" ];  # output formatting error
-  propagatedBuildInputs = [ matplotlib numpy seaborn ];
+  disabledTests = [
+    # Output formatting error
+    "pycm.pycm_compare.Compare"
+    "plot_test"
+  ];
+
+  pythonImportsCheck = [
+    "pycm"
+  ];
 
   meta = with lib; {
     description = "Multiclass confusion matrix library";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/162153774)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
