### PR TITLE
Slim down iso_gnome output size

### DIFF
--- a/pkgs/applications/graphics/gnome-photos/default.nix
+++ b/pkgs/applications/graphics/gnome-photos/default.nix
@@ -78,7 +78,6 @@ stdenv.mkDerivation rec {
     gfbgraph
     glib
     gnome-online-accounts
-    gnome.adwaita-icon-theme
     grilo
     grilo-plugins
     gsettings-desktop-schemas

--- a/pkgs/desktops/gnome/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-shell/default.nix
@@ -55,7 +55,7 @@
 , gnome-clocks
 , gnome-settings-daemon
 , gnome-autoar
-, asciidoc-full
+, asciidoc
 , bash-completion
 , mesa
 }:
@@ -119,7 +119,7 @@ stdenv.mkDerivation rec {
     desktop-file-utils
     libxslt.bin
     python3
-    asciidoc-full
+    asciidoc
   ];
 
   buildInputs = [
@@ -179,6 +179,9 @@ stdenv.mkDerivation rec {
     patchShebangs src/data-to-c.pl
     chmod +x meson/postinstall.py
     patchShebangs meson/postinstall.py
+
+    # We can generate it ourselves.
+    rm -f man/gnome-shell.1
 
     substituteInPlace src/gnome-shell-extension-tool.in --replace "@PYTHON@" "${pythonEnv}/bin/python"
     substituteInPlace src/gnome-shell-perf-tool.in --replace "@PYTHON@" "${pythonEnv}/bin/python"

--- a/pkgs/development/libraries/aws-crt-cpp/0001-build-Make-includedir-properly-overrideable.patch
+++ b/pkgs/development/libraries/aws-crt-cpp/0001-build-Make-includedir-properly-overrideable.patch
@@ -1,0 +1,58 @@
+From 6be95cf45c4b5beae8b364468cef42d5c5880836 Mon Sep 17 00:00:00 2001
+From: Jan Tojnar <jtojnar@gmail.com>
+Date: Sun, 9 Jan 2022 01:57:18 +0100
+Subject: [PATCH] build: Make includedir properly overrideable
+
+This is required by some package managers like Nix.
+---
+ CMakeLists.txt | 20 ++++++++++++--------
+ 1 file changed, 12 insertions(+), 8 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ad50174..e0be58c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -54,6 +54,10 @@ elseif(NOT DEFINED CMAKE_INSTALL_LIBDIR)
+     set(CMAKE_INSTALL_LIBDIR "lib")
+ endif()
+ 
++if(NOT DEFINED CMAKE_INSTALL_INCLUDEDIR)
++    set(CMAKE_INSTALL_INCLUDEDIR "include")
++endif()
++
+ if (${CMAKE_INSTALL_LIBDIR} STREQUAL "lib64")
+     set(FIND_LIBRARY_USE_LIB64_PATHS true)
+ endif()
+@@ -302,7 +306,7 @@ endif ()
+ 
+ target_include_directories(${PROJECT_NAME} PUBLIC
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+-        $<INSTALL_INTERFACE:include>)
++        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+ 
+ aws_use_package(aws-c-http)
+ aws_use_package(aws-c-mqtt)
+@@ -316,13 +320,13 @@ aws_use_package(aws-c-s3)
+ 
+ target_link_libraries(${PROJECT_NAME} ${DEP_AWS_LIBS})
+ 
+-install(FILES ${AWS_CRT_HEADERS} DESTINATION "include/aws/crt" COMPONENT Development)
+-install(FILES ${AWS_CRT_AUTH_HEADERS} DESTINATION "include/aws/crt/auth" COMPONENT Development)
+-install(FILES ${AWS_CRT_CRYPTO_HEADERS} DESTINATION "include/aws/crt/crypto" COMPONENT Development)
+-install(FILES ${AWS_CRT_IO_HEADERS} DESTINATION "include/aws/crt/io" COMPONENT Development)
+-install(FILES ${AWS_CRT_IOT_HEADERS} DESTINATION "include/aws/iot" COMPONENT Development)
+-install(FILES ${AWS_CRT_MQTT_HEADERS} DESTINATION "include/aws/crt/mqtt" COMPONENT Development)
+-install(FILES ${AWS_CRT_HTTP_HEADERS} DESTINATION "include/aws/crt/http" COMPONENT Development)
++install(FILES ${AWS_CRT_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/aws/crt" COMPONENT Development)
++install(FILES ${AWS_CRT_AUTH_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/aws/crt/auth" COMPONENT Development)
++install(FILES ${AWS_CRT_CRYPTO_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/aws/crt/crypto" COMPONENT Development)
++install(FILES ${AWS_CRT_IO_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/aws/crt/io" COMPONENT Development)
++install(FILES ${AWS_CRT_IOT_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/aws/iot" COMPONENT Development)
++install(FILES ${AWS_CRT_MQTT_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/aws/crt/mqtt" COMPONENT Development)
++install(FILES ${AWS_CRT_HTTP_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/aws/crt/http" COMPONENT Development)
+ 
+ install(
+         TARGETS ${PROJECT_NAME}
+-- 
+2.34.1
+

--- a/pkgs/development/libraries/aws-crt-cpp/default.nix
+++ b/pkgs/development/libraries/aws-crt-cpp/default.nix
@@ -18,12 +18,20 @@ stdenv.mkDerivation rec {
   pname = "aws-crt-cpp";
   version = "0.17.8";
 
+  outputs = [ "out" "dev" ];
+
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-crt-cpp";
     rev = "v${version}";
     sha256 = "sha256-eHABIg3v5ycpQzacW/8C74PT6yDOXGmJqDa9P1hN7Mo=";
   };
+
+  patches = [
+    # Correct include path for split outputs.
+    # https://github.com/awslabs/aws-crt-cpp/pull/325
+    ./0001-build-Make-includedir-properly-overrideable.patch
+  ];
 
   postPatch = ''
     substituteInPlace CMakeLists.txt --replace '-Werror' ""
@@ -52,6 +60,11 @@ stdenv.mkDerivation rec {
     "-DCMAKE_SKIP_BUILD_RPATH=OFF"
     "-DBUILD_SHARED_LIBS=ON"
   ];
+
+  postInstall = ''
+    # Prevent dependency cycle.
+    moveToOutput lib/aws-crt-cpp/cmake "$dev"
+  '';
 
   meta = with lib; {
     description = "C++ wrapper around the aws-c-* libraries";

--- a/pkgs/development/libraries/libgtop/default.nix
+++ b/pkgs/development/libraries/libgtop/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
   pname = "libgtop";
   version = "2.40.0";
 
+  outputs = [ "out" "dev" ];
+
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "1m6jbqk8maa52gxrf223442fr5bvvxgb7ham6v039i3r1i62gwvq";

--- a/pkgs/development/libraries/libvncserver/default.nix
+++ b/pkgs/development/libraries/libvncserver/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
   pname = "libvncserver";
   version = "0.9.13";
 
+  outputs = [ "out" "dev" ];
+
   src = fetchFromGitHub {
     owner = "LibVNC";
     repo = "libvncserver";
@@ -23,11 +25,24 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-gQT/M2u4nWQ0MfO2gWAqY0ZJc7V9eGczGzcsxKmG4H8=";
   };
 
-  nativeBuildInputs = [ cmake ];
-  buildInputs = [ libjpeg openssl libgcrypt libpng ]
-    ++ lib.optional stdenv.isLinux systemd
-    ++ lib.optional stdenv.isDarwin Carbon;
-  propagatedBuildInputs = [ zlib ];
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    libjpeg
+    openssl
+    libgcrypt
+    libpng
+  ] ++ lib.optionals stdenv.isLinux [
+    systemd
+  ] ++ lib.optional stdenv.isDarwin [
+    Carbon
+  ];
+
+  propagatedBuildInputs = [
+    zlib
+  ];
 
   meta = with lib; {
     description = "VNC server library";


### PR DESCRIPTION
The iso is now too big for Hydra: https://github.com/NixOS/nixpkgs/issues/141521

```ShellSession
$ nix-build nixos/release.nix -A iso_gnome
[...]
$ du result/
2105304 result/
$ du -h result/
2.1G  result/
```
