### PR TITLE
spigot: 20200901 -> 20210527

### DIFF
--- a/pkgs/tools/misc/spigot/default.nix
+++ b/pkgs/tools/misc/spigot/default.nix
@@ -1,36 +1,43 @@
 { lib
 , stdenv
-, buildPackages
-, fetchgit
-, autoreconfHook
+, fetchurl
+, cmake
 , gmp
-, ncurses
 , halibut
+, ncurses
 , perl
 }:
 
 stdenv.mkDerivation rec {
   pname = "spigot";
-  version = "20200901";
-  src = fetchgit {
-    url = "https://git.tartarus.org/simon/spigot.git";
-    rev = "9910e5bdc203bae6b7bbe1ed4a93f13755c1cae";
-    sha256 = "1az6v9gk0g2k197lr288nmr9jv20bvgc508vn9ic3v7mav7hf5bf";
+  version = "20210527";
+  srcVersion = "20210527.7dd3cfd";
+
+  src = fetchurl {
+    url = "https://www.chiark.greenend.org.uk/~sgtatham/spigot/${pname}-${srcVersion}.tar.gz";
+    hash = "sha256-EBS3lgfLtsyBQ8mzoJPyZhRBJNmkVSeF5XecGgcvqtw=";
   };
 
-  nativeBuildInputs = [ autoreconfHook halibut perl ];
+  nativeBuildInputs = [
+    cmake
+    halibut
+    perl
+  ];
 
-  configureFlags = [ "--with-gmp" ];
+  buildInputs = [
+    gmp
+    ncurses
+  ];
 
-  buildInputs = [ gmp ncurses ];
+  outputs = [ "out" "man" ];
 
   strictDeps = true;
 
   meta = with lib; {
-    description = "A command-line exact real calculator";
     homepage = "https://www.chiark.greenend.org.uk/~sgtatham/spigot/";
-    license = lib.licenses.mit;
-    platforms = lib.platforms.all;
-    maintainers = with maintainers; [ mcbeth ];
+    description = "A command-line exact real calculator";
+    license = licenses.mit;
+    maintainers = with maintainers; [ AndersonTorres mcbeth ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
