### PR TITLE
kitty: 0.23.1 -> 0.24.1

### DIFF
--- a/pkgs/applications/terminal-emulators/kitty/default.nix
+++ b/pkgs/applications/terminal-emulators/kitty/default.nix
@@ -6,6 +6,7 @@
   librsync,
   installShellFiles,
   dbus,
+  darwin,
   Cocoa,
   CoreGraphics,
   Foundation,
@@ -47,6 +48,8 @@ buildPythonApplication rec {
     libpng
     python3
     zlib
+  ] ++ lib.optionals (stdenv.isDarwin && (builtins.hasAttr "UserNotifications" darwin.apple_sdk.frameworks)) [
+    darwin.apple_sdk.frameworks.UserNotifications
   ] ++ lib.optionals stdenv.isLinux [
     fontconfig libunistring libcanberra libX11
     libXrandr libXinerama libXcursor libxkbcommon libXi libXext

--- a/pkgs/applications/terminal-emulators/kitty/default.nix
+++ b/pkgs/applications/terminal-emulators/kitty/default.nix
@@ -125,10 +125,7 @@ buildPythonApplication rec {
       --bash <("$out/bin/kitty" + complete setup bash) \
       --fish <("$out/bin/kitty" + complete setup fish) \
       --zsh  <("$out/bin/kitty" + complete setup zsh)
-    runHook postInstall
-  '';
 
-  postInstall = ''
     terminfo_src=${if stdenv.isDarwin then
       ''"$out/Applications/kitty.app/Contents/Resources/terminfo"''
       else
@@ -139,6 +136,8 @@ buildPythonApplication rec {
 
     mkdir -p $out/nix-support
     echo "$terminfo" >> $out/nix-support/propagated-user-env-packages
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/applications/terminal-emulators/kitty/default.nix
+++ b/pkgs/applications/terminal-emulators/kitty/default.nix
@@ -3,6 +3,7 @@
   libstartup_notification, libGL, libX11, libXrandr, libXinerama, libXcursor,
   libxkbcommon, libXi, libXext, wayland-protocols, wayland,
   lcms2,
+  librsync,
   installShellFiles,
   dbus,
   Cocoa,
@@ -21,20 +22,21 @@
 with python3Packages;
 buildPythonApplication rec {
   pname = "kitty";
-  version = "0.23.1";
+  version = "0.24.1";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "kovidgoyal";
     repo = "kitty";
     rev = "v${version}";
-    sha256 = "sha256-2RwDU6EOJWF0u2ikJFg9U2yqSXergDkJH3h2i+QJ7G4=";
+    sha256 = "sha256-WPkyub7CwNXRksUmqiZeznnSqEPFpyHTeFLQ+D4Fb5c=";
   };
 
   buildInputs = [
     harfbuzz
     ncurses
     lcms2
+    librsync
   ] ++ lib.optionals stdenv.isDarwin [
     Cocoa
     CoreGraphics


### PR DESCRIPTION
###### Motivation for this change
https://github.com/kovidgoyal/kitty/releases/tag/v0.23.1
A new dependency is needed.
Closes #153928.
https://sw.kovidgoyal.net/kitty/build/#notes-for-linux-macos-packagers recommends to split kitty into three packages with kitty-shell-integration being the one that includes some files useful for the shell integration. We already use kitty.terminfo in Nixpkgs instead of kitty-terminfo but we can't use kitty.shell-integration instead of kitty-shell-integration because shell-integration is not a valid shell variable name. I named it kitty.shell_integration instead. This package can then be used by a future kitty nixos module that still needs to be created. Without this commit, kitty would modify the user's ~/.bashrc when using bash.
I also included the commit from #137512 so that kitty will finally compile on Macs with Apple silicon.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).