### PR TITLE
python3Packages.spacy: 3.2.1 fix

### DIFF
--- a/pkgs/development/python-modules/spacy-loggers/default.nix
+++ b/pkgs/development/python-modules/spacy-loggers/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, callPackage
+, fetchPypi
+, buildPythonPackage
+, wandb
+, wasabi
+}:
+
+buildPythonPackage rec {
+  pname = "spacy-loggers";
+  version = "1.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-F9DiSbLmxlRsSfxlYaCmhfkajtvySlsrd1nq1EPHRlQ=";
+  };
+
+  propagatedBuildInputs = [
+    wandb
+    wasabi
+  ];
+
+  pythonImportsCheck = [ "spacy_loggers" ];
+
+  # skipping the checks, becaus it requires a cycle dependency to spacy as well.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Logging utilities for spaCy";
+    homepage = "https://github.com/explosion/spacy-loggers";
+    license = licenses.mit;
+    maintainers = with maintainers; [ stunkymonkey ];
+  };
+}

--- a/pkgs/development/python-modules/spacy/default.nix
+++ b/pkgs/development/python-modules/spacy/default.nix
@@ -25,17 +25,19 @@
 , python
 , tqdm
 , typing-extensions
+, spacy-loggers
+, langcodes
 }:
 
 buildPythonPackage rec {
   pname = "spacy";
-  version = "3.2.0";
+  version = "3.2.1";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "68e54b2a14ce74eeecea9bfb0b9bdadf8a4a8157765dbefa7e50d25a1bf0f2f3";
+    sha256 = "sha256-9uusURYndAqMorEXuR71UVyPCy+xF6aevgHQEN1PxTw=";
   };
 
   propagatedBuildInputs = [
@@ -58,6 +60,8 @@ buildPythonPackage rec {
     tqdm
     typer
     wasabi
+    spacy-loggers
+    langcodes
   ] ++ lib.optional (pythonOlder "3.8") typing-extensions;
 
   checkInputs = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9132,6 +9132,8 @@ in {
 
   spacy-legacy = callPackage ../development/python-modules/spacy/legacy.nix { };
 
+  spacy-loggers = callPackage ../development/python-modules/spacy-loggers { };
+
   spacy_models = callPackage ../development/python-modules/spacy/models.nix { };
 
   spacy-pkuseg = callPackage ../development/python-modules/spacy-pkuseg { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
the initial Idea was to fix `spacy`. But all fixes took more work then expected. The update was done by @jonringer.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
