### PR TITLE
gfold: init at 3.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10781,6 +10781,16 @@
     githubId = 6720672;
     name = "Shane Pearlman";
   };
+  shanesveller = {
+    email = "shane@sveller.dev";
+    github = "shanesveller";
+    githubId = 831;
+    keys = [{
+      longkeyid = "rsa4096/0x9210C218023C15CD";
+      fingerprint = "F83C 407C ADC4 5A0F 1F2F  44E8 9210 C218 023C 15CD";
+    }];
+    name = "Shane Sveller";
+  };
   shawndellysse = {
     email = "sdellysse@gmail.com";
     github = "shawndellysse";

--- a/pkgs/applications/version-management/git-and-tools/gfold/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gfold/default.nix
@@ -1,0 +1,30 @@
+{ lib, fetchFromGitHub, gitMinimal, makeWrapper, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "gfold";
+  version = "3.0.0";
+
+  src = fetchFromGitHub {
+    owner = "nickgerace";
+    repo = pname;
+    rev = version;
+    sha256 = "0ss6vfrc6h3jlh5qilh82psd3vdnfawf1wl4cf64mfm4hm9dda63";
+  };
+
+  cargoSha256 = "09ywwgxm8l1p0jypp65zpqryjnb2g4gririf1dmqb9148dsj29x2";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram "$out/bin/gfold" --prefix PATH : "${gitMinimal}/bin"
+  '';
+
+  meta = with lib; {
+    inherit (src.meta) homepage;
+    description =
+      "A tool to help keep track of your Git repositories, written in Rust";
+    license = licenses.asl20;
+    maintainers = [ maintainers.shanesveller ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5619,6 +5619,8 @@ with pkgs;
 
   gfbgraph = callPackage ../development/libraries/gfbgraph { };
 
+  gfold = callPackage ../applications/version-management/git-and-tools/gfold { };
+
   ggobi = callPackage ../tools/graphics/ggobi { };
 
   gh = callPackage ../applications/version-management/git-and-tools/gh { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Introduces a new package, [gfold](https://github.com/nickgerace/gfold), which is a CLI allowing bulk read-only review of the local git state of a tree of folders containing cloned/bare repositories. 

Example usage:
```shell
gfold [--classic] path/to/some/tree
```

Example output:
```
# default
nixpkgs ~ /path/to/nixpkgs
  clean (shanesveller/gfold-3.0)
  git@github.com:shanesveller/nixpkgs.git
  <email>
# --classic
nixpkgs  clean  shanesveller/gfold-3.0  git@github.com:shanesveller/nixpkgs.git
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
