### PR TITLE
tagtime: init at 2018-09-02

### DIFF
--- a/pkgs/applications/misc/tagtime/default.nix
+++ b/pkgs/applications/misc/tagtime/default.nix
@@ -1,0 +1,79 @@
+{ lib, stdenv, fetchFromGitHub, perl, xterm, coreutils }:
+
+stdenv.mkDerivation {
+  pname = "tagtime";
+  version = "2018-09-02";
+
+  src = fetchFromGitHub {
+    owner = "tagtime";
+    repo = "TagTime";
+    rev = "59343e2cbe451eb16109e782c194ccbd0ee4196d";
+    sha256 = "1xpmra3f9618b0gajfxqh061r4phkiklvcgpglsyx82bhmgf9n1f";
+  };
+
+  buildInputs = [
+    perl
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{libexec,bin}
+
+    # We don’t support a config file for now,
+    # since it’s not entirely clear how to split nix-set paths
+    # from the actual config options.
+    for pl in *.pl; do
+      substituteInPlace "$pl" \
+        --replace 'require "$ENV{HOME}/.tagtimerc";' \
+                  'require "${placeholder "out"}/libexec/settings.pl";'
+    done;
+
+    install tagtimed.pl $out/bin/tagtimed
+
+    substituteInPlace util.pl \
+      --replace '/usr/bin/touch' \
+                '${coreutils}/bin/touch' \
+      --replace '/bin/rm -f $lockf' \
+                '${coreutils}/bin/rm -f $lockf' \
+      --replace '$lockf = "''${path}tagtime.lock";' \
+                'mkdir "$ENV{HOME}/.cache/tagtime";
+    $lockf = "$ENV{HOME}/.cache/tagtime/tagtime.lock";'
+
+    mv *.pl $out/libexec/
+    mv template.tsk $out/libexec/
+
+
+    # set the default template arguments to sane defaults.
+    substitute settings.pl.template $out/libexec/settings.pl \
+      --replace '"__USER__"' \
+                'getlogin()' \
+      --replace '"__PATH__"' \
+                '"${placeholder "out"}/libexec/"' \
+      --replace '$logf = "$path$usr.log";' \
+                'mkdir "$ENV{HOME}/.local/share/tagtime";
+    $logf = "$ENV{HOME}/.local/share/tagtime/pings.log";' \
+      --replace '"__ED__ +"' \
+                '$ENV{"EDITOR"}' \
+      --replace '"__XT__"' \
+                '"${xterm}/bin/xterm"'
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Stochastic Time Tracking for Space Cadets";
+    longDescription = ''
+      To determine how you spend your time, TagTime literally randomly samples
+      you. At random times it pops up and asks what you're doing right at that
+      moment. You answer with tags.
+
+      See https://messymatters.com/tagtime for the whole story.
+
+      [maintainer’s note]: This is the original perl script implementation.
+    '';
+    homepage = "http://messymatters.com/tagtime/";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.Profpatsch ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10048,6 +10048,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) IOKit;
   };
 
+  tagtime = callPackage ../applications/misc/tagtime { };
+
   inherit (callPackages ../applications/networking/taler { })
     taler-exchange taler-merchant;
 


### PR DESCRIPTION
The original perl implementation of tagtime.

I packaged it to the point of being able to use it on my system, in a
very barebones state.
The configuration is … well it just assumes you have a perl file
somewhere and it evals it at startup. Since that configuration needs
access to the distpath of tagtime, we just patch it a bit for
now (which also means no user configuration is possible atm).

The main changes to the config are:

- instead of defaulting to `vim`, we use `$EDITOR`
- The log file is placed in `$HOME/.local/share/tagtime/pings.log`
  (which corresponds to `$XDG_DATA_HOME` on normal unix systems), but
  could be patched to use the real logic instead.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
