### PR TITLE
gdal: 3.3.2 -> 3.4.1, t-rex: 0.14.2 -> 0.14.3-beta4

### DIFF
--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -7,13 +7,13 @@ with lib;
 
 stdenv.mkDerivation rec {
   pname = "gdal";
-  version = "3.3.2";
+  version = "3.4.1";
 
   src = fetchFromGitHub {
     owner = "OSGeo";
     repo = "gdal";
     rev = "v${version}";
-    sha256 = "sha256-fla3EMDmuW0+vmmU0sgtLsGfO7dDApLQ2EoKJeR/1IM=";
+    sha256 = "11rjdaxmsp9n3r9xhmgd7ksy8bh5fazwsxdj0xvl4hsy6bcn4n97";
   };
 
   sourceRoot = "source/gdal";
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     expat
     libxml2
     postgresql
-  ] ++ (with pythonPackages; [ python numpy wrapPython ])
+  ] ++ (with pythonPackages; [ python setuptools numpy wrapPython ])
     ++ lib.optional stdenv.isDarwin libiconv
     ++ lib.optionals netcdfSupport [ netcdf hdf5 curl ];
 

--- a/pkgs/servers/t-rex/default.nix
+++ b/pkgs/servers/t-rex/default.nix
@@ -2,16 +2,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "t-rex";
-  version = "0.14.2";
+  version = "0.14.3-beta4";
 
   src = fetchFromGitHub {
     owner = "t-rex-tileserver";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-QNowkQzEYLOgJ2h0yq+gShmW5WgqPF3iiSejqwrOrHo=";
+    hash = "sha256-EG/nnHxnBwlxreJ+RWHvKqLpaVtlU95+YTJynEnypOE=";
+
   };
 
-  cargoHash = "sha256-k10DjLJCJLqjmtEED5pwQDt3mOiey89UYC36lG+3AmM=";
+  cargoHash = "sha256-noDZNFZlfX6lZ4czsSrHXe7xbBLTD0Gz8i5EyfEp8lc=";
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-45943

~Labelling with `topic: rust` and inviting @sikmir to take a look at this because it breaks `t-rex`, which fails with:~

```
No pre-built bindings available for GDAL version 3.4. Use `--features bindgen` to generate your own bindings.
```

~Applying upstream patch https://github.com/t-rex-tileserver/t-rex/commit/bb971303c29352ab86547fecd42b2522c321502d doesn't help, and enabling features of a dependency more than one level deep appears to require patching `Cargo.toml`/`Cargo.lock`, which still seems to be quite painful. Is there no `postPatch` equivalent of `cargoPatches`, for e.g. making small programmatic substitutions?~

~Anyway, a solution would be appreciated as there's a small amount of urgency to this.~

~Failing that though, as a stopgap I should be able to _patch_ this vulnerability in as I'm planning on doing for 21.11.~

`t-rex` bumped and fixed now :point_down: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
