### PR TITLE
Aether: avoid srcs usage, refactor

### DIFF
--- a/pkgs/applications/networking/aether/default.nix
+++ b/pkgs/applications/networking/aether/default.nix
@@ -9,31 +9,27 @@
 
 let
   binaryName = "AetherP2P";
+  aether-app-git = fetchFromGitHub {
+    owner = "aethereans";
+    repo = "aether-app";
+    rev = "53b6c8b2a9253cbf056ea3ebb077e0e08cbc5b1d";
+    sha256 = "1kgkzh7ih2q9dsckdkinh5dbzvr7gdykf8yz6h8pyhvzyjhk1v0r";
+  };
 in
 stdenv.mkDerivation rec {
   pname = "aether";
   version = "2.0.0-dev.15";
 
-  srcs = [
-    (fetchurl {
-      url = "https://static.getaether.net/Releases/Aether-${version}/2011262249.19338c93/linux/Aether-${version}%2B2011262249.19338c93.tar.gz";
-      sha256 = "1hi8w83zal3ciyzg2m62shkbyh6hj7gwsidg3dn88mhfy68himf7";
-      # % in the url / canonical filename causes an error
-      name = "aether-tarball.tar.gz";
-    })
-    (fetchFromGitHub {
-      owner = "aethereans";
-      repo = "aether-app";
-      rev = "53b6c8b2a9253cbf056ea3ebb077e0e08cbc5b1d";
-      sha256 = "1kgkzh7ih2q9dsckdkinh5dbzvr7gdykf8yz6h8pyhvzyjhk1v0r";
-    })
-  ];
-
-  sourceRoot = "Aether-${version}+2011262249.19338c93";
+  src = fetchurl {
+    url = "https://static.getaether.net/Releases/Aether-${version}/2011262249.19338c93/linux/Aether-${version}%2B2011262249.19338c93.tar.gz";
+    sha256 = "1hi8w83zal3ciyzg2m62shkbyh6hj7gwsidg3dn88mhfy68himf7";
+    # % in the url / canonical filename causes an error
+    name = "aether-tarball.tar.gz";
+  };
 
   # there is no logo in the tarball so we grab it from github and convert it in the build phase
   buildPhase = ''
-    convert ../source/aether-core/aether/client/src/app/ext_dep/images/Linux-Windows-App-Icon.png -resize 512x512 aether.png
+    convert ${aether-app-git}/aether-core/aether/client/src/app/ext_dep/images/Linux-Windows-App-Icon.png -resize 512x512 aether.png
   '';
 
   dontWrapGApps = true;


### PR DESCRIPTION
###### Motivation for this change
Avoid confusion about second source.

related: #153386

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
