### PR TITLE
python3Packages.typesystem: 0.2.4 -> 0.4.1, python3Packages.orm: 0.1.5 -> 0.3.1

### DIFF
--- a/pkgs/development/python-modules/orm/default.nix
+++ b/pkgs/development/python-modules/orm/default.nix
@@ -1,43 +1,52 @@
 { lib
-, buildPythonPackage
-, fetchFromGitHub
-, databases
-, typesystem
+, aiomysql
 , aiosqlite
-, pytestCheckHook
-, pytest-cov
-, typing-extensions
+, asyncpg
+, buildPythonPackage
+, databases
+, fetchFromGitHub
+, pythonOlder
+, typesystem
 }:
 
 buildPythonPackage rec {
   pname = "orm";
-  version = "0.1.5";
+  version = "0.3.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "encode";
     repo = "orm";
     rev = version;
-    sha256 = "1g70cr0559iyqfzidwh6n2qq6d4dcnrr4sg0jkn1s4qzka828mj7";
+    hash = "sha256-nlKEWdqttFnjBnXutlxTy9oILqFzKHKKPJpTtCUbJ5k=";
   };
 
   propagatedBuildInputs = [
+    aiomysql
+    aiosqlite
+    asyncpg
     databases
     typesystem
   ];
 
-  checkInputs = [
-    aiosqlite
-    pytestCheckHook
-    pytest-cov
-    typing-extensions
-  ];
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "typesystem==0.3.1" "typesystem"
+  '';
 
-  pythonImportsCheck = [ "orm" ];
+  # Tests require databases
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "orm"
+  ];
 
   meta = with lib; {
     description = "An async ORM";
     homepage = "https://github.com/encode/orm";
     license = licenses.bsd3;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc ];
   };
 }

--- a/pkgs/development/python-modules/typesystem/default.nix
+++ b/pkgs/development/python-modules/typesystem/default.nix
@@ -1,23 +1,24 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, isPy27
-, pytestCheckHook
-, pytest-cov
 , jinja2
+, pytestCheckHook
+, pythonOlder
 , pyyaml
 }:
 
 buildPythonPackage rec {
   pname = "typesystem";
-  version = "0.2.4";
-  disabled = isPy27;
+  version = "0.4.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "encode";
     repo = pname;
     rev = version;
-    sha256 = "1k0jwcky17zwaz2vx4x2zbsnp270g4mgn7kx5bpl8jgx76qmsnba";
+    hash = "sha256-fjnheHWjIDbJY1iXCRKCpqTCwtUWK9YXbynRCZquQ7c=";
   };
 
   propagatedBuildInputs = [
@@ -27,23 +28,16 @@ buildPythonPackage rec {
 
   checkInputs = [
     pytestCheckHook
-    pytest-cov
   ];
 
-  disabledTests = [
-    # https://github.com/encode/typesystem/issues/102. cosmetic issue where python3.8 changed
-    # the default string formatting of regular expression flags which breaks test assertion
-    "test_to_json_schema_complex_regular_expression"
-  ];
-  disabledTestPaths = [
-    # for some reason jinja2 not picking up forms directory (1% of tests)
-    "tests/test_forms.py"
+  pythonImportsCheck = [
+    "typesystem"
   ];
 
   meta = with lib; {
     description = "A type system library for Python";
     homepage = "https://github.com/encode/typesystem";
     license = licenses.bsd3;
-    maintainers = [ maintainers.costrouc ];
+    maintainers =  with maintainers; [ costrouc ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/encode/orm/releases/tag/0.3.1
https://github.com/encode/typesystem/releases/tag/0.4.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
