### PR TITLE
python3Packages.tensorflow-metadata: init at 1.5.0

### DIFF
--- a/pkgs/development/python-modules/tensorflow-metadata/build.patch
+++ b/pkgs/development/python-modules/tensorflow-metadata/build.patch
@@ -1,0 +1,24 @@
+diff --git a/setup.py b/setup.py
+index 7a09b2f..94c5aa6 100644
+--- a/setup.py
++++ b/setup.py
+@@ -125,7 +125,7 @@ setup(
+     ],
+     namespace_packages=[],
+     install_requires=[
+-        'absl-py>=0.9,<0.13',
++        'absl-py>=0.9',
+         'googleapis-common-protos>=1.52.0,<2',
+         'protobuf>=3.13,<4',
+     ],
+@@ -137,8 +137,5 @@ setup(
+     long_description_content_type='text/markdown',
+     keywords='tensorflow metadata tfx',
+     download_url='https://github.com/tensorflow/metadata/tags',
+-    requires=[],
+-    cmdclass={
+-        'build': _BuildCommand,
+-        'bazel_build': _BazelBuildCommand,
+-    })
++    requires=[]
++    )

--- a/pkgs/development/python-modules/tensorflow-metadata/default.nix
+++ b/pkgs/development/python-modules/tensorflow-metadata/default.nix
@@ -1,0 +1,46 @@
+{ absl-py
+, buildPythonPackage
+, fetchFromGitHub
+, googleapis-common-protos
+, lib
+}:
+
+buildPythonPackage rec {
+  pname = "tensorflow-metadata";
+  version = "1.5.0";
+
+  src = fetchFromGitHub {
+    owner = "tensorflow";
+    repo = "metadata";
+    rev = "v${version}";
+    sha256 = "17p74k6rwswpmj7m16cw9hdam6b4m7v5bahirmc2l1kwfvrn4w33";
+  };
+
+  patches = [
+    ./build.patch
+  ];
+
+  # Default build pulls in Bazel + extra deps, given the actual build
+  # is literally three lines (see below) - replace it with custom build.
+  preBuild = ''
+    for proto in tensorflow_metadata/proto/v0/*.proto; do
+      protoc --python_out=. $proto
+    done
+  '';
+
+  propagatedBuildInputs = [
+    absl-py
+    googleapis-common-protos
+  ];
+
+  pythonImportsCheck = [
+    "tensorflow_metadata"
+  ];
+
+  meta = with lib; {
+    description = "Standard representations for metadata that are useful when training machine learning models with TensorFlow";
+    homepage = "https://github.com/tensorflow/metadata";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ndl ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9545,6 +9545,8 @@ in {
 
   tensorflow-estimator = callPackage ../development/python-modules/tensorflow-estimator { };
 
+  tensorflow-metadata = callPackage ../development/python-modules/tensorflow-metadata { };
+
   tensorflow-probability = callPackage ../development/python-modules/tensorflow-probability { };
 
   tensorflow = self.tensorflow-build;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is one of the prerequisites for `tensorflow-datasets`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
