### PR TITLE
[Backport release-21.11] nixos/pipewire: add systemWide option

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -351,6 +351,7 @@ in
       hqplayer = 319;
       moonraker = 320;
       distcc = 321;
+      pipewire = 322;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -656,6 +657,7 @@ in
       hqplayer = 319;
       moonraker = 320;
       distcc = 321;
+      pipewire = 322;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/services/desktops/pipewire/pipewire-media-session.nix
+++ b/nixos/modules/services/desktops/pipewire/pipewire-media-session.nix
@@ -94,6 +94,12 @@ in {
   config = mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
     systemd.packages = [ cfg.package ];
+
+    # Enable either system or user units.
+    systemd.services.pipewire-media-session.enable = config.services.pipewire.systemWide;
+    systemd.user.services.pipewire-media-session.enable = !config.services.pipewire.systemWide;
+
+    systemd.services.pipewire-media-session.wantedBy = [ "pipewire.service" ];
     systemd.user.services.pipewire-media-session.wantedBy = [ "pipewire.service" ];
 
     environment.etc."pipewire/media-session.d/media-session.conf" = {

--- a/nixos/modules/services/desktops/pipewire/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire/pipewire.nix
@@ -123,6 +123,22 @@ in {
       pulse = {
         enable = mkEnableOption "PulseAudio server emulation";
       };
+
+      systemWide = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          If true, a system-wide PipeWire service and socket is enabled
+          allowing all users in the "pipewire" group to use it simultaneously.
+          If false, then user units are used instead, restricting access to
+          only one user.
+
+          Enabling system-wide PipeWire is however not recommended and disabled
+          by default according to
+          https://github.com/PipeWire/pipewire/blob/master/NEWS
+        '';
+      };
+
     };
   };
 
@@ -148,9 +164,20 @@ in {
 
     # PipeWire depends on DBUS but doesn't list it. Without this booting
     # into a terminal results in the service crashing with an error.
+    systemd.services.pipewire.bindsTo = [ "dbus.service" ];
+    systemd.user.services.pipewire.bindsTo = [ "dbus.service" ];
+
+    # Enable either system or user units.  Note that for pipewire-pulse there
+    # are only user units, which work in both cases.
+    systemd.sockets.pipewire.enable = cfg.systemWide;
+    systemd.services.pipewire.enable = cfg.systemWide;
+    systemd.user.sockets.pipewire.enable = !cfg.systemWide;
+    systemd.user.services.pipewire.enable = !cfg.systemWide;
+
+    systemd.sockets.pipewire.wantedBy = lib.mkIf cfg.socketActivation [ "sockets.target" ];
     systemd.user.sockets.pipewire.wantedBy = lib.mkIf cfg.socketActivation [ "sockets.target" ];
     systemd.user.sockets.pipewire-pulse.wantedBy = lib.mkIf (cfg.socketActivation && cfg.pulse.enable) ["sockets.target"];
-    systemd.user.services.pipewire.bindsTo = [ "dbus.service" ];
+
     services.udev.packages = [ cfg.package ];
 
     # If any paths are updated here they must also be updated in the package test.
@@ -194,7 +221,22 @@ in {
     environment.sessionVariables.LD_LIBRARY_PATH =
       lib.optional cfg.jack.enable "${cfg.package.jack}/lib";
 
+    users = lib.mkIf cfg.systemWide {
+      users.pipewire = {
+        uid = config.ids.uids.pipewire;
+        group = "pipewire";
+        extraGroups = [
+          "audio"
+          "video"
+        ] ++ lib.optional config.security.rtkit.enable "rtkit";
+        description = "Pipewire system service user";
+        isSystemUser = true;
+      };
+      groups.pipewire.gid = config.ids.gids.pipewire;
+    };
+
     # https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/464#note_723554
+    systemd.services.pipewire.environment."PIPEWIRE_LINK_PASSIVE" = "1";
     systemd.user.services.pipewire.environment."PIPEWIRE_LINK_PASSIVE" = "1";
   };
 }

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitLab
+, fetchpatch
 , removeReferencesTo
 , python3
 , meson
@@ -96,6 +97,15 @@ let
       ./0090-pipewire-config-template-paths.patch
       # Place SPA data files in lib output to avoid dependency cycles
       ./0095-spa-data-dir.patch
+      # Fix attempt to put system service units into pkgs.systemd.
+      (fetchpatch {
+        url = "https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/b666edde787b167c6e19b9356257d48007357acc.diff";
+        sha256 = "1pmnyyvrjykr46ld4a5frq3cc739f8h4jwvfj414lyx8c6ybm63s";
+      })
+      (fetchpatch {
+        url = "https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/5054b48c9de655b4b48f7c801cb305d9eb122520.diff";
+        sha256 = "0myhb7h4g7x2nr08dpx8d7nqhsmzp90yanmkvm627r1xxnnr3ivn";
+      })
     ];
 
     nativeBuildInputs = [
@@ -143,6 +153,7 @@ let
       "-Dlibpulse=${mesonEnable pulseTunnelSupport}"
       "-Davahi=${mesonEnable zeroconfSupport}"
       "-Dgstreamer=${mesonEnable gstreamerSupport}"
+      "-Dsystemd-system-service=enabled"
       "-Dffmpeg=${mesonEnable ffmpegSupport}"
       "-Dbluez5=${mesonEnable bluezSupport}"
       "-Dbluez5-backend-hsp-native=${mesonEnable nativeHspSupport}"

--- a/pkgs/development/libraries/pipewire/media-session.nix
+++ b/pkgs/development/libraries/pipewire/media-session.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitLab
+, fetchpatch
 , meson
 , ninja
 , pkg-config
@@ -30,6 +31,19 @@ let
       sha256 = "sha256-e537gTkiNYMz2YJrOff/MXYWVDgHZDkqkSn8Qh+7Wr4=";
     };
 
+    patches = [
+      # Fix `ERROR: Tried to access unknown option "session-managers".`
+      (fetchpatch {
+        url = "https://gitlab.freedesktop.org/pipewire/media-session/-/commit/dfa740175c83e1cd0d815ad423f90872de566437.diff";
+        sha256 = "01rfwq8ipm8wyv98rxal1s5zrkf0pn9hgrngiq2wdbwj6vjdnr1h";
+      })
+      # Fix attempt to put system service units into pkgs.systemd.
+      (fetchpatch {
+        url = "https://gitlab.freedesktop.org/pipewire/media-session/-/commit/2ff6b0baec7325dde229013b9d37c93f8bc7edee.diff";
+        sha256 = "18gg7ca04ihl4ylnw78wdyrbvg66m8w43gg0wp258x4nv95gpps2";
+      })
+    ];
+
     nativeBuildInputs = [
       doxygen
       graphviz
@@ -48,6 +62,7 @@ let
 
     mesonFlags = [
       "-Ddocs=enabled"
+      "-Dsystemd-system-service=enabled"
       # We generate these empty files from the nixos module, don't bother installing them
       "-Dwith-module-sets=[]"
     ];


### PR DESCRIPTION
Manual backport to `release-21.11`, triggered by manually opening [a pull request](https://github.com/NixOS/nixpkgs/pull/153651) to backport #153426.

* [ ]  Before merging, ensure that this backport complies with the [Criteria for Backporting](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#criteria-for-backporting-changes). 
   * Even as a non-commiter, if you find that it does not comply, leave a comment.

