### PR TITLE
dar: 2.7.1 -> 2.7.3

### DIFF
--- a/pkgs/tools/backup/dar/default.nix
+++ b/pkgs/tools/backup/dar/default.nix
@@ -1,27 +1,30 @@
 { lib, stdenv, fetchurl
+, which
 , attr, e2fsprogs
-, curl, librsync, libthreadar
+, curl, libargon2, librsync, libthreadar
 , gpgme, libgcrypt, openssl
-, bzip2, lzo, xz, zlib
+, bzip2, lz4, lzo, xz, zlib
 }:
 
 with lib;
 
 stdenv.mkDerivation rec {
-  version = "2.7.1";
+  version = "2.7.3";
   pname = "dar";
 
   src = fetchurl {
     url = "mirror://sourceforge/dar/${pname}-${version}.tar.gz";
-    sha256 = "sha256-dtreitvrgX/8eL9ZLIIASHq1ZQI0z1OVOanLxdNGvu8=";
+    sha256 = "sha256-w7005RdZKjP7XrO/h43yM0Lsho4MOKWLynJimD2oHwY=";
   };
 
   outputs = [ "out" "dev" ];
 
+  nativeBuildInputs = [ which ];
+
   buildInputs = [
     curl librsync libthreadar
-    gpgme libgcrypt openssl
-    bzip2 lzo xz zlib
+    gpgme libargon2 libgcrypt openssl
+    bzip2 lz4 lzo xz zlib
   ] ++ optionals stdenv.isLinux [ attr e2fsprogs ];
 
   configureFlags = [


### PR DESCRIPTION
###### Motivation for this change
Update dar to version 2.7.3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
