### PR TITLE
EDA tools update

### DIFF
--- a/pkgs/development/compilers/nextpnr/default.nix
+++ b/pkgs/development/compilers/nextpnr/default.nix
@@ -14,14 +14,14 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "nextpnr";
-  version = "2021.15.21";
+  version = "2022.01.03";
 
   srcs = [
     (fetchFromGitHub {
       owner = "YosysHQ";
       repo  = "nextpnr";
-      rev   = "d04cfd5f0f6da184f5b8a03f0ce18fbd1d98eca3";
-      hash  = "sha256-gm/+kwIZ/m10+KuCJoK45F56nKZD3tM0myHwbFKIKAs=";
+      rev   = "089ca8258e6f4dc93f8d39594c1109a8578cdc98";
+      hash  = "sha256-N8kX/+fN8Qe+qme8RFlZyYQ/3p1WBkt0ztUwjJIQCIw=";
       name  = "nextpnr";
     })
     (fetchFromGitHub {

--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -34,13 +34,13 @@
 
 stdenv.mkDerivation rec {
   pname   = "yosys";
-  version = "0.12+36";
+  version = "0.12+54";
 
   src = fetchFromGitHub {
     owner = "YosysHQ";
     repo  = "yosys";
-    rev   = "60c3ea367c942459a95e610ed98f277ce46c0142";
-    hash  = "sha256-NcfhNUmb3IDG08XgS+NGbRLI8sn4aQkOA7RF7wucDug=";
+    rev   = "59a71503448401d2476cf0872808e0a99c3a4d81";
+    hash  = "sha256-cz4PQymaA9UW91lN+6iniFhbcPRpFNIAeC8ZkwYeg0U=";
   };
 
   enableParallelBuilding = true;
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
     fi
 
     if ! grep -q "YOSYS_VER := $version" Makefile; then
-      echo "ERROR: yosys version in Makefile isn't equivalent to version of the nix package (${version}), failing."
+      echo "ERROR: yosys version in Makefile isn't equivalent to version of the nix package (allegedly ${version}), failing."
       exit 1
     fi
   '';

--- a/pkgs/development/compilers/yosys/plugins/bluespec.nix
+++ b/pkgs/development/compilers/yosys/plugins/bluespec.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation {
   pname = "yosys-bluespec";
-  version = "2021.08.19";
+  version = "2021.09.08";
 
   src = fetchFromGitHub {
     owner  = "thoughtpolice";
     repo   = "yosys-bluespec";
-    rev    = "bcea1635c97747acd3bcb5b8f1968b3f57ae62bc";
-    sha256 = "0ipx9yjngs3haksdb440wlydviszwqnxgzynpp7yic2x3ai7i8m1";
+    rev    = "f6f4127a4e96e18080fd5362b6769fa3e24c76b1";
+    sha256 = "sha256-3cNFP/k4JsgLyUQHWU10Htl2Rh0staAcA3R4piD6hDE=";
   };
 
   buildInputs = [ yosys readline zlib bluespec ];

--- a/pkgs/development/python-modules/apycula/default.nix
+++ b/pkgs/development/python-modules/apycula/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "apycula";
-  version = "0.0.1a12";
+  version = "0.2a2";
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit version;
     pname = "Apycula";
-    hash = "sha256-TFb1C1GaMAK+ckEeXDxSyO2Cgx5dmq62daoSnAiAFmI=";
+    hash = "sha256-pcVoYGBhp9jyuWBJ/Rpi8cjwDgPjhJ1PrPblj5DQTpk=";
   };
 
   nativeBuildInputs = [ setuptools-scm ];


### PR DESCRIPTION
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
