### PR TITLE
Misc updates

### DIFF
--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -1,15 +1,13 @@
-{ lib, stdenv, fetchurl, pkg-config
-
-, abiVersion ? "6"
-, mouseSupport ? false
-, unicode ? true
-, enableStatic ? stdenv.hostPlatform.isStatic
-, enableShared ? !enableStatic
-, withCxx ? !stdenv.hostPlatform.useAndroidPrebuilt
-
-, gpm
-
+{ lib
+, stdenv
+, fetchurl
 , buildPackages
+, pkg-config
+, abiVersion ? "6"
+, enableStatic ? stdenv.hostPlatform.isStatic
+, withCxx ? !stdenv.hostPlatform.useAndroidPrebuilt
+, mouseSupport ? false, gpm
+, unicodeSupport ? true
 }:
 
 stdenv.mkDerivation rec {
@@ -31,13 +29,13 @@ stdenv.mkDerivation rec {
   setOutputFlags = false; # some aren't supported
 
   configureFlags = [
-    (lib.withFeature enableShared "shared")
+    (lib.withFeature (!enableStatic) "shared")
     "--without-debug"
     "--enable-pc-files"
     "--enable-symlinks"
     "--with-manpage-format=normal"
     "--disable-stripping"
-  ] ++ lib.optional unicode "--enable-widec"
+  ] ++ lib.optional unicodeSupport "--enable-widec"
     ++ lib.optional (!withCxx) "--without-cxx"
     ++ lib.optional (abiVersion == "5") "--with-abi-version=5"
     ++ lib.optional stdenv.hostPlatform.isNetBSD "--enable-rpath"
@@ -49,12 +47,16 @@ stdenv.mkDerivation rec {
   # Only the C compiler, and explicitly not C++ compiler needs this flag on solaris:
   CFLAGS = lib.optionalString stdenv.isSunOS "-D_XOPEN_SOURCE_EXTENDED";
 
-  depsBuildBuild = [ buildPackages.stdenv.cc ];
+  depsBuildBuild = [
+    buildPackages.stdenv.cc
+  ];
+
   nativeBuildInputs = [
     pkg-config
   ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
     buildPackages.ncurses
   ];
+
   buildInputs = lib.optional (mouseSupport && stdenv.isLinux) gpm;
 
   preConfigure = ''
@@ -147,31 +149,26 @@ stdenv.mkDerivation rec {
     rm "$out"/lib/*.a
   '';
 
-  meta = {
-    description = "Free software emulation of curses in SVR4 and more";
-
-    longDescription = ''
-      The Ncurses (new curses) library is a free software emulation of
-      curses in System V Release 4.0, and more.  It uses Terminfo
-      format, supports pads and color and multiple highlights and
-      forms characters and function-key mapping, and has all the other
-      SYSV-curses enhancements over BSD Curses.
-
-      The ncurses code was developed under GNU/Linux.  It has been in
-      use for some time with OpenBSD as the system curses library, and
-      on FreeBSD and NetBSD as an external package.  It should port
-      easily to any ANSI/POSIX-conforming UNIX.  It has even been
-      ported to OS/2 Warp!
-    '';
-
+  meta = with lib; {
     homepage = "https://www.gnu.org/software/ncurses/";
+    description = "Free software emulation of curses in SVR4 and more";
+    longDescription = ''
+      The Ncurses (new curses) library is a free software emulation of curses in
+      System V Release 4.0, and more. It uses Terminfo format, supports pads and
+      color and multiple highlights and forms characters and function-key
+      mapping, and has all the other SYSV-curses enhancements over BSD Curses.
 
-    license = lib.licenses.mit;
-    platforms = lib.platforms.all;
+      The ncurses code was developed under GNU/Linux. It has been in use for
+      some time with OpenBSD as the system curses library, and on FreeBSD and
+      NetBSD as an external package. It should port easily to any
+      ANSI/POSIX-conforming UNIX. It has even been ported to OS/2 Warp!
+    '';
+    license = licenses.mit;
+    platforms = platforms.all;
   };
 
   passthru = {
     ldflags = "-lncurses";
-    inherit unicode abiVersion;
+    inherit unicodeSupport abiVersion;
   };
 }

--- a/pkgs/tools/misc/dialog/default.nix
+++ b/pkgs/tools/misc/dialog/default.nix
@@ -8,7 +8,7 @@
 }:
 
 assert withLibrary -> libtool != null;
-assert unicodeSupport -> ncurses.unicode && ncurses != null;
+assert unicodeSupport -> ncurses.unicodeSupport && ncurses != null;
 
 stdenv.mkDerivation rec {
   pname = "dialog";

--- a/pkgs/tools/misc/spigot/default.nix
+++ b/pkgs/tools/misc/spigot/default.nix
@@ -33,6 +33,17 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    [ `$out/bin/spigot -b 10 -d 10 e` == "2.7182818284" ] || exit 1
+    [ `$out/bin/spigot -b 10 -d 10 pi` == "3.1415926535" ] || exit 1
+    [ `$out/bin/spigot -b 10 -d 10 sqrt\(2\)` == "1.4142135623" ] || exit 1
+
+    runHook postInstallCheck
+  '';
+
   meta = with lib; {
     homepage = "https://www.chiark.greenend.org.uk/~sgtatham/spigot/";
     description = "A command-line exact real calculator";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
