### PR TITLE
Fix kubernetes

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/addon-manager.nix
+++ b/nixos/modules/services/cluster/kubernetes/addon-manager.nix
@@ -167,4 +167,5 @@ in
     };
   };
 
+  meta.buildDocsInSandbox = false;
 }

--- a/nixos/modules/services/cluster/kubernetes/addons/dns.nix
+++ b/nixos/modules/services/cluster/kubernetes/addons/dns.nix
@@ -363,4 +363,6 @@ in {
 
     services.kubernetes.kubelet.clusterDns = mkDefault cfg.clusterIp;
   };
+
+  meta.buildDocsInSandbox = false;
 }

--- a/nixos/modules/services/cluster/kubernetes/apiserver.nix
+++ b/nixos/modules/services/cluster/kubernetes/apiserver.nix
@@ -496,4 +496,5 @@ in
 
   ];
 
+  meta.buildDocsInSandbox = false;
 }

--- a/nixos/modules/services/cluster/kubernetes/controller-manager.nix
+++ b/nixos/modules/services/cluster/kubernetes/controller-manager.nix
@@ -171,4 +171,6 @@ in
 
     services.kubernetes.controllerManager.kubeconfig.server = mkDefault top.apiserverAddress;
   };
+
+  meta.buildDocsInSandbox = false;
 }

--- a/nixos/modules/services/cluster/kubernetes/controller-manager.nix
+++ b/nixos/modules/services/cluster/kubernetes/controller-manager.nix
@@ -6,7 +6,6 @@ let
   top = config.services.kubernetes;
   otop = options.services.kubernetes;
   cfg = top.controllerManager;
-  klib = options.services.kubernetes.lib.default;
 in
 {
   imports = [
@@ -57,7 +56,7 @@ in
       type = int;
     };
 
-    kubeconfig = klib.mkKubeConfigOptions "Kubernetes controller manager";
+    kubeconfig = top.lib.mkKubeConfigOptions "Kubernetes controller manager";
 
     leaderElect = mkOption {
       description = "Whether to start leader election before executing main loop.";
@@ -130,7 +129,7 @@ in
             "--cluster-cidr=${cfg.clusterCidr}"} \
           ${optionalString (cfg.featureGates != [])
             "--feature-gates=${concatMapStringsSep "," (feature: "${feature}=true") cfg.featureGates}"} \
-          --kubeconfig=${klib.mkKubeConfig "kube-controller-manager" cfg.kubeconfig} \
+          --kubeconfig=${top.lib.mkKubeConfig "kube-controller-manager" cfg.kubeconfig} \
           --leader-elect=${boolToString cfg.leaderElect} \
           ${optionalString (cfg.rootCaFile!=null)
             "--root-ca-file=${cfg.rootCaFile}"} \
@@ -157,7 +156,7 @@ in
       path = top.path;
     };
 
-    services.kubernetes.pki.certs = with klib; {
+    services.kubernetes.pki.certs = with top.lib; {
       controllerManager = mkCert {
         name = "kube-controller-manager";
         CN = "kube-controller-manager";

--- a/nixos/modules/services/cluster/kubernetes/default.nix
+++ b/nixos/modules/services/cluster/kubernetes/default.nix
@@ -313,4 +313,6 @@ in {
                           else "${cfg.masterAddress}:${toString cfg.apiserver.securePort}"}");
     })
   ];
+
+  meta.buildDocsInSandbox = false;
 }

--- a/nixos/modules/services/cluster/kubernetes/default.nix
+++ b/nixos/modules/services/cluster/kubernetes/default.nix
@@ -193,8 +193,6 @@ in {
         inherit mkKubeConfigOptions;
       };
       type = types.attrs;
-      readOnly = true;
-      internal = true;
     };
 
     secretsPath = mkOption {

--- a/nixos/modules/services/cluster/kubernetes/flannel.nix
+++ b/nixos/modules/services/cluster/kubernetes/flannel.nix
@@ -95,4 +95,6 @@ in
 
     };
   };
+
+  meta.buildDocsInSandbox = false;
 }

--- a/nixos/modules/services/cluster/kubernetes/kubelet.nix
+++ b/nixos/modules/services/cluster/kubernetes/kubelet.nix
@@ -395,4 +395,6 @@ in
     })
 
   ];
+
+  meta.buildDocsInSandbox = false;
 }

--- a/nixos/modules/services/cluster/kubernetes/kubelet.nix
+++ b/nixos/modules/services/cluster/kubernetes/kubelet.nix
@@ -6,7 +6,6 @@ let
   top = config.services.kubernetes;
   otop = options.services.kubernetes;
   cfg = top.kubelet;
-  klib = options.services.kubernetes.lib.default;
 
   cniConfig =
     if cfg.cni.config != [] && cfg.cni.configDir != null then
@@ -28,7 +27,7 @@ let
     config.Cmd = ["/bin/pause"];
   };
 
-  kubeconfig = klib.mkKubeConfig "kubelet" cfg.kubeconfig;
+  kubeconfig = top.lib.mkKubeConfig "kubelet" cfg.kubeconfig;
 
   manifestPath = "kubernetes/manifests";
 
@@ -178,7 +177,7 @@ in
       type = str;
     };
 
-    kubeconfig = klib.mkKubeConfigOptions "Kubelet";
+    kubeconfig = top.lib.mkKubeConfigOptions "Kubelet";
 
     manifests = mkOption {
       description = "List of manifests to bootstrap with kubelet (only pods can be created as manifest entry)";
@@ -359,7 +358,7 @@ in
       services.kubernetes.kubelet.hostname = with config.networking;
         mkDefault (hostName + optionalString (domain != null) ".${domain}");
 
-      services.kubernetes.pki.certs = with klib; {
+      services.kubernetes.pki.certs = with top.lib; {
         kubelet = mkCert {
           name = "kubelet";
           CN = top.kubelet.hostname;

--- a/nixos/modules/services/cluster/kubernetes/pki.nix
+++ b/nixos/modules/services/cluster/kubernetes/pki.nix
@@ -401,4 +401,6 @@ in
         };
       };
     });
+
+  meta.buildDocsInSandbox = false;
 }

--- a/nixos/modules/services/cluster/kubernetes/pki.nix
+++ b/nixos/modules/services/cluster/kubernetes/pki.nix
@@ -1,11 +1,10 @@
-{ config, options, lib, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 
 with lib;
 
 let
   top = config.services.kubernetes;
   cfg = top.pki;
-  klib = options.services.kubernetes.lib;
 
   csrCA = pkgs.writeText "kube-pki-cacert-csr.json" (builtins.toJSON {
     key = {
@@ -30,7 +29,7 @@ let
   cfsslAPITokenLength = 32;
 
   clusterAdminKubeconfig = with cfg.certs.clusterAdmin;
-    klib.mkKubeConfig "cluster-admin" {
+    top.lib.mkKubeConfig "cluster-admin" {
         server = top.apiserverAddress;
         certFile = cert;
         keyFile = key;
@@ -251,7 +250,7 @@ in
       # - it would be better with a more Nix-oriented way of managing addons
       systemd.services.kube-addon-manager = mkIf top.addonManager.enable (mkMerge [{
         environment.KUBECONFIG = with cfg.certs.addonManager;
-          klib.mkKubeConfig "addon-manager" {
+          top.lib.mkKubeConfig "addon-manager" {
             server = top.apiserverAddress;
             certFile = cert;
             keyFile = key;
@@ -344,7 +343,7 @@ in
       '';
 
       services.flannel = with cfg.certs.flannelClient; {
-        kubeconfig = klib.mkKubeConfig "flannel" {
+        kubeconfig = top.lib.mkKubeConfig "flannel" {
           server = top.apiserverAddress;
           certFile = cert;
           keyFile = key;

--- a/nixos/modules/services/cluster/kubernetes/proxy.nix
+++ b/nixos/modules/services/cluster/kubernetes/proxy.nix
@@ -97,4 +97,6 @@ in
 
     services.kubernetes.proxy.kubeconfig.server = mkDefault top.apiserverAddress;
   };
+
+  meta.buildDocsInSandbox = false;
 }

--- a/nixos/modules/services/cluster/kubernetes/proxy.nix
+++ b/nixos/modules/services/cluster/kubernetes/proxy.nix
@@ -6,7 +6,6 @@ let
   top = config.services.kubernetes;
   otop = options.services.kubernetes;
   cfg = top.proxy;
-  klib = options.services.kubernetes.lib.default;
 in
 {
   imports = [
@@ -44,7 +43,7 @@ in
       type = str;
     };
 
-    kubeconfig = klib.mkKubeConfigOptions "Kubernetes proxy";
+    kubeconfig = top.lib.mkKubeConfigOptions "Kubernetes proxy";
 
     verbosity = mkOption {
       description = ''
@@ -73,7 +72,7 @@ in
           ${optionalString (cfg.featureGates != [])
             "--feature-gates=${concatMapStringsSep "," (feature: "${feature}=true") cfg.featureGates}"} \
           --hostname-override=${cfg.hostname} \
-          --kubeconfig=${klib.mkKubeConfig "kube-proxy" cfg.kubeconfig} \
+          --kubeconfig=${top.lib.mkKubeConfig "kube-proxy" cfg.kubeconfig} \
           ${optionalString (cfg.verbosity != null) "--v=${toString cfg.verbosity}"} \
           ${cfg.extraOpts}
         '';
@@ -89,7 +88,7 @@ in
     services.kubernetes.proxy.hostname = with config.networking; mkDefault hostName;
 
     services.kubernetes.pki.certs = {
-      kubeProxyClient = klib.mkCert {
+      kubeProxyClient = top.lib.mkCert {
         name = "kube-proxy-client";
         CN = "system:kube-proxy";
         action = "systemctl restart kube-proxy.service";

--- a/nixos/modules/services/cluster/kubernetes/scheduler.nix
+++ b/nixos/modules/services/cluster/kubernetes/scheduler.nix
@@ -96,4 +96,6 @@ in
 
     services.kubernetes.scheduler.kubeconfig.server = mkDefault top.apiserverAddress;
   };
+
+  meta.buildDocsInSandbox = false;
 }

--- a/nixos/modules/services/cluster/kubernetes/scheduler.nix
+++ b/nixos/modules/services/cluster/kubernetes/scheduler.nix
@@ -6,7 +6,6 @@ let
   top = config.services.kubernetes;
   otop = options.services.kubernetes;
   cfg = top.scheduler;
-  klib = options.services.kubernetes.lib.default;
 in
 {
   ###### interface
@@ -33,7 +32,7 @@ in
       type = listOf str;
     };
 
-    kubeconfig = klib.mkKubeConfigOptions "Kubernetes scheduler";
+    kubeconfig = top.lib.mkKubeConfigOptions "Kubernetes scheduler";
 
     leaderElect = mkOption {
       description = "Whether to start leader election before executing main loop.";
@@ -70,7 +69,7 @@ in
           --address=${cfg.address} \
           ${optionalString (cfg.featureGates != [])
             "--feature-gates=${concatMapStringsSep "," (feature: "${feature}=true") cfg.featureGates}"} \
-          --kubeconfig=${klib.mkKubeConfig "kube-scheduler" cfg.kubeconfig} \
+          --kubeconfig=${top.lib.mkKubeConfig "kube-scheduler" cfg.kubeconfig} \
           --leader-elect=${boolToString cfg.leaderElect} \
           --port=${toString cfg.port} \
           ${optionalString (cfg.verbosity != null) "--v=${toString cfg.verbosity}"} \
@@ -88,7 +87,7 @@ in
     };
 
     services.kubernetes.pki.certs = {
-      schedulerClient = klib.mkCert {
+      schedulerClient = top.lib.mkCert {
         name = "kube-scheduler-client";
         CN = "system:kube-scheduler";
         action = "systemctl restart kube-scheduler.service";


### PR DESCRIPTION
###### Motivation for this change

split docs build broke kubernetes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
