### PR TITLE
apio: 0.7.6 -> 0.8.0

### DIFF
--- a/pkgs/development/embedded/fpga/apio/default.nix
+++ b/pkgs/development/embedded/fpga/apio/default.nix
@@ -7,6 +7,7 @@
 , colorama
 , pyserial
 , wheel
+, scons
 , setuptools
 , tinyprog
 , pytestCheckHook
@@ -14,17 +15,20 @@
 
 buildPythonApplication rec {
   pname = "apio";
-  version = "0.7.6";
+  version = "0.8.0";
   format = "flit";
 
   src = fetchFromGitHub {
     owner = "FPGAwars";
     repo = "apio";
     rev = "v${version}";
-    sha256 = "sha256-KmqxwYKsvcTSuUSVXgegR47y9VeU/vICbYWD7z3aDRM=";
+    sha256 = "sha256-nOZI+FHdZRnkJF/No8z0mZ4Q5aHFnF7c20ajTPI00N4=";
   };
 
   postPatch = ''
+    substituteInPlace pyproject.toml --replace \
+      'scons==4.2.0' 'scons'
+
     substituteInPlace apio/managers/scons.py --replace \
       'return "tinyprog --libusb --program"' \
       'return "${tinyprog}/bin/tinyprog --libusb --program"'
@@ -49,6 +53,7 @@ buildPythonApplication rec {
     colorama
     pyserial
     wheel
+    scons
     setuptools # needs pkg_resources at runtime (technically not needed when tinyprog is also in this list because of the propagatedBuildInputs of tinyprog)
 
     tinyprog # needed for upload to TinyFPGA


### PR DESCRIPTION
###### Motivation for this change
https://github.com/FPGAwars/apio/releases/tag/v0.8.0

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).