### PR TITLE
lib: add new assert function: assertSubListOf

### DIFF
--- a/doc/functions/library/asserts.xml
+++ b/doc/functions/library/asserts.xml
@@ -109,4 +109,61 @@ stderr> trace: sslLibrary must be one of "openssl", "libressl", but is: "bearssl
         ]]></programlisting>
   </example>
  </section>
+
+ <section xml:id="function-library-lib.asserts.assertSubListOf">
+  <title><function>lib.asserts.assertSubListOf</function></title>
+
+  <subtitle><literal>assertSubListOf :: String -> StringList ->
+      StringList -> Bool</literal>
+  </subtitle>
+
+  <xi:include href="./locations.xml" xpointer="lib.asserts.assertSubListOf" />
+
+  <para>
+   Specialized <function>asserts.assertMsg</function> for checking if <varname>val</varname> is a sublist of <varname>xs</varname>. Useful for checking enums.
+  </para>
+
+  <variablelist>
+   <varlistentry>
+    <term>
+     <varname>name</varname>
+    </term>
+    <listitem>
+     <para>
+      The name of the variable the user entered <varname>val</varname> into, for inclusion in the error message.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <varname>val</varname>
+    </term>
+    <listitem>
+     <para>
+      The value of what the user provided, to be compared against the values in <varname>xs</varname>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <varname>xs</varname>
+    </term>
+    <listitem>
+     <para>
+      The list of valid values.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+  <example xml:id="function-library-lib.asserts.assertSubListOf-example">
+   <title>Ensuring a user provided a valid value</title>
+<programlisting><![CDATA[
+let colorVariants = ["bright" "dark" "black"]
+in assertSubListOf "color variants" colorVariants [ "standard" "light" "dark" ];
+=> false
+stderr> trace: color variants must be a sublist of "standard", "light", "dark", but contains: "bright", "black"
+]]></programlisting>
+  </example>
+ </section>
 </section>

--- a/lib/asserts.nix
+++ b/lib/asserts.nix
@@ -41,4 +41,25 @@ rec {
       lib.generators.toPretty {} xs}, but is: ${
         lib.generators.toPretty {} val}";
 
+  /* Specialized `assertMsg` for checking if val is a sublist of a
+     list. Useful for checking enums.
+
+     Example:
+       let colorVariants = ["bright" "dark" "black"]
+       in assertSubListOf "color variants" colorVariants [ "standard" "light" "dark" ];
+       => false
+       stderr> trace: color variants must be a sublist of "standard", "light", "dark", but contains: "bright", "black"
+
+     Type:
+       assertOneOf :: String -> List ComparableVal -> List ComparableVal -> Bool
+  */
+  assertSubListOf = name: val: xs:
+    let
+      unexpected = lib.subtractLists xs val;
+    in
+      lib.assertMsg (unexpected == [])
+        "${name} must be a sublist of ${
+          lib.generators.toPretty {} xs}, but contains: ${
+            lib.generators.toPretty {} unexpected}";
+
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -129,7 +129,7 @@ let
     inherit (self.types) isType setType defaultTypeMerge defaultFunctor
       isOptionType mkOptionType;
     inherit (self.asserts)
-      assertMsg assertOneOf;
+      assertMsg assertOneOf assertSubListOf;
     inherit (self.debug) addErrorContextToAttrs traceIf traceVal traceValFn
       traceXMLVal traceXMLValMarked traceSeq traceSeqN traceValSeq
       traceValSeqFn traceValSeqN traceValSeqNFn traceFnSeqN traceShowVal


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The new function `assertSubListOf` is useful for instance in the nix expression in https://github.com/NixOS/nixpkgs/pull/153497

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
