### PR TITLE
cxxopts: unstable-2020-12-14 -> 3.0.0

### DIFF
--- a/pkgs/development/libraries/cxxopts/default.nix
+++ b/pkgs/development/libraries/cxxopts/default.nix
@@ -1,21 +1,29 @@
-{ cmake, fetchFromGitHub, icu, lib, pkg-config, stdenv, enableUnicodeHelp ? true }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, icu
+, pkg-config
+, enableUnicodeHelp ? true
+}:
 
 stdenv.mkDerivation rec {
   name = "cxxopts";
-  version = "unstable-2020-12-14";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "jarro2783";
     repo = name;
-    rev = "2d8e17c4f88efce80e274cb03eeb902e055a91d3";
-    sha256 = "0pwrac81zfqjs17g3hx8r3ds2xf04npb6mz111qjy4bx17314ib7";
+    rev = "v${version}";
+    sha256 = "08x7j168l1xwj0r3rv89cgghmfhsx98lpq35r3vkh504m1pd55a6";
   };
+
+  # CMake does not set CMAKE_LIBRARY_ARCHITECTURE variable in Nix, which breaks architecture-independent library path generation
+  patches = [ ./fix-install-path.patch ];
 
   buildInputs = lib.optional enableUnicodeHelp [ icu.dev ];
   cmakeFlags = [ "-DCXXOPTS_BUILD_EXAMPLES=OFF" ]
-    ++ lib.optional enableUnicodeHelp "-DCXXOPTS_USE_UNICODE_HELP=TRUE"
-    # Due to -Wsuggest-override, remove when cxxopts is updated
-    ++ lib.optional stdenv.isDarwin "-DCXXOPTS_ENABLE_WARNINGS=OFF";
+    ++ lib.optional enableUnicodeHelp "-DCXXOPTS_USE_UNICODE_HELP=TRUE";
   nativeBuildInputs = [ cmake ] ++ lib.optional enableUnicodeHelp [ pkg-config ];
 
   doCheck = true;

--- a/pkgs/development/libraries/cxxopts/fix-install-path.patch
+++ b/pkgs/development/libraries/cxxopts/fix-install-path.patch
@@ -1,0 +1,18 @@
+diff --git a/cmake/cxxopts.cmake b/cmake/cxxopts.cmake
+index 46e87ba..0ead543 100644
+--- a/cmake/cxxopts.cmake
++++ b/cmake/cxxopts.cmake
+@@ -87,7 +87,12 @@ endfunction()
+ 
+ # Helper function to ecapsulate install logic
+ function(cxxopts_install_logic)
+-    string(REPLACE "/${CMAKE_LIBRARY_ARCHITECTURE}" "" CMAKE_INSTALL_LIBDIR_ARCHIND "${CMAKE_INSTALL_LIBDIR}")
++    if(CMAKE_LIBRARY_ARCHITECTURE)
++        string(REPLACE "/${CMAKE_LIBRARY_ARCHITECTURE}" "" CMAKE_INSTALL_LIBDIR_ARCHIND "${CMAKE_INSTALL_LIBDIR}")
++    else()
++        # On some systems (e.g. NixOS), `CMAKE_LIBRARY_ARCHITECTURE` can be empty
++        set(CMAKE_INSTALL_LIBDIR_ARCHIND "${CMAKE_INSTALL_LIBDIR}")
++    endif()
+     set(CXXOPTS_CMAKE_DIR "${CMAKE_INSTALL_LIBDIR_ARCHIND}/cmake/cxxopts" CACHE STRING "Installation directory for cmake files, relative to ${CMAKE_INSTALL_PREFIX}.")
+     set(version_config "${PROJECT_BINARY_DIR}/cxxopts-config-version.cmake")
+     set(project_config "${PROJECT_BINARY_DIR}/cxxopts-config.cmake")


### PR DESCRIPTION
###### Motivation for this change

Update to the latest stable version. The issue with `-Wsuggest-override` is seemingly resolved in upstream https://github.com/jarro2783/cxxopts/commit/174510285a451d5e2ab2c4054bc88ce8b4ba933d

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
