### PR TITLE
Start decoupling X and graphics support with `videoDrivers`

### DIFF
--- a/nixos/doc/manual/configuration/x-windows.chapter.md
+++ b/nixos/doc/manual/configuration/x-windows.chapter.md
@@ -12,7 +12,7 @@ driver from a set of X.org drivers (such as `vesa` and `intel`). You can
 also specify a driver manually, e.g.
 
 ```nix
-services.xserver.videoDrivers = [ "r128" ];
+hardware.graphics.videoDrivers = [ "r128" ];
 ```
 
 to enable X.org's `xf86-video-r128` driver.
@@ -115,11 +115,11 @@ officially updated since 2015.
 
 The results vary depending on the hardware, so you may have to try both
 drivers. Use the option
-[](#opt-services.xserver.videoDrivers)
+[](#opt-hardware.graphics.videoDrivers)
 to set one. The recommended configuration for modern systems is:
 
 ```nix
-services.xserver.videoDrivers = [ "modesetting" ];
+hardware.graphics.videoDrivers = [ "modesetting" ];
 services.xserver.useGlamor = true;
 ```
 
@@ -127,7 +127,7 @@ If you experience screen tearing no matter what, this configuration was
 reported to resolve the issue:
 
 ```nix
-services.xserver.videoDrivers = [ "intel" ];
+hardware.graphics.videoDrivers = [ "intel" ];
 services.xserver.deviceSection = ''
   Option "DRI" "2"
   Option "TearFree" "true"
@@ -144,16 +144,16 @@ better 3D performance than the X.org drivers. It is not enabled by
 default because it's not free software. You can enable it as follows:
 
 ```nix
-services.xserver.videoDrivers = [ "nvidia" ];
+hardware.graphics.videoDrivers = [ "nvidia" ];
 ```
 
 Or if you have an older card, you may have to use one of the legacy
 drivers:
 
 ```nix
-services.xserver.videoDrivers = [ "nvidiaLegacy390" ];
-services.xserver.videoDrivers = [ "nvidiaLegacy340" ];
-services.xserver.videoDrivers = [ "nvidiaLegacy304" ];
+hardware.graphics.videoDrivers = [ "nvidiaLegacy390" ];
+hardware.graphics.videoDrivers = [ "nvidiaLegacy340" ];
+hardware.graphics.videoDrivers = [ "nvidiaLegacy304" ];
 ```
 
 You may need to reboot after enabling this driver to prevent a clash
@@ -168,7 +168,7 @@ performance. If you still want to use it anyway, you need to explicitly
 set:
 
 ```nix
-services.xserver.videoDrivers = [ "amdgpu-pro" ];
+hardware.graphics.videoDrivers = [ "amdgpu-pro" ];
 ```
 
 You will need to reboot after enabling this driver to prevent a clash

--- a/nixos/doc/manual/from_md/configuration/x-windows.chapter.xml
+++ b/nixos/doc/manual/from_md/configuration/x-windows.chapter.xml
@@ -14,7 +14,7 @@ services.xserver.enable = true;
     manually, e.g.
   </para>
   <programlisting language="bash">
-services.xserver.videoDrivers = [ &quot;r128&quot; ];
+hardware.graphics.videoDrivers = [ &quot;r128&quot; ];
 </programlisting>
   <para>
     to enable X.org’s <literal>xf86-video-r128</literal> driver.
@@ -128,11 +128,11 @@ services.xserver.displayManager.autoLogin.user = &quot;alice&quot;;
     <para>
       The results vary depending on the hardware, so you may have to try
       both drivers. Use the option
-      <xref linkend="opt-services.xserver.videoDrivers" /> to set one.
+      <xref linkend="opt-hardware.graphics.videoDrivers" /> to set one.
       The recommended configuration for modern systems is:
     </para>
     <programlisting language="bash">
-services.xserver.videoDrivers = [ &quot;modesetting&quot; ];
+hardware.graphics.videoDrivers = [ &quot;modesetting&quot; ];
 services.xserver.useGlamor = true;
 </programlisting>
     <para>
@@ -140,7 +140,7 @@ services.xserver.useGlamor = true;
       configuration was reported to resolve the issue:
     </para>
     <programlisting language="bash">
-services.xserver.videoDrivers = [ &quot;intel&quot; ];
+hardware.graphics.videoDrivers = [ &quot;intel&quot; ];
 services.xserver.deviceSection = ''
   Option &quot;DRI&quot; &quot;2&quot;
   Option &quot;TearFree&quot; &quot;true&quot;
@@ -161,16 +161,16 @@ services.xserver.deviceSection = ''
       it as follows:
     </para>
     <programlisting language="bash">
-services.xserver.videoDrivers = [ &quot;nvidia&quot; ];
+hardware.graphics.videoDrivers = [ &quot;nvidia&quot; ];
 </programlisting>
     <para>
       Or if you have an older card, you may have to use one of the
       legacy drivers:
     </para>
     <programlisting language="bash">
-services.xserver.videoDrivers = [ &quot;nvidiaLegacy390&quot; ];
-services.xserver.videoDrivers = [ &quot;nvidiaLegacy340&quot; ];
-services.xserver.videoDrivers = [ &quot;nvidiaLegacy304&quot; ];
+hardware.graphics.videoDrivers = [ &quot;nvidiaLegacy390&quot; ];
+hardware.graphics.videoDrivers = [ &quot;nvidiaLegacy340&quot; ];
+hardware.graphics.videoDrivers = [ &quot;nvidiaLegacy304&quot; ];
 </programlisting>
     <para>
       You may need to reboot after enabling this driver to prevent a
@@ -187,7 +187,7 @@ services.xserver.videoDrivers = [ &quot;nvidiaLegacy304&quot; ];
       need to explicitly set:
     </para>
     <programlisting language="bash">
-services.xserver.videoDrivers = [ &quot;amdgpu-pro&quot; ];
+hardware.graphics.videoDrivers = [ &quot;amdgpu-pro&quot; ];
 </programlisting>
     <para>
       You will need to reboot after enabling this driver to prevent a

--- a/nixos/modules/hardware/graphics.nix
+++ b/nixos/modules/hardware/graphics.nix
@@ -1,0 +1,77 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  # Abbreviations.
+  cfg = config.hardware.graphics;
+  xorg = pkgs.xorg;
+
+
+in
+
+{
+
+  imports = [
+    (mkRenamedOptionModule [ "services" "xserver" "videoDrivers" ] [ "hardware" "graphics" "videoDrivers" ])
+  ];
+
+
+
+  ###### interface
+
+  options = {
+
+    hardware.graphics = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = config.services.xserver.enable;
+        description = ''
+          Whether to enable GPU support, whether for graphics like X or Wayland, or other purposes.
+        '';
+      };
+
+      videoDrivers = mkOption {
+        type = types.listOf types.str;
+        default = [ "amdgpu" "radeon" "nouveau" "modesetting" "fbdev" ];
+        example = [
+          "nvidia" "nvidiaLegacy390" "nvidiaLegacy340" "nvidiaLegacy304"
+          "amdgpu-pro"
+        ];
+        # TODO(@oxij): think how to easily add the rest, like those nvidia things
+        relatedPackages = concatLists
+          (mapAttrsToList (n: v:
+            optional (hasPrefix "xf86video" n) {
+              path  = [ "xorg" n ];
+              title = removePrefix "xf86video" n;
+            }) pkgs.xorg);
+        description = ''
+          The names of the video drivers the configuration
+          supports. They will be tried in order until one that
+          supports your card is found.
+          Don't combine those with "incompatible" OpenGL implementations,
+          e.g. free ones (mesa-based) with proprietary ones.
+
+          For unfree "nvidia*", the supported GPU lists are on
+          https://www.nvidia.com/object/unix.html
+        '';
+      };
+
+    };
+
+  };
+
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+
+  };
+
+  # uses relatedPackages
+  meta.buildDocsInSandbox = false;
+}

--- a/nixos/modules/hardware/opengl.nix
+++ b/nixos/modules/hardware/opengl.nix
@@ -8,7 +8,7 @@ let
 
   kernelPackages = config.boot.kernelPackages;
 
-  videoDrivers = config.services.xserver.videoDrivers;
+  videoDrivers = config.hardware.graphics.videoDrivers;
 
   package = pkgs.buildEnv {
     name = "opengl-drivers";
@@ -41,7 +41,7 @@ in
           like sway and Weston. It is enabled by default
           by the corresponding modules, so you do not usually have to
           set it yourself, only if there is no module for your wayland
-          compositor of choice. See services.xserver.enable and
+          compositor of choice. See hardware.graphics.enable and
           programs.sway.enable.
         '';
         type = types.bool;

--- a/nixos/modules/hardware/video/amdgpu-pro.nix
+++ b/nixos/modules/hardware/video/amdgpu-pro.nix
@@ -6,7 +6,7 @@ with lib;
 
 let
 
-  drivers = config.services.xserver.videoDrivers;
+  drivers = config.hardware.graphics.videoDrivers;
 
   enabled = elem "amdgpu-pro" drivers;
 

--- a/nixos/modules/hardware/video/displaylink.nix
+++ b/nixos/modules/hardware/video/displaylink.nix
@@ -4,7 +4,7 @@ with lib;
 
 let
 
-  enabled = elem "displaylink" config.services.xserver.videoDrivers;
+  enabled = elem "displaylink" config.hardware.graphics.videoDrivers;
 
   evdi = config.boot.kernelPackages.evdi;
 

--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -6,7 +6,7 @@ with lib;
 
 let
   nvidia_x11 = let
-    drivers = config.services.xserver.videoDrivers;
+    drivers = config.hardware.graphics.videoDrivers;
     isDeprecated = str: (hasPrefix "nvidia" str) && (str != "nvidia");
     hasDeprecated = drivers: any isDeprecated drivers;
   in if (hasDeprecated drivers) then
@@ -107,7 +107,7 @@ in
         without a multiplexer.
 
         Note that this option only has any effect if the "nvidia" driver is specified
-        in <option>services.xserver.videoDrivers</option>, and it should preferably
+        in <option>hardware.graphics.videoDrivers</option>, and it should preferably
         be the only driver there.
 
         If this is enabled, then the bus IDs of the NVIDIA and Intel GPUs have to be
@@ -341,7 +341,7 @@ in
 
     # nvidia-uvm is required by CUDA applications.
     boot.kernelModules = [ "nvidia-uvm" ] ++
-      optionals config.services.xserver.enable [ "nvidia" "nvidia_modeset" "nvidia_drm" ];
+      optionals config.hardware.graphics.enable [ "nvidia" "nvidia_modeset" "nvidia_drm" ];
 
     # If requested enable modesetting via kernel parameter.
     boot.kernelParams = optional (offloadCfg.enable || cfg.modesetting.enable) "nvidia-drm.modeset=1"

--- a/nixos/modules/installer/cd-dvd/system-tarball-sheevaplug.nix
+++ b/nixos/modules/installer/cd-dvd/system-tarball-sheevaplug.nix
@@ -134,7 +134,7 @@ in
   };
 
   # Setting vesa, we don't get the nvidia driver, which can't work in arm.
-  services.xserver.videoDrivers = [ "vesa" ];
+  hardware.graphics.videoDrivers = [ "vesa" ];
 
   documentation.nixos.enable = false;
 

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -330,7 +330,7 @@ sub findStableDevPath {
     return $dev;
 }
 
-push @attrs, "services.xserver.videoDrivers = [ \"$videoDriver\" ];" if $videoDriver;
+push @attrs, "hardware.graphics.videoDrivers = [ \"$videoDriver\" ];" if $videoDriver;
 
 # Generate the swapDevices option from the currently activated swap
 # devices.

--- a/nixos/modules/installer/virtualbox-demo.nix
+++ b/nixos/modules/installer/virtualbox-demo.nix
@@ -18,7 +18,7 @@ with lib;
 
   # Add some more video drivers to give X11 a shot at working in
   # VMware and QEMU.
-  services.xserver.videoDrivers = mkOverride 40 [ "virtualbox" "vmware" "cirrus" "vesa" "modesetting" ];
+  hardwware.graphics.videoDrivers = mkOverride 40 [ "virtualbox" "vmware" "cirrus" "vesa" "modesetting" ];
 
   powerManagement.enable = false;
   system.stateVersion = mkDefault "18.03";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -49,6 +49,7 @@
   ./hardware/corectrl.nix
   ./hardware/digitalbitbox.nix
   ./hardware/device-tree.nix
+  ./hardware/graphics.nix
   ./hardware/gkraken.nix
   ./hardware/flirc.nix
   ./hardware/gpgsmartcards.nix

--- a/nixos/modules/services/x11/display-managers/xpra.nix
+++ b/nixos/modules/services/x11/display-managers/xpra.nix
@@ -46,7 +46,7 @@ in
   ###### implementation
 
   config = mkIf cfg.enable {
-    services.xserver.videoDrivers = ["dummy"];
+    hardware.graphics.videoDrivers = ["dummy"];
 
     services.xserver.monitorSection = ''
       HorizSync   1.0 - 2000.0

--- a/nixos/modules/services/x11/terminal-server.nix
+++ b/nixos/modules/services/x11/terminal-server.nix
@@ -14,7 +14,7 @@ with lib;
   config = {
 
     services.xserver.enable = true;
-    services.xserver.videoDrivers = [];
+    hardware.graphics.videoDrivers = [];
 
     # Enable GDM.  Any display manager will do as long as it supports XDMCP.
     services.xserver.displayManager.gdm.enable = true;

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -970,7 +970,7 @@ in
 
     # When building a regular system configuration, override whatever
     # video driver the host uses.
-    services.xserver.videoDrivers = mkVMOverride [ "modesetting" ];
+    hardware.graphics.videoDrivers = mkVMOverride [ "modesetting" ];
     services.xserver.defaultDepth = mkVMOverride 0;
     services.xserver.resolutions = mkVMOverride [ cfg.resolution ];
     services.xserver.monitorSection =

--- a/nixos/modules/virtualisation/virtualbox-guest.nix
+++ b/nixos/modules/virtualisation/virtualbox-guest.nix
@@ -68,7 +68,7 @@ in
         SUBSYSTEM=="misc", KERNEL=="vboxguest", TAG+="systemd"
       '';
   } (mkIf cfg.x11 {
-    services.xserver.videoDrivers = [ "vmware" "virtualbox" "modesetting" ];
+    hardware.graphics.videoDrivers = [ "vmware" "virtualbox" "modesetting" ];
 
     services.xserver.config =
       ''

--- a/nixos/modules/virtualisation/vmware-guest.nix
+++ b/nixos/modules/virtualisation/vmware-guest.nix
@@ -63,8 +63,11 @@ in
 
     environment.etc.vmware-tools.source = "${open-vm-tools}/etc/vmware-tools/*";
 
-    services.xserver = mkIf (!cfg.headless) {
+    hardware.graphics = mkIf (!cfg.headless) {
       videoDrivers = mkOverride 50 [ "vmware" ];
+    };
+
+    services.xserver = mkIf (!cfg.headless) {
       modules = [ xf86inputvmmouse ];
 
       config = ''


### PR DESCRIPTION
###### Motivation for this change

Now that Wayland is less unviable, we should begin to refactor our
options so you don't need to use X11-named options just to do graphics
without X11.

I don't really know what I am doing, so someone please advise.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
