### PR TITLE
etcd_3_5: init at 3.5.1

### DIFF
--- a/pkgs/servers/etcd/3.5.nix
+++ b/pkgs/servers/etcd/3.5.nix
@@ -1,0 +1,82 @@
+{ lib, buildGoModule, fetchFromGitHub, symlinkJoin }:
+
+let
+  etcdVersion = "3.5.1";
+  etcdSrc = fetchFromGitHub {
+    owner = "etcd-io";
+    repo = "etcd";
+    rev = "v${etcdVersion}";
+    sha256 = "sha256-Ip7JAWbZBZcc8MXd+Sw05QmTs448fQXpQ5XXo6RW+Gs=";
+  };
+
+  commonMeta = with lib; {
+    description = "Distributed reliable key-value store for the most critical data of a distributed system";
+    license = licenses.asl20;
+    homepage = "https://etcd.io/";
+    maintainers = with maintainers; [ offline zowoq endocrimes ];
+    platforms = platforms.darwin ++ platforms.linux;
+  };
+
+  etcdserver = buildGoModule rec {
+    pname = "etcdserver";
+    version = etcdVersion;
+
+    vendorSha256 = "sha256-hJzmxCcwN6MTgE0NpjtFlm8pjZ83clQXv1k5YM8Gmes=";
+
+    src = etcdSrc;
+    modRoot = "./server";
+
+    postBuild = ''
+      mv $GOPATH/bin/{server,etcd}
+    '';
+
+    CGO_ENABLED = 0;
+
+    # We set the GitSHA to `GitNotFound` to match official build scripts when
+    # git is unavailable. This is to avoid doing a full Git Checkout of etcd.
+    # User facing version numbers are still available in the binary, just not
+    # the sha it was built from.
+    ldflags = [ "-X go.etcd.io/etcd/api/v3/version.GitSHA=GitNotFound" ];
+
+    meta = commonMeta;
+  };
+
+  etcdutl = buildGoModule rec {
+    pname = "etcdutl";
+    version = etcdVersion;
+
+    vendorSha256 = "sha256-My0kzsN2i8DgPm2yIkbql3VyMXPaHmQSeaa/uK/RFxo=";
+
+    src = etcdSrc;
+    modRoot = "./etcdutl";
+
+    CGO_ENABLED = 0;
+
+    meta = commonMeta;
+  };
+
+  etcdctl = buildGoModule rec {
+    pname = "etcdutl";
+    version = etcdVersion;
+
+    vendorSha256 = "sha256-XZKBA95UrhbiefnDvpaXcBA0wUjnpH+Pb6yXp7yc4HQ=";
+
+    src = etcdSrc;
+    modRoot = "./etcdctl";
+
+    CGO_ENABLED = 0;
+
+    meta = commonMeta;
+  };
+in
+symlinkJoin {
+  name = "etcd";
+  version = etcdVersion;
+  meta = commonMeta;
+
+  paths = [
+    etcdserver
+    etcdutl
+    etcdctl
+  ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20950,6 +20950,7 @@ with pkgs;
 
   etcd = callPackage ../servers/etcd { };
   etcd_3_4 = callPackage ../servers/etcd/3.4.nix { };
+  etcd_3_5 = callPackage ../servers/etcd/3.5.nix { };
 
   ejabberd = callPackage ../servers/xmpp/ejabberd { };
 


### PR DESCRIPTION
###### Motivation for this change

adding the latest version of etcd for local development.

This is a big departure from previous versions as the etcd buildsystem changed dramatically since 3.4.x, which raises the difficulty in maintaining the existing packaging style.

In 3.4.x and before, a single vendor directory was constructed, then the build scripts set a gopath based on this to construct various binaries. In 3.5.x, this is no longer the case, and every binary has its own directory and `go.mod`. 

Because of this change, we now build the three publicly-facing binaries as seperate derivation, and join them with `symlinkJoin` to present a single `etcd` package to minimize breakages and to simplify package bumps.

At the same time, we no longer build or distribute etcd's functional testing binaries as part of `etcd` as they don't really make sense for end-users of etcd.

```
[(nxs: ripgrep) danielle@berlin nixpkgs(dani/etcd-3.5)] $ ls /nix/store/hgrnv7bq3m9h9v1l5mfaw3ydqyw119dn-etcd/bin 
etcd  etcdctl  etcdutl
```

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
