### PR TITLE
rebar3: 3.17.0 -> 3.18.0

### DIFF
--- a/pkgs/development/tools/build-managers/rebar3/default.nix
+++ b/pkgs/development/tools/build-managers/rebar3/default.nix
@@ -3,7 +3,7 @@
   writeScript, common-updater-scripts, coreutils, git, gnused, nix, rebar3-nix }:
 
 let
-  version = "3.17.0";
+  version = "3.18.0";
   owner = "erlang";
   deps = import ./rebar-deps.nix { inherit fetchFromGitHub fetchgit fetchHex; };
   rebar3 = stdenv.mkDerivation rec {
@@ -16,7 +16,7 @@ let
       inherit owner;
       repo = pname;
       rev = version;
-      sha256 = "02sk3whrbprzlih4pgcsd6ngmassfjfmkz21gwvb7mq64pib40k6";
+      sha256 = "09648hzc2mnjwf9klm20cg4hb5rn2xv2gmzcg98ffv37p5yfl327";
     };
 
     buildInputs = [ erlang ];

--- a/pkgs/development/tools/build-managers/rebar3/rebar-deps.nix
+++ b/pkgs/development/tools/build-managers/rebar3/rebar-deps.nix
@@ -16,23 +16,23 @@ let
     };
     relx = builder {
       name = "relx";
-      version = "4.5.0";
+      version = "4.6.0";
       src = fetchHex {
         pkg = "relx";
-        version = "4.5.0";
-        sha256 = "sha256-3bWPIMzmymP1onJeklgW3XITR2aYo/PDy0+ownIgLFI=";
+        version = "4.6.0";
+        sha256 = "sha256-L/gTHGMJPGIcazfcUtGyhIqTiIZYS0twHTW9vkN39Qk=";
       };
       beamDeps = [ bbmustache ];
     };
     providers = builder {
       name = "providers";
-      version = "1.8.1";
+      version = "1.9.0";
       src = fetchHex {
         pkg = "providers";
-        version = "1.8.1";
-        sha256 = "sha256-5FdFrenEdqmkaeoIQOQYqxk2DcRPAaIzME4RikRIa6A=";
+        version = "1.9.0";
+        sha256 = "sha256-0ofodEBqFQVghkKwo9tbaNato/KrABrsh+f018efwBc=";
       };
-      beamDeps = [ getopt ];
+      beamDeps = [ erlware_commons getopt ];
     };
     getopt = builder {
       name = "getopt";
@@ -86,21 +86,21 @@ let
     };
     certifi = builder {
       name = "certifi";
-      version = "2.6.1";
+      version = "2.8.0";
       src = fetchHex {
         pkg = "certifi";
-        version = "2.6.1";
-        sha256 = "sha256-UkyXtJkbOEndXBemMSI4licsawr0RneLpGdaHf9Tu34=";
+        version = "2.8.0";
+        sha256 = "sha256-asfvwcb4YAsI1iUpLUu/WE4UhHzhtrXETZg9Jz4Ql+o=";
       };
       beamDeps = [ ];
     };
     bbmustache = builder {
       name = "bbmustache";
-      version = "1.10.0";
+      version = "1.12.2";
       src = fetchHex {
         pkg = "bbmustache";
-        version = "1.10.0";
-        sha256 = "sha256-Q+/6P9S7lSMVevWp4idsSTSVuEWfyHNxRKoYbLE84u4=";
+        version = "1.12.2";
+        sha256 = "sha256-aIszpNXMLVH1da3ws2g/xAo4MUovFQkG7c/Hf1tXezs=";
       };
       beamDeps = [ ];
     };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
