### PR TITLE
metersLv2: refactor

### DIFF
--- a/pkgs/applications/audio/meters_lv2/default.nix
+++ b/pkgs/applications/audio/meters_lv2/default.nix
@@ -1,46 +1,53 @@
-{ lib, stdenv, fetchurl, pkg-config
-, lv2, libGLU, libGL, gtk2, cairo, pango, fftwFloat, libjack2 }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, lv2
+, libGLU
+, libGL
+, gtk2
+, cairo
+, pango
+, fftwFloat
+, libjack2
+}:
 
-let
+stdenv.mkDerivation rec {
+  pname = "meters.lv2";
   version = "0.9.10";
-  name = "meters.lv2-${version}";
-
-  # robtk submodule is pegged to this version
   robtkVersion = "0.6.2";
-  robtkName = "robtk-${robtkVersion}";
-
-  src = fetchurl {
-    name = "${name}.tar.gz";
-    url = "https://github.com/x42/meters.lv2/archive/v${version}.tar.gz";
-    sha256 = "0yfyn7j8g50w671b1z7ph4ppjx8ddj5c6nx53syp5y5mfr1b94nx";
-  };
-
-  robtkSrc = fetchurl {
-    name = "${robtkName}.tar.gz";
-    url = "https://github.com/x42/robtk/archive/v${robtkVersion}.tar.gz";
-    sha256 = "1v79xys1k2923wpivdjd44vand6c4agwvnrqi4c8kdv9r07b559v";
-  };
-
-in
-stdenv.mkDerivation {
-  inherit name;
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ lv2 libGLU libGL gtk2 cairo pango fftwFloat libjack2 ];
 
-  srcs = [ src robtkSrc ];
-  sourceRoot = name;
+  src = fetchFromGitHub {
+    owner = "x42";
+    repo = "meters.lv2";
+    rev = "v${version}";
+    sha256 = "sha256-u2KIsaia0rAteQoEh6BLNCiRHFufHYF95z6J/EMgeSE=";
+  };
 
-  postUnpack = "mv ${robtkName}/* ${name}/robtk"; # */
+  robtkSrc = fetchFromGitHub {
+    owner = "x42";
+    repo = "robtk";
+    rev = "v${robtkVersion}";
+    sha256 = "sha256-zeRMobfKW0+wJwYVem74tglitkI6DSoK75Auywcu4Tw=";
+  };
 
-  preConfigure = "makeFlagsArray=( PREFIX=$out )";
+  postUnpack = ''
+    rm -rf $sourceRoot/robtk/
+    ln -s ${robtkSrc} $sourceRoot/robtk
+  '';
+
   meter_VERSION = version;
+  enableParallelBuilding = true;
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
-  meta = with lib;
-    { description = "Collection of audio level meters with GUI in LV2 plugin format";
-      homepage = "http://x42.github.io/meters.lv2/";
-      maintainers = with maintainers; [ ehmry ];
-      license = licenses.gpl2;
-      platforms = platforms.linux;
-    };
+  meta = with lib; {
+    description = "Collection of audio level meters with GUI in LV2 plugin format";
+    homepage = "https://x42.github.io/meters.lv2/";
+    maintainers = with maintainers; [ ehmry ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
