### PR TITLE
parallels: update support for Parallels Tools

### DIFF
--- a/nixos/modules/virtualisation/parallels-guest.nix
+++ b/nixos/modules/virtualisation/parallels-guest.nix
@@ -34,7 +34,8 @@ in
       package = mkOption {
         type = types.nullOr types.package;
         default = config.boot.kernelPackages.prl-tools;
-        defaultText = literalExpression "config.boot.kernelPackages.prl-tools";
+        defaultText = "config.boot.kernelPackages.prl-tools";
+        example = literalExpression "config.boot.kernelPackages.prl-tools";
         description = ''
           Defines which package to use for prl-tools. Override to change the version.
         '';
@@ -45,26 +46,28 @@ in
 
   config = mkIf config.hardware.parallels.enable {
     services.xserver = {
-      drivers = singleton
-        { name = "prlvideo"; modules = [ prl-tools ]; };
+      videoDrivers = [ "prlvideo" ];
 
-      screenSection = ''
-        Option "NoMTRR"
-      '';
+      modules = [ prl-tools ];
 
       config = ''
         Section "InputClass"
-          Identifier "prlmouse"
-          MatchIsPointer "on"
-          MatchTag "prlmouse"
-          Driver "prlmouse"
+          Identifier      "prlmouse"
+          MatchIsPointer  "on"
+          MatchTag        "prlmouse"
+          Driver          "prlmouse"
         EndSection
+      '';
+
+      screenSection = ''
+        Option "NoMTRR"
       '';
     };
 
     hardware.opengl.package = prl-tools;
     hardware.opengl.package32 = pkgs.pkgsi686Linux.linuxPackages.prl-tools.override { libsOnly = true; kernel = null; };
-    hardware.opengl.setLdLibraryPath = true;
+    hardware.opengl.extraPackages = [ pkgs.mesa.drivers ];
+    hardware.opengl.extraPackages32 = [ pkg.pkgsi686Linux.mesa.drivers ];
 
     services.udev.packages = [ prl-tools ];
 
@@ -72,7 +75,7 @@ in
 
     boot.extraModulePackages = [ prl-tools ];
 
-    boot.kernelModules = [ "prl_tg" "prl_eth" "prl_fs" "prl_fs_freeze" ];
+    boot.kernelModules = [ "prl_fs" "prl_fs_freeze" "prl_notifier" "prl_tg" ];
 
     services.timesyncd.enable = false;
 
@@ -119,13 +122,6 @@ in
         wantedBy = [ "graphical-session.target" ];
         serviceConfig = {
           ExecStart = "${prl-tools}/bin/prldnd";
-        };
-      };
-      prl_wmouse_d  = {
-        description = "Parallels Walking Mouse Daemon";
-        wantedBy = [ "graphical-session.target" ];
-        serviceConfig = {
-          ExecStart = "${prl-tools}/bin/prl_wmouse_d";
         };
       };
       prlcp = {

--- a/nixos/modules/virtualisation/parallels-guest.nix
+++ b/nixos/modules/virtualisation/parallels-guest.nix
@@ -4,6 +4,7 @@ with lib;
 
 let
   prl-tools = config.hardware.parallels.package;
+  aarch64 = stdenv.hostPlatform.system == "aarch64-linux";
 in
 
 {
@@ -75,7 +76,7 @@ in
 
     boot.extraModulePackages = [ prl-tools ];
 
-    boot.kernelModules = [ "prl_fs" "prl_fs_freeze" "prl_notifier" "prl_tg" ];
+    boot.kernelModules = if aarch64 then [ "prl_fs" "prl_fs_freeze" "prl_notifier" "prl_tg" ] else [ "prl_fs" "prl_fs_freeze" "prl_tg" ];
 
     services.timesyncd.enable = false;
 

--- a/nixos/modules/virtualisation/parallels-guest.nix
+++ b/nixos/modules/virtualisation/parallels-guest.nix
@@ -4,7 +4,7 @@ with lib;
 
 let
   prl-tools = config.hardware.parallels.package;
-  aarch64 = stdenv.hostPlatform.system == "aarch64-linux";
+  aarch64 = pkgs.stdenv.hostPlatform.system == "aarch64-linux";
 in
 
 {

--- a/pkgs/os-specific/linux/prl-tools/default.nix
+++ b/pkgs/os-specific/linux/prl-tools/default.nix
@@ -122,8 +122,5 @@ stdenv.mkDerivation rec {
     homepage = "https://parallels.com";
     platforms = [ "aarch64-linux" "i686-linux" "x86_64-linux" ];
     license = licenses.unfree;
-    # I was making this package blindly and requesting testing from the real user,
-    # so I can't even test it by myself and won't provide future updates.
-    maintainers = with maintainers; [ abbradar ];
   };
 }

--- a/pkgs/os-specific/linux/prl-tools/default.nix
+++ b/pkgs/os-specific/linux/prl-tools/default.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
         mkdir -p $out/lib/modules/${kernelVersion}/extra
         cp prl_fs/SharedFolders/Guest/Linux/prl_fs/prl_fs.ko $out/lib/modules/${kernelVersion}/extra
         cp prl_fs_freeze/Snapshot/Guest/Linux/prl_freeze/prl_fs_freeze.ko $out/lib/modules/${kernelVersion}/extra
-        cp prl_notifier/Installation/lnx/prl_notifier/prl_notifier.ko $out/lib/modules/${kernelVersion}/extra
+        ${if aarch64 then "cp prl_notifier/Installation/lnx/prl_notifier/prl_notifier.ko $out/lib/modules/${kernelVersion}/extra" else ""}
         cp prl_tg/Toolgate/Guest/Linux/prl_tg/prl_tg.ko $out/lib/modules/${kernelVersion}/extra
       )
     fi

--- a/pkgs/os-specific/linux/prl-tools/default.nix
+++ b/pkgs/os-specific/linux/prl-tools/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, makeWrapper, p7zip
-, gawk, utillinux, xorg, glib, dbus-glib, zlib
+, gawk, util-linux, xorg, glib, dbus-glib, zlib
 , kernel ? null, libsOnly ? false
 , fetchurl, undmg, perl, autoPatchelfHook
 }:
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
 
   kernelVersion = if libsOnly then "" else lib.getVersion kernel.name;
   kernelDir = if libsOnly then "" else "${kernel.dev}/lib/modules/${kernelVersion}";
-  scriptPath = lib.concatStringsSep ":" (lib.optionals (!libsOnly) [ "${utillinux}/bin" "${gawk}/bin" ]);
+  scriptPath = lib.concatStringsSep ":" (lib.optionals (!libsOnly) [ "${util-linux}/bin" "${gawk}/bin" ]);
 
   buildPhase = ''
     if test -z "$libsOnly"; then
@@ -107,6 +107,13 @@ stdenv.mkDerivation rec {
 
       cd $out/lib
       ln -s libPrlWl.so.1.0.0 libPrlWl.so.1
+      ${if aarch64 then "" else "
+      ln -s libGL.so.1.0.0 libGL.so
+      ln -s libGL.so.1.0.0 libGL.so.1
+      ln -s libPrlDRI.so.1.0.0 libPrlDRI.so.1
+      ln -s libEGL.so.1.0.0 libEGL.so.1
+      ln -s libgbm.so.1.0.0 libgbm.so.1
+      "}
     )
   '';
 

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -385,8 +385,7 @@ in {
 
     phc-intel = if lib.versionAtLeast kernel.version "4.10" then callPackage ../os-specific/linux/phc-intel { } else null;
 
-    # Disable for kernels 4.15 and above due to compatibility issues
-    prl-tools = if lib.versionOlder kernel.version "4.15" then callPackage ../os-specific/linux/prl-tools { } else null;
+    prl-tools = callPackage ../os-specific/linux/prl-tools { };
 
     sch_cake = callPackage ../os-specific/linux/sch_cake { };
 


### PR DESCRIPTION
Install Parallel Tools updated for version 17 of Parallels for macOS. This
fixes clipboard sharing, so that copy and paste works between the host
macOS and the guest NixOS VM. Support for guests on M1 Apple Silicon-based
Macs (aarch64-linux) is also added.