### PR TITLE
notcurses: 2.4.9 -> 3.0.3

### DIFF
--- a/pkgs/development/libraries/notcurses/default.nix
+++ b/pkgs/development/libraries/notcurses/default.nix
@@ -1,51 +1,63 @@
-{ stdenv
+{ lib
+, stdenv
+, fetchFromGitHub
 , cmake
-, pkg-config
-, pandoc
+, libdeflate
 , libunistring
 , ncurses
+, pandoc
+, pkg-config
 , zlib
-, ffmpeg
-, fetchFromGitHub
-, lib
-, multimediaSupport ? true
+, multimediaSupport ? true, ffmpeg
+, qrcodegenSupport ? true, qrcodegen
 }:
 
 stdenv.mkDerivation rec {
   pname = "notcurses";
-  version = "2.4.9";
+  version = "3.0.3";
 
   src = fetchFromGitHub {
     owner = "dankamongmen";
     repo = "notcurses";
     rev = "v${version}";
-    sha256 = "sha256-J7yTNMvmcm69B+yF0PYLXFG8kkcnffWyUx3kEFU0ToI=";
+    sha256 = "sha256-jIUIr7roX9ciYkNmvS9m14RdNgFTElwrKadYzi0lCP0=";
   };
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ cmake pkg-config pandoc ];
+  nativeBuildInputs = [
+    cmake
+    pandoc
+    pkg-config
+  ];
 
-  buildInputs = [ libunistring ncurses zlib ]
-    ++ lib.optional multimediaSupport ffmpeg;
+  buildInputs = [
+    libdeflate
+    libunistring
+    ncurses
+    zlib
+  ]
+  ++ lib.optional qrcodegenSupport qrcodegen
+  ++ lib.optional multimediaSupport ffmpeg;
 
-  cmakeFlags = [ "-DUSE_QRCODEGEN=OFF" ]
+  cmakeFlags =
+    lib.optional (qrcodegenSupport) "-DUSE_QRCODEGEN=ON"
     ++ lib.optional (!multimediaSupport) "-DUSE_MULTIMEDIA=none";
 
   meta = with lib; {
-    description = "blingful TUIs and character graphics";
+    homepage = "https://github.com/dankamongmen/notcurses";
+    description = "Blingful TUIs and character graphics";
     longDescription = ''
-      A library facilitating complex TUIs on modern terminal emulators,
-      supporting vivid colors, multimedia, and Unicode to the maximum degree
-      possible. Things can be done with Notcurses that simply can't be done
-      with NCURSES.
+      Notcurses is a library facilitating complex TUIs on modern terminal
+      emulators, supporting vivid colors, multimedia, and Unicode to the maximum
+      degree possible. Things can be done with Notcurses that simply can't be
+      done with NCURSES.
 
       It is not a source-compatible X/Open Curses implementation, nor a
       replacement for NCURSES on existing systems.
     '';
-    homepage = "https://github.com/dankamongmen/notcurses";
     license = licenses.asl20;
-    platforms = platforms.all;
-    maintainers = with maintainers; [ jb55 ];
+    maintainers = with maintainers; [ jb55 AndersonTorres ];
+    inherit (ncurses.meta) platforms;
   };
 }

--- a/pkgs/development/libraries/qrcodegen/default.nix
+++ b/pkgs/development/libraries/qrcodegen/default.nix
@@ -1,4 +1,8 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib
+, stdenv
+, fetchFromGitHub
+}:
+
 stdenv.mkDerivation rec {
   pname = "qrcodegen";
   version = "1.7.0";
@@ -10,25 +14,27 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-WH6O3YE/+NNznzl52TXZYL+6O25GmKSnaFqDDhRl4As=";
   };
 
-  preBuild = "cd c";
+  preBuild = ''
+    cd c/
+  '';
+
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/lib $out/include/qrcodegen
     cp libqrcodegen.a $out/lib
     cp qrcodegen.h $out/include/qrcodegen/
+
+    runHook postInstall
   '';
 
-  meta = with lib;
-    {
-      description = "qrcode generator library in multiple languages";
-
-      longDescription = ''
-        This project aims to be the best, clearest library for generating QR Codes. My primary goals are flexible options and absolute correctness. Secondary goals are compact implementation size and good documentation comments.
-      '';
-
-      homepage = "https://github.com/nayuki/QR-Code-generator";
-
-      license = licenses.mit;
-      platforms = platforms.all;
-      maintainers = with maintainers; [ mcbeth ];
-    };
+  meta = with lib; {
+    homepage = "https://www.nayuki.io/page/qr-code-generator-library";
+    description = "High-quality QR Code generator library in many languages";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mcbeth AndersonTorres ];
+    platforms = platforms.unix;
+  };
 }
+# TODO: build the other languages
+# TODO: multiple outputs

--- a/pkgs/development/libraries/qrcodegen/default.nix
+++ b/pkgs/development/libraries/qrcodegen/default.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ mcbeth AndersonTorres ];
     platforms = platforms.unix;
+    broken = stdenv.isDarwin;
   };
 }
 # TODO: build the other languages


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
