### PR TITLE
emacs.pkgs.melpa*: Fix version numbers with negative numbers

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/libgenerated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/libgenerated.nix
@@ -69,7 +69,10 @@ in {
           melpaBuild {
             inherit pname ename commit;
             version = if isNull version then "" else
-              lib.concatStringsSep "." (map toString version);
+              lib.concatStringsSep "." (map toString
+                # Hack: Melpa archives contains versions with parse errors such as [ 4 4 -4 413 ] which should be 4.4-413
+                # This filter method is still technically wrong, but it's computationally cheap enough and tapers over the issue
+                (builtins.filter (n: n > 0) version));
             # TODO: Broken should not result in src being null (hack to avoid eval errors)
             src = if (isNull sha256 || broken) then null else
               lib.getAttr fetcher (fetcherGenerators args sourceArgs);


### PR DESCRIPTION
###### Motivation for this change
Melpa archives contains versions with parse errors such as [ 4 4 -4 413 ] which should be 4.4-413.
This filter method is still technically wrong (the result looks like "4.4.413"), but it's computationally cheap enough and tapers over the issue.

Closes https://github.com/nix-community/emacs-overlay/issues/178.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
