### PR TITLE
docs: add section about fake user data

### DIFF
--- a/doc/contributing/coding-conventions.chapter.md
+++ b/doc/contributing/coding-conventions.chapter.md
@@ -495,6 +495,24 @@ Let's say Man-in-the-Middle (MITM) sits close to your network. Then instead of f
 
 - `https://` URLs are not secure in method 5. When obtaining hashes with fake hash method, TLS checks are disabled. So refetch source hash from several different networks to exclude MITM scenario. Alternatively, use fake hash method to make Nix error, but instead of extracting hash from error, extract `https://` URL and prefetch it with method 1.
 
+## Using fake user data for download {#sec-fake-data}
+
+Some software require user data like name and address to download it. When it does not matter which data we put in, we can use this fake data.
+
+```
+First Name: NixOS
+Last Name: Linux
+Email: someone@nixos.org
+Phone: +31 71 452 5670
+Country: Netherlands
+State/Province: Province of Utrecht
+Postcode: 3584CX
+City: Utrecht
+Address: Heidelberglaan 200
+```
+
+This fake data is inspired by the origin of the NixOS project which was started in 2003 as a research project at Utrecht University.
+
 ## Patches {#sec-patches}
 
 Patches available online should be retrieved using `fetchpatch`.


### PR DESCRIPTION
###### Motivation for this change

This topic came up in https://github.com/NixOS/nixpkgs/pull/152113.

It was also discussed in the forum: https://discourse.nixos.org/t/fake-user-data-for-download/16875

###### Preview

![Screenshot from 2022-01-09 00-16-20](https://user-images.githubusercontent.com/91113/148663159-e6feccad-c1ba-409a-b301-7c5840bc3cdf.png)


###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
