### PR TITLE
nixos/test-driver: fix #153766

### DIFF
--- a/nixos/lib/test-driver/default.nix
+++ b/nixos/lib/test-driver/default.nix
@@ -14,7 +14,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "nixos-test-driver";
-  version = "1.1";
+  version = "1.1.1";
   src = ./.;
 
   propagatedBuildInputs = [ coreutils netpbm python3Packages.colorama python3Packages.ptpython qemu_pkg socat vde2 ]

--- a/nixos/lib/test-driver/test_driver/__init__.py
+++ b/nixos/lib/test-driver/test_driver/__init__.py
@@ -36,6 +36,13 @@ class EnvDefault(argparse.Action):
 def main() -> None:
     arg_parser = argparse.ArgumentParser(prog="nixos-test-driver")
     arg_parser.add_argument(
+        "-o",
+        "--output-dir",
+        help="specify the directory where the output (screenshots, etc.) should be placed",
+        default=None,
+        type=Path,
+    )
+    arg_parser.add_argument(
         "-K",
         "--keep-vm-state",
         help="re-use a VM state coming from a previous run",
@@ -77,7 +84,11 @@ def main() -> None:
         rootlog.info("Machine state will be reset. To keep it, pass --keep-vm-state")
 
     with Driver(
-        args.start_scripts, args.vlans, args.testscript.read_text(), args.keep_vm_state
+        start_scripts=args.start_scripts,
+        vlans=args.vlans,
+        tests=args.testscript.read_text(),
+        keep_vm_state=args.keep_vm_state,
+        out_dir=args.output_dir,
     ) as driver:
         if args.interactive:
             ptpython.repl.embed(driver.test_symbols(), {})

--- a/nixos/lib/test-driver/test_driver/driver.py
+++ b/nixos/lib/test-driver/test_driver/driver.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Union, Optional, Callable, ContextManager
+from typing import Any, Callable, ContextManager, Dict, Iterator, List, Optional, Union
 import os
 import tempfile
 
@@ -25,6 +25,7 @@ class Driver:
         vlans: List[int],
         tests: str,
         keep_vm_state: bool = False,
+        out_dir: Optional[Path] = None,
     ):
         self.tests = tests
 
@@ -47,6 +48,7 @@ class Driver:
                 name=cmd.machine_name,
                 tmp_dir=tmp_dir,
                 callbacks=[self.check_polling_conditions],
+                out_dir=out_dir,
             )
             for cmd in cmd(start_scripts)
         ]

--- a/nixos/lib/test-driver/test_driver/machine.py
+++ b/nixos/lib/test-driver/test_driver/machine.py
@@ -328,7 +328,7 @@ class Machine:
         self,
         tmp_dir: Path,
         start_command: StartCommand,
-        out_dir: Optional[Path] = None,
+        out_dir: Path,
         name: str = "machine",
         keep_vm_state: bool = False,
         allow_reboot: bool = False,
@@ -339,11 +339,8 @@ class Machine:
         self.allow_reboot = allow_reboot
         self.name = name
         self.start_command = start_command
-        self.callbacks = callbacks if callbacks is not None else []
-
-        if out_dir is None:
-            out_dir = Path(".").resolve()
         self.out_dir = out_dir
+        self.callbacks = callbacks if callbacks is not None else []
 
         # set up directories
         self.shared_dir = self.tmp_dir / "shared-xchg"

--- a/nixos/lib/test-driver/test_driver/machine.py
+++ b/nixos/lib/test-driver/test_driver/machine.py
@@ -342,7 +342,7 @@ class Machine:
         self.callbacks = callbacks if callbacks is not None else []
 
         if out_dir is None:
-            out_dir = Path(".")
+            out_dir = Path(".").resolve()
         self.out_dir = out_dir
 
         # set up directories

--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -30,7 +30,7 @@ rec {
           # effectively mute the XMLLogger
           export LOGFILE=/dev/null
 
-          ${driver}/bin/nixos-test-driver
+          ${driver}/bin/nixos-test-driver --output-dir "$out"
         '';
 
       passthru = driver.passthru // {


### PR DESCRIPTION
###### Motivation for this change

Fixes #153766, alternative to #153854

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
