### PR TITLE
root: explicitly opt-out GPL-licensed libraries/plugins

### DIFF
--- a/pkgs/applications/science/misc/root/default.nix
+++ b/pkgs/applications/science/misc/root/default.nix
@@ -8,6 +8,7 @@
 , ftgl
 , gl2ps
 , glew
+, lapack
 , libX11
 , libXpm
 , libXft
@@ -18,6 +19,7 @@
 , llvm_9
 , lz4
 , xz
+, openblas
 , pcre
 , nlohmann_json
 , pkg-config
@@ -54,10 +56,12 @@ stdenv.mkDerivation rec {
     pcre
     zlib
     zstd
+    lapack
     libxml2
     llvm_9
     lz4
     xz
+    openblas
     xxHash
     libAfterImage
     giflib

--- a/pkgs/applications/science/misc/root/default.nix
+++ b/pkgs/applications/science/misc/root/default.nix
@@ -8,7 +8,6 @@
 , ftgl
 , gl2ps
 , glew
-, gsl
 , libX11
 , libXpm
 , libXft
@@ -59,7 +58,6 @@ stdenv.mkDerivation rec {
     llvm_9
     lz4
     xz
-    gsl
     xxHash
     libAfterImage
     giflib


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Due to the "infectious" nature of GPL license, the parts of code that makes use of GPL-licensed libraries in the ROOT source tree, e.g. MathMore, are deliberately seperated, and most of them are not included by default.

Two of those third-party libraries, are FFTW and GSL. The former is excluded in the Nix expression building ROOT, but the latter is still part of the `buildInputs`.

To prevent researchers from being forced to GPL their analysis scripts, this PR explicitly disable GSL from the cmakeFlags and remove it from buildInputs. GPL licensed plugin `MathMore` and its reverse dependency `RooFitMore` are explicitly opt-out as well.

https://root.cern/doc/master/group__MathMore.html

This PR also add openblas and lapack as build inputs to satisfy the requirement of TMVA. For the former, TMVA falls back to GSL CBLAS when OpenBLAS isn't presented, but the latter is recommended. The latter is used by TMVA SOFIE.

https://root-forum.cern.ch/t/tmva-sofie-undefined-reference-to-sgemm/47248

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
