### PR TITLE
python3Packages.hydra: disable failing tests

### DIFF
--- a/pkgs/development/python-modules/hydra/default.nix
+++ b/pkgs/development/python-modules/hydra/default.nix
@@ -1,9 +1,18 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder, pytestCheckHook
-, importlib-resources, omegaconf, jre_headless, antlr4-python3-runtime }:
+{ lib
+, antlr4-python3-runtime
+, buildPythonPackage
+, fetchFromGitHub
+, importlib-resources
+, jre_headless
+, omegaconf
+, pytestCheckHook
+, pythonOlder
+}:
 
 buildPythonPackage rec {
   pname = "hydra";
   version = "1.1.1";
+  format = "setuptools";
 
   disabled = pythonOlder "3.6";
 
@@ -14,17 +23,35 @@ buildPythonPackage rec {
     sha256 = "sha256:1svzysrjg47gb6lxx66fzd8wbhpbbsppprpbqssf5aqvhxgay3qk";
   };
 
-  nativeBuildInputs = [ jre_headless ];
-  checkInputs = [ pytestCheckHook ];
-  propagatedBuildInputs = [ omegaconf antlr4-python3-runtime ]
-    ++ lib.optionals (pythonOlder "3.9") [ importlib-resources ];
+  nativeBuildInputs = [
+    jre_headless
+  ];
 
-  # test environment setup broken under Nix for a few tests:
+  propagatedBuildInputs = [
+    antlr4-python3-runtime
+    omegaconf
+  ] ++ lib.optionals (pythonOlder "3.9") [
+    importlib-resources
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  # Test environment setup broken under Nix for a few tests:
   disabledTests = [
     "test_bash_completion_with_dot_in_path"
     "test_install_uninstall"
+    "test_config_search_path"
   ];
-  disabledTestPaths = [ "tests/test_hydra.py" ];
+
+  disabledTestPaths = [
+    "tests/test_hydra.py"
+  ];
+
+  pythonImportsCheck = [
+    "hydra"
+  ];
 
   meta = with lib; {
     description = "A framework for configuring complex applications";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/162220417)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
