### PR TITLE
dtrx: 7.1 -> 8.2.1 (resurrected)

### DIFF
--- a/pkgs/tools/compression/dtrx/default.nix
+++ b/pkgs/tools/compression/dtrx/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+, gnutar
+, unzip
+, lhasa
+, rpm
+, binutils
+, cpio
+, gzip
+, p7zip
+, cabextract
+, unrar
+, unshield
+, bzip2
+, xz
+, lzip
+, unzipSupport ? false
+, unrarSupport ? false
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "dtrx";
+  version = "8.2.1";
+
+  src = fetchFromGitHub {
+    owner = "dtrx-py";
+    repo = "dtrx";
+    rev = version;
+    sha256 = "sha256-ayQ52teXWpw3ZvPhfqxFHxMZatQK9NKv/97ovANFZcE=";
+  };
+
+  postInstall =
+    let
+      archivers = lib.makeBinPath (
+        [ gnutar lhasa rpm binutils cpio gzip p7zip cabextract unshield bzip2 xz lzip ]
+        ++ lib.optional (unzipSupport) unzip
+        ++ lib.optional (unrarSupport) unrar
+      );
+    in ''
+      wrapProgram "$out/bin/dtrx" --prefix PATH : "${archivers}"
+    '';
+
+  buildInputs = [ python3Packages.twine ];
+
+  meta = with lib; {
+    description = "Do The Right Extraction: A tool for taking the hassle out of extracting archives";
+    homepage = "https://github.com/dtrx-py/dtrx";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.spwhitt ];
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -230,7 +230,6 @@ mapAliases ({
   double_conversion = double-conversion; # 2017-11-22
   docker_compose = docker-compose; # 2018-11-10
   draftsight = throw "draftsight has been removed, no longer available as freeware"; # added 2020-08-14
-  dtrx = throw "dtrx has been removed from nixpkgs as the upstream has abandoned the project."; # added 2022-01-01
   dvb_apps = throw "dvb_apps has been removed."; # added 2020-11-03
   dwarf_fortress = dwarf-fortress; # added 2016-01-23
   dwm-git = throw "dwm-git has been removed from nixpkgs, as it had no updates for 2 years not serving it's purpose."; # added 2021-02-07

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2859,6 +2859,8 @@ with pkgs;
 
   dtools = callPackage ../development/tools/dtools { };
 
+  dtrx = callPackage ../tools/compression/dtrx { };
+
   dua = callPackage ../tools/misc/dua {
     inherit (darwin.apple_sdk.frameworks) Foundation;
   };


### PR DESCRIPTION
The original developer has abandoned this package but some Ubuntu
developers have forked it and maintain it. This means the tests now
work and the package supports Python 3.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
