### PR TITLE
python3Packages.treex: init at 0.6.7

### DIFF
--- a/pkgs/development/python-modules/treex/default.nix
+++ b/pkgs/development/python-modules/treex/default.nix
@@ -1,0 +1,71 @@
+{ buildPythonPackage
+, cloudpickle
+, dm-haiku
+, einops
+, fetchFromGitHub
+, flax
+, hypothesis
+, keras
+, lib
+, poetry-core
+, pytestCheckHook
+, pyyaml
+, rich
+, tensorflow
+, treeo
+}:
+
+buildPythonPackage rec {
+  pname = "treex";
+  version = "0.6.7";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "cgarciae";
+    repo = pname;
+    rev = version;
+    sha256 = "1hl3wj71c7cp7jzkhyjy7xgs2vc8c89icq0bgfr49y4pwv69n43m";
+  };
+
+  patches = [
+    ./relax-deps.patch
+  ];
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    einops
+    flax
+    pyyaml
+    rich
+    treeo
+  ];
+
+  checkInputs = [
+    cloudpickle
+    dm-haiku
+    hypothesis
+    keras
+    pytestCheckHook
+    tensorflow
+  ];
+
+  pythonImportsCheck = [
+    "treex"
+  ];
+
+  disabledTestPaths = [
+    # Require `torchmetrics` which is not packaged in `nixpkgs`.
+    "tests/metrics/test_mean_absolute_error.py"
+    "tests/metrics/test_mean_square_error.py"
+  ];
+
+  meta = with lib; {
+    description = "Pytree Module system for Deep Learning in JAX";
+    homepage = "https://github.com/cgarciae/treex";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ndl ];
+  };
+}

--- a/pkgs/development/python-modules/treex/relax-deps.patch
+++ b/pkgs/development/python-modules/treex/relax-deps.patch
@@ -1,0 +1,13 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 7b9ef68..ec11f32 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -18,7 +18,7 @@ python = "^3.7"
+ flax = "^0.3.4"
+ PyYAML = "^5.4.1"
+ rich = "^10.7.0"
+-optax = "^0.0.9"
++optax = ">=0.0.9"
+ einops = "^0.3.2"
+ treeo = "^0.0.9"
+ # treeo = { path = "../treeo", develop = true }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9808,6 +9808,8 @@ in {
 
   treeo = callPackage ../development/python-modules/treeo { };
 
+  treex = callPackage ../development/python-modules/treex { };
+
   treq = callPackage ../development/python-modules/treq { };
 
   trezor_agent = callPackage ../development/python-modules/trezor_agent { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Part of "extra JAX libraries / frameworks" implementation, see the discussion in #152754

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
