### PR TITLE
python3Packages.pep517: 0.9.1 -> 0.12.0

### DIFF
--- a/pkgs/development/python-modules/pep517/default.nix
+++ b/pkgs/development/python-modules/pep517/default.nix
@@ -2,24 +2,26 @@
 , buildPythonPackage
 , fetchPypi
 , flit-core
-, toml
-, pythonOlder
 , importlib-metadata
-, zipp
-, pytestCheckHook
-, testpath
-, mock
 , pip
+, pytestCheckHook
+, pythonOlder
+, setuptools
+, testpath
+, tomli
+, zipp
 }:
 
 buildPythonPackage rec {
   pname = "pep517";
-  version = "0.9.1";
+  version = "0.12.0";
   format = "pyproject";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0zqidxah03qpnp6zkg3zd1kmd5f79hhdsfmlc0cldaniy80qddxf";
+    hash = "sha256-kxN42T0RspjPUR3WNM9epMskmijvhBYLMkfumvtOirA=";
   };
 
   nativeBuildInputs = [
@@ -27,26 +29,42 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    toml
+    tomli
   ] ++ lib.optionals (pythonOlder "3.8") [
-    importlib-metadata zipp
+    importlib-metadata
+    zipp
   ];
 
   checkInputs = [
-    pytestCheckHook
-    testpath
-    mock
     pip
+    pytestCheckHook
+    setuptools
+    testpath
   ];
 
-  preCheck = ''
-    rm pytest.ini # wants flake8
-    rm tests/test_meta.py # wants to run pip
+  postPatch = ''
+    substituteInPlace pytest.ini \
+      --replace "--flake8" ""
   '';
 
-  meta = {
+  disabledTestPaths = [
+    # Tests require network access
+    "tests/test_meta.py"
+  ];
+
+  disabledTests = [
+    "test_issue_104"
+    "test_setup_py"
+  ];
+
+  pythonImportsCheck = [
+    "pep517"
+  ];
+
+  meta = with lib; {
     description = "Wrappers to build Python packages using PEP 517 hooks";
-    license = lib.licenses.mit;
+    license = licenses.mit;
     homepage = "https://github.com/pypa/pep517";
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://pep517.readthedocs.io/en/latest/changelog.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
