### PR TITLE
gns3: 2.2.18 -> 2.2.28

### DIFF
--- a/pkgs/applications/networking/gns3/default.nix
+++ b/pkgs/applications/networking/gns3/default.nix
@@ -1,7 +1,7 @@
 { callPackage, libsForQt5 }:
 
 let
-  stableVersion = "2.2.18";
+  stableVersion = "2.2.28";
   previewVersion = stableVersion;
   addVersion = args:
     let version = if args.stable then stableVersion else previewVersion;
@@ -18,16 +18,16 @@ let
         });
       };
     commonOverrides = [
-      (mkOverride "psutil" "5.6.7"
-        "1an5llivfkwpbcfaapbx78p8sfnvzyfypf60wfxihib1mjr8xbgz")
+      (mkOverride "psutil" "5.8.0"
+        "sha256-DJzLmat2Al8vC77PNB1GVunBNR24zIoDzNYuMYq0tcY=")
       (mkOverride "jsonschema" "3.2.0"
         "0ykr61yiiizgvm3bzipa3l73rvj49wmrybbfwhvpgk3pscl5pa68")
     ];
   };
   mkGui = args: libsForQt5.callPackage (import ./gui.nix (addVersion args // extraArgs)) { };
   mkServer = args: callPackage (import ./server.nix (addVersion args // extraArgs)) { };
-  guiSrcHash = "118z6asl6hsv0777rld4plnrwzkbkh3gb9lg9i6bqrjs93p028fw";
-  serverSrcHash = "0gd37zpvibhlvqqpflpwlrgg8g9rpbxwi9w9fsym00mfwf7sdd3b";
+  guiSrcHash = "sha256-5GPGn0ZFlqoKkb5BOzxf2FqwPlu7hZe4ysWDGSROCj0=";
+  serverSrcHash = "sha256-7xsgpm4KFeGFbW81/oMUGQSwXWXnBPTHzVVR0/cUe6U=";
 in {
   guiStable = mkGui {
     stable = true;

--- a/pkgs/applications/networking/gns3/gui.nix
+++ b/pkgs/applications/networking/gns3/gui.nix
@@ -32,6 +32,10 @@ in python.pkgs.buildPythonPackage rec {
   postFixup = ''
       wrapQtApp "$out/bin/gns3"
   '';
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "sentry-sdk==1.3.1" "sentry-sdk>=1.3.1" \
+  '';
 
   meta = with lib; {
     description = "Graphical Network Simulator 3 GUI (${branch} release)";

--- a/pkgs/applications/networking/gns3/server.nix
+++ b/pkgs/applications/networking/gns3/server.nix
@@ -8,12 +8,12 @@ let
     (self: super: {
       aiofiles = super.aiofiles.overridePythonAttrs (oldAttrs: rec {
         pname = "aiofiles";
-        version = "0.5.0";
+        version = "0.7.0";
         src = fetchFromGitHub {
           owner = "Tinche";
           repo = pname;
           rev = "v${version}";
-          sha256 = "17bsg2x5r0q6jy74hajnbp717pvbf752w0wgih6pbb4hdvfg5lcf";
+          sha256 = "sha256-njQ7eRYJO+dUrwO5pZwKHXn9nVSGYcEhwhs3x5BMc28=";
         };
         doCheck = false;
       });
@@ -36,8 +36,10 @@ in python.pkgs.buildPythonPackage {
 
   postPatch = ''
     substituteInPlace requirements.txt \
-      --replace "aiohttp==3.6.2" "aiohttp>=3.6.2" \
-      --replace "py-cpuinfo==7.0.0" "py-cpuinfo>=8.0.0"
+      --replace "aiohttp==3.7.4" "aiohttp>=3.7.4" \
+      --replace "Jinja2==3.0.1" "Jinja2>=3.0.1" \
+      --replace "sentry-sdk==1.3.1" "sentry-sdk>=1.3.1" \
+      --replace "async-timeout==3.0.1" "async-timeout>=3.0.1" \
   '';
 
   propagatedBuildInputs = with python.pkgs; [


### PR DESCRIPTION
###### Motivation for this change

Update and fix gns3 (currently [broken](https://hydra.nixos.org/job/nixpkgs/trunk/gns3-server.x86_64-linux)). Upstream has dependencies [pinned](https://github.com/GNS3/gns3-server/blob/master/requirements.txt), which can impede build (see #150269 and #126008). We relax some of these in order to enable build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
