### PR TITLE
python3Packages.cylp: init at 0.91.4

### DIFF
--- a/pkgs/development/python-modules/cvxpy/default.nix
+++ b/pkgs/development/python-modules/cvxpy/default.nix
@@ -9,6 +9,7 @@
 , osqp
 , scipy
 , scs
+, cylp
 , useOpenmp ? (!stdenv.isDarwin)
   # Check inputs
 , pytestCheckHook
@@ -28,6 +29,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     cvxopt
+    cylp
     ecos
     numpy
     osqp

--- a/pkgs/development/python-modules/cylp/default.nix
+++ b/pkgs/development/python-modules/cylp/default.nix
@@ -1,0 +1,79 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, cython
+, pkg-config
+, cbc
+, bzip2
+, zlib
+, numpy
+, scipy
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "cylp";
+  version = "0.91.4";
+
+  src = fetchFromGitHub {
+    owner = "coin-or";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-m09s+QrkLGtF83tDLNjU4ECOqgW5RT0h9+fSwDeADag=";
+  };
+
+  nativeBuildInputs = [
+    cython
+    pkg-config
+  ];
+
+  buildInputs = [
+    cbc
+    bzip2
+    zlib
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+  ];
+
+  # Leak some memory, reverting this commit. Otherwise there's a segfault
+  # that's being debugged in https://github.com/coin-or/CyLP/issues/105
+  postPatch = ''
+    substituteInPlace cylp/cy/CyClpSimplex.pyx --replace \
+      'del self.CppSelf' \
+      'pass'
+  '';
+
+  # CyLP ships pre-generated cython-created c++ files even on github. For nixpkgs
+  # it's preferable to regenerate the C++ files from the actual cython source code,
+  # which this flag does for their build system.
+  preBuild = ''
+    export CYLP_USE_CYTHON=1
+  '';
+
+  checkInputs = [ pytestCheckHook ];
+  pythonImportsCheck = [ "cylp" ];
+  pytestFlagsArray = [ "-s" ];
+
+  # pytest gets confused by local imports if run from the base directory.
+  preCheck = ''
+    cd cylp/tests
+    rm __init__.py
+  '';
+
+  # This commit removes a function used in each of the tests in this file, so the tests
+  # are just broken.
+  # https://github.com/coin-or/CyLP/commit/e5bab3cca81c0ad9886bcd8127923a436bcdaf9b
+  disabledTestPaths = [
+    "test_MIP.py"
+  ];
+
+  meta = with lib; {
+    description = "Python interface to COIN-OR's Linear and mixed-integer program solvers (CLP, CBC, and CGL)";
+    homepage = "https://github.com/coin-or/CyLP";
+    maintainers = with maintainers; [ rmcgibbo ];
+    license = licenses.epl20;
+   };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1918,6 +1918,8 @@ in {
 
   cyclonedx-python-lib = callPackage ../development/python-modules/cyclonedx-python-lib { };
 
+  cylp = callPackage ../development/python-modules/cylp { };
+
   cymem = callPackage ../development/python-modules/cymem { };
 
   cypari2 = callPackage ../development/python-modules/cypari2 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adds the package requested here: https://github.com/NixOS/nixpkgs/issues/112353, and adds it as a dependency of CVXPY, so that it has access to another good solver.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
