### PR TITLE
netdata: 1.31.0 -> 1.32.1

### DIFF
--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -16,14 +16,14 @@ with lib;
 let
   go-d-plugin = callPackage ./go.d.plugin.nix {};
 in stdenv.mkDerivation rec {
-  version = "1.31.0";
+  version = "1.32.1";
   pname = "netdata";
 
   src = fetchFromGitHub {
     owner = "netdata";
     repo = "netdata";
     rev = "v${version}";
-    sha256 = "0735cxmljrp8zlkcq7hcxizy4j4xiv7vf782zkz5chn06n38mcik";
+    sha256 = "sha256-DbuR3x7d6synJELOxI+frK4LY9zFgPKmY7hGY8B5z7o=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/tools/system/netdata/go.d.plugin.nix
+++ b/pkgs/tools/system/netdata/go.d.plugin.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "netdata-go.d.plugin";
-  version = "0.28.1";
+  version = "0.31.0";
 
   src = fetchFromGitHub {
     owner = "netdata";
     repo = "go.d.plugin";
     rev = "v${version}";
-    sha256 = "0i77nvqi3dcby0gr3b06bai170q2ibp5390qfjijrk1yqz6x6sd5";
+    sha256 = "sha256-wS8+C03K/qn8zKIAQvZ7nF7CmFfIvKU/dtm80bTeniM=";
   };
 
-  vendorSha256 = "1q8z4smaxzqd5iwvbnkkr33c3b94rjwa3xjirwlr595g0wn93wc7";
+  vendorSha256 = "sha256-17/f6tAxDD5TgjmwnqAlnQSxDhnFidjsN55/sUMDej8=";
 
   doCheck = false;
 

--- a/pkgs/tools/system/netdata/no-files-in-etc-and-var.patch
+++ b/pkgs/tools/system/netdata/no-files-in-etc-and-var.patch
@@ -25,10 +25,10 @@ index 03c7f0a94..01985db01 100644
  
  chartsconfigdir=$(libconfigdir)/charts.d
 diff --git a/collectors/ebpf.plugin/Makefile.am b/collectors/ebpf.plugin/Makefile.am
-index 18b1fc6c8..b4b0c7852 100644
+index 2d5f92a6b..8b11c7502 100644
 --- a/collectors/ebpf.plugin/Makefile.am
 +++ b/collectors/ebpf.plugin/Makefile.am
-@@ -13,7 +13,7 @@ SUFFIXES = .in
+@@ -9,7 +9,7 @@ SUFFIXES = .in
  userebpfconfigdir=$(configdir)/ebpf.d
  
  # Explicitly install directories to avoid permission issues due to umask
@@ -36,7 +36,7 @@ index 18b1fc6c8..b4b0c7852 100644
 +no-install-exec-local:
  	$(INSTALL) -d $(DESTDIR)$(userebpfconfigdir)
  
- dist_plugins_SCRIPTS = \
+ dist_noinst_DATA = \
 diff --git a/collectors/node.d.plugin/Makefile.am b/collectors/node.d.plugin/Makefile.am
 index c3142d433..95e324455 100644
 --- a/collectors/node.d.plugin/Makefile.am
@@ -75,7 +75,7 @@ index 71f2d468d..2c9ced2bf 100644
 +no-install-exec-local:
  	$(INSTALL) -d $(DESTDIR)$(userstatsdconfigdir)
 diff --git a/health/Makefile.am b/health/Makefile.am
-index b963ea0cd..6979e69bf 100644
+index 349b86d61..514f1874f 100644
 --- a/health/Makefile.am
 +++ b/health/Makefile.am
 @@ -19,7 +19,7 @@ dist_userhealthconfig_DATA = \
@@ -88,14 +88,26 @@ index b963ea0cd..6979e69bf 100644
  
  healthconfigdir=$(libconfigdir)/health.d
 diff --git a/system/Makefile.am b/system/Makefile.am
-index 5323738c9..06e1b6a73 100644
+index a88ccab65..bda6ee2b6 100644
 --- a/system/Makefile.am
 +++ b/system/Makefile.am
-@@ -20,11 +20,10 @@ include $(top_srcdir)/build/subst.inc
+@@ -3,7 +3,6 @@
+ 
+ MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
+ CLEANFILES = \
+-    edit-config \
+     netdata-openrc \
+     netdata.logrotate \
+     netdata.service \
+@@ -20,15 +19,13 @@ include $(top_srcdir)/build/subst.inc
  SUFFIXES = .in
  
  dist_config_SCRIPTS = \
 -    edit-config \
+     $(NULL)
+ 
+ dist_config_DATA = \
+-    .install-type \
      $(NULL)
  
  # Explicitly install directories to avoid permission issues due to umask


### PR DESCRIPTION
###### Motivation for this change
﻿Update netdata:
- netdata: go.d.plugin: 0.28.1 -> 0.31.0
- netdata: 1.31.0 -> 1.32.1

cc @Mic92 @TilCreator
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
