### PR TITLE
python3Packages.algebraic-data-types: 0.1.1 -> 0.2.1

### DIFF
--- a/pkgs/development/python-modules/algebraic-data-types/default.nix
+++ b/pkgs/development/python-modules/algebraic-data-types/default.nix
@@ -1,21 +1,39 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder, hypothesis, mypy }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, hypothesis
+, mypy
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "algebraic-data-types";
-  version = "0.1.1";
+  version = "0.2.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "jspahrsummers";
     repo = "adt";
     rev = "v" + version;
-    sha256 = "1py94jsgh6wch59n9dxnwvk74psbpa1679zfmripa1qfc2218kqi";
+    hash = "sha256-RHLI5rmFxklzG9dyYgYfSS/srCjcxNpzNcK/RPNJBPE=";
   };
 
-  disabled = pythonOlder "3.6";
-
   checkInputs = [
+    pytestCheckHook
     hypothesis
     mypy
+  ];
+
+  disabledTestPaths = [
+    # AttributeError: module 'mypy.types' has no attribute 'TypeVarDef'
+    "tests/test_mypy_plugin.py"
+  ];
+
+  pythonImportsCheck = [
+    "adt"
   ];
 
   meta = with lib; {
@@ -23,6 +41,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/jspahrsummers/adt";
     license = licenses.mit;
     maintainers = with maintainers; [ uri-canva ];
-    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/jspahrsummers/adt/releases/tag/v0.2.1

Fix build (https://hydra.nixos.org/build/162948877)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
