### PR TITLE
python3Packages.gradient-utils: disable metrics tests, python3Packages.gradient: 1.8.13 -> 1.9.1

### DIFF
--- a/pkgs/development/python-modules/gql/default.nix
+++ b/pkgs/development/python-modules/gql/default.nix
@@ -1,0 +1,77 @@
+{ lib
+, aiofiles
+, aiohttp
+, botocore
+, buildPythonPackage
+, fetchFromGitHub
+, graphql-core
+, mock
+, parse
+, pytest-asyncio
+, pytestCheckHook
+, pythonOlder
+, requests
+, requests-toolbelt
+, urllib3
+, vcrpy
+, websockets
+, yarl
+}:
+
+buildPythonPackage rec {
+  pname = "gql";
+  version = "3.0.0rc0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "graphql-python";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-yr1DyMj/0C9XPTyGdbQbn7nMRKr4JwItFDsqvl/goqU=";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    botocore
+    graphql-core
+    requests
+    requests-toolbelt
+    urllib3
+    websockets
+    yarl
+  ];
+
+  checkInputs = [
+    aiofiles
+    mock
+    parse
+    pytest-asyncio
+    pytestCheckHook
+    vcrpy
+  ];
+
+  disabledTests = [
+    # Tests requires network access
+    "test_execute_result_error"
+    "test_http_transport"
+  ];
+
+  disabledTestPaths = [
+    # Exclude linter tests
+    "gql-checker/tests/test_flake8_linter.py"
+    "gql-checker/tests/test_pylama_linter.py"
+  ];
+
+  pythonImportsCheck = [
+    "gql"
+  ];
+
+  meta = with lib; {
+    description = "GraphQL client in Python";
+    homepage = "https://github.com/graphql-python/gql";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/gradient-utils/default.nix
+++ b/pkgs/development/python-modules/gradient-utils/default.nix
@@ -7,6 +7,7 @@
 , poetry-core
 , prometheus-client
 , pytestCheckHook
+, pythonOlder
 , requests
 }:
 
@@ -15,6 +16,8 @@ buildPythonPackage rec {
   version = "0.5.0";
   format = "pyproject";
 
+  disabled = pythonOlder "3.6";
+
   src = fetchFromGitHub {
     owner = "Paperspace";
     repo = pname;
@@ -22,15 +25,9 @@ buildPythonPackage rec {
     sha256 = "19plkgwwfs6298vjplgsvhirixi3jbngq5y07x9c0fjxk39fa2dk";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace 'numpy = "1.18.5"' 'numpy = "^1.18.5"' \
-      --replace 'hyperopt = "0.1.2"' 'hyperopt = ">=0.1.2"' \
-      --replace 'wheel = "^0.35.1"' 'wheel = "*"' \
-      --replace 'prometheus-client = ">=0.8,<0.10"' 'prometheus-client = "*"'
-  '';
-
-  nativeBuildInputs = [ poetry-core ];
+  nativeBuildInputs = [
+    poetry-core
+  ];
 
   propagatedBuildInputs = [
     hyperopt
@@ -44,15 +41,24 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'wheel = "^0.35.1"' 'wheel = "*"' \
+      --replace 'prometheus-client = ">=0.8,<0.10"' 'prometheus-client = "*"'
+  '';
+
   preCheck = ''
     export HOSTNAME=myhost-experimentId
   '';
 
-  disabledTests = [
-    "test_add_metrics_pushes_metrics" # requires a working prometheus push gateway
+  disabledTestPaths = [
+    # Requires a working Prometheus push gateway
+    "tests/integration/test_metrics.py"
   ];
 
-  pythonImportsCheck = [ "gradient_utils" ];
+  pythonImportsCheck = [
+    "gradient_utils"
+  ];
 
   meta = with lib; {
     description = "Python utils and helpers library for Gradient";

--- a/pkgs/development/python-modules/gradient/default.nix
+++ b/pkgs/development/python-modules/gradient/default.nix
@@ -9,6 +9,7 @@
 , fetchPypi
 , gradient_statsd
 , gradient-utils
+, gql
 , halo
 , marshmallow
 , progressbar2
@@ -22,17 +23,19 @@
 
 buildPythonPackage rec {
   pname = "gradient";
-  version = "1.8.13";
+  version = "1.9.1";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0fa4a0553c28839e364d3aac27ec7292d26c1df27b8c54701d57eb7eda0b14f2";
+    hash = "sha256-zimOh4bc9EQGpqMky/etwnAF04onJ2m/KAl29IaAeAY=";
   };
 
   postPatch = ''
     substituteInPlace setup.py \
       --replace 'attrs<=' 'attrs>=' \
       --replace 'colorama==' 'colorama>=' \
+      --replace 'gql[requests]==3.0.0a6' 'gql' \
       --replace 'PyYAML==' 'PyYAML>=' \
       --replace 'marshmallow<' 'marshmallow>=' \
       --replace 'websocket-client==' 'websocket-client>='
@@ -45,6 +48,7 @@ buildPythonPackage rec {
     click-didyoumean
     click-help-colors
     colorama
+    gql
     gradient_statsd
     gradient-utils
     halo
@@ -58,8 +62,14 @@ buildPythonPackage rec {
     websocket-client
   ];
 
-  # tries to use /homeless-shelter to mimic container usage, etc
+  # Tries to use /homeless-shelter to mimic container usage, etc
   doCheck = false;
+
+  # marshmallow.exceptions.StringNotCollectionError: "only" should be a collection of strings.
+  # Support for marshmallow > 3
+  # pythonImportsCheck = [
+  #   "gradient"
+  # ];
 
   meta = with lib; {
     description = "The command line interface for Gradient";
@@ -67,8 +77,5 @@ buildPythonPackage rec {
     license = licenses.isc;
     platforms = platforms.unix;
     maintainers = with maintainers; [ thoughtpolice ];
-    # There is no support for click > 8
-    # https://github.com/Paperspace/gradient-cli/issues/368
-    broken = true;
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3419,6 +3419,8 @@ in {
 
   gpyopt = callPackage ../development/python-modules/gpyopt { };
 
+  gql = callPackage ../development/python-modules/gql { };
+
   gradient = callPackage ../development/python-modules/gradient { };
 
   gradient-utils = callPackage ../development/python-modules/gradient-utils { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/163299754)

Unbreak `gradient`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
