### PR TITLE
nixos/test-driver: add Machine.record_audio

### DIFF
--- a/nixos/lib/test-driver/test_driver/machine.py
+++ b/nixos/lib/test-driver/test_driver/machine.py
@@ -746,7 +746,7 @@ class Machine:
 
         def capture_info() -> Optional[Tuple[int, int]]:
             output = self.send_monitor_command("info capture")
-            lines = output.split("\r\n")
+            lines = output.splitlines()
             for line in lines:
                 match = info_capture_regex.match(line)
                 if match is None:

--- a/nixos/lib/test-driver/test_driver/machine.py
+++ b/nixos/lib/test-driver/test_driver/machine.py
@@ -1,7 +1,7 @@
-from contextlib import _GeneratorContextManager
+from contextlib import _GeneratorContextManager, contextmanager
 from pathlib import Path
 from queue import Queue
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Iterator
 import base64
 import io
 import os
@@ -129,6 +129,13 @@ def retry(fn: Callable, timeout: int = 900) -> None:
 
     if not fn(True):
         raise Exception(f"action timed out after {timeout} seconds")
+
+
+def add_extension_if_simple_name(filename: str, extension: str) -> str:
+    word_pattern = re.compile(r"^[\w\-]+$")
+    if word_pattern.match(filename):
+        filename = f"{filename}.{extension}"
+    return filename
 
 
 class StartCommand:
@@ -719,6 +726,77 @@ class Machine:
             os.unlink(tmp)
             if ret.returncode != 0:
                 raise Exception("Cannot convert screenshot")
+
+    @contextmanager
+    def record_audio(
+        self,
+        filename: str,
+        allow_silence: bool = False,
+        device: str = "audio_device",
+        sample_rate: int = 44100,
+        bit_depth: int = 16,
+        channels: int = 2,
+    ) -> Iterator[None]:
+        filename = add_extension_if_simple_name(filename, "wav")
+        out_path = self.out_dir / filename
+
+        info_capture_regex = re.compile(
+            r"^\[(\d+)\]: Capturing audio\(\d+,\d+,\d+\) to (.*): (\d+) bytes$",
+        )
+
+        def capture_info() -> Optional[Tuple[int, int]]:
+            output = self.send_monitor_command("info capture")
+            lines = output.split("\r\n")
+            for line in lines:
+                match = info_capture_regex.match(line)
+                if match is None:
+                    continue
+                if match[2] != str(out_path):
+                    continue
+                idx = int(match[1])
+                n_bytes = int(match[3])
+                return idx, n_bytes
+            return None
+
+        if capture_info() is not None:
+            raise Exception("Capture already running...?")
+
+        res = self.send_monitor_command(
+            f"wavcapture {out_path} {device} {sample_rate} {bit_depth} {channels}"
+        )
+
+        if f"Audiodev '{device}' not found" in res:
+            msg = f"Audio device {repr(device)} not found"
+            if device == "audio_device":
+                msg += " (is virtualisation.audio = true set?)"
+            raise Exception(msg)
+
+        r = capture_info()
+        if r is None:
+            raise Exception("Could not start capture...", res)
+
+        assert r is not None
+        capture_idx: int = r[0]
+
+        yield
+
+        r = capture_info()
+        if r is None:
+            raise Exception(
+                f"Recording {capture_idx} ({out_path}) stopped prematurely?"
+            )
+
+        assert r is not None
+        n_bytes = r[1]
+        if n_bytes == 0 and not allow_silence:
+            raise Exception("No audio recorded!")
+
+        self.send_monitor_command(f"stopcapture {capture_idx}")
+
+        if capture_info() is not None:
+            raise Exception(
+                f"Recording {capture_idx} ({out_path}) could not be stopped"
+            )
 
     def copy_from_host_via_shell(self, source: str, target: str) -> None:
         """Copy a file from the host into the guest by piping it over the

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -382,6 +382,17 @@ in
           '';
       };
 
+    virtualisation.audio =
+      mkOption {
+        type = types.bool;
+        default = false;
+        description =
+          ''
+            Whether to add an audio device to QEMU. This is just visible to
+            the guest, and not passed through to the host.
+          '';
+      };
+
     virtualisation.cores =
       mkOption {
         type = types.ints.positive;
@@ -856,6 +867,10 @@ in
       ])
       (mkIf (!cfg.graphics) [
         "-nographic"
+      ])
+      # TODO: ALSA driver might be preferred, but it's laggy as can be. Investigate?
+      (mkIf (cfg.audio) [
+        "-soundhw hda -audiodev id=audio_device,driver=pa"
       ])
     ];
 

--- a/nixos/tests/firefox.nix
+++ b/nixos/tests/firefox.nix
@@ -13,77 +13,11 @@ import ./make-test-python.nix ({ pkgs, firefoxPackage, ... }: {
         pkgs.xdotool
       ];
 
-      # Create a virtual sound device, with mixing
-      # and all, for recording audio.
-      boot.kernelModules = [ "snd-aloop" ];
       sound.enable = true;
-      sound.extraConfig = ''
-        pcm.!default {
-          type plug
-          slave.pcm pcm.dmixer
-        }
-        pcm.dmixer {
-          type dmix
-          ipc_key 1
-          slave {
-            pcm "hw:Loopback,0,0"
-            rate 48000
-            periods 128
-            period_time 0
-            period_size 1024
-            buffer_size 8192
-          }
-        }
-        pcm.recorder {
-          type hw
-          card "Loopback"
-          device 1
-          subdevice 0
-        }
-      '';
-
-      systemd.services.audio-recorder = {
-        description = "Record NixOS test audio to /tmp/record.wav";
-        script = "${pkgs.alsa-utils}/bin/arecord -D recorder -f S16_LE -r48000 /tmp/record.wav";
-      };
-
+      virtualisation.audio = true;
     };
 
   testScript = ''
-      from contextlib import contextmanager
-
-
-      @contextmanager
-      def audio_recording(machine: Machine) -> None:
-          """
-          Perform actions while recording the
-          machine audio output.
-          """
-          machine.systemctl("start audio-recorder")
-          yield
-          machine.systemctl("stop audio-recorder")
-
-
-      def wait_for_sound(machine: Machine) -> None:
-          """
-          Wait until any sound has been emitted.
-          """
-          machine.wait_for_file("/tmp/record.wav")
-          while True:
-              # Get at most 2M of the recording
-              machine.execute("tail -c 2M /tmp/record.wav > /tmp/last")
-              # Get the exact size
-              size = int(machine.succeed("stat -c '%s' /tmp/last").strip())
-              # Compare it against /dev/zero using `cmp` (skipping 50B of WAVE header).
-              # If some non-NULL bytes are found it returns 1.
-              status, output = machine.execute(
-                  f"cmp -i 50 -n {size - 50} /tmp/last /dev/zero 2>&1"
-              )
-              if status == 1:
-                  break
-              machine.sleep(2)
-
-
       machine.wait_for_x()
 
       with subtest("Wait until Firefox has finished loading the Valgrind docs page"):
@@ -94,12 +28,12 @@ import ./make-test-python.nix ({ pkgs, firefoxPackage, ... }: {
           machine.sleep(40)
 
       with subtest("Check whether Firefox can play sound"):
-          with audio_recording(machine):
+          with machine.record_audio("record"):
               machine.succeed(
                   "firefox file://${pkgs.sound-theme-freedesktop}/share/sounds/freedesktop/stereo/phone-incoming-call.oga >&2 &"
               )
-              wait_for_sound(machine)
-          machine.copy_from_vm("/tmp/record.wav")
+              machine.wait_for_window("phone-incoming-call.oga")
+              machine.sleep(10)
 
       with subtest("Close sound test tab"):
           machine.execute("xdotool key ctrl+w")

--- a/nixos/tests/mpd.nix
+++ b/nixos/tests/mpd.nix
@@ -97,17 +97,18 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
 
   testScript = ''
     mpc = "${pkgs.mpc-cli}/bin/mpc --wait"
+    start_all()
 
     # Connects to the given server and attempts to play a tune.
     def play_some_music(server):
         server.wait_for_unit("mpd.service")
         server.succeed(f"{mpc} update")
-        _, tracks = server.execute(f"{mpc} ls")
+        tracks = server.succeed(f"{mpc} ls")
 
         for track in tracks.splitlines():
             server.succeed(f"{mpc} add {track}")
 
-        _, added_tracks = server.execute(f"{mpc} playlist")
+        added_tracks = server.succeed(f"{mpc} playlist")
 
         # Check we succeeded adding audio tracks to the playlist
         assert len(added_tracks.splitlines()) > 0
@@ -115,7 +116,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
         with server.record_audio(server.name):
             server.succeed(f"{mpc} play")
 
-            _, output = server.execute(f"{mpc} status")
+            output = server.succeed(f"{mpc} status")
             # Assure audio track is playing
             assert "playing" in output
 

--- a/nixos/tests/pulseaudio.nix
+++ b/nixos/tests/pulseaudio.nix
@@ -13,7 +13,7 @@ let
           pkgs.writeScriptBin key ''
             set -euxo pipefail
             ${sox}/bin/play ${testFile}
-            ${sox}/bin/sox ${testFile} -t wav - | ${alsa-utils}/bin/aplay
+            # ${sox}/bin/sox ${testFile} -t wav - | ${alsa-utils}/bin/aplay
             touch /tmp/${key}_success
           '';
 

--- a/nixos/tests/pulseaudio.nix
+++ b/nixos/tests/pulseaudio.nix
@@ -36,7 +36,7 @@ let
               support32Bit = true;
               inherit systemWide;
             };
-
+            virtualisation.audio = true;
             environment.systemPackages = [ testers.testPlay pkgs.pavucontrol ]
               ++ lib.optional pkgs.stdenv.isx86_64 testers.testPlay32;
           } // lib.optionalAttrs systemWide {
@@ -47,16 +47,22 @@ let
         enableOCR = true;
 
         testScript = { ... }: ''
+          import platform
+
+          tests = ['testPlay']
+          if platform.machine() == "x86_64":
+              tests.append('testPlay32')
+
           machine.wait_until_succeeds("pgrep xterm")
           machine.wait_for_text("alice@machine")
 
-          machine.send_chars("testPlay \n")
-          machine.wait_for_file("/tmp/testPlay_success")
-          ${lib.optionalString pkgs.stdenv.isx86_64 ''
-            machine.send_chars("testPlay32 \n")
-            machine.wait_for_file("/tmp/testPlay32_success")
-          ''}
-          machine.screenshot("testPlay")
+          for test in tests:
+              machine.send_chars(test)
+              with machine.record_audio(test):
+                  machine.send_key("ret")
+                  machine.wait_for_file(f"/tmp/{test}_success")
+              machine.screenshot(test)
+              machine.send_key("ctrl-l")
 
           # Pavucontrol only loads when Pulseaudio is running. If it isn't, the
           # text "Playback" (one of the tabs) will never show.


### PR DESCRIPTION
###### Motivation for this change

Allows you to record audio from a VM and verify that sound actually played.
Depends on #153866

###### TODO:

 - [ ] Write some docs 
 - [ ] Get ALSA driver to work for QEMU? It's so choppy on my machine it's actually interfering with the proper functioning of the machine (cage threw a warning that "my machine is too slow" 😅)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
