### PR TITLE
Idris2: Use derivation provided by idris2 project

### DIFF
--- a/pkgs/development/compilers/idris2/default.nix
+++ b/pkgs/development/compilers/idris2/default.nix
@@ -1,96 +1,83 @@
-{ lib
-, stdenv
+{ stdenv
+, lib
+, chez
+, chez-racket
+, clang
+, gmp
 , fetchFromGitHub
 , makeWrapper
-, clang
-, chez
-, gmp
+, gambit
+, nodejs
 , zsh
 , callPackage
 }:
 
-# NOTICE: An `idris2WithPackages` is available at: https://github.com/claymager/idris2-pkgs
+let
+  idris2-version = "0.5.1";  # When updating this, remove postInstall override below
 
-# Uses scheme to bootstrap the build of idris2
-stdenv.mkDerivation rec {
-  pname = "idris2";
-  version = "0.5.1";
-
-  src = fetchFromGitHub {
+  idris2-src = fetchFromGitHub {
     owner = "idris-lang";
     repo = "Idris2";
-    rev = "v${version}";
+    rev = "v${idris2-version}";
     sha256 = "sha256-6CTn8o5geWSesXO7vTrrV/2EOQ3f+nPQ2M5cem13ZSY=";
   };
 
-  # We do not add any propagatedNativeBuildInputs because we do not want the
-  # executables idris2 produces to depend on the nix-store. As such, it is left
-  # to the user to guarantee chez (or any other codgen dependency) is available
-  # in the path during compilation of programs with idris2.
-  strictDeps = true;
-  nativeBuildInputs = [ makeWrapper clang chez ]
-    ++ lib.optional stdenv.isDarwin [ zsh ];
-  buildInputs = [ gmp ];
+  idris2-derivation = callPackage "${idris2-src}/nix/package.nix" {
+    inherit idris2-version;
+    srcRev = "dirty";
+    # This is taken from idris2/flake.nix. Check every now and then
+    # if they still do the same thing.
+    chez = if stdenv.isLinux then chez else chez-racket;
+  };
 
-  prePatch = ''
-    patchShebangs --build tests
-  '';
+  # Backport of fix for macOS as tracked in github issue #150521
+  # The override of postInstall can be removed as soon as idris2-version
+  # is larger than 0.5.1
+  # To do this, just remove the definition of idirs2-derivation-backport-fix
+  # and replace it with idris2-derivation in the "in" expression below.
+  idris2-derivation-backport-fix = idris2-derivation.overrideAttrs (attrs: {
+    postInstall = let
+      name = idris2-derivation.name;
 
-  makeFlags = [ "PREFIX=$(out)" ]
-    ++ lib.optional stdenv.isDarwin "OS=";
-
-  # The name of the main executable of pkgs.chez is `scheme`
-  buildFlags = [ "bootstrap" "SCHEME=scheme" ];
-
-  checkTarget = "test";
-
-  # TODO: Move this into its own derivation, such that this can be changed
-  #       without having to recompile idris2 every time.
-  postInstall = let
-    includedLibs = [ "base" "contrib" "network" "prelude" ];
-    name = "${pname}-${version}";
-    packagePaths =
-      builtins.map (l: "$out/${name}/${l}-${version}") includedLibs;
-    additionalIdris2Paths = builtins.concatStringsSep ":" packagePaths;
-  in ''
-    # Remove existing idris2 wrapper that sets incorrect LD_LIBRARY_PATH
-    rm $out/bin/idris2
-    # Move actual idris2 binary
-    mv $out/bin/idris2_app/idris2.so $out/bin/idris2
-
-    # After moving the binary, there is nothing left in idris2_app that isn't
-    # either contained in lib/ or is useless to us.
-    rm $out/bin/idris2_app/*
-    rmdir $out/bin/idris2_app
-
-    # idris2 needs to find scheme at runtime to compile
-    # idris2 installs packages with --install into the path given by PREFIX.
-    # Since PREFIX is in nix-store, it is immutable so --install does not work.
-    # If the user redefines PREFIX to be able to install packages, idris2 will
-    # not find the libraries and packages since all paths are relative to
-    # PREFIX by default.
-    # We explicitly make all paths to point to nix-store, such that they are
-    # independent of what IDRIS2_PREFIX is. This allows the user to redefine
-    # IDRIS2_PREFIX and use --install as expected.
-    # TODO: Make support libraries their own derivation such that
-    #       overriding LD_LIBRARY_PATH is unnecessary
-    # TODO: Maybe set IDRIS2_PREFIX to the users home directory
-    wrapProgram "$out/bin/idris2" \
-      --set-default CHEZ "${chez}/bin/scheme" \
-      --suffix IDRIS2_LIBS ':' "$out/${name}/lib" \
-      --suffix IDRIS2_DATA ':' "$out/${name}/support" \
-      --suffix IDRIS2_PATH ':' "${additionalIdris2Paths}" \
-      --suffix ${if stdenv.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH"} ':' "$out/${name}/lib"
-  '';
-
-  # Run package tests
-  passthru.tests = callPackage ./tests.nix { inherit pname; };
-
+      globalLibraries = [
+        "\\$HOME/.nix-profile/lib/${name}"
+        "/run/current-system/sw/lib/${name}"
+        "$out/${name}"
+      ];
+      globalLibrariesPath = builtins.concatStringsSep ":" globalLibraries;
+    in ''
+      # Remove existing idris2 wrapper that sets incorrect LD_LIBRARY_PATH
+      rm $out/bin/idris2
+      # The only thing we need from idris2_app is the actual binary
+      mv $out/bin/idris2_app/idris2.so $out/bin/idris2
+      rm $out/bin/idris2_app/*
+      rmdir $out/bin/idris2_app
+      # idris2 needs to find scheme at runtime to compile
+      # idris2 installs packages with --install into the path given by
+      #   IDRIS2_PREFIX. We set that to a default of ~/.idris2, to mirror the
+      #   behaviour of the standard Makefile install.
+      # TODO: Make support libraries their own derivation such that
+      #       overriding LD_LIBRARY_PATH is unnecessary
+      wrapProgram "$out/bin/idris2" \
+        --set-default CHEZ "${chez}/bin/scheme" \
+        --run 'export IDRIS2_PREFIX=''${IDRIS2_PREFIX-"$HOME/.idris2"}' \
+        --suffix IDRIS2_LIBS ':' "$out/${name}/lib" \
+        --suffix IDRIS2_DATA ':' "$out/${name}/support" \
+        --suffix IDRIS2_PACKAGE_PATH ':' "${globalLibrariesPath}" \
+        --suffix DYLD_LIBRARY_PATH ':' "$out/${name}/lib" \
+        --suffix LD_LIBRARY_PATH ':' "$out/${name}/lib"
+    '';
+  });
+in idris2-derivation-backport-fix // {
   meta = {
     description = "A purely functional programming language with first class types";
     homepage = "https://github.com/idris-lang/Idris2";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ fabianhjr wchresta ];
-    inherit (chez.meta) platforms;
+    platforms = lib.subtractLists chez.meta.platforms lib.platforms.aarch64;
   };
+
+  # Run package tests
+  tests = callPackage ./tests.nix { pname = idris2-derivation.pname; };
 }
+

--- a/pkgs/development/compilers/idris2/tests.nix
+++ b/pkgs/development/compilers/idris2/tests.nix
@@ -50,6 +50,7 @@ in {
   # Data.Vect.Sort is available via --package contrib
   use-contrib = testCompileAndRun {
     testName = "use-contrib";
+    packages = [ "contrib" ];
     code = ''
       module Main
 


### PR DESCRIPTION
Since we created the nix derivation in nixpkgs, the idris2 project
has incorporated our derivation and improved on it. By now, the
derivation managed by the project has many more features than ours.
Furthermore, it would be unwise for us not to reuse the derivation
that is provided by the project maintainers themselves.

Improvements on the derivation should be done upstream in the
project, whenever possible, instead of overwriting them here.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
