### PR TITLE
fetchCargoTarball: make it work with sandbox

### DIFF
--- a/pkgs/build-support/rust/fetch-cargo-tarball/default.nix
+++ b/pkgs/build-support/rust/fetch-cargo-tarball/default.nix
@@ -72,10 +72,13 @@ in stdenv.mkDerivation ({
   '';
 
   # Build a reproducible tar, per instructions at https://reproducible-builds.org/docs/archives/
+  # Note: rather than calling `tar -czf` and having `tar` call `gzip`, we call
+  # `gzip` manually, because `tar` tries to call it through `/bin/sh -c gzip`,
+  # and `/bin/sh` may not be available with sandboxing enabled.
   installPhase = ''
     tar --owner=0 --group=0 --numeric-owner --format=gnu \
         --sort=name --mtime="@$SOURCE_DATE_EPOCH" \
-        -czf $out $name
+        -c $name | gzip > $out
   '';
 
   inherit (hash_) outputHashAlgo outputHash;


### PR DESCRIPTION
###### Motivation for this change

Fixes #153774.

The call to `tar -z` in `fetchCargoTarball` causes `tar` to execve `/bin/sh -c gzip`. But with sandboxing enabled, this results in a ENOENT no such file or directory error on `/bin/sh`. We can work around this by not letting `tar` call `gzip`, but calling it ourselves without the intermediate `/bin/sh` step, and then it does work with the sandbox.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Tested by building the package that I originally could not build because of this, and I can now. This also confirms that the output hash is still the same, because it was provided by somebody else who generated it on Darwin, and I did not get a mismatch error on the -vendor archive.