### PR TITLE
mercurial: move tests to passthru.tests

### DIFF
--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -7,6 +7,7 @@
 , highlightSupport ? fullBuild
 , ApplicationServices
 # test dependencies
+, runCommand
 , unzip
 , which
 , sqlite
@@ -39,15 +40,6 @@ let
     } else null;
     cargoRoot = if rustSupport then "rust" else null;
 
-    postPatch = ''
-      patchShebangs .
-
-      for f in **/*.{py,c,t}; do
-        # not only used in shebangs
-        substituteAllInPlace "$f" '/bin/sh' '${stdenv.shell}'
-      done
-    '';
-
     propagatedBuildInputs = lib.optional re2Support fb-re2
       ++ lib.optional gitSupport pygit2
       ++ lib.optional highlightSupport pygments;
@@ -62,31 +54,6 @@ let
 
     makeFlags = [ "PREFIX=$(out)" ]
       ++ lib.optional rustSupport "PURE=--rust";
-
-    doCheck = stdenv.isLinux;  # tests seem unstable on Darwin
-    checkInputs = [
-      unzip
-      which
-      sqlite
-      git
-      gnupg
-    ];
-    SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";  # needed for git
-    checkPhase = ''
-      cat << EOF > tests/blacklists/nix
-      # tests enforcing "/usr/bin/env" shebangs, which are patched for nix
-      test-run-tests.t
-      test-check-shbang.t
-
-      # unstable experimental/unsupported features
-      # https://bz.mercurial-scm.org/show_bug.cgi?id=6633#c1
-      test-git-interop.t
-      EOF
-
-      # extended timeout necessary for tests to pass on the busy CI workers
-      export HGTESTFLAGS="--blacklist blacklists/nix --timeout 1800"
-      make check
-    '';
 
     postInstall = (lib.optionalString guiSupport ''
       mkdir -p $out/etc/mercurial
@@ -115,7 +82,9 @@ let
         --zsh contrib/zsh_completion
     '';
 
-    passthru.tests = {};
+    passthru.tests = {
+      mercurial-tests = makeTests { flags = "--with-hg=$MERCURIAL_BASE/bin/hg"; };
+    };
 
     meta = with lib; {
       description = "A fast, lightweight SCM system for very large distributed projects";
@@ -127,6 +96,67 @@ let
       platforms = platforms.unix;
     };
   };
+
+  makeTests = { mercurial ? self, nameSuffix ? "", flags ? "" }: runCommand "${mercurial.pname}${nameSuffix}-tests" {
+    inherit (mercurial) src;
+
+    SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";  # needed for git
+    MERCURIAL_BASE = mercurial;
+    nativeBuildInputs = [
+      python
+      unzip
+      which
+      sqlite
+      git
+      gnupg
+    ];
+
+    postPatch = ''
+      patchShebangs .
+
+      for f in **/*.{py,c,t}; do
+        # not only used in shebangs
+        substituteAllInPlace "$f" '/bin/sh' '${stdenv.shell}'
+      done
+
+      for f in **/*.t; do
+        substituteInPlace 2>/dev/null "$f" \
+          --replace '*/hg:' '*/*hg*:' \${/* paths emitted by our wrapped hg look like ..hg-wrapped-wrapped */""}
+          --replace '"$PYTHON" "$BINDIR"/hg' '"$BINDIR"/hg' ${/* 'hg' is a wrapper; don't run using python directly */""}
+      done
+    '';
+
+    # This runs Mercurial _a lot_ of times.
+    requiredSystemFeatures = [ "big-parallel" ];
+
+    # Don't run tests if not-Linux or if cross-compiling.
+    meta.broken = !stdenv.hostPlatform.isLinux || stdenv.buildPlatform != stdenv.hostPlatform;
+  } ''
+    addToSearchPathWithCustomDelimiter : PYTHONPATH "${mercurial}/${python.sitePackages}"
+
+    unpackPhase
+    cd "$sourceRoot"
+    patchPhase
+
+    cat << EOF > tests/blacklists/nix
+    # tests enforcing "/usr/bin/env" shebangs, which are patched for nix
+    test-run-tests.t
+    test-check-shbang.t
+
+    # unstable experimental/unsupported features
+    # https://bz.mercurial-scm.org/show_bug.cgi?id=6633#c1
+    test-git-interop.t
+
+    # doesn't like the extra setlocale warnings emitted by our bash wrappers
+    test-locale.t
+    EOF
+
+    export HGTEST_REAL_HG="${mercurial}/bin/hg"
+    # extended timeout necessary for tests to pass on the busy CI workers
+    export HGTESTFLAGS="--blacklist blacklists/nix --timeout 1800 -j$NIX_BUILD_CORES ${flags}"
+    make check
+    touch $out
+  '';
 in
   self.overridePythonAttrs (origAttrs: {
     passthru = origAttrs.passthru // rec {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

They're very expensive to run, especially if you don't have that many
cores, and can sometimes be a bit flaky (it looks like their CI doesn't
run things under the same constraints as we tend to).

Move them to a separate derivation, and make them test the actual
installed output rather than the local copy.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
