### PR TITLE
dura: init at 0.1.0

### DIFF
--- a/pkgs/development/tools/misc/dura/default.nix
+++ b/pkgs/development/tools/misc/dura/default.nix
@@ -1,0 +1,40 @@
+{ lib, fetchFromGitHub, rustPlatform, openssl, pkg-config }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "dura";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "tkellogg";
+    repo = "dura";
+    rev = "v0.1.0";
+    sha256 = "sha256-XnsR1oL9iImtj0X7wJ8Pp/An0/AVF5y+sD551yX4IGo=";
+  };
+
+  cargoSha256 = "sha256-+Tq0a5cs2XZoT7yzTf1oIPd3kgD6SyrQqxQ1neTcMwk=";
+
+  doCheck = false;
+
+  buildInputs = [
+    openssl
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  meta = with lib; {
+    description = "A background process that saves uncommited changes on git";
+    longDescription = ''
+      Dura is a background process that watches your Git repositories and
+      commits your uncommitted changes without impacting HEAD, the current
+      branch, or the Git index (staged files). If you ever get into an
+      "oh snap!" situation where you think you just lost days of work,
+      checkout a "dura" branch and recover.
+    '';
+    homepage = "https://github.com/tkellogg/dura";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ drupol ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14602,6 +14602,8 @@ with pkgs;
 
   drush = callPackage ../development/tools/misc/drush { };
 
+  dura = callPackage ../development/tools/misc/dura { };
+
   dwfv = callPackage ../applications/science/electronics/dwfv { };
 
   dwz = callPackage ../development/tools/misc/dwz { };


### PR DESCRIPTION
###### Motivation for this change

New derivation for Nixos: [Dura](https://github.com/tkellogg/dura)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
