### PR TITLE
postgresqlPackages.tds_fdw: 2.0.2 -> unstable-2021-12-14

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/tds_fdw.nix
+++ b/pkgs/servers/sql/postgresql/ext/tds_fdw.nix
@@ -2,21 +2,23 @@
 
 stdenv.mkDerivation rec {
   pname = "tds_fdw";
-  version = "2.0.2";
+  # Move to stable version when it's released.
+  version = "unstable-2021-12-14";
 
   buildInputs = [ postgresql freetds ];
 
   src = fetchFromGitHub {
     owner  = "tds-fdw";
     repo   =  pname;
-    rev    = "refs/tags/v${version}";
-    sha256 = "024syj21gmdfkpr51l8ca70n5jimr35zwdy719b8h4zjn64ci1fk";
+    rev    = "1611a2805f85d84f463ae50c4e0765cb9bed72dc";
+    sha256 = "sha256-SYHo/o9fJjB1yzN4vLJB0RrF3HEJ4MzmEO44/Jih/20=";
   };
 
   installPhase = ''
-    install -D tds_fdw.so                  -t $out/lib
-    install -D sql/tds_fdw--${version}.sql -t $out/share/postgresql/extension
-    install -D tds_fdw.control             -t $out/share/postgresql/extension
+    version="$(sed -En "s,^default_version *= *'([^']*)'.*,\1,p" tds_fdw.control)"
+    install -D tds_fdw.so      -t $out/lib
+    install -D sql/tds_fdw.sql    "$out/share/postgresql/extension/tds_fdw--$version.sql"
+    install -D tds_fdw.control -t $out/share/postgresql/extension
   '';
 
   meta = with lib; {
@@ -25,6 +27,5 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.steve-chavez ];
     platforms   = postgresql.meta.platforms;
     license     = licenses.postgresql;
-    broken = versionAtLeast postgresql.version "11.0";
   };
 }


### PR DESCRIPTION
Unmark as broken.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Migrate a server from MS SQL to PostgreSQL. Release version crashes the database.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
