### PR TITLE
yosys: Add yosys-symbiflow-plugins

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8874,6 +8874,12 @@
     githubId = 72201;
     name = "Ole Jørgen Brønner";
   };
+  ollieB = {
+    email = "1237862+oliverbunting@users.noreply.github.com";
+    github = "oliverbunting";
+    githubId = 1237862;
+    name = "Ollie Bunting";
+  };
   olynch = {
     email = "owen@olynch.me";
     github = "olynch";

--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -6,13 +6,19 @@
 , fetchFromGitHub
 , flex
 , libffi
+, makeWrapper
 , pkg-config
 , protobuf
 , python3
 , readline
+, symlinkJoin
 , tcl
 , verilog
 , zlib
+, yosys
+, yosys-bluespec
+, yosys-ghdl
+, yosys-symbiflow
 }:
 
 # NOTE: as of late 2020, yosys has switched to an automation robot that
@@ -32,7 +38,39 @@
 # yosys version number helps users report better bugs upstream, and is
 # ultimately less confusing than using dates.
 
-stdenv.mkDerivation rec {
+let
+
+  # Provides a wrapper for creating a yosys with the specifed plugins preloaded
+  #
+  # Example:
+  #
+  #     my_yosys = yosys.withPlugins (with yosys.allPlugins; [
+  #        fasm
+  #        bluespec
+  #     ]);
+  withPlugins = plugins:
+    let
+      paths = lib.closePropagation plugins;
+      module_flags = with builtins; concatStringsSep " "
+        (map (n: "--add-flags -m --add-flags ${n.plugin}") plugins);
+    in lib.appendToName "with-plugins" ( symlinkJoin {
+      inherit (yosys) name;
+      paths = paths ++ [ yosys ] ;
+      buildInputs = [ makeWrapper ];
+      postBuild = ''
+        wrapProgram $out/bin/yosys \
+          --set NIX_YOSYS_PLUGIN_DIRS $out/share/yosys/plugins \
+          ${module_flags}
+      '';
+    });
+
+  allPlugins = {
+    bluespec = yosys-bluespec;
+    ghdl     = yosys-ghdl;
+  } // (yosys-symbiflow);
+
+
+in stdenv.mkDerivation rec {
   pname   = "yosys";
   version = "0.12+54";
 
@@ -98,6 +136,10 @@ stdenv.mkDerivation rec {
   postInstall = "ln -sfv ${abc-verifier}/bin/abc $out/bin/yosys-abc";
 
   setupHook = ./setup-hook.sh;
+
+  passthru = {
+    inherit withPlugins allPlugins;
+  };
 
   meta = with lib; {
     description = "Open RTL synthesis framework and tools";

--- a/pkgs/development/compilers/yosys/plugins/bluespec.nix
+++ b/pkgs/development/compilers/yosys/plugins/bluespec.nix
@@ -5,6 +5,7 @@
 stdenv.mkDerivation {
   pname = "yosys-bluespec";
   version = "2021.09.08";
+  plugin = "bluespec";
 
   src = fetchFromGitHub {
     owner  = "thoughtpolice";

--- a/pkgs/development/compilers/yosys/plugins/ghdl.nix
+++ b/pkgs/development/compilers/yosys/plugins/ghdl.nix
@@ -5,6 +5,7 @@
 stdenv.mkDerivation {
   pname = "yosys-ghdl";
   version = "2021.01.25";
+  plugin = "ghdl";
 
   src = fetchFromGitHub {
     owner  = "ghdl";

--- a/pkgs/development/compilers/yosys/plugins/symbiflow-pmgen.patch
+++ b/pkgs/development/compilers/yosys/plugins/symbiflow-pmgen.patch
@@ -1,0 +1,15 @@
+diff --git a/yql-qlf-plugin/Makefile b/ql-qlf-plugin/Makefile
+index 2819055c9fe..0e391581012 100644
+--- a/ql-qlf-plugin/Makefile
++++ b/ql-qlf-plugin/Makefile
+@@ -55,10 +55,6 @@ VERILOG_MODULES = $(COMMON)/cells_sim.v         \
+                   $(PP3_DIR)/mult_sim.v        \
+                   $(PP3_DIR)/qlal3_sim.v       \
+
+-retrieve-pmgen:=$(shell mkdir -p pmgen && wget -nc -O pmgen/pmgen.py https://raw.githubusercontent.com/SymbiFlow/yosys/master%2Bwip/passes/pmgen/pmgen.py)
+-
+-pre-build:=$(shell python3 pmgen/pmgen.py -o pmgen/ql-dsp-pm.h -p ql_dsp ql_dsp.pmg)
+-
+ install_modules: $(VERILOG_MODULES)
+ 	$(foreach f,$^,install -D $(f) $(DATA_DIR)/quicklogic/$(f);)
+

--- a/pkgs/development/compilers/yosys/plugins/symbiflow.nix
+++ b/pkgs/development/compilers/yosys/plugins/symbiflow.nix
@@ -1,0 +1,106 @@
+{ fetchFromGitHub
+, gtest
+, lib
+, python3
+, readline
+, stdenv
+, which
+, yosys
+, zlib
+, yosys-symbiflow
+}: let
+
+  src = fetchFromGitHub {
+    owner  = "SymbiFlow";
+    repo   = "yosys-symbiflow-plugins";
+    rev    = "35c6c33811a8de7c80dff6a7bcf7aa6ec9b21233";
+    hash   = "sha256-g5dX9+R+gWt8e7Bhbbg60O9qa+Vi6Ar0M1sHhYlAre8=";
+  };
+
+  version = "2022.01.06";
+
+  # Supported symbiflow plugins.
+  #
+  # The following are disabled:
+  #
+  # "ql-qlf" builds but fails to load the plugin, so is not currently supported.
+  #
+  # "UHDM" doesn't currently build, as the work to package UHDM and surelog has
+  # not (yet) been undertaken.
+  plugins = [
+    "design_introspection"
+    "fasm"
+    "integrateinv"
+    "params"
+    "ql-iob"
+    # "ql-qlf"
+    "sdc"
+    "xdc"
+    # "UHDM"
+  ];
+
+  static_gtest = gtest.dev.overrideAttrs (old: {
+    dontDisableStatic = true;
+    disableHardening = [ "pie" ];
+    cmakeFlags = old.cmakeFlags ++ ["-DBUILD_SHARED_LIBS=OFF"];
+  });
+
+in lib.genAttrs plugins (plugin: stdenv.mkDerivation (rec {
+  pname = "yosys-symbiflow-${plugin}-plugin";
+  inherit src version plugin;
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ which python3 ];
+  buildInputs = [ yosys readline zlib ] ;
+
+  # xdc has an incorrect path to a test which has yet to be patched
+  doCheck = plugin != "xdc";
+  checkInputs = [ static_gtest ];
+
+  # ql-qlf tries to fetch a yosys script from github
+  # Run the script in preBuild instead.
+  patches = lib.optional ( plugin == "ql-qlf" ) ./symbiflow-pmgen.patch;
+
+  preBuild = ''
+    mkdir -p ql-qlf-plugin/pmgen
+  ''
+  + lib.optionalString ( plugin == "ql-qlf" ) ''
+    python3 ${yosys.src}/passes/pmgen/pmgen.py -o ql-qlf-plugin/pmgen/ql-dsp-pm.h -p ql_dsp ql-qlf-plugin/ql_dsp.pmg
+  '';
+
+  # Providing a symlink avoids the need for patching the test makefile
+  postUnpack = ''
+    mkdir -p source/third_party/googletest/googletest/build/
+    ln -s ${static_gtest}/lib source/third_party/googletest/googletest/build/lib
+  '';
+
+  makeFlags = [
+    "PLUGIN_LIST=${plugin}"
+  ];
+
+  buildFlags = [
+    "PLUGINS_DIR=\${out}/share/yosys/plugins/"
+    "DATA_DIR=\${out}/share/yosys/"
+  ];
+
+  checkFlags = [
+    "PLUGINS_DIR=\${NIX_BUILD_TOP}/source/${plugin}-plugin"
+    "DATA_DIR=\${NIX_BUILD_TOP}/source/${plugin}-plugin"
+    ( "NIX_YOSYS_PLUGIN_DIRS=\${NIX_BUILD_TOP}/source/${plugin}-plugin"
+      # sdc and xdc plugins use design introspection for their tests
+      + (lib.optionalString ( plugin == "sdc" || plugin == "xdc" )
+        ":${yosys-symbiflow.design_introspection}/share/yosys/plugins/")
+    )
+  ];
+
+  installFlags = buildFlags;
+
+  meta = with lib; {
+    description = "Symbiflow ${plugin} plugin for Yosys";
+    license     = licenses.isc;
+    platforms   = platforms.all;
+    maintainers = with maintainers; [ ollieB thoughtpolice ];
+  };
+}))
+
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13315,6 +13315,7 @@ with pkgs;
   yosys = callPackage ../development/compilers/yosys { };
   yosys-bluespec = callPackage ../development/compilers/yosys/plugins/bluespec.nix { };
   yosys-ghdl = callPackage ../development/compilers/yosys/plugins/ghdl.nix { };
+  yosys-symbiflow = callPackage ../development/compilers/yosys/plugins/symbiflow.nix { };
 
   z88dk = callPackage ../development/compilers/z88dk { };
 


### PR DESCRIPTION
###### Motivation for this change

This PR adds (most) of these [plugins](https://github.com/SymbiFlow/yosys-symbiflow-plugins). In addition, the familiar `withPlugins` pattern is to wrap yosys, which loads yosys with the plugins preloaded.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
