### PR TITLE
ghc8107: fix seperate bin outputs on aarch64-darwin

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -212,6 +212,15 @@ stdenv.mkDerivation (rec {
       url = "https://gitlab.haskell.org/ghc/ghc/-/commit/97d0b0a367e4c6a52a17c3299439ac7de129da24.patch";
       sha256 = "0r4zjj0bv1x1m2dgxp3adsf2xkr94fjnyj1igsivd9ilbs5ja0b5";
     })
+  ] ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [
+
+    # Prevent the paths module from emitting symbols that we don't use
+    # when building with separate outputs.
+    #
+    # These cause problems as they're not eliminated by GHC's dead code
+    # elimination on aarch64-darwin. (see
+    # https://github.com/NixOS/nixpkgs/issues/140774 for details).
+    ./cabal-paths.patch
   ];
 
   postPatch = "patchShebangs .";

--- a/pkgs/development/compilers/ghc/cabal-paths.patch
+++ b/pkgs/development/compilers/ghc/cabal-paths.patch
@@ -1,0 +1,99 @@
+diff --git a/Cabal/Distribution/Simple/Build/PathsModule.hs b/Cabal/Distribution/Simple/Build/PathsModule.hs
+index 5e660e8d6..1ae603c94 100644
+--- a/libraries/Cabal/Cabal/Distribution/Simple/Build/PathsModule.hs
++++ b/libraries/Cabal/Cabal/Distribution/Simple/Build/PathsModule.hs
+@@ -37,6 +37,9 @@ import System.FilePath ( pathSeparator )
+ -- * Building Paths_<pkg>.hs
+ -- ------------------------------------------------------------
+ 
++splitPath :: FilePath -> [ String ]
++splitPath = unintersperse pathSeparator
++
+ generatePathsModule :: PackageDescription -> LocalBuildInfo -> ComponentLocalBuildInfo -> String
+ generatePathsModule pkg_descr lbi clbi =
+    let pragmas =
+@@ -78,12 +81,44 @@ generatePathsModule pkg_descr lbi clbi =
+           "import System.Environment (getExecutablePath)\n"
+         | otherwise = ""
+ 
++       dirs = [ (flat_libdir, "LibDir")
++              , (flat_dynlibdir, "DynLibDir")
++              , (flat_datadir, "DataDir")
++              , (flat_libexecdir, "LibexecDir")
++              , (flat_sysconfdir, "SysconfDir") ];
++
++       shouldEmitPath p
++         | (splitPath flat_prefix) `isPrefixOf` (splitPath flat_bindir) = True
++         | (splitPath flat_prefix) `isPrefixOf` (splitPath p) = False
++         | otherwise = True
++
++       shouldEmitDataDir = shouldEmitPath flat_datadir
++
++       nixEmitPathFn (path, name) = let
++         varName = toLower <$> name
++         fnName = "get"++name
++         in if shouldEmitPath path then
++              varName ++ " :: FilePath\n"++
++              varName ++ " = " ++ show path ++
++              "\n" ++ fnName ++ " :: IO FilePath" ++
++              "\n" ++ fnName ++ " = " ++ mkGetEnvOr varName ("return " ++ varName)++"\n"
++            else ""
++
++       absBody = intercalate "\n" $ nixEmitPathFn <$> dirs
++
++       warnPragma = case filter (not . shouldEmitPath . fst) dirs of
++         [] -> ""
++         omittedDirs -> "{-# WARNING \"The functions: "++omittedFns++" Have been omitted by the Nix build system.\" #-}"
++           where omittedFns = intercalate ", " $ map snd omittedDirs
++
++       importList = intercalate ", " $ ("get" ++) . snd <$> filter (shouldEmitPath . fst) dirs
++
+        header =
+         pragmas++
+-        "module " ++ prettyShow paths_modulename ++ " (\n"++
+-        "    version,\n"++
+-        "    getBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir,\n"++
+-        "    getDataFileName, getSysconfDir\n"++
++        "module " ++ prettyShow paths_modulename ++ " " ++ warnPragma ++ " (\n"++
++        "    version, getBinDir,\n"++
++        (if shouldEmitDataDir then "    getDataFileName, \n" else "\n")++
++        "    " ++ importList ++"\n"++
+         "  ) where\n"++
+         "\n"++
+         foreign_imports++
+@@ -136,26 +171,18 @@ generatePathsModule pkg_descr lbi clbi =
+           "\n"++
+           filename_stuff
+         | absolute =
+-          "\nbindir, libdir, dynlibdir, datadir, libexecdir, sysconfdir :: FilePath\n"++
++          "\nbindir :: FilePath\n"++
+           "\nbindir     = " ++ show flat_bindir ++
+-          "\nlibdir     = " ++ show flat_libdir ++
+-          "\ndynlibdir  = " ++ show flat_dynlibdir ++
+-          "\ndatadir    = " ++ show flat_datadir ++
+-          "\nlibexecdir = " ++ show flat_libexecdir ++
+-          "\nsysconfdir = " ++ show flat_sysconfdir ++
+           "\n"++
+-          "\ngetBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath\n"++
++          "\ngetBinDir :: IO FilePath\n"++
+           "getBinDir = "++mkGetEnvOr "bindir" "return bindir"++"\n"++
+-          "getLibDir = "++mkGetEnvOr "libdir" "return libdir"++"\n"++
+-          "getDynLibDir = "++mkGetEnvOr "dynlibdir" "return dynlibdir"++"\n"++
+-          "getDataDir = "++mkGetEnvOr "datadir" "return datadir"++"\n"++
+-          "getLibexecDir = "++mkGetEnvOr "libexecdir" "return libexecdir"++"\n"++
+-          "getSysconfDir = "++mkGetEnvOr "sysconfdir" "return sysconfdir"++"\n"++
+-          "\n"++
+-          "getDataFileName :: FilePath -> IO FilePath\n"++
+-          "getDataFileName name = do\n"++
+-          "  dir <- getDataDir\n"++
+-          "  return (dir ++ "++path_sep++" ++ name)\n"
++          absBody ++ "\n"++
++          (if shouldEmitDataDir then
++             "getDataFileName :: FilePath -> IO FilePath\n"++
++             "getDataFileName name = do\n"++
++             "  dir <- getDataDir\n"++
++             "  return (dir ++ "++path_sep++" ++ name)\n"
++           else "\n")
+         | otherwise =
+           "\nprefix, bindirrel :: FilePath" ++
+           "\nprefix        = " ++ show flat_prefix ++


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix for separate outputs on `aarch64-darwin`. Here we patch Cabal so that it only outputs the `get*` functions when `binpath` shares the same prefix as `prefix`.  See #140774 for details.

This builds `niv`, `ormolu` and `ghcid` successfully.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
