### PR TITLE
nixos/gnome-settings-daemon: pick up correct .wants directories

### DIFF
--- a/nixos/modules/services/desktops/gnome/gnome-settings-daemon.nix
+++ b/nixos/modules/services/desktops/gnome/gnome-settings-daemon.nix
@@ -57,26 +57,12 @@ in
       pkgs.gnome.gnome-settings-daemon
     ];
 
-    systemd.user.targets."gnome-session-initialized".wants = [
-      "gsd-color.target"
-      "gsd-datetime.target"
-      "gsd-keyboard.target"
-      "gsd-media-keys.target"
-      "gsd-print-notifications.target"
-      "gsd-rfkill.target"
-      "gsd-screensaver-proxy.target"
-      "gsd-sharing.target"
-      "gsd-smartcard.target"
-      "gsd-sound.target"
-      "gsd-wacom.target"
-      "gsd-wwan.target"
-      "gsd-a11y-settings.target"
-      "gsd-housekeeping.target"
-      "gsd-power.target"
+    systemd.user.targets."gnome-session-x11-services".wants = [
+      "org.gnome.SettingsDaemon.XSettings.service"
     ];
 
-    systemd.user.targets."gnome-session-x11-services".wants = [
-      "gsd-xsettings.target"
+    systemd.user.targets."gnome-session-x11-services-ready".wants = [
+      "org.gnome.SettingsDaemon.XSettings.service"
     ];
 
   };


### PR DESCRIPTION
###### Motivation for this change

Maybe those GSD components are managed in `/etc/systemd/user/gnome-session@gnome.target.d/gnome.session.conf` instead now...


##### g-s-d 41

```
# bobby285271 @ inspiron in /nix/store/iqzy2a6wn9bq9hqx7pqx0a153s5xlnwp-gnome-settings-daemon-41.0 [20:31:00] 
$ find | grep wants
./share/systemd/user/gnome-session-x11-services-ready.target.wants
./share/systemd/user/gnome-session-x11-services-ready.target.wants/org.gnome.SettingsDaemon.XSettings.service
./share/systemd/user/gnome-session-x11-services.target.wants
./share/systemd/user/gnome-session-x11-services.target.wants/org.gnome.SettingsDaemon.XSettings.service
```

##### g-s-d 3.34

```
# bobby285271 @ inspiron in /nix/store/armzljlnsvc1gn0nq0bncb9lf8fy32zy-gnome-settings-daemon-3.34.0 [20:31:03] 
$ find | grep wants
./lib/systemd/user/gnome-session-initialized.target.wants
./lib/systemd/user/gnome-session-initialized.target.wants/gsd-a11y-settings.target
./lib/systemd/user/gnome-session-initialized.target.wants/gsd-color.target
./lib/systemd/user/gnome-session-initialized.target.wants/gsd-datetime.target
./lib/systemd/user/gnome-session-initialized.target.wants/gsd-power.target
./lib/systemd/user/gnome-session-initialized.target.wants/gsd-housekeeping.target
./lib/systemd/user/gnome-session-initialized.target.wants/gsd-keyboard.target
./lib/systemd/user/gnome-session-initialized.target.wants/gsd-media-keys.target
./lib/systemd/user/gnome-session-initialized.target.wants/gsd-screensaver-proxy.target
./lib/systemd/user/gnome-session-initialized.target.wants/gsd-sharing.target
./lib/systemd/user/gnome-session-initialized.target.wants/gsd-sound.target
./lib/systemd/user/gnome-session-initialized.target.wants/gsd-smartcard.target
./lib/systemd/user/gnome-session-initialized.target.wants/gsd-wacom.target
./lib/systemd/user/gnome-session-initialized.target.wants/gsd-print-notifications.target
./lib/systemd/user/gnome-session-initialized.target.wants/gsd-rfkill.target
./lib/systemd/user/gnome-session-initialized.target.wants/gsd-wwan.target
./lib/systemd/user/gnome-session-x11-services.target.wants
./lib/systemd/user/gnome-session-x11-services.target.wants/gsd-xsettings.target
```
###### Things done

- Asked ofborg to test gnome and gnome-xorg.
- On NixOS 22.05.20220107.[0c56bdf](https://github.com/NixOS/nixpkgs/pull/153840/commits/0c56bdf5ff8535261a6c504f1e99f8eb640302ad) (GNOME and GNOME on Xorg):
  - Ran `systemctl --user | grep SettingsDaemon` 
  - Checked if the media keys are working.


![2022-01-07 21-54-23 的屏幕截图](https://user-images.githubusercontent.com/20080233/148553800-56139a89-3c8a-4fac-9372-e56fa4ccd8bd.png)
