### PR TITLE
mkYarnPackage: Change default arguments

### DIFF
--- a/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
@@ -33,9 +33,10 @@ mkYarnPackage rec {
 
   packageJSON = ./element-desktop-package.json;
   offlineCache = fetchYarnDeps {
-    yarnLock = src + "/yarn.lock";
+    inherit yarnLock;
     sha256 = pinData.desktopYarnHash;
   };
+  yarnLock = src + "/yarn.lock";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/applications/networking/powerdns-admin/default.nix
+++ b/pkgs/applications/networking/powerdns-admin/default.nix
@@ -33,6 +33,7 @@ let
     inherit src version;
     packageJSON = ./package.json;
     yarnNix = ./yarndeps.nix;
+    yarnLock = src + "/yarn.lock";
 
     nativeBuildInputs = pythonDeps;
     patchPhase = ''

--- a/pkgs/development/tools/yarn2nix-moretea/yarn2nix/default.nix
+++ b/pkgs/development/tools/yarn2nix-moretea/yarn2nix/default.nix
@@ -160,8 +160,8 @@ in rec {
 
   mkYarnWorkspace = {
     src,
-    packageJSON ? src + "/package.json",
-    yarnLock ? src + "/yarn.lock",
+    packageJSON,
+    yarnLock,
     packageOverrides ? {},
     ...
   }@attrs:
@@ -228,8 +228,8 @@ in rec {
   mkYarnPackage = {
     name ? null,
     src,
-    packageJSON ? src + "/package.json",
-    yarnLock ? src + "/yarn.lock",
+    packageJSON,
+    yarnLock,
     yarnNix ? mkYarnNix { inherit yarnLock; },
     offlineCache ? importOfflineCache yarnNix,
     yarnFlags ? defaultYarnFlags,
@@ -373,7 +373,7 @@ in rec {
       } // (attrs.meta or {});
     });
 
-  yarn2nix = mkYarnPackage {
+  yarn2nix = mkYarnPackage rec {
     src =
       let
         src = ./.;
@@ -402,6 +402,7 @@ in rec {
     # source results in an error in restricted mode. To circumvent this,
     # we import package.json from the unfiltered source
     packageJSON = ./package.json;
+    yarnLock = src + "/yarn.lock";
 
     yarnFlags = defaultYarnFlags ++ ["--production=true"];
 

--- a/pkgs/servers/gotify/ui.nix
+++ b/pkgs/servers/gotify/ui.nix
@@ -7,6 +7,7 @@ yarn2nix-moretea.mkYarnPackage rec {
 
   packageJSON = ./package.json;
   yarnNix = ./yarndeps.nix;
+  yarnLock = src + "/yarn.lock";
 
   version = import ./version.nix;
 

--- a/pkgs/servers/mastodon/default.nix
+++ b/pkgs/servers/mastodon/default.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation rec {
   mastodon-js-modules = mkYarnPackage {
     pname = "${pname}-modules";
     yarnNix = dependenciesDir + "/yarn.nix";
+    yarnLock = src + "/yarn.lock";
     packageJSON = dependenciesDir + "/package.json";
     inherit src version;
   };

--- a/pkgs/servers/matrix-appservice-discord/default.nix
+++ b/pkgs/servers/matrix-appservice-discord/default.nix
@@ -23,6 +23,7 @@ in mkYarnPackage rec {
 
   packageJSON = ./package.json;
   yarnNix = ./yarn-dependencies.nix;
+  yarnLock = src + "/yarn.lock";
 
   pkgConfig = {
     better-sqlite3 = {

--- a/pkgs/servers/web-apps/lemmy/ui.nix
+++ b/pkgs/servers/web-apps/lemmy/ui.nix
@@ -33,15 +33,16 @@ let
     sha256 = pinData.uiSha256;
   };
 in
-mkYarnPackage {
+mkYarnPackage rec {
 
   inherit src pkgConfig name version;
 
   extraBuildInputs = [ libsass ];
 
   packageJSON = ./package.json;
+  yarnLock = src + "/yarn.lock";
   offlineCache = fetchYarnDeps {
-    yarnLock = src + "/yarn.lock";
+    inherit yarnLock;
     sha256 = pinData.uiYarnDepsSha256;
   };
 


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/95821#issuecomment-1006237261, https://github.com/NixOS/nixpkgs/pull/152160#discussion_r776702498

The packageJSON default was overwritten by literally every package using it, since
the default produces IFD which is forbidden in nixpkgs. 95% of packages vendored the
packageJSON locally, so that is the new default now.

The yarnLock argument was overwritten in about 70% of the packages (but to different
values respectively), so the default value was removed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
