### PR TITLE
deluge: 2.0.3 -> 2.0.5

### DIFF
--- a/pkgs/applications/networking/p2p/deluge/default.nix
+++ b/pkgs/applications/networking/p2p/deluge/default.nix
@@ -13,26 +13,12 @@
 
 pythonPackages.buildPythonPackage rec {
   pname = "deluge";
-  version = "2.0.3";
+  version = "2.0.5";
 
   src = fetchurl {
     url = "http://download.deluge-torrent.org/source/2.0/${pname}-${version}.tar.xz";
-    sha256 = "14d8kn2pvr1qv8mwqrxmj85jycr73vwfqz12hzag0ararbkfhyky";
+    sha256 = "sha256-xL0Eq/0hG2Uhi+A/PEbSb0QCSITeEOAYWfuFb91vJdg=";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/deluge-torrent/deluge/commit/d6c96d629183e8bab2167ef56457f994017e7c85.patch";
-      sha256 = "sha256-slGMt2bgp36pjDztJUXFeZNbzdJsus0s9ARRD6IpNUw=";
-      name = "fix_ngettext_warning.patch";
-    })
-
-    (fetchpatch {
-      url = "https://github.com/deluge-torrent/deluge/commit/351664ec071daa04161577c6a1c949ed0f2c3206.patch";
-      sha256 = "sha256-ry1LFgMe9lys66xAvATcPqIa3rzBPWVnsf8FL1dXkHo=";
-      name = "fix_logging_on_py38.patch";
-    })
-  ];
 
   propagatedBuildInputs = with pythonPackages; [
     twisted


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).