### PR TITLE
baresip: 0.6.5 -> 1.1.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/baresip/default.nix
+++ b/pkgs/applications/networking/instant-messengers/baresip/default.nix
@@ -1,17 +1,60 @@
-{ lib, stdenv, fetchurl, zlib, openssl, libre, librem, pkg-config, gst_all_1
-, cairo, mpg123, alsa-lib, SDL, libv4l, celt, libsndfile, srtp, ffmpeg
-, gsm, speex, portaudio, spandsp, libuuid, libvpx
+{ lib
+, stdenv
+, fetchFromGitHub
+, zlib
+, openssl
+, libre
+, librem
+, pkg-config
+, gst_all_1
+, cairo
+, mpg123
+, alsa-lib
+, SDL2
+, libv4l
+, celt
+, libsndfile
+, srtp
+, ffmpeg
+, gsm
+, speex
+, portaudio
+, spandsp3
+, libuuid
+, libvpx
 }:
 stdenv.mkDerivation rec {
-  version = "0.6.5";
+  version = "1.1.0";
   pname = "baresip";
-  src=fetchurl {
-    url = "http://www.creytiv.com/pub/baresip-${version}.tar.gz";
-    sha256 = "13di0ycdcr2q2a20mjvyaqfmvk5xldwqaxklqsz7470jnbc5n0rb";
+  src = fetchFromGitHub {
+    owner = "baresip";
+    repo = "baresip";
+    rev = "v${version}";
+    sha256 = "sha256-9mc1Beo7/iNhDXSDC/jiTL+lJRt8ah/1xF1heoHTE+g=";
   };
+  postPatch = ''
+    patchShebangs modules/ctrl_dbus/gen.sh
+  '';
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [zlib openssl libre librem cairo mpg123
-    alsa-lib SDL libv4l celt libsndfile srtp ffmpeg gsm speex portaudio spandsp libuuid
+  buildInputs = [
+    zlib
+    openssl
+    libre
+    librem
+    cairo
+    mpg123
+    alsa-lib
+    SDL2
+    libv4l
+    celt
+    libsndfile
+    srtp
+    ffmpeg
+    gsm
+    speex
+    portaudio
+    spandsp3
+    libuuid
     libvpx
   ] ++ (with gst_all_1; [ gstreamer gst-libav gst-plugins-base gst-plugins-bad gst-plugins-good ]);
   makeFlags = [
@@ -23,30 +66,55 @@ stdenv.mkDerivation rec {
     "USE_VIDEO=1"
     "CCACHE_DISABLE=1"
 
-    "USE_ALSA=1" "USE_AMR=1" "USE_CAIRO=1" "USE_CELT=1"
-    "USE_CONS=1" "USE_EVDEV=1" "USE_FFMPEG=1"  "USE_GSM=1" "USE_GST1=1"
-    "USE_L16=1" "USE_MPG123=1" "USE_OSS=1" "USE_PLC=1" "USE_VPX=1"
-    "USE_PORTAUDIO=1" "USE_SDL=1" "USE_SNDFILE=1" "USE_SPEEX=1"
-    "USE_SPEEX_AEC=1" "USE_SPEEX_PP=1" "USE_SPEEX_RESAMP=1" "USE_SRTP=1"
-    "USE_STDIO=1" "USE_SYSLOG=1" "USE_UUID=1" "USE_V4L2=1" "USE_X11=1"
+    "USE_ALSA=1"
+    "USE_AMR=1"
+    "USE_CAIRO=1"
+    "USE_CELT=1"
+    "USE_CONS=1"
+    "USE_EVDEV=1"
+    "USE_FFMPEG=1"
+    "USE_GSM=1"
+    "USE_GST1=1"
+    "USE_L16=1"
+    "USE_MPG123=1"
+    "USE_OSS=1"
+    "USE_PLC=1"
+    "USE_VPX=1"
+    "USE_PORTAUDIO=1"
+    "USE_SDL=1"
+    "USE_SNDFILE=1"
+    "USE_SPEEX=1"
+    "USE_SPEEX_AEC=1"
+    "USE_SPEEX_PP=1"
+    "USE_SPEEX_RESAMP=1"
+    "USE_SRTP=1"
+    "USE_STDIO=1"
+    "USE_SYSLOG=1"
+    "USE_UUID=1"
+    "USE_V4L2=1"
+    "USE_X11=1"
 
-    "USE_BV32=" "USE_COREAUDIO=" "USE_G711=1" "USE_G722=1" "USE_G722_1="
-    "USE_ILBC=" "USE_OPUS=" "USE_SILK="
+    "USE_BV32="
+    "USE_COREAUDIO="
+    "USE_G711=1"
+    "USE_G722=1"
+    "USE_G722_1="
+    "USE_ILBC="
+    "USE_OPUS="
+    "USE_SILK="
   ]
   ++ lib.optional (stdenv.cc.cc != null) "SYSROOT_ALT=${stdenv.cc.cc}"
   ++ lib.optional (stdenv.cc.libc != null) "SYSROOT=${stdenv.cc.libc}"
   ;
 
-  NIX_CFLAGS_COMPILE='' -I${librem}/include/rem -I${gsm}/include/gsm
+  NIX_CFLAGS_COMPILE = '' -I${librem}/include/rem -I${gsm}/include/gsm
     -DHAVE_INTTYPES_H -D__GLIBC__
     -D__need_timeval -D__need_timespec -D__need_time_t '';
+
   meta = {
-    homepage = "http://www.creytiv.com/baresip.html";
-    platforms = with lib.platforms; linux;
-    maintainers = with lib.maintainers; [raskin];
+    description = "A modular SIP User-Agent with audio and video support";
+    homepage = "https://github.com/baresip/baresip";
+    maintainers = with lib.maintainers; [ elohmeier raskin ];
     license = lib.licenses.bsd3;
-    downloadPage = "http://www.creytiv.com/pub/";
-    updateWalker = true;
-    downloadURLRegexp = "/baresip-.*[.]tar[.].*";
   };
 }

--- a/pkgs/development/libraries/libre/default.nix
+++ b/pkgs/development/libraries/libre/default.nix
@@ -1,24 +1,22 @@
-{lib, stdenv, fetchurl, zlib, openssl}:
+{ lib, stdenv, fetchFromGitHub, zlib, openssl }:
 stdenv.mkDerivation rec {
-  version = "0.6.1";
+  version = "2.0.1";
   pname = "libre";
-  src = fetchurl {
-    url = "http://www.creytiv.com/pub/re-${version}.tar.gz";
-    sha256 = "0hzyc0hdlw795nyx6ik7h2ihs8wapbj32x8c40xq0484ciwzqnyd";
+  src = fetchFromGitHub {
+    owner = "baresip";
+    repo = "re";
+    rev = "v${version}";
+    sha256 = "sha256-/1J9cs0W96CtnHAoX/jg3FLGD9coa0eOEgf8uMQHuUk=";
   };
   buildInputs = [ zlib openssl ];
   makeFlags = [ "USE_ZLIB=1" "USE_OPENSSL=1" "PREFIX=$(out)" ]
-  ++ lib.optional (stdenv.cc.cc != null) "SYSROOT_ALT=${stdenv.cc.cc}"
-  ++ lib.optional (stdenv.cc.libc != null) "SYSROOT=${lib.getDev stdenv.cc.libc}"
+    ++ lib.optional (stdenv.cc.cc != null) "SYSROOT_ALT=${stdenv.cc.cc}"
+    ++ lib.optional (stdenv.cc.libc != null) "SYSROOT=${lib.getDev stdenv.cc.libc}"
   ;
   meta = {
     description = "A library for real-time communications with async IO support and a complete SIP stack";
-    homepage = "http://www.creytiv.com/re.html";
-    platforms = with lib.platforms; linux;
-    maintainers = with lib.maintainers; [raskin];
+    homepage = "https://github.com/baresip/re";
+    maintainers = with lib.maintainers; [ elohmeier raskin ];
     license = lib.licenses.bsd3;
-    downloadPage = "http://www.creytiv.com/pub/";
-    updateWalker = true;
-    downloadURLRegexp = "/re-.*[.]tar[.].*";
   };
 }

--- a/pkgs/development/libraries/librem/default.nix
+++ b/pkgs/development/libraries/librem/default.nix
@@ -1,12 +1,14 @@
-{lib, stdenv, fetchurl, zlib, openssl, libre}:
+{ lib, stdenv, fetchFromGitHub, zlib, openssl, libre }:
 stdenv.mkDerivation rec {
-  version = "0.6.0";
+  version = "1.0.0";
   pname = "librem";
-  src=fetchurl {
-    url = "http://www.creytiv.com/pub/rem-${version}.tar.gz";
-    sha256 = "0b17wma5w9acizk02isk5k83vv47vf1cf9zkmsc1ail677d20xj1";
+  src = fetchFromGitHub {
+    owner = "baresip";
+    repo = "rem";
+    rev = "v${version}";
+    sha256 = "sha256-6Xe9zT0qLLGe1+QCQ9NALoDTaRhHpaTLbCbA+kV7hOA=";
   };
-  buildInputs = [zlib openssl libre];
+  buildInputs = [ zlib openssl libre ];
   makeFlags = [
     "LIBRE_MK=${libre}/share/re/re.mk"
     "LIBRE_INC=${libre}/include/re"
@@ -16,13 +18,9 @@ stdenv.mkDerivation rec {
   ++ lib.optional (stdenv.cc.libc != null) "SYSROOT=${lib.getDev stdenv.cc.libc}"
   ;
   meta = {
-    description = " A library for real-time audio and video processing";
-    homepage = "http://www.creytiv.com/rem.html";
-    platforms = with lib.platforms; linux;
-    maintainers = with lib.maintainers; [raskin];
+    description = "A library for real-time audio and video processing";
+    homepage = "https://github.com/baresip/rem";
+    maintainers = with lib.maintainers; [ elohmeier raskin ];
     license = lib.licenses.bsd3;
-    downloadPage = "http://www.creytiv.com/pub/";
-    updateWalker = true;
-    downloadURLRegexp = "/rem-.*[.]tar[.].*";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
baresip moved it's web presence & repo to GitHub, the old page is 404ing and the package & some libs were outdated.

###### Things done
Updated the libs & baresip package, updated the metadata & applied nixpkgs-fmt formatting.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
