### PR TITLE
timg: 1.4.2 -> 1.4.3

### DIFF
--- a/pkgs/tools/graphics/timg/default.nix
+++ b/pkgs/tools/graphics/timg/default.nix
@@ -1,18 +1,18 @@
 { lib, stdenv, fetchFromGitHub, cmake, pkg-config, graphicsmagick, libjpeg
-, ffmpeg, zlib, libexif }:
+, ffmpeg, zlib, libexif, openslide }:
 
 stdenv.mkDerivation rec {
   pname = "timg";
-  version = "1.4.2";
+  version = "1.4.3";
 
   src = fetchFromGitHub {
     owner = "hzeller";
     repo = "timg";
     rev = "v${version}";
-    sha256 = "1zjcaxnik8imkn22g5kz6zly3yxpknrzd093sfxpgqnfw4sq8149";
+    sha256 = "1lanr2y9rchl0xmycsyl0bhnh9mrmr5dj46pglw4lykz4rxslzcx";
   };
 
-  buildInputs = [ graphicsmagick ffmpeg libexif libjpeg zlib ];
+  buildInputs = [ graphicsmagick ffmpeg libexif libjpeg openslide zlib ];
 
   nativeBuildInputs = [ cmake pkg-config ];
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     "-DTIMG_VERSION_FROM_GIT=Off"
     "-DWITH_VIDEO_DECODING=On"
     "-DWITH_VIDEO_DEVICE=On"
-    "-DWITH_OPENSLIDE_SUPPORT=Off" # https://openslide.org/ lib not yet in nix
+    "-DWITH_OPENSLIDE_SUPPORT=On"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
Update version. Also include openslide support. The needed
dependency library became available since last release thanks
to @lromor.

Signed-off-by: Henner Zeller <h.zeller@acm.org>

###### Motivation for this change

Update to latest version.
(I am owner of this package)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
