### PR TITLE
zsh-history-search-multi-word: init at unstable-2021-11-13

### DIFF
--- a/pkgs/shells/zsh/zsh-history-search-multi-word/default.nix
+++ b/pkgs/shells/zsh/zsh-history-search-multi-word/default.nix
@@ -1,0 +1,30 @@
+{ stdenvNoCC, lib, fetchFromGitHub }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "zsh-history-search-multi-word";
+  version = "unstable-2021-11-13";
+
+  src = fetchFromGitHub {
+    owner = "zdharma-continuum";
+    repo = "history-search-multi-word";
+    rev = "5b44d8cea12351d91fbdc3697916556f59f14b8c";
+    sha256 = "11r2mmy6bg3b6pf6qc0ml3idh333cj8yz754hrvd1sc4ipfkkqh7";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    plugindir="$out/share/zsh/${pname}"
+
+    mkdir -p "$plugindir"
+    cp -r -- history-* hsmw-* "$plugindir"/
+  '';
+
+  meta = with lib; {
+    description = "Multi-word, syntax highlighted history searching for Zsh";
+    homepage = "https://github.com/zdharma-continuum/history-search-multi-word";
+    license = with licenses; [ gpl3 mit ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11315,6 +11315,8 @@ with pkgs;
 
   zsh-history = callPackage ../shells/zsh/zsh-history { };
 
+  zsh-history-search-multi-word = callPackage ../shells/zsh/zsh-history-search-multi-word { };
+
   zsh-history-substring-search = callPackage ../shells/zsh/zsh-history-substring-search { };
 
   zsh-navigation-tools = callPackage ../tools/misc/zsh-navigation-tools { };


### PR DESCRIPTION
###### Motivation for this change

This PR just adds [zdharma-continuum/history-search-multi-word](https://github.com/zdharma-continuum/history-search-multi-word).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
