### PR TITLE
indradb: init at unstable-2021-01-05

### DIFF
--- a/pkgs/development/tools/database/indradb/default.nix
+++ b/pkgs/development/tools/database/indradb/default.nix
@@ -1,0 +1,51 @@
+{ stdenv
+, fetchFromGitHub
+, lib
+, rustPlatform
+, rustfmt
+}:
+let
+  src = fetchFromGitHub {
+    owner = "indradb";
+    repo = "indradb";
+    rev = "06134dde5bb53eb1d2aaa52afdaf9ff3bf1aa674";
+    sha256 = "sha256-g4Jam7yxMc+piYQzgMvVsNTF+ce1U3thzYl/M9rKG4o=";
+  };
+
+  meta = with lib; {
+    description = "A graph database written in rust ";
+    homepage = "https://github.com/indradb/indradb";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ happysalada ];
+    platforms = platforms.unix;
+  };
+in
+{
+  indradb-server = rustPlatform.buildRustPackage {
+    pname = "indradb-server";
+    version = "unstable-2021-01-05";
+    inherit src;
+
+    cargoSha256 = "sha256-3WtiW31AkyNX7HiT/zqfNo2VSKR7Q57/wCigST066Js=";
+
+    buildAndTestSubdir = "server";
+
+    nativeBuildInputs = [ rustfmt ];
+
+    # test rely on libindradb and it can't be found
+    # failure at https://github.com/indradb/indradb/blob/master/server/tests/plugins.rs#L63
+    # `let _server = Server::start(&format!("../target/debug/libindradb_plugin_*.{}", LIBRARY_EXTENSION)).unwrap();`
+    doCheck = false;
+  };
+  indradb-client = rustPlatform.buildRustPackage {
+    pname = "indradb-client";
+    version = "unstable-2021-01-05";
+    inherit src;
+
+    cargoSha256 = "sha256-pxan6W/CEsOxv8DbbytEBuIqxWn/C4qT4ze/RnvESOM=";
+
+    nativeBuildInputs = [ rustfmt ];
+
+    buildAndTestSubdir = "client";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12398,6 +12398,10 @@ with pkgs;
 
   idris2 = callPackage ../development/compilers/idris2 { };
 
+  inherit (callPackage ../development/tools/database/indradb { })
+    indradb-server
+    indradb-client;
+
   intel-graphics-compiler = callPackage ../development/compilers/intel-graphics-compiler { };
 
   intercal = callPackage ../development/compilers/intercal { };


### PR DESCRIPTION
###### Motivation for this change

using unstable since on version 3.0 there was no cargo lock. upstream nicely added it after it was pointed out.
https://github.com/indradb/indradb

only thing I regret a bit is that the vendor directory should be shared between the 2, however because the derivations have different names, those are not shared.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
