### PR TITLE
Update http3 libraries

### DIFF
--- a/pkgs/development/libraries/nghttp3/default.nix
+++ b/pkgs/development/libraries/nghttp3/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   pname = "nghttp3";
-  version = "unstable-2021-11-10";
+  version = "unstable-2021-12-22";
 
   src = fetchFromGitHub {
     owner = "ngtcp2";
     repo = pname;
-    rev = "270e75447ed9e2a05b78ba89d0699d076230ea60";
-    sha256 = "01cla03cv8nd2rf5p77h0xzvn9f8sfwn8pp3r2jshvqp9ipa8065";
+    rev = "8d8184acf850b06b53157bba39022bc7b7b5f1cd";
+    sha256 = "sha256-pV1xdQa5RBz17jDINC2uN1Q+jpa2edDwqTqf8D5VU3E=";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config cunit file ];

--- a/pkgs/development/libraries/ngtcp2/default.nix
+++ b/pkgs/development/libraries/ngtcp2/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "ngtcp2";
-  version = "unstable-2021-11-10";
+  version = "unstable-2021-12-19";
 
   src = fetchFromGitHub {
     owner = "ngtcp2";
     repo = pname;
-    rev = "7039808c044152c14b44046468bd16249b4d7048";
-    sha256 = "1cjsky24f6fazw9b1r6w9cgp09vi8wp99sv76gg2b1r8ic3hgq23";
+    rev = "20c710a8789ec910455ae4e588c72e9e39f8cec9";
+    sha256 = "sha256-uBmD26EYT8zxmHD5FuHCbEuTdWxer/3uhRp8PhUT87M=";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config cunit file ];

--- a/pkgs/development/libraries/quictls/default.nix
+++ b/pkgs/development/libraries/quictls/default.nix
@@ -16,13 +16,13 @@ assert (
 
 stdenv.mkDerivation rec {
   pname = "quictls";
-  version = "3.0.0+quick_unstable-2021-11.02";
+  version = "3.0.1+quick_unstable-2021-12.14";
 
   src = fetchFromGitHub {
     owner = "quictls";
     repo = "openssl";
-    rev = "62d4de00abfa82fc01efa2eba1982a86c4864f39";
-    sha256 = "11mi4bkkyy4qd2wml6p7xcsbps0mabk3bp537rp7n43qnhwyg1g3";
+    rev = "ab8b87bdb436b11bf2a10a2a57a897722224f828";
+    sha256 = "sha256-835oZgoM1CTS+JLxPO3oGSTnhLmJXGT1cFaJhCJK++8=";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change
Update packages:
﻿- quictls: 3.0.0+quic_unstable-2021-11-02 -> 3.0.1+quick_unstable-2021-12.14
- ngtcp2: unstable-2021.11.10 -> unstable-2021-12-19
- nghttp3: unstable-2021.11.10 -> unstable-2021-12-22


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
