### PR TITLE
varnish: build modules for varnish 6 & 7.

### DIFF
--- a/pkgs/servers/varnish/modules.nix
+++ b/pkgs/servers/varnish/modules.nix
@@ -1,36 +1,48 @@
 { lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, varnish, docutils, removeReferencesTo }:
+let
+  common = { version, sha256, extraNativeBuildInputs ? [] }:
+    stdenv.mkDerivation rec {
+      pname = "${varnish.name}-modules";
+      inherit version;
 
-stdenv.mkDerivation rec {
-  version = "0.15.0";
-  pname = "${varnish.name}-modules";
+      src = fetchFromGitHub {
+        owner = "varnish";
+        repo = "varnish-modules";
+        rev = version;
+        inherit sha256;
+      };
 
-  src = fetchFromGitHub {
-    owner = "varnish";
-    repo = "varnish-modules";
-    rev = version;
-    sha256 = "00p9syl765lfg1d2ka7da6h46dfl388f8h36x9cmrjix95rg0yr8";
+      nativeBuildInputs = [
+        autoreconfHook
+        docutils
+        pkg-config
+        removeReferencesTo
+        varnish.python  # use same python version as varnish server
+      ];
+
+      buildInputs = [ varnish ];
+
+      postPatch = ''
+        substituteInPlace bootstrap   --replace "''${dataroot}/aclocal"                  "${varnish.dev}/share/aclocal"
+        substituteInPlace Makefile.am --replace "''${LIBVARNISHAPI_DATAROOTDIR}/aclocal" "${varnish.dev}/share/aclocal"
+      '';
+
+      postInstall = "find $out -type f -exec remove-references-to -t ${varnish.dev} '{}' +"; # varnish.dev captured only as __FILE__ in assert messages
+
+      meta = with lib; {
+        description = "Collection of Varnish Cache modules (vmods) by Varnish Software";
+        homepage = "https://github.com/varnish/varnish-modules";
+        inherit (varnish.meta) license platforms maintainers;
+      };
+    };
+in
+{
+  modules15 = common {
+    version = "0.15.1";
+    sha256 = "1lwgjhgr5yw0d17kbqwlaj5pkn70wvaqqjpa1i0n459nx5cf5pqj";
   };
-
-  nativeBuildInputs = [
-    autoreconfHook
-    docutils
-    pkg-config
-    removeReferencesTo
-    varnish.python  # use same python version as varnish server
-  ];
-
-  buildInputs = [ varnish ];
-
-  postPatch = ''
-    substituteInPlace bootstrap   --replace "''${dataroot}/aclocal"                  "${varnish.dev}/share/aclocal"
-    substituteInPlace Makefile.am --replace "''${LIBVARNISHAPI_DATAROOTDIR}/aclocal" "${varnish.dev}/share/aclocal"
-  '';
-
-  postInstall = "find $out -type f -exec remove-references-to -t ${varnish.dev} '{}' +"; # varnish.dev captured only as __FILE__ in assert messages
-
-  meta = with lib; {
-    description = "Collection of Varnish Cache modules (vmods) by Varnish Software";
-    homepage = "https://github.com/varnish/varnish-modules";
-    inherit (varnish.meta) license platforms maintainers;
+  modules19 = common {
+    version = "0.19.0";
+    sha256 = "0qq5g6bbd1a1ml1wk8jj9z39a899jzqbf7aizr3pvyz0f4kz8mis";
   };
 }

--- a/pkgs/servers/varnish/packages.nix
+++ b/pkgs/servers/varnish/packages.nix
@@ -1,6 +1,7 @@
-{ callPackage, varnish60, varnish70, fetchFromGitHub }: {
+{ callPackages, callPackage, varnish60, varnish70, fetchFromGitHub }: {
   varnish60Packages = rec {
     varnish = varnish60;
+    modules = (callPackages ./modules.nix { inherit varnish; }).modules15;
     digest  = callPackage ./digest.nix {
       inherit varnish;
       version = "libvmod-digest-1.0.2";
@@ -14,6 +15,7 @@
   };
   varnish70Packages = rec {
     varnish = varnish70;
+    modules = (callPackages ./modules.nix { inherit varnish; }).modules19;
     digest  = callPackage ./digest.nix {
       inherit varnish;
       version = "6.6";


### PR DESCRIPTION


###### Motivation for this change

varnish-modules for varnish 7 were not available from nixpkgs, and were not built for varnish 6.

not a breaking change: candidate for backport to nixos-21.11.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
