### PR TITLE
gitlab: 14.6.0 -> 14.6.1

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,14 +1,14 @@
 {
-  "version": "14.6.0",
-  "repo_hash": "0b77nh7xq5qalzhvfmsymmkrb78lmaffk464b074wi5c8gy3f5dn",
+  "version": "14.6.1",
+  "repo_hash": "0zgznf0f7jxyznil6q3fac2rvhaa2lhlpxcnbmkg9djyx1vcm7k1",
   "yarn_hash": "1kcjbf8xn3bwac2s9i2i7dpgbkwcjh09wvgbgysm5yffpdswg6nl",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v14.6.0-ee",
+  "rev": "v14.6.1-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "14.6.0",
+    "GITALY_SERVER_VERSION": "14.6.1",
     "GITLAB_PAGES_VERSION": "1.49.0",
     "GITLAB_SHELL_VERSION": "13.22.1",
-    "GITLAB_WORKHORSE_VERSION": "14.6.0"
+    "GITLAB_WORKHORSE_VERSION": "14.6.1"
   }
 }

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -33,7 +33,7 @@ let
       };
   };
 
-  version = "14.6.0";
+  version = "14.6.1";
   gitaly_package = "gitlab.com/gitlab-org/gitaly/v${lib.versions.major version}";
 in
 
@@ -45,7 +45,7 @@ buildGoModule {
     owner = "gitlab-org";
     repo = "gitaly";
     rev = "v${version}";
-    sha256 = "sha256-YiDZtWRb1PnCAv+UCPRQFoCA12vf3xoHoJ1i/hW+vMg=";
+    sha256 = "sha256-nbE71s+KoDC6EK26cmq+YIw9MFSQv1y6qwZAJXVXGj4=";
   };
 
   vendorSha256 = "sha256-ZLd4E3+e25Hqmd6ZyF3X6BveMEg7OF0FX9IvNBWn3v0=";

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
@@ -5,7 +5,7 @@ in
 buildGoModule rec {
   pname = "gitlab-workhorse";
 
-  version = "14.6.0";
+  version = "14.6.1";
 
   src = fetchFromGitLab {
     owner = data.owner;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://about.gitlab.com/releases/2022/01/04/gitlab-14-6-1-released/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
