### PR TITLE
python3Packages.datashader: relax xarray constraint

### DIFF
--- a/pkgs/development/python-modules/datashader/default.nix
+++ b/pkgs/development/python-modules/datashader/default.nix
@@ -25,18 +25,12 @@
 buildPythonPackage rec {
   pname = "datashader";
   version = "0.13.0";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-6JscHm1QjDmXOLLa83qhAvY/xwvlPM6duQ1lSxnCVV8=";
   };
-
-  # the complete extra is for usage with conda, which we
-  # don't care about
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "dask[complete]" "dask"
-  '';
 
   propagatedBuildInputs = [
     dask
@@ -56,12 +50,20 @@ buildPythonPackage rec {
 
   checkInputs = [
     pytestCheckHook
-    pytest-xdist # not needed
+    pytest-xdist
     nbsmoke
     fastparquet
     nbconvert
     netcdf4
   ];
+
+  # The complete extra is for usage with conda, which we
+  # don't care about
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "dask[complete]" "dask" \
+      --replace "xarray >=0.9.6" "xarray"
+  '';
 
   preCheck = ''
     export HOME=$TMPDIR
@@ -73,10 +75,10 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
-    # not compatible with current version of bokeh
+    # Not compatible with current version of bokeh
     # see: https://github.com/holoviz/datashader/issues/1031
     "test_interactive_image_update"
-    # latest dask broken array marshalling
+    # Latest dask broken array marshalling
     # see: https://github.com/holoviz/datashader/issues/1032
     "test_raster_quadmesh_autorange_reversed"
   ];
@@ -86,10 +88,14 @@ buildPythonPackage rec {
     "datashader/tests/test_datatypes.py"
   ];
 
+  pythonImportsCheck = [
+    "datashader"
+  ];
+
   meta = with lib;{
     description = "Data visualization toolchain based on aggregating into a grid";
     homepage = "https://datashader.org";
     license = licenses.bsd3;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/163299372)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
