### PR TITLE
mercurial: attempt to fix build on Hydra (extend timeout and add CA bundle)

### DIFF
--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -78,7 +78,7 @@ let
       EOF
 
       # extended timeout necessary for tests to pass on the busy CI workers
-      export HGTESTFLAGS="--blacklist blacklists/nix --timeout 600"
+      export HGTESTFLAGS="--blacklist blacklists/nix --timeout 1800"
       make check
     '';
 

--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -11,6 +11,7 @@
 , which
 , sqlite
 , git
+, cacert
 , gnupg
 }:
 
@@ -70,6 +71,7 @@ let
       git
       gnupg
     ];
+    SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";  # needed for git
     checkPhase = ''
       cat << EOF > tests/blacklists/nix
       # tests enforcing "/usr/bin/env" shebangs, which are patched for nix


### PR DESCRIPTION
###### Motivation for this change

This extends the timeout for the tests of the mercurial package to 30 minutes.
They are otherwise currently timing out at 10 minutes
(see https://github.com/NixOS/nixpkgs/pull/146451#issuecomment-1006565342).

This also registers a CA bundle in the test environment for libgit (see
https://github.com/NixOS/nixpkgs/pull/72544#issuecomment-582674047).

The tests already passed locally on NixOS with sandboxing, so I have no idea
whether those changes will be enough to fix the package on Hydra.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
