### PR TITLE
nixos/adguard-dnsproxy: init

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -119,6 +119,14 @@
           <link xlink:href="options.html#opt-services.archisteamfarm.enable">services.archisteamfarm</link>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://github.com/AdguardTeam/dnsproxy">dnsproxy</link>,
+          a simple DNS proxy with DoH, DoT, DoQ and DNSCrypt support.
+          Available at
+          <link xlink:href="options.html#opt-services.adguard-dnscrypt.enable">services.adguard-dnscrypt</link>.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-22.05-incompatibilities">

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -37,6 +37,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [ArchiSteamFarm](https://github.com/JustArchiNET/ArchiSteamFarm), a C# application with primary purpose of idling Steam cards from multiple accounts simultaneously. Available as [services.archisteamfarm](options.html#opt-services.archisteamfarm.enable).
 
+- [dnsproxy](https://github.com/AdguardTeam/dnsproxy), a simple DNS proxy with DoH, DoT, DoQ and DNSCrypt support. Available at [services.adguard-dnscrypt](options.html#opt-services.adguard-dnscrypt.enable).
+
 ## Backward Incompatibilities {#sec-release-22.05-incompatibilities}
 
 - `pkgs.ghc` now refers to `pkgs.targetPackages.haskellPackages.ghc`.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -696,6 +696,7 @@
   ./services/network-filesystems/xtreemfs.nix
   ./services/network-filesystems/ceph.nix
   ./services/networking/3proxy.nix
+  ./services/networking/adguard-dnsproxy.nix
   ./services/networking/adguardhome.nix
   ./services/networking/amuled.nix
   ./services/networking/antennas.nix

--- a/nixos/modules/services/networking/adguard-dnsproxy.nix
+++ b/nixos/modules/services/networking/adguard-dnsproxy.nix
@@ -1,0 +1,98 @@
+{ config, lib, pkgs, ... }:
+with lib;
+
+let cfg = config.services.adguard-dnsproxy;
+
+in {
+  meta.maintainers = with lib.maintainers; [ ckie ];
+  options.services.adguard-dnsproxy = {
+    enable = mkEnableOption
+      "dnsproxy, a simple DNS proxy with DoH, DoT, DoQ and DNSCrypt support.";
+    extraOptions = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = "Extra arguments to pass to dnsproxy.";
+    };
+    package = mkOption {
+      type = types.package;
+      default = pkgs.dnsproxy;
+      defaultText = literalExpression "pkgs.dnsproxy";
+      description = "The package containing the dnsproxy binary.";
+    };
+    port = mkOption {
+      type = types.nullOr types.port;
+      default = null;
+      description = "An optional port to listen on for raw DNS traffic.";
+    };
+    upstreams = mkOption {
+      type = types.listOf types.str;
+      default = null;
+      description = "Upstream servers to talk with.";
+    };
+    fallbacks = mkOption {
+      type = types.listOf types.str;
+      default = [ "1.1.1.1" "9.9.9.9" "8.8.8.8" ];
+      description =
+        "Fallback upstream servers to talk with, used for bootstrapping the connection to the primary upstreams.";
+    };
+    verbose = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Enable verbose debugging output.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.adguard-dnsproxy.extraOptions = [ ]
+      ++ optional (cfg.port != null) "--port ${toString cfg.port}"
+      ++ map (u: "--upstream ${escapeShellArg u}") cfg.upstreams
+      ++ map (u: "--fallback ${escapeShellArg u}") cfg.fallbacks
+      ++ optional cfg.verbose "--verbose";
+
+    systemd.services.adguard-dnsproxy = {
+      description = "adguard-dnsproxy";
+      wants = [ "network-online.target" "nss-lookup.target" ];
+      before = [ "nss-lookup.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        AmbientCapabilities = "CAP_NET_BIND_SERVICE";
+        CacheDirectory = "adguard-dnsproxy";
+        DynamicUser = true;
+        ExecStart = "${cfg.package}/bin/dnsproxy ${
+            concatStringsSep " " cfg.extraOptions
+          }";
+        LockPersonality = true;
+        LogsDirectory = "adguard-dnsproxy";
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        NonBlocking = true;
+        PrivateDevices = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectSystem = "strict";
+        Restart = "always";
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RuntimeDirectory = "adguard-dnsproxy";
+        StateDirectory = "adguard-dnsproxy";
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "@chown"
+          "~@aio"
+          "~@keyring"
+          "~@memlock"
+          "~@resources"
+          "~@setuid"
+          "~@timer"
+        ];
+      };
+    };
+  };
+}

--- a/nixos/tests/adguard-dnsproxy/default.nix
+++ b/nixos/tests/adguard-dnsproxy/default.nix
@@ -1,0 +1,32 @@
+import ../make-test-python.nix ({ pkgs, ... }: {
+  name = "adguard-dnsproxy";
+  meta.maintainers = with pkgs.lib.maintainers; [ ckiee ];
+
+  nodes.server = { ... }: {
+    services.adguard-dnsproxy = {
+      enable = true;
+      fallbacks = [];
+      port = 53;
+      upstreams = [ "127.0.0.1:1238" ];
+    };
+
+    services.coredns = {
+      enable = true;
+      config = ''
+        test:1238 {
+          file ${./test.zone}
+        }
+      '';
+    };
+  };
+
+  testScript = ''
+    server.wait_for_unit("adguard-dnsproxy")
+    server.wait_for_open_port("53")
+    server.wait_for_unit("coredns")
+    server.wait_for_open_port("1238")
+    # check reliability
+    for i in range(2000):
+        server.succeed("${pkgs.dig}/bin/dig @127.0.0.1 +tries=1 test.test")
+  '';
+})

--- a/nixos/tests/adguard-dnsproxy/test.zone
+++ b/nixos/tests/adguard-dnsproxy/test.zone
@@ -1,0 +1,14 @@
+
+$TTL 60
+
+$ORIGIN test.
+@       IN      SOA     dns.test. example@example.com. (
+                        2022010710 ; serial number YYMMDDNN
+                        28800           ; Refresh
+                        7200            ; Retry
+                        864000          ; Expire
+                        86400           ; Min TTL
+                        )
+
+dns IN A 127.0.0.1
+test IN A 100.64.0.1

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -23,6 +23,7 @@ in
 {
   _3proxy = handleTest ./3proxy.nix {};
   acme = handleTest ./acme.nix {};
+  adguard-dnsproxy = handleTest ./adguard-dnsproxy {};
   aesmd = handleTest ./aesmd.nix {};
   agda = handleTest ./agda.nix {};
   airsonic = handleTest ./airsonic.nix {};


### PR DESCRIPTION
This module is somewhat equivalent to the `dnscrypt-proxy2` module, but that
one drops about ~2% of requests which is occasionally noticeable and annoying.

Tested on `nixpkgs` commit https://github.com/nixos/nixpkgs/commit/f54682dd96f.

<details><summary><code>systemd-analyze security adguard-dnsproxy</code> report</summary>
<pre>
  NAME                                                        DESCRIPTION                                                                                     EXPOSURE
✗ PrivateNetwork=                                             Service has access to the host's network                                                             0.5
✓ User=/DynamicUser=                                          Service runs under a transient non-root user identity                                           
✗ CapabilityBoundingSet=~CAP_SET(UID|GID|PCAP)                Service may change UID/GID identities/capabilities                                                   0.3
✗ CapabilityBoundingSet=~CAP_SYS_ADMIN                        Service has administrator privileges                                                                 0.3
✗ CapabilityBoundingSet=~CAP_SYS_PTRACE                       Service has ptrace() debugging abilities                                                             0.3
✗ RestrictAddressFamilies=~AF_(INET|INET6)                    Service may allocate Internet sockets                                                                0.3
✓ RestrictNamespaces=~CLONE_NEWUSER                           Service cannot create user namespaces                                                           
✓ RestrictAddressFamilies=~…                                  Service cannot allocate exotic sockets                                                          
✗ CapabilityBoundingSet=~CAP_(CHOWN|FSETID|SETFCAP)           Service may change file ownership/access mode/capabilities unrestricted                              0.2
✗ CapabilityBoundingSet=~CAP_(DAC_*|FOWNER|IPC_OWNER)         Service may override UNIX file/IPC permission checks                                                 0.2
✗ CapabilityBoundingSet=~CAP_NET_ADMIN                        Service has network configuration privileges                                                         0.2
✓ CapabilityBoundingSet=~CAP_SYS_MODULE                       Service cannot load kernel modules                                                              
✓ CapabilityBoundingSet=~CAP_SYS_RAWIO                        Service has no raw I/O access                                                                   
✓ CapabilityBoundingSet=~CAP_SYS_TIME                         Service processes cannot change the system clock                                                
✗ DeviceAllow=                                                Service has a device ACL with some special devices                                                   0.1
✗ IPAddressDeny=                                              Service does not define an IP address allow list                                                     0.2
✓ KeyringMode=                                                Service doesn't share key material with other services                                          
✓ NoNewPrivileges=                                            Service processes cannot acquire new privileges                                                 
✓ NotifyAccess=                                               Service child processes cannot alter service state                                              
✓ PrivateDevices=                                             Service has no access to hardware devices                                                       
✓ PrivateMounts=                                              Service cannot install system mounts                                                            
✓ PrivateTmp=                                                 Service has no access to other software's temporary files                                       
✗ PrivateUsers=                                               Service has access to other users                                                                    0.2
✓ ProtectClock=                                               Service cannot write to the hardware clock or system clock                                      
✓ ProtectControlGroups=                                       Service cannot modify the control group file system                                             
✓ ProtectHome=                                                Service has no access to home directories                                                       
✓ ProtectKernelLogs=                                          Service cannot read from or write to the kernel log ring buffer                                 
✓ ProtectKernelModules=                                       Service cannot load or read kernel modules                                                      
✓ ProtectKernelTunables=                                      Service cannot alter kernel tunables (/proc/sys, …)                                             
✗ ProtectProc=                                                Service has full access to process tree (/proc hidepid=)                                             0.2
✓ ProtectSystem=                                              Service has strict read-only access to the OS file hierarchy                                    
✓ RestrictAddressFamilies=~AF_PACKET                          Service cannot allocate packet sockets                                                          
✓ RestrictSUIDSGID=                                           SUID/SGID file creation by service is restricted                                                
✓ SystemCallArchitectures=                                    Service may execute system calls only with native ABI                                           
✓ SystemCallFilter=~@clock                                    System call allow list defined for service, and @clock is not included                          
✓ SystemCallFilter=~@debug                                    System call allow list defined for service, and @debug is not included                          
✓ SystemCallFilter=~@module                                   System call allow list defined for service, and @module is not included                         
✓ SystemCallFilter=~@mount                                    System call allow list defined for service, and @mount is not included                          
✓ SystemCallFilter=~@raw-io                                   System call allow list defined for service, and @raw-io is not included                         
✓ SystemCallFilter=~@reboot                                   System call allow list defined for service, and @reboot is not included                         
✓ SystemCallFilter=~@swap                                     System call allow list defined for service, and @swap is not included                           
✗ SystemCallFilter=~@privileged                               System call allow list defined for service, and @privileged is included (e.g. chown is allowed)      0.2
✓ SystemCallFilter=~@resources                                System call allow list defined for service, and @resources is not included                      
✗ AmbientCapabilities=                                        Service process receives ambient capabilities                                                        0.1
✗ CapabilityBoundingSet=~CAP_AUDIT_*                          Service has audit subsystem access                                                                   0.1
✗ CapabilityBoundingSet=~CAP_KILL                             Service may send UNIX signals to arbitrary processes                                                 0.1
✓ CapabilityBoundingSet=~CAP_MKNOD                            Service cannot create device nodes                                                              
✗ CapabilityBoundingSet=~CAP_NET_(BIND_SERVICE|BROADCAST|RAW) Service has elevated networking privileges                                                           0.1
✓ CapabilityBoundingSet=~CAP_SYSLOG                           Service has no access to kernel logging                                                         
✗ CapabilityBoundingSet=~CAP_SYS_(NICE|RESOURCE)              Service has privileges to change resource use parameters                                             0.1
✓ RestrictNamespaces=~CLONE_NEWCGROUP                         Service cannot create cgroup namespaces                                                         
✓ RestrictNamespaces=~CLONE_NEWIPC                            Service cannot create IPC namespaces                                                            
✓ RestrictNamespaces=~CLONE_NEWNET                            Service cannot create network namespaces                                                        
✓ RestrictNamespaces=~CLONE_NEWNS                             Service cannot create file system namespaces                                                    
✓ RestrictNamespaces=~CLONE_NEWPID                            Service cannot create process namespaces                                                        
✓ RestrictRealtime=                                           Service realtime scheduling access is restricted                                                
✓ SystemCallFilter=~@cpu-emulation                            System call allow list defined for service, and @cpu-emulation is not included                  
✓ SystemCallFilter=~@obsolete                                 System call allow list defined for service, and @obsolete is not included                       
✓ RestrictAddressFamilies=~AF_NETLINK                         Service cannot allocate netlink sockets                                                         
✗ RootDirectory=/RootImage=                                   Service runs within the host's root directory                                                        0.1
✓ SupplementaryGroups=                                        Service has no supplementary groups                                                             
✗ CapabilityBoundingSet=~CAP_MAC_*                            Service may adjust SMACK MAC                                                                         0.1
✗ CapabilityBoundingSet=~CAP_SYS_BOOT                         Service may issue reboot()                                                                           0.1
✓ Delegate=                                                   Service does not maintain its own delegated control group subtree                               
✓ LockPersonality=                                            Service cannot change ABI personality                                                           
✓ MemoryDenyWriteExecute=                                     Service cannot create writable executable memory mappings                                       
✓ RemoveIPC=                                                  Service user cannot leave SysV IPC objects around                                               
✓ RestrictNamespaces=~CLONE_NEWUTS                            Service cannot create hostname namespaces                                                       
✗ UMask=                                                      Files created by service are world-readable by default                                               0.1
✗ CapabilityBoundingSet=~CAP_LINUX_IMMUTABLE                  Service may mark files immutable                                                                     0.1
✗ CapabilityBoundingSet=~CAP_IPC_LOCK                         Service may lock memory into RAM                                                                     0.1
✗ CapabilityBoundingSet=~CAP_SYS_CHROOT                       Service may issue chroot()                                                                           0.1
✓ ProtectHostname=                                            Service cannot change system host/domainname                                                    
✗ CapabilityBoundingSet=~CAP_BLOCK_SUSPEND                    Service may establish wake locks                                                                     0.1
✗ CapabilityBoundingSet=~CAP_LEASE                            Service may create file leases                                                                       0.1
✗ CapabilityBoundingSet=~CAP_SYS_PACCT                        Service may use acct()                                                                               0.1
✗ CapabilityBoundingSet=~CAP_SYS_TTY_CONFIG                   Service may issue vhangup()                                                                          0.1
✓ CapabilityBoundingSet=~CAP_WAKE_ALARM                       Service cannot program timers that wake up the system                                           
✓ RestrictAddressFamilies=~AF_UNIX                            Service cannot allocate local sockets                                                           
✗ ProcSubset=                                                 Service has full access to non-process /proc files (/proc subset=)                                   0.1

→ Overall exposure level for adguard-dnsproxy.service: 3.4 OK 🙂
</pre>
</details>
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all ~~binary files~~ systemd services
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [X] (Module addition) Added a release notes entry if adding a new NixOS module
  - [X] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
