### PR TITLE
Update elisp packages

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -3757,21 +3757,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    shell-command-plus = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
-      elpaBuild {
-        pname = "shell-command-plus";
-        ename = "shell-command+";
-        version = "2.3.2";
-        src = fetchurl {
-          url = "https://elpa.gnu.org/packages/shell-command+-2.3.2.tar";
-          sha256 = "03hmk4gr9kjy3238n0ys9na00py035j9s0y8d87c45f5af6c6g2c";
-        };
-        packageRequires = [ emacs ];
-        meta = {
-          homepage = "https://elpa.gnu.org/packages/shell-command+.html";
-          license = lib.licenses.free;
-        };
-      }) {};
     shen-mode = callPackage ({ elpaBuild, fetchurl, lib }:
       elpaBuild {
         pname = "shen-mode";

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -234,10 +234,10 @@
       elpaBuild {
         pname = "auctex";
         ename = "auctex";
-        version = "13.0.14";
+        version = "13.0.15";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/auctex-13.0.14.tar";
-          sha256 = "1gmqdcg9s6xf8kvzh1j27nbimakd5cy8pwsn0il19l026kxjimr8";
+          url = "https://elpa.gnu.org/packages/auctex-13.0.15.tar";
+          sha256 = "1rm8s02d1mx5sw7yj65zlr07xhimnmvqav7f45nz2h8bwka02c3c";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -335,14 +335,29 @@
           license = lib.licenses.free;
         };
       }) {};
+    blist = callPackage ({ elpaBuild, fetchurl, lib }:
+      elpaBuild {
+        pname = "blist";
+        ename = "blist";
+        version = "0.1";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/blist-0.1.tar";
+          sha256 = "0p9jx7m05ynfi3bnd91jghw7101ym8qzm5r42rb1vy85pcf9lbad";
+        };
+        packageRequires = [];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/blist.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     bluetooth = callPackage ({ dash, elpaBuild, emacs, fetchurl, lib }:
       elpaBuild {
         pname = "bluetooth";
         ename = "bluetooth";
-        version = "0.2";
+        version = "0.3";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/bluetooth-0.2.el";
-          sha256 = "1dq04p6ms0zx4awlypp4crkz7dzal4xg8ac7p8fqacz196rczssp";
+          url = "https://elpa.gnu.org/packages/bluetooth-0.3.tar";
+          sha256 = "1q27hk4j7k0q9vqgn9nq7q0vhn9jdqbygs7d9lv5gwfhdzdnl4az";
         };
         packageRequires = [ dash emacs ];
         meta = {
@@ -681,10 +696,10 @@
       elpaBuild {
         pname = "consult";
         ename = "consult";
-        version = "0.13";
+        version = "0.14";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/consult-0.13.tar";
-          sha256 = "08hwvyj9sif9r92nhd09prwlryyqgnifjfqj51xgx98m0rg7ks3p";
+          url = "https://elpa.gnu.org/packages/consult-0.14.tar";
+          sha256 = "0lb72j4nxvaar2vip6jlyn62b9z2p2vsmijk3m9nsrshbqnlf0rc";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -711,10 +726,10 @@
       elpaBuild {
         pname = "corfu";
         ename = "corfu";
-        version = "0.16";
+        version = "0.17";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/corfu-0.16.tar";
-          sha256 = "04xgq5rkz8a0lykcyjsxq76yapbzz8vfw8gxqvdx0y58bhcw82y6";
+          url = "https://elpa.gnu.org/packages/corfu-0.17.tar";
+          sha256 = "13nmbyrsvglzv57n9srl0kz75y07v8imr6c99nbf1mssli3h6n7y";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -816,10 +831,10 @@
       elpaBuild {
         pname = "csv-mode";
         ename = "csv-mode";
-        version = "1.17";
+        version = "1.18";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/csv-mode-1.17.tar";
-          sha256 = "16kv3n70pl4h3jfmmqy9bzflsm4nv7cwvrj7g4mgy8yb76nbyka2";
+          url = "https://elpa.gnu.org/packages/csv-mode-1.18.tar";
+          sha256 = "0fv7hvsfbc9n4hsgg3ywk8qf4ig5a986zfq0lwnjj8pcz1bpmrxj";
         };
         packageRequires = [ cl-lib emacs ];
         meta = {
@@ -921,10 +936,10 @@
       elpaBuild {
         pname = "devdocs";
         ename = "devdocs";
-        version = "0.2";
+        version = "0.3";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/devdocs-0.2.tar";
-          sha256 = "1npc7yra7pvf86ahmz1h7hnjxrz15ar1vjcalg4ilizypycpgrwj";
+          url = "https://elpa.gnu.org/packages/devdocs-0.3.tar";
+          sha256 = "03asw26nsnnx7hmyqhksq165vpii0h8y6qjjn0x4sdkyyns16yp7";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -1176,10 +1191,10 @@
       elpaBuild {
         pname = "eev";
         ename = "eev";
-        version = "20211205";
+        version = "20211226";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/eev-20211205.tar";
-          sha256 = "0qicm3ym9n6iamlj0xyzn8729gfwjp5lwq6lj8r3ydgs4ggsr4jy";
+          url = "https://elpa.gnu.org/packages/eev-20211226.tar";
+          sha256 = "15ggg7sv4m5yc8ldyyffz7vgaj00xbw15zga0x2lpdfmahh6y2as";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -1294,10 +1309,10 @@
       elpaBuild {
         pname = "embark";
         ename = "embark";
-        version = "0.13";
+        version = "0.14";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/embark-0.13.tar";
-          sha256 = "04x3cfikfvzr2xl1zh6kj0q31160kmh1vrzyrla3n6f8z5qch63x";
+          url = "https://elpa.gnu.org/packages/embark-0.14.tar";
+          sha256 = "12d4lza54sf493z9hx1fqlrhrx19girrdh560syi4gg03kg8s7nr";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -1314,10 +1329,10 @@
       elpaBuild {
         pname = "embark-consult";
         ename = "embark-consult";
-        version = "0.2";
+        version = "0.3";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/embark-consult-0.2.tar";
-          sha256 = "0f1022yk6d88glrrawa8cl6yd5n44p8wnbfwn0f8z6j1n8wxq37z";
+          url = "https://elpa.gnu.org/packages/embark-consult-0.3.tar";
+          sha256 = "1l38bnphfq65r2fjy8zi7a8l4h361bfz756sswa3r7446jhd48rv";
         };
         packageRequires = [ consult emacs embark ];
         meta = {
@@ -1334,10 +1349,10 @@
       elpaBuild {
         pname = "emms";
         ename = "emms";
-        version = "7.8";
+        version = "8";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/emms-7.8.tar";
-          sha256 = "1nlb9rrdlbcqghph30r9i9m1brbdha818czbms0zhzdisxb0smi0";
+          url = "https://elpa.gnu.org/packages/emms-8.tar";
+          sha256 = "1iffh6n8q9xag25m9bgnpywa27bkdvvz2gr500hdgwwddgdm4pq8";
         };
         packageRequires = [ cl-lib nadvice seq ];
         meta = {
@@ -1699,10 +1714,10 @@
       elpaBuild {
         pname = "gnorb";
         ename = "gnorb";
-        version = "1.6.9";
+        version = "1.6.10";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/gnorb-1.6.9.tar";
-          sha256 = "027qqcxd3531f0j6frwlnw542lis4xgsx0ss1mdwb6hqc5f0vaxm";
+          url = "https://elpa.gnu.org/packages/gnorb-1.6.10.tar";
+          sha256 = "0kwgpyydnzphlw8rwyw9rim3j1awd0njxssm47db76nwwyxl1ry3";
         };
         packageRequires = [ cl-lib ];
         meta = {
@@ -1751,10 +1766,10 @@
       elpaBuild {
         pname = "gnugo";
         ename = "gnugo";
-        version = "3.1.1";
+        version = "3.1.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/gnugo-3.1.1.tar";
-          sha256 = "035rgiz42q042h41l4cvf0hr8igy2vyn3s1hsl2pgh2dq2jjylv6";
+          url = "https://elpa.gnu.org/packages/gnugo-3.1.2.tar";
+          sha256 = "138gzdyi8scqimvs49da66j8f5a43bhgpasn1bxzdj2zffwlwp6g";
         };
         packageRequires = [ ascii-art-to-unicode cl-lib xpm ];
         meta = {
@@ -1949,14 +1964,29 @@
           license = lib.licenses.free;
         };
       }) {};
+    ilist = callPackage ({ elpaBuild, fetchurl, lib }:
+      elpaBuild {
+        pname = "ilist";
+        ename = "ilist";
+        version = "0.1";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/ilist-0.1.tar";
+          sha256 = "1ihh44276ivgykva805540nkkrqmc61lydv20l99si3amg07q9bh";
+        };
+        packageRequires = [];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/ilist.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     ioccur = callPackage ({ cl-lib ? null, elpaBuild, emacs, fetchurl, lib }:
       elpaBuild {
         pname = "ioccur";
         ename = "ioccur";
-        version = "2.5";
+        version = "2.6";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/ioccur-2.5.tar";
-          sha256 = "06a6djln2rry3qnb063yarji3p18hcpp5zrw7q43a45k7qaiaji8";
+          url = "https://elpa.gnu.org/packages/ioccur-2.6.tar";
+          sha256 = "0k7nr73gmd0z5zqkwdacvfsmyflri3f15a15zpr7va28pnxqzsdk";
         };
         packageRequires = [ cl-lib emacs ];
         meta = {
@@ -2108,10 +2138,10 @@
       elpaBuild {
         pname = "js2-mode";
         ename = "js2-mode";
-        version = "20201220";
+        version = "20211229";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/js2-mode-20201220.tar";
-          sha256 = "0zdrp8lap1ijrmsn9jsnvm44b6vxlgh9vcla5ysh1ga95zkjxrwm";
+          url = "https://elpa.gnu.org/packages/js2-mode-20211229.tar";
+          sha256 = "0qf7z0mmrvlncf1ac6yiza5wmcaf588d53ma41vhj58adaahimz6";
         };
         packageRequires = [ cl-lib emacs ];
         meta = {
@@ -2168,10 +2198,10 @@
       elpaBuild {
         pname = "kind-icon";
         ename = "kind-icon";
-        version = "0.1.3";
+        version = "0.1.4";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/kind-icon-0.1.3.tar";
-          sha256 = "0iqbjlqna5n8dx78350macs129wnri7kgmxk2qf3w9bj6qp760sn";
+          url = "https://elpa.gnu.org/packages/kind-icon-0.1.4.tar";
+          sha256 = "00pyvnq4dx51l2wbhvm6k6cx5xmy32j4h1lkr5kr8s3j5w83ip25";
         };
         packageRequires = [ emacs svg-lib ];
         meta = {
@@ -2183,10 +2213,10 @@
       elpaBuild {
         pname = "kiwix";
         ename = "kiwix";
-        version = "1.1.4";
+        version = "1.1.5";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/kiwix-1.1.4.tar";
-          sha256 = "1ls11a7fc6d4gj85g8m09r95fvc4ppc0k0fs28d1hzybmgl89rgl";
+          url = "https://elpa.gnu.org/packages/kiwix-1.1.5.tar";
+          sha256 = "17k4aa8s9m24c572qvl5a481iw9ny6wmd5yrg47iv4d2lb2i13h2";
         };
         packageRequires = [ emacs request ];
         meta = {
@@ -2363,10 +2393,10 @@
       elpaBuild {
         pname = "marginalia";
         ename = "marginalia";
-        version = "0.10";
+        version = "0.11";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/marginalia-0.10.tar";
-          sha256 = "0sw4kfqda3z9bph4vgzqvg045li64ww2gdc2cgddi2m5p7anq20g";
+          url = "https://elpa.gnu.org/packages/marginalia-0.11.tar";
+          sha256 = "0mri8awary11hwg6lib903q5jcv2isnf8mi62mgndiki5s9cgrbs";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2547,10 +2577,10 @@
       elpaBuild {
         pname = "modus-themes";
         ename = "modus-themes";
-        version = "1.7.0";
+        version = "2.0.0";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/modus-themes-1.7.0.tar";
-          sha256 = "1ncpgya5lbwr5z7gbq59prfqqnjxhqgaylcjr23mwrhbvvfrj5ff";
+          url = "https://elpa.gnu.org/packages/modus-themes-2.0.0.tar";
+          sha256 = "16kvkm7hsdk6jfdjkzafwdkwwri7cqki29qxqqhzkpwwghqlissl";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2706,10 +2736,10 @@
       elpaBuild {
         pname = "nano-modeline";
         ename = "nano-modeline";
-        version = "0.2";
+        version = "0.5";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/nano-modeline-0.2.tar";
-          sha256 = "13m8j8jnd33wwv1siv6frzdbs7bhspg859sflq58vimv444zjzac";
+          url = "https://elpa.gnu.org/packages/nano-modeline-0.5.tar";
+          sha256 = "0f6xgrxykd5jmlzf9xmywh0jc2jfq698m4nqk60h40dm6pi0gfi2";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2890,10 +2920,10 @@
       elpaBuild {
         pname = "org";
         ename = "org";
-        version = "9.5.1";
+        version = "9.5.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/org-9.5.1.tar";
-          sha256 = "033q5rpk8kfp43qymll339dybk4ig3gc6jz7av6zwjjcz2iawpj1";
+          url = "https://elpa.gnu.org/packages/org-9.5.2.tar";
+          sha256 = "12pvr47b11pq5rncpb3x8y11fhnakk5bi73j9l9w4d4ss3swcrnh";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2935,10 +2965,10 @@
       elpaBuild {
         pname = "org-transclusion";
         ename = "org-transclusion";
-        version = "1.0.1";
+        version = "1.1.1";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/org-transclusion-1.0.1.tar";
-          sha256 = "1mn66a82nk3daf2vjw6pg9zgff48inik04ffizgm6cdlgn6ymrcs";
+          url = "https://elpa.gnu.org/packages/org-transclusion-1.1.1.tar";
+          sha256 = "12dp5fc7iw78qx2f501ch8mvhvw90bxg8hhvx0kz3y24gf2h8d4d";
         };
         packageRequires = [ emacs org ];
         meta = {
@@ -3160,10 +3190,10 @@
       elpaBuild {
         pname = "posframe";
         ename = "posframe";
-        version = "1.1.2";
+        version = "1.1.5";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/posframe-1.1.2.tar";
-          sha256 = "0vrv46v7qwmax5m1i6b7lwdh789dfr18ggxjl4bk05qn7waway6j";
+          url = "https://elpa.gnu.org/packages/posframe-1.1.5.tar";
+          sha256 = "1kyd3r926hhs03mmpyvbjjyqcbvqrxk62rrscgfyl7rqi9ar56i0";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3220,10 +3250,10 @@
       elpaBuild {
         pname = "pyim";
         ename = "pyim";
-        version = "3.9.5";
+        version = "4.0.3";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/pyim-3.9.5.tar";
-          sha256 = "1dj46yprbl3l6n83aj0hsnd0rwjcp4ypyg2nhwig39wxirwlf9an";
+          url = "https://elpa.gnu.org/packages/pyim-4.0.3.tar";
+          sha256 = "110d9d8xglnyv0cn0slwk3msgqq8rs01xq2qmx5ya7i2v77gd5ql";
         };
         packageRequires = [ async emacs xr ];
         meta = {
@@ -3727,6 +3757,21 @@
           license = lib.licenses.free;
         };
       }) {};
+    shell-command-plus = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "shell-command-plus";
+        ename = "shell-command+";
+        version = "2.3.2";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/shell-command+-2.3.2.tar";
+          sha256 = "03hmk4gr9kjy3238n0ys9na00py035j9s0y8d87c45f5af6c6g2c";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/shell-command+.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     shen-mode = callPackage ({ elpaBuild, fetchurl, lib }:
       elpaBuild {
         pname = "shen-mode";
@@ -4016,14 +4061,29 @@
       elpaBuild {
         pname = "svg-lib";
         ename = "svg-lib";
-        version = "0.2";
+        version = "0.2.4";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/svg-lib-0.2.tar";
-          sha256 = "0361w1paqrgqlv8wj5vf9ifssddrk2bwlarp2c2wzlxks3ahdf2x";
+          url = "https://elpa.gnu.org/packages/svg-lib-0.2.4.tar";
+          sha256 = "0vcf3vbrzhgwssf6mi4xyic32yzjsrllp2zaqdk3c0qjvq9w4wxa";
         };
         packageRequires = [ emacs ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/svg-lib.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    svg-tag-mode = callPackage ({ elpaBuild, emacs, fetchurl, lib, svg-lib }:
+      elpaBuild {
+        pname = "svg-tag-mode";
+        ename = "svg-tag-mode";
+        version = "0.3.2";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/svg-tag-mode-0.3.2.tar";
+          sha256 = "1sg05dg0d9ai21l8rgpqywmwgw29sl21x2zkvlv04rl3hdvdq75y";
+        };
+        packageRequires = [ emacs svg-lib ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/svg-tag-mode.html";
           license = lib.licenses.free;
         };
       }) {};
@@ -4155,10 +4215,10 @@
       elpaBuild {
         pname = "tramp";
         ename = "tramp";
-        version = "2.5.1.5";
+        version = "2.5.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/tramp-2.5.1.5.tar";
-          sha256 = "1g3xf97q5h6sr67w9bphcbbqx9jz2lbl8lij5rz1r0zbsnlcv7n8";
+          url = "https://elpa.gnu.org/packages/tramp-2.5.2.tar";
+          sha256 = "1j71x3q6x9xyf21capjxcp85b7z2x9khrqsd2sy2s3qwxz3jbg5n";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -4436,10 +4496,10 @@
       elpaBuild {
         pname = "vertico";
         ename = "vertico";
-        version = "0.17";
+        version = "0.19";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/vertico-0.17.tar";
-          sha256 = "1zhrkdhnc32wsc5f958hwa7mgf2vcjh3x6ng1cpndds5yllxb7s9";
+          url = "https://elpa.gnu.org/packages/vertico-0.19.tar";
+          sha256 = "1i9aqxsplmzyy7nv4czspa66a6v33lnng1d8zsgjf1m9sz0kyzxp";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -4456,10 +4516,10 @@
       elpaBuild {
         pname = "vertico-posframe";
         ename = "vertico-posframe";
-        version = "0.4.2";
+        version = "0.4.8";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/vertico-posframe-0.4.2.tar";
-          sha256 = "1kajkjnjlisws2zdahy3bym942f3zvf05qhbmw9i2lv54jiy07pz";
+          url = "https://elpa.gnu.org/packages/vertico-posframe-0.4.8.tar";
+          sha256 = "1cvihfj59qycd3kifxbg9ndrmiihc62si8q5b8fxc1p20acw4f69";
         };
         packageRequires = [ emacs posframe vertico ];
         meta = {
@@ -4730,16 +4790,16 @@
           license = lib.licenses.free;
         };
       }) {};
-    xpm = callPackage ({ elpaBuild, fetchurl, lib }:
+    xpm = callPackage ({ cl-lib ? null, elpaBuild, fetchurl, lib, queue }:
       elpaBuild {
         pname = "xpm";
         ename = "xpm";
-        version = "1.0.4";
+        version = "1.0.5";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/xpm-1.0.4.tar";
-          sha256 = "075miyashh9cm3b0gk6ngld3rm8bfgnh4qxnhxmmvjgzf6a64grh";
+          url = "https://elpa.gnu.org/packages/xpm-1.0.5.tar";
+          sha256 = "13p6s6b2v7h4bnwdkkrd1qz84jd7g2s18w0czhpxv6hvj9sqf5hx";
         };
-        packageRequires = [];
+        packageRequires = [ cl-lib queue ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/xpm.html";
           license = lib.licenses.free;

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
@@ -60,6 +60,21 @@
           license = lib.licenses.free;
         };
       }) {};
+    anzu = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "anzu";
+        ename = "anzu";
+        version = "0.64";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/anzu-0.64.tar";
+          sha256 = "1znw7wlpjb3d8wsijqziiq21j966x95q9g5j16wx48xyrrzr1mcs";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/anzu.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     apache-mode = callPackage ({ elpaBuild, fetchurl, lib }:
       elpaBuild {
         pname = "apache-mode";
@@ -105,6 +120,26 @@
           license = lib.licenses.free;
         };
       }) {};
+    autothemer = callPackage ({ cl-lib ? null
+                              , dash
+                              , elpaBuild
+                              , emacs
+                              , fetchurl
+                              , lib }:
+      elpaBuild {
+        pname = "autothemer";
+        ename = "autothemer";
+        version = "0.2.3";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/autothemer-0.2.3.tar";
+          sha256 = "10r4lf3nl7mk6yzfcyld5k0njslw8ly2sd0iz1zkzywnv31lsxnd";
+        };
+        packageRequires = [ cl-lib dash emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/autothemer.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     bison-mode = callPackage ({ elpaBuild, fetchurl, lib }:
       elpaBuild {
         pname = "bison-mode";
@@ -120,6 +155,36 @@
           license = lib.licenses.free;
         };
       }) {};
+    boxquote = callPackage ({ cl-lib ? null, elpaBuild, fetchurl, lib }:
+      elpaBuild {
+        pname = "boxquote";
+        ename = "boxquote";
+        version = "2.2";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/boxquote-2.2.tar";
+          sha256 = "0vcqm78b5fsizkn2xalnzmdci5m02yxxypcr9q2sai04j7lhmwd9";
+        };
+        packageRequires = [ cl-lib ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/boxquote.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    buttercup = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "buttercup";
+        ename = "buttercup";
+        version = "1.24";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/buttercup-1.24.tar";
+          sha256 = "1ch949xf03gw9r5v32akx7hqnq7zrp3qr3gcic5b52yl5nmy8mhn";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/buttercup.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     caml = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
       elpaBuild {
         pname = "caml";
@@ -132,6 +197,38 @@
         packageRequires = [ emacs ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/caml.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    cider = callPackage ({ clojure-mode
+                         , elpaBuild
+                         , emacs
+                         , fetchurl
+                         , lib
+                         , parseedn
+                         , queue
+                         , seq
+                         , sesman
+                         , spinner }:
+      elpaBuild {
+        pname = "cider";
+        ename = "cider";
+        version = "1.2.0";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/cider-1.2.0.tar";
+          sha256 = "1dkn5mcp4vyk6h4mqrn7fcqjs4h0dx1y1b1pcg2jpyx11mhdpjxf";
+        };
+        packageRequires = [
+          clojure-mode
+          emacs
+          parseedn
+          queue
+          seq
+          sesman
+          spinner
+        ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/cider.html";
           license = lib.licenses.free;
         };
       }) {};
@@ -278,6 +375,139 @@
           license = lib.licenses.free;
         };
       }) {};
+    evil-anzu = callPackage ({ anzu, elpaBuild, evil, fetchurl, lib }:
+      elpaBuild {
+        pname = "evil-anzu";
+        ename = "evil-anzu";
+        version = "0.2";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/evil-anzu-0.2.tar";
+          sha256 = "0fv7kan67g24imhbgggrg8r4pjhpmicpq3g8g1wnq8p9zkwxbm7s";
+        };
+        packageRequires = [ anzu evil ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/evil-anzu.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    evil-exchange = callPackage ({ cl-lib ? null
+                                 , elpaBuild
+                                 , evil
+                                 , fetchurl
+                                 , lib }:
+      elpaBuild {
+        pname = "evil-exchange";
+        ename = "evil-exchange";
+        version = "0.41";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/evil-exchange-0.41.tar";
+          sha256 = "1i07c0zc75mbgb6hzj6py248gxzy0mk3xyaskvwlc371fyyn6v6c";
+        };
+        packageRequires = [ cl-lib evil ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/evil-exchange.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    evil-indent-plus = callPackage ({ cl-lib ? null
+                                    , elpaBuild
+                                    , evil
+                                    , fetchurl
+                                    , lib }:
+      elpaBuild {
+        pname = "evil-indent-plus";
+        ename = "evil-indent-plus";
+        version = "1.0.1";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/evil-indent-plus-1.0.1.tar";
+          sha256 = "0wnn5xjdbc70cxwllz1gf6xf91ijlfhlps7gkb9c3v1kwpsfp3s3";
+        };
+        packageRequires = [ cl-lib evil ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/evil-indent-plus.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    evil-lisp-state = callPackage ({ bind-map
+                                   , elpaBuild
+                                   , evil
+                                   , fetchurl
+                                   , lib
+                                   , smartparens }:
+      elpaBuild {
+        pname = "evil-lisp-state";
+        ename = "evil-lisp-state";
+        version = "8.2";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/evil-lisp-state-8.2.tar";
+          sha256 = "0hwv39rkwadm3jri84nf9mw48ybd5a0y02yzjp5cayy7alpf6zcn";
+        };
+        packageRequires = [ bind-map evil smartparens ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/evil-lisp-state.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    evil-matchit = callPackage ({ elpaBuild, emacs, evil, fetchurl, lib }:
+      elpaBuild {
+        pname = "evil-matchit";
+        ename = "evil-matchit";
+        version = "2.4.1";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/evil-matchit-2.4.1.tar";
+          sha256 = "0ybw0jfjkwiz4ln3z5pizbw5d9d612crpk410czcyi8adyj018nc";
+        };
+        packageRequires = [ emacs evil ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/evil-matchit.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    evil-nerd-commenter = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "evil-nerd-commenter";
+        ename = "evil-nerd-commenter";
+        version = "3.5.6";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/evil-nerd-commenter-3.5.6.tar";
+          sha256 = "0bv7s2jcgi3ma3dspczy7jrb55vqkhsz0rq0nz14qiay5j9dwghd";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/evil-nerd-commenter.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    evil-numbers = callPackage ({ elpaBuild, emacs, evil, fetchurl, lib }:
+      elpaBuild {
+        pname = "evil-numbers";
+        ename = "evil-numbers";
+        version = "0.6";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/evil-numbers-0.6.tar";
+          sha256 = "0zl16ljb64cawcj11f4ndz941sllj8nhgjcb4w0r1afxbvpn5rss";
+        };
+        packageRequires = [ emacs evil ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/evil-numbers.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    evil-visualstar = callPackage ({ elpaBuild, evil, fetchurl, lib }:
+      elpaBuild {
+        pname = "evil-visualstar";
+        ename = "evil-visualstar";
+        version = "0.2.0";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/evil-visualstar-0.2.0.tar";
+          sha256 = "0vjhwdp2ms7k008mm68vzlkxrq0zyrsf4r10w57w77qg5a96151c";
+        };
+        packageRequires = [ evil ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/evil-visualstar.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     flymake-kondor = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
       elpaBuild {
         pname = "flymake-kondor";
@@ -293,16 +523,16 @@
           license = lib.licenses.free;
         };
       }) {};
-    geiser = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+    geiser = callPackage ({ elpaBuild, emacs, fetchurl, lib, transient }:
       elpaBuild {
         pname = "geiser";
         ename = "geiser";
-        version = "0.19";
+        version = "0.22";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/geiser-0.19.tar";
-          sha256 = "13w6gx6y8ilppcpfib5293600n0xy4xc4xa6idpmbcfd2pkmnw1x";
+          url = "https://elpa.nongnu.org/nongnu/geiser-0.22.tar";
+          sha256 = "0jcxjfn9d7cnsir2pva0axaz180d01sn0l9f175sj57ws8spj2h2";
         };
-        packageRequires = [ emacs ];
+        packageRequires = [ emacs transient ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/geiser.html";
           license = lib.licenses.free;
@@ -312,10 +542,10 @@
       elpaBuild {
         pname = "geiser-chez";
         ename = "geiser-chez";
-        version = "0.16";
+        version = "0.17";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/geiser-chez-0.16.tar";
-          sha256 = "016b7n5rv7fyrw4lqcprhhf2rai5vvmmc8a13l4w3a30rwcgm7cd";
+          url = "https://elpa.nongnu.org/nongnu/geiser-chez-0.17.tar";
+          sha256 = "139x7b3q5n04ig0m263jljm4bsjiiyvi3f84pcq3bgnj3dk5dlxh";
         };
         packageRequires = [ emacs geiser ];
         meta = {
@@ -387,10 +617,10 @@
       elpaBuild {
         pname = "geiser-guile";
         ename = "geiser-guile";
-        version = "0.19";
+        version = "0.20.1";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/geiser-guile-0.19.tar";
-          sha256 = "1rjml11gkl80x4hmh84m84r4qb3kxi36d7mwm25n791v5fs1cl32";
+          url = "https://elpa.nongnu.org/nongnu/geiser-guile-0.20.1.tar";
+          sha256 = "0psm53ryh1wica2730xcw4lc2jv06d08wnjfyd8f61952zzj57k7";
         };
         packageRequires = [ emacs geiser ];
         meta = {
@@ -524,18 +754,48 @@
           license = lib.licenses.free;
         };
       }) {};
+    gotham-theme = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "gotham-theme";
+        ename = "gotham-theme";
+        version = "1.1.9";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/gotham-theme-1.1.9.tar";
+          sha256 = "0ikczh9crs02hlvnpdknxfbpqmpiicdbshjhi5pz3v7ynizj64vm";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/gotham-theme.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     goto-chg = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
       elpaBuild {
         pname = "goto-chg";
         ename = "goto-chg";
-        version = "1.7.4";
+        version = "1.7.5";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/goto-chg-1.7.4.tar";
-          sha256 = "1sg2gp48b83gq0j821lk241lwyxkhqr6w5d1apbnkm3qf08qjwba";
+          url = "https://elpa.nongnu.org/nongnu/goto-chg-1.7.5.tar";
+          sha256 = "08wdrwmgy5hanir6py6wiq0pq4lbv9jiyz1m3h947kb35kxalmks";
         };
         packageRequires = [ emacs ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/goto-chg.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    gruvbox-theme = callPackage ({ autothemer, elpaBuild, fetchurl, lib }:
+      elpaBuild {
+        pname = "gruvbox-theme";
+        ename = "gruvbox-theme";
+        version = "1.26.0";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/gruvbox-theme-1.26.0.tar";
+          sha256 = "19q5i0jz01hdn09wwg929yva6278fhyvk68id5p9dyi8h2n73djn";
+        };
+        packageRequires = [ autothemer ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/gruvbox-theme.html";
           license = lib.licenses.free;
         };
       }) {};
@@ -641,10 +901,10 @@
       elpaBuild {
         pname = "idris-mode";
         ename = "idris-mode";
-        version = "0.9.18";
+        version = "1.1.0";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/idris-mode-0.9.18.tar";
-          sha256 = "1z4wsqzxsmn1vdqp44b32m4wzs4bbnsyzv09v9ggr4l4h2j4c3x5";
+          url = "https://elpa.nongnu.org/nongnu/idris-mode-1.1.0.tar";
+          sha256 = "00xbb63kidkygs2zp334nw38gn5mrbky3ii0g8c9k9si4k1dn5gq";
         };
         packageRequires = [ cl-lib emacs prop-menu ];
         meta = {
@@ -806,6 +1066,43 @@
           license = lib.licenses.free;
         };
       }) {};
+    mentor = callPackage ({ async
+                          , cl-lib ? null
+                          , elpaBuild
+                          , emacs
+                          , fetchurl
+                          , lib
+                          , seq
+                          , xml-rpc }:
+      elpaBuild {
+        pname = "mentor";
+        ename = "mentor";
+        version = "0.3.5";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/mentor-0.3.5.tar";
+          sha256 = "01zrvfk2njzyzjzkvp5hv5cjl1k1qjrila1ab4bv26gf6bkq5xh3";
+        };
+        packageRequires = [ async cl-lib emacs seq xml-rpc ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/mentor.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    moe-theme = callPackage ({ elpaBuild, fetchurl, lib }:
+      elpaBuild {
+        pname = "moe-theme";
+        ename = "moe-theme";
+        version = "1.0.2";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/moe-theme-1.0.2.tar";
+          sha256 = "1hdbm6hw94yyw5cdgfmc5fgnfc2glf0ba8a9ch2y33nzjawklb8x";
+        };
+        packageRequires = [];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/moe-theme.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     monokai-theme = callPackage ({ elpaBuild, fetchurl, lib }:
       elpaBuild {
         pname = "monokai-theme";
@@ -818,6 +1115,27 @@
         packageRequires = [];
         meta = {
           homepage = "https://elpa.gnu.org/packages/monokai-theme.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    mpv = callPackage ({ cl-lib ? null
+                       , elpaBuild
+                       , emacs
+                       , fetchurl
+                       , json ? null
+                       , lib
+                       , org }:
+      elpaBuild {
+        pname = "mpv";
+        ename = "mpv";
+        version = "0.2.0";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/mpv-0.2.0.tar";
+          sha256 = "14d5376y9b3jxxhzjcscx03ss61yd129dkb0ki9gmp2sk7cns3n5";
+        };
+        packageRequires = [ cl-lib emacs json org ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/mpv.html";
           license = lib.licenses.free;
         };
       }) {};
@@ -881,6 +1199,102 @@
           license = lib.licenses.free;
         };
       }) {};
+    org-journal = callPackage ({ elpaBuild, emacs, fetchurl, lib, org }:
+      elpaBuild {
+        pname = "org-journal";
+        ename = "org-journal";
+        version = "2.1.2";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/org-journal-2.1.2.tar";
+          sha256 = "1s5hadcps283c5a1sy8fp1ih064l0hl97frj93jw3fkx6jwbqf0v";
+        };
+        packageRequires = [ emacs org ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/org-journal.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    org-mime = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "org-mime";
+        ename = "org-mime";
+        version = "0.2.4";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/org-mime-0.2.4.tar";
+          sha256 = "048psi5h8ln83pra4f24iq794w00b8p8pk67cylbd8afjdhh2x1r";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/org-mime.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    org-superstar = callPackage ({ elpaBuild, emacs, fetchurl, lib, org }:
+      elpaBuild {
+        pname = "org-superstar";
+        ename = "org-superstar";
+        version = "1.5.1";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/org-superstar-1.5.1.tar";
+          sha256 = "0qwnjd6i3mzkvwdwpm3hn8hp3jwza43x1xq1hfi8d6fa9mwzw9nl";
+        };
+        packageRequires = [ emacs org ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/org-superstar.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    pacmacs = callPackage ({ cl-lib ? null
+                           , dash
+                           , elpaBuild
+                           , emacs
+                           , f
+                           , fetchurl
+                           , lib }:
+      elpaBuild {
+        pname = "pacmacs";
+        ename = "pacmacs";
+        version = "0.1";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/pacmacs-0.1.tar";
+          sha256 = "0vhxxnk8n4h2klvr4xahsm845dwds895fxxgcs7dz2262g9myd93";
+        };
+        packageRequires = [ cl-lib dash emacs f ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/pacmacs.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    parseclj = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "parseclj";
+        ename = "parseclj";
+        version = "1.0.6";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/parseclj-1.0.6.tar";
+          sha256 = "0cs6a394pll9sl8ybpsygg9mkznpz119f8hjgw3n7mgkwfc5a30k";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/parseclj.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    parseedn = callPackage ({ elpaBuild, emacs, fetchurl, lib, map, parseclj }:
+      elpaBuild {
+        pname = "parseedn";
+        ename = "parseedn";
+        version = "1.0.6";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/parseedn-1.0.6.tar";
+          sha256 = "1274pr91hcrvy4srdy2dw14hbcg2qy24z4klx6mashgzb1r42n3d";
+        };
+        packageRequires = [ emacs map parseclj ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/parseedn.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     pdf-tools = callPackage ({ elpaBuild
                              , emacs
                              , fetchurl
@@ -920,10 +1334,10 @@
       elpaBuild {
         pname = "popup";
         ename = "popup";
-        version = "0.5.8";
+        version = "0.5.9";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/popup-0.5.8.tar";
-          sha256 = "1amwxsymzvzmj8696fa6i0cqx4ac581rvr4dwkri7akkr7amh3yh";
+          url = "https://elpa.nongnu.org/nongnu/popup-0.5.9.tar";
+          sha256 = "0zyn6q3fwj20y7zdk49jbid2h3yf8l5x8y1kv9mj717kjbxiw063";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -961,6 +1375,21 @@
           license = lib.licenses.free;
         };
       }) {};
+    rainbow-delimiters = callPackage ({ elpaBuild, fetchurl, lib }:
+      elpaBuild {
+        pname = "rainbow-delimiters";
+        ename = "rainbow-delimiters";
+        version = "2.1.5";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/rainbow-delimiters-2.1.5.tar";
+          sha256 = "0bb7sqjgpm3041srr44l23p3mcjhvnpxl594ma25pbs11qqipz5w";
+        };
+        packageRequires = [];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/rainbow-delimiters.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     request = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
       elpaBuild {
         pname = "request";
@@ -995,10 +1424,10 @@
       elpaBuild {
         pname = "rust-mode";
         ename = "rust-mode";
-        version = "1.0.2";
+        version = "1.0.3";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/rust-mode-1.0.2.tar";
-          sha256 = "08zkq5md20ppqlvd5xxsbzargs6ffzmjr1b1pq9i937l3n9d4swl";
+          url = "https://elpa.nongnu.org/nongnu/rust-mode-1.0.3.tar";
+          sha256 = "1hg5hr5jma5v4rilchwyyw1fzm8lkfd3fxay0sb9dgzrgypvh5am";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -1037,6 +1466,36 @@
         packageRequires = [];
         meta = {
           homepage = "https://elpa.gnu.org/packages/scala-mode.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    sesman = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "sesman";
+        ename = "sesman";
+        version = "0.3.2";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/sesman-0.3.2.tar";
+          sha256 = "1nv0xh6dklpw1jq8b9biv70gzqa7par5jbqacx2lx0xhkyf0c7c1";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/sesman.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    shellcop = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "shellcop";
+        ename = "shellcop";
+        version = "0.0.7";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/shellcop-0.0.7.tar";
+          sha256 = "1zwj22bf37ffdbz5iqkwz5mzzsxffhj521dmwkgp5sh4r1fwip8a";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/shellcop.html";
           license = lib.licenses.free;
         };
       }) {};
@@ -1119,10 +1578,10 @@
       elpaBuild {
         pname = "subed";
         ename = "subed";
-        version = "0.0.2";
+        version = "0.0.3";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/subed-0.0.2.tar";
-          sha256 = "1q9sb8kn1g5hvmm5zl4hm90fvf5kb82da69y24x7yzgs6axy0dga";
+          url = "https://elpa.nongnu.org/nongnu/subed-0.0.3.tar";
+          sha256 = "1qwpzj9j5fbis6vlgnqyilc49gbnxf48wcrjl8kljwzna3hsk7bx";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -1175,6 +1634,57 @@
           license = lib.licenses.free;
         };
       }) {};
+    tangotango-theme = callPackage ({ elpaBuild, fetchurl, lib }:
+      elpaBuild {
+        pname = "tangotango-theme";
+        ename = "tangotango-theme";
+        version = "0.0.7";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/tangotango-theme-0.0.7.tar";
+          sha256 = "0xl90c7hzzd2wanz41mb5ikjgrfga28qb893yvdcy0pa6mgdmpmx";
+        };
+        packageRequires = [];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/tangotango-theme.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    telephone-line = callPackage ({ cl-generic
+                                  , cl-lib ? null
+                                  , elpaBuild
+                                  , emacs
+                                  , fetchurl
+                                  , lib
+                                  , seq }:
+      elpaBuild {
+        pname = "telephone-line";
+        ename = "telephone-line";
+        version = "0.5";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/telephone-line-0.5.tar";
+          sha256 = "09glq2ljd10mqx54i3vflk7yjb1abhykzm9kng4wrw5156ssn6zs";
+        };
+        packageRequires = [ cl-generic cl-lib emacs seq ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/telephone-line.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    toc-org = callPackage ({ elpaBuild, fetchurl, lib }:
+      elpaBuild {
+        pname = "toc-org";
+        ename = "toc-org";
+        version = "1.1";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/toc-org-1.1.tar";
+          sha256 = "1wy48z4x756r7k6v9znn3f6bfxh867vy58wal7wmhxxig6sn9bk3";
+        };
+        packageRequires = [];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/toc-org.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     tuareg = callPackage ({ caml, elpaBuild, emacs, fetchurl, lib }:
       elpaBuild {
         pname = "tuareg";
@@ -1217,6 +1727,21 @@
         packageRequires = [];
         meta = {
           homepage = "https://elpa.gnu.org/packages/vc-fossil.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    visual-fill-column = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "visual-fill-column";
+        ename = "visual-fill-column";
+        version = "2.4";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/visual-fill-column-2.4.tar";
+          sha256 = "0100v17s9w9nqjpr7h3zianfy1i4i71idk2qrlzqzcd8qn1m3vjx";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/visual-fill-column.html";
           license = lib.licenses.free;
         };
       }) {};
@@ -1274,14 +1799,44 @@
       elpaBuild {
         pname = "with-editor";
         ename = "with-editor";
-        version = "3.0.5";
+        version = "3.1.1";
         src = fetchurl {
-          url = "https://elpa.nongnu.org/nongnu/with-editor-3.0.5.tar";
-          sha256 = "0bri6jr99133k9w0d754rw2f6hgjzndczngfw2lf2rvxks448krm";
+          url = "https://elpa.nongnu.org/nongnu/with-editor-3.1.1.tar";
+          sha256 = "175k68mr0n3v5l3gbv2fsdfznm9yjy32l3ay6hj0d4c53kw76hvn";
         };
         packageRequires = [ emacs ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/with-editor.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    ws-butler = callPackage ({ elpaBuild, fetchurl, lib }:
+      elpaBuild {
+        pname = "ws-butler";
+        ename = "ws-butler";
+        version = "0.6";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/ws-butler-0.6.tar";
+          sha256 = "1mm1c2awq2vs5fz773f1pa6ham29ws1agispxfjvj5nx15a0kqzl";
+        };
+        packageRequires = [];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/ws-butler.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    xml-rpc = callPackage ({ elpaBuild, fetchurl, lib }:
+      elpaBuild {
+        pname = "xml-rpc";
+        ename = "xml-rpc";
+        version = "1.6.15";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/xml-rpc-1.6.15.tar";
+          sha256 = "0z87rn7zbd8335iqfvk16zpvby66l0izzw438pxdr7kf60i5vgwl";
+        };
+        packageRequires = [];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/xml-rpc.html";
           license = lib.licenses.free;
         };
       }) {};

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -36,15 +36,6 @@
    ],
    "commit": "63cd5eccc85e527f28e1acc89502a53245000428",
    "sha256": "1cd0drlhi0lf1vmarcfl3vc7ldkymaj50dhqb1ajm7r0s5ps3asb"
-  },
-  "stable": {
-   "version": [
-    0,
-    4,
-    3
-   ],
-   "commit": "ab3e213607e6349aecc0063332972ac40506edd9",
-   "sha256": "1aywyarjl8fghy5py05rd64sidhkla0xzks1596p1gwpk5pm7n0n"
   }
  },
  {
@@ -1044,8 +1035,8 @@
     "auto-complete",
     "yasnippet"
    ],
-   "commit": "fc834dcc193e7168ffa0b3ae81ab3eefa4fd3c59",
-   "sha256": "08hnw5dbcs4ww2ir7ilnfc6r0b123alh4l8i1mzvng0h3mvmlhgq"
+   "commit": "92d559309d0c7614e2ccc982002b7ff963f3c9dd",
+   "sha256": "0aidj0hz97qw8jpwcbdmhjqk8wsdls3jiq9j6bbrqh458j6p317h"
   },
   "stable": {
    "version": [
@@ -1070,8 +1061,8 @@
   "repo": "xcwen/ac-php",
   "unstable": {
    "version": [
-    20211204,
-    733
+    20211220,
+    219
    ],
    "deps": [
     "dash",
@@ -1081,8 +1072,8 @@
     "s",
     "xcscope"
    ],
-   "commit": "fc834dcc193e7168ffa0b3ae81ab3eefa4fd3c59",
-   "sha256": "08hnw5dbcs4ww2ir7ilnfc6r0b123alh4l8i1mzvng0h3mvmlhgq"
+   "commit": "92d559309d0c7614e2ccc982002b7ff963f3c9dd",
+   "sha256": "0aidj0hz97qw8jpwcbdmhjqk8wsdls3jiq9j6bbrqh458j6p317h"
   },
   "stable": {
    "version": [
@@ -1558,8 +1549,8 @@
    "deps": [
     "avy"
    ],
-   "commit": "c7cb315c14e36fded5ac4096e158497ae974bec9",
-   "sha256": "06zkb5v6h0gwrqx7xiz2vlzf13kzf3z79xc5jhv2j73rqcajjy9v"
+   "commit": "0577c426a9833ab107bab46c60d1885c611b2fb9",
+   "sha256": "07b9fs6ynnc0xdsfkiclq6ri8ghza6lpsv5r8nibdf59yjj3xcia"
   },
   "stable": {
    "version": [
@@ -1680,7 +1671,7 @@
   "stable": {
    "version": [
     1,
-    3,
+    4,
     0
    ],
    "deps": [
@@ -1688,8 +1679,8 @@
     "json",
     "request"
    ],
-   "commit": "9d591c5ec9a2b2c7b55a754dd37c7434b2ef9fdc",
-   "sha256": "0a1ylq0il5aca5y9acykaa47p8d9xb3jy4wgi1lpm60z06n4m99y"
+   "commit": "89902927023781e23f09d033a780fbed546c53e1",
+   "sha256": "1y0k282nsn6y18ai8vky3yy78ay2a6lgv5lhrmh0xl0r8hydv21g"
   }
  },
  {
@@ -1878,14 +1869,14 @@
   "repo": "minad/affe",
   "unstable": {
    "version": [
-    20211011,
-    725
+    20211221,
+    1304
    ],
    "deps": [
     "consult"
    ],
-   "commit": "8bf8b0a365e7a4c0a7088ca47553d437de19f45a",
-   "sha256": "021wbixfgb4lzj4kq4d0hi12smzmh2j5pjh0n2xa70jidsclnfcg"
+   "commit": "425e46cbc44d532b5bcacd90ad55b784834e536b",
+   "sha256": "0r51mf9s2cbh3qq4y04rc4b5x6b4qfqd5n5ix8xsq5x154ivmfcj"
   },
   "stable": {
    "version": [
@@ -2089,8 +2080,8 @@
     20180131,
     328
    ],
-   "commit": "a038d91ec593d1f1b19ca66a0576d59bbc24c523",
-   "sha256": "0f86xp7l8bv4z5dgf3pamjgqyiq3kfx9gbi9wcw0m6lbza8db15a"
+   "commit": "7d18c85c014671573628686012f3952fcd72c97b",
+   "sha256": "0x8p1899cd6v3446ld8p524f6v94ffcnk4nh5qsaaw254s61580c"
   },
   "stable": {
    "version": [
@@ -2133,14 +2124,14 @@
   "repo": "AnthonyDiGirolamo/airline-themes",
   "unstable": {
    "version": [
-    20200511,
-    1543
+    20211214,
+    1749
    ],
    "deps": [
     "powerline"
    ],
-   "commit": "a6a3bd55baee29bd372869c835aded0f7d5e5f76",
-   "sha256": "1yg9wdagysfa5xswdrnwngbzf7gmdhjsl40ivqnxxvb74adxcwp6"
+   "commit": "6bd102e49a7d87af1a72eb86e953991ff7bc954e",
+   "sha256": "0yrkbg4wwbp2rm60gmsalz7vrrklw908m6ws66j611z6h6wgmj48"
   },
   "stable": {
    "version": [
@@ -2182,15 +2173,15 @@
   "repo": "alan-platform/AlanForEmacs",
   "unstable": {
    "version": [
-    20210916,
-    1135
+    20220106,
+    727
    ],
    "deps": [
     "flycheck",
     "s"
    ],
-   "commit": "217ffe99e3acf7d545827605ec95434e392a9f5f",
-   "sha256": "09wd1k3hnf1hri8c9m27g8cnqka59szr2anfkkh35s52bynvpxf2"
+   "commit": "e96b06115f53ef81097f585f627855d97b35b89f",
+   "sha256": "08b3m6233yzkx7ff0pch4k9lzysk6dkwc9vhn0dhip7s775laa63"
   },
   "stable": {
    "version": [
@@ -2440,11 +2431,11 @@
   "repo": "domtronn/all-the-icons.el",
   "unstable": {
    "version": [
-    20211108,
-    7
+    20220106,
+    2021
    ],
-   "commit": "483dba65e897071c156cefec937edcf51aa333db",
-   "sha256": "01v0pyfz49a74d7vqg8nhq9jpbyqbywcpk3ajc59d9fwg7wmzjvq"
+   "commit": "9dd3d7a24956fa9400106626e3bca407861521ec",
+   "sha256": "1yxdr3bm7vfnk1p98ai2769zvypkpv2lyddsnzyxmdx1jzh96gr5"
   },
   "stable": {
    "version": [
@@ -2464,14 +2455,14 @@
   "repo": "iyefrat/all-the-icons-completion",
   "unstable": {
    "version": [
-    20211009,
-    2207
+    20220106,
+    1310
    ],
    "deps": [
     "all-the-icons"
    ],
-   "commit": "a0f34d68cc12330ab3992a7521f9caa1de3b8470",
-   "sha256": "18dd37p1vh8ixc2q07jqwzpc82qq31m89nzps192pdgkfffhdp8r"
+   "commit": "9e7d456b0934ecb568b6f05a8445e3f4ce32261f",
+   "sha256": "04bnmmd6lyx0p39sgymqvmcy7bk8mr7sikbpy49adxi7d2891ldg"
   }
  },
  {
@@ -2530,14 +2521,14 @@
   "repo": "seagle0128/all-the-icons-ibuffer",
   "unstable": {
    "version": [
-    20210927,
-    1407
+    20220104,
+    1421
    ],
    "deps": [
     "all-the-icons"
    ],
-   "commit": "f689582a413ba5bb722067ea470829819e1f1131",
-   "sha256": "1r4v86jgp656cs1mxxsb30i1kwka29nzfri151bjrnbyy0z99qrg"
+   "commit": "df9822a782c409f7e19481921c985d4290882c65",
+   "sha256": "1906z26h84zz9f7zj1lzqgr92i05h2vgkx2mg5aa2k8kiv4v8p3j"
   },
   "stable": {
    "version": [
@@ -2592,15 +2583,15 @@
   "repo": "seagle0128/all-the-icons-ivy-rich",
   "unstable": {
    "version": [
-    20210927,
-    1411
+    20220104,
+    1420
    ],
    "deps": [
     "all-the-icons",
     "ivy-rich"
    ],
-   "commit": "8c0cd543c8d79cf223216b3f44ac3a4b0695c484",
-   "sha256": "0yhg39gg5w3gjhwfgz6v33ld0qyjj4v627ka9az97biz2xvvvrl1"
+   "commit": "f7d3d1bb69c86087f8b05fa672dd62e096370bfa",
+   "sha256": "0xnrhrc51hvjxn1mc53jdz868a7gbr6frkl2vgcdbbm2v41jqxlv"
   },
   "stable": {
    "version": [
@@ -2666,8 +2657,8 @@
     20200723,
     1037
    ],
-   "commit": "fb8550cb690b0ec954968afc7e8e953fd6859cdb",
-   "sha256": "1flw5msh1sda3ymkkg8xcgixpa5jgm2i1ligna5h501xbybnk1iz"
+   "commit": "2219a8326f8cd8ea5cd91583ba84cae7557b6fd7",
+   "sha256": "1sx8mp875dfbrir26fl33hql2ypjx2alqzn55qrkhyafyn6lmcmv"
   },
   "stable": {
    "version": [
@@ -3038,14 +3029,6 @@
    ],
    "commit": "8720cde86af0f1859ccc8580571e8d0ad1c52cff",
    "sha256": "04kg2x0lif91knmkkh05mj42xw3dkzsnysjda6ian95v57wfg377"
-  },
-  "stable": {
-   "version": [
-    1,
-    0
-   ],
-   "commit": "7c0fb37f59dfd9e69f00b50e90a0e88c4e25d8c2",
-   "sha256": "1798nv4djhxzbin68zf6w7dbfm9sc39d0kygky52ii36arg5r1zp"
   }
  },
  {
@@ -3249,8 +3232,8 @@
     20200914,
     644
    ],
-   "commit": "756ac774b5191b252bf993b67c7ccd5648cbbb65",
-   "sha256": "174vd5dw7wz2kf08mcaakr0r0qx64bigkdhr9zg7c68xj0w0kasn"
+   "commit": "a0b3eea0c19c47ffbe2be525316311f5795d760d",
+   "sha256": "06hqdmhlxr8air3hfpw434ycfvyjby34ng6xj0knjyfja0044sb0"
   },
   "stable": {
    "version": [
@@ -3602,20 +3585,19 @@
   "repo": "raxod502/apheleia",
   "unstable": {
    "version": [
-    20211121,
-    1845
+    20220105,
+    2335
    ],
-   "commit": "2cf903e9a2faa3b50c97896b59361960472330f9",
-   "sha256": "04wgv5mhh9r2814k0332c8dxn89hyxh06vls2g89zzqmy5nm6gi5"
+   "commit": "53f243b111b18f49d910d1501b5795a1ec045420",
+   "sha256": "15r3xgyd3qi331k7p66kf10bjy8ixm0pdb6v4z6fhs29s2wzqb5j"
   },
   "stable": {
    "version": [
     1,
-    1,
     2
    ],
-   "commit": "53ac964e53e75b9a35a7bd173f23290d0f42d95c",
-   "sha256": "0f2dqid4h0psdyx3p18c7xn7nf8zr6y4qq98yvyjfbwq5lcjk4rn"
+   "commit": "443f5aeb1a7115a2db7af4a0a66e111c13d4252c",
+   "sha256": "06i912zybc6c1djb9xqfqydl6achgxsmx6hjy50y9lxc0f2p5py9"
   }
  },
  {
@@ -4015,6 +3997,36 @@
   }
  },
  {
+  "ename": "arxiv-mode",
+  "commit": "1207f9108fae0bdb11b74971dbb6b6d9ec25e5c0",
+  "sha256": "01am6h9h2m0fqsmxgk9c36jwraznh5wp2k1ajmwawplx4cshhx1x",
+  "fetcher": "github",
+  "repo": "fizban007/arxiv-mode",
+  "unstable": {
+   "version": [
+    20211231,
+    100
+   ],
+   "deps": [
+    "hydra"
+   ],
+   "commit": "209a026f528d5b8de0da996d46fddc47ce0749fd",
+   "sha256": "1kaikdh2mcp6qg45wlhi3ffq9ws2n07i26byxjvxbwwpd5f0335v"
+  },
+  "stable": {
+   "version": [
+    0,
+    3,
+    0
+   ],
+   "deps": [
+    "hydra"
+   ],
+   "commit": "74105e665758bad77bd67c00435dbee95c83d791",
+   "sha256": "1d9aw5x2ypx6d5dyjrnmlrfdj0k5a6z6nqvrllb1n38a8gsr47ym"
+  }
+ },
+ {
   "ename": "ascii-table",
   "commit": "d6d5599ff68bf9125a9825ddd2a00009242bf2e1",
   "sha256": "0p3dyxzs5xaq17209nnf2cqs87hz2b1k3x1nkq4jvhn71v4jcaj1",
@@ -4150,11 +4162,11 @@
   "repo": "jwiegley/emacs-async",
   "unstable": {
    "version": [
-    20210823,
-    528
+    20220104,
+    1222
    ],
-   "commit": "5d365ffc6a2c2041657eaa5d762c395ea748c8d7",
-   "sha256": "0fn2dyj43ag7abh7x2m4qcn7ij1kp65d3vqlkcri780fv4wp7mc4"
+   "commit": "0d52411d3accc3e11a2c64838703a8ce9755c77c",
+   "sha256": "0afjx74l0fywjr1gdf023prkbv9xglicjakbfbyw41m7vvlzcvk3"
   },
   "stable": {
    "version": [
@@ -4255,8 +4267,8 @@
     20201026,
     339
    ],
-   "commit": "781e07c6972591e4147edf81f6314f297cc4c0df",
-   "sha256": "0gzhf8004fz0a3zi9nihdgyhya01zihhcqfzr2wdp8a9rczlavrb"
+   "commit": "411e9c943cf8ee966d7850c69b5e3c405e268246",
+   "sha256": "00977n8sp0bbpnbqwj2jfdvm9d9cqwfl4mn1wv1dj6bzfzxp68mc"
   },
   "stable": {
    "version": [
@@ -4279,8 +4291,8 @@
     20210731,
     609
    ],
-   "commit": "69780e11cfccbd05516b7c2724e02242e3d188d7",
-   "sha256": "0vp4hm4xgi7kq97b4gyzafs7sbyd9mjrzwnv8xwacib71jn74vnr"
+   "commit": "7d6332093d2ad6963b2305ad3038f44b941a43c1",
+   "sha256": "01xdll1gyachgh9p9pc3c0pdki2h2xmiri9cslsaq48y9gklgaw2"
   },
   "stable": {
    "version": [
@@ -4371,8 +4383,8 @@
   "repo": "jyp/attrap",
   "unstable": {
    "version": [
-    20210426,
-    1348
+    20211223,
+    1443
    ],
    "deps": [
     "dash",
@@ -4380,8 +4392,8 @@
     "flycheck",
     "s"
    ],
-   "commit": "a5bc695af27349ae6fe4541a581e6fd449d2a026",
-   "sha256": "06j1cpqmplh1xy5aal8fk7r8s42jf3zlk92mh3lll9knx81xix9q"
+   "commit": "12b06e076689f9b85f2d247b80779b98efb4daa4",
+   "sha256": "00qcdwq59gyg4qz7lsmkr9khx88dfhvixfrgq3cmzj4czpmbf856"
   },
   "stable": {
    "version": [
@@ -4580,8 +4592,8 @@
     "keytar",
     "s"
    ],
-   "commit": "a1e0a364a64900839b544d88347fa229b3aa91ab",
-   "sha256": "0cinmvmzmlqms4kx4qc78fzxgwxki4jd6zk62y2rghk307i97qbb"
+   "commit": "c9ce75de3784ba68b44a643e4d00e59e351d976a",
+   "sha256": "03pa44qhyyyv476gbpzshywr2yg6m48rq6kgzli3bajd4ysm9ism"
   },
   "stable": {
    "version": [
@@ -4716,15 +4728,15 @@
   "repo": "auto-complete/auto-complete",
   "unstable": {
    "version": [
-    20211210,
-    1808
+    20220105,
+    439
    ],
    "deps": [
     "cl-lib",
     "popup"
    ],
-   "commit": "027dd93ffdd6219c9229fbb98d0ee25496dec1ee",
-   "sha256": "013g2dkyhvvx44l9q8lphv1011ilanyikhs7jf6qxp5v2plp4i6q"
+   "commit": "57cb8f2ee32dff17ea1b4431fe5920272aa38d72",
+   "sha256": "185q90ibw17dh2nwdljapdw2747hzv32n4hkjfcfsgw5asy58r8z"
   },
   "stable": {
    "version": [
@@ -5045,14 +5057,14 @@
   "repo": "elp-revive/auto-highlight-symbol",
   "unstable": {
    "version": [
-    20211125,
-    747
+    20220103,
+    1602
    ],
    "deps": [
     "ht"
    ],
-   "commit": "40efce76ee0dff920f2ba2315e568e75e5218830",
-   "sha256": "0nisaafqlns76wqvd4ys68h5ys4vcrzwy7lxrb4nvlhvq840g9f6"
+   "commit": "5949aa269d3781985c3c9fc5e557bd82c3c1f7e4",
+   "sha256": "01qqdkd16zy5sqla821k2q3bh4gmlq5xp5wdar58rm7cww6r4w5x"
   },
   "stable": {
    "version": [
@@ -5201,8 +5213,8 @@
     20210805,
     1344
    ],
-   "commit": "0f138b6e64d79d16ccdd0b74995d7e30aff9555a",
-   "sha256": "0a2inh57vipf24ahjp00lbb31v26z8gj1931pb5rxz6nry9app3n"
+   "commit": "77f66b75209628a267a5ced84cd85774e0e26b9a",
+   "sha256": "1n0b74zhj4v9gniy33im4cahxx33mhbkhjpb4ra4qahqdyl5a7c9"
   },
   "stable": {
    "version": [
@@ -5299,16 +5311,16 @@
   "repo": "marcwebbie/auto-virtualenv",
   "unstable": {
    "version": [
-    20200729,
-    2204
+    20211215,
+    907
    ],
    "deps": [
     "cl-lib",
     "pyvenv",
     "s"
    ],
-   "commit": "214604ebd3366078d03814a344c3249268d1f15a",
-   "sha256": "14waa4v6nr0ybyncgfjg96r43ma4lw57iyma0chvpqifmbs6ski0"
+   "commit": "07064e05feb62277991b8a7c04f7cdad50acaddf",
+   "sha256": "1f1fi57dc19mp1cbkg7xh62g4xpqc3i0pzqpjkg8m5361gb67qz4"
   }
  },
  {
@@ -5406,11 +5418,11 @@
   "url": "https://git.sr.ht/~pkal/autocrypt",
   "unstable": {
    "version": [
-    20210917,
-    1556
+    20211218,
+    1848
    ],
-   "commit": "709dc5b3bf5963f527006cbd504e7d6d558562db",
-   "sha256": "0w9rm66d6dvb8qmpsfwxhmjgcpwmn3jkgsiq91qhphwqvmgl3vvy"
+   "commit": "222954754ace827a80999955f02008841b260325",
+   "sha256": "01xg2g7fr6l495yvxsrln4q1i6v626spdy2yw9jkbc2jzpx34v0q"
   }
  },
  {
@@ -5470,8 +5482,8 @@
     20190331,
     2230
    ],
-   "commit": "2d76365d2aa13543121d5c623df465adb68b76f7",
-   "sha256": "1n247g5dq73rkxf0wys5lsbvma44y5qlh577s3rcx7l0yrylwdry"
+   "commit": "842ae4df222bbd6596068814ac1b1e505c2a6b7a",
+   "sha256": "19j76bgv5hca8i9385f1s66zj31y70fgppmvxdqrws4265zqc11d"
   }
  },
  {
@@ -5500,15 +5512,15 @@
   "repo": "jasonm23/autothemer",
   "unstable": {
    "version": [
-    20180920,
-    923
+    20220106,
+    416
    ],
    "deps": [
     "cl-lib",
     "dash"
    ],
-   "commit": "8ec0c27a73b2d0a335eda63fde695a101e2956b2",
-   "sha256": "1m2r5fg5r4gqhim5l1g5937ngkc2hvidb5kr8r4pffcg8xv8djgn"
+   "commit": "36f1f4f0c71d546b0b19d1d359832ec91d02532d",
+   "sha256": "1syp5qnwcpapxl5b3m1dmcx698043d1mkmgm32dmlin2sklyavp2"
   },
   "stable": {
    "version": [
@@ -5577,14 +5589,14 @@
   "repo": "abo-abo/avy",
   "unstable": {
    "version": [
-    20201226,
-    1734
+    20220102,
+    805
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "e92cb37457b43336b765630dbfbea8ba4be601fa",
-   "sha256": "1w7421h9arxj39w4q3000avcbasl1c95r0hys7rchmlbkqas32cb"
+   "commit": "ba5f035be33693d1a136a5cbeedb24327f551a92",
+   "sha256": "0pimrjxxvx48vl5nbp9zskfmlcmdgrrkfa218qpck8igahh3nswl"
   },
   "stable": {
    "version": [
@@ -5614,8 +5626,8 @@
     "avy",
     "embark"
    ],
-   "commit": "54e5efae17a5c2898faabeaca9564a4d5f05761f",
-   "sha256": "0vpjszfqvkjzkjpma47rdyjzgkqdfg7palyzlii62wsrh04frg4l"
+   "commit": "8cf1fdbfacdbdb98ca3b4e50bf295059a02fe4a2",
+   "sha256": "1ff1vicshrnfi02ss7xcvglpg6lhw7pib142x99hqfi8a4jrvz28"
   },
   "stable": {
    "version": [
@@ -6179,11 +6191,11 @@
   "repo": "belak/base16-emacs",
   "unstable": {
    "version": [
-    20210805,
-    1401
+    20211225,
+    2032
    ],
-   "commit": "9836cc26c2f8ed9d809feee2bfd8c082cfdbd033",
-   "sha256": "146fmjkib6d05xyz88yc903w8wla19f0vy3f91yr4qj7ab74frxf"
+   "commit": "ad2fd1137d6ec144f87b26dce15ce5c5d42bde39",
+   "sha256": "009k9j7bi7x8pmp5d12bdzng3ampqwy8l1jf1dxxf9989wv27hrc"
   },
   "stable": {
    "version": [
@@ -6805,20 +6817,11 @@
   "url": "https://git.sr.ht/~technomancy/better-defaults",
   "unstable": {
    "version": [
-    20211212,
-    1841
+    20211216,
+    420
    ],
-   "commit": "5383a9b2560adc4f7ebbdf148d87b19bf7cf8cc4",
-   "sha256": "1h1nfmpa4prfhi4j7l46q99y315ds6kl3qnxjgkdnw57nxqbwfl5"
-  },
-  "stable": {
-   "version": [
-    0,
-    1,
-    3
-   ],
-   "commit": "90df5752a0a0602feb47aadfd3542aa7fc841bd8",
-   "sha256": "1rxznx2l0cdpiz8mad8s6q17m1fngpgb1cki7ch6yh18r3qz8ysr"
+   "commit": "4b833e0601e77a8ed86b30929da2aba2b88f33be",
+   "sha256": "0g28ra3x38nq6qaxn163iyjjipj4pspwsyyi1y15qqp264fv1002"
   }
  },
  {
@@ -6847,8 +6850,8 @@
     20210715,
     1004
    ],
-   "commit": "319c24d9aa46a66d43cf689134c7e1703288d251",
-   "sha256": "033kaj3pbfggm55dgb9xagfdzzmrybsmz7kr358az7233cl9qasm"
+   "commit": "0be8e2ef7b40d9006b2812f103746799bc529828",
+   "sha256": "1grzlfa4dxf30yf7y40fw9fqm4fl74k5kcyxpffy3d876c7qdfnp"
   },
   "stable": {
    "version": [
@@ -7145,20 +7148,20 @@
   "repo": "tarsius/bicycle",
   "unstable": {
    "version": [
-    20210615,
-    1459
+    20220101,
+    1042
    ],
-   "commit": "2f0d6fbe0e363a0ed1f878316d1c0d7c1d6e1082",
-   "sha256": "1zlbz5kkqz4r3a2d5y563s1isbs1328kjjrfmn69gwd6w2zi5pii"
+   "commit": "c69b010c7b4899b6c016f926ad3a6e11ebfec0bc",
+   "sha256": "141mq2ivwpmb952zdh7rvr24awi0ffpz5nm7wyc6kz8wlm5pgavv"
   },
   "stable": {
    "version": [
     0,
     4,
-    4
+    5
    ],
-   "commit": "e3fbc0737bb5f891e4d57d048bbc1fe17401f17f",
-   "sha256": "1jgrnd3yxaqgd3rxls41xxzfaq9hkmjk9wbdg06ak9h5xw4fi17j"
+   "commit": "c69b010c7b4899b6c016f926ad3a6e11ebfec0bc",
+   "sha256": "141mq2ivwpmb952zdh7rvr24awi0ffpz5nm7wyc6kz8wlm5pgavv"
   }
  },
  {
@@ -7278,11 +7281,11 @@
   "repo": "justbur/emacs-bind-map",
   "unstable": {
    "version": [
-    20161207,
-    1511
+    20220108,
+    228
    ],
-   "commit": "bf4181e3a41463684adfffc6c5c305b30480e30f",
-   "sha256": "0vrk17yg3jbww92p433p64ijmjf7cjg2wmzi9w418235w1xdfzz8"
+   "commit": "510a24138d8de3b8df0783f1ac493a551fc9bd74",
+   "sha256": "0crxjy1ykgb429z8ikjv5iy8vg5i0qn8n86p2lgri4glx45sxxx0"
   },
   "stable": {
    "version": [
@@ -7542,8 +7545,8 @@
    "deps": [
     "a"
    ],
-   "commit": "d452006a31895a79216bf35a64482631a83cfc2d",
-   "sha256": "0gi0q60q9r5nx5wzavxywajmh9gw4nl20msgh9k9k9ilj4jy3a1b"
+   "commit": "9e7517cfee9272e9e4822b4efc3fac7e32d7bb38",
+   "sha256": "00b8pnm1990fjiznz568mf3680cb2wq2qphbd3h0kdbzzanfn1fl"
   },
   "stable": {
    "version": [
@@ -7803,8 +7806,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "2d1ee12f3ba6e75841066bf429d7bf836d4b89d7",
-   "sha256": "1hls8463fl8ndbfry1x4pimx2fz1b9zl3b6wfgcrb3jw3p4ys86x"
+   "commit": "d9329dd90e5d4f629295e85898362d9682047898",
+   "sha256": "1b4a43nhv52k4vg2cmf5n63i29n3lcd0d789z7w895q1z5zfmh5s"
   },
   "stable": {
    "version": [
@@ -7961,11 +7964,11 @@
   "repo": "minad/bookmark-view",
   "unstable": {
    "version": [
-    20211019,
-    511
+    20211223,
+    1106
    ],
-   "commit": "59078eaa37ec168c37d52798c9f1020741271a64",
-   "sha256": "01yklj4nkpz5x45szs9b0d77xdn05rkwgl3dwjyr2j3134828mk6"
+   "commit": "841750afb272a596f1536e6a5731d9de22c7c5cb",
+   "sha256": "0bgbmjbjq70q4zmdhaz9jnhi5gkzxwz9fbh60sgnm90hjmfrrr2d"
   },
   "stable": {
    "version": [
@@ -8008,16 +8011,16 @@
   "repo": "jyp/boon",
   "unstable": {
    "version": [
-    20211125,
-    2054
+    20211217,
+    737
    ],
    "deps": [
     "dash",
     "expand-region",
     "multiple-cursors"
    ],
-   "commit": "12d6838c90058fea768cb55a0018807db804b11b",
-   "sha256": "1hcm9a09sy038kn1ij50q24w73485q55gypzx1yypz3wp5a2s8yd"
+   "commit": "654fb8051a5c00dd524710fbf917b00f6afc8844",
+   "sha256": "0rhrq2nj1cqcqbnsf0npn5372yi85czi7r1h9lqjbyfgb2ifxvdn"
   },
   "stable": {
    "version": [
@@ -8035,34 +8038,34 @@
  },
  {
   "ename": "borg",
-  "commit": "878ab90d444f3a1fd2c9f9068ca7b477e218f1da",
-  "sha256": "0gn4hf7hn190gl0kg59nr6jzjnb39c0hy9b3brrsfld9hyxga9jr",
+  "commit": "325cca8031b99c6abe2ee9858a6b547d1af0cdde",
+  "sha256": "0rklhjm6zpmyjvw39475fsfn5n5mxkf33b8hkfx0pjjdp0ylr21n",
   "fetcher": "github",
   "repo": "emacscollective/borg",
   "unstable": {
    "version": [
-    20211111,
-    2352
+    20220105,
+    1143
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "bcae8f00dc60eca1a7cdd837e9be3b0fc942097d",
-   "sha256": "1agdddpjfxqrpiz7b9xnffw0bmb09a2mglcjb3xmhgn7zv309m3h"
+   "commit": "b4bb2a377ef277feade958dc22212652d0efb678",
+   "sha256": "0rb7mwh86w96arammq3aca7zxwvzfmjii85p3bhpcd0p35kshpsz"
   },
   "stable": {
    "version": [
     3,
-    2,
+    3,
     0
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "e2263534e16ed8bbc935ee466f6ad2acbe9c603e",
-   "sha256": "169sdgi476hnxxv0s9qfi8cply9q7gb8i1hli4i74ynlrhc9wfq7"
+   "commit": "e4d54aac5c2307cafb5c509094701b9ca78cace8",
+   "sha256": "102qdb4581gfhrxv61pd6yw5xbyd3vs8ifq2wp9wq6bf19il2rm9"
   }
  },
  {
@@ -8103,14 +8106,14 @@
   "repo": "davep/boxquote.el",
   "unstable": {
    "version": [
-    20200727,
-    1203
+    20220105,
+    1515
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "bdc6c84b9274b228dbc383a14abf9694157e869c",
-   "sha256": "0wwjawgylaaifdsszqxcfsyhfzgxbjkzqhzrnxnr9b16wghb7xf7"
+   "commit": "67775ce80886b776efedceb31cdbacec1e26678e",
+   "sha256": "0qp4ffly2amlj78vzp05z7f8b8klh5rwj67gbsw1n6vik1xdihb1"
   },
   "stable": {
    "version": [
@@ -8234,25 +8237,25 @@
   "url": "https://bitbucket.org/MikeWoolley/brf-mode",
   "unstable": {
    "version": [
-    20210509,
-    1534
+    20220104,
+    2222
    ],
    "deps": [
     "fringe-helper"
    ],
-   "commit": "9e66643e1153133508bb1d63a21f3bd8f46908fd",
-   "sha256": "1z5gwmdifrr5r3gmv1dw44vad08cvdfndv555pb8bdksnd9jm130"
+   "commit": "59ec15094917666f253eaf61d17664525a7971f4",
+   "sha256": "0cxcjjslh9n678abs289d32880z97xb8cxmglhrhnfly2zx7h8p7"
   },
   "stable": {
    "version": [
     1,
-    20
+    22
    ],
    "deps": [
     "fringe-helper"
    ],
-   "commit": "9d6b6797c465589ca39a1020d7af5775f5ddc801",
-   "sha256": "1jpsrsc4qi2yiwxccdagxz1gj9fgzaxnd5fszgdmwvsgzqwfasvh"
+   "commit": "59ec15094917666f253eaf61d17664525a7971f4",
+   "sha256": "0cxcjjslh9n678abs289d32880z97xb8cxmglhrhnfly2zx7h8p7"
   }
  },
  {
@@ -8742,8 +8745,8 @@
     20200924,
     345
    ],
-   "commit": "db7ab16c98307855e7e258f215703a54911be22c",
-   "sha256": "05g1k43ilkfx9mxqmikkd8v6yv89lri5m4mr0prpq4yqb3xv0bx3"
+   "commit": "b48834a688e35b9966fa5a189781c7638092fd54",
+   "sha256": "1msg17qw6clld78jb40hd1fnsgswql57yw4kh37mn0v2ksa8a9s5"
   },
   "stable": {
    "version": [
@@ -9144,8 +9147,8 @@
     20210105,
     2255
    ],
-   "commit": "108d2298cc34d906b196178ad955e3dc139e1779",
-   "sha256": "1vwg82haclgwgjaq0r84gj416ribv7qn1lz8ixf05xhqsvq7ja87"
+   "commit": "1cb7afcb0b6d87a3e623dc26ffcb2c7d4d6dd280",
+   "sha256": "07f8lxcyi007qfhgq0yvpq1pg8hklzq94pfkzpqq2hb2cvyj2zb5"
   },
   "stable": {
    "version": [
@@ -9761,11 +9764,11 @@
   "repo": "ocaml/caml-mode",
   "unstable": {
    "version": [
-    20210907,
-    2124
+    20211226,
+    27
    ],
-   "commit": "2905a436e956c5bba16c4633a6e4c4fceefa6535",
-   "sha256": "0i1p4w9zkbvpcplhvkk8n8ymcp8i7cxn2j6can70rlwwbcnyvzjf"
+   "commit": "204bfde9ad21cb94c273db8b0c12d31a4eb425e5",
+   "sha256": "1pn6whyp66bf2a4zj7g3g1ljlzfn0ia1xwb8lclvmjv0ind12zsz"
   },
   "stable": {
    "version": [
@@ -9818,19 +9821,19 @@
   "repo": "minad/cape",
   "unstable": {
    "version": [
-    20211213,
-    1130
+    20220105,
+    2127
    ],
-   "commit": "700c9d7bc221e04e259947f8fb7a908bf1909bc0",
-   "sha256": "1z2qddbirvzz017wflvc3wl5mnc7l8p8j8sc1wn7v0k8c0vdcw63"
+   "commit": "c6290431566e5e6f30518fc925183907820a1edf",
+   "sha256": "1y20il2y06phkdhzbq6y50fqvxx1xcyl11dcjyh8v7ccj143d7ax"
   },
   "stable": {
    "version": [
     0,
-    3
+    4
    ],
-   "commit": "edb2be3b71ce29ba3dbbafcafbd4e02e5a2e0ba3",
-   "sha256": "162jx3d50yxqsh5dgwvhzf6mgfgpb6lk5dwqg7j6s92alh5ardvb"
+   "commit": "bcf2fe1bdc21a61e11a635cf728a131b403989cf",
+   "sha256": "0f9w06gxdhmj4x74q9jss8byxs8x3qsb30lrj32rqwmd2fmmdjks"
   }
  },
  {
@@ -9844,7 +9847,7 @@
     20210707,
     2310
    ],
-   "commit": "2ed8664a08e2c92f0af39e213c20b13d15c03346",
+   "commit": "8009588ff84cbdf233f6d23d1d507462b050b427",
    "sha256": "1rp0fx1d8mafk08smxmkdgx2gwxkvn44hyw2rxn4ax72lli61j2g"
   },
   "stable": {
@@ -9895,14 +9898,14 @@
   "repo": "kwrooijen/cargo.el",
   "unstable": {
    "version": [
-    20211007,
-    739
+    20220102,
+    1217
    ],
    "deps": [
     "markdown-mode"
    ],
-   "commit": "c5e66a31eff5bdc0cc89e946e6cbf16af91602ec",
-   "sha256": "0kyb492w35igdzn2s1mhjpy7apydw8irv6sa098lwzbq7c9xm484"
+   "commit": "5589f9f46f3e1cdeb6261515ce314aab40f3d786",
+   "sha256": "133cj1qbb53hm3ffkvf80cyd6hj69l8kxklnig8ap1ymhha075g3"
   },
   "stable": {
    "version": [
@@ -10016,8 +10019,8 @@
     "s",
     "shut-up"
    ],
-   "commit": "467979414c85bb2ce83f5c6ab9f95721164e9efa",
-   "sha256": "0jccv6aprs4fq2m7b2hdxp0dgkjkwjfmlh5ywbl5pacms3c3l82l"
+   "commit": "751435bd56c7123d8244d9d156309e21e63cd5c0",
+   "sha256": "0jxwsaam7hqvqbxrkzd7hy09l87yjsg7z89jikzs6vzc72h02g8x"
   },
   "stable": {
    "version": [
@@ -10533,8 +10536,8 @@
     20171115,
     2108
    ],
-   "commit": "945aee7d4538e71a990dbb42ce99bf3f74e17b40",
-   "sha256": "0g1ak590qjfqd0nyj9spf10jbyb9f8mxrhjm6cq9p3hlzcbjl11c"
+   "commit": "9bdaecc79318acf668216db49dbf7a273a9736a8",
+   "sha256": "0869w2zh5jqzcb6nkd2pij833w8cqxi3zqsf5girk0l39rl8753n"
   },
   "stable": {
    "version": [
@@ -10667,31 +10670,24 @@
    "version": [
     1,
     5,
-    4
+    6
    ],
    "deps": [
     "dash",
     "posframe",
     "s"
    ],
-   "commit": "7c42f2c82c7ae689f3ef291b066688c58ab96298",
-   "sha256": "1x8y4cc1cgln4qv6yzhsiqgnziilg5fh07bvg9ygcjmdhvnhsvcm"
+   "commit": "8e9b79e38306b11411543d31cb483201131ba42a",
+   "sha256": "1sa0klkyr55xmshzxm9hz3j5vdkisxg67w8q00z7zbsald0imxbx"
   }
  },
  {
   "ename": "cg",
   "commit": "be27e728327016b819535ef8cae10020e5a07c2e",
   "sha256": "1xffjilr9f2s3w7j8f3clq7qvsnr0lr8gadlybpzzy8x5fbmk4n3",
+  "error": "Not in archive",
   "fetcher": "github",
-  "repo": "emacsmirror/cg",
-  "unstable": {
-   "version": [
-    20201211,
-    1238
-   ],
-   "commit": "6e0ad3007ab39e8438baaf87bde11aa72c6606f2",
-   "sha256": "152iqasjabrskwiyhik7v8vh2x14bglng3yg7yqx7xbw4jli4p8f"
-  }
+  "repo": "emacsmirror/cg"
  },
  {
   "ename": "challenger-deep-theme",
@@ -10742,15 +10738,6 @@
    ],
    "commit": "39fd24bb7cf44808200354ac0496be4fc4fddd9a",
    "sha256": "1482n2wwlgwf2dbn4kx4mcl0ylcl66yf9s8gkqcpszfdpw672kfh"
-  },
-  "stable": {
-   "version": [
-    1,
-    0,
-    0
-   ],
-   "commit": "936a76a26bdc4f9570c4d54369f74bcd1cb0a698",
-   "sha256": "0n93qz5hzsnrs6c3y5yighfpdpkkmabxyi5i755hfcs5007v199v"
   }
  },
  {
@@ -11180,16 +11167,16 @@
   "url": "https://tildegit.org/contrapunctus/chronometrist.git",
   "unstable": {
    "version": [
-    20211206,
-    928
+    20220108,
+    1756
    ],
    "deps": [
     "dash",
     "seq",
     "ts"
    ],
-   "commit": "7ca6413907ac57e09010265257c48b5500fe09f8",
-   "sha256": "06lsaw2z7q131dfgfcmm0dgiimjd6psxlk1biyzrahgs992gm7d2"
+   "commit": "0938841b26efa5dd3886ec6d7e14f4edfc2360d2",
+   "sha256": "0kcqy9hgs4h0gb1ixxnx3b49c32d88kwbrb4ml5x9pzr90i2apc9"
   },
   "stable": {
    "version": [
@@ -11223,19 +11210,6 @@
    ],
    "commit": "6cb939d160f5d5966d7853aa23f3ed7c7ef9df44",
    "sha256": "05jcn67fzf349h3vqvfrwhklan0i037mp0nq53wghfzapv1m7lv8"
-  },
-  "stable": {
-   "version": [
-    0,
-    3,
-    0
-   ],
-   "deps": [
-    "alert",
-    "chronometrist"
-   ],
-   "commit": "7a878bd3709b9638caff17b5f49b27c03b06862a",
-   "sha256": "1gyz0cfq7sqqrcj8d5ikm6xqmbg3njhmbi291fs5jr8bdqrcbbmg"
   }
  },
  {
@@ -11252,8 +11226,8 @@
    "deps": [
     "chronometrist"
    ],
-   "commit": "7ca6413907ac57e09010265257c48b5500fe09f8",
-   "sha256": "06lsaw2z7q131dfgfcmm0dgiimjd6psxlk1biyzrahgs992gm7d2"
+   "commit": "0938841b26efa5dd3886ec6d7e14f4edfc2360d2",
+   "sha256": "0kcqy9hgs4h0gb1ixxnx3b49c32d88kwbrb4ml5x9pzr90i2apc9"
   },
   "stable": {
    "version": [
@@ -11324,26 +11298,25 @@
   "repo": "clojure-emacs/cider",
   "unstable": {
    "version": [
-    20211209,
-    1217
+    20220105,
+    613
    ],
    "deps": [
     "clojure-mode",
     "parseedn",
-    "pkg-info",
     "queue",
     "seq",
     "sesman",
     "spinner"
    ],
-   "commit": "e7387f07b1398021cfce09aaf29bdc572f925154",
-   "sha256": "16pdq27c269bch1hmrc4j8xmxkiz6n26mapvgzks65156qrv9gfm"
+   "commit": "318fe6878d8bedf5db9dfa649dedb45d72b2e7ee",
+   "sha256": "0dq7k8x2sspg2r2275wj9sygscavvs0cy3pbl4d7r3hxy1i8r49n"
   },
   "stable": {
    "version": [
     1,
-    1,
-    1
+    2,
+    0
    ],
    "deps": [
     "clojure-mode",
@@ -11354,8 +11327,8 @@
     "sesman",
     "spinner"
    ],
-   "commit": "8b3dabeefa8a3352d7a30a9fd9027c05a4c4f6e2",
-   "sha256": "0psd8zrhs5w1cfmksd5sjgy9xzfs9i9zp55g97rp7zp6y5als0lx"
+   "commit": "7869c66f81d8a2b47f2e2d912fcb96934f5aa39a",
+   "sha256": "1c21hdrf6b7zc65nr7wqjhcyq5a0f4aa91wrxgzx374q81xym2rf"
   }
  },
  {
@@ -11484,26 +11457,26 @@
   "repo": "ailiop/cilk-mode",
   "unstable": {
    "version": [
-    20211207,
-    1656
+    20211222,
+    1541
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "51eb3088337674389275b9352a1b16dce2d917db",
-   "sha256": "0mbfk0r14n7kx5m49b0j50m2kzg042nzrk2y91y7pj8sc7vh1lm6"
+   "commit": "6e46cdb72ae0348c77b70f1679b34a1155e70797",
+   "sha256": "02rrjjaak0kjm0kifdfb7a427b6q86whs1hkc515fdl1bdr7slaj"
   },
   "stable": {
    "version": [
     0,
-    1,
-    1
+    2,
+    2
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "51eb3088337674389275b9352a1b16dce2d917db",
-   "sha256": "0mbfk0r14n7kx5m49b0j50m2kzg042nzrk2y91y7pj8sc7vh1lm6"
+   "commit": "6e46cdb72ae0348c77b70f1679b34a1155e70797",
+   "sha256": "02rrjjaak0kjm0kifdfb7a427b6q86whs1hkc515fdl1bdr7slaj"
   }
  },
  {
@@ -11636,8 +11609,8 @@
   "repo": "bdarcus/citar",
   "unstable": {
    "version": [
-    20211212,
-    2349
+    20220104,
+    2300
    ],
    "deps": [
     "citeproc",
@@ -11645,8 +11618,8 @@
     "parsebib",
     "s"
    ],
-   "commit": "51b30f2e4091a41243ae62cfbac53e7a579f3168",
-   "sha256": "1gym9nsqpxhmjx03j2hc4vsx6y20w2ara6nwhgyf6723dkjdg47m"
+   "commit": "99fa3749b48dfc5651806589848d081f48d3ef2d",
+   "sha256": "1ijm5drgs2h6maa18smbki8pdpcfx7kbbakzdhjsc010w81qf2b8"
   },
   "stable": {
    "version": [
@@ -11670,8 +11643,8 @@
   "repo": "andras-simonyi/citeproc-el",
   "unstable": {
    "version": [
-    20211213,
-    1446
+    20220104,
+    2053
    ],
    "deps": [
     "dash",
@@ -11682,8 +11655,8 @@
     "s",
     "string-inflection"
    ],
-   "commit": "538fed794c29acf81efee8a2674268bd3d7cc471",
-   "sha256": "0z6i352f7gjxml7cl2yi35phw0dqw5kb14bsrhk4rh0vs065g7vg"
+   "commit": "d1a0804a832a00ff549630321700f3bfa8e08bd3",
+   "sha256": "0n2qn21952qpjzwy63bsqn4knvmyg4vsi8gq1fc2bqbkccj3n556"
   },
   "stable": {
    "version": [
@@ -11721,8 +11694,8 @@
     "org",
     "org-ref"
    ],
-   "commit": "0fb4c96f48b3055a59a397af24d3f1a82cf77b66",
-   "sha256": "1n69016gds7kmf3253w36i40rf26g3qvgac7n0z67im9jvjfa6a7"
+   "commit": "20cd7e817420a3f6e7b82faea901a3c67c6d4d9f",
+   "sha256": "1qwcfjiqgr3kspqcv0j5irmqyawbi3wqzcpi3phw9rjy6pp928ji"
   },
   "stable": {
    "version": [
@@ -11749,11 +11722,11 @@
   "repo": "universal-ctags/citre",
   "unstable": {
    "version": [
-    20211204,
-    1356
+    20211225,
+    1020
    ],
-   "commit": "b9e274b180fcda981eec35dae0355d9d1305ad42",
-   "sha256": "1nxqcr560ahsfx1ffc97zz80cm173q9hjdv1nhnz31cdcyjrb35s"
+   "commit": "641f2f7f69de2c0f4f055efe55b3ecd899a60b24",
+   "sha256": "052b0zwxn7cnm9l9hb8nv794fbl9vds39f1a9xp0grg5q70qy3k3"
   },
   "stable": {
    "version": [
@@ -12083,15 +12056,15 @@
   "repo": "bsless/clj-decompiler.el",
   "unstable": {
    "version": [
-    20201004,
-    1019
+    20220103,
+    1746
    ],
    "deps": [
     "cider",
     "clojure-mode"
    ],
-   "commit": "f04e97af2678f170b872ff35dcbe81f86f7c39f2",
-   "sha256": "09267smjngms21rc1fl6c5ip45lzqx4iqzqaqi9sbfpy8vggxkd3"
+   "commit": "8c0c53f87e6e33f2be7e7aff6095eb586b50be1a",
+   "sha256": "0ay3iy1idiy46cic49wifd5qhmzgiswy2ynqs9gi9cpmnvk9lcm5"
   }
  },
  {
@@ -12102,8 +12075,8 @@
   "repo": "clojure-emacs/clj-refactor.el",
   "unstable": {
    "version": [
-    20211117,
-    1008
+    20220101,
+    1352
    ],
    "deps": [
     "cider",
@@ -12116,8 +12089,8 @@
     "seq",
     "yasnippet"
    ],
-   "commit": "363b95c5d2855abc93ac011e9adc778cf7a773e5",
-   "sha256": "1fm01ns63l1yrrya37aby4sx91kcnm56ba1bm3y7r8ilm4zcz40x"
+   "commit": "12af23ad8b76519cb8b95eec4e8a5706d3186cd0",
+   "sha256": "10f5gn9a8a3f5xr9lspqndj8w162vrsz1ws4lk7w4ilp74yxz4km"
   },
   "stable": {
    "version": [
@@ -12367,8 +12340,8 @@
     20211119,
     1904
    ],
-   "commit": "7d3c0c16e4aa14a051b393c249f0f4d307a2c74d",
-   "sha256": "1b3442z4awk3h1ns0fn0mif8vzlrdqzq1gbj9k848df5qz2qgvcv"
+   "commit": "e31186843d06ea86f3771244d1cde0112f9e2079",
+   "sha256": "0dlbwz0vkn2sf394r86s7vbc78jkq7wd3ldziqkwf57ci2068nyi"
   },
   "stable": {
    "version": [
@@ -12388,14 +12361,14 @@
   "repo": "clojure-emacs/clojure-mode",
   "unstable": {
    "version": [
-    20211110,
-    1015
+    20211230,
+    817
    ],
    "deps": [
     "clojure-mode"
    ],
-   "commit": "7d3c0c16e4aa14a051b393c249f0f4d307a2c74d",
-   "sha256": "1b3442z4awk3h1ns0fn0mif8vzlrdqzq1gbj9k848df5qz2qgvcv"
+   "commit": "e31186843d06ea86f3771244d1cde0112f9e2079",
+   "sha256": "0dlbwz0vkn2sf394r86s7vbc78jkq7wd3ldziqkwf57ci2068nyi"
   },
   "stable": {
    "version": [
@@ -12559,11 +12532,11 @@
   "repo": "vallyscode/cloud-theme",
   "unstable": {
    "version": [
-    20200221,
-    2201
+    20211229,
+    2131
    ],
-   "commit": "bdac53baf1c38f83a16091db515047f7d42dac14",
-   "sha256": "0ikhngr4cq4v6dgj59fffbdd6z9pdfcckgblsk3xs26frqqqxknf"
+   "commit": "72f1f430c94b93701851567853097b2df7cdd19a",
+   "sha256": "14jqq522hdy2zy3iqh3r5ql5wgc5jh7mlz9m7h8pgcrwh9h7zjk2"
   }
  },
  {
@@ -12642,14 +12615,14 @@
   "repo": "Lindydancer/cmake-font-lock",
   "unstable": {
    "version": [
-    20210103,
-    1558
+    20211224,
+    2006
    ],
    "deps": [
     "cmake-mode"
    ],
-   "commit": "5e20ed32193c2c7ebae920a6a3cd711c8c950597",
-   "sha256": "030j8k2yi1vli7xw10vz24qigq7jxg8yhc15kwjscfczl38x8vh4"
+   "commit": "0d6111b36a66013aa9b452e664c93308df3b07e1",
+   "sha256": "12ga8ri7v9r5y46pghk80ww27i7nhbrg0r3s2ina42drlkkliqj4"
   }
  },
  {
@@ -12697,8 +12670,8 @@
     20210104,
     1831
    ],
-   "commit": "cd6b08440752f335f01c3419417dc817d20423ec",
-   "sha256": "1np0hnx9c7prc40abwy43m2ycvayxjdibcgrw68a4c4bx0hljw6z"
+   "commit": "3279cec0129805f003ff1371e5931f3ae122cfbe",
+   "sha256": "0xdd92fcfxhc5p728jvkpx58v14pzvp9cf82v14ymy4limpvnk7r"
   },
   "stable": {
    "version": [
@@ -12775,11 +12748,11 @@
   "repo": "tumashu/cnfonts",
   "unstable": {
    "version": [
-    20211208,
-    2153
+    20211227,
+    248
    ],
-   "commit": "2f14a3c169896f5bfe92a0bf7a76d5ebf480eb6a",
-   "sha256": "0p7x3rlfg4q61xbd5mvwyr6lxjfr0m24nhj2l24z5r4qfldzsknf"
+   "commit": "7279d4178b4d52ae763d2224140488887ce57261",
+   "sha256": "0zfgpzjsl8nwpi1q40n6canm0bfi76x3cnxsss23iwsa1f6i1ipk"
   },
   "stable": {
    "version": [
@@ -12862,8 +12835,8 @@
     20211014,
     738
    ],
-   "commit": "68148cfc1f0723e554a09cbae4c732cfc348ecfd",
-   "sha256": "07y8ry0rwlxqdw39fi2maw114yyga8yzlbrxypw6irhnpm8mscjw"
+   "commit": "f5150fc213da470da2d4fedaa4b86f476167b235",
+   "sha256": "1p8a4ga6pysqd41frzzpi0a5bv1a0qmn136srfqqkkg60y5rlnl0"
   }
  },
  {
@@ -12892,8 +12865,8 @@
   "repo": "wandersoncferreira/code-review",
   "unstable": {
    "version": [
-    20211212,
-    1051
+    20220107,
+    1355
    ],
    "deps": [
     "a",
@@ -12906,14 +12879,14 @@
     "markdown-mode",
     "uuidgen"
    ],
-   "commit": "a440c3429c158a88af6517bbcd0efb1a2956bf12",
-   "sha256": "0mabb6z0hp34w93az3x2hzkrlwi2mv885m5j4xy1rz5k9vc31ssq"
+   "commit": "ccc3795a72554439f230969322c0e3239252c193",
+   "sha256": "17vn75v7hh5mj27g28m62xinv50f2h00kjyk84gk72j7ivymlcc9"
   },
   "stable": {
    "version": [
     0,
     0,
-    4
+    6
    ],
    "deps": [
     "a",
@@ -12926,8 +12899,8 @@
     "markdown-mode",
     "uuidgen"
    ],
-   "commit": "36f62479c263a3b1832d89e1eb0576e958d477f1",
-   "sha256": "1gsmrczhj1vjs6v5anxc9kbv22dmq37a3l16xnb1p76zyk3p7cmm"
+   "commit": "136c0933ba9dc19ce3efedb36a7dbd401e2e98b2",
+   "sha256": "1jlzh81m8knms0wm91hgxabpxa9v2v29wi6cvjfbk59xi4fmr8xs"
   }
  },
  {
@@ -13359,8 +13332,8 @@
    "deps": [
     "s"
    ],
-   "commit": "19bec333477f36e14acc9d00813e4bcc6201692f",
-   "sha256": "1wb7kig728dbggd2q24kgy6381gg2zpqdr9az5q3yg0326zns62y"
+   "commit": "d4715c27815e41db8b489c860a470215b6098d02",
+   "sha256": "151cbiizw57l1n4c1bcdzx5rxg86wiqm7qmd8gn8l42prmh7iwm0"
   },
   "stable": {
    "version": [
@@ -13694,11 +13667,11 @@
   "repo": "company-mode/company-mode",
   "unstable": {
    "version": [
-    20211201,
-    2335
+    20220108,
+    126
    ],
-   "commit": "8b58e5895c2eaf8686de0e25c807b00fdb205c7a",
-   "sha256": "1rc4hcg3bgqmllgb4xfylpkmg2wkx5qk7nagwdhx6klq87jbxdz9"
+   "commit": "8e4716172a2ba7fdd3f1d37096de88142ebbcc8d",
+   "sha256": "1bhvqh3w5qiyjm5ksqicmwybar4baj7dizpbywfdvn6kirwhwird"
   },
   "stable": {
    "version": [
@@ -14152,8 +14125,8 @@
     "emojify",
     "ht"
    ],
-   "commit": "5cc4bd886c1fc373eb1642ab0f0ba33de4f5d3d2",
-   "sha256": "0d383561fb8nfgqns3j9s0sjwgqchwpil0gs4n4vw31yaphyy83l"
+   "commit": "32cd04a1c2f692e6ece07cc3d3a7627240edaa8e",
+   "sha256": "0fb5zyp3cgv7iyjbxxm7bjqq0pmhlv212wnylldqwij647w22iia"
   },
   "stable": {
    "version": [
@@ -14256,8 +14229,8 @@
     "ht",
     "s"
    ],
-   "commit": "44ef04f5f21285d68bd419f4f153e192777d9991",
-   "sha256": "1gca3i7ylk28wx7wa722ismy6irya96k8qf1zjh851sn2m7bkfin"
+   "commit": "ca52f1bf0a2ad927d629274f648726769ce770de",
+   "sha256": "0wfryqkvj9xcka2j22mzxjr8cb9f2llyqkxjz9l2zvpijqfp1n49"
   },
   "stable": {
    "version": [
@@ -14329,16 +14302,6 @@
    ],
    "commit": "31948b463f2fc18f8801e5a8fe511fef300eb3dd",
    "sha256": "0jd7swa2s9a6lci81hfhfnnkxbmca2kh07hsj7c5lv2r9adxrwxw"
-  },
-  "stable": {
-   "version": [
-    20150303
-   ],
-   "deps": [
-    "company"
-   ],
-   "commit": "eef10fdde96a12528a6da32f51bf638b2863a3b1",
-   "sha256": "03snnra31b5j6iy94gql240vhkynbjql9b4b5j8bsqp9inmbsia3"
   }
  },
  {
@@ -14497,8 +14460,8 @@
     "lean-mode",
     "s"
    ],
-   "commit": "4a90f2ae6e33c162a3dd6f624fb080c2ed8e8494",
-   "sha256": "1zikz4qaxabs3j86gljpp2qbhbzxsjzz544k9vsngibd468dszlv"
+   "commit": "a4205749d20a09871f0951c34f919d4ee5fbdb55",
+   "sha256": "0jqfnwjwn5payjj1lfl1zvw8gpcdlc6k3lqbw6iwpzlyal7y0nyb"
   }
  },
  {
@@ -14665,15 +14628,15 @@
   "repo": "CeleritasCelery/emacs-native-shell-complete",
   "unstable": {
    "version": [
-    20200315,
-    2144
+    20220103,
+    1622
    ],
    "deps": [
     "company",
     "native-complete"
    ],
-   "commit": "cf142e84eaa4dd91bc75d96a5d26dab5e38eba4c",
-   "sha256": "01li6c271v5j35chg3a8nl9az3bwq4hk1j8lfjq5a27p91iszpc0"
+   "commit": "20e1dceb459856c8c4f903e6d8562991069bb8c1",
+   "sha256": "11m3y6kbjm0nqmdqbcv4xrchcabh4x1w4gy1p8gp36k600s1h7zj"
   }
  },
  {
@@ -14796,8 +14759,8 @@
     "cl-lib",
     "company"
    ],
-   "commit": "fc834dcc193e7168ffa0b3ae81ab3eefa4fd3c59",
-   "sha256": "08hnw5dbcs4ww2ir7ilnfc6r0b123alh4l8i1mzvng0h3mvmlhgq"
+   "commit": "92d559309d0c7614e2ccc982002b7ff963f3c9dd",
+   "sha256": "0aidj0hz97qw8jpwcbdmhjqk8wsdls3jiq9j6bbrqh458j6p317h"
   },
   "stable": {
    "version": [
@@ -14962,27 +14925,27 @@
   "repo": "raxod502/prescient.el",
   "unstable": {
    "version": [
-    20210227,
-    600
+    20211228,
+    417
    ],
    "deps": [
     "company",
     "prescient"
    ],
-   "commit": "292ac9fe351d469f44765d487f6b9a1c1a68ad1e",
-   "sha256": "0ywx7q41i9pzmfgwv83mz5z17gril2s0r7y77hbbriww5yy1ihx4"
+   "commit": "3dbcef387502d309d130a518a18d48cd2f0e15b7",
+   "sha256": "024l7s0b6apbzanw3cnhjypxnxfinfb5b3nhaabrc138m5pis8j5"
   },
   "stable": {
    "version": [
     5,
-    1
+    2
    ],
    "deps": [
     "company",
     "prescient"
    ],
-   "commit": "2c0e9fc061ab723ec532428f312974ca7d8def12",
-   "sha256": "0d6kbczkamhhcmc8bf01q6k1x0g7dwjihwllzsldgga3dclyh4ks"
+   "commit": "3dbcef387502d309d130a518a18d48cd2f0e15b7",
+   "sha256": "024l7s0b6apbzanw3cnhjypxnxfinfb5b3nhaabrc138m5pis8j5"
   }
  },
  {
@@ -15051,8 +15014,8 @@
     "company-quickhelp",
     "popup"
    ],
-   "commit": "40c2fc569bfc0613b8fac4b9d6242f6682f50827",
-   "sha256": "0kd2f1qhxmg1x9wlz1gqi5m772sk865csry6zm6xznlzbggc7h5a"
+   "commit": "d56b17f234232e739838891b958877511cfe73f1",
+   "sha256": "05sp0z6gsvfp0phkdhzpnh8q3r4rkrqlhlqxvlsdnyaw78872hlh"
   },
   "stable": {
    "version": [
@@ -15224,8 +15187,8 @@
     "company",
     "solidity-mode"
    ],
-   "commit": "bac439dbd2097664df45e9fac0ce57e23462c14c",
-   "sha256": "1vs64gwm6zn47fl4nvaizkwh8zwnqh764yqcmggyz4awsxsxg6ym"
+   "commit": "f0f68b038c5edf16c85fc8ca58537e1c6479738b",
+   "sha256": "0hfp07bg348ppkgp5wca1sqpcprhc6jyxkpb1pmsm0vrifb3261l"
   },
   "stable": {
    "version": [
@@ -15584,18 +15547,6 @@
    ],
    "commit": "3b43c1aeaa6676d1d3d0c47e78790db9bee150b6",
    "sha256": "1pmwsjwj1sb9dqy46p7ky94m9dawd79klcjg1vpl9l7mfvz5i34m"
-  },
-  "stable": {
-   "version": [
-    1,
-    1,
-    4
-   ],
-   "deps": [
-    "yasnippet"
-   ],
-   "commit": "b0245fcbabf035d89b80150add5d6a47859ab555",
-   "sha256": "07l495vv3by6r62i48jbfyr5pp1p6896cz25gkc7p3xqwrhi2min"
   }
  },
  {
@@ -15923,19 +15874,19 @@
   "repo": "minad/consult",
   "unstable": {
    "version": [
-    20211213,
-    1713
+    20220101,
+    2318
    ],
-   "commit": "cc8eff9578f5d089735e8b7dd7a08732890ed648",
-   "sha256": "17rq9l54hvchbr8z0cr8zd1w3j7sf1ykgxgclwrprrq74qs5dmps"
+   "commit": "0940ca016531f3412003c231b476e5023a510ff9",
+   "sha256": "0kdg79jzqsxa6gsl2fxmds1yx1347csjzcl75wbbg388nrp0p9zh"
   },
   "stable": {
    "version": [
     0,
-    13
+    14
    ],
-   "commit": "c2fed383c9c555ed017200a22efad0a9734725b0",
-   "sha256": "0ik5j4i4vb9hz629cjwnzhimskpv0fc8wca37z4ak0q1d898ayph"
+   "commit": "f9170bb75f9b4362b42cebee9cd8643b04093342",
+   "sha256": "051fjp03lj3b5kkzpdhk78g2lj37v973q0f012zld1n6937srj6h"
   }
  },
  {
@@ -16112,15 +16063,15 @@
   "url": "https://codeberg.org/jao/consult-notmuch.git",
   "unstable": {
    "version": [
-    20211210,
-    338
+    20211229,
+    420
    ],
    "deps": [
     "consult",
     "notmuch"
    ],
-   "commit": "2fd4befde0a2664b862a0e0c4ed3ccaedfc19c00",
-   "sha256": "1snl2qi9d7mhycz3aspqh24rgd57xnykj4378whryq0590i7ca82"
+   "commit": "0b7fae73f51bc855078dca9593c8c7f67fe2ed98",
+   "sha256": "0kiwc7qbhkmaj5hlarxsv3gy3gikykvxklgqkq8f68jjfgb0hdag"
   },
   "stable": {
    "version": [
@@ -16330,14 +16281,14 @@
   "stable": {
    "version": [
     1,
-    2,
-    1
+    1,
+    0
    ],
    "deps": [
     "transient"
    ],
-   "commit": "fa0eaa173c3b89be2ecd0db55511e1d896f9a422",
-   "sha256": "01qngmxaw7am5idr1mlb3lb39bgxfc8l802cjksp7k640gpmkk31"
+   "commit": "9db9dcfdff2ff8cf6a88e938646cb26ce0f61774",
+   "sha256": "1qm6v88mz6bxz0yg2yw5xfiz5jjnz3i9vwaa3irnywzs6prw7pa4"
   }
  },
  {
@@ -16564,15 +16515,15 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20210928,
-    949
+    20211230,
+    1909
    ],
    "deps": [
     "ivy",
     "swiper"
    ],
-   "commit": "1c6b3da377a840e898b14020133f59fca9ceea1c",
-   "sha256": "1w8x2qk8lafnn6ksv1anixayyl476y1j6hp2amfnqmdkh0vnh63v"
+   "commit": "c97ea72285f2428ed61b519269274d27f2b695f9",
+   "sha256": "05ivdsq6l6ixdn5p0rjh7mcgw19fm38m137xb8yi2c9gii6yk6g2"
   },
   "stable": {
    "version": [
@@ -16605,6 +16556,24 @@
    ],
    "commit": "41d85fe36edd72da68f5009ad9cf9013cd19960d",
    "sha256": "1gfppiwx0cilg97bfb2cpdk7j10rdm473kklrkvb6wlwwg3j9w3q"
+  }
+ },
+ {
+  "ename": "counsel-at-point",
+  "commit": "76600c160b01ac365ba6fed2304128961a8761cc",
+  "sha256": "1sq9jfzrbr5jai25irkz2nlpj20vw2la8hfchp3zf94vkcvswv27",
+  "fetcher": "gitlab",
+  "repo": "ideasman42/emacs-counsel-at-point",
+  "unstable": {
+   "version": [
+    20220104,
+    645
+   ],
+   "deps": [
+    "counsel"
+   ],
+   "commit": "942cf8e5475c10c80b69f6ac38feecf4137fba6b",
+   "sha256": "0fqwjccvmi2p4bsk2qh78dzqmbl5kl49cf9b51jxnaciv4shim8k"
   }
  },
  {
@@ -17702,11 +17671,11 @@
   "repo": "crystal-lang-tools/emacs-crystal-mode",
   "unstable": {
    "version": [
-    20210929,
-    1521
+    20220104,
+    2146
    ],
-   "commit": "3e37f282af06a8b82d266b2d7a7863f3df2ffc3b",
-   "sha256": "1rwm7srb3xlsja4hana83an9a6l9f9rmi299qkjxhjcry8x9p78g"
+   "commit": "96a8058205b24b513d0b9307db32f05e30f9570b",
+   "sha256": "02i1wwr2h9r5ssdysnvp5lh2i7ghh0fv3flqf57a1s388mk4giia"
   },
   "stable": {
    "version": [
@@ -17783,8 +17752,8 @@
   "repo": "hlolli/csound-mode",
   "unstable": {
    "version": [
-    20200518,
-    1546
+    20211215,
+    1925
    ],
    "deps": [
     "dash",
@@ -17792,8 +17761,8 @@
     "multi",
     "shut-up"
    ],
-   "commit": "b6e8167c927c400c291daaa46a8aea132834b07c",
-   "sha256": "12k3z7azwbg11gs8sc8j6h0rb3zy3kw19z6l9ynxys4vzm9ln7dm"
+   "commit": "44c49e5a9262ede4b4477bafb13b42b1ba047b9c",
+   "sha256": "0kfhca1n0iv1400jf4ggjbarg7ry8ccd5bs7cf2brjdiqp74cvwb"
   },
   "stable": {
    "version": [
@@ -18008,19 +17977,19 @@
   "repo": "raxod502/ctrlf",
   "unstable": {
    "version": [
-    20211019,
-    244
+    20211228,
+    415
    ],
-   "commit": "e915c5920cd3e39f481a6ce024073dd28cc9f743",
-   "sha256": "0asy33mgyjiz7kvpsh09npqigb3x9bk64p8j81czaa3jxw40mnh1"
+   "commit": "282eaa836d2198bb5947dfd3c454ae5305f55efb",
+   "sha256": "04w708g7d1pnsc18h8fjyqkhk08jkq853alaidriamxyycvdwk0i"
   },
   "stable": {
    "version": [
     1,
-    3
+    4
    ],
-   "commit": "d7fad32584c3e569046691bf7f27b21e294c0a2a",
-   "sha256": "06wq6scqy2ax0h6aahy2r7hn3bbmkzl4w99bkrc3cqd4ij78sc8g"
+   "commit": "282eaa836d2198bb5947dfd3c454ae5305f55efb",
+   "sha256": "04w708g7d1pnsc18h8fjyqkhk08jkq853alaidriamxyycvdwk0i"
   }
  },
  {
@@ -18455,17 +18424,17 @@
     20211111,
     1407
    ],
-   "commit": "b2fac63f4a653bfd32eb4bba20bfb30b2ebad190",
-   "sha256": "1h20vkj3m2igb2ny7nrjphg1k0r2jqz7ijj859gb85avrv9mffdh"
+   "commit": "ddaaa7b8bfe9885b7bed432cd0a5ab8191d112cd",
+   "sha256": "0kznk6hjdhl773sm5a15jyis0kb9i16w3ydjyplkr310fjmahca7"
   },
   "stable": {
    "version": [
     0,
     29,
-    25
+    26
    ],
-   "commit": "4c4585ce459e258b70dbff6765e841685d4e19fd",
-   "sha256": "0fg0fwklvsjdnkga314rw3v6ywq51r4fdha5yzdhgz51bnilymd5"
+   "commit": "3028e8c7ac296bc848d996e397c3354b3dbbd431",
+   "sha256": "175k9f5dzrpg1xqc941n0xa1frxq8vnqlw6ccx59xf9p43ws9rc1"
   }
  },
  {
@@ -18553,11 +18522,11 @@
   "repo": "cbowdon/daemons.el",
   "unstable": {
    "version": [
-    20211204,
-    1202
+    20211214,
+    1251
    ],
-   "commit": "cf0ab15a26490ca82aaf6c258f1fc7da195e4fdd",
-   "sha256": "1icd6l8cpiqiyg1489dnwsqdxq3l62j7iib0c2a54wr83l7zyp7w"
+   "commit": "e18e84ccc13101f1609c213029cf011ae0ad1178",
+   "sha256": "0ylcwwp6asl3w9fmx46z822wpr4mrlr0mgny6n1hi3wnsvcjagka"
   },
   "stable": {
    "version": [
@@ -19027,11 +18996,11 @@
   "repo": "emacs-dashboard/emacs-dashboard",
   "unstable": {
    "version": [
-    20210928,
-    656
+    20211221,
+    2005
    ],
-   "commit": "a19868f2fb8f7fc4132b4e9bfac5cdd65f245181",
-   "sha256": "1gmcnj3ldhqy417wv2lqfh53pg8glfz28bgd26sx5nbw7w5lhd9r"
+   "commit": "1bb5c43b6be65f72c2ff3ab948697c902458a32f",
+   "sha256": "18k73aqnlcxzlcqzlls6haps2h5j5qngp3lssiyyk0m4731dpi26"
   },
   "stable": {
    "version": [
@@ -19073,30 +19042,26 @@
   "repo": "emacs-dashboard/dashboard-ls",
   "unstable": {
    "version": [
-    20210927,
-    1042
+    20211222,
+    1402
    ],
    "deps": [
-    "dashboard",
-    "f",
-    "s"
+    "dashboard"
    ],
-   "commit": "2639eb0f20a7b62be4106f555d00862c161bebf0",
-   "sha256": "149a0lhdfqm8rv78yi5v3a6ndrf44m2zv4f3mphzalmq4wslvmww"
+   "commit": "1c1a88eba0290ce0548d23055508364ef938380b",
+   "sha256": "1lx2b5ybmhzkxlpapxkbw7b99wcr6ayvhqv8g2lamdl1b1ibd8nq"
   },
   "stable": {
    "version": [
     0,
-    2,
-    2
+    3,
+    0
    ],
    "deps": [
-    "dashboard",
-    "f",
-    "s"
+    "dashboard"
    ],
-   "commit": "86ad7ca7b09e98524de6c64e1fd63f61d41f9177",
-   "sha256": "052072jk22dz141wsr6wg3wfnvwfaikalhmqc7mpp15iwwg1ppa4"
+   "commit": "5c6a11bfda542892775b5c55c8430773cc82b3c9",
+   "sha256": "0fcfjy4gvnzm5s3235pd2mkb8jd386jblh8r9hyw2351ln1pwnjn"
   }
  },
  {
@@ -19414,16 +19379,16 @@
   "repo": "Wilfred/deadgrep",
   "unstable": {
    "version": [
-    20211201,
-    1747
+    20211228,
+    1756
    ],
    "deps": [
     "dash",
     "s",
     "spinner"
    ],
-   "commit": "7f1a537783bdad65246cb7a510aa0ae539bdd526",
-   "sha256": "045j8jl4cdwp45qxsxlzykqh5iz3z7njl3qb9fdz9bspa659db4r"
+   "commit": "aebaf72e35546fd235b4861399791814e4e4c7d8",
+   "sha256": "1qd60winrrpxmrjsx77i24921p6dad9halz5l5s6biwa421zcgr3"
   },
   "stable": {
    "version": [
@@ -19538,15 +19503,15 @@
   "repo": "preetpalS/decl.el",
   "unstable": {
    "version": [
-    20171212,
-    1458
+    20220102,
+    1310
    ],
    "deps": [
     "cl-lib",
     "dash"
    ],
-   "commit": "ff7f8a4f1225cbdf141c86172104e67a4cf58c86",
-   "sha256": "1ns1ni6aalr541df3a0ylqy0gj68fcsxdfvm4m1ga5532kxnswnj"
+   "commit": "9e6e2395e1f739e390697c35a9af99452642869e",
+   "sha256": "0f59v25j7z1ga7h4s36407wwmbbb2qjy29q6jymiilyd4bjgkq8f"
   }
  },
  {
@@ -19620,11 +19585,11 @@
   "repo": "ideasman42/emacs-default-font-presets",
   "unstable": {
    "version": [
-    20211104,
-    52
+    20220104,
+    215
    ],
-   "commit": "dbb6c6c5350ba76b12bd69a584b0634a8262a76f",
-   "sha256": "1yjc4g50r0jghf5a0qipfzys6krgz5vqizm3hlq4lh29hvkazc6i"
+   "commit": "6b6fe704ea233c65e50263dc0ff584409065e42f",
+   "sha256": "0ly7k6rkvhw1pwgmmn4cpgbizw2f2ry1swlaq0zf2k6ln7pyl96z"
   }
  },
  {
@@ -19682,8 +19647,8 @@
   "repo": "jcs-elpa/define-it",
   "unstable": {
    "version": [
-    20201005,
-    1731
+    20211216,
+    719
    ],
    "deps": [
     "google-translate",
@@ -19693,8 +19658,8 @@
     "s",
     "wiki-summary"
    ],
-   "commit": "57a9c601e732c85b0b45550434b04d996c1b92a3",
-   "sha256": "14bm85a5im3m910gsmp220brqrlm4190zl9qbvqmp180c63j43yc"
+   "commit": "e19fcc96c94a161289f97a64275c016920587a53",
+   "sha256": "10c140n5g18v3rq14dzq9n2c3xa5ibzz2zkyiawkjfl664802170"
   },
   "stable": {
    "version": [
@@ -19722,11 +19687,11 @@
   "repo": "abo-abo/define-word",
   "unstable": {
    "version": [
-    20210103,
-    1812
+    20220104,
+    1848
    ],
-   "commit": "6e4a427503aef096484f88332962c346cdd10847",
-   "sha256": "1mpsc9cfdl5lzn2yzn63gxvshjl3m2aiwsv12g3qvya2a1xskjj8"
+   "commit": "31a8c67405afa99d0e25e7c86a4ee7ef84a808fe",
+   "sha256": "0h3dasg81f1b08xvz38nyd887pdlv60kj8q50kk2aqlpkr8j0y18"
   },
   "stable": {
    "version": [
@@ -19846,11 +19811,11 @@
   "repo": "howardabrams/demo-it",
   "unstable": {
    "version": [
-    20190828,
-    26
+    20211221,
+    2152
    ],
-   "commit": "9cfa5c3f92a0dca7eebb1f1a2011643c9b009d26",
-   "sha256": "1fcmrhm6h0j7jjw6kijrcacv628fy80ssxn6h5bilwmw0r4c7wm6"
+   "commit": "e399fd7ceb73caeae7cb50b247359bafcaee2a3f",
+   "sha256": "1hbhdgp69sqab1qd388flv5dzxprwf44b127da0fpl8mpqf94npa"
   }
  },
  {
@@ -20056,11 +20021,11 @@
   "repo": "astoff/devdocs.el",
   "unstable": {
    "version": [
-    20211002,
-    1657
+    20220107,
+    1051
    ],
-   "commit": "e1b4b0258289d442e349f67f175f05be6f4347d4",
-   "sha256": "0yqmaa12sdci6wy95fany03rcqsm9avrjldzrypa9xv5a2ayi48f"
+   "commit": "8abcac28030c0f770b214823b4a1a5024f121b30",
+   "sha256": "1717y9fkvppbd1cyf9bhr32cjy0n1zd0vrjs1ynal40ymrv9jnpp"
   }
  },
  {
@@ -20071,11 +20036,11 @@
   "repo": "blahgeek/emacs-devdocs-browser",
   "unstable": {
    "version": [
-    20211212,
-    1544
+    20211218,
+    949
    ],
-   "commit": "2d265d48d40156d4a2dd2b6b433c8d969e037c5a",
-   "sha256": "1y6akvcky85z45d9s7ll8i1v2xz4a1xy0pfg7c1qi0xs5d3xw4i1"
+   "commit": "a46a2cdb83ed27869befe56fea04914a33252b3a",
+   "sha256": "0vw9q3639rj1v6b1si0qzqwa5ps4m3kaxdmyfq7342ahp7g2m8sj"
   }
  },
  {
@@ -20294,8 +20259,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "6fa3af0843093f44e028584a93eef091ec7e79d2",
-   "sha256": "0fg7mdcjjnibqi8f7zj2pig35kcq4gqfi4jvg4hvw9fcncdv0yln"
+   "commit": "902e097bc435cbcde3df81a1a96c59b450c89062",
+   "sha256": "19zmfnjmrgsf78bdvwk0g4dbz3qcwj9mw4nnr89321rg5jakwg7b"
   },
   "stable": {
    "version": [
@@ -20552,20 +20517,20 @@
   "repo": "tarsius/dim-autoload",
   "unstable": {
    "version": [
-    20210615,
-    1502
+    20220101,
+    1042
    ],
-   "commit": "77b6a5814ffb49e33679fd67b53b9f05042b6ebc",
-   "sha256": "1a1xhmsm1c4k3mkbbhzd7fmb8q60fhs0lrf39m261180kz0wnhrq"
+   "commit": "d7f5ba3169c1c6962bc7fb0bdbfb2c6fae018025",
+   "sha256": "1apipnqpmzfvlarsyjkpx02773krw878hxdgcax2y0f77vmqpnrr"
   },
   "stable": {
    "version": [
     2,
     0,
-    3
+    4
    ],
-   "commit": "c8dc02259d6c1aa25fb58742ae8b181f83b39a13",
-   "sha256": "0k9m57zrdpabb6b34j9xy3cmcpzni89wq71pzzwgdi47p1n4r4vd"
+   "commit": "d7f5ba3169c1c6962bc7fb0bdbfb2c6fae018025",
+   "sha256": "1apipnqpmzfvlarsyjkpx02773krw878hxdgcax2y0f77vmqpnrr"
   }
  },
  {
@@ -20606,11 +20571,11 @@
   "repo": "myrjola/diminish.el",
   "unstable": {
    "version": [
-    20191127,
-    1326
+    20220104,
+    1539
    ],
-   "commit": "6ec6ebc391371418efc6c98d70b013f34af5a2ee",
-   "sha256": "0q8pihj9fwq9w978ycmvzv8kq8ksrdf8zfadjy8i2iwc4ib0jg7y"
+   "commit": "fd486ef76e4c1d8211ae337a43b8bba106d4bca7",
+   "sha256": "1vlgn7swwfzy6yr880698h3qsmfcqprcb1jvffkzmbvhvf458szf"
   },
   "stable": {
    "version": [
@@ -20632,8 +20597,8 @@
     20210715,
     1026
    ],
-   "commit": "2cb177f70e5dc2e9df45844d565280b79cfc68a5",
-   "sha256": "13km90jhjpmlxcw8gpmlzivy8mvqys418n9ca6sr08cj9sbnjsij"
+   "commit": "5ea0f4da3b9ad863ce21503715fd62722e4cd6ec",
+   "sha256": "139dwggd97mbq1p5g1dqxaml6j0wbk2w0gcgy4wv8fb4xppzklkb"
   },
   "stable": {
    "version": [
@@ -21427,11 +21392,11 @@
   "repo": "renard/dired-toggle-sudo",
   "unstable": {
    "version": [
-    20200401,
-    1353
+    20211216,
+    102
    ],
-   "commit": "13bbe52c54893f5aa3e56228450ffdd0c9e1d169",
-   "sha256": "1fw1pb1z6krqd1pfxxhr6rrfr9ckkcb0zsjzbjk0i2i1q5cg6car"
+   "commit": "9f86cdf858225b15c20affb97ed105e4109047bf",
+   "sha256": "19p2yl61m7krjj2p6pg9cjw8n4zm3a6shv1k9vq0xvxjq86dx59l"
   },
   "stable": {
    "version": [
@@ -21507,11 +21472,11 @@
   "repo": "purcell/diredfl",
   "unstable": {
    "version": [
-    20191227,
-    2028
+    20220103,
+    1744
    ],
-   "commit": "4ca32658aebaf2335f0368a0fd08f52eb1aee960",
-   "sha256": "1dwzlxz0q9wqn1az1b0bfl8ywib4nd5grdfqaa06fqd63zlp71pg"
+   "commit": "f9140b2c42151dca669003d685c9f079b2e3dc37",
+   "sha256": "0m4hsg50ykbkgmv5kl6y0h4i20ln813fw9yzwslxgnz2479nad2b"
   },
   "stable": {
    "version": [
@@ -21553,14 +21518,14 @@
   "repo": "wbolster/emacs-direnv",
   "unstable": {
    "version": [
-    20211011,
-    1804
+    20220103,
+    1342
    ],
    "deps": [
     "dash"
    ],
-   "commit": "bd161f38621d1a9e4d70c9bafab9b7e3520f00b2",
-   "sha256": "0cf5npgksl9a03mnfdhfdhlf46gr9qz9adjxz3dbckq9b1vl0dfc"
+   "commit": "d71ceb415732c3b76a2948147fa3559622aceba2",
+   "sha256": "01fgn8gcprx747x382ka1y5yjfcarjdhpmfr9gal8blhvlknqc8f"
   },
   "stable": {
    "version": [
@@ -21669,20 +21634,17 @@
  },
  {
   "ename": "dirvish",
-  "commit": "7361fcfc439b061eb365cb4113a05b6f3de8efb6",
-  "sha256": "1l2a6d68vdsdgjsh0kl02hnxsf14k6p981w8cy9vzzz5nfw7cjwx",
+  "commit": "bc3749e394a45d961fa36638798a3acface47478",
+  "sha256": "1x71a920vznpn1kdxg7cmcs6hz18ij1wn5hlwznh7r0lyz5zvmiy",
   "fetcher": "github",
   "repo": "alexluigit/dirvish",
   "unstable": {
    "version": [
-    20211213,
-    610
+    20220108,
+    1527
    ],
-   "deps": [
-    "posframe"
-   ],
-   "commit": "e92752e7ebbe527b00a104d56c68607e917eae9e",
-   "sha256": "1fvqwmibhqdl76z2rrvmjqfqj89mz67358yp0fybcpxaqmfg4nka"
+   "commit": "aa94c57cc7faf1c6e3fc2257b489e374f07b889d",
+   "sha256": "0lprf1y48cg6j3xmzzwq8d03gijbrx5b99qljqz6l0lkibd019a8"
   }
  },
  {
@@ -21983,14 +21945,14 @@
   "repo": "unhammer/dix",
   "unstable": {
    "version": [
-    20211124,
-    1227
+    20220105,
+    1017
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "80d5ea3bceff75b842065e2f99657f3f70c7e604",
-   "sha256": "0l7ls9967km1vsmhqqrmbyykc6hx21frz5pjr8znasz5yhflbzwg"
+   "commit": "a2d924725380aca4d61df4a70825fc4b76185938",
+   "sha256": "1cg565l7iviis7888in7bf3v59b2a67jb552yshq6yb4d63v0b6f"
   },
   "stable": {
    "version": [
@@ -22020,8 +21982,8 @@
     "dix",
     "evil"
    ],
-   "commit": "80d5ea3bceff75b842065e2f99657f3f70c7e604",
-   "sha256": "0l7ls9967km1vsmhqqrmbyykc6hx21frz5pjr8znasz5yhflbzwg"
+   "commit": "a2d924725380aca4d61df4a70825fc4b76185938",
+   "sha256": "1cg565l7iviis7888in7bf3v59b2a67jb552yshq6yb4d63v0b6f"
   },
   "stable": {
    "version": [
@@ -22309,11 +22271,11 @@
   "repo": "ideasman42/emacs-doc-show-inline",
   "unstable": {
    "version": [
-    20211210,
-    102
+    20220104,
+    216
    ],
-   "commit": "3a4eee3ef3fb3b50252418308f1b45e22a67bc8e",
-   "sha256": "1ihp3hva01zs5gwmjzsr62rbd5gmd7k23sjxg887vq04qmwcqcb5"
+   "commit": "6bfea44e0b54c80255d34d15130940a09814e2a3",
+   "sha256": "0rkshqiy9msnsif9fxi484by76fl8zjyzijgxphqlv2h2bb3pbgd"
   }
  },
  {
@@ -22539,7 +22501,7 @@
     "s",
     "transient"
    ],
-   "commit": "6e1105347decbf9b4b848d952858455f9b145c56",
+   "commit": "2e49c2f4e9ee023d2a143086463bac47db914846",
    "sha256": "0vkmgfgw8qica21hcqila62ivqxshkay2r2dyy4dxxj3xypk3083"
   },
   "stable": {
@@ -22573,8 +22535,8 @@
    "deps": [
     "s"
    ],
-   "commit": "aa2e30dc6b1d3fa6fb1da309fb87df683eab1e62",
-   "sha256": "1pqs4z97vs6s08g7pfbp3qqjx1q3z09lrjdzxjb24vrcfkki9cmi"
+   "commit": "b3f9e6c209c2c98de01211aa7a0a4cf6ee3cdf4f",
+   "sha256": "0ffnq0inxal39725amfv72yprynwx2hqrxhdb7pyx7x8z4zh8f4y"
   },
   "stable": {
    "version": [
@@ -22597,11 +22559,11 @@
   "repo": "progfolio/doct",
   "unstable": {
    "version": [
-    20211018,
-    1902
+    20220106,
+    709
    ],
-   "commit": "c1919a4297e5479d3a22ded90095245317b29935",
-   "sha256": "0vzkva3nn8fbk0xhyyns5vfr3irgy8hbn1wcxwpi3ygchrflckia"
+   "commit": "e92ccc084f164ed87b7ae325669ce5720044179e",
+   "sha256": "0r53f580grrxgl839l7lrhg8vcrjxy7n2qw10z9bkabmkvbcl20d"
   }
  },
  {
@@ -22734,16 +22696,16 @@
   "repo": "seagle0128/doom-modeline",
   "unstable": {
    "version": [
-    20211128,
-    1709
+    20220104,
+    1417
    ],
    "deps": [
     "all-the-icons",
     "dash",
     "shrink-path"
    ],
-   "commit": "69ede7d719764f26671897c5020f295e5eb1e6c8",
-   "sha256": "1czl20z1sc2cfgdwhl8hly1mcbdyx41zr2swrwmzl6w3xai9lsa5"
+   "commit": "bd21ee28cc25da400fb32b1e9e65b09514fa7f57",
+   "sha256": "1k9addpiyk2x56b317awbrmj5d0wlc9fjzp02yicjqzsslakb7hf"
   },
   "stable": {
    "version": [
@@ -22781,20 +22743,20 @@
  },
  {
   "ename": "doom-themes",
-  "commit": "c5084bc2c3fe378af6ff39d65e40649c6359b7b5",
-  "sha256": "0plqhis9ki3ck1pbv4hiqk4x428fps8qsfx72mamdayyx2nncdrs",
+  "commit": "72422eadf120e6759220789135dddef396a38ce6",
+  "sha256": "0xbdzjiidsmn1hd9x9n2ffyhfc5nr4i63jjyvz487p1rx76cz1pl",
   "fetcher": "github",
-  "repo": "hlissner/emacs-doom-themes",
+  "repo": "doomemacs/themes",
   "unstable": {
    "version": [
-    20211212,
-    2109
+    20220105,
+    1406
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "7d1a56623c08da769fd424e901916e9c3d8fdb25",
-   "sha256": "1ifwb8mw0jcif3plj6wz9ak2ankpvxfqndv6qlcr6yij7xvi9qnk"
+   "commit": "56e8a93b2dd8f2c10a693f36c3317833211201f2",
+   "sha256": "0ph2slvcf5fncw3s6mc3hmgs02g8prljycqymqz813fcqrbdsmqb"
   },
   "stable": {
    "version": [
@@ -23038,11 +23000,11 @@
   "repo": "dracula/emacs",
   "unstable": {
    "version": [
-    20211206,
-    1333
+    20220105,
+    1056
    ],
-   "commit": "049257458288cbc2d94737e30bc0005601c9727c",
-   "sha256": "0nry6fjjlwm0n8rqwk0g6jbjzqf97hzicaq1mf438f06f7h6h2mr"
+   "commit": "7d622209de758c3ccf88bf042c85fe13de9dc225",
+   "sha256": "0b6w3k4rpkcvxa816khdri9yjpchsyrq79zq38jabzfladai0kwd"
   },
   "stable": {
    "version": [
@@ -23450,8 +23412,8 @@
     20210909,
     1010
    ],
-   "commit": "f9dfb2ff556ff4d32def138dbb53b54a6187b046",
-   "sha256": "0q347dm67xds8kz9f4r7br5iszd65xbgicn75qpn2mzyidlhdqbc"
+   "commit": "35829887efe398ac04f2fe6270ed31d3e82840aa",
+   "sha256": "1fadpd47mwgqw2393p4h81w94lamsxcak9kzxzwl7qpxhzvy4rx7"
   },
   "stable": {
    "version": [
@@ -23968,20 +23930,20 @@
   "repo": "redguardtoo/eacl",
   "unstable": {
    "version": [
-    20211205,
-    122
+    20220101,
+    1517
    ],
-   "commit": "e68203765549c85050c26a4d37b12528c96b912a",
-   "sha256": "1hs0xjpqn1zl5pr7zc9akwr9kin7s6yjnhi7vav2x5gsgr5xdm8h"
+   "commit": "4d9d42fa05e550dbac71a2c93e1da71c48af9449",
+   "sha256": "1bpnrvjiz6k9s36v23y1b6pjyl78741g4rc2mpdwxcnk0vzmi0aj"
   },
   "stable": {
    "version": [
     2,
-    1,
+    2,
     0
    ],
-   "commit": "478abf3c72176b8887035921270e254202ff9a0f",
-   "sha256": "0n1vlzvq5mv7z1yffjjqm9ixd3r0cljr60kg55l9pj9kp72a4iv8"
+   "commit": "a9485331789de245445b2b4a9d5befc7498628a6",
+   "sha256": "1d2krw9x1mw6jn1q07nbq2qi92fms85q3i9wa2q5drs3368l55vr"
   }
  },
  {
@@ -24070,26 +24032,26 @@
   "repo": "masasam/emacs-easy-jekyll",
   "unstable": {
    "version": [
-    20211209,
-    1521
+    20211217,
+    2311
    ],
    "deps": [
     "request"
    ],
-   "commit": "07e54052a141b32edb55f0a12b03248b0d5b1325",
-   "sha256": "1vfk49b0pi0wwjl64x4jbw7drhvmwblmkhskin3zmyr073a91k2r"
+   "commit": "7f19af310162464956f2bc4c38c6b7e95cb20321",
+   "sha256": "0l8yb3mwzd6kjnz1lnxx55ns0w6vv3cy9wda26hwr6d6hdms34xy"
   },
   "stable": {
    "version": [
     2,
-    5,
+    6,
     30
    ],
    "deps": [
     "request"
    ],
-   "commit": "a680696a46d3d1aaa589ee443f816808f4e12b64",
-   "sha256": "1css68pfl88ygxgdibyzcb5mwx3xp1s900w91jmqnj0hf2w5zsks"
+   "commit": "7f19af310162464956f2bc4c38c6b7e95cb20321",
+   "sha256": "0l8yb3mwzd6kjnz1lnxx55ns0w6vv3cy9wda26hwr6d6hdms34xy"
   }
  },
  {
@@ -24216,14 +24178,14 @@
   "repo": "joostkremers/ebib",
   "unstable": {
    "version": [
-    20211212,
-    2107
+    20220106,
+    2256
    ],
    "deps": [
     "parsebib"
    ],
-   "commit": "37b9c4ec7a57ffdda53f3345cc99cf6819e94863",
-   "sha256": "1mk487k20baqjx2ysd763nrj14b2ialddpp5rvscbyiw5mll598s"
+   "commit": "e2fee50b6589a52b5f45de45d19370cf0eb1f805",
+   "sha256": "1wpq1fjig076373awxl6kvaixs879nf98ggxwb33iiqffh5za2h9"
   },
   "stable": {
    "version": [
@@ -24245,11 +24207,11 @@
   "repo": "flexibeast/ebuku",
   "unstable": {
    "version": [
-    20211001,
-    246
+    20220106,
+    902
    ],
-   "commit": "0f853e9fd7647a33b38925727d283f5731fafef8",
-   "sha256": "18f4yk45b2l3w5i05nwqy67phm4ai1kyjf2r4yjcr89bv7bvd1ag"
+   "commit": "5004d377f8c89436c28d4a7ffbef407a2b28861e",
+   "sha256": "05cwxlqkj9wwy35pc8dq37rdvmkrc8528s64qw0pji406r6qs9l3"
   }
  },
  {
@@ -24881,15 +24843,6 @@
    ],
    "commit": "5564f5292eba339afa7760af9467c896ccd708da",
    "sha256": "0dkpijsfprlckaggnzmarrbny2qn02927s0fh94dql2gqkvfxhd0"
-  },
-  "stable": {
-   "version": [
-    0,
-    1,
-    0
-   ],
-   "commit": "61855db6f1315ea45f97ed95b47a3f182ec4c6be",
-   "sha256": "1a1apa48n24yisd2zw5k4lfkngx3016x6y11qi80hg75vrnmg7f1"
   }
  },
  {
@@ -25063,17 +25016,17 @@
     20200107,
     2333
    ],
-   "commit": "54fc2af0efdbb9e000667749bcfc9fda659304cf",
-   "sha256": "032iacivlg86fi3kwgsh0dsggx7kp8l9yvngb4ih7ilfd33mzrza"
+   "commit": "dbb395b41a4e4eb69f3f045cbfbe95a1575ac45b",
+   "sha256": "14g0dpn8j7kh3iiq7qlhaa1wdk6xvl60hkl3j87ncjwkh6h4imcg"
   },
   "stable": {
    "version": [
     4,
     1,
-    2
+    3
    ],
-   "commit": "87db16156ded2b39c87383f2fe6e1ee5e8e8757e",
-   "sha256": "0227p1qg0qgnbcpxiv58b2bp9iwckvfw8a6c1bm7z5r91a9xjgxg"
+   "commit": "dbb395b41a4e4eb69f3f045cbfbe95a1575ac45b",
+   "sha256": "14g0dpn8j7kh3iiq7qlhaa1wdk6xvl60hkl3j87ncjwkh6h4imcg"
   }
  },
  {
@@ -25084,8 +25037,8 @@
   "repo": "joaotavora/eglot",
   "unstable": {
    "version": [
-    20211116,
-    823
+    20220108,
+    1847
    ],
    "deps": [
     "eldoc",
@@ -25094,8 +25047,8 @@
     "project",
     "xref"
    ],
-   "commit": "55c13a91378cdd7822c99bbbf340ea76b1f0bf38",
-   "sha256": "01861nbwkgx88ndhqcb2dcy9mzsk7za61ngbw02mxlg3ninl15ic"
+   "commit": "a5f60dd6bf7ba2210de53637a9837cc049faddf5",
+   "sha256": "0nwyml7bn7b3h46cjgdrm8acfz4j569jjxi81dlqyizskfbf3hkq"
   },
   "stable": {
    "version": [
@@ -25129,8 +25082,8 @@
     "fsharp-mode",
     "jsonrpc"
    ],
-   "commit": "0ba09a8124cee35cf81f55b4db9144efeb00a92f",
-   "sha256": "1y11q6zbmdfwswgy205f0iqsd5c4075zsf135vsnc7bpmmkpgcvw"
+   "commit": "b3aa4c53fc9e98648b25ad036e657632ae2fe192",
+   "sha256": "14n1xpj5waflhc1zj8mfnm4xavy560n1hamqk6a0dvsahpixjx6g"
   },
   "stable": {
    "version": [
@@ -25225,11 +25178,11 @@
   "url": "https://forge.chapril.org/hjuvi/eide.git",
   "unstable": {
    "version": [
-    20211210,
-    2050
+    20211229,
+    844
    ],
-   "commit": "3a36db2bf007cc5afeead407492add1e2d2a51c7",
-   "sha256": "0gsai42nv3cgpa1lz11pbrcms9rlbpb1a30vwx1syqyi22rkcdns"
+   "commit": "35f128ec30cdd7216b9f84dda7c2bdf64d420f1c",
+   "sha256": "0m20r5gipg6xnmhn4mwvwa8miryjfd8riqlgmcscdcpc6ycaqqyp"
   },
   "stable": {
    "version": [
@@ -25264,8 +25217,8 @@
   "repo": "millejoh/emacs-ipython-notebook",
   "unstable": {
    "version": [
-    20211107,
-    1724
+    20211225,
+    1355
    ],
    "deps": [
     "anaphora",
@@ -25276,29 +25229,8 @@
     "websocket",
     "with-editor"
    ],
-   "commit": "1e42a2b26c2b113884170a94229c2743978e2dec",
-   "sha256": "0fvsbhv65z6vjw41s4yrk2j71cm7rw9yljlizrv55gazrpd5g6i8"
-  },
-  "stable": {
-   "version": [
-    0,
-    16,
-    2,
-    3
-   ],
-   "deps": [
-    "auto-complete",
-    "dash",
-    "deferred",
-    "markdown-mode",
-    "polymode",
-    "request",
-    "s",
-    "skewer-mode",
-    "websocket"
-   ],
-   "commit": "42f8efc54bfb915248972490a4b438b8d5bda381",
-   "sha256": "0jnqi8pq83s8q0dy2y1518yz8lsc0graqrqf8frss21fcj7ny22g"
+   "commit": "6063cee7fb0bdefa22fb05e4b17e58631f8187d6",
+   "sha256": "0kfl8jv9lkp92c811r1qdw1xw23pd8ga2v9j7bizx9hvvnh8nc7j"
   }
  },
  {
@@ -25422,11 +25354,11 @@
   "repo": "dimitri/el-get",
   "unstable": {
    "version": [
-    20210613,
-    1418
+    20211224,
+    959
    ],
-   "commit": "960f3fb962c35d3196bab20b2a3f6d6228119277",
-   "sha256": "1d1lkcnjjdca73frn611gz9rck73mn2kxq207lh2ykww3wkaa0pa"
+   "commit": "9353309744e4f8a7c9b1adf22ec99536fb2146b0",
+   "sha256": "14r7n9dkx1kf3j549h0kmdnsl89nwxadbx0qqmj2xzin7n9c412y"
   },
   "stable": {
    "version": [
@@ -25539,20 +25471,19 @@
   "repo": "raxod502/el-patch",
   "unstable": {
    "version": [
-    20211121,
-    1808
+    20220105,
+    443
    ],
-   "commit": "93c414f9a93035a8467aff53b43eded2edfb4a3e",
-   "sha256": "13v59nx2a6iwbvr8pk2ka47vwgpw5rmcfil9k4vjdmf892hnxr76"
+   "commit": "f2739ec466ed438dad9c7bed46f4eff9aa379c5a",
+   "sha256": "00wyhpjzz945hdjxh1p12bdxczmm1lzja528xxzxz4x5p2b2czp6"
   },
   "stable": {
    "version": [
     2,
-    3,
-    1
+    4
    ],
-   "commit": "ff1951d776f80d2fd4a0cd9a0c930182fbb57b3c",
-   "sha256": "1f783xapqa6zigg0gqayxsf8lfkldng8r4ns9x04rqg9vmhkxmk0"
+   "commit": "7378385a81ad9f033ee5033e0010c96f9b396b55",
+   "sha256": "0vankik1dh2yd554h59s5vlzanwx8sx9j31kr15830m3hfgikygz"
   }
  },
  {
@@ -25570,8 +25501,8 @@
     "hercules",
     "org-ql"
    ],
-   "commit": "915b98b901b3ea50416461dea624537ae8796847",
-   "sha256": "0bnkacmznbyj0q26br3vdvg43jmsczsksv61mp864q7l77vixgg4"
+   "commit": "aaf183877156c69bf5eb02832dc33a1908eb1091",
+   "sha256": "0nj4axympsls5hnhkwlm0v2pnbm82yks03ndk5iqyf261x7rbhna"
   }
  },
  {
@@ -25582,15 +25513,15 @@
   "url": "https://git.sr.ht/~zetagon/el-secretario",
   "unstable": {
    "version": [
-    20211205,
-    1916
+    20211214,
+    1851
    ],
    "deps": [
     "el-secretario",
     "elfeed"
    ],
-   "commit": "915b98b901b3ea50416461dea624537ae8796847",
-   "sha256": "0bnkacmznbyj0q26br3vdvg43jmsczsksv61mp864q7l77vixgg4"
+   "commit": "aaf183877156c69bf5eb02832dc33a1908eb1091",
+   "sha256": "0nj4axympsls5hnhkwlm0v2pnbm82yks03ndk5iqyf261x7rbhna"
   }
  },
  {
@@ -25601,15 +25532,15 @@
   "url": "https://git.sr.ht/~zetagon/el-secretario",
   "unstable": {
    "version": [
-    20211205,
-    1916
+    20211214,
+    1851
    ],
    "deps": [
     "el-secretario",
     "org-ql"
    ],
-   "commit": "915b98b901b3ea50416461dea624537ae8796847",
-   "sha256": "0bnkacmznbyj0q26br3vdvg43jmsczsksv61mp864q7l77vixgg4"
+   "commit": "aaf183877156c69bf5eb02832dc33a1908eb1091",
+   "sha256": "0nj4axympsls5hnhkwlm0v2pnbm82yks03ndk5iqyf261x7rbhna"
   }
  },
  {
@@ -25620,15 +25551,15 @@
   "url": "https://git.sr.ht/~zetagon/el-secretario",
   "unstable": {
    "version": [
-    20211205,
-    1916
+    20211214,
+    1851
    ],
    "deps": [
     "el-secretario",
     "notmuch"
    ],
-   "commit": "915b98b901b3ea50416461dea624537ae8796847",
-   "sha256": "0bnkacmznbyj0q26br3vdvg43jmsczsksv61mp864q7l77vixgg4"
+   "commit": "aaf183877156c69bf5eb02832dc33a1908eb1091",
+   "sha256": "0nj4axympsls5hnhkwlm0v2pnbm82yks03ndk5iqyf261x7rbhna"
   }
  },
  {
@@ -25639,16 +25570,16 @@
   "url": "https://git.sr.ht/~zetagon/el-secretario",
   "unstable": {
    "version": [
-    20211212,
-    1409
+    20211222,
+    1620
    ],
    "deps": [
     "dash",
     "el-secretario",
     "org-ql"
    ],
-   "commit": "915b98b901b3ea50416461dea624537ae8796847",
-   "sha256": "0bnkacmznbyj0q26br3vdvg43jmsczsksv61mp864q7l77vixgg4"
+   "commit": "aaf183877156c69bf5eb02832dc33a1908eb1091",
+   "sha256": "0nj4axympsls5hnhkwlm0v2pnbm82yks03ndk5iqyf261x7rbhna"
   }
  },
  {
@@ -25822,11 +25753,11 @@
   "repo": "Mstrodl/elcord",
   "unstable": {
    "version": [
-    20211011,
-    158
+    20211218,
+    1738
    ],
-   "commit": "f4a45e47e58414da0984f9ac1328be207a897ba9",
-   "sha256": "1s1i665a3bknjchg47jsaxydmmq4fqyb59i18np7w0zhhzzpjxxs"
+   "commit": "eb4ae2e7e03a5fc26b054ba2fa9a1d308e239c76",
+   "sha256": "0wznxssmh2f0jx4c8mci5idzsixpzcxyaa7yxi9ip5h4qig73sqm"
   }
  },
  {
@@ -25871,11 +25802,11 @@
   "repo": "doublep/eldev",
   "unstable": {
    "version": [
-    20211213,
-    1900
+    20211219,
+    1520
    ],
-   "commit": "182170f076ccd90f601df8af5e8dcf75c5703743",
-   "sha256": "16wlgxldarj5ky1cyzs2lfry8hr2hfchfx1rgb9jal0bk7jxp5bi"
+   "commit": "bcfbef5062b54451171db56159e22765a25ec22a",
+   "sha256": "119qm2g3zwgmlrh82ydi343phmwvic5flppzm3ya4k8nklr2dlgk"
   },
   "stable": {
    "version": [
@@ -25934,11 +25865,11 @@
   "repo": "thierryvolpiatto/eldoc-eval",
   "unstable": {
    "version": [
-    20200902,
-    1339
+    20220106,
+    1951
    ],
-   "commit": "f6e639047d9b3695877e63dd3de8f24e704d6d23",
-   "sha256": "0avl9yfprf4q1xpnvhdx0dbcgrf25sln7w7d76jqjmp93cn4idrc"
+   "commit": "e91800503c90cb75dc70abe42f1d6ae499346cc1",
+   "sha256": "01iklccpvd5n4jpmh0bhfl73a2q3cfk4q6dg70qx7ij87xg5pblf"
   },
   "stable": {
    "version": [
@@ -26036,11 +25967,20 @@
   "repo": "duckwork/electric-cursor",
   "unstable": {
    "version": [
-    20210501,
-    2107
+    20220108,
+    314
    ],
-   "commit": "e20c6f6e85c020e472ef05b12af7a12bbae65dbf",
-   "sha256": "0x1bhpb86bhkyyg28w81jw124l6zcbbqmf8i3fx28sc14q4y1gsd"
+   "commit": "0db38e5655658fe23253b59fef97fd87163533a4",
+   "sha256": "0x682ckminvjk13q9snib2p5iz8q3gibwfc21ghw1cbgfa3p3caf"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    1
+   ],
+   "commit": "0db38e5655658fe23253b59fef97fd87163533a4",
+   "sha256": "0x682ckminvjk13q9snib2p5iz8q3gibwfc21ghw1cbgfa3p3caf"
   }
  },
  {
@@ -26341,14 +26281,14 @@
   "repo": "sp1ff/elfeed-score",
   "unstable": {
    "version": [
-    20211123,
-    1505
+    20211231,
+    54
    ],
    "deps": [
     "elfeed"
    ],
-   "commit": "dc9901aabf6f6659beef1c876bd3c9cc4c7d17b6",
-   "sha256": "10wsjq2zd6kz9182gnkjzlzywx16j29dgm1gzwynr79xmvgs4r2b"
+   "commit": "38988ebdbc335f990e9a90042141f18e3fc3ddb1",
+   "sha256": "19g98xpb0kk8i0js4syb2k7sfj0lia3xmywzn9dmrxkpslhfsyms"
   },
   "stable": {
    "version": [
@@ -26418,14 +26358,14 @@
   "repo": "TobiasZawada/elgrep",
   "unstable": {
    "version": [
-    20210829,
-    1619
+    20211221,
+    852
    ],
    "deps": [
     "async"
    ],
-   "commit": "ed1ddf377447a82d643b46f3a72cbf5ecb21fb4b",
-   "sha256": "0na0s42ifv260mbv1djn7yqalcsyahsgyqrqf8lvxc1qbiisrzxv"
+   "commit": "f8124c699b6a4abfb471269bc26afbcc8136f476",
+   "sha256": "08f5kbbgmpg0nc0i148xbbm4dsp34nkr73m6ipx0fwi9dcldk8z1"
   },
   "stable": {
    "version": [
@@ -26694,8 +26634,8 @@
     20211013,
     1408
    ],
-   "commit": "7373e91e859c3ddc66457723d531cfab821160a3",
-   "sha256": "0g1krxgm3x8mj959yin1k8khqhgdr70cymvn78kb0w286079xkmn"
+   "commit": "6f61e04c8537c2e9a807dc29908f619b5202b0f8",
+   "sha256": "1hcmb3n2av3zdxsh4wk9d1l2x9065mjjgzbf5i3lh3ij1qrgakcm"
   },
   "stable": {
    "version": [
@@ -27517,11 +27457,11 @@
   "repo": "skeeto/emacsql",
   "unstable": {
    "version": [
-    20210615,
-    1539
+    20220101,
+    1820
    ],
-   "commit": "9dca5996168c4963eb67e61c7f17fdcb8228e314",
-   "sha256": "1gjwll970avjv0ah4m8w56ybi4l4bc4n8p29wq77za56m0g6jzrg"
+   "commit": "c82a0e6b4d256a3743b718cfb640fa9efc045f6e",
+   "sha256": "016lnzdsrwrghnnm8ljmzbqrcdj77pmg23nh3k3ayrh5n20ssdli"
   },
   "stable": {
    "version": [
@@ -27541,21 +27481,21 @@
   "repo": "emacscollective/emacsql-libsqlite3",
   "unstable": {
    "version": [
-    20210927,
-    2137
+    20211209,
+    1243
    ],
    "deps": [
     "emacsql",
     "emacsql-sqlite",
     "sqlite"
    ],
-   "commit": "ce95d8a373321bdeafa13e81dac18495c055fd95",
-   "sha256": "1v0v0akwcc6pklv3abalcbzglkmk9z38v7a31mcacn6fnnf75sl9"
+   "commit": "d3e401750410979be50cab3fee0ec8d0d2a9998c",
+   "sha256": "07c9dc49sh1vh1rzw80sqk4nivc4mwkjq3amhx3knm8dpysa1208"
   },
   "stable": {
    "version": [
     0,
-    1,
+    2,
     0
    ],
    "deps": [
@@ -27563,8 +27503,8 @@
     "emacsql-sqlite",
     "sqlite"
    ],
-   "commit": "d0fac65db8bd10abd845fa18c275d581219086d3",
-   "sha256": "00w1p1ax2xiv1m0p2wlrawyj98fwg69y2p2scqkd4ny1zydc7x73"
+   "commit": "d3e401750410979be50cab3fee0ec8d0d2a9998c",
+   "sha256": "07c9dc49sh1vh1rzw80sqk4nivc4mwkjq3amhx3knm8dpysa1208"
   }
  },
  {
@@ -27581,8 +27521,8 @@
    "deps": [
     "emacsql"
    ],
-   "commit": "9dca5996168c4963eb67e61c7f17fdcb8228e314",
-   "sha256": "1gjwll970avjv0ah4m8w56ybi4l4bc4n8p29wq77za56m0g6jzrg"
+   "commit": "c82a0e6b4d256a3743b718cfb640fa9efc045f6e",
+   "sha256": "016lnzdsrwrghnnm8ljmzbqrcdj77pmg23nh3k3ayrh5n20ssdli"
   },
   "stable": {
    "version": [
@@ -27605,14 +27545,14 @@
   "repo": "skeeto/emacsql",
   "unstable": {
    "version": [
-    20171219,
-    227
+    20220101,
+    1820
    ],
    "deps": [
     "emacsql"
    ],
-   "commit": "9dca5996168c4963eb67e61c7f17fdcb8228e314",
-   "sha256": "1gjwll970avjv0ah4m8w56ybi4l4bc4n8p29wq77za56m0g6jzrg"
+   "commit": "c82a0e6b4d256a3743b718cfb640fa9efc045f6e",
+   "sha256": "016lnzdsrwrghnnm8ljmzbqrcdj77pmg23nh3k3ayrh5n20ssdli"
   },
   "stable": {
    "version": [
@@ -27635,14 +27575,14 @@
   "repo": "skeeto/emacsql",
   "unstable": {
    "version": [
-    20190727,
-    1710
+    20220101,
+    1820
    ],
    "deps": [
     "emacsql"
    ],
-   "commit": "9dca5996168c4963eb67e61c7f17fdcb8228e314",
-   "sha256": "1gjwll970avjv0ah4m8w56ybi4l4bc4n8p29wq77za56m0g6jzrg"
+   "commit": "c82a0e6b4d256a3743b718cfb640fa9efc045f6e",
+   "sha256": "016lnzdsrwrghnnm8ljmzbqrcdj77pmg23nh3k3ayrh5n20ssdli"
   },
   "stable": {
    "version": [
@@ -27791,11 +27731,11 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20211213,
-    1517
+    20220108,
+    145
    ],
-   "commit": "54e5efae17a5c2898faabeaca9564a4d5f05761f",
-   "sha256": "0vpjszfqvkjzkjpma47rdyjzgkqdfg7palyzlii62wsrh04frg4l"
+   "commit": "8cf1fdbfacdbdb98ca3b4e50bf295059a02fe4a2",
+   "sha256": "1ff1vicshrnfi02ss7xcvglpg6lhw7pib142x99hqfi8a4jrvz28"
   },
   "stable": {
    "version": [
@@ -27814,15 +27754,15 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20211213,
-    1625
+    20211231,
+    1502
    ],
    "deps": [
     "consult",
     "embark"
    ],
-   "commit": "54e5efae17a5c2898faabeaca9564a4d5f05761f",
-   "sha256": "0vpjszfqvkjzkjpma47rdyjzgkqdfg7palyzlii62wsrh04frg4l"
+   "commit": "8cf1fdbfacdbdb98ca3b4e50bf295059a02fe4a2",
+   "sha256": "1ff1vicshrnfi02ss7xcvglpg6lhw7pib142x99hqfi8a4jrvz28"
   },
   "stable": {
    "version": [
@@ -27939,25 +27879,6 @@
   }
  },
  {
-  "ename": "emlib",
-  "commit": "46b3738975c8082d9eb6da9fe733edb353aa7069",
-  "sha256": "02l135v3pqpf6ngfq11h4rc843iwh3dgi4rr3gcc63pjl4ws2w2c",
-  "fetcher": "github",
-  "repo": "narendraj9/emlib",
-  "unstable": {
-   "version": [
-    20161126,
-    1523
-   ],
-   "deps": [
-    "cl-lib",
-    "dash"
-   ],
-   "commit": "dea2af00f551ea580c641d86dd69219f7d4f3685",
-   "sha256": "0p52pkq3wvnhg0l7cribhc39zl1cjjxgw9qzpmwd0jw1g1lslwbm"
-  }
- },
- {
   "ename": "emmet-mode",
   "commit": "7fabdb05de9b8ec18a3a566f99688b50443b6b44",
   "sha256": "0wjv4hqddjvbdrmsxzav5rpwnm2n6lr86jzkrnav8f2kyzypdsnr",
@@ -27989,8 +27910,20 @@
   "url": "https://git.savannah.gnu.org/git/emms.git",
   "unstable": {
    "version": [
-    20211211,
-    232
+    20220104,
+    2105
+   ],
+   "deps": [
+    "cl-lib",
+    "nadvice",
+    "seq"
+   ],
+   "commit": "2c24a16fa2e57ccedf4b502c887213c8f4eeb872",
+   "sha256": "1qsshfnrkimpvz6w5hy1wrx9s70ffbfcqzrdlwcvaly66zna7zq1"
+  },
+  "stable": {
+   "version": [
+    8
    ],
    "deps": [
     "cl-lib",
@@ -27999,19 +27932,6 @@
    ],
    "commit": "32ff8a70ca9726dd0e3b8ad68430bc6fd66bf387",
    "sha256": "127xvjsqqk1a5m5qf06ksr3y378fm5h2vyckvm38y3mgrx1kvxx0"
-  },
-  "stable": {
-   "version": [
-    7,
-    8
-   ],
-   "deps": [
-    "cl-lib",
-    "nadvice",
-    "seq"
-   ],
-   "commit": "4529ea69dd86c5e88d7fb7d568a5258b20988042",
-   "sha256": "1hyxcpv020dhm15fvdq2jgdqzsn2ara8156dpz4c93g8kj614crx"
   }
  },
  {
@@ -28282,8 +28202,8 @@
     "emojify",
     "request"
    ],
-   "commit": "23a0cf469999854fa681d02e3122840864fd4c65",
-   "sha256": "1n3znp78hhbjna6w0raixd439nmy9m0sa38g4pd70kj5l0ci1848"
+   "commit": "91111bbec3f43f85b680de68d408919b33800200",
+   "sha256": "15j4cci54rgd3ic2g4k1jf4v2yiph8y92gpg76jvrikyjby9zfj5"
   },
   "stable": {
    "version": [
@@ -28386,8 +28306,8 @@
   "repo": "Wilfred/emacs-refactor",
   "unstable": {
    "version": [
-    20211211,
-    500
+    20220108,
+    548
    ],
    "deps": [
     "cl-lib",
@@ -28400,8 +28320,8 @@
     "projectile",
     "s"
    ],
-   "commit": "64b7fb7b8dea85865db01e471414c1b2a636d5d3",
-   "sha256": "1bi5x7iald8q4p1fjgfikizxx4aryc4q8rjpmbkg247vrsxd7ljx"
+   "commit": "cac1b52932926f56d7f6d2923732d20bbd20670d",
+   "sha256": "06rmknnhzcm3fy1iipvryl85fcshpalz50500rrz8k3vkl2dps2i"
   },
   "stable": {
    "version": [
@@ -28595,15 +28515,15 @@
   "repo": "purcell/envrc",
   "unstable": {
    "version": [
-    20210516,
-    2143
+    20220103,
+    1759
    ],
    "deps": [
     "inheritenv",
     "seq"
    ],
-   "commit": "8a9a142cf9d35e62a70d9d100a946f78fe0b066a",
-   "sha256": "0nqqx4qlw75lmbn0v927sg3xyjkk86ihw1q3rdbbn59va41grds4"
+   "commit": "456c4100de41d2cb50813058a9e727b6e83c5d1e",
+   "sha256": "1l80sr74lb275i49xna5li64v2ip598xs0fdqcnhc449b1zpazm3"
   },
   "stable": {
    "version": [
@@ -28734,32 +28654,32 @@
  },
  {
   "ename": "epkg",
-  "commit": "2df16abf56e53d4a1cc267a78797419520ff8a1c",
-  "sha256": "0vvkjjaffvwvsvld3c6hwd18icmp2lc7f9yqvclifpadi98dhpww",
+  "commit": "2133b10c735ce47fc8d8ff8c51f29ec4b13982a3",
+  "sha256": "1cj53l3fdxjwkky3j3rfmv3l11m5xkn4l8qx8x2fr35rkldii5w3",
   "fetcher": "github",
   "repo": "emacscollective/epkg",
   "unstable": {
    "version": [
-    20211119,
-    21
+    20220101,
+    1312
    ],
    "deps": [
     "closql"
    ],
-   "commit": "eac43b29286e05192cbeada4cad09774493e0ab7",
-   "sha256": "0j9kp7ar6zccqhaihqphfxxkrvw63ipayy3dp876l9cr1ywxnv8f"
+   "commit": "44bcdb03bb11891f5966b39be942d76a4a57f5cf",
+   "sha256": "18kjp0f5ch4mpd6yrd83p73pw7ykp2lv5686is8vcvyyys53jrf1"
   },
   "stable": {
    "version": [
     3,
     3,
-    1
+    2
    ],
    "deps": [
     "closql"
    ],
-   "commit": "44b7b2519f84056ee94a6c4ce21fce146532174c",
-   "sha256": "0z9sz9ydfjzhawh4qip41h3vid1lslaf0h14hkjz9kx8fkrzib8a"
+   "commit": "44bcdb03bb11891f5966b39be942d76a4a57f5cf",
+   "sha256": "18kjp0f5ch4mpd6yrd83p73pw7ykp2lv5686is8vcvyyys53jrf1"
   }
  },
  {
@@ -29340,14 +29260,14 @@
   "repo": "ergoemacs/ergoemacs-mode",
   "unstable": {
    "version": [
-    20211105,
-    1531
+    20220104,
+    2107
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "df8d4253c44aee607308826093222188c4732099",
-   "sha256": "1rss0k7yvgbi326x2zjhbx9a5m80a58w1vj86c9ykrd0n4wj2nk0"
+   "commit": "b0ede648b660cc7fe2b15abf6d85cf59ab01bc96",
+   "sha256": "0hhrd3fllmvjpl3kj96sv9k9qn2cb4wy74gz2czy712xj5bh0y4w"
   },
   "stable": {
    "version": [
@@ -29394,8 +29314,8 @@
     20200914,
     644
    ],
-   "commit": "756ac774b5191b252bf993b67c7ccd5648cbbb65",
-   "sha256": "174vd5dw7wz2kf08mcaakr0r0qx64bigkdhr9zg7c68xj0w0kasn"
+   "commit": "a0b3eea0c19c47ffbe2be525316311f5795d760d",
+   "sha256": "06hqdmhlxr8air3hfpw434ycfvyjby34ng6xj0knjyfja0044sb0"
   },
   "stable": {
    "version": [
@@ -29419,17 +29339,16 @@
     20211213,
     1046
    ],
-   "commit": "9b07aedd669c2cb1e12e8a9b4f06210d0892041e",
-   "sha256": "0jnxrj17s37mgjmv6smjpfd4qzlql6his4k5f6xpmxabv7kx6lgf"
+   "commit": "f8e41f8553239fb02598ef6c019cdb8a174d4eea",
+   "sha256": "1nfz1mcwymx327fbb94hnrc68fbavlgc2czg4l4f7rdlv56h8axd"
   },
   "stable": {
    "version": [
     24,
-    1,
-    7
+    2
    ],
-   "commit": "5d0fa9d31812947479eb29f797990da6655d4fa2",
-   "sha256": "1d86yczbb2dndkjcbzc6lcq8aq6gdibh6pkxrg76n07xr5adk2j7"
+   "commit": "df48c260e74c3e9058ff8681ce9f554e6fa0fe34",
+   "sha256": "10s57v2i2qqyg3gddm85n3crzrkikl4zfwgzqmxjzdynsyb4xg68"
   }
  },
  {
@@ -29886,14 +29805,14 @@
   "repo": "mallt/eshell-fixed-prompt-mode",
   "unstable": {
    "version": [
-    20190111,
-    2235
+    20220104,
+    1535
    ],
    "deps": [
     "s"
    ],
-   "commit": "2c860029354bf1f69edc1f12e4a0d9aeb9054f5d",
-   "sha256": "1j1m661rgbfr04357wq2a7vhm04s3vrbw4r6y1k2cx2ap9amkb25"
+   "commit": "302c241b42764bd6b4ed6d3c6ea360b5a2292fbc",
+   "sha256": "10igzz5vhjkq4m7mc45ngfi3ahimcn2c0zcqqazk3jgysy1hjgp2"
   }
  },
  {
@@ -29951,15 +29870,26 @@
   "repo": "Phundrak/eshell-info-banner.el",
   "unstable": {
    "version": [
-    20211119,
-    1806
+    20220107,
+    1109
    ],
    "deps": [
-    "f",
     "s"
    ],
-   "commit": "9b75d1945170fdf89ad24db8d150bfb6e08ea56a",
-   "sha256": "0ysj2hdnsf6j7ywz140k94q2sqhh567ipf2ccd5qrj90n6f5crrp"
+   "commit": "d4033120c1259c454aaba21eb1c297b0507b34d4",
+   "sha256": "0f1zgbgzfc6djr3h5lkw9z614wcr5sfz77lfya31brpbiqpvqz6d"
+  },
+  "stable": {
+   "version": [
+    0,
+    8,
+    6
+   ],
+   "deps": [
+    "s"
+   ],
+   "commit": "d4033120c1259c454aaba21eb1c297b0507b34d4",
+   "sha256": "0f1zgbgzfc6djr3h5lkw9z614wcr5sfz77lfya31brpbiqpvqz6d"
   }
  },
  {
@@ -30318,11 +30248,11 @@
   "repo": "emacs-ess/ESS",
   "unstable": {
    "version": [
-    20211204,
-    958
+    20211231,
+    1746
    ],
-   "commit": "5e6bfa14a328095833a038275105f3aa31715a17",
-   "sha256": "0djlhrjrrkwnlw77aip4bj7jx3fg2cfzbap4z09vhnf77asrz6j2"
+   "commit": "5ec55b95940ac63ef6209c76035a13d02a3248cd",
+   "sha256": "149x113z4k0bgcir82wv0915zcg9mb1zl2qfymp9s6g31xx3m4dc"
   },
   "stable": {
    "version": [
@@ -30913,15 +30843,15 @@
   "repo": "emacs-evil/evil",
   "unstable": {
    "version": [
-    20211211,
-    1737
+    20220107,
+    1637
    ],
    "deps": [
     "cl-lib",
     "goto-chg"
    ],
-   "commit": "b00018bf550fbbe1b55165579e6ede973d70f53b",
-   "sha256": "1qw33vhiiia14rzwzmvsp2w4vyrf1z6v3b8vgkcmlxyhns22g26f"
+   "commit": "a5fd96dadc44ab3a00c354aed33cb576f65a50de",
+   "sha256": "06kc8m8pj5jxs8ljq1x9wpm12ya3k9y77vqg7zy07rkbrbgjacyp"
   },
   "stable": {
    "version": [
@@ -31115,28 +31045,28 @@
   "repo": "emacs-evil/evil-collection",
   "unstable": {
    "version": [
-    20211208,
-    2219
+    20220104,
+    1329
    ],
    "deps": [
     "annalist",
     "evil"
    ],
-   "commit": "1b9d5c5d939b6eae13b6e545e53faee958af460a",
-   "sha256": "03i3lv9h61jnnzfjasxszwrkcf0bkkyq65lh22852n35yg7ylxyc"
+   "commit": "e6be41bed7b4399db116038c7f0bf2f484065b48",
+   "sha256": "1m3y0xsaawgirc2a61a0n8cqg9x8wf4qvbvjp9aw5fiaifmgcyln"
   },
   "stable": {
    "version": [
     0,
     0,
-    6
+    7
    ],
    "deps": [
     "annalist",
     "evil"
    ],
-   "commit": "d97e0ff4afa67bd19443245d4f663de29b043a6b",
-   "sha256": "0ssb3n1i67b6zp2j8djaalkr33x4c7zalw6vl6p5kqxkh8vy8cdf"
+   "commit": "f31162b2536d14bf97fe96d6e54be0d091ba9493",
+   "sha256": "1f5mbg2k527brn6b7njdjizpbzj252c53crzl8sf2564czcprqj0"
   }
  },
  {
@@ -31494,15 +31424,15 @@
   "repo": "TheBB/evil-indent-plus",
   "unstable": {
    "version": [
-    20151109,
-    1906
+    20220106,
+    931
    ],
    "deps": [
     "cl-lib",
     "evil"
    ],
-   "commit": "0c7501e6efed661242c3a20e0a6c79a6455c2c40",
-   "sha256": "1g6r1ydscwjvmhh1zg4q3nap4avk8lb9msdqrh7dff6pla0r2qs6"
+   "commit": "b4dacbfdb57f474f798bfbf5026d434d549eb65c",
+   "sha256": "1hlw0zv5niap3vwm4fkqqk8c1bysij76s54ksp84wb8sggkga53p"
   }
  },
  {
@@ -31687,8 +31617,8 @@
    "deps": [
     "evil"
    ],
-   "commit": "f9faa0b9bf36888d83143db226938344dfc1801f",
-   "sha256": "03jrkzjamh8xxs3h8ga7i3jrv3rhcq0mwysrirqqvxz283hwk9mv"
+   "commit": "14c7c7ed0a1ca8d3407688e0150f794db9389997",
+   "sha256": "1yhn38hh8rqi60h3pfqb18fvdgxks91v561dbfrbsnwnlw8babxn"
   },
   "stable": {
    "version": [
@@ -31816,20 +31746,20 @@
   "repo": "redguardtoo/evil-nerd-commenter",
   "unstable": {
    "version": [
-    20211014,
-    455
+    20220106,
+    1224
    ],
-   "commit": "63baf2d1c796edd11bbec5fe1dee711173d4155d",
-   "sha256": "0kk9l9wvvb40hric4wdzvccp98mbipln7ah9h8grl5ayb9kw6xxg"
+   "commit": "42ba1a473b4f1df061baddd2f8b812a2f35e366e",
+   "sha256": "1y6qy4gv7k8aghi5snvh248nxpgxv0daryd2794n6gfb4ciwycrr"
   },
   "stable": {
    "version": [
     3,
     5,
-    5
+    6
    ],
-   "commit": "8b0d9654ecf8f3f1d88db6be8238aaf76afa8a94",
-   "sha256": "1qrlg4cxlsd4cf1z8j2662pfb9p6pnqpsyb74flja9cqv6g5ylp8"
+   "commit": "42ba1a473b4f1df061baddd2f8b812a2f35e366e",
+   "sha256": "1y6qy4gv7k8aghi5snvh248nxpgxv0daryd2794n6gfb4ciwycrr"
   }
  },
  {
@@ -32417,14 +32347,14 @@
   "repo": "7696122/evil-terminal-cursor-changer",
   "unstable": {
    "version": [
-    20211002,
-    709
+    20211225,
+    600
    ],
    "deps": [
     "evil"
    ],
-   "commit": "5b2d76fd26bf33022bbad0198acd9b83c9759750",
-   "sha256": "0f9i5w2vdvrsmcf4vv0vf5bkrqpqdq3gm6p9a0hm1j2p0dfvh8hd"
+   "commit": "3d7db4d6b4a3121ffd7e505b12ea94fcdb8c5df8",
+   "sha256": "01haj9b1vhgmnc12csdfsw0lwv2kvgka9k0smlcc6rr840aapi72"
   }
  },
  {
@@ -32441,8 +32371,8 @@
    "deps": [
     "evil"
    ],
-   "commit": "b00018bf550fbbe1b55165579e6ede973d70f53b",
-   "sha256": "1qw33vhiiia14rzwzmvsp2w4vyrf1z6v3b8vgkcmlxyhns22g26f"
+   "commit": "a5fd96dadc44ab3a00c354aed33cb576f65a50de",
+   "sha256": "06kc8m8pj5jxs8ljq1x9wpm12ya3k9y77vqg7zy07rkbrbgjacyp"
   },
   "stable": {
    "version": [
@@ -32644,15 +32574,15 @@
   "repo": "meain/evil-textobj-tree-sitter",
   "unstable": {
    "version": [
-    20211210,
-    1354
+    20211227,
+    410
    ],
    "deps": [
     "evil",
     "tree-sitter"
    ],
-   "commit": "31b6b20f5dae9edd2f733b347b4f7a0d0a5cb962",
-   "sha256": "108gp9iq7mrmdim0xm845g90f8n9kws4d70ad2gjwl9dcamgjxnz"
+   "commit": "d226f5f03235a914f8620ca841908180d5e5c33b",
+   "sha256": "1zfs9g1lpb8dispngkyfvc70mah5k06hxgjmvvg8sqwc7915hcs2"
   }
  },
  {
@@ -32675,14 +32605,14 @@
  },
  {
   "ename": "evil-tree-edit",
-  "commit": "43726f8e4c4f7f673ca892ec17329471dba77b3e",
-  "sha256": "126jkiy9jganamn9xv2d357mxipgbz9skpvygwb7lkhnvkz263dg",
+  "commit": "7ec29a86aac242dd20a4632ee40e6fd582ad8a0d",
+  "sha256": "1wgs02w99cz54i8a69qn3pwm89ygq31hwv5a84gs9syxkjzs50sd",
   "fetcher": "github",
   "repo": "ethan-leba/tree-edit",
   "unstable": {
    "version": [
-    20211211,
-    2301
+    20220105,
+    1638
    ],
    "deps": [
     "avy",
@@ -32691,8 +32621,8 @@
     "tree-edit",
     "tree-sitter"
    ],
-   "commit": "1a670b73cd990af3b08633b01f84b57edaeb92ba",
-   "sha256": "1sr8h96rzghxbs42rzv0c2abhrydjsxf98hijnffa7yqd8gffjdr"
+   "commit": "4ef6bd9ffe5047beb00cf473d0ce80e657cceae2",
+   "sha256": "0n67ka9yyqc1mvz6646kixly1ixp7vhfydgy5wx00rjpp6yxf4ni"
   }
  },
  {
@@ -33201,8 +33131,8 @@
     20210708,
     1952
    ],
-   "commit": "95a773bd8f557cbd43d3b2dab2fa4417ec5927ab",
-   "sha256": "05zdh71zkp2n740dcixanw9cziw93rkix2bb24vw9phkj271m0d7"
+   "commit": "7e5bbe2763c12bae3e77fe0c49bcad05ff91dbfe",
+   "sha256": "167mxvhpr1laad3iznpxbfczvzjyi5c1w6h58amn60gq8v78j9rl"
   },
   "stable": {
    "version": [
@@ -33222,14 +33152,15 @@
   "repo": "md-arif-shaikh/expenses",
   "unstable": {
    "version": [
-    20211213,
-    438
+    20220104,
+    1459
    ],
    "deps": [
-    "dash"
+    "dash",
+    "ht"
    ],
-   "commit": "df8faaf5c6741dc3387707567940021274c93c5b",
-   "sha256": "017c8vgqn08qn2l3mkinn80922g1rcg7pj8lx9dqylh5nylrp0gn"
+   "commit": "51733c3b96e2fe4720ef0b5468f4830c2fd9d24c",
+   "sha256": "0y8zb11s7h11z1zpb2xk2yxn4xc9zx7gmrsffi2s4islb0zv18hs"
   }
  },
  {
@@ -33537,20 +33468,8 @@
    "deps": [
     "dash"
    ],
-   "commit": "88c7b59aa7c5c93bc23812217213adfa238f977b",
-   "sha256": "09s07mvg5bz3dm9sxgn40c7z6d6ry1sdjzsxwgmy825f3xm66avs"
-  },
-  "stable": {
-   "version": [
-    0,
-    7,
-    8
-   ],
-   "deps": [
-    "dash"
-   ],
-   "commit": "d75e37a048718d6981c366c431b93ccbe884f356",
-   "sha256": "08k6dcz2pzgv0n4rfpq0gmpzs9319h5jk5xznmh2s8y42imvp5l7"
+   "commit": "f7e129b84183367f54f0d0d3c9db8540f754bd8d",
+   "sha256": "0wzqwxshvsr51ibyz5mdbgxzxblp22d9rlqjxm2d5nkn35pn50wn"
   }
  },
  {
@@ -34121,8 +34040,8 @@
   "repo": "jumper047/fb2-reader",
   "unstable": {
    "version": [
-    20211205,
-    58
+    20211214,
+    954
    ],
    "deps": [
     "async",
@@ -34131,8 +34050,8 @@
     "s",
     "visual-fill-column"
    ],
-   "commit": "4e2e20ea6ac7fe4063ad3ecabebf8864b1d48e4f",
-   "sha256": "09b0nkfyrsyinpjbjspr7zd07i77w8m8ic2i8h7fbc84ki2xl2g1"
+   "commit": "9dcc0801a7dd302ee0620781ea17868895d3f082",
+   "sha256": "1i74nqivp59129w2n81x86zrf0cy4ws6wyxdsw65nib96jrwg683"
   }
  },
  {
@@ -34350,8 +34269,8 @@
     "f",
     "s"
    ],
-   "commit": "3d524dd404862de1a40ec5834cc1b85137a1acd2",
-   "sha256": "1ds46hl7givwmw4zsz4nx7wg4n9xxmn1a806dxkjjqcp0cvhv4l5"
+   "commit": "7b961721f36bd23ac8fae6e6eaa490ac6e8527d0",
+   "sha256": "1kgjb8qjscs1a08w4qwynd6yb94hi6lai9lgf0mnwvvmv6rpzfwv"
   },
   "stable": {
    "version": [
@@ -34454,15 +34373,17 @@
   "repo": "knpatel401/filetree",
   "unstable": {
    "version": [
-    20211128,
-    205
+    20220108,
+    249
    ],
    "deps": [
     "dash",
-    "helm"
+    "helm",
+    "seq",
+    "transient"
    ],
-   "commit": "03a58d6de1e76c3a88f50cc3e8735b8b1c09650a",
-   "sha256": "1zm7zlzzxddpbaz9mzg2r7za2p573b3v1kzdywh47hcsa7b1sxss"
+   "commit": "bb266a8306844f83267a539bca00fb8fab5bb973",
+   "sha256": "13ldh2vp3c1sigl24h3pjlr7pp1kqps4pypr9xs9nfp8p1lxyd14"
   }
  },
  {
@@ -34522,8 +34443,8 @@
     20210707,
     354
    ],
-   "commit": "562d6d5118097b4e62f20773fd90d600ab19fb61",
-   "sha256": "0v5irns6061qx0madrf2dc1ahkn4j90v8jpx16l69y9i98dh6n5k"
+   "commit": "9e076f56f58a195df9dd88f6541b63201bd5c38b",
+   "sha256": "0pffcv4nhwap85sx2rxxr4li3rg2bb5ykanaq6kg5wcliqck29hg"
   },
   "stable": {
    "version": [
@@ -34548,6 +34469,30 @@
    ],
    "commit": "501468082e46bd0975ef4d8765363fd564338099",
    "sha256": "0z18x3gxh004nd648hwqdlb60a6ss61pkkqg30xpdmsrj8darf5q"
+  }
+ },
+ {
+  "ename": "filldent",
+  "commit": "4e3d46311b4d15314b6d1a0d5ff95c5f7e366223",
+  "sha256": "0if5fxr5vy4b8w36d0vi43cba5xpvqc2ma46d80bpark95jj8cvq",
+  "fetcher": "github",
+  "repo": "duckwork/filldent.el",
+  "unstable": {
+   "version": [
+    20220103,
+    10
+   ],
+   "commit": "5969bdf50a1fcf0bd3a1507782152effb5be85e7",
+   "sha256": "05g8jwd7qq3g6viayhr7szjb5vfj53ynj2krxnhl7cgqbpfbaq4v"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    1
+   ],
+   "commit": "ec406d76c97fd8a59df9308d60dba63061dc716a",
+   "sha256": "114p7p4qby2mj6z1lz1gv4ca2cqgyr3c1v250ka9m2m46lnrml40"
   }
  },
  {
@@ -34899,15 +34844,6 @@
    ],
    "commit": "76070c9074aa363350abe6ad06143e90b3e12ab1",
    "sha256": "0agw50yrv2hylqqq8c4cjwl3hwfyfsbk74mpys8mi9lsycfw1sg9"
-  },
-  "stable": {
-   "version": [
-    0,
-    2,
-    5
-   ],
-   "commit": "4d6b106f325ac1802eabce3c8a7cd0a4c7a32864",
-   "sha256": "13daz15v0sshl7lxcg1xcbpl64gklgh50pzk0qxmn5ygw7nlifn0"
   }
  },
  {
@@ -34980,11 +34916,11 @@
   "repo": "marcowahl/fit-text-scale",
   "unstable": {
    "version": [
-    20210112,
-    2246
+    20211230,
+    2002
    ],
-   "commit": "3f93650a8e8899114ea48048b7962210f1024862",
-   "sha256": "1yjfvb2vn5pmrq5fw4sfx1lfkbnkwlc160izpvkrf9ww9xsas6al"
+   "commit": "c53c8ce606380088643463848a9ee3502b0c64f4",
+   "sha256": "00jbfi2k72w01lzxn9gjam7nabbaqwas3gr922a5s04494yyc8rp"
   },
   "stable": {
    "version": [
@@ -35917,14 +35853,14 @@
   "repo": "alexmurray/flycheck-clang-analyzer",
   "unstable": {
    "version": [
-    20200429,
-    238
+    20211214,
+    648
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "0c9b6e4626cd5376037464f8d6b8c64aa32768ee",
-   "sha256": "0nr3wipmcalxfp48hi23vmrj2rwbwk6gipdqmic8ay4z9x2csi8v"
+   "commit": "646d9f3a80046ab231a07526778695d5decad92d",
+   "sha256": "1v6h5602vf831qnlxxncbvc6hjvshr2gkg878ksdgb2bl708a1gx"
   }
  },
  {
@@ -35985,14 +35921,14 @@
   "repo": "borkdude/flycheck-clj-kondo",
   "unstable": {
    "version": [
-    20201102,
-    1128
+    20211227,
+    2226
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "a558bda44c4cb65b69fa53df233e8941ebd195c5",
-   "sha256": "1i8nf2ip0gag3f3p3fh7p4iccdyydzf523r762c66vrixvr5syl9"
+   "commit": "d8a6ee9a16aa24b5be01f1edf9843d41bdc75555",
+   "sha256": "010gzxwvr2p2wv358r76ajkn48ilgmkmv7z6bckqbap0cjhrqq43"
   },
   "stable": {
    "version": [
@@ -36141,8 +36077,8 @@
    "deps": [
     "flycheck"
    ],
-   "commit": "3e37f282af06a8b82d266b2d7a7863f3df2ffc3b",
-   "sha256": "1rwm7srb3xlsja4hana83an9a6l9f9rmi299qkjxhjcry8x9p78g"
+   "commit": "96a8058205b24b513d0b9307db32f05e30f9570b",
+   "sha256": "02i1wwr2h9r5ssdysnvp5lh2i7ghh0fv3flqf57a1s388mk4giia"
   },
   "stable": {
    "version": [
@@ -36466,14 +36402,14 @@
   "repo": "alexmurray/flycheck-flawfinder",
   "unstable": {
    "version": [
-    20170116,
-    327
+    20211214,
+    647
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "7d964d38023b088adf3ffc2fddeead81f4491a45",
-   "sha256": "0y023brz8adwa6gdaaixk6dnrq4kj2i5h56rj54cxrjkagyklfxl"
+   "commit": "85701b849ea1ed8438ed4b7ae236e99d0f5528c7",
+   "sha256": "1wfba0p54qnr2s6nhzg1vapzppb7m124whasfrl4ki124c4sf6v1"
   }
  },
  {
@@ -36647,16 +36583,16 @@
   "repo": "emacs-grammarly/flycheck-grammarly",
   "unstable": {
    "version": [
-    20211027,
-    1357
+    20211231,
+    914
    ],
    "deps": [
     "flycheck",
     "grammarly",
     "s"
    ],
-   "commit": "cb086c996db0837e774a5dc9edca9592e2e8f9a8",
-   "sha256": "08njaf2fxfiww5c967qrz18zq3sazdlwdvg66nbxkyzhyhgy6r3b"
+   "commit": "1352c1d970e42afbbb93d029636e17aa7b921cd0",
+   "sha256": "0m6zhqm0n3fhni5h7ky18zrcmmw3rwizq6wrpl1cnbyp38vljl7h"
   },
   "stable": {
    "version": [
@@ -36711,8 +36647,8 @@
   "repo": "flycheck/flycheck-haskell",
   "unstable": {
    "version": [
-    20210829,
-    1143
+    20211223,
+    104
    ],
    "deps": [
     "dash",
@@ -36721,8 +36657,8 @@
     "let-alist",
     "seq"
    ],
-   "commit": "16b748c033e30216259fa8c9c23616db36750a58",
-   "sha256": "08agklr9mw4rxr5mq9c5ynhqsjp5knc7571rnr19iziq33r8srl9"
+   "commit": "8110ef5a1953594d065b67df25d5f0c05c711df4",
+   "sha256": "1qdgcykn2rdf9jj9pzd0zyk7pdcf9lr942hr6w3kmkc299qiajf8"
   },
   "stable": {
    "version": [
@@ -37081,8 +37017,8 @@
    "deps": [
     "flycheck"
    ],
-   "commit": "457860482eb1b63aafe8930a08ecfa0ca5073ab1",
-   "sha256": "071h40lh4l47x0b9sfwllxvaqnp1sxidy4c73icf83wikw8h81jr"
+   "commit": "4c22da6aa2878cbf490214b034f2ac25209f0fdc",
+   "sha256": "07qlaay65gs2v4zbawnfwf5ry2ag9dl0zzjrr8slqk7z6wy2c5wb"
   },
   "stable": {
    "version": [
@@ -37528,8 +37464,8 @@
    "deps": [
     "flycheck"
    ],
-   "commit": "3c303551cb9c317e49878cb860c6ed6d142d9613",
-   "sha256": "1mm558vjyjk5cxxwns69fh477ws02hhmh0ain46zp7qdz6h08nbk"
+   "commit": "5331235970e5bc7906e328b07e11ebc95b974d05",
+   "sha256": "1y54xg9faakcmajc5c0v6i1sq5fjxfhss2lshk895iql78xfjcxg"
   },
   "stable": {
    "version": [
@@ -38590,15 +38526,15 @@
   "repo": "emacs-grammarly/flymake-grammarly",
   "unstable": {
    "version": [
-    20210913,
-    1416
+    20211231,
+    914
    ],
    "deps": [
     "grammarly",
     "s"
    ],
-   "commit": "3cdf30a6d45778640252c6ab563b53382fd4a4d3",
-   "sha256": "0hbjixzzgm0jmpp5xp3407n0rm0b1iah94kzj2mqk2xrg1qmbbbk"
+   "commit": "57d6d69b1b55eca484d643d180682a7e683b4b0e",
+   "sha256": "0a2azplyv9mp6xjjxdff35sz2r65h4svnrrsraib9jvz5hbqmny5"
   },
   "stable": {
    "version": [
@@ -38838,14 +38774,14 @@
   "repo": "emacs-languagetool/flymake-languagetool",
   "unstable": {
    "version": [
-    20210627,
-    434
+    20211227,
+    1908
    ],
    "deps": [
     "s"
    ],
-   "commit": "cd6e5602e58bd9c03ec1c6a3b01c337d17ebf0fe",
-   "sha256": "1gjwxycbpvf3z332y5my6w57mjmqgs9mwfcfi0p3jdby18ykwyd2"
+   "commit": "a43fd0d92dbec5f1d4129b30ab0ed917e0864129",
+   "sha256": "03nfbdjfx5bnv5phs3fcysvfza9lcw32mai1a8gjdmm8p4cgc851"
   },
   "stable": {
    "version": [
@@ -39336,11 +39272,11 @@
   "repo": "shaohme/flymake-yamllint",
   "unstable": {
    "version": [
-    20211206,
-    907
+    20211215,
+    1416
    ],
-   "commit": "34fb579087a1d97cabd001dbf3f44ea48914bcde",
-   "sha256": "1x6npp5prgcl0ahcv7x3gvv0g52fjrkgapa1sp2c62l6is5zig3h"
+   "commit": "22690dd862089f470980cceea06153682a397b7a",
+   "sha256": "1x3ivvwnbwpsavbypgkh1il7l7vmq8vp4w3y40f60zv3zz06nf16"
   }
  },
  {
@@ -40019,8 +39955,8 @@
   "repo": "magit/forge",
   "unstable": {
    "version": [
-    20211211,
-    15
+    20220105,
+    1146
    ],
    "deps": [
     "closql",
@@ -40033,8 +39969,8 @@
     "transient",
     "yaml"
    ],
-   "commit": "402773ef7e83ddfab64bfee23daea2776d50dbc1",
-   "sha256": "1n8x0bx3av935ky56rzy38d0ry73g57nsax26z3scc4na4h46yip"
+   "commit": "0ff9b8a0dea2483203646ba82ce155bb4957a88a",
+   "sha256": "11gvv19vr5giidg0s7pc22krds7z622wp067k4bzg4dx1l2mcanx"
   },
   "stable": {
    "version": [
@@ -40234,14 +40170,14 @@
   "repo": "rnkn/fountain-mode",
   "unstable": {
    "version": [
-    20211202,
-    1215
+    20211223,
+    405
    ],
    "deps": [
     "seq"
    ],
-   "commit": "3090858848a596ffa88a3b3616e31f70826c8fad",
-   "sha256": "0qvw6s4g2lbxd0w1hja5rzns2h8i40igq137603q1pp6ysmdmqsy"
+   "commit": "0aab300c0a6225d93087ae112f123eb89048ce1d",
+   "sha256": "102g7n43ji47ssj7rdyx34frbgl84lgmppww4f3x6wbkvfwa2p6f"
   },
   "stable": {
    "version": [
@@ -40784,14 +40720,14 @@
   "repo": "fsharp/emacs-fsharp-mode",
   "unstable": {
    "version": [
-    20211115,
-    1418
+    20211229,
+    1121
    ],
    "deps": [
     "s"
    ],
-   "commit": "0ba09a8124cee35cf81f55b4db9144efeb00a92f",
-   "sha256": "1y11q6zbmdfwswgy205f0iqsd5c4075zsf135vsnc7bpmmkpgcvw"
+   "commit": "b3aa4c53fc9e98648b25ad036e657632ae2fe192",
+   "sha256": "14n1xpj5waflhc1zj8mfnm4xavy560n1hamqk6a0dvsahpixjx6g"
   },
   "stable": {
    "version": [
@@ -40815,8 +40751,8 @@
   "repo": "FStarLang/fstar-mode.el",
   "unstable": {
    "version": [
-    20201012,
-    2201
+    20220106,
+    2256
    ],
    "deps": [
     "company",
@@ -40826,8 +40762,8 @@
     "quick-peek",
     "yasnippet"
    ],
-   "commit": "3afbf04e4eb21af950cfdb727d8b808164fd9415",
-   "sha256": "1ks949zcqk3dqcxjv2lj9jyz6mnrvcgwg9iaa70lsb772lxza8wj"
+   "commit": "c95c2a61a6c42a1fa8bab9a8eb812a41be3e6f69",
+   "sha256": "1vj0lgj2q9bjspaqd0qlfifzwilzwnhkn21csnra78bvbhk2pd3p"
   },
   "stable": {
    "version": [
@@ -40851,14 +40787,14 @@
   "repo": "factor/factor",
   "unstable": {
    "version": [
-    20210602,
-    1531
+    20211221,
+    2127
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "ce86de6c23826a318be6dab8c6105542d76d52eb",
-   "sha256": "11h92862sy6s0g830w88j8z0kfi2rdfhwrzwzy8bvapl8b8xw8xm"
+   "commit": "449c6c19017daf7ca7720e59de4635101d0c083f",
+   "sha256": "0g7cnzsirdcglai6lsvqk9709xqd5h2ns03vww8p8plw5kj5cjqh"
   },
   "stable": {
    "version": [
@@ -40951,14 +40887,14 @@
   "repo": "abo-abo/function-args",
   "unstable": {
    "version": [
-    20171031,
-    1704
+    20211231,
+    1150
    ],
    "deps": [
     "ivy"
    ],
-   "commit": "609b25305670fff08d5e357298e7128e4f4e3497",
-   "sha256": "1xymwk42n2l7c7iaigz23i4l580qpjgq8nqhgr4mnw6invdsgg2c"
+   "commit": "503e78fad9e7741ef4b8f5c24ff70c8909240db2",
+   "sha256": "124sgm6jhr20zn0p15fg3f226vgrmsfsqb5qkd1rssxsjp3jplb6"
   },
   "stable": {
    "version": [
@@ -41011,14 +40947,14 @@
   "repo": "diku-dk/futhark-mode",
   "unstable": {
    "version": [
-    20211212,
-    2032
+    20220104,
+    1200
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "4c340703cb749298dd472cd981df182335e3b4af",
-   "sha256": "1bkckcz2z9hnay3c85yai34hll1fwi4569hvhnpikhabk048k2mq"
+   "commit": "ea4b26bc5fbc074a011918172ea0c624a81c8092",
+   "sha256": "1i4gdascsjpvvks61wwwv0qmw0nbj6jy0slc95jymd2vnyz1p715"
   }
  },
  {
@@ -41053,11 +40989,11 @@
   "repo": "auto-complete/fuzzy-el",
   "unstable": {
    "version": [
-    20210317,
-    140
+    20211231,
+    1837
    ],
-   "commit": "edce468a3077d03ca63e1559f7ffebfa09c8effd",
-   "sha256": "126wbccdilqi7yf1w7z9gjr6zr4lmrrii6bz65jg5ffnpx8kj30d"
+   "commit": "f63d6279a781cf9f33dd2f22826788d98d475961",
+   "sha256": "11dj0qg2411r2nby2nzi1i4s2v5wnz4594cl5c8gq9hws7cmp6q2"
   },
   "stable": {
    "version": [
@@ -41124,20 +41060,20 @@
   "repo": "tarsius/fwb-cmds",
   "unstable": {
    "version": [
-    20211118,
-    2244
+    20220101,
+    1035
    ],
-   "commit": "69409a996ec589ea27df8fa92899900afe8d1011",
-   "sha256": "0xam1zyk6mgk3jvwjcamcmrk5gvxipjfczax7vv37vzzh2wvlqhx"
+   "commit": "1143188080e33afd3330f540c7e7df48898a4777",
+   "sha256": "032ykl67f5x1f98gm8s9jiynlvip16r4lkl64a7xn36g32a4g4x9"
   },
   "stable": {
    "version": [
     1,
-    1,
-    1
+    2,
+    0
    ],
-   "commit": "90258a5c7dbbaa2ac227e0fb4ff6c7d5aec3628f",
-   "sha256": "1xwvv8wjgdaz96v1x1xc5w697bfvcanlcixd0n5qbx6ryakqrb72"
+   "commit": "1143188080e33afd3330f540c7e7df48898a4777",
+   "sha256": "032ykl67f5x1f98gm8s9jiynlvip16r4lkl64a7xn36g32a4g4x9"
   }
  },
  {
@@ -41192,11 +41128,11 @@
   "repo": "bling/fzf.el",
   "unstable": {
    "version": [
-    20210826,
-    140
+    20211228,
+    2005
    ],
-   "commit": "e045e7ede6a3d5f792cd11efe5e83cf60d8081bb",
-   "sha256": "0y4abgwcb28dpnzqcl2dylymnkg1v91nrnpsrly0dp8bf0aiafrq"
+   "commit": "d61cecbdb60b0f10cecd50ff2ae115aeb77f9fdc",
+   "sha256": "1p392jq76jaqjk12rrnwkk4bmxmgav8bigqvp5a39c6jaw5ybrcd"
   },
   "stable": {
    "version": [
@@ -41457,19 +41393,25 @@
   "repo": "emacs-geiser/geiser",
   "unstable": {
    "version": [
-    20211205,
-    2014
+    20211229,
+    1905
    ],
-   "commit": "365764db5e3e07042f83d120595421770db771b2",
-   "sha256": "1ixkhkq01v8vhm9drih7hisxppjhgml1xfppb120njs12wqkfrl7"
+   "deps": [
+    "transient"
+   ],
+   "commit": "e204771601e5c985bb0d6b373666be4bc22582f9",
+   "sha256": "0rg15hhf0yzcacyk1bx93fn4g60vgnzyi0a677dqgm240dasp02g"
   },
   "stable": {
    "version": [
     0,
-    19
+    22
    ],
-   "commit": "5be7153e650a9817d30cb480439e3f56ce7422e7",
-   "sha256": "1ixkhkq01v8vhm9drih7hisxppjhgml1xfppb120njs12wqkfrl7"
+   "deps": [
+    "transient"
+   ],
+   "commit": "e204771601e5c985bb0d6b373666be4bc22582f9",
+   "sha256": "0rg15hhf0yzcacyk1bx93fn4g60vgnzyi0a677dqgm240dasp02g"
   }
  },
  {
@@ -41480,25 +41422,25 @@
   "repo": "emacs-geiser/chez",
   "unstable": {
    "version": [
-    20211120,
-    250
+    20211216,
+    2332
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "ab2dde7a345c1c135ec0ed8fcd49eff1114951bd",
-   "sha256": "0cwm3xpn4bwgvmcmi06ijydp038054nch2hnjv1lprmnk1jg6d8p"
+   "commit": "48427d4aecc6fed751d266673f1ce2ad57ddbcfc",
+   "sha256": "03fc9ahb0pmznkcnxzgpni4clj1zgky6vaqkc94nf8b8swniwkm9"
   },
   "stable": {
    "version": [
     0,
-    16
+    17
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "03da1c17253856d8713bc5a25140cb5002c9c188",
-   "sha256": "0cc1z5z5cpvxa5f3n8kvms0wxlybzcg4l1bh3rwv1l1sb0lk1xzx"
+   "commit": "48427d4aecc6fed751d266673f1ce2ad57ddbcfc",
+   "sha256": "03fc9ahb0pmznkcnxzgpni4clj1zgky6vaqkc94nf8b8swniwkm9"
   }
  },
  {
@@ -41622,25 +41564,26 @@
   "repo": "emacs-geiser/guile",
   "unstable": {
    "version": [
-    20211204,
-    2047
+    20220105,
+    326
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "961bb01d1930d1edef07cdb3f91fe140f9617caf",
-   "sha256": "177n5z301j82cy47bx39r1h1zkrvicr28a52j7579b26ww639bvd"
+   "commit": "a2634fa2be4bce5042aaa14b33fc5246f78922d7",
+   "sha256": "1fzx3w2ddr330vs7qs4cd7f679778mqrpc9x0i4hg0ibxnpn8jrn"
   },
   "stable": {
    "version": [
     0,
-    19
+    20,
+    1
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "adf31d3a36bf9be4b92d5c8854b4a055b1ef6f1f",
-   "sha256": "177n5z301j82cy47bx39r1h1zkrvicr28a52j7579b26ww639bvd"
+   "commit": "3b802f3b2d2e51c3aface8307dbfd74c8e8adbbf",
+   "sha256": "1fzx3w2ddr330vs7qs4cd7f679778mqrpc9x0i4hg0ibxnpn8jrn"
   }
  },
  {
@@ -41772,15 +41715,6 @@
    ],
    "commit": "60bd07b3a1e532c950c132673777ceb635c9960d",
    "sha256": "1dj6bmlrqkqvykasdav9f4jw8aykqj6c0jr09r9x4sb2w0pcd9ik"
-  },
-  "stable": {
-   "version": [
-    1,
-    0,
-    0
-   ],
-   "commit": "0a227125a4112266c06ed7247de039090314b525",
-   "sha256": "0fiix0ssaannim5kxpckhd5z6fssij3igv1dg9y7143dzxf274zz"
   }
  },
  {
@@ -41950,8 +41884,8 @@
   "repo": "thisch/gerrit.el",
   "unstable": {
    "version": [
-    20211210,
-    1616
+    20211227,
+    1125
    ],
    "deps": [
     "dash",
@@ -41959,8 +41893,8 @@
     "magit",
     "s"
    ],
-   "commit": "b2e4ef23c2dd66d10526b58defcaea7beac7442f",
-   "sha256": "0spmljgh82nssv5d7bsywhlgpr4n4xz9vi1ar9kaba2981q3xd2p"
+   "commit": "6cf54b59c166e3f27f260cdf805988e895906b75",
+   "sha256": "1lvhb6x3wmh0ldjq8g0s5n27khd9ywki51fsswivc0bgllg9mrkg"
   }
  },
  {
@@ -42244,21 +42178,21 @@
  },
  {
   "ename": "ghub",
-  "commit": "f403587f77380d1db214aa34933a9b5cce1ef2bd",
-  "sha256": "15kjyi8ialpr1zjqvw68w9pa5sigcwy2szq21yvcy295z7ylzy4i",
+  "commit": "2133b10c735ce47fc8d8ff8c51f29ec4b13982a3",
+  "sha256": "1xqhjhr08qrbv4g6i73f60h6ph4rc2m419f2p5n54hrq929qsdri",
   "fetcher": "github",
   "repo": "magit/ghub",
   "unstable": {
    "version": [
-    20211205,
-    17
+    20220101,
+    1019
    ],
    "deps": [
     "let-alist",
     "treepy"
    ],
-   "commit": "a32d5f8725607684b091a537375ded61bc2cb818",
-   "sha256": "0q68wv2d8msqygigrgaq2v3nm3a0ymabnxzp4a7mai0brhdb35hj"
+   "commit": "d36c2b2419b04d7bc559756d37d39d615add6395",
+   "sha256": "1029yzlimcbsxybwbajswh6ihy81wh4c7vbycnx2kzm7kjz4k4wv"
   },
   "stable": {
    "version": [
@@ -42610,22 +42544,22 @@
  },
  {
   "ename": "git-commit",
-  "commit": "cca2c57104e14cb0c47e27d7fe4b437b38009a5c",
-  "sha256": "0j4z9pmkbn366gqc9521dix5g5capqw4r6prjfxc6g0vlnzan30g",
+  "commit": "325cca8031b99c6abe2ee9858a6b547d1af0cdde",
+  "sha256": "0cdrrmkjxl6dr967i0q9q4f9gw46gic6igw56276ahjk4n1ksqc7",
   "fetcher": "github",
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20211204,
-    2135
+    20220101,
+    841
    ],
    "deps": [
     "dash",
     "transient",
     "with-editor"
    ],
-   "commit": "1eb183e7672bf25fa77ea06d97b3d9c502a698ae",
-   "sha256": "08ci7w0pzbzs02fd8zklvhixkj8ab9vvc41w39mcik8qhr1fz5j4"
+   "commit": "a5f6705bf9a0b040a77eba67bafeec51ada90649",
+   "sha256": "1jm6clcpa4qdhpk09ibnx5qn8zj0dc608j48h2ri4a7xyiv1g6si"
   },
   "stable": {
    "version": [
@@ -42719,11 +42653,11 @@
   "repo": "emacsorphanage/git-gutter",
   "unstable": {
    "version": [
-    20211002,
-    2345
+    20211222,
+    913
    ],
-   "commit": "c1e51865eb26739052035177846f53476c8605da",
-   "sha256": "00rldkgmrjzr8nc3mngfh4vjscsdswqfqzrdwxmwmc0m3kx2yppz"
+   "commit": "9174c74cd607e297d7f14c0595d4c20ebb53847d",
+   "sha256": "1jkhvxlk4lkfjgd5vlfjy8z7w6n7j91rxqr48ricyzzl62p4v2wr"
   },
   "stable": {
    "version": [
@@ -43213,10 +43147,10 @@
  },
  {
   "ename": "github-dark-vscode-theme",
-  "commit": "a81f7dcb441c13e0bd8d5c5901f135d7f26a2bd9",
-  "sha256": "19c56h6v2lsgj7agmmks56z9iflp6mnm0qnrv6h0il75bpah8j2z",
+  "commit": "0b2893e0a3f86d8da5f7adc229877c25053c00de",
+  "sha256": "1nlbsipr78j7ywfi2smdwysm50ls0vs25fiyksc97fgw2b0chia0",
   "fetcher": "github",
-  "repo": "justintime50/github-dark-vscode-emacs-theme",
+  "repo": "Justintime50/github-dark-vscode-emacs-theme",
   "unstable": {
    "version": [
     20211122,
@@ -43268,14 +43202,14 @@
   "repo": "TxGVNN/github-explorer",
   "unstable": {
    "version": [
-    20211031,
-    120
+    20211216,
+    749
    ],
    "deps": [
     "graphql"
    ],
-   "commit": "a40c122e6768578254641fc0f24a8437ee70fac9",
-   "sha256": "1n7h5sw6b6907w2ry9d1knmda86s8iy9bim75ggyy6qcy06w0jdh"
+   "commit": "069e25c3e72290adc5d32c380999840ba42ccd78",
+   "sha256": "1c8hsh2jb9670dwhnrcyk1jcbkji1zrgr5g9ra170ya5gi16cann"
   },
   "stable": {
    "version": [
@@ -44033,11 +43967,11 @@
   "repo": "emacsorphanage/gnuplot",
   "unstable": {
    "version": [
-    20210609,
-    834
+    20220102,
+    1637
    ],
-   "commit": "7138b139d2dca9683f1a81325c643b2744aa1ea3",
-   "sha256": "1v30avyx5klccpxqi85l5467dbc2v7s1jk5xv7rzvhg27azr4jm2"
+   "commit": "d1a6a606dcb389a7c91a6b0d9fb995434df561be",
+   "sha256": "1p1nbgr4ffpp7plllsimshjr9ykcz27afz6fq1xqpnbslryi0bag"
   },
   "stable": {
    "version": [
@@ -44320,16 +44254,6 @@
    ],
    "commit": "5327738ec1be51061a3f31010c89bdd4924ca496",
    "sha256": "0a5zga3jxs4pidcakd88im9ddin8xfn7y6xjp27x645fm5in4j05"
-  },
-  "stable": {
-   "version": [
-    20150303
-   ],
-   "deps": [
-    "auto-complete"
-   ],
-   "commit": "eef10fdde96a12528a6da32f51bf638b2863a3b1",
-   "sha256": "03snnra31b5j6iy94gql240vhkynbjql9b4b5j8bsqp9inmbsia3"
   }
  },
  {
@@ -44554,8 +44478,8 @@
     "cl-lib",
     "go-mode"
    ],
-   "commit": "5bd8efab64352dccf31dbc99c4fc96d3b985ef27",
-   "sha256": "0j430sd72pkh00773yqrg1jllli9yccdf645yxrxsf3n3k95s603"
+   "commit": "32cbd78c0af29837ace3db04a224d6d01ec6851e",
+   "sha256": "1gq6hm7r5c3k5na5s0rmfzglg9vlc70g50avpayb22x3v5bz6245"
   },
   "stable": {
    "version": [
@@ -44647,11 +44571,11 @@
   "repo": "dominikh/go-mode.el",
   "unstable": {
    "version": [
-    20211113,
-    705
+    20211215,
+    1139
    ],
-   "commit": "5bd8efab64352dccf31dbc99c4fc96d3b985ef27",
-   "sha256": "0j430sd72pkh00773yqrg1jllli9yccdf645yxrxsf3n3k95s603"
+   "commit": "32cbd78c0af29837ace3db04a224d6d01ec6851e",
+   "sha256": "1gq6hm7r5c3k5na5s0rmfzglg9vlc70g50avpayb22x3v5bz6245"
   },
   "stable": {
    "version": [
@@ -44686,27 +44610,28 @@
   "repo": "grafov/go-playground",
   "unstable": {
    "version": [
-    20200818,
-    2215
+    20220106,
+    1618
    ],
    "deps": [
     "go-mode",
     "gotest"
    ],
-   "commit": "ede417a52c0eea1a69658f4c6c6c12d6165e64a4",
-   "sha256": "1zzdkp6zqh03gfiirmvwv5c8s9m4511zcaya9cp5sjzmh0g5wjip"
+   "commit": "9ee7dcc7f78be67cc391f13efa6570c2baac0204",
+   "sha256": "0xjdgk7w8b1c8mx568whfrlkj20qqw7mzgva7blr92l5zx86ni3g"
   },
   "stable": {
    "version": [
     1,
-    7
+    7,
+    1
    ],
    "deps": [
     "go-mode",
     "gotest"
    ],
-   "commit": "ede417a52c0eea1a69658f4c6c6c12d6165e64a4",
-   "sha256": "1zzdkp6zqh03gfiirmvwv5c8s9m4511zcaya9cp5sjzmh0g5wjip"
+   "commit": "d2eb9ee18a7934c8f5395bdeedf52cb0f62f8aa2",
+   "sha256": "02p99180nqsy78g9xwqx2rvyxxv1bq95b09vwz0k1vz8xf6lqfbf"
   }
  },
  {
@@ -44770,8 +44695,8 @@
    "deps": [
     "go-mode"
    ],
-   "commit": "5bd8efab64352dccf31dbc99c4fc96d3b985ef27",
-   "sha256": "0j430sd72pkh00773yqrg1jllli9yccdf645yxrxsf3n3k95s603"
+   "commit": "32cbd78c0af29837ace3db04a224d6d01ec6851e",
+   "sha256": "1gq6hm7r5c3k5na5s0rmfzglg9vlc70g50avpayb22x3v5bz6245"
   },
   "stable": {
    "version": [
@@ -44887,11 +44812,11 @@
   "repo": "lorniu/go-translate",
   "unstable": {
    "version": [
-    20211127,
-    1059
+    20220105,
+    1541
    ],
-   "commit": "6aec3af53e69dcacfaa6186660cd4174170ca1c4",
-   "sha256": "0hgr6w7vfa0g385l1b00ngnrp3vjhgg6w2978q3f778vjsz9ipb5"
+   "commit": "277216f83f6843f8c6cade704ca39ea2f23aeae7",
+   "sha256": "031kfp31wg8ykmq4f6c5njjk52xvcpm4sc79a5bj6arblhfzliix"
   },
   "stable": {
    "version": [
@@ -45358,20 +45283,20 @@
   "url": "https://depp.brause.cc/gotham-theme.git",
   "unstable": {
    "version": [
-    20211023,
-    2056
+    20220107,
+    1730
    ],
-   "commit": "885ea8c8dd19686bdf152f363cbf4c38f1096ab2",
-   "sha256": "1fxwsqqgk2vhahkqczkhzxq9x6xwscryzjgav6j8qkxdpgz887z5"
+   "commit": "4b8214df0851bb69b44c3e864568b7e0030a95d2",
+   "sha256": "19ylb7d5jxr7mwjrmgq7acvb4a1q39909xaz3y6s3kjvsyg426pg"
   },
   "stable": {
    "version": [
     1,
     1,
-    8
+    9
    ],
-   "commit": "417d61978d139cb5d089c5365fc8d3166d76d3ac",
-   "sha256": "0rc40cfj2mby1q7bk1pp1fxdi72nh9ip80spjdm1csvjjc4dbkwr"
+   "commit": "4b8214df0851bb69b44c3e864568b7e0030a95d2",
+   "sha256": "19ylb7d5jxr7mwjrmgq7acvb4a1q39909xaz3y6s3kjvsyg426pg"
   }
  },
  {
@@ -45385,8 +45310,8 @@
     20210323,
     332
    ],
-   "commit": "51a66148c31f0ee7fdcc7aa554ae42e9c4db876c",
-   "sha256": "1g5ccjlqrgwifnsxq995isd09h7dx182ii0gxb5536dp26cd0464"
+   "commit": "08ac17dee21739edd16606273c35bc83de75fc7c",
+   "sha256": "0iwidx21lsrncz4kcd6zvpkx4ksmwrn7hp4p3lma62qw0327yh71"
   },
   "stable": {
    "version": [
@@ -45406,20 +45331,20 @@
   "repo": "emacs-evil/goto-chg",
   "unstable": {
    "version": [
-    20210508,
-    1632
+    20220107,
+    1733
    ],
-   "commit": "3ce1389fea12edde4e343bc7d54c8da97a1a6136",
-   "sha256": "13v9d97ypkfa3g0x64psk29hpicl4djk35iwxhvw080bagrn5gls"
+   "commit": "278cd3e6d5107693aa2bb33189ca503f22f227d0",
+   "sha256": "0rgdzhan4n5bd78wvivacqkp0g7jvnwzgh0571p2m4yra09a36mv"
   },
   "stable": {
    "version": [
     1,
     7,
-    3
+    5
    ],
-   "commit": "16a63aae80db90713fb1f7d378c5d591c2ce15ff",
-   "sha256": "0kpalpssfrwcqrmp47i3j2x04m01fm7cspwsm6fks8pn71lagcwm"
+   "commit": "278cd3e6d5107693aa2bb33189ca503f22f227d0",
+   "sha256": "0rgdzhan4n5bd78wvivacqkp0g7jvnwzgh0571p2m4yra09a36mv"
   }
  },
  {
@@ -45472,8 +45397,8 @@
     20210323,
     422
    ],
-   "commit": "0af704e85d3b15ecb8c45b2f48ed9a34a375a2fe",
-   "sha256": "05h7jzm31b139vsv1175ck0nk33wim63k01x42dn6ffmlgkvc8lc"
+   "commit": "67e3d3d649240c048f4088bd9e18f614218c9fe7",
+   "sha256": "0zchmlngw4pjdfdfb7zj42vh3ngphc8d8436n8is9dd09f26l7y9"
   },
   "stable": {
    "version": [
@@ -45502,8 +45427,8 @@
     "magit-popup",
     "s"
    ],
-   "commit": "f032fbe4a8627ef85a39f590a6bdeffcdc48daa6",
-   "sha256": "0jlpl0wsypsi1iv092jlcx5807nn26mav2xynm207q042cwi1w8s"
+   "commit": "18f21c33e5e783d9c8e0d431b6b3e37a3c58b7a3",
+   "sha256": "08g4rv9mfxasyb563ijqlhq4aslffd86q484g58jq7ff2s57i5l3"
   },
   "stable": {
    "version": [
@@ -45677,8 +45602,8 @@
     20160504,
     911
    ],
-   "commit": "84f89b68ec8f79bce0b3f5b29af155a85124e3a6",
-   "sha256": "1pfaan0chvxpvf1zp3inpx47smm7rb22q4cklhw27n70cqh6qix5"
+   "commit": "02670e1401c070e6ae3f50a8d79b210ca4f3a0ee",
+   "sha256": "13xlpmp2d96a9hzcwmyl6r9acmqdnvxfa239h00xn8ak0xpr17c0"
   },
   "stable": {
    "version": [
@@ -45729,16 +45654,16 @@
   "repo": "emacs-grammarly/grammarly",
   "unstable": {
    "version": [
-    20211027,
-    1359
+    20211231,
+    919
    ],
    "deps": [
     "request",
     "s",
     "websocket"
    ],
-   "commit": "38d5c0384e90d577c4c657110fe4ef2d76b6146a",
-   "sha256": "0dxds8w213ad4czw5mrrb8a2i41jwsvrphy797lln5j7h404gs07"
+   "commit": "ed552610a59fdd2f8fe5bcbf50e3ebc3b5d383f7",
+   "sha256": "0jr1dxpsp33zi744rsk2djnix5lyqy8qfiqi9nyb37vzffpzdpgi"
   },
   "stable": {
    "version": [
@@ -46147,11 +46072,11 @@
   "repo": "seagle0128/grip-mode",
   "unstable": {
    "version": [
-    20211203,
-    254
+    20220104,
+    1419
    ],
-   "commit": "5be9942e8f76ebc8b55bcc1a29fb01277cb43743",
-   "sha256": "1a4hq8n7v1310v4fr04fpbx22rfb3dbiini091fk7kcpj21f5x5b"
+   "commit": "9220a560b4ac8431067be9c25a4c7f19075dc525",
+   "sha256": "0vq5nj4a6v7736lif992c3pdrpflp6p3y4x9l96qhi5fvbga7pfz"
   },
   "stable": {
    "version": [
@@ -46230,15 +46155,15 @@
   "repo": "Groovy-Emacs-Modes/groovy-emacs-modes",
   "unstable": {
    "version": [
-    20210831,
-    1601
+    20220108,
+    555
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "84f89b68ec8f79bce0b3f5b29af155a85124e3a6",
-   "sha256": "1pfaan0chvxpvf1zp3inpx47smm7rb22q4cklhw27n70cqh6qix5"
+   "commit": "02670e1401c070e6ae3f50a8d79b210ca4f3a0ee",
+   "sha256": "13xlpmp2d96a9hzcwmyl6r9acmqdnvxfa239h00xn8ak0xpr17c0"
   },
   "stable": {
    "version": [
@@ -46261,11 +46186,11 @@
   "repo": "rexim/gruber-darker-theme",
   "unstable": {
    "version": [
-    20210921,
-    1408
+    20220107,
+    1815
    ],
-   "commit": "091515cee37e586f2028d1226f5ec40e2080f2f9",
-   "sha256": "0dp2c97rww8brpw933szfcgdvxaxnq748bs274favsq9ikm12708"
+   "commit": "72278089c440d45c00fb8afcd53af82fd30f451b",
+   "sha256": "15akxpc1zgdbhzcjc1cs8w1wm4yjgnxicgmqjrcgcqc8g0zhagcf"
   },
   "stable": {
    "version": [
@@ -46340,14 +46265,14 @@
   "repo": "greduan/emacs-theme-gruvbox",
   "unstable": {
    "version": [
-    20211022,
-    318
+    20220101,
+    1208
    ],
    "deps": [
     "autothemer"
    ],
-   "commit": "b9e661e2e141ef1a9e82b57f3b277090474a9b4d",
-   "sha256": "15926n5cmz4772wzwk06c6c1y7hm71dvfafs5qj7rl0w62lrn581"
+   "commit": "921bfd7a2f5174b68682b04e6010b156bbfe6c70",
+   "sha256": "12s9879spz1d5a90x2mp85crxkxz42jq20qk5vkkka1rqfmfmlk1"
   },
   "stable": {
    "version": [
@@ -46649,11 +46574,11 @@
   "repo": "Overdr0ne/gumshoe",
   "unstable": {
    "version": [
-    20211029,
-    2148
+    20211229,
+    152
    ],
-   "commit": "397379a3e032f31e98a57f5eb2187a0607c6bd7a",
-   "sha256": "0qmknrb4h20cp4ldzkiwnvgggr3pg1qjbkql0wz9vg4h90bf3gfh"
+   "commit": "2366f1c65cdcf09c6b98ca466110842cd88c9db3",
+   "sha256": "01ha47h7ylkkplxz2bm6h5d773lvvjdgmqh3b9r5asjiyma8zn31"
   }
  },
  {
@@ -46788,14 +46713,14 @@
   "repo": "hhvm/hack-mode",
   "unstable": {
    "version": [
-    20211005,
-    25
+    20211224,
+    19
    ],
    "deps": [
     "s"
    ],
-   "commit": "211b5a8f43b852e9e73de83013f51cb01855a530",
-   "sha256": "1s9ab1ca072hi2bg7zfzsqwz8md23jd78ky9h9jjra1a75lfbgxb"
+   "commit": "a522f61c088ee2a13ab17f289a3131329e59badf",
+   "sha256": "0nz3mcrdkjjmnj0b1n3hs9hy2kbn004w64j2v6f2i8np2k2il6sd"
   },
   "stable": {
    "version": [
@@ -47336,26 +47261,26 @@
   "repo": "purplg/hass",
   "unstable": {
    "version": [
-    20210913,
-    2051
+    20211222,
+    2321
    ],
    "deps": [
     "request"
    ],
-   "commit": "f7a24c34631aa09fb7bc5bd13e8e4037e256730a",
-   "sha256": "1qvmxjl2f9qlj27aqvrpw6w5qkrp35pzdlzj622n5pc5xfpb64x0"
+   "commit": "6b025d526dbb9f701a318f4163b4bab0d3b47e59",
+   "sha256": "1zrkfdf1dmjbfblswl3bhsa3dbwdcbxzmjkqlx06ayjbq48q990f"
   },
   "stable": {
    "version": [
-    1,
     2,
-    1
+    0,
+    0
    ],
    "deps": [
     "request"
    ],
-   "commit": "7b068b91f99ac37c36ad9785863bb2e626179a8b",
-   "sha256": "0w7q0394q52bxhmn1f72dmfrisg03y6j35hp0rsb2i7rqzv8fdkp"
+   "commit": "3deecf853a1089186973dddf3a1a2a78d874feac",
+   "sha256": "14aiybj07w65a1hd8izc6awlqffz02gl670szwrk4lj9abxrs0gj"
   }
  },
  {
@@ -47546,16 +47471,16 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20211208,
-    606
+    20220104,
+    1904
    ],
    "deps": [
     "async",
     "helm-core",
     "popup"
    ],
-   "commit": "a246a9b278fb973d38d13ade7417f55e0a57eae4",
-   "sha256": "1z38jyfw8id62508rxfrkxd2ln70s6sc0cyvngn8zq94z47aqyjx"
+   "commit": "72c61b2d0cb3cd48fb1b24d7708ad1794eeeb10c",
+   "sha256": "17b5h8ajqhqpvsagxdhf2wd38x4iwixccaxv5fpvba1ywff1nn4a"
   },
   "stable": {
    "version": [
@@ -48235,28 +48160,28 @@
   "repo": "clojure-emacs/helm-cider",
   "unstable": {
    "version": [
-    20180307,
-    458
+    20220102,
+    1626
    ],
    "deps": [
     "cider",
     "helm-core"
    ],
-   "commit": "9363cc537f06233345aa3af5cd46aa5681ad607b",
-   "sha256": "0vfn4smqba1vsshz48ggkj8gs94la0sxb1sq4shrb41qj2x3dci7"
+   "commit": "00809e45de919c82753f332f29358f0ddbf21936",
+   "sha256": "0jjjy68pmmsx0biawyi5581cqh2b4zb0q8f5vs49ihpzn6zc04vk"
   },
   "stable": {
    "version": [
     0,
-    4,
+    5,
     0
    ],
    "deps": [
     "cider",
     "helm-core"
    ],
-   "commit": "9a948b834dd31b3f60d4701d6dd0ecfab0adbb72",
-   "sha256": "0wssd9jv6xighjhfh3p8if1anz3rcrjr71a4j063v6gyknb7fv27"
+   "commit": "00809e45de919c82753f332f29358f0ddbf21936",
+   "sha256": "0jjjy68pmmsx0biawyi5581cqh2b4zb0q8f5vs49ihpzn6zc04vk"
   }
  },
  {
@@ -48454,14 +48379,14 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20211202,
-    1641
+    20220104,
+    1344
    ],
    "deps": [
     "async"
    ],
-   "commit": "a246a9b278fb973d38d13ade7417f55e0a57eae4",
-   "sha256": "1z38jyfw8id62508rxfrkxd2ln70s6sc0cyvngn8zq94z47aqyjx"
+   "commit": "72c61b2d0cb3cd48fb1b24d7708ad1794eeeb10c",
+   "sha256": "17b5h8ajqhqpvsagxdhf2wd38x4iwixccaxv5fpvba1ywff1nn4a"
   },
   "stable": {
    "version": [
@@ -49018,8 +48943,8 @@
    "deps": [
     "helm"
    ],
-   "commit": "0828c3c8975b34394d6ac7b73940113020cd50ab",
-   "sha256": "0pmrypz9zbs3zc26brh3rl30jmzxxh1iyjdg2rvsx0630bdgkfw9"
+   "commit": "85c1413dc28a5f5257eeebb6678dad503072b9ec",
+   "sha256": "1k96284xfsdashlaw1cv61md4fqhynhs674bzphs59h9k8g1vrf5"
   },
   "stable": {
    "version": [
@@ -49283,8 +49208,8 @@
     "flx",
     "helm"
    ],
-   "commit": "8d44247fd3600fe3e5e7a64a1904ae6b11bcc9fe",
-   "sha256": "1k86gz89s16sxqyab3gc6lxafdxcddvwmmpgqbg9mn2c8imsl8hd"
+   "commit": "bc2068dd0da7e77ac7b394544d703720913fa660",
+   "sha256": "0gd2z8b2blc3flnz196yqcxi2r66lrkm2z0pd5j0n7p5a9ajdfb4"
   },
   "stable": {
    "version": [
@@ -50016,8 +49941,8 @@
     "helm",
     "lean-mode"
    ],
-   "commit": "4a90f2ae6e33c162a3dd6f624fb080c2ed8e8494",
-   "sha256": "1zikz4qaxabs3j86gljpp2qbhbzxsjzz544k9vsngibd468dszlv"
+   "commit": "a4205749d20a09871f0951c34f919d4ee5fbdb55",
+   "sha256": "0jqfnwjwn5payjj1lfl1zvw8gpcdlc6k3lqbw6iwpzlyal7y0nyb"
   }
  },
  {
@@ -50047,14 +49972,14 @@
   "repo": "torgeir/helm-lines.el",
   "unstable": {
    "version": [
-    20180601,
-    2033
+    20220103,
+    1909
    ],
    "deps": [
     "helm"
    ],
-   "commit": "3bfe15a60c6405682085ab289de3eb364624c4e9",
-   "sha256": "1fi0khqx35v48s14jr59jp06bpnhx9dy2rdasj2wn1a34jwgd49i"
+   "commit": "f5ad178818d223f32a0bf60d370b50c01df5f3da",
+   "sha256": "0w68k1q9p48kyjzcfdrmrp5milydf5yi6w4f8p87bzc0jfaynfr8"
   }
  },
  {
@@ -51455,8 +51380,8 @@
     "s",
     "searcher"
    ],
-   "commit": "326b5777db284f1e24c4f94730834e4b1e2bb66c",
-   "sha256": "17dzzqgd3sn69g3idbrdbqw162rsa7s4fa15rh6jpyx42ylbgiba"
+   "commit": "0f89d04d322763a6db9ef58bbad747d41d9479ae",
+   "sha256": "03q6bs4zhyg7q5rpp1339h3dihl7fp0a16q8253nfr4k3b5qs79x"
   },
   "stable": {
    "version": [
@@ -52279,8 +52204,8 @@
   "repo": "Wilfred/helpful",
   "unstable": {
    "version": [
-    20211211,
-    703
+    20211226,
+    1843
    ],
    "deps": [
     "dash",
@@ -52288,8 +52213,8 @@
     "f",
     "s"
    ],
-   "commit": "2afbde902742b1aa64daa31a635ba564f14b35ae",
-   "sha256": "0qwsifzsjw95l83m7z07fr9h1sqbhggwmcps1qgbddpan2a8ab8a"
+   "commit": "f865f17ad04cd270685187b0a5331ec8eb06e541",
+   "sha256": "1vxjf2mgnnh0dkk727nm7gw4fajizl6c52y27bi6rs0ahhy4ybib"
   },
   "stable": {
    "version": [
@@ -52529,14 +52454,6 @@
    ],
    "commit": "f0828c15e50db5eddb905de783e7683b04d1eca3",
    "sha256": "1pw0wp1pzy6snycvz12nj0q7jxxj07h3lqas184w44nhrira7qhj"
-  },
-  "stable": {
-   "version": [
-    20130623,
-    1701
-   ],
-   "commit": "4bfb4c6f4769bd6c637e4c18bbf65506832fc9f0",
-   "sha256": "01cy7v9ql70bsvjz3idq23jpyb8jb61bs9ff8vf5y3fj45pc32ps"
   }
  },
  {
@@ -53406,16 +53323,16 @@
   "repo": "thanhvg/emacs-hnreader",
   "unstable": {
    "version": [
-    20211018,
-    1746
+    20220103,
+    1909
    ],
    "deps": [
     "org",
     "promise",
     "request"
    ],
-   "commit": "5eb55aff411406882b8928ff233ac3d761641c6f",
-   "sha256": "13i08hb4i6am4ljvdh9ifi616jbrld05pvhd159vmmli3wpyzgaw"
+   "commit": "e17006072b0cd06ab7ff32c6187e9565131a78b2",
+   "sha256": "0fyfgdzjc1xy2v13wz96xj09fa18q4285xksc77wm9gxn7ghpvz4"
   }
  },
  {
@@ -53729,14 +53646,14 @@
   "url": "https://scm.osdn.net/gitroot/howm/howm.git",
   "unstable": {
    "version": [
-    20210217,
-    1128
+    20211230,
+    1221
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "bac98b873d07baf039fe252b9d67f71c235dca06",
-   "sha256": "0rhyhkm84fsff5lyvb0z9rnbhmqn4ix0d8wixzll2n2yclj9d9my"
+   "commit": "c381e50f0c771c38306bda37bd972a37a36a5db5",
+   "sha256": "1azzsbvnjbd5y0isl2bq9yjaqbbiivmswkrvyx3mgmq7rw6xvn61"
   }
  },
  {
@@ -53911,8 +53828,8 @@
     20200929,
     559
    ],
-   "commit": "ec85e68a4cba064d4caa593e1dec69b1b35b12dd",
-   "sha256": "143c4in1hykd3rnzrznri60aikmsm9fyhmmsx5gzapyr18lbw9wq"
+   "commit": "40075bdd61cb0f839c26d2f86b67d22d04f21093",
+   "sha256": "05565ybwz4mkcfdqihphm47am842x8mibh7p95qg6y3myr3g4dl7"
   },
   "stable": {
    "version": [
@@ -54093,11 +54010,11 @@
   "repo": "humanoid-colors/emacs-humanoid-themes",
   "unstable": {
    "version": [
-    20211206,
-    1411
+    20211225,
+    1711
    ],
-   "commit": "8ad6d9ae8e6c2cd7e282922416a596bbb20438c8",
-   "sha256": "0y1kazfhjsyghqm1ddd2dbk1jipwn0l1n15mcm4d7038dd3x6d99"
+   "commit": "3d18cb0075c87f15172242f6032caf4121422e87",
+   "sha256": "1hk9cdcqfskv83c4pxkgzdlcizmmcn60r7cnhb769fd4i3bpyi5b"
   },
   "stable": {
    "version": [
@@ -54280,15 +54197,15 @@
   "repo": "abo-abo/hydra",
   "unstable": {
    "version": [
-    20201115,
-    1055
+    20220102,
+    803
    ],
    "deps": [
     "cl-lib",
     "lv"
    ],
-   "commit": "2d553787aca1aceb3e6927e426200e9bb9f056f1",
-   "sha256": "13zjw64x728pm1a44lzzv9s9r5kkss0ncwqzzczhk8bvmsi7m1l3"
+   "commit": "9e9e00cb240ea1903ffd36a54956b3902c379d29",
+   "sha256": "11xlhm098gi6fnksnykciwdx5a46xmxwx9y8r6kjpb92vpjfak80"
   },
   "stable": {
    "version": [
@@ -54809,15 +54726,6 @@
    ],
    "commit": "0916be7075e792773440c3bdb5cf9c153691846b",
    "sha256": "0817y99zm1x01nya6lnhby96da2w9kivw4p59bbaxm7hi0ycrsfz"
-  },
-  "stable": {
-   "version": [
-    1,
-    1,
-    3
-   ],
-   "commit": "c466f2a9e291f9da1167dc879577b2e1a7880482",
-   "sha256": "0x4w1ksrw7dicl84zpf4d4scg672dyan9g95jkn6zvri0lr8xciv"
   }
  },
  {
@@ -55231,15 +55139,15 @@
   "repo": "idris-hackers/idris-mode",
   "unstable": {
    "version": [
-    20211103,
-    1521
+    20220105,
+    1300
    ],
    "deps": [
     "cl-lib",
     "prop-menu"
    ],
-   "commit": "2e4b5c6a979b04d9383c44423388f6cb0988f14f",
-   "sha256": "0bl6wz05m325h2y4in7fv280p73a2iv2k52jg7qp26aggmpfrjxa"
+   "commit": "65d6db1b7574ceccd3d97eee3790c2f74aa9724d",
+   "sha256": "0dc5mfm0gh7y4yzsz2lgc3802m4pv85l213j04k347xqqcl414lc"
   },
   "stable": {
    "version": [
@@ -55277,11 +55185,11 @@
   "repo": "victorhge/iedit",
   "unstable": {
    "version": [
-    20211116,
-    11
+    20211228,
+    613
    ],
-   "commit": "012de2e8d8519e850a790f8a2c71a5b08358c29c",
-   "sha256": "00b1hmr8p6fwydppql75cqkcqbnc89271b7h1kydgnwm7pcg177w"
+   "commit": "3c7159a107b01b8f740ced72f10351b10bb69784",
+   "sha256": "0mmvpg1pymzss0mpsrmmaah2ngzp77fvfc4lnf1ik95s90qynzz2"
   },
   "stable": {
    "version": [
@@ -55775,8 +55683,8 @@
    "deps": [
     "impatient-mode"
    ],
-   "commit": "04ba1617d9f11105f7db01ce39b4c7746aa13974",
-   "sha256": "0pjr6bnd3vjqf3i64gyp9sqx81an9xc2sgawza33b8hmnwvgarmw"
+   "commit": "a57c628abb765a834c85f9299bf816e50ee35d23",
+   "sha256": "1j9lfxxvgg97l2cmdwyc9c82n09xvc9ybpqn31hm7i71y9l943w7"
   },
   "stable": {
    "version": [
@@ -55889,11 +55797,11 @@
   "repo": "flashcode/impostman",
   "unstable": {
    "version": [
-    20211212,
-    851
+    20220102,
+    1856
    ],
-   "commit": "130ef8218c9e2a776130ab95b6cd199955328913",
-   "sha256": "0w9x6iq7cmzd3vqrjh7l8b457fcphpl8z1xk4dcc3lj113nczyig"
+   "commit": "5b122f3d5a3421aa2d89bdc9dc4aafaf19cf85d4",
+   "sha256": "095g54cxicd5ysxpw2zaw4i92yxmr3inwacbla34aa0l62lqy5ig"
   },
   "stable": {
    "version": [
@@ -55916,8 +55824,8 @@
     20210508,
     309
    ],
-   "commit": "ed99e867f81ef69854182b519db1b9141fcdb2a2",
-   "sha256": "04l6ws5fr19k7klpib5yz4zyqmf2aiywdm85kz5skhf196hm21g9"
+   "commit": "208f21c7ece23acec6b2eb2b0c64928464f6863e",
+   "sha256": "0i5jhvsjjgfmpi4j9scv618sl0p26hpq7x3yp81s1f390brmf4dz"
   },
   "stable": {
    "version": [
@@ -56632,14 +56540,6 @@
    ],
    "commit": "bf6450a3540aa3538546d312324c41befd0a4e54",
    "sha256": "05by3mzz8gw13c42m2z3cr13zng62mbany0hvixx3jmn1q4hj9r0"
-  },
-  "stable": {
-   "version": [
-    1,
-    0
-   ],
-   "commit": "29357186beca825e3d0451b700ec09b9ed65e37b",
-   "sha256": "15nasjknmzy57ilj1gaz3w5sj8b3ijcpgwcd6w2r9xhgcl86m40q"
   }
  },
  {
@@ -56697,15 +56597,6 @@
    ],
    "commit": "e818845a99d418e04c1685f06fe25116916f6168",
    "sha256": "0acyzysz04sd3rahymw6x3a8zy57sy84d36zp6prd62y4w0sw361"
-  },
-  "stable": {
-   "version": [
-    0,
-    1,
-    1
-   ],
-   "commit": "110186d2ebfae303b05d2d33a6939d30ce3ac995",
-   "sha256": "0cy2kj33lnb4d2bzjmgj216l1f63hsz4ssdq7hkb4d7jngb29g09"
   }
  },
  {
@@ -57169,8 +57060,8 @@
    "deps": [
     "f"
    ],
-   "commit": "ac829919c144aef94232837a63ed19f029a90515",
-   "sha256": "0ykzjflb101jn7x6g902xn2bkpc6v3ymm79vwndkl01n172v23m3"
+   "commit": "c1e3cc7971c278a95eda16ade7b68ad157481a5a",
+   "sha256": "0lppyr74bsq9dx2qm6cc34vg4i2i8dnrrlbm3xc3nzcsay85cbjx"
   },
   "stable": {
    "version": [
@@ -57402,11 +57293,11 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20210930,
-    1450
+    20211231,
+    1730
    ],
-   "commit": "1c6b3da377a840e898b14020133f59fca9ceea1c",
-   "sha256": "1w8x2qk8lafnn6ksv1anixayyl476y1j6hp2amfnqmdkh0vnh63v"
+   "commit": "c97ea72285f2428ed61b519269274d27f2b695f9",
+   "sha256": "05ivdsq6l6ixdn5p0rjh7mcgw19fm38m137xb8yi2c9gii6yk6g2"
   },
   "stable": {
    "version": [
@@ -57426,15 +57317,15 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20210310,
-    1230
+    20211021,
+    1602
    ],
    "deps": [
     "avy",
     "ivy"
    ],
-   "commit": "1c6b3da377a840e898b14020133f59fca9ceea1c",
-   "sha256": "1w8x2qk8lafnn6ksv1anixayyl476y1j6hp2amfnqmdkh0vnh63v"
+   "commit": "c97ea72285f2428ed61b519269274d27f2b695f9",
+   "sha256": "05ivdsq6l6ixdn5p0rjh7mcgw19fm38m137xb8yi2c9gii6yk6g2"
   },
   "stable": {
    "version": [
@@ -57680,8 +57571,8 @@
     "ivy",
     "s"
    ],
-   "commit": "368c0c2db6b2ff279a956b8075eaf9ba2c334234",
-   "sha256": "1q2k6118yip8vlpaf8jhygi23wvf7zy7s3bpv51jgfkw89a3vgxa"
+   "commit": "cb7e0f03e1df90855b7cb1433706a8b46f5592aa",
+   "sha256": "0l2r32k6lzxsww245afddzfpwhy0k80kw0q3jkm5hfw3qgkwd864"
   },
   "stable": {
    "version": [
@@ -57801,8 +57692,8 @@
     "hydra",
     "ivy"
    ],
-   "commit": "1c6b3da377a840e898b14020133f59fca9ceea1c",
-   "sha256": "1w8x2qk8lafnn6ksv1anixayyl476y1j6hp2amfnqmdkh0vnh63v"
+   "commit": "c97ea72285f2428ed61b519269274d27f2b695f9",
+   "sha256": "05ivdsq6l6ixdn5p0rjh7mcgw19fm38m137xb8yi2c9gii6yk6g2"
   },
   "stable": {
    "version": [
@@ -57970,15 +57861,15 @@
   "repo": "tumashu/ivy-posframe",
   "unstable": {
    "version": [
-    20211103,
-    233
+    20211217,
+    234
    ],
    "deps": [
     "ivy",
     "posframe"
    ],
-   "commit": "5d9420252ca855d6d206f1f8ef5993a6be3c618f",
-   "sha256": "1yan9h12208dalzgpffqxnzv8b0hwzhzna01gnzb9wmkcfi3fpmh"
+   "commit": "533a8e368fcabfd534761a5c685ce713376fa594",
+   "sha256": "137mh0jgvkawdrv1d7w9giazz57c40n0yw2580q8zmxmv5dvkrl7"
   },
   "stable": {
    "version": [
@@ -58002,27 +57893,27 @@
   "repo": "raxod502/prescient.el",
   "unstable": {
    "version": [
-    20210425,
-    1720
+    20211228,
+    417
    ],
    "deps": [
     "ivy",
     "prescient"
    ],
-   "commit": "292ac9fe351d469f44765d487f6b9a1c1a68ad1e",
-   "sha256": "0ywx7q41i9pzmfgwv83mz5z17gril2s0r7y77hbbriww5yy1ihx4"
+   "commit": "3dbcef387502d309d130a518a18d48cd2f0e15b7",
+   "sha256": "024l7s0b6apbzanw3cnhjypxnxfinfb5b3nhaabrc138m5pis8j5"
   },
   "stable": {
    "version": [
     5,
-    1
+    2
    ],
    "deps": [
     "ivy",
     "prescient"
    ],
-   "commit": "2c0e9fc061ab723ec532428f312974ca7d8def12",
-   "sha256": "0d6kbczkamhhcmc8bf01q6k1x0g7dwjihwllzsldgga3dclyh4ks"
+   "commit": "3dbcef387502d309d130a518a18d48cd2f0e15b7",
+   "sha256": "024l7s0b6apbzanw3cnhjypxnxfinfb5b3nhaabrc138m5pis8j5"
   }
  },
  {
@@ -58134,8 +58025,8 @@
     "s",
     "searcher"
    ],
-   "commit": "0e8280ef40814eab1065d442146fe81ab1fc6149",
-   "sha256": "0cfhdmbrm41q3iwmrr0amhk3csrwxhqbisayjc5s01bf129rx7rf"
+   "commit": "b38ddcbce45f604948c4880cde224beab099b8da",
+   "sha256": "0719r16pwnvpq9qpa0d2pd2s5yzvawm5gycvxqzvlkgjw49h5rhv"
   },
   "stable": {
    "version": [
@@ -58443,15 +58334,6 @@
    ],
    "commit": "a780e4c2adb2e85a4daadcefd1a2b189d761872f",
    "sha256": "0s2piak1iyxj06z3hhywkrnrq5i1ppjcl5v55fys900fnyqzzgjy"
-  },
-  "stable": {
-   "version": [
-    0,
-    1,
-    1
-   ],
-   "commit": "1ba232b71507b468c60dc53c2bc8888bef36c858",
-   "sha256": "0x0vz7m9kn7b2aiqvrdqx8qh84ynbpzy2asz2b18l47bcwa7r5bh"
   }
  },
  {
@@ -59368,8 +59250,8 @@
     20200117,
     615
    ],
-   "commit": "0dedaf4753fbe8cdbab14aa85f05d7673cbee8b6",
-   "sha256": "09wfafrklkybfg44skn1lg2hvcj4gfdv908dq87w1r4wv6ibkvka"
+   "commit": "7920252e88eb610add7c9760f7016bb9b884307a",
+   "sha256": "0bnwk8p8yyf76yzihv3g1ns15la6a661c31qxfbydz1ccjs313gy"
   },
   "stable": {
    "version": [
@@ -59520,24 +59402,24 @@
   "repo": "mooz/js2-mode",
   "unstable": {
    "version": [
-    20211201,
-    1250
+    20211229,
+    135
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "d18730505e4ab57ec2b036980a62f6c6a60381e9",
-   "sha256": "1q26y3fmxlz2hmxdlkh5qpv20c49nv9vd0dmcmzzimr6c8y5yscq"
+   "commit": "997cac4c80a03062145b541b006c51cc91ee0c24",
+   "sha256": "1wcz3xji7viqxa5is81jd7in7x1fya6rzybm8qj9rwgdc8camvyb"
   },
   "stable": {
    "version": [
-    20201220
+    20211229
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "f9564769e81c612b43f99802d6a2c5e6b1f8fca4",
-   "sha256": "00jy917cgp5xzfgs4m0spzlbqk8mg63layin8nxmn2647rfjnik4"
+   "commit": "997cac4c80a03062145b541b006c51cc91ee0c24",
+   "sha256": "1wcz3xji7viqxa5is81jd7in7x1fya6rzybm8qj9rwgdc8camvyb"
   }
  },
  {
@@ -59742,14 +59624,14 @@
   "repo": "taku0/json-par",
   "unstable": {
    "version": [
-    20211122,
-    942
+    20211219,
+    829
    ],
    "deps": [
     "json-mode"
    ],
-   "commit": "2bc383c4f88a111202b4d00303f3345b32e4b8e9",
-   "sha256": "1k1jv0m6mj772dkjzsy86k528lqljqmffcpz9l2lzrm6q1bqnw43"
+   "commit": "255e99ba789fc69f977129a1ea22e57334874cb8",
+   "sha256": "09674zsxlza4b1p6z2r73zhmfa08v2ywkn388qa7lkpyjvd0n09j"
   },
   "stable": {
    "version": [
@@ -59913,14 +59795,14 @@
   "repo": "tminor/jsonnet-mode",
   "unstable": {
    "version": [
-    20211003,
-    1518
+    20211228,
+    1346
    ],
    "deps": [
     "dash"
    ],
-   "commit": "f3d1f5118fa8328a2a43fd3d750c2afdd02b65ac",
-   "sha256": "02dqr916vxzqvlaf6wffnd7s1q082hnxhjwwip8iyjfj9fzk9yk1"
+   "commit": "d188745d1b42e1a28723dade1e5f7caf1282cb01",
+   "sha256": "1xd53m6n6hs9i6bxqajvnc64cqagx4im62zv5id91v0aj9n2phr4"
   },
   "stable": {
    "version": [
@@ -60021,14 +59903,14 @@
   "repo": "tpapp/julia-repl",
   "unstable": {
    "version": [
-    20210913,
-    1256
+    20211230,
+    814
    ],
    "deps": [
     "s"
    ],
-   "commit": "3f888ecd30f613ed50f67c614be0b42b7546c693",
-   "sha256": "04baf40gqd1mzk7pvyq663ndg5byyq848r802j10zvggvacjwcbx"
+   "commit": "e90b1ed2cc806262b0ee772dcc88f8da693d9210",
+   "sha256": "0jhfb2shz71kwfzmvlpzhldm2rms3wgwikrym2a2fr9hw91i2zy7"
   },
   "stable": {
    "version": [
@@ -60069,8 +59951,8 @@
   "repo": "gcv/julia-snail",
   "unstable": {
    "version": [
-    20211213,
-    1514
+    20211218,
+    552
    ],
    "deps": [
     "dash",
@@ -60079,8 +59961,8 @@
     "spinner",
     "vterm"
    ],
-   "commit": "465f95a54a82a40ee047085115b10ab3e7c2daa9",
-   "sha256": "0vspf2imgvcjyavzj3ljsi7xrhk97is05l1c4d2bypnsq35x3549"
+   "commit": "c3dc0717da4cb837dfb28888b27c9b481662f7ba",
+   "sha256": "1rw2c0q3cyk8v5wcdpai329szwnjmc5d5xfb3pc2djc8x989snp3"
   },
   "stable": {
    "version": [
@@ -60260,8 +60142,8 @@
   "repo": "nnicandro/emacs-jupyter",
   "unstable": {
    "version": [
-    20211130,
-    1647
+    20220105,
+    1943
    ],
    "deps": [
     "cl-lib",
@@ -60269,8 +60151,8 @@
     "websocket",
     "zmq"
    ],
-   "commit": "df343af5e9187a400a9291fa6a2b0c69f3ad0425",
-   "sha256": "0sa8mi5gmb0n1ylgh1vz72nfgrjxny770l5z3xyxl0myw668vmcf"
+   "commit": "42a9765897ad36518b5371f558b36cdac3a0ec74",
+   "sha256": "09nrw32bmkcafbr69csz94lykpmbib7f22xa4y165szrd3va8qk9"
   },
   "stable": {
    "version": [
@@ -61112,26 +60994,26 @@
   "repo": "tarsius/keymap-utils",
   "unstable": {
    "version": [
-    20211128,
-    1356
+    20220101,
+    1036
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "2f247333435b8b036547658caf04228831f613d2",
-   "sha256": "1iykzph614sjdpxgfx5y55bgzv9m7j9g6b4n1d8icj7r1620yr5w"
+   "commit": "753fa7b5bdb761a1eb9a7b09db50c0bee3ae5241",
+   "sha256": "0604l1rxvxq88i2pnb4q0jaf9i3pmf3756nkrivvaj1l4v6nswlk"
   },
   "stable": {
    "version": [
     3,
-    1,
+    2,
     0
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "0b282e19ac3d23b9a74f656b137b9eebeb2aaa39",
-   "sha256": "0ni03xnakai9ncq07gwzqy4walgijd04bnxslk3b4xnnk60i8m2h"
+   "commit": "753fa7b5bdb761a1eb9a7b09db50c0bee3ae5241",
+   "sha256": "0604l1rxvxq88i2pnb4q0jaf9i3pmf3756nkrivvaj1l4v6nswlk"
   }
  },
  {
@@ -61250,8 +61132,8 @@
     20210523,
     403
    ],
-   "commit": "584395339f85a95ffe3ade3f4e30898bad495ecd",
-   "sha256": "0vqi7cq8952idymp9hm89v0pin5icj7ng2wxdsysqsy2crfyd5zm"
+   "commit": "f725c1113879bae4c04f2ccf59c6b1ced3bf7583",
+   "sha256": "0ipqqc4jsg43yv4626265478nd6gwy9am9ligx4jjn2vpwsrkjz9"
   },
   "stable": {
    "version": [
@@ -61307,8 +61189,8 @@
     20211114,
     1233
    ],
-   "commit": "313f74b17580c2a55f5c068e1bda17821b50c31e",
-   "sha256": "0m4448qvlh06n26l8l8hax4ir08mbai17mdi6inzvch7b09p0gpl"
+   "commit": "77ff12684182f80bbd529796f95d73780effc791",
+   "sha256": "0bfswjnbl0xjs5bcmw47jv4dyrgm280wjjzif55k6scipsi5sscr"
   },
   "stable": {
    "version": [
@@ -61506,8 +61388,8 @@
     20210318,
     2106
    ],
-   "commit": "c27fb3187b527deea585c72bad000b44af520bce",
-   "sha256": "0p91qz7xqbril7yhmxdf1dciy8f8mf5vw4z2xbm1j8al2d3jimyz"
+   "commit": "25c00cc7e8b76fda7f2b664a019f430134dc2ada",
+   "sha256": "0pdx49v0mn5xpl8n37yfvdhh1xbg41skj006hxz1b51ja7950aj7"
   },
   "stable": {
    "version": [
@@ -61806,8 +61688,8 @@
   "repo": "abrochard/kubel",
   "unstable": {
    "version": [
-    20211129,
-    2118
+    20220104,
+    2320
    ],
    "deps": [
     "dash",
@@ -61815,8 +61697,8 @@
     "transient",
     "yaml-mode"
    ],
-   "commit": "f75a78f785ef1782a32f4464a89fd4c33bf368ca",
-   "sha256": "0as26hsvkkjzls68wf6f1wwcrpnhj31g13cykclgq3jdwcah6xsp"
+   "commit": "68d2925c7942039e3fb3eb6c113adec5369c6c72",
+   "sha256": "173ympabfa14rc6y4f3rjxapj7py0dsnzp8zg7q2gkyxv1iwhh55"
   },
   "stable": {
    "version": [
@@ -61848,8 +61730,8 @@
     "evil",
     "kubel"
    ],
-   "commit": "f75a78f785ef1782a32f4464a89fd4c33bf368ca",
-   "sha256": "0as26hsvkkjzls68wf6f1wwcrpnhj31g13cykclgq3jdwcah6xsp"
+   "commit": "68d2925c7942039e3fb3eb6c113adec5369c6c72",
+   "sha256": "173ympabfa14rc6y4f3rjxapj7py0dsnzp8zg7q2gkyxv1iwhh55"
   },
   "stable": {
    "version": [
@@ -61872,8 +61754,8 @@
   "repo": "kubernetes-el/kubernetes-el",
   "unstable": {
    "version": [
-    20211211,
-    727
+    20211225,
+    1536
    ],
    "deps": [
     "dash",
@@ -61882,8 +61764,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "73361de919cff8d773f347868850f6c694d942e7",
-   "sha256": "17imkanh7ay88s1ppzsdr7hf91rgqimx9v6p69srmqq5bpnwpnmy"
+   "commit": "4d69f6f4d9ec46a8aeb18d9d32776d9c6825d5b1",
+   "sha256": "0cwz4gfdgy265rjckfp00pkbjpsvgxf3ycwsbl5z684dfx0i4ij2"
   },
   "stable": {
    "version": [
@@ -61910,15 +61792,15 @@
   "repo": "kubernetes-el/kubernetes-el",
   "unstable": {
    "version": [
-    20210830,
-    2219
+    20211225,
+    300
    ],
    "deps": [
     "evil",
     "kubernetes"
    ],
-   "commit": "73361de919cff8d773f347868850f6c694d942e7",
-   "sha256": "17imkanh7ay88s1ppzsdr7hf91rgqimx9v6p69srmqq5bpnwpnmy"
+   "commit": "4d69f6f4d9ec46a8aeb18d9d32776d9c6825d5b1",
+   "sha256": "0cwz4gfdgy265rjckfp00pkbjpsvgxf3ycwsbl5z684dfx0i4ij2"
   },
   "stable": {
    "version": [
@@ -62068,16 +61950,16 @@
   "repo": "tecosaur/LaTeX-auto-activating-snippets",
   "unstable": {
    "version": [
-    20211208,
-    1617
+    20220108,
+    1536
    ],
    "deps": [
     "aas",
     "auctex",
     "yasnippet"
    ],
-   "commit": "fa32c7affc1d232e5ab63b7c7a8a29461a465536",
-   "sha256": "1y4lp5y55r43kjw47wjxdx0i8cd8id8sd7s8cac01c5n9hcsjyiz"
+   "commit": "14c6cc2ff8c0c6b20b83fb075b94a8661a985249",
+   "sha256": "1vz0q7z3n6iv2m3xiw5m5f17ifig47c08zz2sm3svqwjq328pnwh"
   },
   "stable": {
    "version": [
@@ -62193,16 +62075,16 @@
   "repo": "Deducteam/lambdapi",
   "unstable": {
    "version": [
-    20211207,
-    1509
+    20220106,
+    1308
    ],
    "deps": [
     "eglot",
     "highlight",
     "math-symbol-lists"
    ],
-   "commit": "19bd984c9695a7cc4f6b66916b89818082c7da27",
-   "sha256": "0cnv4wwimpz7b17vm2j6602ly2jf4drsa220wj60qqqympcq6nil"
+   "commit": "c4a729052ba6ed6baf224dcc7b63cd0ead3fbecd",
+   "sha256": "12hhfmy7fwh1smr0b7pjqbmnw58cfp2m2zry98yas43yv7v81n2q"
   },
   "stable": {
    "version": [
@@ -62488,11 +62370,11 @@
   "repo": "latex-math-preview/latex-math-preview",
   "unstable": {
    "version": [
-    20190123,
-    802
+    20211228,
+    641
    ],
-   "commit": "90fd86da2d9514882146a5db40cb916fc533cf55",
-   "sha256": "063vnjhnxm2z9shkdv1j8kwyf37syczfkzxzh5z7w7aidvx55jzj"
+   "commit": "1c082179493eed3ce8bc255f87791eb4acb1fbdb",
+   "sha256": "11kx0fk4lxhwjwy66xy4gvw77ffvghazc1wqld7nbck85wzp33h6"
   },
   "stable": {
    "version": [
@@ -62723,11 +62605,11 @@
   "repo": "conao3/leaf.el",
   "unstable": {
    "version": [
-    20211115,
-    1551
+    20211226,
+    1633
    ],
-   "commit": "0a698d240e49ebfbe57f7637ba104498478052ee",
-   "sha256": "004nbm2l9pwhzyd8y12hr24brni6m3k3hxj35kd93dn2zw1wvy0h"
+   "commit": "9eb18e8c9c375aa0158fbd06ea906bfbf54408fe",
+   "sha256": "0bxl842qnijz29bglp1zpmv07ga91q999l3gzk4k5n1a96j03qsc"
   },
   "stable": {
    "version": [
@@ -62813,16 +62695,16 @@
   "repo": "conao3/leaf-manager.el",
   "unstable": {
    "version": [
-    20200920,
-    1643
+    20211225,
+    624
    ],
    "deps": [
     "leaf",
     "leaf-convert",
     "ppp"
    ],
-   "commit": "b9aaa539677d1492cb16ee595c2e81bf29967475",
-   "sha256": "0klp0yjpf8njdavwh71i7wkl5yrjh42wgakigizgb1l1sksp9iy9"
+   "commit": "a9fb7fda1432d0cf6bd8546d98a11b3fbe1d84e6",
+   "sha256": "13rgx4ny534r0q9fyf2r0r6lhw97c9g7c75gj0nfwynx7fz3cic9"
   },
   "stable": {
    "version": [
@@ -62877,8 +62759,8 @@
   "repo": "leanprover/lean-mode",
   "unstable": {
    "version": [
-    20211203,
-    1418
+    20211220,
+    917
    ],
    "deps": [
     "dash",
@@ -62886,8 +62768,8 @@
     "flycheck",
     "s"
    ],
-   "commit": "4a90f2ae6e33c162a3dd6f624fb080c2ed8e8494",
-   "sha256": "1zikz4qaxabs3j86gljpp2qbhbzxsjzz544k9vsngibd468dszlv"
+   "commit": "a4205749d20a09871f0951c34f919d4ee5fbdb55",
+   "sha256": "0jqfnwjwn5payjj1lfl1zvw8gpcdlc6k3lqbw6iwpzlyal7y0nyb"
   }
  },
  {
@@ -62983,11 +62865,11 @@
   "repo": "ledger/ledger-mode",
   "unstable": {
    "version": [
-    20210516,
-    2045
+    20211214,
+    1449
    ],
-   "commit": "19b84dc7664ea069e1a9fd446daf699574c44986",
-   "sha256": "0mq5wzx8vzaljwy9qszsa0ibzk1lr9kfwk9f956h69n4dfl6ig85"
+   "commit": "3ec65b8931e8989ac590e95921e46f9e2fac6821",
+   "sha256": "10dxcwl94192yhilp9dimm2zrxpcz48rayd9w0vzk874qmn5mzz3"
   },
   "stable": {
    "version": [
@@ -63144,11 +63026,11 @@
   "repo": "mtenders/emacs-leo",
   "unstable": {
    "version": [
-    20211119,
-    1636
+    20211221,
+    1538
    ],
-   "commit": "41db8f64a0b4d335196f8d1c319518a68ccb2e50",
-   "sha256": "1a4nfw617m6zr17xhhpa8ll2hjfl83gpf59d39an47rn7k8cpqay"
+   "commit": "bf3ca048479058023a7b109a5b84e84d24feecf7",
+   "sha256": "19zyrwwcp8ghfdwmaiwwzpymfzrd7lhxr11fs84ffjkds77jwlxy"
   }
  },
  {
@@ -63225,15 +63107,6 @@
    ],
    "commit": "b8b5076d643046008ea1496559acdd4ddfdb649a",
    "sha256": "16rfyjk0cp487ra6v5c1cmf106ixipr9b71zfp0bwm35wa2mvdic"
-  },
-  "stable": {
-   "version": [
-    1,
-    1,
-    2
-   ],
-   "commit": "c72db2d5aeb5ed8e4ca066c803ae8d30e7540f79",
-   "sha256": "1mv5lv98b3351cwkiw51bq8xx4hmnvk93sx6lkdmq0sciw2qz22i"
   }
  },
  {
@@ -63308,11 +63181,11 @@
   "repo": "rvirding/lfe",
   "unstable": {
    "version": [
-    20210603,
-    1241
+    20220102,
+    1653
    ],
-   "commit": "3d2483d6a46552eaa832f8e6df5dc1162e58fc79",
-   "sha256": "1vpif0g45xh16sqqsjh9hin61kzc2la79pmrxl3rmw2jvpg6pzym"
+   "commit": "993a76da94472d0bf7b378f56070c4e77f20aefa",
+   "sha256": "18ibp43dbjpv25h7pc8h7ds44wbcqvnh6bw228pscw6f7xsmpjpw"
   },
   "stable": {
    "version": [
@@ -63535,8 +63408,8 @@
    "deps": [
     "request"
    ],
-   "commit": "9d945eecb31c6be02bf0388c5c6883dfd1782bb9",
-   "sha256": "1f1ykbjrvz11i4sj1ff9hyl3kl65ll1c88gxgb66gmbxggqy5mja"
+   "commit": "a4273a6dcc45dabf237c4bfd780ec22420711c70",
+   "sha256": "0lj997453mywdnl6zf5fvdgw4j4k3i2q9ayi2rnhdaikn5a36nmd"
   },
   "stable": {
    "version": [
@@ -63577,17 +63450,17 @@
     20211119,
     1813
    ],
-   "commit": "a8bb654339da8d192dbbdb30dbcef86e8e2dd749",
-   "sha256": "08050ri7acngvhizrjgqgvjsyh4jwjn3gzknpji7qs161gzvi74r"
+   "commit": "0469b8a3e1a5e562b45744e2c006fb46c300b7d4",
+   "sha256": "0jn9wc11q2mv15nfq1agkidvcw7iajijkj5dbj0qm0apdqm74708"
   },
   "stable": {
    "version": [
     0,
-    31,
+    33,
     0
    ],
-   "commit": "921934a9f54f9e10f7723bf5b61c1c79bbcc3a6e",
-   "sha256": "08050ri7acngvhizrjgqgvjsyh4jwjn3gzknpji7qs161gzvi74r"
+   "commit": "de46a9f2df2d8fbcb96808150fe550ea3fd973bc",
+   "sha256": "0jn9wc11q2mv15nfq1agkidvcw7iajijkj5dbj0qm0apdqm74708"
   }
  },
  {
@@ -63598,16 +63471,16 @@
   "repo": "emacs-vs/line-reminder",
   "unstable": {
    "version": [
-    20211116,
-    614
+    20220102,
+    1539
    ],
    "deps": [
     "fringe-helper",
     "ht",
     "indicators"
    ],
-   "commit": "41783a2ecd76c2d02ad87295bb8719eda1ee4ed3",
-   "sha256": "1v8x2kf0w5vwl4myiwraq5b1nyfx0b0fgwpzvb9bnjjdj2nsk36p"
+   "commit": "ff58aceed180bb6bc0d4477620689c7656144055",
+   "sha256": "1sbvrnin5q178b72aaqpz47jf5gn3d3znjqs4j7ydv4g1pxj3960"
   },
   "stable": {
    "version": [
@@ -63739,14 +63612,14 @@
   "repo": "noctuid/link-hint.el",
   "unstable": {
    "version": [
-    20211128,
-    1600
+    20211224,
+    1358
    ],
    "deps": [
     "avy"
    ],
-   "commit": "3be270f3a732dc4acae6a20ff449eef0c4f9a966",
-   "sha256": "14f0x319mqbk7vyh5nm9gijy59m45j342fl8fxgvkr7ajn4rg7aw"
+   "commit": "676dac6621e321b33a8d396fa27dd0ea619d21e3",
+   "sha256": "1g9w2ymihs649cck3vm0pb4591jzsyf2b2jfpyrwcxipqw30rj63"
   }
  },
  {
@@ -63851,8 +63724,8 @@
     20211004,
     1429
    ],
-   "commit": "e42baf790629cc3a7310194c4f00d9dafa34f933",
-   "sha256": "1p3bgfcp1pqilmc4jxs3y182mcddrqd7m0l9b2k2wbdcar1fphpf"
+   "commit": "5450cf3fae023cb652ef7391d96d9969eadf3866",
+   "sha256": "005s4p73zman1pnk46ajwj1m0b648i067frfg6i37wikryrcnz95"
   },
   "stable": {
    "version": [
@@ -63967,18 +63840,18 @@
   "repo": "abo-abo/lispy",
   "unstable": {
    "version": [
-    20211020,
-    907
+    20220107,
+    1902
    ],
    "deps": [
     "ace-window",
-    "counsel",
     "hydra",
     "iedit",
+    "swiper",
     "zoutline"
    ],
-   "commit": "bf315768020f98f6139d5f722bd365f1ddd1fb52",
-   "sha256": "1sd3czlvvpsfq44ppk8jrv53d7irnk1c8nxvjjlyjbxpxj6zk5zh"
+   "commit": "a4844b9f46b97715524beb8d19c9f3192328394c",
+   "sha256": "1n73p74xq2fgv7l9iy88zf0m4qskaz3jhcmxqk65a1myara0i9ib"
   },
   "stable": {
    "version": [
@@ -64315,11 +64188,11 @@
   "repo": "jingtaozf/literate-elisp",
   "unstable": {
    "version": [
-    20211004,
-    212
+    20220103,
+    717
    ],
-   "commit": "d1eb390e01407a0b17bbed51f2928afdc26cc488",
-   "sha256": "0ixwdw6d8hxrmi86wka4sy8i3sscgzcddihkbyf70niclrllspra"
+   "commit": "399f3cbaac0d81f9b44ed048b9e6698c39c69c3d",
+   "sha256": "0279jsgmc74f1dk8qm94pkq08327fyq8arzk8x6qj1blb7xkzgp1"
   },
   "stable": {
    "version": [
@@ -64412,20 +64285,20 @@
   "repo": "donkirkby/live-py-plugin",
   "unstable": {
    "version": [
-    20211204,
-    2255
+    20220107,
+    329
    ],
-   "commit": "82a34879d4a607fe9f09376d20222ff3c77ef809",
-   "sha256": "01zhzbsdgrsflqpg68qcairg5478n51khp3241x1ga7ga8dyfqz8"
+   "commit": "7f005d1f114f3167d0d5102bcfb0912f9b2a11c0",
+   "sha256": "1bpyb5gznvpbc3rgyfzynqw0pjl92ky9za9im9ivm6f5ix829k4r"
   },
   "stable": {
    "version": [
     4,
-    5,
-    1
+    7,
+    0
    ],
-   "commit": "82a34879d4a607fe9f09376d20222ff3c77ef809",
-   "sha256": "01zhzbsdgrsflqpg68qcairg5478n51khp3241x1ga7ga8dyfqz8"
+   "commit": "a5f1953904ae6ad7d347f15975d905b7f74ef16a",
+   "sha256": "0kaf7gki5m351gipa92kqbp3jf74c2vjj7nm57vkq4gkxr4wmfi1"
   }
  },
  {
@@ -64811,8 +64684,8 @@
     "ht",
     "s"
    ],
-   "commit": "904d90665fc67b5baba0357bf1ef2ac87e8cd43b",
-   "sha256": "1adqlm92skfndv4f6qpy3kas6mk23dy3b54f9i6b8pbw8g7p13rs"
+   "commit": "40e3b873e91393a19bd3251615817166aa2f5d4b",
+   "sha256": "1c4fx533xbffj5hj2nnlr76v6l9a1ah3pwbhncw7w31dq5v6vzx7"
   },
   "stable": {
    "version": [
@@ -65022,20 +64895,20 @@
   "repo": "0x60df/loophole",
   "unstable": {
    "version": [
-    20211212,
-    1302
+    20220104,
+    1452
    ],
-   "commit": "384ad0ac69483595332cc011f30b7d74065cdef9",
-   "sha256": "0xrqhmry5y61sbbda83jhmbvvz0z9bbv3wbv9068sdihqfik3fq2"
+   "commit": "65e35072d8d38c4882a3f9ff9c88c796ad4ad07d",
+   "sha256": "1ccy25ba16k6v7s64g774i328x0rcq8jnikh2sa6vywnlb1kyxx7"
   },
   "stable": {
    "version": [
     0,
-    6,
+    7,
     4
    ],
-   "commit": "5f280e036cad9617212f68348ab5bed159740970",
-   "sha256": "1ks5hm67100ri0v9mxsgs057laadmkpv01f7g0bn3f3d8kpkizda"
+   "commit": "72abf6ed623697be1aef29d88acd84dae88c49a2",
+   "sha256": "0idcjgdxxhjdkv9pidxc17zhfajhv7ndfwgksjvvc294gk4gjnfi"
   }
  },
  {
@@ -65166,8 +65039,8 @@
   "repo": "emacs-lsp/lsp-dart",
   "unstable": {
    "version": [
-    20211119,
-    1320
+    20220102,
+    1814
    ],
    "deps": [
     "dap-mode",
@@ -65177,14 +65050,14 @@
     "lsp-mode",
     "lsp-treemacs"
    ],
-   "commit": "7afe141fe2a60265049a846abd254b5ff4169c10",
-   "sha256": "0wrcrqvlyp6gpanp5r67qyrn3q8n2pk1w8qwrkxh6kr466cd2lxp"
+   "commit": "813d3c92db02596a8e8aa7802977c50ec1262f9d",
+   "sha256": "1l0208bys0zq9qgnih27aldi5v3rp5bj8i9nar24hgfm42ld75gz"
   },
   "stable": {
    "version": [
     1,
-    20,
-    1
+    21,
+    0
    ],
    "deps": [
     "dap-mode",
@@ -65194,8 +65067,8 @@
     "lsp-mode",
     "lsp-treemacs"
    ],
-   "commit": "e2f4ee0d3a88956afdd8515a055678b06f947bf0",
-   "sha256": "0ma0q36q7i0bxbxx525h8s0y0p63pc1hnc5bidbdykrp3hlxw50c"
+   "commit": "813d3c92db02596a8e8aa7802977c50ec1262f9d",
+   "sha256": "1l0208bys0zq9qgnih27aldi5v3rp5bj8i9nar24hgfm42ld75gz"
   }
  },
  {
@@ -65270,8 +65143,8 @@
     "request",
     "s"
    ],
-   "commit": "02c1d83c6e7ef703ce7426f8eff2c3fc7733cf72",
-   "sha256": "06qrd42hnz0cg28wkxcwb2mi0xpsgdy0yb8x9x7k23hzwdv6wrr6"
+   "commit": "8b2368675ab820b48abed3a3d7b5208fdc88d94b",
+   "sha256": "0wx51wra4gg7i2bf0q0y42gmnm8nn5vrzhlya678g36pk2h48h2z"
   },
   "stable": {
    "version": [
@@ -65298,15 +65171,15 @@
   "repo": "emacs-lsp/lsp-haskell",
   "unstable": {
    "version": [
-    20211213,
-    1950
+    20211214,
+    1110
    ],
    "deps": [
     "haskell-mode",
     "lsp-mode"
    ],
-   "commit": "401724f9b934894c5f010d6db47bb2aa3ef6b36a",
-   "sha256": "0iga29q2yw16bx6fsrbdkvwyizz2c6ymi1783y3masyw8bg38jwq"
+   "commit": "001032265f8770fc6a88c1dcd8838cd2707f0b30",
+   "sha256": "1axjafwfacsy5rcxavd6jf28gxrks94mnf4jcdvy5b78nz9imkpq"
   }
  },
  {
@@ -65455,34 +65328,34 @@
  },
  {
   "ename": "lsp-julia",
-  "commit": "ca6a06ed4de499bcccce05163ea3d54e4dca9539",
-  "sha256": "1frjvq2x0xsf93kgpy6bp9mgzfpr7zhacskmm6x8kknb9vj18h4v",
+  "commit": "5f9e73d6ed472924cf17e602a13fde79140ed148",
+  "sha256": "033sw2zzqcych8nrn4ax3jam6m6dqgd17281vrwx7vlvmpfxcz4k",
   "fetcher": "github",
-  "repo": "non-Jedi/lsp-julia",
+  "repo": "gdkrmr/lsp-julia",
   "unstable": {
    "version": [
-    20210530,
-    2152
+    20211229,
+    1534
    ],
    "deps": [
     "julia-mode",
     "lsp-mode"
    ],
-   "commit": "809da95c05fe668acbae5a35e03082d9b9577728",
-   "sha256": "1v3f9hwbnd4vji6say5k9110ac4qbc3gd7hb62pvsbfa7vqd06gi"
+   "commit": "d6688bb131ff4a5a0201f6d3826ef0b018265389",
+   "sha256": "1qx1z4v6yxbxkrcpl4ry79zj64q3ckcp7qxx7cavpjcf4zzkj6jb"
   },
   "stable": {
    "version": [
     0,
-    5,
-    0
+    7,
+    1
    ],
    "deps": [
     "julia-mode",
     "lsp-mode"
    ],
-   "commit": "d4a7a27d6ac7c6831b4f493dd89f82fa0c75bdf5",
-   "sha256": "1rkf2ibjilf023fv68ql4bray8bdnl2biq5zmn1qk5pdp988iq4j"
+   "commit": "e6ff5c09eb73c9b376bfbbd94f47c0366a01cf44",
+   "sha256": "169f1h27qcnhph68793abz1bvdzsipphsn3c7vnyqi5313wgkrkx"
   }
  },
  {
@@ -65531,8 +65404,8 @@
     "lsp-mode",
     "s"
    ],
-   "commit": "f600d5f1d65c6209fa73a7bb916f6de2b60e5fc5",
-   "sha256": "1ss0b2rk22i58sl430844vi119maz9rd0j1zv9wkcn81k6wmrdlq"
+   "commit": "8e30ee2f9190921f9549620145e46961db273d39",
+   "sha256": "052jw0an51wj3y995cxf7mxdbjsx8140196siq87fkccvwry18sy"
   },
   "stable": {
    "version": [
@@ -65557,8 +65430,8 @@
   "repo": "emacs-lsp/lsp-metals",
   "unstable": {
    "version": [
-    20211112,
-    1442
+    20220107,
+    1434
    ],
    "deps": [
     "dap-mode",
@@ -65570,8 +65443,8 @@
     "scala-mode",
     "treemacs"
    ],
-   "commit": "38dda2c22db66547d99e3cfa6b7e76c42e7c6b5a",
-   "sha256": "0p2pz6272h2rbb1si9psb4rh92mahlcr58slkm2mwqjwwbi5hfjl"
+   "commit": "743db8df15375ff9270424951d2dcc3a7e8e7a0b",
+   "sha256": "1251hkpjh0s51znpqhfg193c67fcyr9b7i9hfs8xfalivjpnj254"
   },
   "stable": {
    "version": [
@@ -65601,8 +65474,8 @@
   "repo": "emacs-lsp/lsp-mode",
   "unstable": {
    "version": [
-    20211212,
-    1601
+    20220104,
+    1319
    ],
    "deps": [
     "dash",
@@ -65612,8 +65485,8 @@
     "markdown-mode",
     "spinner"
    ],
-   "commit": "41173dca4d6a7fa381ba6dc154e7149cb113f7e1",
-   "sha256": "0sc6a0cw2497gq6d8dybi0mwma5cslkxnwhiwrbgl3jymmflajwb"
+   "commit": "a82a4fa3467ec918273ab65d48c5c7d2dbfaec74",
+   "sha256": "1ah1ys1f7s24dnbnnqqcfaqp7y8c5rlwrsdg07469nmp96cjk868"
   },
   "stable": {
    "version": [
@@ -65887,8 +65760,8 @@
    "deps": [
     "lsp-mode"
    ],
-   "commit": "629ece1acc3280ee506660170cdee77446ba8c18",
-   "sha256": "0wlh68qxk811p8vs6vvjlxz48gb0vx00r4a0i5m74f6n5h41pzvh"
+   "commit": "dc4d5246afe8620cdffaff1a362529f5d63b1ef5",
+   "sha256": "1sb7apaqxv3mf601v3wxnx3v9jb71avh5m0dw4r80wbkxcgi65f2"
   },
   "stable": {
    "version": [
@@ -65910,8 +65783,8 @@
   "repo": "emacs-lsp/lsp-treemacs",
   "unstable": {
    "version": [
-    20211129,
-    955
+    20220102,
+    1517
    ],
    "deps": [
     "dash",
@@ -65920,8 +65793,8 @@
     "lsp-mode",
     "treemacs"
    ],
-   "commit": "c40a381730251039d33400cc14539c1e0729385f",
-   "sha256": "1nx5ffgy3yzyynz3ll82flxwci4zrmg608iyk8bqzgfpmdlb4ass"
+   "commit": "72d367757a89453a712f6ba1df9b6e789ece2bbd",
+   "sha256": "0jy4zq1b5l6m2nd2zz99m0fy88w570d4n8v84lrkkzllc1n488lk"
   },
   "stable": {
    "version": [
@@ -65947,16 +65820,16 @@
   "repo": "emacs-lsp/lsp-ui",
   "unstable": {
    "version": [
-    20211206,
-    1840
+    20220104,
+    1635
    ],
    "deps": [
     "dash",
     "lsp-mode",
     "markdown-mode"
    ],
-   "commit": "98d0ad00b8bf1d3a7cea490002169f2286d7208c",
-   "sha256": "1s9h593f0hjb8h4ciimvr78k19cp18h3hdwsadmjafshfdq54szw"
+   "commit": "21ce926eedd41ef305c2d89412506ce59b1a7eac",
+   "sha256": "0v58imgrcgqs4fla1cncsd3wk6a8d5v7j014nn0pirypwfznyq0j"
   },
   "stable": {
    "version": [
@@ -66078,8 +65951,8 @@
     20200507,
     1518
    ],
-   "commit": "2d553787aca1aceb3e6927e426200e9bb9f056f1",
-   "sha256": "13zjw64x728pm1a44lzzv9s9r5kkss0ncwqzzczhk8bvmsi7m1l3"
+   "commit": "9e9e00cb240ea1903ffd36a54956b3902c379d29",
+   "sha256": "11xlhm098gi6fnksnykciwdx5a46xmxwx9y8r6kjpb92vpjfak80"
   },
   "stable": {
    "version": [
@@ -66461,14 +66334,14 @@
  },
  {
   "ename": "magit",
-  "commit": "cca2c57104e14cb0c47e27d7fe4b437b38009a5c",
-  "sha256": "0n327xp6zdyp5bbqr84qp0f779qqv6jrlr2kaf00whkgp59g5kf4",
+  "commit": "2133b10c735ce47fc8d8ff8c51f29ec4b13982a3",
+  "sha256": "12g26kc5lzyj02wr16qhkh2p5ac8aaxj2dkw2zd0ymnmskpgwzbx",
   "fetcher": "github",
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20211207,
-    2244
+    20220107,
+    915
    ],
    "deps": [
     "dash",
@@ -66477,8 +66350,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "1eb183e7672bf25fa77ea06d97b3d9c502a698ae",
-   "sha256": "08ci7w0pzbzs02fd8zklvhixkj8ab9vvc41w39mcik8qhr1fz5j4"
+   "commit": "a5f6705bf9a0b040a77eba67bafeec51ada90649",
+   "sha256": "1jm6clcpa4qdhpk09ibnx5qn8zj0dc608j48h2ri4a7xyiv1g6si"
   },
   "stable": {
    "version": [
@@ -66836,15 +66709,15 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20211004,
-    1956
+    20220101,
+    841
    ],
    "deps": [
     "libgit",
     "magit"
    ],
-   "commit": "1eb183e7672bf25fa77ea06d97b3d9c502a698ae",
-   "sha256": "08ci7w0pzbzs02fd8zklvhixkj8ab9vvc41w39mcik8qhr1fz5j4"
+   "commit": "a5f6705bf9a0b040a77eba67bafeec51ada90649",
+   "sha256": "1jm6clcpa4qdhpk09ibnx5qn8zj0dc608j48h2ri4a7xyiv1g6si"
   },
   "stable": {
    "version": [
@@ -66894,22 +66767,9 @@
   "ename": "magit-p4",
   "commit": "e6c16a59ca48a0b17cae90354e8929d31a5eef1f",
   "sha256": "1c5qv1f2d8c114a5z21j0nkw285k3gx787l0c3cd9ls7awxfp1is",
+  "error": "Not in archive",
   "fetcher": "github",
-  "repo": "emacsorphanage/magit-p4",
-  "unstable": {
-   "version": [
-    20170414,
-    1246
-   ],
-   "deps": [
-    "cl-lib",
-    "magit",
-    "magit-popup",
-    "p4"
-   ],
-   "commit": "cdc05f2d564409baac9ca15b1a2a0110a6ff12b7",
-   "sha256": "0s2zmfw449gyc8lf8cqwm47wnqy9g5nai72agvapam2h5613mx4i"
-  }
+  "repo": "emacsorphanage/magit-p4"
  },
  {
   "ename": "magit-patch-changelog",
@@ -66999,20 +66859,20 @@
  },
  {
   "ename": "magit-section",
-  "commit": "cca2c57104e14cb0c47e27d7fe4b437b38009a5c",
-  "sha256": "13dxx1rjpj465h1ns2nki7wfsmnfh9m1gzlm49jkka38iwnqr81j",
+  "commit": "2133b10c735ce47fc8d8ff8c51f29ec4b13982a3",
+  "sha256": "0p7x5s6sr9d7v633hqkp36iq601323vkr07402c563rs3a7anarx",
   "fetcher": "github",
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20211019,
-    2114
+    20220101,
+    841
    ],
    "deps": [
     "dash"
    ],
-   "commit": "1eb183e7672bf25fa77ea06d97b3d9c502a698ae",
-   "sha256": "08ci7w0pzbzs02fd8zklvhixkj8ab9vvc41w39mcik8qhr1fz5j4"
+   "commit": "a5f6705bf9a0b040a77eba67bafeec51ada90649",
+   "sha256": "1jm6clcpa4qdhpk09ibnx5qn8zj0dc608j48h2ri4a7xyiv1g6si"
   },
   "stable": {
    "version": [
@@ -67031,25 +66891,9 @@
   "ename": "magit-stgit",
   "commit": "72a38bbc5bba53dfb971f17213287caf0d190db0",
   "sha256": "1spli6yq258zwx95y16s27hr7hlc2h0kc9mjnvjjl13y2l6shm0i",
+  "error": "Not in archive",
   "fetcher": "github",
-  "repo": "emacsorphanage/magit-stgit",
-  "unstable": {
-   "version": [
-    20190313,
-    1158
-   ],
-   "commit": "8294f34e4927798d9db883cafe946a9041b7e331",
-   "sha256": "16i67h0f2w6gaf34w6v50ahmb3358wqhgnijfmzyd6j19zw39d3d"
-  },
-  "stable": {
-   "version": [
-    2,
-    2,
-    0
-   ],
-   "commit": "8294f34e4927798d9db883cafe946a9041b7e331",
-   "sha256": "16i67h0f2w6gaf34w6v50ahmb3358wqhgnijfmzyd6j19zw39d3d"
-  }
+  "repo": "emacsorphanage/magit-stgit"
  },
  {
   "ename": "magit-svn",
@@ -67630,8 +67474,8 @@
    "deps": [
     "manage-minor-mode"
    ],
-   "commit": "22a00d919d56ae7b3c3bf3090cafacffaeb50d7e",
-   "sha256": "1pidsjdx1wdd02vmcl74ps622n9fyydbn8jpbrlbm6y6ffhy6rrz"
+   "commit": "67cac2f9e3804fa815490b305e98e37fa55023ea",
+   "sha256": "1a36fpl6qhby64cnpm359sgsdbn0qakfc7qc8nkb6dl0lmbkfxdg"
   },
   "stable": {
    "version": [
@@ -67807,19 +67651,19 @@
   "repo": "minad/marginalia",
   "unstable": {
    "version": [
-    20211203,
-    2231
+    20211231,
+    939
    ],
-   "commit": "2fb2787bc302a5533e09bc558c76eb914e98543b",
-   "sha256": "1ypr2chn5fi2ycpz4dawczcjmyll5a71mfjsx8fqbms73izd5392"
+   "commit": "9229d88ae4757f3439e81f51799758c009838cb4",
+   "sha256": "0gaqybj52skqcmxcx6k3zmw6lznzlr1fjvlaraic9m6n85xkvzki"
   },
   "stable": {
    "version": [
     0,
-    9
+    11
    ],
-   "commit": "37e24b798afca98da0d0364dde3fa63a42c5853e",
-   "sha256": "19l3fwh6phd17rssxk30v2380bs04x7w6cb3hjy4mx7vkc7w6ymv"
+   "commit": "9229d88ae4757f3439e81f51799758c009838cb4",
+   "sha256": "0gaqybj52skqcmxcx6k3zmw6lznzlr1fjvlaraic9m6n85xkvzki"
   }
  },
  {
@@ -67930,8 +67774,8 @@
     20211022,
     55
    ],
-   "commit": "c3c2f0d473a3f8ca8c4ffb2ecc094d5c3541769f",
-   "sha256": "1pmkpddvs589v9b6sgpfq5mzsli4ifczwvw4396qimx1dh86sb1c"
+   "commit": "4469553a7395359e96b8796e1fac4de73cb6ccc4",
+   "sha256": "1z8w77nkyn2h4g0r3yxdhcr3dr4z788x9sf6r710d4vq31s9khk2"
   },
   "stable": {
    "version": [
@@ -68142,8 +67986,8 @@
     20200720,
     1034
    ],
-   "commit": "5a63cff899eeb58abc3d0cdc6a0e5a6bbf13eaf6",
-   "sha256": "0g47ch2wnd25vc2g0mypkxdgjjkqznknk14qxxmmyf5ygp5f4ysg"
+   "commit": "9c2fca7a7709d5ba4d83020669ab9d8b6d992624",
+   "sha256": "1frlnh73aygiz099r3dh7jlfr55ijplww3zyj4ig70mzd8qm08b9"
   },
   "stable": {
    "version": [
@@ -68217,17 +68061,21 @@
  },
  {
   "ename": "mastodon",
-  "commit": "809d963b69b154325faaf61e54ca87b94c1c9a90",
-  "sha256": "1bsyf4j6zs9gin0k7p22yv5gaqd6m3vdc2fiagfbs7gxsmhb6p4i",
+  "commit": "9d48c26d28ebf3bf8fc435c08c26792860acf377",
+  "sha256": "07ha97rr4078l2gri5i1kjvl5nbv8k3rjanh87919ljrv4c0qhsq",
   "fetcher": "github",
-  "repo": "jdenen/mastodon.el",
+  "repo": "mooseyboots/mastodon.el",
   "unstable": {
    "version": [
-    20190305,
-    344
+    20211223,
+    1924
    ],
-   "commit": "5095797ef32b922d2a624fa6beb970b5e9cf5ca0",
-   "sha256": "0hwax6y9dghqwsbnb6f1bnc7gh8xsh5cvcnayk2sn49x8b0zi5h1"
+   "deps": [
+    "request",
+    "seq"
+   ],
+   "commit": "f9f4ce55ecf93cd8eeb609a38d4679aed5c5bace",
+   "sha256": "1jp1x9rmk7gs2b2y8yfrf16mbzsi2j4gv0q74mkzdm2jbk7027i7"
   },
   "stable": {
    "version": [
@@ -68270,15 +68118,15 @@
   "repo": "matsievskiysv/math-preview",
   "unstable": {
    "version": [
-    20210909,
-    1220
+    20211221,
+    1611
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "90821e2993c8976e6a06f3bc2bf39aae6fbad016",
-   "sha256": "04hb48ncxvh3ia416iyy0x0wpvkhmpqg369565zgmhg9mvl3njmz"
+   "commit": "75dd44ad8dcfa12fe03f8e65babe0ea04e1a7d1a",
+   "sha256": "183m24yj54j8mix27q731wdxp1yyjm9qgd82hqflfivldlabm0x8"
   }
  },
  {
@@ -68588,11 +68436,10 @@
   "repo": "ahungry/md4rd",
   "unstable": {
    "version": [
-    20211015,
-    2123
+    20220105,
+    1558
    ],
    "deps": [
-    "cl-extra",
     "cl-lib",
     "dash",
     "hierarchy",
@@ -68600,8 +68447,8 @@
     "s",
     "tree-mode"
    ],
-   "commit": "fc5fbf6c966dcee1075ef359638eb23003417f30",
-   "sha256": "19ay7n5ds8622qs799icdcmkyhfcqfxd2myffzswsrhvkm9afr8r"
+   "commit": "6aa4fd6339d7fac78ce57e5d8821cd7009d21172",
+   "sha256": "0fvd4x079bxyzarjccwy9vcxrn8l38jxbv5cckp4pw2syb2dks03"
   },
   "stable": {
    "version": [
@@ -68653,46 +68500,39 @@
   "repo": "mopemope/meghanada-emacs",
   "unstable": {
    "version": [
-    20210505,
-    652
+    20220101,
+    501
    ],
    "deps": [
     "company",
     "flycheck",
     "yasnippet"
    ],
-   "commit": "6c57e8a0ae27e2929bb12572cf33059cd4ecbc04",
-   "sha256": "1wq4x80lqzlpixy701xncvmz0jwk1zgp1kpz1z7wgl5i0jnb1516"
+   "commit": "59c46cabb7eee715fe810ce59424934a1286df84",
+   "sha256": "1azjp340wxv25c7bg1y5m8gwmgsdfvlxxcisczz44v87v8jbjhyw"
   },
   "stable": {
    "version": [
     1,
     3,
-    1
+    2
    ],
    "deps": [
     "company",
     "flycheck",
     "yasnippet"
    ],
-   "commit": "1e41f7f2c7a172e9699f3557c97c3f39a149bfc2",
-   "sha256": "1cplw3x94xc2yqvvimkjgppbb36mnj8n3gcx0k2gy7zwzdvzg4c6"
+   "commit": "59c46cabb7eee715fe810ce59424934a1286df84",
+   "sha256": "1azjp340wxv25c7bg1y5m8gwmgsdfvlxxcisczz44v87v8jbjhyw"
   }
  },
  {
   "ename": "melancholy-theme",
   "commit": "8b8f708d1300d401697c099709718fcb70d5db1f",
   "sha256": "1wihbv44234lwsgp5w4hmmi3pgxbcfjvs1nclv0yg600z9s8sn8w",
+  "error": "Not in archive",
   "fetcher": "github",
-  "repo": "techquila/melancholy-theme",
-  "unstable": {
-   "version": [
-    20211018,
-    1911
-   ],
-   "commit": "0401c849203f8f497c8a93c1700451de7ff0675a",
-   "sha256": "0l4xdnhw630klg2yhz7zrh8qscna8fa8cahayyykc7m257blvpiz"
-  }
+  "repo": "techquila/melancholy-theme"
  },
  {
   "ename": "mellow-theme",
@@ -68807,23 +68647,22 @@
   "repo": "skangas/mentor",
   "unstable": {
    "version": [
-    20211023,
-    431
+    20220107,
+    2206
    ],
    "deps": [
     "async",
-    "cl-lib",
     "seq",
     "xml-rpc"
    ],
-   "commit": "b68c47b3d898a441da2278e2e0636197397d755e",
-   "sha256": "0yrfnzj1havjzvlr6s6mamrr875fniafb2wwck76yggfyhdvmxxv"
+   "commit": "3f4fda68fcfd7b2fa73910b3e9e122927e3256ee",
+   "sha256": "128k5zjk4pjbwx2jzld1g6k09ywdml2gnyxazpabqy5m2gjdq1pl"
   },
   "stable": {
    "version": [
     0,
     3,
-    4
+    5
    ],
    "deps": [
     "async",
@@ -68831,8 +68670,8 @@
     "seq",
     "xml-rpc"
    ],
-   "commit": "9415472470ff23ee9600d94123c51c455d63018d",
-   "sha256": "05gfprcrh9p06arsni58nf60inlf1zbd18i678r9xd4q0v35k491"
+   "commit": "ebc43db934fab4345ef63c1c0f7113b9293d0646",
+   "sha256": "1aa5z0gbk09m8ccfcylick5biakyid7sw0ghakgnmq6bak0akj0h"
   }
  },
  {
@@ -68843,25 +68682,20 @@
   "repo": "meow-edit/meow",
   "unstable": {
    "version": [
-    20211213,
-    1752
+    20220108,
+    1514
    ],
-   "commit": "c111e74296579614847bff9df8f7a1c7e1d6ff45",
-   "sha256": "0pfx5sr6vdghappgl37a3wcd34fnds6kc75qkwwqagvxyfkiaa90"
+   "commit": "b4eefbfb1e0d8a766757f2f4f0ceaaf533bc617c",
+   "sha256": "1yb38v9a6c4q3vpw7yysz92qrh8yilsaivbrzblz5xi3f14mch9m"
   },
   "stable": {
    "version": [
     1,
-    1,
+    2,
     1
    ],
-   "deps": [
-    "cl-lib",
-    "dash",
-    "s"
-   ],
-   "commit": "94fe6e5cf8450a243917e6f6ff9f9c358d19ddb1",
-   "sha256": "1jwzhwvv422i5y1mxjgb305szblqgvdzad1rzrn52xmlx0x5j9lc"
+   "commit": "aa274c3a25200664f8cdad4f166a1d2433c59447",
+   "sha256": "048y1sgsl7amcsq8pxw9m2fws1zcjwbsqs1lnsz30dx6qasdmjf1"
   }
  },
  {
@@ -68875,8 +68709,8 @@
     20210720,
     950
    ],
-   "commit": "d136be61cdd2d25c2b69abb88c005f497775c431",
-   "sha256": "0kqbmysshhr4h6gmgi4brd5kya2p5cqkv672v1hiyxzlnnq9f927"
+   "commit": "f1d1cfc6bdc76146a08ec89a926de42a57589704",
+   "sha256": "0l2dp2qdgslg0v3gp9529631z84x3h44yhya28id9ankhkh7g01m"
   },
   "stable": {
    "version": [
@@ -68904,8 +68738,8 @@
     "auto-complete",
     "merlin"
    ],
-   "commit": "d136be61cdd2d25c2b69abb88c005f497775c431",
-   "sha256": "0kqbmysshhr4h6gmgi4brd5kya2p5cqkv672v1hiyxzlnnq9f927"
+   "commit": "f1d1cfc6bdc76146a08ec89a926de42a57589704",
+   "sha256": "0l2dp2qdgslg0v3gp9529631z84x3h44yhya28id9ankhkh7g01m"
   },
   "stable": {
    "version": [
@@ -68937,8 +68771,8 @@
     "company",
     "merlin"
    ],
-   "commit": "d136be61cdd2d25c2b69abb88c005f497775c431",
-   "sha256": "0kqbmysshhr4h6gmgi4brd5kya2p5cqkv672v1hiyxzlnnq9f927"
+   "commit": "f1d1cfc6bdc76146a08ec89a926de42a57589704",
+   "sha256": "0l2dp2qdgslg0v3gp9529631z84x3h44yhya28id9ankhkh7g01m"
   },
   "stable": {
    "version": [
@@ -68999,8 +68833,8 @@
     "iedit",
     "merlin"
    ],
-   "commit": "d136be61cdd2d25c2b69abb88c005f497775c431",
-   "sha256": "0kqbmysshhr4h6gmgi4brd5kya2p5cqkv672v1hiyxzlnnq9f927"
+   "commit": "f1d1cfc6bdc76146a08ec89a926de42a57589704",
+   "sha256": "0l2dp2qdgslg0v3gp9529631z84x3h44yhya28id9ankhkh7g01m"
   },
   "stable": {
    "version": [
@@ -69984,8 +69818,8 @@
    "deps": [
     "mmm-mode"
    ],
-   "commit": "c8cb763174fa2fb61b9a0e5e0ff8cb0210f8492f",
-   "sha256": "0big2i3bg4cm14f68ncaiz2h6dk6zqiisrz4l0bv10q9kaa9q2sj"
+   "commit": "0bdcb5c7547cbf353f960c36ca4090520f6fc3c3",
+   "sha256": "1kaipcazf3d1p5n4wq0p9psfccpf07738rr8czpckvcdr5s75w7f"
   },
   "stable": {
    "version": [
@@ -70420,20 +70254,20 @@
   "repo": "protesilaos/modus-themes",
   "unstable": {
    "version": [
-    20211213,
-    700
+    20220106,
+    629
    ],
-   "commit": "8f9491d0e2b915dda99224bdbf5b0c063ea537a5",
-   "sha256": "05s7y80020ff8qf9vlql1i1y21g0il80lwijd49n77byawa27cby"
+   "commit": "38236a925ef34f8e8c51babee587b594e77dffbe",
+   "sha256": "0fh9nw7gz3bqpk6r1v6rggajhqaymk6hyww7i3hfb34g74qhyq3i"
   },
   "stable": {
    "version": [
-    1,
-    7,
+    2,
+    0,
     0
    ],
-   "commit": "6f69627703caffbd62ba1a89d4a337fc29773ab4",
-   "sha256": "05s7y80020ff8qf9vlql1i1y21g0il80lwijd49n77byawa27cby"
+   "commit": "e02480f0b0a56b8575351db6504bf0d0417719ad",
+   "sha256": "0fh9nw7gz3bqpk6r1v6rggajhqaymk6hyww7i3hfb34g74qhyq3i"
   }
  },
  {
@@ -70444,11 +70278,11 @@
   "repo": "kuanyui/moe-theme.el",
   "unstable": {
    "version": [
-    20210308,
-    1053
+    20220107,
+    1114
    ],
-   "commit": "b23975ba57a68f69551424552f484227db8a7b97",
-   "sha256": "0vr02ng574k1xfykxn2j2xhl78x4zsvzcszswqjrlps55bvxkm7b"
+   "commit": "376245293a0d84c5ba3e7d760e020c13056791f1",
+   "sha256": "0025pibqdj557hmj3h87vz28pivh68cvf9vfgh9l1kr60fhp1r7r"
   },
   "stable": {
    "version": [
@@ -70498,11 +70332,11 @@
   "repo": "alloy-d/color-theme-molokai",
   "unstable": {
    "version": [
-    20151016,
-    1545
+    20220106,
+    1520
    ],
-   "commit": "04a44f21184b6a26caae4f2c92db9019d883309c",
-   "sha256": "1hqa59pdrnwfykyl58lr8pfbh2f13sygvmrh707hbwc2aii0jjv2"
+   "commit": "cc53e997e7eff93b58ad16a376a292c1dd66044b",
+   "sha256": "109z13y6f54idzxk4incd4r0d3fr7wm7r8ifmd0s5hv1v1i93jc0"
   }
  },
  {
@@ -70767,20 +70601,20 @@
   "repo": "tarsius/moody",
   "unstable": {
    "version": [
-    20211130,
-    1719
+    20220103,
+    1539
    ],
-   "commit": "60d49cb8ead8fc24b7034fff4de3c4ad959398b6",
-   "sha256": "0lqqxxhrfr9bad6i9xas0b8fcgqwfgvgh6zfla63j5mm4x4azj7x"
+   "commit": "6e0ee218788ec5b2d9e1d765ee4cf6a3deec25b6",
+   "sha256": "1c1lrf1b7hpip8248m13pjs5yg66d20vva2vym9j1il95ql2c348"
   },
   "stable": {
    "version": [
     0,
-    6,
+    7,
     0
    ],
-   "commit": "9b679400ca885b8ff51bcfd75b87f79d66c0ee26",
-   "sha256": "14x3hd0z0nh0dyfi434vqywi7aawfxhlqj6sp7m17np56zq32yhi"
+   "commit": "ee5df762d10e60cc19e771b1a64da9459c584cf3",
+   "sha256": "1xzi93hp4jrxqi3x31cpx4ff1yh2gq9y7qvv65gj19cfk9a0da88"
   }
  },
  {
@@ -71055,8 +70889,8 @@
     20210306,
     1053
    ],
-   "commit": "01306d0c67c5faa203994bab281c515b9d1248fa",
-   "sha256": "109p65vwii1ppvpnvmgpzn0k0iraby23da1xsb2frad6lc3clz65"
+   "commit": "c914d1dfe8b4193731b22da7ee3f53612a94269d",
+   "sha256": "0jx0rl66pihvpj25v7n9pqrsxf68406x636ck5h5znqbhf0zqwrb"
   },
   "stable": {
    "version": [
@@ -71273,31 +71107,30 @@
   "repo": "kljohann/mpv.el",
   "unstable": {
    "version": [
-    20211121,
-    1801
+    20211228,
+    2043
    ],
    "deps": [
     "cl-lib",
     "json",
     "org"
    ],
-   "commit": "b026ae5bb6139b8bbbc572d24974dcd295c1465c",
-   "sha256": "1knipmddx8nrd762v7lsnjjqacfrj53ya28yji8k2929k9s3rq83"
+   "commit": "4fd8baa508dbc1a6b42b4e40292c0dbb0f19c9b9",
+   "sha256": "03zziy1lcvpf1wq15bsxwy0dhdb2z7rrdcj6srgrmgykz2wf33q7"
   },
   "stable": {
    "version": [
     0,
-    1,
+    2,
     0
    ],
    "deps": [
     "cl-lib",
     "json",
-    "names",
     "org"
    ],
-   "commit": "059135de3979e044f14503806047476d9be9f0e8",
-   "sha256": "1pjhch8vah0kf73fl2fk6khhrx1kflggd3zlxrf7w4fxr0qn8la3"
+   "commit": "4fd8baa508dbc1a6b42b4e40292c0dbb0f19c9b9",
+   "sha256": "03zziy1lcvpf1wq15bsxwy0dhdb2z7rrdcj6srgrmgykz2wf33q7"
   }
  },
  {
@@ -71630,16 +71463,16 @@
   "repo": "lordpretzel/mu4e-views",
   "unstable": {
    "version": [
-    20210729,
-    1158
+    20211222,
+    1457
    ],
    "deps": [
     "esxml",
     "ht",
     "xwidgets-reuse"
    ],
-   "commit": "f3f454c7f92e8a9eecb5501af9ca81a547fd1841",
-   "sha256": "137r0kbd386954ydiwz6g9ff3j5289nqfzkvhp13rjjkrs668332"
+   "commit": "a1d7268eb2b737ee69b5bdf45aacbc30e50204fe",
+   "sha256": "00yj0ldyxhzqdsbxr4jr4rd4j1njy1r0blh7py2nlxqia22c015g"
   },
   "stable": {
    "version": [
@@ -71754,8 +71587,8 @@
   "repo": "IvanMalison/multi-line",
   "unstable": {
    "version": [
-    20170822,
-    226
+    20220106,
+    630
    ],
    "deps": [
     "cl-lib",
@@ -71763,8 +71596,8 @@
     "s",
     "shut-up"
    ],
-   "commit": "d5ae863ced0adeb7032ada398005f27a6c669d79",
-   "sha256": "0hj2afqw36pxc091k4w4rk110y076lghnap51x3w53k9xfcfwhwa"
+   "commit": "7c5fbaea5216949820ba8a8d5969d87f36d7d41d",
+   "sha256": "1zk3w0z2k3ifv2i1rd9y4a8bf51igl5s07l2db9p6bbxpi3h6lvl"
   },
   "stable": {
    "version": [
@@ -71790,11 +71623,11 @@
   "url": "https://hg.osdn.net/view/multi-project/multi-project",
   "unstable": {
    "version": [
-    20210908,
-    1233
+    20211230,
+    2223
    ],
-   "commit": "e213d1f64e173b437a2981afc5d85f90aa40a03e",
-   "sha256": "1cpssylbfw3ir4dh14z5p4b7yfw4k2ky49i09jk2prq7swk0f6xm"
+   "commit": "81262345927d30571d2797a8fb8dbd9eeeb6ccf8",
+   "sha256": "1ps0dvbms7bgpgbrvy2yajy4xp3nxrscvw94krdxvnb8ycnvdqrk"
   }
  },
  {
@@ -71838,14 +71671,6 @@
    ],
    "commit": "017c77c550115936860e2ea71b88e585371475d5",
    "sha256": "043dqd8i8h6hbcg11rzprxin2yq5lb902zlrb7mxah44vyp8wrdi"
-  },
-  "stable": {
-   "version": [
-    1,
-    2
-   ],
-   "commit": "c9e67edb772f2d9f9da8d887dc746459cfbce244",
-   "sha256": "1bn6zx931vz2fa72ab999r33bxv8brn3cqmalvq25x7s4z3q1lyi"
   }
  },
  {
@@ -72710,11 +72535,11 @@
   "repo": "CeleritasCelery/emacs-native-shell-complete",
   "unstable": {
    "version": [
-    20210315,
-    2048
+    20220103,
+    1622
    ],
-   "commit": "cf142e84eaa4dd91bc75d96a5d26dab5e38eba4c",
-   "sha256": "01li6c271v5j35chg3a8nl9az3bwq4hk1j8lfjq5a27p91iszpc0"
+   "commit": "20e1dceb459856c8c4f903e6d8562991069bb8c1",
+   "sha256": "11m3y6kbjm0nqmdqbcv4xrchcabh4x1w4gy1p8gp36k600s1h7zj"
   }
  },
  {
@@ -73430,11 +73255,11 @@
   "repo": "m-cat/nimbus-theme",
   "unstable": {
    "version": [
-    20211209,
-    1529
+    20220106,
+    2017
    ],
-   "commit": "5ae0bee99d005e62c3b18e793a81405a1a3ca0e5",
-   "sha256": "15fhim7cj7inc2kyl0xgv18a8p4lygnpkxgbq34nl567y9374vs4"
+   "commit": "f9bcec4ce0f6cd656a56034ace7811dea769a7bb",
+   "sha256": "1mfx03mjm8w5djvwafd9p3zyw4aysalw4j57x1sv51shf1fzz2g6"
   },
   "stable": {
    "version": [
@@ -73457,8 +73282,8 @@
     20181024,
     1439
    ],
-   "commit": "e5935b63757f3a788bc56d2c7afd9e390daf2f07",
-   "sha256": "0arrxdpf4mcbr3mhl5955xiyw8772r571hvamacdln3cz044lr3p"
+   "commit": "e234b25bb51a4d3ce5376febb4ad9a11e77d5ca3",
+   "sha256": "0j0c4zdii67j6r69wjc726yjs5ad2nc75k93d6w9v9b7wxvjf4wb"
   },
   "stable": {
    "version": [
@@ -73759,16 +73584,16 @@
   "repo": "dickmao/nnhackernews",
   "unstable": {
    "version": [
-    20211031,
-    1221
+    20220107,
+    1537
    ],
    "deps": [
     "anaphora",
     "dash",
     "request"
    ],
-   "commit": "34d82e2c2e4c190b85e751dd3f295daa264baa55",
-   "sha256": "1ivmybr94rwrdgxp5d761yy8hnhcdwmiqkhxnyk1bbbyd0a1kxj4"
+   "commit": "6748065db2f12ae6ea07058e7d643f586fb4b3bc",
+   "sha256": "0b566hb8j0mwl8b8plaf10majn8v70r9j7ffwsk1jnkixc8y4l37"
   }
  },
  {
@@ -73852,26 +73677,26 @@
   "repo": "emacscollective/no-littering",
   "unstable": {
    "version": [
-    20211110,
-    1900
+    20220101,
+    1040
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "4a7bcaf077d049931120255edf476f34ced8c73d",
-   "sha256": "0p8jm5fms4krij7ydhrj2jwayyx6979bdq2w7v88ybk6b0md9yw1"
+   "commit": "665e324abb690fb50e9d255bc656eb12bb83b0c6",
+   "sha256": "1gk1l5zk5r8alnzfbfsck5gxcwr55k04rd08sxmb4j9jds6w6zyv"
   },
   "stable": {
    "version": [
     1,
     2,
-    3
+    4
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "dcc96cbf5f018a91d406926d3b69715847ef665a",
-   "sha256": "1c6nq2sykbsjy30zakfpny503644bbwgb4pxhfsd4wywj5yyzw66"
+   "commit": "665e324abb690fb50e9d255bc656eb12bb83b0c6",
+   "sha256": "1gk1l5zk5r8alnzfbfsck5gxcwr55k04rd08sxmb4j9jds6w6zyv"
   }
  },
  {
@@ -74172,11 +73997,11 @@
   "url": "https://git.notmuchmail.org/git/notmuch",
   "unstable": {
    "version": [
-    20211212,
-    1414
+    20211229,
+    1824
    ],
-   "commit": "ed03babd053d679a85ea3baa1632d8ae1dff31b6",
-   "sha256": "1hchhwy2kv90014f52zpf2a8qycknplhb9lrpf71aci8f58ndnv0"
+   "commit": "d99b0d4dc8b9262373e2d0ae158dd8336fc28e41",
+   "sha256": "098z49d13mmsi4ci9cgj7kjlkan8mi6hrxa6y0v14lppjavai8xc"
   },
   "stable": {
    "version": [
@@ -74345,15 +74170,15 @@
   "url": "https://depp.brause.cc/nov.el.git",
   "unstable": {
    "version": [
-    20211130,
-    1805
+    20211230,
+    954
    ],
    "deps": [
     "dash",
     "esxml"
    ],
-   "commit": "436f5ec473b69a9d3b6cb6405508e3564f61cd4b",
-   "sha256": "020akj3vi0m63kmda4i6rm9ax7s6di28v5s2cmjkggb4al0n0n6m"
+   "commit": "2b4a7231aff6211a5a2f28719d830887aec6cc57",
+   "sha256": "11lwhwiyvhcj0gk9ifdjjj9iw41j3b5rdhk0x3hl8mfibrpqg3fs"
   },
   "stable": {
    "version": [
@@ -74704,15 +74529,15 @@
   "repo": "douglasdavis/numpydoc.el",
   "unstable": {
    "version": [
-    20210811,
-    1458
+    20220106,
+    1703
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "2d280dd704a1a54bcb3e8091f06656c3311894bc",
-   "sha256": "1hqagy3ailigy2r43vhk2aayxxlr3qs4xk18mnx2r6bgmnbrzr5m"
+   "commit": "385fc0bdd648d5f8bffabc073662577c8941c86d",
+   "sha256": "0310lhaxybzlid418ngw11zc26pqfyp6hgiim49wwva26h8z5if6"
   },
   "stable": {
    "version": [
@@ -75597,14 +75422,14 @@
   "repo": "stardiviner/ob-php",
   "unstable": {
    "version": [
-    20211109,
-    146
+    20211229,
+    744
    ],
    "deps": [
     "org"
    ],
-   "commit": "3699808eb1ba56268ccc2e366151183e91e8c711",
-   "sha256": "0m0qgssa0rxh7apcxr7lz0wi5vsrgnsysjw0zj2mk6fz1drg02dw"
+   "commit": "cff022a2aaaf1785e1937e232c31670d748b8c6e",
+   "sha256": "1g53j5wy7m3mkfbyk5m5rz49sacmx64j1xl5535fdc06cl2kcxjm"
   }
  },
  {
@@ -76108,8 +75933,8 @@
     20210923,
     1348
    ],
-   "commit": "51cd55ad0aa6c6ccbea7fe3041de0931c0292be5",
-   "sha256": "1kga1izbp301rv8y2kdcwc2jrvy4bplaglsbspqm64yz6jcj570l"
+   "commit": "c1eaa46bec29d372251a4b3f8292d2b40c72bff0",
+   "sha256": "02nxgn6g8c7b61298dpfk3f24acmkkl8n0m3qh8lf67d2dbd6jck"
   },
   "stable": {
    "version": [
@@ -77211,16 +77036,16 @@
   "repo": "eyeinsky/org-anki",
   "unstable": {
    "version": [
-    20211108,
-    751
+    20220102,
+    1248
    ],
    "deps": [
     "dash",
     "promise",
     "request"
    ],
-   "commit": "e6221b1654d34bc3a06500ae4706419bc176b575",
-   "sha256": "1xnqih87sipqd6q5cvgvw2mpn5m4j605bxhlbmpr4kzhni9vd9sh"
+   "commit": "400f472e7b2e45502cac2b96bdde33830b84ea60",
+   "sha256": "1qj07k5j6493n76q23f4llmbkv5chf9fr43c2b5a5a8cx8qpp48f"
   },
   "stable": {
    "version": [
@@ -77319,8 +77144,8 @@
    "deps": [
     "async"
    ],
-   "commit": "ad3c332f062b5830e88b2ab13287a096ae434657",
-   "sha256": "05yrw59zrzxj1p8n65sk6mvy7jzik812mp9i2nsimwhlhn3si1pj"
+   "commit": "5d9f2734c96166722c5057f3a2641ff8e08184cc",
+   "sha256": "10isxdaw7mqnw8flc76rva9y04wsyzpv6v0f3lsvkrx044rcz3cr"
   },
   "stable": {
    "version": [
@@ -77343,11 +77168,11 @@
   "repo": "calvinwyoung/org-autolist",
   "unstable": {
    "version": [
-    20210810,
-    2215
+    20211225,
+    658
    ],
-   "commit": "943de3a76a16acd54d924392f86e8ef04f1cb086",
-   "sha256": "1i6sa7pavgk4gal7fppd68brr8vm4jxma6nbkqwcb1djys1vg21b"
+   "commit": "48666001f9ae1fdf9e295410d5a494e79284e2f7",
+   "sha256": "0ij0j96ns4scrlcf52ljwhi3y4q9jfv9kra3nw162fs3f4q6lp7m"
   },
   "stable": {
    "version": [
@@ -77863,14 +77688,6 @@
    ],
    "commit": "07ddbfc238cba31e4990c9b52e9a2757b39111da",
    "sha256": "1d9gf6wf3jp07bn2h6bbc75iy0wwdvzdlj9n4nwbc46nf3k154pa"
-  },
-  "stable": {
-   "version": [
-    0,
-    1
-   ],
-   "commit": "e099514cfc162f8fe3d383456a7964743b0455d5",
-   "sha256": "1hvnrw0y3chlfv6zxsczmm8zybrnakn3x13ykv2zblw96am9kd2s"
   }
  },
  {
@@ -78214,11 +78031,11 @@
   "repo": "io12/org-fragtog",
   "unstable": {
    "version": [
-    20210815,
-    2349
+    20220106,
+    758
    ],
-   "commit": "15861261a437aca2ec858317de71603d2957b423",
-   "sha256": "0ra4sfy48p8pm1c7h8wlmbl68r4s0f4qc49xapvs550pm4mf3hiq"
+   "commit": "5b346068c346c4164f5e48e81d1e1bb285da8fd5",
+   "sha256": "0r21dpgjxljckl32aicqj0lqwrf30gc52l1yxy2n1qv332gdmpy6"
   },
   "stable": {
    "version": [
@@ -78253,8 +78070,8 @@
   "repo": "kidd/org-gcal.el",
   "unstable": {
    "version": [
-    20211007,
-    1843
+    20220105,
+    400
    ],
    "deps": [
     "alert",
@@ -78262,8 +78079,8 @@
     "request",
     "request-deferred"
    ],
-   "commit": "8b6df4b727339e3933c68045e104b6b1d99816f7",
-   "sha256": "0gkdh32cfmqbmvvqd67i2x9i1fm5yfmhw6i5yvrb9swsl24kv194"
+   "commit": "ad4261ac34f6270a9ddd61c3a0471d582c462365",
+   "sha256": "0df3kgkxhkyb729mnjagh0cjy03014bx8rff8115nxlb7vxhl8rg"
   },
   "stable": {
    "version": [
@@ -78371,17 +78188,18 @@
   "repo": "Trevoke/org-gtd.el",
   "unstable": {
    "version": [
-    20211124,
-    2203
+    20211229,
+    214
    ],
    "deps": [
     "f",
     "org",
     "org-agenda-property",
-    "org-edna"
+    "org-edna",
+    "transient"
    ],
-   "commit": "ca5b19dcfd3af5c5222654b2c12ce7bd6f3667c7",
-   "sha256": "1laxw7ixcvdh4cgx5z669wvmwn5x9qqq0gyvl3rj79nrdv755wwr"
+   "commit": "1eeb45d03a3de8125df73e5c9d1133f2832ed5e0",
+   "sha256": "0ijvg69237415ragzbj1iwqbnylifyy95k2dw2jlwhhlgvh8mszj"
   },
   "stable": {
    "version": [
@@ -78609,14 +78427,14 @@
   "repo": "bastibe/org-journal",
   "unstable": {
    "version": [
-    20211003,
-    805
+    20220103,
+    829
    ],
    "deps": [
     "org"
    ],
-   "commit": "71e8b10088ae52c4ac17f7af87020ea85fbc6ff7",
-   "sha256": "1fld2l1nxhim21icq10bnscw99xl9p398zbwvcm07vm0n0pm3dvf"
+   "commit": "f121450610650c63aabf13afd0d2089e05fad2e4",
+   "sha256": "0hai9m2bxwhnk3xcbcdis93spz4ncvcrhdwi8cdp1j5gsvgdxm86"
   },
   "stable": {
    "version": [
@@ -78728,14 +78546,14 @@
   "repo": "stardiviner/org-link-beautify",
   "unstable": {
    "version": [
-    20211209,
-    448
+    20211229,
+    241
    ],
    "deps": [
     "all-the-icons"
    ],
-   "commit": "29a44cff345928d8ded7ff814edcbf5a3ea0550e",
-   "sha256": "0cgf6bb3b0s378w48sdma0lyasdj93ngfvrdlnnjggk5hlcr98sx"
+   "commit": "c755af07a9ca0c75e99ba06412d29829a7dfccc6",
+   "sha256": "1m0l864rw27myrdyby3706f8ir4znibkjyprpi83i5b04hkbyfbx"
   }
  },
  {
@@ -78857,20 +78675,20 @@
   "repo": "org-mime/org-mime",
   "unstable": {
    "version": [
-    20211130,
-    716
+    20220105,
+    1255
    ],
-   "commit": "3b119a22be0ee22d16773e4d9a26478d3c8bf2df",
-   "sha256": "1khvfw2vqakvnai0i5wzr6mlxr01ijbcjm655xv17yp95d878bqw"
+   "commit": "a3519ebb94aae41005417ee4376b145e84feeebc",
+   "sha256": "17pwl8pf50hhdlg9xlnwl5qzxrmn0r2pzww492j3z6c0nz54hz00"
   },
   "stable": {
    "version": [
     0,
     2,
-    3
+    4
    ],
-   "commit": "23cc52bb539c898de228fc438cd24ed10213bea3",
-   "sha256": "1g32chan6rhlp3kvzd2lvf104i3p37q1sm0d89pq6sya0ia2as1n"
+   "commit": "d52a7b52b652bb87a82be02f66ba14d54dee0cb5",
+   "sha256": "0in83jlrwjn81qgw1i7n228sbf314bj8hkrl14ahfn0zmfll60sw"
   }
  },
  {
@@ -78900,16 +78718,16 @@
   "repo": "ndwarshuis/org-ml",
   "unstable": {
    "version": [
-    20211213,
-    105
+    20211231,
+    700
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "4fdf359fb716bf9b606650ac119ba10021f94f26",
-   "sha256": "0chnvs577wvddmcx37gij1zw95hii1lmdycr7w2wp5ig2dyz67ns"
+   "commit": "3974435bbf72722801f7ed78855381d77a773162",
+   "sha256": "0zdvz8lzrf7dj6giryy98wkxrrcawigvhab3prxwhjrkp8n9wvbv"
   },
   "stable": {
    "version": [
@@ -79070,18 +78888,6 @@
    ],
    "commit": "4eb8aa0aada012b2346cc7f0c55e07783141a2c3",
    "sha256": "0ivgvwrakgr527lylz9si1z3ip3n7bx02pj1acw8ab8swp1cxmy3"
-  },
-  "stable": {
-   "version": [
-    0,
-    2
-   ],
-   "deps": [
-    "cl-lib",
-    "org"
-   ],
-   "commit": "20eb3be6be9f0abbad9f0d007e40cb00c8109201",
-   "sha256": "0yxfhzygiki8sha1dddac4g72r51yi4jnga2scmk51f9jgwqbihp"
   }
  },
  {
@@ -79413,34 +79219,23 @@
   "repo": "rlister/org-present",
   "unstable": {
    "version": [
-    20210619,
-    1614
+    20211221,
+    822
    ],
    "deps": [
     "org"
    ],
-   "commit": "7414e406326622dbfb5aaf2905c4ac9f6696d6ed",
-   "sha256": "0cq2j0fcjlg7zvqim7hkbdsnlzw247vaba847d5n0d1yxl0527b6"
+   "commit": "f63302a21a9f7c9f66f443bf83b7a1150d0bdd9d",
+   "sha256": "0853hrqc8mq6dk6pafk3si49xy7ykj8v4p42zfrhfbfgs32bb75f"
   }
  },
  {
   "ename": "org-present-remote",
   "commit": "66b092084565634cac8dd07b7b1694d0ddb236ba",
   "sha256": "06xxxa8hxfxx47bs6wxi8nbgqc8nm82c3h0yv1ddlm35qfscggks",
+  "error": "Not in archive",
   "fetcher": "gitlab",
-  "repo": "duncan-bayne/org-present-remote",
-  "unstable": {
-   "version": [
-    20191206,
-    533
-   ],
-   "deps": [
-    "elnode",
-    "org-present"
-   ],
-   "commit": "dc3be74c544efc4723f5f64f54b4c74b523f0bbd",
-   "sha256": "0axl2wbkgb5vd7dm471gxw45lxv8za6wfcai15rjrfbhlxckj7l9"
-  }
+  "repo": "duncan-bayne/org-present-remote"
  },
  {
   "ename": "org-pretty-tags",
@@ -79450,11 +79245,11 @@
   "repo": "marcowahl/org-pretty-tags",
   "unstable": {
    "version": [
-    20201110,
-    1020
+    20211228,
+    1546
    ],
-   "commit": "5c7521651b35ae9a7d3add4a66ae8cc176ae1c76",
-   "sha256": "0ksj6hssyr44qnvb32qj9lrq825ivvndhck9gzx4h7gbxmvq12a4"
+   "commit": "e127a1e08df8273b909a99594ffaad84960ff212",
+   "sha256": "0wf58yrl05c6kw317szyyfipwn2sgi3d7sc49qw2ivk4w10ffwcg"
   },
   "stable": {
    "version": [
@@ -79639,8 +79434,8 @@
    "deps": [
     "dash"
    ],
-   "commit": "4ba26bbd26102c45c234bc6ce9a8e9c655c6a0a2",
-   "sha256": "0zhf4yfs6a50b5lq4yp9cmm6sv1j94hak6c353df76nssg4vbil5"
+   "commit": "86d7581202a37d2004589b8c8e9d8638806c6bcc",
+   "sha256": "1j5g90y5cwdwhdghg5zbm1fp7017acrl94napf90w156a1flmmgg"
   }
  },
  {
@@ -79877,8 +79672,8 @@
   "repo": "jkitchin/org-ref",
   "unstable": {
    "version": [
-    20211209,
-    2052
+    20220106,
+    1945
    ],
    "deps": [
     "avy",
@@ -79891,8 +79686,8 @@
     "parsebib",
     "s"
    ],
-   "commit": "12e5f9e89b92e731d5c199ff46f4f887ace9b791",
-   "sha256": "1h8sjcylqklssc5pw723cbl2paha47s3gcgqsn2ak9wzd0zkwads"
+   "commit": "413606f42e9fb206c9670bb54af5236646a3c564",
+   "sha256": "0k9bmfnnpdmfxnx5nz745y9flpw0hycral1g6158xqq1lg7d6gj0"
   },
   "stable": {
    "version": [
@@ -80039,8 +79834,8 @@
   "repo": "org-roam/org-roam",
   "unstable": {
    "version": [
-    20211213,
-    944
+    20220102,
+    603
    ],
    "deps": [
     "dash",
@@ -80050,8 +79845,8 @@
     "magit-section",
     "org"
    ],
-   "commit": "7068d63e966c0ca8d098ac4f7a90434f4c9b6822",
-   "sha256": "0yb2n4jvfpnbcvik8v2kfklgl4pbsxbkahl98m9bn56vgian9m2b"
+   "commit": "679ef6ef001fd1a69b691108178721aa913e7f0f",
+   "sha256": "1m36qs8jgn118pzjybs5kf2wxxz7013mzdm4sdszc2qk05syvzav"
   },
   "stable": {
    "version": [
@@ -80079,30 +79874,28 @@
   "repo": "org-roam/org-roam-bibtex",
   "unstable": {
    "version": [
-    20211203,
-    1348
+    20220105,
+    2300
    ],
    "deps": [
     "bibtex-completion",
-    "org-ref",
     "org-roam"
    ],
-   "commit": "196e5815dd13b014804122c4e32ee5f16f0ad66b",
-   "sha256": "1d09y923d9n5v7m201myba85m4064s2hdy3pgzssy70mjncg3m1g"
+   "commit": "070a7a732cf38f51245116ddd41aad8ac697c3b0",
+   "sha256": "166n1q30xamms4lfqq9vp0yknq33gwlk54qaravxxwz01fdpgb25"
   },
   "stable": {
    "version": [
     0,
     6,
-    1
+    2
    ],
    "deps": [
     "bibtex-completion",
-    "org-ref",
     "org-roam"
    ],
-   "commit": "196e5815dd13b014804122c4e32ee5f16f0ad66b",
-   "sha256": "1d09y923d9n5v7m201myba85m4064s2hdy3pgzssy70mjncg3m1g"
+   "commit": "070a7a732cf38f51245116ddd41aad8ac697c3b0",
+   "sha256": "166n1q30xamms4lfqq9vp0yknq33gwlk54qaravxxwz01fdpgb25"
   }
  },
  {
@@ -80131,16 +79924,16 @@
   "repo": "org-roam/org-roam-ui",
   "unstable": {
    "version": [
-    20211209,
-    1418
+    20220104,
+    1733
    ],
    "deps": [
     "org-roam",
     "simple-httpd",
     "websocket"
    ],
-   "commit": "9ed0c5705a302a91fab2b8bcc777a12dcf9b3682",
-   "sha256": "1am11vnzklv0cbivsw5r8x8fx457166mvfgyv7cdhrz88s8iqm23"
+   "commit": "5ecd418060bf606924ac86faa1aa4036d4c785fb",
+   "sha256": "1gj8bca7y8zjjnqjs0mg6vv2nvjrkqbqrj055zwkhz9sj36q5s5h"
   }
  },
  {
@@ -80169,20 +79962,11 @@
   "repo": "tyler-dodge/org-runbook",
   "unstable": {
    "version": [
-    20210825,
-    1544
+    20220107,
+    451
    ],
-   "deps": [
-    "dash",
-    "f",
-    "ht",
-    "ivy",
-    "mustache",
-    "s",
-    "seq"
-   ],
-   "commit": "f4c5e612d87d1ab96323b09cee1da859d9d74775",
-   "sha256": "0jbvrzigw0bjcm4lq7mmg97yh2kzchcmv4gwpmd6izgr1ajp2nir"
+   "commit": "dd11d253d3ee94b70f0d2cc74c6e85c6f5ac189d",
+   "sha256": "1vjmpdvcsqrry4jg07l84nfp7kx0wmjn60l60bcfmzj2mwcz4nak"
   },
   "stable": {
    "version": [
@@ -80396,14 +80180,14 @@
   "repo": "akirak/org-starter",
   "unstable": {
    "version": [
-    20210314,
-    1558
+    20211230,
+    1606
    ],
    "deps": [
     "dash"
    ],
-   "commit": "786257e682bf147022d5b19e6df6e7c9939193af",
-   "sha256": "1vfw06c08yhpc1dbqb4gprh9l3j0rgsyvhhgmvcv3y5cq2yaibhb"
+   "commit": "6b1b3b045390bf1cff8214ece54da07c7a0aa8ad",
+   "sha256": "0zih4bfncjkkrx9v4f88a26kz41vgd7wvvfm2is5wk93nbcrazz4"
   },
   "stable": {
    "version": [
@@ -80434,8 +80218,8 @@
     "org-starter",
     "swiper"
    ],
-   "commit": "786257e682bf147022d5b19e6df6e7c9939193af",
-   "sha256": "1vfw06c08yhpc1dbqb4gprh9l3j0rgsyvhhgmvcv3y5cq2yaibhb"
+   "commit": "6b1b3b045390bf1cff8214ece54da07c7a0aa8ad",
+   "sha256": "0zih4bfncjkkrx9v4f88a26kz41vgd7wvvfm2is5wk93nbcrazz4"
   },
   "stable": {
    "version": [
@@ -80462,8 +80246,8 @@
     20211201,
     1221
    ],
-   "commit": "cb1fa87896c5cc31430f2d375737144bb1982a76",
-   "sha256": "0q8vznz2q54qkvkspjamlphsgk95pjvlf89fc5m3v5pr92qhvzbk"
+   "commit": "a9b2a1fadba46952455281e6e5cde49fa2b1a3f5",
+   "sha256": "0r391bv1pi6vci03j521038r2ysz9m8l648rywpm6r1jc239sm8r"
   },
   "stable": {
    "version": [
@@ -81094,6 +80878,30 @@
   }
  },
  {
+  "ename": "org-visibility",
+  "commit": "74651e72ddac645b792786d7c590180298201da7",
+  "sha256": "0cwddhkk5wkff1ss52amifaybjk7lwrb04d4c48mgx0lyihdks76",
+  "fetcher": "github",
+  "repo": "nullman/emacs-org-visibility",
+  "unstable": {
+   "version": [
+    20220108,
+    1535
+   ],
+   "commit": "d01f93bb63740dedacbd446a05d55e9cd41d480e",
+   "sha256": "000y9228dhvmyr4j5vb969s482qnb9jhd0blwnmrbwm8cyb6ayyr"
+  },
+  "stable": {
+   "version": [
+    1,
+    1,
+    0
+   ],
+   "commit": "8e239079cb5f7df6dd0067cf48649ec95d16dbad",
+   "sha256": "000y9228dhvmyr4j5vb969s482qnb9jhd0blwnmrbwm8cyb6ayyr"
+  }
+ },
+ {
   "ename": "org-wc",
   "commit": "852e0a5cee285cc9b5e2cd9e18061fc0fe91d5a6",
   "sha256": "1yk2py4bzm2yr8vw6rbgl2hfpd21hf4fga0d5q6y779631klp6wl",
@@ -81465,8 +81273,8 @@
     "ht",
     "s"
    ],
-   "commit": "0a716d38268735b1df336161b3a7f3f8303539bb",
-   "sha256": "1nh51npi4j0g4kpshsipy9midi8n17qddfcv0isaizv6bm3z8aa4"
+   "commit": "8d90885d5a0cb5ad57b5202e2046bd3a0f3ce1f4",
+   "sha256": "1rp4dqm1qr6ndhrs7b06jhsy2ch8n9a82yma7abaz9hjdx6a6gz3"
   },
   "stable": {
    "version": [
@@ -81524,28 +81332,28 @@
   "repo": "magit/orgit",
   "unstable": {
    "version": [
-    20210620,
-    1943
+    20220107,
+    1206
    ],
    "deps": [
     "magit",
     "org"
    ],
-   "commit": "f956d802f19ea495efa95af6c673588afeb3adc5",
-   "sha256": "0mbcr98xq3zim01dk1fbyc1vajnjwx90k62mygv343rhrd05v44m"
+   "commit": "66367d6bfc5e00726fb74f7cd20c32175ab8521b",
+   "sha256": "0lc2lk9c7b92c1cna2pyb88x9fa4bydcqkp4zcn0khpdv54fmszq"
   },
   "stable": {
    "version": [
     1,
     7,
-    1
+    2
    ],
    "deps": [
     "magit",
     "org"
    ],
-   "commit": "f956d802f19ea495efa95af6c673588afeb3adc5",
-   "sha256": "0mbcr98xq3zim01dk1fbyc1vajnjwx90k62mygv343rhrd05v44m"
+   "commit": "66367d6bfc5e00726fb74f7cd20c32175ab8521b",
+   "sha256": "0lc2lk9c7b92c1cna2pyb88x9fa4bydcqkp4zcn0khpdv54fmszq"
   }
  },
  {
@@ -81592,28 +81400,28 @@
   "repo": "tarsius/orglink",
   "unstable": {
    "version": [
-    20211010,
-    2105
+    20220101,
+    1045
    ],
    "deps": [
     "org",
     "seq"
    ],
-   "commit": "05df4989c987dece40a450bd5cfbbd6cda0f2e7a",
-   "sha256": "184hag1kjbzfc7k7c1nd1y9w3gimgxjgkkyqawjzv00sph3mnvd4"
+   "commit": "d0210403b62eaf5c68f04a313f509589f253bc12",
+   "sha256": "1619ly90vh2lla5rbw87a4n0rfal3wpbf7005jjiyv2ay88nc7l9"
   },
   "stable": {
    "version": [
     1,
-    1,
-    6
+    2,
+    0
    ],
    "deps": [
     "org",
     "seq"
    ],
-   "commit": "2f1939488204f67d2a427f224b45596361b402b1",
-   "sha256": "0ipy1p2cr5i0465hchqazmgn9jrgwzbyrb3prfgkl7z2m1gd7fcg"
+   "commit": "d0210403b62eaf5c68f04a313f509589f253bc12",
+   "sha256": "1619ly90vh2lla5rbw87a4n0rfal3wpbf7005jjiyv2ay88nc7l9"
   }
  },
  {
@@ -82436,14 +82244,14 @@
   "repo": "yashi/org-asciidoc",
   "unstable": {
    "version": [
-    20210919,
-    1844
+    20211224,
+    538
    ],
    "deps": [
     "org"
    ],
-   "commit": "d60ac439278cec214882f92c47bc16e0f43ae98e",
-   "sha256": "1h5vjw4byhixl1vwgd13cy09z7zdh3mjrac4ffvc7xpzkmg4r0zm"
+   "commit": "27bf9a3e900c782bd57719c81c0aa68d9a1e3b46",
+   "sha256": "1xz5qr1kfhc9r5krdvg4lqc39gdszip44qqwkrkj9jm8pw713yfq"
   }
  },
  {
@@ -82632,14 +82440,14 @@
   "repo": "kaushalmodi/ox-hugo",
   "unstable": {
    "version": [
-    20211203,
-    1553
+    20220105,
+    1808
    ],
    "deps": [
     "org"
    ],
-   "commit": "88e60681901573797ce53c91ad8fa0936f6e4ee2",
-   "sha256": "0z2ln4iml780xk7qq996aihd7954jx2cpc6f7ayhhx9190dh6lcz"
+   "commit": "458142675bb5a0e7ee26ecea07d75c10aa52184b",
+   "sha256": "0m414myhyvk6ql7j9xr72frj7a1d6kn3s4va5zsyvzi5k5byh9nj"
   },
   "stable": {
    "version": [
@@ -82713,11 +82521,11 @@
   "repo": "gonsie/ox-jekyll-md",
   "unstable": {
    "version": [
-    20180831,
-    1732
+    20211222,
+    1718
    ],
-   "commit": "ff7b81733354c2b427293e531bb51647fa84fc88",
-   "sha256": "1fb08c1f9rky0akv9y2brbd38d7s36wcc7z9yvvk343p1kxfipid"
+   "commit": "26edb3f4575bcb0f1a2aed56237cd89694284449",
+   "sha256": "0zlmpz7j2b1vixr1mk16sllrj23m3jgrns81z2cab4bbyszs242y"
   }
  },
  {
@@ -82896,16 +82704,16 @@
   "repo": "emacsorphanage/ox-pandoc",
   "unstable": {
    "version": [
-    20211127,
-    1430
+    20211224,
+    1240
    ],
    "deps": [
     "dash",
     "ht",
     "org"
    ],
-   "commit": "eda1f21fd519427c070d165f8a663db07b87ac29",
-   "sha256": "1d8ymkxgfz5z3nrxaad90q4xdc8vj0vqyv9rwv2fhyx9gl72xhg9"
+   "commit": "b2e43b936249de2a100afb4262698105c39ce289",
+   "sha256": "1fj0d37xdn0xgr5xihc6g24j75snwpq5vijyc2n1w2qrw8sav0ak"
   },
   "stable": {
    "version": [
@@ -82962,14 +82770,14 @@
   "repo": "DarkBuffalo/ox-report",
   "unstable": {
    "version": [
-    20210604,
-    1436
+    20211226,
+    2004
    ],
    "deps": [
     "org-msg"
    ],
-   "commit": "9354a9687f7175d26c854204878b2fe545c069b5",
-   "sha256": "15jqcwmcpcb8vczzd50jasz46db9667yqcmzd4v4ahnxhvvb2vfb"
+   "commit": "37a173e9fa40728f121eb0da2ece0ebab4102d1e",
+   "sha256": "0xz6n8zabaimdh7dqikh3hm41akfwwm49hyjxbfyshbg8r4kld0s"
   },
   "stable": {
    "version": [
@@ -82997,8 +82805,8 @@
    "deps": [
     "org"
    ],
-   "commit": "59adea80013e962811b204403cc500a4d28b85a0",
-   "sha256": "133vzdhyzg5w5fqrams9n88adr8klpgb53g2ig2rvir3sckp449v"
+   "commit": "ec6092d2d5ed0693413a86ad83a2c0936861d130",
+   "sha256": "0xbk5q9vcy4n814a077kgsvhsbbr51v5lyqdpyy9j4sakh1sxw3k"
   }
  },
  {
@@ -83256,16 +83064,16 @@
   "repo": "LaurenceWarne/ox-yaow.el",
   "unstable": {
    "version": [
-    20210815,
-    1957
+    20220103,
+    2307
    ],
    "deps": [
     "dash",
     "f",
     "s"
    ],
-   "commit": "e20e52ef2968323d26a2e6cd0843c9b36195a1ff",
-   "sha256": "0q5k38raqq7ms4wdxqwxhc0pga31wn3v35dc0cv8dr687i9ck0s5"
+   "commit": "378eb55e39cbc06ead0f0c399351612dca22d716",
+   "sha256": "1vls5mhy2crn8zq6j627ywav85v7y782j6azb6bh326hasxhwikl"
   },
   "stable": {
    "version": [
@@ -83428,14 +83236,14 @@
   "repo": "melpa/package-build",
   "unstable": {
    "version": [
-    20211213,
-    1428
+    20211219,
+    302
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "da9fcbb6bf020922987914a96f1d12012c914d4c",
-   "sha256": "033137h1wwg37c45mmxzyz9ixx6sm90pin131nb6pi5z8jr80hw0"
+   "commit": "12da8c305ce8c7e753473d2f35ba2f6faa0c4d02",
+   "sha256": "03v5yh6jsxv2ihjvlyil0pb3pd7pmpwd6s1c4q3i425qlskvv4p6"
   },
   "stable": {
    "version": [
@@ -83631,16 +83439,16 @@
   "repo": "codingteam/pacmacs.el",
   "unstable": {
    "version": [
-    20210225,
-    1255
+    20220106,
+    2248
    ],
    "deps": [
     "cl-lib",
     "dash",
     "f"
    ],
-   "commit": "5e0bcba1eeb10a4218087ff9cd6217d662fb775b",
-   "sha256": "15w7wr3bdqmwg459nl6vyf4ymrhqxk9pvli5q55qyvy905n3281j"
+   "commit": "25a8c30210f6bd94634a7ff743a2f8be391ed3b3",
+   "sha256": "0wklzqwds2dxf41g677rr9b5n3hviza5145j6aknj2mjjvsrb0zi"
   }
  },
  {
@@ -83746,14 +83554,14 @@
   "repo": "zainab-ali/pair-tree.el",
   "unstable": {
    "version": [
-    20210214,
-    1651
+    20211219,
+    1816
    ],
    "deps": [
     "dash"
    ],
-   "commit": "972ba441c40edf9b2c212f64fc6670104749662b",
-   "sha256": "1v4d17hdh3dvb2a4n10gxlr20zal8c7v456wiknkfrpv06d8awap"
+   "commit": "6fe6143954bb4025ce6b05aad41e777fcbf413d9",
+   "sha256": "1m8499jy2fsxw41d4kmsc77rbrlagl0bfnlk83644vjrxk8ljwjk"
   }
  },
  {
@@ -84207,11 +84015,11 @@
   "repo": "dp12/parrot",
   "unstable": {
    "version": [
-    20191015,
-    2127
+    20220101,
+    518
    ],
-   "commit": "29265d118267e524453aaa9121c4eae213a63164",
-   "sha256": "04mpwsn16i00rbjyd3959kjyw1qn9xw9d9as6syhsfq5mzhwksni"
+   "commit": "1d381f24d74242018e306d1a0c891bed9a465ac3",
+   "sha256": "0jvnaplab6bsq9pv89zl6amrs39ay6qlzgm0lls6ij9bbrsyjlvp"
   },
   "stable": {
    "version": [
@@ -84252,8 +84060,8 @@
    "deps": [
     "s"
    ],
-   "commit": "d14391468c6693016a1960a0480d5589658adddd",
-   "sha256": "1gykb9h4pq428w135591dj49ikp078jrxv8n2hhvf9ri69q3cdg6"
+   "commit": "b9b77285fdef7936baea5447b37651f67c51f041",
+   "sha256": "1xg829a0wjrjh64lzccr65j5sr1zh9wzvbid65f0c733nyizcy0f"
   },
   "stable": {
    "version": [
@@ -85035,27 +84843,29 @@
   "repo": "vedang/pdf-tools",
   "unstable": {
    "version": [
-    20211110,
-    513
+    20220107,
+    1241
    ],
    "deps": [
     "let-alist",
+    "nadvice",
     "tablist"
    ],
-   "commit": "a8847b75d3487d60e27762816bdbdd23b6dc1c11",
-   "sha256": "1dv244rxlgb56fzx1d1w9ngdjdrc7bgssshvkrfkxbwy69i803b3"
+   "commit": "4e6c778194bea39d81871a3caa0b72539fdb6868",
+   "sha256": "076597i0c3s8l010m6xirass0grcs3pjxs7l19xj8219x9lkf8l5"
   },
   "stable": {
    "version": [
     0,
-    90
+    91
    ],
    "deps": [
     "let-alist",
+    "nadvice",
     "tablist"
    ],
-   "commit": "af1a5949c2dae59ffcbcf21cc4299fa2fc57ce72",
-   "sha256": "0iv2g5kd14zk3r5dzdw7b7hk4b5w7qpbilcqkja46jgxbb6xnpl9"
+   "commit": "2f5a1b939369657eb56d4cfa4bdf0b5c11aacb1d",
+   "sha256": "07ixspgn4s1jg66w7m2f3sh43giakz9srhp7rpw389z32g57i1rx"
   }
  },
  {
@@ -85201,16 +85011,9 @@
   "ename": "per-buffer-theme",
   "commit": "2a2a6c0bf1cad99ed82db7b90b8b7ab79827ac17",
   "sha256": "06vykjgf4rxh832z74jxkhi4jxlh60hnh8zjvdyr9nbh1dy35bjn",
+  "error": "Not in archive",
   "fetcher": "hg",
-  "url": "https://hg.serna.eu/emacs/per-buffer-theme",
-  "unstable": {
-   "version": [
-    20200527,
-    1256
-   ],
-   "commit": "f29b5c57198ebfedbf142f95129190c6c00b4822",
-   "sha256": "0b39m8zmy4yfj3z93q3gqqqhhmyb10kd76fl7347pm6xgq4sl1g0"
-  }
+  "url": "https://hg.serna.eu/emacs/per-buffer-theme"
  },
  {
   "ename": "perfect-margin",
@@ -85474,6 +85277,40 @@
   }
  },
  {
+  "ename": "perspective-exwm",
+  "commit": "fc6d6ed5106cde74a56f4deeb99fe5e9a80dabe3",
+  "sha256": "0vrpvy68al0xs6cwqjxv0yq9h24g1r67sydmls9yb2i8qf9ba472",
+  "fetcher": "github",
+  "repo": "SqrtMinusOne/perspective-exwm.el",
+  "unstable": {
+   "version": [
+    20220103,
+    909
+   ],
+   "deps": [
+    "burly",
+    "exwm",
+    "perspective"
+   ],
+   "commit": "3a4d382a744149b8bdbea5b62f66f6705fd5e2c7",
+   "sha256": "1kpciigv0lxdxswnqjdbqlk30jlzvzy9li21z1kbnr5plflj3ffb"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    4
+   ],
+   "deps": [
+    "burly",
+    "exwm",
+    "perspective"
+   ],
+   "commit": "ebe6f50be216d55ff2aea878aaf4b7c2c1032bdc",
+   "sha256": "0drjfyfmhil20pv96af8s4w3xzm3pqx095n89r0aqzp2falvrvpw"
+  }
+ },
+ {
   "ename": "perspeen",
   "commit": "855ea20024b606314f8590129259747cac0bcc97",
   "sha256": "0kwmllas9vnppsfaviy58d0nk4hmlqp566mfr4l53x46sybv1y04",
@@ -85531,19 +85368,20 @@
   "repo": "Alexander-Miller/pfuture",
   "unstable": {
    "version": [
-    20200425,
-    1357
+    20211229,
+    1513
    ],
-   "commit": "d7926de3ba0105a36cfd00811fd6278aea903eef",
-   "sha256": "1chpin5277vbl2xvsl04pzzk7a9dbcvclibm2496gz6yvd19pwsf"
+   "commit": "bde5b06795e3e35bfb2bba4c34b538d506a0856e",
+   "sha256": "0cks18fwir8h9b35ryz2yr5rligv1da2iqkqz0fcb5dx2a4fxwjj"
   },
   "stable": {
    "version": [
     1,
-    9
+    10,
+    2
    ],
-   "commit": "d7926de3ba0105a36cfd00811fd6278aea903eef",
-   "sha256": "1chpin5277vbl2xvsl04pzzk7a9dbcvclibm2496gz6yvd19pwsf"
+   "commit": "bde5b06795e3e35bfb2bba4c34b538d506a0856e",
+   "sha256": "0cks18fwir8h9b35ryz2yr5rligv1da2iqkqz0fcb5dx2a4fxwjj"
   }
  },
  {
@@ -86535,8 +86373,8 @@
     "dash",
     "s"
    ],
-   "commit": "5493309f17e7d30254e3832162f73b486079d12d",
-   "sha256": "1agnag5n516966np9027zjvpyr27nrawh1l0l6hmy6hy8hb1jwpq"
+   "commit": "1e96053ffdcbf64e4c8a0a622feddc3cb0a82ded",
+   "sha256": "00rnzy7r397k6dwsflnv5lc7x5hcnkr4g784zj3bs8rq64h7dcz0"
   }
  },
  {
@@ -86680,13 +86518,6 @@
    ],
    "commit": "48b37b9b19d8f1e0accbf930f30b5346cf7959fe",
    "sha256": "0pi4sjp0aq279m449lw4rbppdivzkazd07bh9jqrmyrw9wib3hbl"
-  },
-  "stable": {
-   "version": [
-    8
-   ],
-   "commit": "2609a811335d58cfb73a65d6307c156fe09037d3",
-   "sha256": "0g5vl4xigdm2pn2mnkwgj1kxdjr66w7ynr77bchy3ij6qvzdzkqd"
   }
  },
  {
@@ -87743,11 +87574,11 @@
   "repo": "polymode/polymode",
   "unstable": {
    "version": [
-    20211124,
-    913
+    20220106,
+    1236
    ],
-   "commit": "47a7b6541a1e1cea9c22052fa202b7fdb715f03b",
-   "sha256": "02znv2pg07wn13jxgfbik306y3haafapjfib9pnl96aqbv264kp3"
+   "commit": "4ded73e39e5b367d349b9c6e490865e72c070b13",
+   "sha256": "0gm1604pbhkyfd1hiqpjkkdwl99y9kc46c1sgljyyyvw04lpf15j"
   },
   "stable": {
    "version": [
@@ -87776,15 +87607,6 @@
    ],
    "commit": "52134701fa76b12252b06c9d6fd4e8665596a95a",
    "sha256": "1h94dgjcbpd6vr1wgvajx7d0ikz5jl4zdmxjgqzff0cg2vqin3r6"
-  },
-  "stable": {
-   "version": [
-    0,
-    6,
-    1
-   ],
-   "commit": "bf3ca99c24a84befe9ed76b9636ec9adb37ab844",
-   "sha256": "1qsgx1vh0xsk1wwpyx8lpnpa4879bzf0gil28v94sncbri2c6f7w"
   }
  },
  {
@@ -87795,30 +87617,30 @@
   "repo": "SqrtMinusOne/pomm.el",
   "unstable": {
    "version": [
-    20211125,
-    1806
+    20211219,
+    728
    ],
    "deps": [
     "alert",
     "seq",
     "transient"
    ],
-   "commit": "2b58c3cad0106299d98e4a12de4f78dbd96fe67b",
-   "sha256": "1i3rimbyw7bkjdifwmzhf56alkhhhvblkjrxpgbnjmbg26xd6zdd"
+   "commit": "596eed778fa30e7b33910f015543eda13abd1888",
+   "sha256": "0arhl9x9d4d1s4x5qcf1kn9hkwgsrs6sjn0rky10pgja7gqh6214"
   },
   "stable": {
    "version": [
     0,
     1,
-    3
+    4
    ],
    "deps": [
     "alert",
     "seq",
     "transient"
    ],
-   "commit": "2b58c3cad0106299d98e4a12de4f78dbd96fe67b",
-   "sha256": "1i3rimbyw7bkjdifwmzhf56alkhhhvblkjrxpgbnjmbg26xd6zdd"
+   "commit": "596eed778fa30e7b33910f015543eda13abd1888",
+   "sha256": "0arhl9x9d4d1s4x5qcf1kn9hkwgsrs6sjn0rky10pgja7gqh6214"
   }
  },
  {
@@ -87902,8 +87724,8 @@
     "yafolding",
     "yasnippet"
    ],
-   "commit": "1abf04bc8f4f09a6add4b587c7cf5ca23735e7c0",
-   "sha256": "1iv04dj2nc9cyyslhir7aj5sligwan1yyclsiarn86lik7b9lmwn"
+   "commit": "61f54d0620229afdd049dfe75681942bcf52e53d",
+   "sha256": "1z04y3kxbj2lisawl5yxwg7q8qry02fhmv0is6wwv3gmgnbk1kns"
   },
   "stable": {
    "version": [
@@ -87980,11 +87802,11 @@
   "repo": "karthink/popper",
   "unstable": {
    "version": [
-    20211116,
-    624
+    20211226,
+    2111
    ],
-   "commit": "4d58a6dbba5d488ff9ac9318e202d84da505e691",
-   "sha256": "0l4y8f6j6sfr91rqcdv0lx6bgzskpsamd4w4fb7lp6qghmm8iyvk"
+   "commit": "8af5e6b3bb08a71abbafba2491e3ab001a13a067",
+   "sha256": "1pcf5jdzh94c1x99z2w71cp3866g4qnqv9bs4aqmik54xklnkrh5"
   },
   "stable": {
    "version": [
@@ -88003,11 +87825,11 @@
   "repo": "auto-complete/popup-el",
   "unstable": {
    "version": [
-    20210625,
-    400
+    20211231,
+    1823
    ],
-   "commit": "cf899f8012f4189e76a009bebb589ff71631b1e9",
-   "sha256": "09nf95bin4dq50vapax8xndm0bay2cbsws4zvpb4hp3kk0gdzrl6"
+   "commit": "ec3d3169a4d60b0374198580e31b6c59f51ab08a",
+   "sha256": "12ymj71fsps0q4rk2hcj80nf93i5iq93sg0fw6dkn8swdvmhp1lz"
   },
   "stable": {
    "version": [
@@ -88248,11 +88070,11 @@
   "repo": "tumashu/posframe",
   "unstable": {
    "version": [
-    20211126,
-    944
+    20220107,
+    2350
    ],
-   "commit": "3b1dc400d286b0a4bd42e518bf3e7eedb49fd1e6",
-   "sha256": "0z05wfw1rv0jiqwyybvs4g4br5mb7xw1r2s1cdvirzi5z8ikh658"
+   "commit": "8a76d75aa851a314e60a3c20eec81e7e6f952a13",
+   "sha256": "14cvakpp5nmincpcyvb6pzv2d5dky7qap43zk3kbydbp0va9r9dy"
   },
   "stable": {
    "version": [
@@ -88391,19 +88213,11 @@
   "repo": "jschaf/powershell.el",
   "unstable": {
    "version": [
-    20201005,
-    1642
+    20220103,
+    925
    ],
-   "commit": "d1b3f95669343399f199f291ef76c09a0ede5e60",
-   "sha256": "1cxhzaaig88zhylyycvb3849r85j1ijqklnh9zbqsfl2zhpb0g5c"
-  },
-  "stable": {
-   "version": [
-    0,
-    1
-   ],
-   "commit": "7316f44d0b528552f5a0692f778e5f0efd964299",
-   "sha256": "010b151wblgxlfpy590yanbl2r8qhpbqgi02v0pyir340frm9ngn"
+   "commit": "ce1f0ae0b2e41cd0934a9dfbf2ff016b1d14e9c0",
+   "sha256": "111aqj1858ykimwdp2kh2j599n3rzz0nnv0sq424jn8dypx0fcvr"
   }
  },
  {
@@ -88492,8 +88306,8 @@
   "repo": "blahgeek/emacs-pr-review",
   "unstable": {
    "version": [
-    20211128,
-    755
+    20211219,
+    224
    ],
    "deps": [
     "ghub",
@@ -88501,8 +88315,8 @@
     "magit-section",
     "markdown-mode"
    ],
-   "commit": "f1e1bc2a5ad2092afdba8568d554f35ebc98bec7",
-   "sha256": "07f98c2d9wszlxj6gvrnnb60krbgf55wahg1d16p2mwqczgdl7cp"
+   "commit": "bae2d8aff61cbe05da6f3f41e6cf854ece4a41f0",
+   "sha256": "1p9vbhsal667cjh36wmww95c6c3srp3hqi2yfq9srmplma7ffc5n"
   }
  },
  {
@@ -88551,19 +88365,19 @@
   "repo": "raxod502/prescient.el",
   "unstable": {
    "version": [
-    20211031,
-    1908
+    20211228,
+    417
    ],
-   "commit": "292ac9fe351d469f44765d487f6b9a1c1a68ad1e",
-   "sha256": "0ywx7q41i9pzmfgwv83mz5z17gril2s0r7y77hbbriww5yy1ihx4"
+   "commit": "3dbcef387502d309d130a518a18d48cd2f0e15b7",
+   "sha256": "024l7s0b6apbzanw3cnhjypxnxfinfb5b3nhaabrc138m5pis8j5"
   },
   "stable": {
    "version": [
     5,
-    1
+    2
    ],
-   "commit": "2c0e9fc061ab723ec532428f312974ca7d8def12",
-   "sha256": "0d6kbczkamhhcmc8bf01q6k1x0g7dwjihwllzsldgga3dclyh4ks"
+   "commit": "3dbcef387502d309d130a518a18d48cd2f0e15b7",
+   "sha256": "024l7s0b6apbzanw3cnhjypxnxfinfb5b3nhaabrc138m5pis8j5"
   }
  },
  {
@@ -88681,16 +88495,16 @@
   "url": "https://gitee.com/shaqxu/prettify-math.git",
   "unstable": {
    "version": [
-    20211107,
-    38
+    20220101,
+    549
    ],
    "deps": [
     "dash",
     "jsonrpc",
     "s"
    ],
-   "commit": "e1925aa3419b1b4d5670040fcc8543382489507f",
-   "sha256": "0vnwncr3vvckg7mk9z5zfr2pphzid5lbv32jah1ii2cmjcksdhwg"
+   "commit": "5bdb9a8af7593d3a38492a618aedc545278fe8a1",
+   "sha256": "1aid6z5hwrnqx2gidfwpgy6kx2v29kw2q29cnq1rbhh3w49l6m7z"
   }
  },
  {
@@ -88780,6 +88594,24 @@
    ],
    "commit": "582cbe51ecfe1cc0a5b185bc06113c8a661e3956",
    "sha256": "1f00l9f6an1mh8yhf629mw0p37m4jcpl8giz47xbdyw1k6bqn830"
+  }
+ },
+ {
+  "ename": "preview-dvisvgm",
+  "commit": "bfb12c03689d61a02f5cf725d8877678c284f4c7",
+  "sha256": "1qmaqlabgx0r66kzmz3fzlkl160vkpgqybb1qx8na7lfj6dcnbfs",
+  "fetcher": "github",
+  "repo": "TobiasZawada/preview-dvisvgm",
+  "unstable": {
+   "version": [
+    20211225,
+    635
+   ],
+   "deps": [
+    "auctex"
+   ],
+   "commit": "630e2f008c4a6c67a01824b7ad6b844977b28f87",
+   "sha256": "1nkyxgqcwxp29prp69j5xg06am4gd3sghr0j7r7ws3q85rq197xf"
   }
  },
  {
@@ -89054,8 +88886,8 @@
     20210715,
     1213
    ],
-   "commit": "4b059ff6ce8cc2ca817247fcc251994bee2090e4",
-   "sha256": "0jn8drn49ab15a7j0584hihzyw66zyq5zv7wwbipnwwkqrd4cagk"
+   "commit": "8c76f26c667a9748835a86ded0c7fc8f1c558b4c",
+   "sha256": "05fxlia6bqf9jcx963fa0kn06va256dj7hmdli04vlp8h748sljj"
   },
   "stable": {
    "version": [
@@ -89171,29 +89003,6 @@
   }
  },
  {
-  "ename": "project-root",
-  "commit": "bcf69e7e859145cb908e79abf4a2f51050e52ace",
-  "sha256": "0mhc7l6px5q2x13h6nmf4ixsghjlzbxjm2liscwn6485yg4bsmja",
-  "fetcher": "github",
-  "repo": "piranha/project-root",
-  "unstable": {
-   "version": [
-    20110206,
-    2030
-   ],
-   "commit": "a49b1be864357683d9489074148b6d667f4ed23b",
-   "sha256": "0nw02f5lmbqdfnw93d3383sdxx1d31szk23zvjlrmmdwv2124281"
-  },
-  "stable": {
-   "version": [
-    0,
-    7
-   ],
-   "commit": "fc1d024a497755c1abfa3eaffde1b18bd3c54865",
-   "sha256": "1z0sqdwa8caick2179bj03qbhjmvh2l5gv1ny6aya979vjgsk0g8"
-  }
- },
- {
   "ename": "project-shells",
   "commit": "becf54de5ae9582d7c76382dff16d40b04b1a464",
   "sha256": "0mhifxcpgsfwrhbs7axg6ja4klgzzy9pc0nqa7w3qg45xgi9s4m8",
@@ -89234,11 +89043,11 @@
   "repo": "bbatsov/projectile",
   "unstable": {
    "version": [
-    20211206,
-    1920
+    20211220,
+    1144
    ],
-   "commit": "2bb7ec28b1275bbce7cac743ee9e7b2cf41c5bbd",
-   "sha256": "1m1d5p87k09wxs2pbia37s9c4ik60vj094xnkxnr3vwyvs5d0a17"
+   "commit": "4e6f66c329e57d66269b4bd3fc02518eb0c677bc",
+   "sha256": "10imlg3qmyskpzbw5i1ac1chn5yiyl3wi3wx9l3sn4kkjgggiicl"
   },
   "stable": {
    "version": [
@@ -89640,19 +89449,11 @@
   "repo": "ProofGeneral/PG",
   "unstable": {
    "version": [
-    20211125,
-    1509
+    20211217,
+    1753
    ],
-   "commit": "1b1083e86e0cddc20ff2f1a6b25c7a7eee2edf02",
-   "sha256": "1pnysczhscapgwmvf6ix7f31lf3hnh8h977bfll1m7jlxl9b9c0j"
-  },
-  "stable": {
-   "version": [
-    4,
-    4
-   ],
-   "commit": "771cab48b2f9ea2ae3fa8f944d0e36a805bf9f3b",
-   "sha256": "0bdfk91wf71z80mdfnl8hpinripndcjgdkz854zil6521r84nqk8"
+   "commit": "a61a1d8e5ffa610b794535995d58adf18e9ec47b",
+   "sha256": "1c6216yz2wb9c5yn5rq6jr9pwxb44vhvgnsi0wsh0rcccm24mdp8"
   }
  },
  {
@@ -89747,17 +89548,17 @@
     20211013,
     1726
    ],
-   "commit": "29b3d01572d50c0e5bc0ab2eea32f9779c7576f4",
-   "sha256": "041m090j0pc3svfvybfg8lcip9hzgfvwklf82ynkv2hsddfn9q1b"
+   "commit": "0ac74b8126b76498075f43c37603d67a15d8d205",
+   "sha256": "0bir3qvs0ycx4xi74hnjpnzw9dz52i1bdv9l7hfcw1h8qba0z354"
   },
   "stable": {
    "version": [
     3,
     19,
-    1
+    2
    ],
-   "commit": "7c40b2df1fdf6f414c1c18c789715a9c948a0725",
-   "sha256": "1swpq2lkkgz5pwq6q3jn6xgkbaiq9dy20rvmrlghdp0fkfg2a011"
+   "commit": "cb46755e6405e083b45481f5ea4754b180705529",
+   "sha256": "085gxmrinxcm0yy4bm2hkcz7g3s0vbfp6afp7ka17pr80ixqgq22"
   }
  },
  {
@@ -89900,15 +89701,15 @@
   "repo": "thierryvolpiatto/psession",
   "unstable": {
    "version": [
-    20211002,
-    939
+    20211228,
+    839
    ],
    "deps": [
     "async",
     "cl-lib"
    ],
-   "commit": "76da05f5fb798572a911c398d2dd6f5f30a74746",
-   "sha256": "07kf8panrfdvqqzklxkhkjbry1fpsb9c6cijjkzrnj4fjwggbkbp"
+   "commit": "97f6fb308fcb007e53c7277fb4603a6faef99c79",
+   "sha256": "0k2myrd1ar2nlgnavsvbawiff7x27fr72921xnzp7rwnl07klyji"
   },
   "stable": {
    "version": [
@@ -90653,15 +90454,15 @@
   "repo": "tumashu/pyim",
   "unstable": {
    "version": [
-    20211213,
-    1253
+    20220108,
+    806
    ],
    "deps": [
     "async",
     "xr"
    ],
-   "commit": "02c50045cb14ab253d8d8435e83e7f10b0bbc130",
-   "sha256": "1gydldssvg368nqpk9xy9snzhp3rb33nlygnwmh9ah4yaq412lh3"
+   "commit": "6e3394ba8b72bdc3e018a6d18817ae69403afb87",
+   "sha256": "0vd5diyb4m9qbv8bsasqq1yaac1jbqc6cna4lrpvfbvx25yinvay"
   },
   "stable": {
    "version": [
@@ -90838,8 +90639,8 @@
     20210411,
     1931
    ],
-   "commit": "35254c29eb3a0f1c7847cfcb3451501a4180373d",
-   "sha256": "1cqslii8dyvrc934v5ydhdmrhq2bj2ravrpj7d3ag38gq4lskwlx"
+   "commit": "3fc855f9d0fa8e6410be5a23cf954ffd5471b4eb",
+   "sha256": "0v54z3r629c6z4pxbf4h5nhvfdyxp33ld4vpb8c4681r60wnh6qj"
   },
   "stable": {
    "version": [
@@ -90967,15 +90768,15 @@
   "repo": "wbolster/emacs-python-black",
   "unstable": {
    "version": [
-    20210511,
-    1545
+    20211217,
+    2037
    ],
    "deps": [
     "dash",
     "reformatter"
    ],
-   "commit": "01f1f4269136cfb36938567854383628730faaab",
-   "sha256": "1a8dfz5riw2vlbi9mgb768gb29s5fnbfzas4fw8v1a4cxgwx6b0w"
+   "commit": "cc6919e758b5845b201e1cb08a9b5d9a2598a7f1",
+   "sha256": "1jz4kyj08s1pn7d5z0hpc8asy8kfs3mfqg3i8bps1cbrpx5aky5m"
   },
   "stable": {
    "version": [
@@ -90999,11 +90800,31 @@
   "repo": "thisch/python-cell.el",
   "unstable": {
    "version": [
-    20200314,
-    1147
+    20220105,
+    2315
    ],
-   "commit": "4f0778b05bfb936861449bcb998ed620cd9b31ad",
-   "sha256": "0fjqy8wkxm8m94xfvvj12fpx8ybaln8x4ss9b0iaz9y9jvfwzg21"
+   "commit": "9a111dcee0cbb5922662bfecb37b6983b740950a",
+   "sha256": "17izy7sd7v2144yhshv0nymqx6bkrc1grb60imz5ipqhm6b6yf92"
+  }
+ },
+ {
+  "ename": "python-coverage",
+  "commit": "1c0afcc1904056c290a31cd8e9e144d425dc4c67",
+  "sha256": "1c1vx3zakay1l670i9mh7ing27w9k35a4xfipi4ldimgjxrlnbxr",
+  "fetcher": "github",
+  "repo": "wbolster/emacs-python-coverage",
+  "unstable": {
+   "version": [
+    20211224,
+    1420
+   ],
+   "deps": [
+    "dash",
+    "s",
+    "xml+"
+   ],
+   "commit": "a341615af03dbe3ce0ac9b63cf43dc01c1ae5ebe",
+   "sha256": "1k5air9sgg95jl949lwf9hz8i4ivy646mnm4pc37wsxkh4g46wqh"
   }
  },
  {
@@ -91142,11 +90963,11 @@
   "repo": "jdtsmith/python-mls",
   "unstable": {
    "version": [
-    20211211,
-    1934
+    20211215,
+    240
    ],
-   "commit": "6987b9fa0f664a1ede7e6a24684ed328eb412d5c",
-   "sha256": "176g9vg3xs8sys0kk3lfx3qq7p6q65d7f7d014pb8fwsi5nvhl47"
+   "commit": "2f7ce2c44e5d94eade297c07139bec6353e18ad7",
+   "sha256": "1m26nsdzciy5p1hv5vwhg51aw3bym6w7dqmjhk2y8nm3vdn48dn6"
   },
   "stable": {
    "version": [
@@ -91166,11 +90987,11 @@
   "repo": "python-mode-devs/python-mode",
   "unstable": {
    "version": [
-    20211117,
-    1920
+    20211229,
+    1002
    ],
-   "commit": "220379ffcd7961f290d7a4d9f67da136fffb25a6",
-   "sha256": "1h2hplhsqlh6vhdbjc93mf6hkvix8c5s49gbl48v3hr34pj6992r"
+   "commit": "dcb376044d020dfe30f8e4273e61863b7d9615ce",
+   "sha256": "1638zl7aa2rf74d7rc396b5hda9fvlndapnivv3axc06mnf86rkk"
   },
   "stable": {
    "version": [
@@ -91190,8 +91011,8 @@
   "repo": "wbolster/emacs-python-pytest",
   "unstable": {
    "version": [
-    20211111,
-    1912
+    20211215,
+    1101
    ],
    "deps": [
     "dash",
@@ -91199,8 +91020,8 @@
     "s",
     "transient"
    ],
-   "commit": "e77469fcb727f1b63f0d921ed15b1631a6bd0cae",
-   "sha256": "1dgk8s4wdjckaiv20gnlj3p6xbxp8g9i7q26lmmzbf40ri2qq7hk"
+   "commit": "b603c5c7f21d351364deeb78e503d3a54d08a152",
+   "sha256": "176c4banbgd474iw49cw17wbvncr13xwgqjsfpvvakd0awpyvzw1"
   },
   "stable": {
    "version": [
@@ -91481,11 +91302,11 @@
   "repo": "quelpa/quelpa",
   "unstable": {
    "version": [
-    20210329,
-    639
+    20211228,
+    248
    ],
-   "commit": "9acc440f8c200b1e6134f53e219d84360ee1b6b7",
-   "sha256": "1qk7x9fdcvr84hhrmpvx4lq798n9xlw2fi7zpqgfp1mci9qks0z1"
+   "commit": "54fc5b951f103fadba25dde38274964737815883",
+   "sha256": "0ckbl69d4xk64gzvy2mmgqa9v3z76nm673k3an937gnnh0l4xssx"
   },
   "stable": {
    "version": [
@@ -91511,8 +91332,8 @@
     "leaf",
     "quelpa"
    ],
-   "commit": "cc13df4a6c6cdf1dea558be5b6e99b6e8d8b4065",
-   "sha256": "0jiwdz1psfkha17by281ii0adjschld0hwl439bawgvzpw1a0zi2"
+   "commit": "1fb156302a4b14ee003720b7dbac5f3041345842",
+   "sha256": "18cy7kjhi6jcixnbl3vvmszrbkh04cbpkjk8ls1m6apvc0l0g9ll"
   },
   "stable": {
    "version": [
@@ -91809,11 +91630,11 @@
   "repo": "greghendershott/racket-mode",
   "unstable": {
    "version": [
-    20211130,
-    1748
+    20220106,
+    1455
    ],
-   "commit": "ef54a42ddd32f8827eef430f0410e392f9cb1726",
-   "sha256": "1x81l60k4qb2ffb85sqjr704dyh8dy28wq4rc8d5vc9qpmm1z3kf"
+   "commit": "184c2c8be4d9eff00477995a99153889fea46305",
+   "sha256": "1yfryz3vpsd32y496ccvnimg84pbvgnbgjnfsa6v165xw1xky92v"
   }
  },
  {
@@ -91944,8 +91765,8 @@
     20210515,
     1254
    ],
-   "commit": "d576e6694ad3a3e88b2bb1363305b38fa364c149",
-   "sha256": "0sw5zjpg8xg0ri550vmblfm0h0ra56vh0vsxwglk24w29flvn18m"
+   "commit": "a32b39bdfe6c61c322c37226d66e1b6d4f107ed0",
+   "sha256": "16nnmpiqg28zfmhfj38nrjcvjlsivzp5a0py7ivm3qhn1g6qzbql"
   },
   "stable": {
    "version": [
@@ -92552,8 +92373,8 @@
     "loc-changes",
     "test-simple"
    ],
-   "commit": "978b455d7da4dc41995192bfabc32092622651dd",
-   "sha256": "00kjkc8fpvcjapnrk2fmnxspn9p3z9b3niyrqnyzif3kzmdsqz1i"
+   "commit": "3c88611c4ed59069093187c2a039b8d05cbe53e8",
+   "sha256": "0dcrq6lad538a18nll3fp55d4m2jl65axzilgrksmqshhhi18qk1"
   },
   "stable": {
    "version": [
@@ -92863,19 +92684,20 @@
   "repo": "nickdrozd/reazon",
   "unstable": {
    "version": [
-    20210831,
-    1208
+    20211229,
+    1733
    ],
-   "commit": "d697c0dfe38ac7483e453e8ce8056acf95c89ba2",
-   "sha256": "12s2h4wd7cz9x078698wwjjpy874rk8cm2d17p6ksb10y3cmrqsn"
+   "commit": "f31c8b2e911c5885551d063c0a2b5de49a646eb1",
+   "sha256": "1w8gv48ixf4fp35isr4jlnwygwqh8q04i3bbgwf3zldpzgmm3iwa"
   },
   "stable": {
    "version": [
     0,
-    4
+    4,
+    1
    ],
-   "commit": "d697c0dfe38ac7483e453e8ce8056acf95c89ba2",
-   "sha256": "12s2h4wd7cz9x078698wwjjpy874rk8cm2d17p6ksb10y3cmrqsn"
+   "commit": "21a4218538eee90af66c20519457efeb5b319e22",
+   "sha256": "163cfji24f0qc6kbrm9ckcvijsslcfb3qnc6y4iy1i9mcwknkkcj"
   }
  },
  {
@@ -93119,11 +92941,11 @@
   "repo": "minad/recursion-indicator",
   "unstable": {
    "version": [
-    20211017,
-    1727
+    20220102,
+    1257
    ],
-   "commit": "bf3aa89893c10a01d5605b8d19b3583cd432cb27",
-   "sha256": "1fg2m1n61sy6iqv5m299rbwdrdkphpd68jq6l1npnlszwa3814ka"
+   "commit": "c5ad65274f8e20fbf7a4485a5b51b50a5cc6b4c9",
+   "sha256": "0vnnkz5fgbdkr44yfyhv8w8vyzj4pfvi7858rgxw4sgj3zbj3x3p"
   },
   "stable": {
    "version": [
@@ -93147,6 +92969,21 @@
    ],
    "commit": "5e3e2067d5a148d7e64e64e0355d3b6860e4c259",
    "sha256": "1dxghz1fb2l7y7qphqk0kk732vazlk1n1fl6dlqhqhccj450h2qa"
+  }
+ },
+ {
+  "ename": "redacted",
+  "commit": "1a3e52044aac276368371cd08c5d07bd659121ce",
+  "sha256": "0gphrv0cl0bjwcc0h0vm0lr5z85v3vcp6hyr1h9iw5fqxiiamkj7",
+  "fetcher": "github",
+  "repo": "bkaestner/redacted.el",
+  "unstable": {
+   "version": [
+    20220108,
+    1037
+   ],
+   "commit": "c4ea6cbffda9c67af112f25b2db2843aa4abce85",
+   "sha256": "1p693dbnx2vq2a7fps28nxd37jcdw4iba2fkac6qf02sqa2xwxk9"
   }
  },
  {
@@ -93232,15 +93069,6 @@
    ],
    "commit": "c72190de76f7ed1cfbe1d2046c96e99ac5022b0c",
    "sha256": "0rbzwkdai9bpcnldrib90p02p36qfgnwk18iz2pcz32xs73frx82"
-  },
-  "stable": {
-   "version": [
-    0,
-    1,
-    0
-   ],
-   "commit": "d06d39486348a74981b2c4c4c2ed3af95b01d5ca",
-   "sha256": "0k3f7pa332d0fs1js8hi7zszcirir1943bhkgwfxzsqx17m26x3n"
   }
  },
  {
@@ -94005,11 +93833,11 @@
   "repo": "pashky/restclient.el",
   "unstable": {
    "version": [
-    20210923,
-    2234
+    20220101,
+    1239
    ],
-   "commit": "f59a7f5abf366145a2c9c1e9f0a2184139d2adce",
-   "sha256": "0war99vbim62l010gxq3l68ac5w13gs5lh24yn1rpnq2jfp4jn3r"
+   "commit": "9e2cfa86529133eba6c9ef53794be182f15e4c21",
+   "sha256": "0cq7vqfj8g2wd4ip2ia60rs2bpwkxd2rlz4wpp6as6ncidnzwzzc"
   }
  },
  {
@@ -94027,8 +93855,8 @@
     "helm",
     "restclient"
    ],
-   "commit": "f59a7f5abf366145a2c9c1e9f0a2184139d2adce",
-   "sha256": "0war99vbim62l010gxq3l68ac5w13gs5lh24yn1rpnq2jfp4jn3r"
+   "commit": "9e2cfa86529133eba6c9ef53794be182f15e4c21",
+   "sha256": "0cq7vqfj8g2wd4ip2ia60rs2bpwkxd2rlz4wpp6as6ncidnzwzzc"
   }
  },
  {
@@ -94113,8 +93941,8 @@
     "f",
     "s"
    ],
-   "commit": "c894fc46e5846ecb47ab9a456fadb548cc7359a6",
-   "sha256": "13v6qpxwcsxm12754n4i8s68bp6q2lg9c7bw1g8asa69bvwh2yfk"
+   "commit": "083771a0e57fa971c257c0f39fec3b93d082ad9b",
+   "sha256": "075cycjzi46k8jaa9vqb89kk8vck7qimrgc5qq6152k2wiv5inim"
   },
   "stable": {
    "version": [
@@ -94802,11 +94630,11 @@
   "repo": "marcowahl/rope-read-mode",
   "unstable": {
    "version": [
-    20201025,
-    948
+    20211228,
+    1126
    ],
-   "commit": "6f024d9409ba454b83a2a1ccd57d9a3ebba90a39",
-   "sha256": "0y18i4ly61jyvxymvgjr99arhxfn5y5s659jnqf4gvyp3d671dkf"
+   "commit": "6aad44e006a2999980c138f608d28c8ecab92b35",
+   "sha256": "1hgkndd5y7hihzyb19pixdx3pnsxspaknq0kvxj8sq1d8iqk0300"
   },
   "stable": {
    "version": [
@@ -94826,11 +94654,11 @@
   "repo": "DerBeutlin/ros.el",
   "unstable": {
    "version": [
-    20210730,
-    844
+    20211231,
+    1807
    ],
-   "commit": "63d46cefa8552b59556dcb4af0849253dc501ee9",
-   "sha256": "0imwdapwfj8qn7zqc4842bvxwip7j8gw9bip7mc05l4c9v2v73r0"
+   "commit": "eab72f172304db8e76dafd7e5d86fe7626f22a00",
+   "sha256": "13pyiawdrprsz609ivgyhydi78pcs4295mlsjh68pq05karbjp0z"
   }
  },
  {
@@ -94984,17 +94812,6 @@
    ],
    "commit": "db39790fda5c2443bc790b8971ac140914f7e9c2",
    "sha256": "05cigdvlq5lfahr9a1z8rvlw2s99j4pha2in59pshz9ph8cqgq10"
-  },
-  "stable": {
-   "version": [
-    2,
-    38
-   ],
-   "deps": [
-    "rtags"
-   ],
-   "commit": "9687ccdb9e539981e7934e768ea5c84464a61139",
-   "sha256": "1r6l7dgr2ch586zrdi5l8fhdj4qdva8ldz7cjvi2byc2pd2xs8rx"
   }
  },
  {
@@ -95512,20 +95329,20 @@
   "repo": "rust-lang/rust-mode",
   "unstable": {
    "version": [
-    20211127,
-    1713
+    20220108,
+    808
    ],
-   "commit": "3f67a880dc8b31b330cf59aee875d9dc96e7c475",
-   "sha256": "0qvsmm9dgxclg0h2d60bh87msbn4cq9l2dq7vipzzibn999yxj4l"
+   "commit": "541786c9bb0887e2357b4d6210b25ca4ceea3ab3",
+   "sha256": "0s2bgnga3808fnx3yqpik9rpdzk8nhpkymfa947icxp0axvbknl2"
   },
   "stable": {
    "version": [
     1,
     0,
-    1
+    3
    ],
-   "commit": "d2b4cde98b660efd746d8853cf8ac04e4570e047",
-   "sha256": "1chb3a97cwf1pkxn8cm3wc35gfh9k55l7khg7pklmx36isr3csjv"
+   "commit": "b017f746503df27ccdca8ee6d2627529d64d76e1",
+   "sha256": "11fdxbv51anrjfdqqpgrqz2md9qkcn5y3524lzjippqi9i31lnjn"
   }
  },
  {
@@ -95559,8 +95376,8 @@
   "repo": "brotzeit/rustic",
   "unstable": {
    "version": [
-    20211211,
-    2202
+    20220108,
+    1543
    ],
    "deps": [
     "dash",
@@ -95574,13 +95391,13 @@
     "spinner",
     "xterm-color"
    ],
-   "commit": "e0285bd19b8f970902042701d28234ebfe160337",
-   "sha256": "1wx6mc1wyzs1d2md8rwsnbkh41ibpbsc1f1ri9diac975gp98w0s"
+   "commit": "52be33a123a454cf89b32ea375b88010f2cac327",
+   "sha256": "02dbhcz0czvaj6c029k9809i9licsnf45dbw4lnqlsjcv36zcprp"
   },
   "stable": {
    "version": [
     2,
-    2
+    4
    ],
    "deps": [
     "dash",
@@ -95594,8 +95411,8 @@
     "spinner",
     "xterm-color"
    ],
-   "commit": "a91b3d99c294a367dc14b9a62a9ca8b462eb7f84",
-   "sha256": "0i72r0kb6f96py3vbprcingik9sy5bndnd19hb9x3yzv1f7r0zfp"
+   "commit": "b4faf3c3e6c87766ebb86fb40c4abf41f6a6b3c9",
+   "sha256": "1w7db1d712rjw55prb3kdcag4z1skk56837q1ig9d2bj4mkhqa2s"
   }
  },
  {
@@ -95649,11 +95466,11 @@
   "repo": "Kungsgeten/ryo-modal",
   "unstable": {
    "version": [
-    20210625,
-    2046
+    20220103,
+    940
    ],
-   "commit": "fc9e227127fa327183d39d28c3afdb2f395a51a2",
-   "sha256": "1j05dyg77fpdh7gl29bq48fdba7kwbhsq3ryn6b8vzhncapsqj99"
+   "commit": "0a61eed4d2917422d6401b6abe2037c26dab658a",
+   "sha256": "1w47wr1hkq6ghw3h9vxw74amnlzpji35ji5250l8gk9k7nr366ss"
   }
  },
  {
@@ -96027,14 +95844,14 @@
   "repo": "clojure-emacs/sayid",
   "unstable": {
    "version": [
-    20200902,
-    703
+    20220101,
+    1357
    ],
    "deps": [
     "cider"
    ],
-   "commit": "614d44b4abb49d0cc3fdd40580d30b9d572d34b2",
-   "sha256": "03wh1kr9yhcagympbd7h3qgrs7qlycd68b0a6nswva48hdc4ay89"
+   "commit": "879aff586336a0ec4d46c0ed4720fb1de22082bd",
+   "sha256": "013afdzz0rvb428pla78an052jvw2q95zzqvnq9z9w16y5yd1n0c"
   },
   "stable": {
    "version": [
@@ -96084,8 +95901,8 @@
     20200830,
     301
    ],
-   "commit": "b5aba496f270736fd91e0b1591bae872ee39fc62",
-   "sha256": "0rr3rbwybly26n16xmf3wagj2bdda27fj2ybf82nxfyknqskrp1n"
+   "commit": "7bfde10d570f82218f1b4bde9a8b68206b4e458a",
+   "sha256": "1rvqshz4wy8lw1lfm618rs97ddplgdirfcwxifgq16831lfbxahy"
   }
  },
  {
@@ -96287,18 +96104,6 @@
    ],
    "commit": "4ec352fb9fe261ffb8b78449dea986dc34d337b3",
    "sha256": "0219jzj3rwcx4k6f4grzrarq0v05jgmmracis3jb25rv0cln3i9r"
-  },
-  "stable": {
-   "version": [
-    0,
-    6,
-    5
-   ],
-   "deps": [
-    "htmlize"
-   ],
-   "commit": "cca8f4ee5402bbf9a4bbb24e81372067cb21bba4",
-   "sha256": "13s8hp16wxd9fb8gf05dn0xr692kkgiqg7v49fgr00gas4xgpfpm"
   }
  },
  {
@@ -96386,11 +96191,11 @@
   "repo": "thisirs/scratch-message",
   "unstable": {
    "version": [
-    20170107,
-    1336
+    20211221,
+    1527
    ],
-   "commit": "3ecc7f5e3b8a597ebd1492fd426d3720a7f34302",
-   "sha256": "1kb664r3gbhv2ja8jyyzfw22db99ini8qbgzcy9xsl56lha4x4xi"
+   "commit": "efb2db33e52e5d4a4f1bafbd8b459a3b91c3c87a",
+   "sha256": "117a3v3s94jra3dlsaafgg6594gw6gbdmh1ay5zar5yjy7q6pi2f"
   }
  },
  {
@@ -96632,8 +96437,8 @@
     20161201,
     711
    ],
-   "commit": "d42a6eedefeb44919fbacf58d302b6df18f05bbc",
-   "sha256": "0r6sm7b15scmjcpdcqvm55hdsvyw5d2g7mrfhsx2hs8sqz64gkwc"
+   "commit": "7fdcf4ead88d451c0a4a6425b2e730818eaf610e",
+   "sha256": "0in30j12zy190pawzwcai2b8prl5ab0z0qk1lffd4a8v2v5a1bdv"
   }
  },
  {
@@ -96674,8 +96479,8 @@
     "dash",
     "f"
    ],
-   "commit": "137c5791fb5a307192138a6d7c62340253bb4521",
-   "sha256": "0i6k8nlvacnpfq9cj42crs2h6iqgsfnkm73f8dhc8nn9lyz6chf4"
+   "commit": "bdef718d17a09ba56b1bda7f6718588b4a33e06b",
+   "sha256": "0cd2lzb2z6cp3hlmwbmp98640q26875k3w5j0hqqg64rncxqx8yk"
   },
   "stable": {
    "version": [
@@ -96912,11 +96717,11 @@
   "repo": "raxod502/selectrum",
   "unstable": {
    "version": [
-    20210707,
-    1827
+    20220108,
+    316
    ],
-   "commit": "97693d0aea2c548197e9d1de3bdedf8e703775a4",
-   "sha256": "0d03sw0w2yhhmnpdn7xc0sm2n3lk11ffhkbz59kzdkcqqi7ppv04"
+   "commit": "40dace03075e0037ab0d15ca712cee5a36f7560a",
+   "sha256": "0j2rw898crbvy32kk5fa2pllzcip1phc74s38w4b5nl8ihv1axbc"
   },
   "stable": {
    "version": [
@@ -96935,27 +96740,27 @@
   "repo": "raxod502/prescient.el",
   "unstable": {
    "version": [
-    20210724,
-    1756
+    20211228,
+    417
    ],
    "deps": [
     "prescient",
     "selectrum"
    ],
-   "commit": "292ac9fe351d469f44765d487f6b9a1c1a68ad1e",
-   "sha256": "0ywx7q41i9pzmfgwv83mz5z17gril2s0r7y77hbbriww5yy1ihx4"
+   "commit": "3dbcef387502d309d130a518a18d48cd2f0e15b7",
+   "sha256": "024l7s0b6apbzanw3cnhjypxnxfinfb5b3nhaabrc138m5pis8j5"
   },
   "stable": {
    "version": [
     5,
-    1
+    2
    ],
    "deps": [
     "prescient",
     "selectrum"
    ],
-   "commit": "2c0e9fc061ab723ec532428f312974ca7d8def12",
-   "sha256": "0d6kbczkamhhcmc8bf01q6k1x0g7dwjihwllzsldgga3dclyh4ks"
+   "commit": "3dbcef387502d309d130a518a18d48cd2f0e15b7",
+   "sha256": "024l7s0b6apbzanw3cnhjypxnxfinfb5b3nhaabrc138m5pis8j5"
   }
  },
  {
@@ -97373,14 +97178,14 @@
   "url": "https://codeberg.org/FelipeLema/session-async.el.git",
   "unstable": {
    "version": [
-    20210902,
-    1533
+    20211227,
+    1609
    ],
    "deps": [
     "jsonrpc"
    ],
-   "commit": "32a36841fbb3c864776a3a1ac08bb94d44ca10b3",
-   "sha256": "1r5b05dvyayj1165w5n7vshkgh3nvfga6xv61bdpvrfpy2xs6y6b"
+   "commit": "589eb5a1c6dee345880a9735c37b8b8f5de1813c",
+   "sha256": "0yj4r6y74w4b8axvljrm4xmd8n4v28s83wkbafsz8k25i1vrm2pj"
   }
  },
  {
@@ -97669,11 +97474,11 @@
   "repo": "ieure/shell-here",
   "unstable": {
    "version": [
-    20210616,
-    2338
+    20220102,
+    1703
    ],
-   "commit": "a3679c52d31d1dc6ed29bcab087cb5455a992eda",
-   "sha256": "0w0mlggb5gnvm109qn50ric3lb9znxvfkzvc7xla2qnmaz037ppz"
+   "commit": "eeb437ff26d62a5009046b1b3b4503b768e3131a",
+   "sha256": "0x8lnybxj7k6wj941lgqmm57f3qqnmb0gc7573l1fxwfhf39fl20"
   }
  },
  {
@@ -97802,8 +97607,8 @@
     20211118,
     1229
    ],
-   "commit": "8213452241244b797f84e936e6ccd18b6dec3de5",
-   "sha256": "01kvxvwq1v87125arv7lpmlcbjf84pqcyyxm3lfhvzka25d5ibga"
+   "commit": "c97a80b58337f7ac257cace4a3fbed86f7fe8456",
+   "sha256": "0spivhcsnjjpc1x51nqy7ax57661ssq46sf7x9z1l3v8paxgaqxs"
   },
   "stable": {
    "version": [
@@ -98090,8 +97895,8 @@
     20210715,
     1227
    ],
-   "commit": "83b9465a3081436df69afc03f9a4f1debdf57882",
-   "sha256": "1qy7ld64qcj4i8c0v6ddp88287gkm2rn6s696bwfgch7ddviya0q"
+   "commit": "c952c072e210c605b08aa5d2a917bfa3f92dfe8b",
+   "sha256": "13abir9kr4h63krnn206gnjfln895zzjidcaidrjc8zwnysaa8k3"
   },
   "stable": {
    "version": [
@@ -98464,11 +98269,11 @@
   "repo": "ideasman42/emacs-sidecar-locals",
   "unstable": {
    "version": [
-    20211006,
-    1413
+    20220104,
+    217
    ],
-   "commit": "ee6b399ebda994b9ea6db095947386e3b7f063f7",
-   "sha256": "0avinj829gm7hbxljk8kys2abywrzw5w3li2kp0dwbda1gf8832c"
+   "commit": "c90ccd6a02538c7263f6499ca7bd4456ec06791e",
+   "sha256": "02nnvf4c78grdzcd62611qvlq93vspd09ffk4jvc047l2jb8nw6l"
   }
  },
  {
@@ -98828,11 +98633,11 @@
   "repo": "DaniruKun/siri-shortcuts.el",
   "unstable": {
    "version": [
-    20211212,
-    1258
+    20211229,
+    1833
    ],
-   "commit": "13d030d0f2bdfd1c1543e0a120c6dc321f068365",
-   "sha256": "09vwxpmzam3vmc5akcz9mdq1j6q0lhp9qghs36ivvb3az6kxc6hq"
+   "commit": "190f242f71e071adfd89fa1f2f6ea22b62afd133",
+   "sha256": "1v8bxvrkmnrl05m98jkwb0kq349jjldhn6jkpsvpxa8hvlwwc15w"
   }
  },
  {
@@ -99118,15 +98923,15 @@
   "repo": "slime/slime",
   "unstable": {
    "version": [
-    20211108,
-    2224
+    20220107,
+    1248
    ],
    "deps": [
     "cl-lib",
     "macrostep"
    ],
-   "commit": "9005cdaac4c0adaa8e26ee5285c7b155762c0ce5",
-   "sha256": "18xywimwhfnqbsr4x9bs8v78qkc287ka3by022aqgpfasr1bi7ff"
+   "commit": "4af8072274aea7c2995824f12a471623b577f656",
+   "sha256": "1iriplf5rfwi0lkd38as71k2g0fmp9n4pp013y0r2p4k67rfwc11"
   },
   "stable": {
    "version": [
@@ -99358,20 +99163,11 @@
   "repo": "joaotavora/sly",
   "unstable": {
    "version": [
-    20211121,
-    1002
+    20211222,
+    1234
    ],
-   "commit": "0470c0281498b9de072fcbf3718fc66720eeb3d0",
-   "sha256": "1ws2a9azmdkkg47xnd4jggna45nf0bh54gyp0799b44c4bgjp029"
-  },
-  "stable": {
-   "version": [
-    2,
-    26,
-    1
-   ],
-   "commit": "15cf0609d30255405957bf0612fd6291fea438bc",
-   "sha256": "11zb8aaay1yirql638ssbap4rnxdf6a4lwmqm761grgssk44rqpd"
+   "commit": "2e00c3bd4bdf6658f258cc78b3254f0ec24591e5",
+   "sha256": "0qlc5ny85dd03i0fj10ypjxkziih23k031m1wlvhjsdjg2ibs0f7"
   }
  },
  {
@@ -100658,8 +100454,8 @@
     "flycheck",
     "solidity-mode"
    ],
-   "commit": "bac439dbd2097664df45e9fac0ce57e23462c14c",
-   "sha256": "1vs64gwm6zn47fl4nvaizkwh8zwnqh764yqcmggyz4awsxsxg6ym"
+   "commit": "f0f68b038c5edf16c85fc8ca58537e1c6479738b",
+   "sha256": "0hfp07bg348ppkgp5wca1sqpcprhc6jyxkpb1pmsm0vrifb3261l"
   },
   "stable": {
    "version": [
@@ -100683,11 +100479,11 @@
   "repo": "ethereum/emacs-solidity",
   "unstable": {
    "version": [
-    20211112,
-    1959
+    20220106,
+    1055
    ],
-   "commit": "bac439dbd2097664df45e9fac0ce57e23462c14c",
-   "sha256": "1vs64gwm6zn47fl4nvaizkwh8zwnqh764yqcmggyz4awsxsxg6ym"
+   "commit": "f0f68b038c5edf16c85fc8ca58537e1c6479738b",
+   "sha256": "0hfp07bg348ppkgp5wca1sqpcprhc6jyxkpb1pmsm0vrifb3261l"
   },
   "stable": {
    "version": [
@@ -100707,20 +100503,20 @@
   "repo": "cstby/solo-jazz-emacs-theme",
   "unstable": {
    "version": [
-    20210924,
-    7
+    20211230,
+    2017
    ],
-   "commit": "f7b9ff800cef2c17ecaad9556fca2bfd4b6cc13d",
-   "sha256": "109r3fsxl1m7cf95h264ncnz91dmlhq6i15lavvg4j7fj3rmh768"
+   "commit": "9975f308e247641cce4a3230fbfc3b01c77612c9",
+   "sha256": "0gr7iwzj8m0h1dzcdcpvd9i7cinph2h6r8v2nvsn0gqaran0lkkf"
   },
   "stable": {
    "version": [
     0,
-    7,
-    0
+    8,
+    1
    ],
-   "commit": "82e9ab129d9c2949a4d91b81c2235295a8d83cd9",
-   "sha256": "0v3zhjx685ppngb01pd1p2iplafwvy9j60z1hgdrixdm2pji3f8d"
+   "commit": "9975f308e247641cce4a3230fbfc3b01c77612c9",
+   "sha256": "0gr7iwzj8m0h1dzcdcpvd9i7cinph2h6r8v2nvsn0gqaran0lkkf"
   }
  },
  {
@@ -100751,8 +100547,8 @@
   "repo": "repl-electric/sonic-pi.el",
   "unstable": {
    "version": [
-    20171205,
-    1205
+    20211214,
+    1242
    ],
    "deps": [
     "cl-lib",
@@ -100760,8 +100556,8 @@
     "highlight",
     "osc"
    ],
-   "commit": "3cf101b3b299735ed91658c7791ea4f04164e076",
-   "sha256": "1x2w7qcx9xcvagb47hlc5vsf5aj5mr0mzvnazyd7ajjilbzn48yr"
+   "commit": "9ae16d0fd4cba77ae0bedac83f2cb46569be6ade",
+   "sha256": "038waszklswq6pb9ayx731924z809b3hf3xy87vzf9a4nl9xv4p0"
   }
  },
  {
@@ -101040,21 +100836,6 @@
    ],
    "commit": "c7f8e665d53bb48fb72f95f706710d53d24bd407",
    "sha256": "06bxsbjyrn4grp9i17p90cs4x50cmw62k6a2c6gapkw8f1xbv7xv"
-  }
- },
- {
-  "ename": "sourcetrail",
-  "commit": "9713bd8030657c8e867409a6aa8173219809173a",
-  "sha256": "0qa3iw82dbfc1b45505s39m99r0m2473312prws6hch0qhjyji7h",
-  "fetcher": "github",
-  "repo": "CoatiSoftware/emacs-sourcetrail",
-  "unstable": {
-   "version": [
-    20170410,
-    2137
-   ],
-   "commit": "b8d5557aa565ae979622312576db20515f65f977",
-   "sha256": "1aqkkbf0xw4kqsy1jjn4xhs5vk2vcsqzs7f4p2sf1plnzsqxflw8"
   }
  },
  {
@@ -101345,11 +101126,11 @@
   "repo": "brailcom/speechd-el",
   "unstable": {
    "version": [
-    20210702,
-    1954
+    20211231,
+    758
    ],
-   "commit": "7f3d3d3545078df2f4a37094c618993145c731d2",
-   "sha256": "126chadfvsfpwa196811s2i8zr4cs1g413ssy52apn2fpzrb3vmp"
+   "commit": "a4be22b5b62a6be1e749df6f64b06e16a6b09790",
+   "sha256": "192fw278mmgqcbagigl97rwlj0jks63vmzgdpakhcr8as8ybc9gz"
   }
  },
  {
@@ -101434,11 +101215,11 @@
   "repo": "ideasman42/emacs-spell-fu",
   "unstable": {
    "version": [
-    20211121,
-    701
+    20220104,
+    646
    ],
-   "commit": "b2da2874f3227c0a969be80946e0c4ea455e8458",
-   "sha256": "1rbczz0i2jddh96ln65kf1gji7rg28lr1kh03p4py46vn6bm9xpd"
+   "commit": "4782667d7b6b97658f7649598e47aa6cf4d1bd80",
+   "sha256": "1bjp4sa935m6gam6rq6nkx26883r0iv1040f2dsxd15pqlrg87qw"
   }
  },
  {
@@ -101984,15 +101765,6 @@
    ],
    "commit": "58dd21cd63e4a2eed15e0082c2547069363f107b",
    "sha256": "128ri2g7jjgpacvaxhwwv4f2h3kdzf5vv3p01yqbs23m8mri8d9w"
-  },
-  "stable": {
-   "version": [
-    0,
-    2,
-    0
-   ],
-   "commit": "96e2f46b7068b84702809163f4d9d379d22f0395",
-   "sha256": "12dg8bficlxc1nb30lz507lq3ywpvjj6f289hc754vslx6w6by0a"
   }
  },
  {
@@ -102026,11 +101798,11 @@
   "repo": "srfi-explorations/emacs-srfi",
   "unstable": {
    "version": [
-    20211116,
-    1936
+    20220108,
+    212
    ],
-   "commit": "8874e933643b91d9c545fd4ca3f0ea986561da31",
-   "sha256": "1s0ivhg6rbk5k9yzy8gy589ybba7dnc9cksz4wwsgcsm931sx9fz"
+   "commit": "a47c0df8b5df36f5a8ca41f3f5dc60e1fbd09924",
+   "sha256": "1if3xyma26vzsivpvyf9vxsy0yv64vbl1kkd5rvnx48ly4axqk3a"
   },
   "stable": {
    "version": [
@@ -102454,8 +102226,8 @@
     20200606,
     1308
    ],
-   "commit": "759a38bd8418116e8cdca41a8aacd7ae13ede93e",
-   "sha256": "0xyddk3mj36mknnadjyi9fdpv24zqfzz8bvfn4dlf2qknlb8b9l5"
+   "commit": "8254ffb2eee53f97e9c6210078db55c15340ead3",
+   "sha256": "1saj40x6gj3w261g7792h92m2wy9fa7klf4s8xya778j3yvy62n1"
   },
   "stable": {
    "version": [
@@ -102965,14 +102737,14 @@
   "url": "https://git.sr.ht/~amk/subsonic.el",
   "unstable": {
    "version": [
-    20211201,
-    939
+    20211231,
+    1449
    ],
    "deps": [
     "transient"
    ],
-   "commit": "ee2b1f20521e647472be7553242eb2253809e1d1",
-   "sha256": "1j8q47vvvsdfb9hg2r72dgmg2a886aa15yrvi6ahp7g5z4jmp19k"
+   "commit": "992bce5fe3c2322101610d53d08a89ec3bb8fc43",
+   "sha256": "0vd003r0f7n5pp1xw6lvg2cvyz1mr5w42v35y67028cyjdlv1mxd"
   },
   "stable": {
    "version": [
@@ -103182,18 +102954,18 @@
   "repo": "tlikonen/suomalainen-kalenteri",
   "unstable": {
    "version": [
-    20211108,
-    1333
+    20220101,
+    718
    ],
-   "commit": "56927306d8046f2ba38b8cadabde47c5b6851262",
-   "sha256": "03y5hh2al8m75bdjxwa052nqa3iryp08dkhvmaaa9b0i2fq233z5"
+   "commit": "30103e6c6fa5dcbae70a636b007afdaad2fbcac0",
+   "sha256": "1b4isqymawq3srcgz4qf5ghdq5074iajwqxsb25jky4niki0kgfz"
   },
   "stable": {
    "version": [
-    2021
+    2022
    ],
-   "commit": "56927306d8046f2ba38b8cadabde47c5b6851262",
-   "sha256": "03y5hh2al8m75bdjxwa052nqa3iryp08dkhvmaaa9b0i2fq233z5"
+   "commit": "30103e6c6fa5dcbae70a636b007afdaad2fbcac0",
+   "sha256": "1b4isqymawq3srcgz4qf5ghdq5074iajwqxsb25jky4niki0kgfz"
   }
  },
  {
@@ -103318,11 +103090,14 @@
   "repo": "rougier/svg-tag-mode",
   "unstable": {
    "version": [
-    20210301,
-    2205
+    20211229,
+    920
    ],
-   "commit": "95b5404997d7194b4946df0a475fd93203a36cb9",
-   "sha256": "06j19jx3bkdsds5rjqdvaqxfq42gsn8yanqd6jrd8rysncds8an0"
+   "deps": [
+    "svg-lib"
+   ],
+   "commit": "fee61c6a0b0570bd24fd335efef17c7385297aa0",
+   "sha256": "1lyizbmh5f6dq5jaymri219k8i5ww7yi1pzncha03qskg8r0qncl"
   }
  },
  {
@@ -103615,8 +103390,8 @@
    "deps": [
     "ivy"
    ],
-   "commit": "1c6b3da377a840e898b14020133f59fca9ceea1c",
-   "sha256": "1w8x2qk8lafnn6ksv1anixayyl476y1j6hp2amfnqmdkh0vnh63v"
+   "commit": "c97ea72285f2428ed61b519269274d27f2b695f9",
+   "sha256": "05ivdsq6l6ixdn5p0rjh7mcgw19fm38m137xb8yi2c9gii6yk6g2"
   },
   "stable": {
    "version": [
@@ -103876,14 +103651,14 @@
   "repo": "wolray/symbol-overlay",
   "unstable": {
    "version": [
-    20210906,
-    614
+    20220103,
+    1747
    ],
    "deps": [
     "seq"
    ],
-   "commit": "8629a4ddbe95d42c39ce817d724877deb1984ba1",
-   "sha256": "1g8zi7qky5vfrl2c2wvdcr0mrm8xkkxl3cbhrkh95bhq1vypz5p8"
+   "commit": "d08c33dc85a118b199415e71bba0e7c330f87c5b",
+   "sha256": "1k9x39hv07wxk4hv60ai5gc9rbx0h423zcgj23cvqxj34knklzgi"
   },
   "stable": {
    "version": [
@@ -103946,8 +103721,8 @@
   "repo": "countvajhula/symex.el",
   "unstable": {
    "version": [
-    20211115,
-    2045
+    20220107,
+    1725
    ],
    "deps": [
     "evil",
@@ -103959,8 +103734,8 @@
     "seq",
     "undo-tree"
    ],
-   "commit": "c042fffef1d575eb356bf585ec78f1606d3349ad",
-   "sha256": "00f9ky5nkivh2b90swgl3aq4xhwvva97xxyr2pdlnmf8v9jlk1p0"
+   "commit": "e616ac9b6e780b66e96836bcc59080f02f88e201",
+   "sha256": "10gnrnnmxw8rpc647y6pp2ys457q0faf68zah6mmdak689s6qjym"
   },
   "stable": {
    "version": [
@@ -104492,10 +104267,10 @@
  },
  {
   "ename": "tabula-rasa",
-  "commit": "a3c6e6adb1a63534275f9d3d3d0fe0f5e85c549b",
-  "sha256": "041yl5727ba0b2ircmfmm693gg7vimrijd80k8w8j13xcrq5i1i3",
+  "commit": "e79d0cf9ea9ce714e784373385132c15ae1ca2f1",
+  "sha256": "0ggmb328hkq415az085zxzk68s6dh2lzrm2cdn7k61yj7889cj6m",
   "fetcher": "github",
-  "repo": "IdoMagal/Tabula-Rasa",
+  "repo": "dppdppd/Tabula-Rasa",
   "unstable": {
    "version": [
     20141216,
@@ -104578,11 +104353,11 @@
   "repo": "tmalsburg/tango-plus-theme",
   "unstable": {
    "version": [
-    20210804,
-    1943
+    20211222,
+    1100
    ],
-   "commit": "0460aff3638b7c9e290f28be8eb2b90887a74eed",
-   "sha256": "1vdr5wsq1bw30zpgmgy0sm7kls0qkn6zs800hf95mixh21l4gzlz"
+   "commit": "774b03f932bbc336ce5f943af175d5faa651f2e0",
+   "sha256": "0nl73ggirjs0a6zapqpp4h2wszkfbj8956qn3yg86fc0hk9jiz05"
   }
  },
  {
@@ -104593,11 +104368,11 @@
   "repo": "juba/color-theme-tangotango",
   "unstable": {
    "version": [
-    20200907,
-    729
+    20220106,
+    1039
    ],
-   "commit": "2293311166308a76bda691898b6952921bb95da9",
-   "sha256": "1964h3sgd5pzh58i1gjawhlpqfli2n183n9c55y8klb5i3kbf32h"
+   "commit": "9509035842c5ea44f594879199a74c9fc6d2a368",
+   "sha256": "0dn8r1rjn89y087kz2rx46kvzz7f99km78pydbs9bbklmn24692n"
   }
  },
  {
@@ -104608,11 +104383,11 @@
   "repo": "11111000000/tao-theme-emacs",
   "unstable": {
    "version": [
-    20211027,
-    1900
+    20211221,
+    1443
    ],
-   "commit": "2d271a2733463f3be711c31da036236b53f6224e",
-   "sha256": "0n4n3ln5n3ygkb2pa9ag8pwqqs7a9lkzzb0j04b0rphjhmsn5hbr"
+   "commit": "891338eba148d8f0e80102323d18ce8e9eda30d4",
+   "sha256": "1sdj6n2ma004m6b88nrd3mri4vyciyac4zbd1ivqc6mgwj5b7vhy"
   },
   "stable": {
    "version": [
@@ -104823,28 +104598,28 @@
   "repo": "zevlg/telega.el",
   "unstable": {
    "version": [
-    20211213,
-    2017
+    20220108,
+    1518
    ],
    "deps": [
     "rainbow-identifiers",
     "visual-fill-column"
    ],
-   "commit": "737399c5050b68cea618e01136c463107c6125a1",
-   "sha256": "0has60kmjy6ysax6xdn22likvi9qygz3znz24v8mfwzxasil5nhw"
+   "commit": "0bab63be730e43a39d7e36b9839d3e87ff52edfe",
+   "sha256": "1d5cvlgin0kbm4ca90sv82afph8l64smyi74iqrpq2df2qnp1zii"
   },
   "stable": {
    "version": [
     0,
-    7,
-    31
+    8,
+    1
    ],
    "deps": [
     "rainbow-identifiers",
     "visual-fill-column"
    ],
-   "commit": "c07f310552643dfeb6bed98860bd63b965baf262",
-   "sha256": "05j82796s4k3yr0igl6hir3p8qj0cw66vvhbpbcy28d6q9v9vjjz"
+   "commit": "7b1107bc11285ef3ed182f638980fba6d7ab2508",
+   "sha256": "1f9asfgjxq73h203cii86irlz4zg29xkr9f5sl59l70bhzchfyx9"
   }
  },
  {
@@ -104878,16 +104653,16 @@
   "repo": "dbordak/telephone-line",
   "unstable": {
    "version": [
-    20210724,
-    1411
+    20220104,
+    507
    ],
    "deps": [
     "cl-generic",
     "cl-lib",
     "seq"
    ],
-   "commit": "ff5fcb2181cf1d52bfc5fb8d76ac37f9cad22ce2",
-   "sha256": "15l5w4avs3y6mj22k6c1vfvk7az69wiws0yym4vyqmfpdpsmwab2"
+   "commit": "ff526441a23ac1f1775628e0e20c61cdbf6cabf9",
+   "sha256": "0vr9ada1f9afinaknzix09mlnymb6qi4cy1dix8g1703z50xn1z7"
   },
   "stable": {
    "version": [
@@ -105740,6 +105515,21 @@
   }
  },
  {
+  "ename": "the-matrix-theme",
+  "commit": "aed1e8ffa09b9f8994811da804019b31d5ef3fe6",
+  "sha256": "00s6hg0ww5pr789frmpgmn7b6bqirz4hwl0m8sbdf8aii8gv4shi",
+  "fetcher": "github",
+  "repo": "monkeyjunglejuice/matrix-emacs-theme",
+  "unstable": {
+   "version": [
+    20220108,
+    658
+   ],
+   "commit": "c6681c695c5c9a36465e9c63f637a381b369f2c6",
+   "sha256": "0f3iridbibf1zjmnq73sbr5m3fskdn5fl56rgr2msn99649g2m5x"
+  }
+ },
+ {
   "ename": "theme-anchor",
   "commit": "74f79dc5db5246a2f70e4d4ad76601be8b5c79d8",
   "sha256": "15819kkxvhk03yfzd0qp78d5ayc33cm064gy7fdpi0aq28nbw6ba",
@@ -105747,11 +105537,11 @@
   "repo": "GongYiLiao/theme-anchor",
   "unstable": {
    "version": [
-    20210408,
-    2149
+    20211224,
+    2042
    ],
-   "commit": "ec7f522ec25c7f8342dfd067b7d9f6862c828c93",
-   "sha256": "00bar56lswvdp9rwa55y4m83av7a3g95b0qz6h0wbqi1v0gbpm5n"
+   "commit": "aad9c0c0c888325cf6f9bb2310677d667b364f21",
+   "sha256": "1cpr11kasmskwx3b5v5x5j6mndlz0dm854p4d793m3m9fwdk3303"
   }
  },
  {
@@ -105929,18 +105719,18 @@
     20200212,
     1903
    ],
-   "commit": "e1286496d4ffe5cfcb97e818b7c0f4a5acdfd4d1",
-   "sha256": "16xmix97xvivjd4g87m6fdh7ffqlwjy0y9la3x4nmxbppkbakmhi"
+   "commit": "bc8d3a2374a4c2d5a3fee4c23aa9f336062f9326",
+   "sha256": "1z1mgzpmn6ldpvpgy497cmn1lnf0lb90s5ks6mvh4k1mgph1ax5c"
   },
   "stable": {
    "version": [
-    2021,
-    12,
-    13,
+    2022,
+    1,
+    3,
     0
    ],
-   "commit": "d99cd8529957d7595602038e55bc5cea26126b3f",
-   "sha256": "0c1aylvj0f1s6d98fza4lz806b96pb7d1677j3hfjkk8sv3cg5wf"
+   "commit": "8b252960f8d3c746427b59538d3413cc9edd4e1e",
+   "sha256": "1kxnl9903cag4ljnr7m2i13qbq9apr2nvf3avzg3kgigmvvji8lz"
   }
  },
  {
@@ -105996,20 +105786,20 @@
    "deps": [
     "haskell-mode"
    ],
-   "commit": "b0a5a3f64b1121fb83d67922f820ed168f45c84c",
-   "sha256": "1p262x6x0rxj5hh0v720h0k5x231827p5bd6qpbn4i1gdrnr3gp1"
+   "commit": "d840106c9981fab04fddfe7b0736b24c53260dfc",
+   "sha256": "1pip4394xgkyc0mqfps17d3jw87fisyb32jm5nnxbmp0xl5nhply"
   },
   "stable": {
    "version": [
     1,
     7,
-    8
+    10
    ],
    "deps": [
     "haskell-mode"
    ],
-   "commit": "95c065a410c20cbeefeaabc3084b2b09d09564c2",
-   "sha256": "02xbzwj1bf0n4lvg1rycmxsbvwi0p0h9a5fqx755kshwx5hngkx3"
+   "commit": "3882d1b5f7e395300200a2ce647858fa762e4805",
+   "sha256": "0qpv6pb71qxx7djhlxah9v8nn5whvhw468b5dl91zmhv55m3y5mr"
   }
  },
  {
@@ -106020,8 +105810,8 @@
   "repo": "ananthakumaran/tide",
   "unstable": {
    "version": [
-    20210930,
-    356
+    20220102,
+    441
    ],
    "deps": [
     "cl-lib",
@@ -106030,14 +105820,14 @@
     "s",
     "typescript-mode"
    ],
-   "commit": "28137ed904deb143dba8f8f67660966e11921c6d",
-   "sha256": "1ikvdxjr9kbs0l5hlann34q79r6gr3796rvi2ci2ki50kp69kfbw"
+   "commit": "4bd7f35d8aae160b16642aef3ca205adc71539a9",
+   "sha256": "0zrapfxdarakp3kwp73c2ymjx51fsnfk6azi2y1wb2kgsdxl2yim"
   },
   "stable": {
    "version": [
     4,
-    2,
-    3
+    5,
+    4
    ],
    "deps": [
     "cl-lib",
@@ -106046,8 +105836,8 @@
     "s",
     "typescript-mode"
    ],
-   "commit": "2a3ac4f38472d66e2d8a6bbe5dadb52bc008acbd",
-   "sha256": "1fj2fghiycnzds2zxfxgj1d9mdzsvs9rvl9bwy2f1vwawqk1m48w"
+   "commit": "4bd7f35d8aae160b16642aef3ca205adc71539a9",
+   "sha256": "0zrapfxdarakp3kwp73c2ymjx51fsnfk6azi2y1wb2kgsdxl2yim"
   }
  },
  {
@@ -106245,11 +106035,11 @@
   "repo": "aimebertrand/timu-spacegrey-theme",
   "unstable": {
    "version": [
-    20211213,
-    33
+    20211217,
+    1942
    ],
-   "commit": "17b7b89334a6a87b58eaacdd54b1c2bea9b7314f",
-   "sha256": "0cvkfzf2pk8qhp2s40nv1rqqg7kayvxi4x6vlh8ggsnxbw80hj11"
+   "commit": "81786aaef72eabac5b7dd483cd2f8b77ffffcc92",
+   "sha256": "1m2rnq9lqq8wrbaxjcsx6gv66sigj954ja1jdls8ndgm26vfmaik"
   },
   "stable": {
    "version": [
@@ -106413,11 +106203,11 @@
   "repo": "dalanicolai/toc-mode",
   "unstable": {
    "version": [
-    20211127,
-    801
+    20211229,
+    1334
    ],
-   "commit": "d5629c71652d80c5c515d30cdafb345f5a0b7595",
-   "sha256": "0jdck6if9adqwvdh0j6hx3jvr6y9mpr2hflr4lbs5pm4criq88ah"
+   "commit": "4c9ce0f54d1e3e0c7c75c7f3c2d9a4d50287ca18",
+   "sha256": "06r0p0lc851g2dmvc2mxhq2kqwqyvhdc8436x3blgdb59cyh9ash"
   }
  },
  {
@@ -106428,11 +106218,11 @@
   "repo": "snosov1/toc-org",
   "unstable": {
    "version": [
-    20210421,
-    657
+    20220102,
+    710
    ],
-   "commit": "df4ad6ff15e3b02f6322305638a441a636b9b37e",
-   "sha256": "00a2al7ghrlabf65kfj1mk30p2pl37h6ppwlgghbgiy7rwlzkdbm"
+   "commit": "953eef6b395acb6230fc4cf4e629391ef2d28db5",
+   "sha256": "1gls2kbc0ni7cz8gb0xv2ar96j4jd2labiwdnnmjsl0dqy19qh9l"
   },
   "stable": {
    "version": [
@@ -106526,8 +106316,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "2d76365d2aa13543121d5c623df465adb68b76f7",
-   "sha256": "1n247g5dq73rkxf0wys5lsbvma44y5qlh577s3rcx7l0yrylwdry"
+   "commit": "842ae4df222bbd6596068814ac1b1e505c2a6b7a",
+   "sha256": "19j76bgv5hca8i9385f1s66zj31y70fgppmvxdqrws4265zqc11d"
   }
  },
  {
@@ -106583,11 +106373,11 @@
   "repo": "topikettunen/tok-theme",
   "unstable": {
    "version": [
-    20211203,
-    2240
+    20220105,
+    836
    ],
-   "commit": "631e8b0b5e72983104084256d30b01ba4bc41e94",
-   "sha256": "10ajqxjwvyv79m5r8k1l98qclrdzlvr78kjlwvnn7dxlv91vrds0"
+   "commit": "5a85936fe19f9c8692fb805527031ea9d1ca87bb",
+   "sha256": "0qj3p9kjygwdb7kd6182af28kk3fb3r6y7fp6z9j9487rgwf26ky"
   }
  },
  {
@@ -107038,17 +106828,17 @@
  },
  {
   "ename": "transient",
-  "commit": "cdd8115e3ab3df5f74a21dbf63d89ee11b4f1c17",
-  "sha256": "04xkdspn475dlch5fcw21phhdhshxlbyznjbi0l7qk8snm130qpv",
+  "commit": "325cca8031b99c6abe2ee9858a6b547d1af0cdde",
+  "sha256": "1pq7pimnkx1j5mia4wjahn9bd4c0jzm98bhhr4am8j8pg2pym49s",
   "fetcher": "github",
   "repo": "magit/transient",
   "unstable": {
    "version": [
-    20211208,
-    1819
+    20220105,
+    1210
    ],
-   "commit": "459e28e28a5f29e4dd59c7d61ec8557ce9b57ef3",
-   "sha256": "1wq4d44lhifg7mhyqih1bbx42krm3j6q5fs58yibs05fd6h2zpdz"
+   "commit": "3de8d9b256a09adfe5ef6d199870a07adffa6acf",
+   "sha256": "05gsjminfvm2dw5sa1ivmjz9j852vscx8bp3qr5ylvib2sk1s5z5"
   },
   "stable": {
    "version": [
@@ -107177,8 +106967,8 @@
     20200910,
     1636
    ],
-   "commit": "a31c7aae9d48edfcd10ccefc7b513214d6ddfb29",
-   "sha256": "0c7q250bkhjrqb8nzbciggngywbh5rkvbpzay8pcqnb04phxxvax"
+   "commit": "090677c53a2127d0960204b7b6d3e39f6bf2c7fd",
+   "sha256": "1b6g83gcjars06vcq7pbrwaw0cn7yqpny162iaf0rqaazr5wggx6"
   },
   "stable": {
    "version": [
@@ -107198,20 +106988,20 @@
   "repo": "shingo256/trashed",
   "unstable": {
    "version": [
-    20200523,
-    231
+    20220106,
+    1358
    ],
-   "commit": "23e782f78d9adf6b5479a01bfac90b2cfbf729fe",
-   "sha256": "0lfza55nbb62nmr27cwpcz2ad1vm95piq4nfd8zvkwqbn6klwmm6"
+   "commit": "ddf5830730544435a068f2dc9ac75a81ea69df1d",
+   "sha256": "08v7g2zgrad0r0n4pla8j3i2aql46byq82jr712cvxhydd5gnzf9"
   },
   "stable": {
    "version": [
     2,
     1,
-    2
+    3
    ],
-   "commit": "23e782f78d9adf6b5479a01bfac90b2cfbf729fe",
-   "sha256": "0lfza55nbb62nmr27cwpcz2ad1vm95piq4nfd8zvkwqbn6klwmm6"
+   "commit": "ddf5830730544435a068f2dc9ac75a81ea69df1d",
+   "sha256": "08v7g2zgrad0r0n4pla8j3i2aql46byq82jr712cvxhydd5gnzf9"
   }
  },
  {
@@ -107282,14 +107072,14 @@
  },
  {
   "ename": "tree-edit",
-  "commit": "43726f8e4c4f7f673ca892ec17329471dba77b3e",
-  "sha256": "0537g2m5k3hwdisbag9724nkzx97x45ry602gjpqr9dzywd30g65",
+  "commit": "7ec29a86aac242dd20a4632ee40e6fd582ad8a0d",
+  "sha256": "0jr5hsgd0ma4pvndzz55m33bxgvishyz4pq55k2db33bxyy7mdww",
   "fetcher": "github",
   "repo": "ethan-leba/tree-edit",
   "unstable": {
    "version": [
-    20211211,
-    2301
+    20220105,
+    1657
    ],
    "deps": [
     "dash",
@@ -107299,8 +107089,8 @@
     "tree-sitter-langs",
     "tsc"
    ],
-   "commit": "1a670b73cd990af3b08633b01f84b57edaeb92ba",
-   "sha256": "1sr8h96rzghxbs42rzv0c2abhrydjsxf98hijnffa7yqd8gffjdr"
+   "commit": "4ef6bd9ffe5047beb00cf473d0ce80e657cceae2",
+   "sha256": "0n67ka9yyqc1mvz6646kixly1ixp7vhfydgy5wx00rjpp6yxf4ni"
   }
  },
  {
@@ -107387,26 +107177,26 @@
   "repo": "emacs-tree-sitter/tree-sitter-langs",
   "unstable": {
    "version": [
-    20211213,
-    159
+    20211228,
+    1446
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "c66b03faba230868b7cb644e0b49ff64a47f6ab4",
-   "sha256": "072y9cmyn926w5vlf6flj83j3n87w6qy7jx9akrnbys0907c17s8"
+   "commit": "3c0c82f9fb0a796f5ebd7e1e4c89f13d5ab6ef58",
+   "sha256": "0jijx5l4wx03wnq5v3qlfw3kwzssiv5glqxz9clr827qdzgpxnlb"
   },
   "stable": {
    "version": [
     0,
     10,
-    13
+    14
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "e537b90bbca6b4deb62042240ed12461251b3f0c",
-   "sha256": "16i3j7iv77l9cqqc2f8ynywhpapgm5sdbvq506h0swk8rg81hsnz"
+   "commit": "53fb0fb0c00f622a4661721ce04b8b5f73eb80f0",
+   "sha256": "1xv3pfbddyky68bc3ckxz5gji54ysl1frazlw6pn74xmr62y99xq"
   }
  },
  {
@@ -107453,8 +107243,8 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20211213,
-    2100
+    20220104,
+    1302
    ],
    "deps": [
     "ace-window",
@@ -107466,8 +107256,8 @@
     "pfuture",
     "s"
    ],
-   "commit": "babf69971ed4c3469b0cdf6a3bf7b637bed1ab18",
-   "sha256": "1s8csgnbcyjkbycx8hwsmzd37fhs7m7qr5mn4k91j5v3vm8ndjb8"
+   "commit": "deb7f2cd9eb06960798edd7393df2602902ed071",
+   "sha256": "0mr7fskkv49awwz81ynqdrv83l8lmg08ihfybxqap1nb88k0pzxm"
   },
   "stable": {
    "version": [
@@ -107504,8 +107294,8 @@
     "all-the-icons",
     "treemacs"
    ],
-   "commit": "babf69971ed4c3469b0cdf6a3bf7b637bed1ab18",
-   "sha256": "1s8csgnbcyjkbycx8hwsmzd37fhs7m7qr5mn4k91j5v3vm8ndjb8"
+   "commit": "deb7f2cd9eb06960798edd7393df2602902ed071",
+   "sha256": "0mr7fskkv49awwz81ynqdrv83l8lmg08ihfybxqap1nb88k0pzxm"
   },
   "stable": {
    "version": [
@@ -107536,8 +107326,8 @@
     "evil",
     "treemacs"
    ],
-   "commit": "babf69971ed4c3469b0cdf6a3bf7b637bed1ab18",
-   "sha256": "1s8csgnbcyjkbycx8hwsmzd37fhs7m7qr5mn4k91j5v3vm8ndjb8"
+   "commit": "deb7f2cd9eb06960798edd7393df2602902ed071",
+   "sha256": "0mr7fskkv49awwz81ynqdrv83l8lmg08ihfybxqap1nb88k0pzxm"
   },
   "stable": {
    "version": [
@@ -107561,14 +107351,14 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20211011,
-    1824
+    20211229,
+    1448
    ],
    "deps": [
     "treemacs"
    ],
-   "commit": "babf69971ed4c3469b0cdf6a3bf7b637bed1ab18",
-   "sha256": "1s8csgnbcyjkbycx8hwsmzd37fhs7m7qr5mn4k91j5v3vm8ndjb8"
+   "commit": "deb7f2cd9eb06960798edd7393df2602902ed071",
+   "sha256": "0mr7fskkv49awwz81ynqdrv83l8lmg08ihfybxqap1nb88k0pzxm"
   },
   "stable": {
    "version": [
@@ -107599,8 +107389,8 @@
     "pfuture",
     "treemacs"
    ],
-   "commit": "babf69971ed4c3469b0cdf6a3bf7b637bed1ab18",
-   "sha256": "1s8csgnbcyjkbycx8hwsmzd37fhs7m7qr5mn4k91j5v3vm8ndjb8"
+   "commit": "deb7f2cd9eb06960798edd7393df2602902ed071",
+   "sha256": "0mr7fskkv49awwz81ynqdrv83l8lmg08ihfybxqap1nb88k0pzxm"
   },
   "stable": {
    "version": [
@@ -107625,16 +107415,16 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20210114,
-    2135
+    20211229,
+    1448
    ],
    "deps": [
     "dash",
     "persp-mode",
     "treemacs"
    ],
-   "commit": "babf69971ed4c3469b0cdf6a3bf7b637bed1ab18",
-   "sha256": "1s8csgnbcyjkbycx8hwsmzd37fhs7m7qr5mn4k91j5v3vm8ndjb8"
+   "commit": "deb7f2cd9eb06960798edd7393df2602902ed071",
+   "sha256": "0mr7fskkv49awwz81ynqdrv83l8lmg08ihfybxqap1nb88k0pzxm"
   },
   "stable": {
    "version": [
@@ -107659,16 +107449,16 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20210116,
-    1155
+    20211229,
+    1448
    ],
    "deps": [
     "dash",
     "perspective",
     "treemacs"
    ],
-   "commit": "babf69971ed4c3469b0cdf6a3bf7b637bed1ab18",
-   "sha256": "1s8csgnbcyjkbycx8hwsmzd37fhs7m7qr5mn4k91j5v3vm8ndjb8"
+   "commit": "deb7f2cd9eb06960798edd7393df2602902ed071",
+   "sha256": "0mr7fskkv49awwz81ynqdrv83l8lmg08ihfybxqap1nb88k0pzxm"
   },
   "stable": {
    "version": [
@@ -107693,15 +107483,15 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20210107,
-    1251
+    20211223,
+    1454
    ],
    "deps": [
     "projectile",
     "treemacs"
    ],
-   "commit": "babf69971ed4c3469b0cdf6a3bf7b637bed1ab18",
-   "sha256": "1s8csgnbcyjkbycx8hwsmzd37fhs7m7qr5mn4k91j5v3vm8ndjb8"
+   "commit": "deb7f2cd9eb06960798edd7393df2602902ed071",
+   "sha256": "0mr7fskkv49awwz81ynqdrv83l8lmg08ihfybxqap1nb88k0pzxm"
   },
   "stable": {
    "version": [
@@ -108040,14 +107830,14 @@
   "repo": "ocaml/tuareg",
   "unstable": {
    "version": [
-    20210913,
-    1031
+    20220104,
+    2039
    ],
    "deps": [
     "caml"
    ],
-   "commit": "b9a145510518c855d5057a1e1b19a32125975202",
-   "sha256": "1jzsjxi1b6cnjrrzbrprlb2rqm5zjnhhzjj58r4aa8mkl1y04n6k"
+   "commit": "04f5ab6be9ae1c594bab359819dbaf708ae57fda",
+   "sha256": "1pbrz7x13zh2k2hang2mdcnm1yzl8ijzg0q3rndk7hpc9sq2rwzh"
   },
   "stable": {
    "version": [
@@ -108357,28 +108147,28 @@
   "repo": "mrkkrp/typit",
   "unstable": {
    "version": [
-    20210318,
-    1747
+    20220106,
+    1722
    ],
    "deps": [
     "f",
     "mmt"
    ],
-   "commit": "d08ed004bfc13f8d0bdfc13fc54e8f7402876903",
-   "sha256": "02fnq52a1i0dgdyhxgqjf89zif23038n8cm9idv9c515835c10m2"
+   "commit": "61dba759f8178550bc067a360c42ce1089e99a66",
+   "sha256": "15m4nfsig8w9hykqy9mzd014pqx4fj9yykiw273bwm384lf3dq6y"
   },
   "stable": {
    "version": [
     0,
     2,
-    1
+    2
    ],
    "deps": [
     "f",
     "mmt"
    ],
-   "commit": "a4e3147dedac5535bdc8b06aca00f34f14f26e35",
-   "sha256": "0hbnwrhxj9wwjvxsk372ffgjqfkb3ljxhgi5h7wps2r15dxfvf3w"
+   "commit": "61dba759f8178550bc067a360c42ce1089e99a66",
+   "sha256": "15m4nfsig8w9hykqy9mzd014pqx4fj9yykiw273bwm384lf3dq6y"
   }
  },
  {
@@ -108711,8 +108501,8 @@
     20200719,
     618
    ],
-   "commit": "fa821425572cc75fbc7b990c800d4659dd893a4e",
-   "sha256": "0k9b5lv9nkfjk8r1kmcal7b4jsgiglpgfwzhfczc61lj4q9i9zq7"
+   "commit": "70b287aad04d97ec902ea2aa71cf9ff4b7d701ec",
+   "sha256": "0api91jqkafqglq6f1fqb0lac81dq7xr2czdwrb4m0lgkxv325sj"
   },
   "stable": {
    "version": [
@@ -108770,11 +108560,11 @@
   "repo": "ideasman42/emacs-undo-fu-session",
   "unstable": {
    "version": [
-    20211007,
-    306
+    20220104,
+    222
    ],
-   "commit": "1810251485a551bc41472ec9e7e7bfab72a45a3c",
-   "sha256": "195zm428c6gan92g8dsgzgdc30xxyrjfk294dmzqdal86jsajvmr"
+   "commit": "5fd4280bce0097fa67ca22c9b25434803bf3ba71",
+   "sha256": "19rfchy6r55cy4xc8nqd5f2gvkg623l795nl7391psmzcshgqhp1"
   }
  },
  {
@@ -109634,8 +109424,8 @@
    "deps": [
     "s"
    ],
-   "commit": "418d8617f5c6431b72baa3d22e5b67dc5307870f",
-   "sha256": "0fkryq2iipjndhykryc0yzj290il217qaa2cgjv2sxpajh499cyy"
+   "commit": "4f9246b46a3f897ef344753c0346c79bf161b766",
+   "sha256": "0bgy93j48wpsmbw53r7dyjpyaqi253m57if36ypfsx0prbi4ck2x"
   },
   "stable": {
    "version": [
@@ -109741,15 +109531,15 @@
   "repo": "damon-kwok/v-mode",
   "unstable": {
    "version": [
-    20211015,
-    309
+    20220104,
+    142
    ],
    "deps": [
     "dash",
     "hydra"
    ],
-   "commit": "a5f39031a3391d0044c716425eb28645af51c79c",
-   "sha256": "0k0100fxhhzfyl2pcsrwblj1h7j0x9fzfnpcxqd751yvwihgrsb6"
+   "commit": "a701f4cedfff91cf4bcd17c9a2cd16a49f942743",
+   "sha256": "0s9dr9lc79arm8sm730hm86yikfsinb56nxkq6lq8sl4lv6ll8rz"
   }
  },
  {
@@ -110031,14 +109821,14 @@
   "repo": "redguardtoo/vc-msg",
   "unstable": {
    "version": [
-    20201210,
-    157
+    20211224,
+    1354
    ],
    "deps": [
     "popup"
    ],
-   "commit": "6c94578b5c692ade27c8b34bf5d99333ee7b4680",
-   "sha256": "1p54m71ypvz7x5wyzv0lfrxfsx23ipmb4zkq6dm0ppgh9al9hd7k"
+   "commit": "3ad560afc1e0610acd1ce4b9509aedae66276b91",
+   "sha256": "02lbjpfyy1hl6kdml9mm7m8aaawaphwqzk3cljw50a0z2m7xrk63"
   },
   "stable": {
    "version": [
@@ -110510,14 +110300,14 @@
   "repo": "noctuid/vertigo.el",
   "unstable": {
    "version": [
-    20180829,
-    2230
+    20211224,
+    1256
    ],
    "deps": [
     "dash"
    ],
-   "commit": "6303d17270ea92290a6960890bca515274f1682b",
-   "sha256": "0570x63l1j75issnq23hrhhpisv2jm18fn5mspsvbs4xy2hy4h8i"
+   "commit": "280b30518529242ee36cd436bd2349c34c35abb0",
+   "sha256": "0g5za16kgsccap2frfv4h6jj9b8x4h5jm0xfdrw3lq0846bnzfwp"
   },
   "stable": {
    "version": [
@@ -110834,14 +110624,6 @@
    ],
    "commit": "a584db9bc88953b23a9648b3e14ade90767207f8",
    "sha256": "1rsi9irv9i03627cmfaqz03f9cvpm7555ga8n2gs622lzp6bb3jf"
-  },
-  "stable": {
-   "version": [
-    0,
-    1
-   ],
-   "commit": "c1852e13b6b61982738b56977a452ec9026faf1b",
-   "sha256": "15zdbvv6c114mv6hdq375l7ax70sss06p9d7m86hgssc3kiv9vsv"
   }
  },
  {
@@ -111095,19 +110877,19 @@
   "repo": "emacs-vs/vs-dark-theme",
   "unstable": {
    "version": [
-    20210627,
-    2121
+    20220101,
+    1028
    ],
-   "commit": "fc9766b4d772df7006998f3d863e9469498cfdc3",
-   "sha256": "1ssjwmv0f24zx0hp1rhicgza1s3pfcr6b04kf2n00zdyn37gwfvn"
+   "commit": "f3f4a667e47bc652be9810f9fa4ae782662e8cf8",
+   "sha256": "1b3d42g4w2wm1j6vnv0iwc4g80knlzra336w5pxic9raxwj4ldrc"
   },
   "stable": {
    "version": [
-    0,
-    2
+    1,
+    0
    ],
-   "commit": "3d087e1c48872b5b623ac72c85a9bd3d80ec02cd",
-   "sha256": "1j326w78drqsr4bxq2sjfnf3ax3hwk1k63flbqj8vfq5w1pc5iy0"
+   "commit": "a888af1719d3954892fb659985d4b74637fb6532",
+   "sha256": "1wmg75wnrw091dx1v31pyj3slaq7syhb1wypmmlg2a1kf8vbh40w"
   }
  },
  {
@@ -111118,19 +110900,19 @@
   "repo": "emacs-vs/vs-light-theme",
   "unstable": {
    "version": [
-    20210627,
-    2121
+    20220104,
+    621
    ],
-   "commit": "1211f09ec83f3f375b2e38e4d704bd102bf3f6e3",
-   "sha256": "18ciz8rvx5n4hqqbr4y7vjkjzyq8dc2393yxfi6rhp3hkdld043p"
+   "commit": "43688534bfbb812c1708983a0dad6787a5d9aea7",
+   "sha256": "05rk4wsmhgyidcykjhxwws7xflcs7lf38iymabhs837bjpik4cvk"
   },
   "stable": {
    "version": [
-    0,
-    2
+    1,
+    0
    ],
-   "commit": "4e6501118bafb62ecfca8797b6c6d81310d95fd2",
-   "sha256": "17n9c6fj70rgrc63g72vdxnv8xjnqa6w0rrvh6ih3z2xmky91b2a"
+   "commit": "2ebed00305ff4ae67e8ed18c1fce8de2f169b753",
+   "sha256": "0apzkbcx9rgcv3hrcdbmjnib6c4kalvdjs45pfci42jsc2rd4lzh"
   }
  },
  {
@@ -111159,8 +110941,8 @@
     20210925,
     1940
    ],
-   "commit": "b6ab14278cc0aaac13fb7cb3a12e73985a781cb7",
-   "sha256": "1f24cd9isxhlr1rdbk3inhc2rx9n090wx35fs47nxicicz8hncas"
+   "commit": "2b86fe42b85b602ba97ea7f757676d623cfbb8d0",
+   "sha256": "0dgg8qmpfwb2z7yzvl5hj298lx1dk056wdbyr74vvwgn450x77sd"
   },
   "stable": {
    "version": [
@@ -111195,11 +110977,11 @@
   "repo": "akermu/emacs-libvterm",
   "unstable": {
    "version": [
-    20211209,
-    58
+    20211226,
+    817
    ],
-   "commit": "ed6e867cfab77c5a311a516d20af44f57526cfdc",
-   "sha256": "0mq2q7yj09812iklj49n8p3kfpk1l6az33hr2dyxyl5i2nqps0vs"
+   "commit": "a940dd2ee8a82684860e320c0f6d5e15d31d916f",
+   "sha256": "0r1iz92sn2ddi11arr9s8z7cdpjli7pn55yhaswvp4sdch7chb5r"
   }
  },
  {
@@ -111365,6 +111147,24 @@
   }
  },
  {
+  "ename": "vunit-mode",
+  "commit": "d265a129c7819d3829e4ead3c802f68eff50e56b",
+  "sha256": "1f7579xckv5ngfl0mrr6xpq5y7vwy0rxab5rkdjh1qj3hcjggvla",
+  "fetcher": "github",
+  "repo": "embed-me/vunit-mode",
+  "unstable": {
+   "version": [
+    20211219,
+    1852
+   ],
+   "deps": [
+    "hydra"
+   ],
+   "commit": "dcd04eda5608b55a8e12a81bc5cc51aca0741f18",
+   "sha256": "1b8q4c869y67n11zskdpnkks1qbg174fwjry3p3sf8f3map1dqi1"
+  }
+ },
+ {
   "ename": "vyper-mode",
   "commit": "492d42d60bc188a567c5e438b838a275a124c699",
   "sha256": "0mf1w4mw0ijmd9zxip1df85cp15fbvv9j5dqjmb8lfm4m43wpd96",
@@ -111525,11 +111325,11 @@
   "repo": "darkstego/wakib-keys",
   "unstable": {
    "version": [
-    20211116,
-    2049
+    20211217,
+    1406
    ],
-   "commit": "b2a62fb74f2fdfd00fd56ff8343651fa0a079f50",
-   "sha256": "0j47xxch74j09xxi2v2m42cyzcfa6zbvb6wpyjk9dif6pjn1q3n8"
+   "commit": "cb65d5e32fae0da77118db492cd40b58585d5cf2",
+   "sha256": "0ai5kw8v3778h5ry9191xb7bcmqp3j92h800223aiclh3hrfdc3b"
   }
  },
  {
@@ -111658,16 +111458,16 @@
   "repo": "wanderlust/wanderlust",
   "unstable": {
    "version": [
-    20211212,
-    909
+    20220103,
+    800
    ],
    "deps": [
     "apel",
     "flim",
     "semi"
    ],
-   "commit": "7b06ce86a925ce3c41a54ecacc3c27afbe00dcf1",
-   "sha256": "0p09rqaxwys2jhmlxlxf0xy3x42b183l3kbfrhbivagxpb10r608"
+   "commit": "638d089bba25ce8184c981d0721eba6417b3d7e2",
+   "sha256": "1rz9ydhhx38xvyggfdw8aqb2dgvv36g1db13ggkcyxcwp3x22y4s"
   }
  },
  {
@@ -111904,11 +111704,11 @@
   "repo": "fxbois/web-mode",
   "unstable": {
    "version": [
-    20210902,
-    1615
+    20220104,
+    1504
    ],
-   "commit": "61f057a6baeba6b3595e412ba79b3080dca17dcc",
-   "sha256": "0qmsczsx867h97yqifn9rv5d3gsy7mgwjl9radbf63wfdd89zgcb"
+   "commit": "4f1c96381a96000358b6621782d79c79b05ca5da",
+   "sha256": "16hh7mzn0jkv6bq4iwy413yq9qppivmnwshlm0n4dx6hwdqadfsq"
   },
   "stable": {
    "version": [
@@ -112441,11 +112241,11 @@
   "repo": "justbur/emacs-which-key",
   "unstable": {
    "version": [
-    20211209,
-    1317
+    20220102,
+    1433
    ],
-   "commit": "1bb1f723dab2fc8b88b7f7273d0a7fa11134b936",
-   "sha256": "0wz3bb7vzxqi3wqpn46z6ps00m9wjcpv9cfvqi7lyvm920sxzlv7"
+   "commit": "9f64733e4ac563c0cda3685acf4e1c2cf600319b",
+   "sha256": "086jcw31jl3cb6ahgrgf40s7ydp7gv58pah2ai12j7j3g6vvdjnj"
   },
   "stable": {
    "version": [
@@ -112738,11 +112538,11 @@
   "repo": "progfolio/wikinfo",
   "unstable": {
    "version": [
-    20210630,
-    1730
+    20210711,
+    249
    ],
-   "commit": "bd60451f661609b1b7bfb25662b8b68c0a842c8a",
-   "sha256": "07jplxs05bwac7i6ksxwl7pm30qk8mc3dvdx0pvim59l67vb61wh"
+   "commit": "c75c588a3ebf4cf155c33ca018c56ac914092860",
+   "sha256": "0vrbqaby2q34350mkpykxqw5kfagrdsz12l3fbmdpqvwh1vhjwdm"
   }
  },
  {
@@ -113131,8 +112931,8 @@
     20210405,
     1410
    ],
-   "commit": "2c18054fb0151201f049029781a558275f78d5e5",
-   "sha256": "0dgkmwbniv5gazzaaxxwwnswrm17njdlj2frhr0079kzsddf5xd8"
+   "commit": "c15e50edbfadf6cc46b8ed22a13438ecdb6757ee",
+   "sha256": "0jg9r9ykad05ng1y12mcva52bi8apid9vxaxxww262hgl647cl2v"
   }
  },
  {
@@ -113167,26 +112967,26 @@
  },
  {
   "ename": "with-editor",
-  "commit": "8c52c840dc35f3fd17ec660e113ddbb53aa99076",
-  "sha256": "1wsl1vwvywlc32r5pcc9jqd0pbzq1sn4fppxk3vwl0s5h40v8rnb",
+  "commit": "2133b10c735ce47fc8d8ff8c51f29ec4b13982a3",
+  "sha256": "1cyq6i54dhmj5pvdq475v39s82k2a0zg55zf7vz38n32cnasdhz1",
   "fetcher": "github",
   "repo": "magit/with-editor",
   "unstable": {
    "version": [
-    20211028,
-    2105
+    20220107,
+    1056
    ],
-   "commit": "d53df360e7abe31d61d6689ab39b62dfa7f064b1",
-   "sha256": "18643svb44mhjdqr0xaa56qq2lj5j7x3jnykg2vhxj9vrk528fj8"
+   "commit": "a4e720b12a0946a271a274bbe0b45ae07f83520b",
+   "sha256": "06a66119rp5vfqdzqk10df3qyh9jvjl6j3pqm03jy0b110v2bfa8"
   },
   "stable": {
    "version": [
     3,
-    0,
-    5
+    1,
+    1
    ],
-   "commit": "0c37fea45603257435294e2e01a403627da23abe",
-   "sha256": "1pynm4ng4rki2b2ka5dz01p66ygghk69mldsfbxs81d52jqfnx8f"
+   "commit": "a4e720b12a0946a271a274bbe0b45ae07f83520b",
+   "sha256": "06a66119rp5vfqdzqk10df3qyh9jvjl6j3pqm03jy0b110v2bfa8"
   }
  },
  {
@@ -113493,8 +113293,8 @@
   "repo": "abo-abo/worf",
   "unstable": {
    "version": [
-    20211014,
-    1207
+    20220102,
+    835
    ],
    "deps": [
     "ace-link",
@@ -113502,8 +113302,8 @@
     "swiper",
     "zoutline"
    ],
-   "commit": "d22146bae521d4eeefd0bc2d95c7b64796760faa",
-   "sha256": "1vakix6pdv4ssmwzw7p7iaprp5kyiqjiw8gpi41hn7l3dsgmi4iq"
+   "commit": "8681241e118585824cd256e5b026978bf06c7e58",
+   "sha256": "1gh341f7rvmah8akzy302y6yv3jbydlgdfhxds14m9njg4lrlv2s"
   },
   "stable": {
    "version": [
@@ -113543,11 +113343,11 @@
   "repo": "pashinin/workgroups2",
   "unstable": {
    "version": [
-    20210511,
-    1128
+    20220106,
+    249
    ],
-   "commit": "c310d1ba0e0238e5a22f2a584c966b8b5e7e6616",
-   "sha256": "0k7p39y0lwqr2021nq34asxc4sya4xv3w2nbxqkzjz0ddnyiw2qr"
+   "commit": "d2e1f33001f1777767a7c6e862d5e6a37e688f42",
+   "sha256": "03lbfbi05g03w1cnys6smaf0yxm6168ckmdbcvkxy0k519ngzyd1"
   },
   "stable": {
    "version": [
@@ -113927,15 +113727,6 @@
    ],
    "commit": "ec6abb0182068294a379cb49ad5346b1d757457d",
    "sha256": "19xh1pzh5kgfjjckg73ljylv14912an536rl04jahaxfknf4ypm6"
-  },
-  "stable": {
-   "version": [
-    0,
-    1,
-    3
-   ],
-   "commit": "bde2b3730a02d237f7d95a8e3f3722f23f2d9201",
-   "sha256": "154xnfcmil9xjjmq4cyrfpir4ga4mgcmmbd7dja1m7rpk1734xk6"
   }
  },
  {
@@ -114054,14 +113845,14 @@
   "repo": "vibhavp/emacs-xkcd",
   "unstable": {
    "version": [
-    20160419,
-    1130
+    20220106,
+    952
    ],
    "deps": [
     "json"
    ],
-   "commit": "66e928706fd660cfdab204c98a347b49c4267bdf",
-   "sha256": "0znhjwlpgg05g39b16ddgw3a71a93fn2dicfsxjkziffn2a95m0s"
+   "commit": "688d0b4ea234adda0c05784e6bb22ab9d71f0884",
+   "sha256": "15swryph0sks7lrcwnxsf436vq99b7psydnv0b2662nlbb0a4fdb"
   },
   "stable": {
    "version": [
@@ -114168,8 +113959,8 @@
     20200907,
     42
    ],
-   "commit": "8020ccd176986d8e49e0bb5dd9f4e756cf12eafc",
-   "sha256": "07vgwnk96i1vpsv2glg6kbkamjcs72xiznsa6xk7nl0nranzr3hd"
+   "commit": "b8c9c3147095983d45532627171c2b2ad422ef10",
+   "sha256": "0mpm40sl299dp8195rka99zhjqzs1v1rgfxvz2q3mxg2dv89s7vd"
   },
   "stable": {
    "version": [
@@ -114623,8 +114414,8 @@
     20200511,
     2005
    ],
-   "commit": "96068216a4f0c4894bf780cd36164fe840cf81d5",
-   "sha256": "11wrvmnr74pqga8a00gd4zskan8wkgah9fyn0bwgp0x4qx4xni17"
+   "commit": "56e6f62b3d1c1fd4db2750a8168902c8104645a8",
+   "sha256": "1b43ciqx2qf9mxj6sggyllcz7ymli532vxkm6vcwsp114pl7jgxy"
   }
  },
  {
@@ -114704,11 +114495,11 @@
   "repo": "yoshiki/yaml-mode",
   "unstable": {
    "version": [
-    20210808,
-    1122
+    20220104,
+    1503
    ],
-   "commit": "63b637f846411806ae47e63adc06fe9427be1131",
-   "sha256": "1z759sg45ws08bj1c97xvxxbvs5a0fq8lgxrh5j5n7yv4jz4vr1k"
+   "commit": "a79d2a7b9281f8c56f461d717b1ba40fc58e22fd",
+   "sha256": "1g5ps5q2q046jb1dhxzqrm2mbdny1dyyqijwh9wk75l97bdashgz"
   },
   "stable": {
    "version": [
@@ -114893,11 +114684,11 @@
   "repo": "emacsorphanage/yascroll",
   "unstable": {
    "version": [
-    20210625,
-    803
+    20220103,
+    1605
    ],
-   "commit": "0d7556d0936e0223003208003470a2fa28f72150",
-   "sha256": "12lz73grpvnjgki93q9aywa5p6ddw67a73dcaryv186j3maq442w"
+   "commit": "42750d23b47c6c8a3aa77088eb7dcf289ffbca4b",
+   "sha256": "1dpxcylckv2fh1m5bs1iphsjjrjf208yzp8s5dmhrgbfhwirzdsv"
   },
   "stable": {
    "version": [
@@ -114947,14 +114738,14 @@
   "repo": "leanprover-community/yasnippet-lean",
   "unstable": {
    "version": [
-    20200526,
-    326
+    20220105,
+    2251
    ],
    "deps": [
     "yasnippet"
    ],
-   "commit": "e0933f55d59da5425d0604bdcdbbf3cb85967563",
-   "sha256": "0h64h47qdv3c20g9hlys2xb4w2jby7pdfhaza52y48wayz6vhpnx"
+   "commit": "c75485757cc8675ad4f36c1eb028d9d54dc21733",
+   "sha256": "0lki128rgk5nshpqkz2mndwvzl4a62nammy0xrm4m84ya4vb9mwi"
   }
  },
  {
@@ -115664,15 +115455,15 @@
   "repo": "EFLS/zetteldeft",
   "unstable": {
    "version": [
-    20210919,
-    1306
+    20211214,
+    2221
    ],
    "deps": [
     "ace-window",
     "deft"
    ],
-   "commit": "f4f227a9cdb69cf06fd3715e40ddf17a069063f1",
-   "sha256": "0baydmll48m0z2pk8gw5z5ki9b04mc7xjxw8ljaz58ph7ik1dpi0"
+   "commit": "7fd18ba9eb3552befcb564ddd5e2201d7aa39ee5",
+   "sha256": "0w252rsfzy3vm08bqxi8f0mb9mpx532c7bkyminal8x7ssn1bdn6"
   },
   "stable": {
    "version": [
@@ -115756,11 +115547,11 @@
   "repo": "ziglang/zig-mode",
   "unstable": {
    "version": [
-    20210831,
-    719
+    20211227,
+    1108
    ],
-   "commit": "aba01b6199b7697692e5e9217f602477dd5ebd9b",
-   "sha256": "1qlvsm4736wr3gw54jvjq3yilf3d7564yydhid4ka1wswvl3sbq3"
+   "commit": "aa20d630b8c413dab8d6bd120ec3ed5db5c9da70",
+   "sha256": "0d081n6244q4y2sbhdya87gacw742v5f62pfs7c3bwgq0pcng997"
   }
  },
  {
@@ -115940,18 +115731,6 @@
    ],
    "commit": "38b6e9f1f5871e9166b00a1db44680caa56773be",
    "sha256": "10zb1ffq98jxzzym1ss9ly9ydbkrqynlkwn6s2hbc3h0av5ymmaq"
-  },
-  "stable": {
-   "version": [
-    0,
-    2,
-    2
-   ],
-   "deps": [
-    "esxml"
-   ],
-   "commit": "e36875d83ad3dce14f23864688959fa0d98ba410",
-   "sha256": "1lrgirfvcvbir7csshkhhwj99jj1x5aprhw7xfiicv7nan9m6gjy"
   }
  },
  {
@@ -116178,11 +115957,11 @@
   "repo": "abo-abo/zoutline",
   "unstable": {
    "version": [
-    20210913,
-    1117
+    20220102,
+    835
    ],
-   "commit": "d678b0ea805dd18c18746455c70ea68e51422c1d",
-   "sha256": "134c9ibk920nnhmgnvkr97zwgxy7a41kqj14dkrzxmw9lhxnmz20"
+   "commit": "32857c6c4b9b0bcbed14d825a10b91a98d5fed0a",
+   "sha256": "02xlyz3zbrzskfgrkn4f781l7dic7gd869sf7asxvcxv0pv058q8"
   },
   "stable": {
    "version": [
@@ -116202,20 +115981,20 @@
   "repo": "Vonfry/zoxide.el",
   "unstable": {
    "version": [
-    20210705,
-    448
+    20211223,
+    245
    ],
-   "commit": "f68d7cf9c8c813bdc1ec75f880e0dd1b64112f7c",
-   "sha256": "030vyh9v89ij1db1riqpzxxfgs50x0lx3isnhzbfj2dy3acmmc7s"
+   "commit": "29508e94255c34174bc07c93749cad5d04700063",
+   "sha256": "12y0vqibb5sn9l42aiy1lm0cp0nl8d27zgql86va28glwzpma6s9"
   },
   "stable": {
    "version": [
     1,
-    0,
+    1,
     0
    ],
-   "commit": "f68d7cf9c8c813bdc1ec75f880e0dd1b64112f7c",
-   "sha256": "030vyh9v89ij1db1riqpzxxfgs50x0lx3isnhzbfj2dy3acmmc7s"
+   "commit": "29508e94255c34174bc07c93749cad5d04700063",
+   "sha256": "12y0vqibb5sn9l42aiy1lm0cp0nl8d27zgql86va28glwzpma6s9"
   }
  },
  {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
