### PR TITLE
pipewire: 0.3.42 -> 0.3.43

### DIFF
--- a/pkgs/development/libraries/libcamera/default.nix
+++ b/pkgs/development/libraries/libcamera/default.nix
@@ -4,9 +4,11 @@
 , meson
 , ninja
 , pkg-config
+, makeFontsConf
 , boost
 , gnutls
 , openssl
+, libdrm
 , libevent
 , lttng-ust
 , gst_all_1
@@ -15,16 +17,17 @@
 , doxygen
 , python3
 , python3Packages
+, systemd # for libudev
 }:
 
 stdenv.mkDerivation {
   pname = "libcamera";
-  version = "unstable-2021-09-24";
+  version = "unstable-2022-01-03";
 
   src = fetchgit {
     url = "https://git.libcamera.org/libcamera/libcamera.git";
-    rev = "40f5fddca7f774944a53f58eeaebc4db79c373d8";
-    sha256 = "0jklgdv5ma4nszxibms5lkf5d2ips7ncynwa1flglrhl5bl4wkzz";
+    rev = "1db1e31e664c1f613dc964d8519fe75d67b154b6";
+    hash = "sha256-pXYPIU9xDWA870Gp1Jgizi5xnUHRvTqEq/ofFXdVZdg=";
   };
 
   postPatch = ''
@@ -44,6 +47,10 @@ stdenv.mkDerivation {
 
     # cam integration
     libevent
+    libdrm
+
+    # hotplugging
+    systemd
 
     # lttng tracing
     lttng-ust
@@ -65,10 +72,17 @@ stdenv.mkDerivation {
     openssl
   ];
 
-  mesonFlags = [ "-Dv4l2=true" "-Dqcam=disabled" ];
+  mesonFlags = [
+    "-Dv4l2=true"
+    "-Dqcam=disabled"
+    "-Dlc-compliance=disabled" # tries unconditionally to download gtest when enabled
+    ];
 
   # Fixes error on a deprecated declaration
   NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
+
+  # Silence fontconfig warnings about missing config
+  FONTCONFIG_FILE = makeFontsConf { fontDirectories = []; };
 
   meta = with lib; {
     description = "An open source camera stack and framework for Linux, Android, and ChromeOS";

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -60,16 +60,12 @@
 }:
 
 let
-  fontsConf = makeFontsConf {
-    fontDirectories = [ ];
-  };
-
-  mesonEnable = b: if b then "enabled" else "disabled";
+  mesonEnableFeature = b: if b then "enabled" else "disabled";
   mesonList = l: "[" + lib.concatStringsSep "," l + "]";
 
   self = stdenv.mkDerivation rec {
     pname = "pipewire";
-    version = "0.3.42";
+    version = "0.3.43";
 
     outputs = [
       "out"
@@ -87,7 +83,7 @@ let
       owner = "pipewire";
       repo = "pipewire";
       rev = version;
-      sha256 = "sha256-Iyd5snOt+iCT7W0+FlfvhMUZo/gF+zr9JX4HIGVdHto=";
+      sha256 = "sha256-vjMA9dQvZe7dPbF9BNtCYf1V240RUBdtxeyqFjWA4j4=";
     };
 
     patches = [
@@ -103,15 +99,6 @@ let
       ./0090-pipewire-config-template-paths.patch
       # Place SPA data files in lib output to avoid dependency cycles
       ./0095-spa-data-dir.patch
-      # Fix attempt to put system service units into pkgs.systemd.
-      (fetchpatch {
-        url = "https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/b666edde787b167c6e19b9356257d48007357acc.diff";
-        sha256 = "1pmnyyvrjykr46ld4a5frq3cc739f8h4jwvfj414lyx8c6ybm63s";
-      })
-      (fetchpatch {
-        url = "https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/5054b48c9de655b4b48f7c801cb305d9eb122520.diff";
-        sha256 = "0myhb7h4g7x2nr08dpx8d7nqhsmzp90yanmkvm627r1xxnnr3ivn";
-      })
     ];
 
     nativeBuildInputs = [
@@ -159,33 +146,32 @@ let
       "-Dinstalled_test_prefix=${placeholder "installedTests"}"
       "-Dpipewire_pulse_prefix=${placeholder "pulse"}"
       "-Dlibjack-path=${placeholder "jack"}/lib"
-      "-Dlibcamera=${mesonEnable libcameraSupport}"
-      "-Droc=${mesonEnable rocSupport}"
-      "-Dlibpulse=${mesonEnable pulseTunnelSupport}"
-      "-Davahi=${mesonEnable zeroconfSupport}"
-      "-Dgstreamer=${mesonEnable gstreamerSupport}"
+      "-Dlibcamera=${mesonEnableFeature libcameraSupport}"
+      "-Droc=${mesonEnableFeature rocSupport}"
+      "-Dlibpulse=${mesonEnableFeature pulseTunnelSupport}"
+      "-Davahi=${mesonEnableFeature zeroconfSupport}"
+      "-Dgstreamer=${mesonEnableFeature gstreamerSupport}"
       "-Dsystemd-system-service=enabled"
-      "-Dffmpeg=${mesonEnable ffmpegSupport}"
-      "-Dbluez5=${mesonEnable bluezSupport}"
-      "-Dbluez5-backend-hsp-native=${mesonEnable nativeHspSupport}"
-      "-Dbluez5-backend-hfp-native=${mesonEnable nativeHfpSupport}"
-      "-Dbluez5-backend-ofono=${mesonEnable ofonoSupport}"
-      "-Dbluez5-backend-hsphfpd=${mesonEnable hsphfpdSupport}"
+      "-Dffmpeg=${mesonEnableFeature ffmpegSupport}"
+      "-Dbluez5=${mesonEnableFeature bluezSupport}"
+      "-Dbluez5-backend-hsp-native=${mesonEnableFeature nativeHspSupport}"
+      "-Dbluez5-backend-hfp-native=${mesonEnableFeature nativeHfpSupport}"
+      "-Dbluez5-backend-ofono=${mesonEnableFeature ofonoSupport}"
+      "-Dbluez5-backend-hsphfpd=${mesonEnableFeature hsphfpdSupport}"
       "-Dsysconfdir=/etc"
       "-Dpipewire_confdata_dir=${placeholder "lib"}/share/pipewire"
       "-Dsession-managers="
       "-Dvulkan=enabled"
     ];
 
-    FONTCONFIG_FILE = fontsConf; # Fontconfig error: Cannot load default config file
+    # Fontconfig error: Cannot load default config file
+    FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
 
     doCheck = true;
 
     postUnpack = ''
-      patchShebangs source/doc/strip-static.sh
       patchShebangs source/doc/input-filter.sh
       patchShebangs source/doc/input-filter-h.sh
-      patchShebangs source/spa/tests/gen-cpp-test.py
     '';
 
     postInstall = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/0.3.43

- pulse-server should use less memory and overall work better
- filter-chain now supports lv2 effects
- libcamera bump since it had an API change that affects spa-libcamera
- Works On My Machine (tm)

NB: backport requires #153124 to land first (feel free to retarget it directly to the release branch, I may have been overly cautious with sending it to staging)

https://git.libcamera.org/libcamera/libcamera.git/log/?id=40f5fddca7f774944a53f58eeaebc4db79c373d8..1db1e31e664c1f613dc964d8519fe75d67b154b6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
