### PR TITLE
nixos/luksroot: Add unlock FIDO2 authenticator

### DIFF
--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -172,7 +172,7 @@ let
                     echo -n "${dev.device}" > /crypt-ramfs/device
 
                     # and try reading it from /dev/console with a timeout
-                    IFS= read -t 1 -r passphrase
+                    IFS= read -t 1 -rs passphrase
                     if [ -n "$passphrase" ]; then
                        ${if luks.reusePassphrases then ''
                          # remember it for the next device
@@ -265,7 +265,7 @@ let
                     break
                 else
                     # Try reading it from /dev/console with a timeout
-                    IFS= read -t 1 -r k_user
+                    IFS= read -t 1 -rs k_user
                     if [ -n "$k_user" ]; then
                        ${if luks.reusePassphrases then ''
                          # Remember it for the next device
@@ -373,7 +373,7 @@ let
                     break
                 else
                     # and try reading it from /dev/console with a timeout
-                    IFS= read -t 1 -r pin
+                    IFS= read -t 1 -rs pin
                     if [ -n "$pin" ]; then
                        ${if luks.reusePassphrases then ''
                          # remember it for the next device

--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -432,7 +432,7 @@ let
           echo "Please move your mouse to create needed randomness."
         ''}
           echo "Waiting for your FIDO2 device..."
-          fido2luks open ${dev.device} ${dev.name} ${dev.fido2.credential} --await-dev ${toString dev.fido2.gracePeriod} --salt string:$passphrase
+          setsid cttyhack fido2luks open ${dev.device} ${dev.name} ${dev.fido2.credential} ${optionalString dev.fido2.unlockAuthenticator "--pin"} --await-dev ${toString dev.fido2.gracePeriod} --salt string:$passphrase
         if [ $? -ne 0 ]; then
           echo "No FIDO2 key found, falling back to normal open procedure"
           open_normally
@@ -697,6 +697,14 @@ in
                 Defines whatever to use an empty string as a default salt.
 
                 Enable only when your device is PIN protected, such as <link xlink:href="https://trezor.io/">Trezor</link>.
+              '';
+            };
+
+            unlockAuthenticator = mkOption {
+              default = false;
+              type = types.bool;
+              description = ''
+                Request a pin to unlock the authenticator
               '';
             };
           };


### PR DESCRIPTION
###### Motivation for this change

Add possibility to unlock the FIDO2 authenticator for luksroot.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
