### PR TITLE
nixos/bind: clean up formatting

### DIFF
--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -3,7 +3,6 @@
 with lib;
 
 let
-
   cfg = config.services.bind;
 
   bindPkg = config.services.bind.package;
@@ -17,29 +16,48 @@ let
       name = mkOption {
         type = types.str;
         default = name;
-        description = "Name of the zone.";
+        description = ''
+          Name of the zone.
+        '';
       };
+
       master = mkOption {
-        description = "Master=false means slave server";
         type = types.bool;
+        default = true;
+        description = ''
+          Whether this server hosts this zone as a master or a slave.
+        '';
       };
+
       file = mkOption {
         type = types.either types.str types.path;
-        description = "Zone file resource records contain columns of data, separated by whitespace, that define the record.";
+        description = ''
+          Zone file resource records contain columns of data, separated by whitespace, that define the record.
+        '';
       };
+
       masters = mkOption {
         type = types.listOf types.str;
-        description = "List of servers for inclusion in stub and secondary zones.";
+        default = [ ];
+        description = ''
+          List of servers for inclusion in stub and secondary zones.
+        '';
       };
+
       slaves = mkOption {
         type = types.listOf types.str;
-        description = "Addresses who may request zone transfers.";
         default = [ ];
+        description = ''
+          Addresses who may request zone transfers.
+        '';
       };
+
       extraConfig = mkOption {
         type = types.str;
-        description = "Extra zone config to be appended at the end of the zone section.";
         default = "";
+        description = ''
+          Extra zone config to be appended at the end of the zone section.
+        '';
       };
     };
   };
@@ -68,8 +86,8 @@ let
 
       ${cfg.extraConfig}
 
-      ${ concatMapStrings
-          ({ name, file, master ? true, slaves ? [], masters ? [], extraConfig ? "" }:
+      ${concatMapStrings
+          ({ name, file, master, slaves, masters, extraConfig }:
             ''
               zone "${name}" {
                 type ${if master then "master" else "slave"};
@@ -91,149 +109,137 @@ let
                 ${extraConfig}
               };
             '')
-          (attrValues cfg.zones) }
+          (attrValues cfg.zones)}
     '';
-
 in
-
 {
+  options.services.bind = {
+    enable = mkEnableOption "BIND domain name server";
 
-  ###### interface
-
-  options = {
-
-    services.bind = {
-
-      enable = mkEnableOption "BIND domain name server";
-
-
-      package = mkOption {
-        type = types.package;
-        default = pkgs.bind;
-        defaultText = literalExpression "pkgs.bind";
-        description = "The BIND package to use.";
-      };
-
-      cacheNetworks = mkOption {
-        default = [ "127.0.0.0/24" ];
-        type = types.listOf types.str;
-        description = "
-          What networks are allowed to use us as a resolver.  Note
-          that this is for recursive queries -- all networks are
-          allowed to query zones configured with the `zones` option.
-          It is recommended that you limit cacheNetworks to avoid your
-          server being used for DNS amplification attacks.
-        ";
-      };
-
-      blockedNetworks = mkOption {
-        default = [ ];
-        type = types.listOf types.str;
-        description = "
-          What networks are just blocked.
-        ";
-      };
-
-      ipv4Only = mkOption {
-        default = false;
-        type = types.bool;
-        description = "
-          Only use ipv4, even if the host supports ipv6.
-        ";
-      };
-
-      forwarders = mkOption {
-        default = config.networking.nameservers;
-        defaultText = literalExpression "config.networking.nameservers";
-        type = types.listOf types.str;
-        description = "
-          List of servers we should forward requests to.
-        ";
-      };
-
-      forward = mkOption {
-        default = "first";
-        type = types.enum ["first" "only"];
-        description = "
-          Whether to forward 'first' (try forwarding but lookup directly if forwarding fails) or 'only'.
-        ";
-      };
-
-      listenOn = mkOption {
-        default = [ "any" ];
-        type = types.listOf types.str;
-        description = "
-          Interfaces to listen on.
-        ";
-      };
-
-      listenOnIpv6 = mkOption {
-        default = [ "any" ];
-        type = types.listOf types.str;
-        description = "
-          Ipv6 interfaces to listen on.
-        ";
-      };
-
-      directory = mkOption {
-        type = types.str;
-        default = "/run/named";
-        description = "Working directory of BIND.";
-      };
-
-      zones = mkOption {
-        default = [ ];
-        type = with types; coercedTo (listOf attrs) bindZoneCoerce (attrsOf (types.submodule bindZoneOptions));
-        description = "
-          List of zones we claim authority over.
-        ";
-        example = {
-          "example.com" = {
-            master = false;
-            file = "/var/dns/example.com";
-            masters = [ "192.168.0.1" ];
-            slaves = [ ];
-            extraConfig = "";
-          };
-        };
-      };
-
-      extraConfig = mkOption {
-        type = types.lines;
-        default = "";
-        description = "
-          Extra lines to be added verbatim to the generated named configuration file.
-        ";
-      };
-
-      extraOptions = mkOption {
-        type = types.lines;
-        default = "";
-        description = ''
-          Extra lines to be added verbatim to the options section of the
-          generated named configuration file.
-        '';
-      };
-
-      configFile = mkOption {
-        type = types.path;
-        default = confFile;
-        defaultText = literalExpression "confFile";
-        description = "
-          Overridable config file to use for named. By default, that
-          generated by nixos.
-        ";
-      };
-
+    package = mkOption {
+      type = types.package;
+      default = pkgs.bind;
+      defaultText = literalExpression "pkgs.bind";
+      description = ''
+        The BIND package to use.
+      '';
     };
 
+    cacheNetworks = mkOption {
+      type = types.listOf types.str;
+      default = [ "127.0.0.0/24" ];
+      description = ''
+        What networks are allowed to use us as a resolver.  Note
+        that this is for recursive queries -- all networks are
+        allowed to query zones configured with the `zones` option.
+        It is recommended that you limit cacheNetworks to avoid your
+        server being used for DNS amplification attacks.
+      '';
+    };
+
+    blockedNetworks = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = ''
+        What networks are just blocked.
+      '';
+    };
+
+    ipv4Only = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Only use IPv4, even if the host supports IPv6.
+      '';
+    };
+
+    forwarders = mkOption {
+      type = types.listOf types.str;
+      default = config.networking.nameservers;
+      defaultText = literalExpression "config.networking.nameservers";
+      description = ''
+        List of servers we should forward requests to.
+      '';
+    };
+
+    forward = mkOption {
+      type = types.enum [ "first" "only" ];
+      default = "first";
+      description = ''
+        Whether to forward 'first' (try forwarding but lookup directly if forwarding fails) or 'only'.
+      '';
+    };
+
+    listenOn = mkOption {
+      type = types.listOf types.str;
+      default = [ "any" ];
+      description = ''
+        Interfaces to listen on.
+      '';
+    };
+
+    listenOnIpv6 = mkOption {
+      type = types.listOf types.str;
+      default = [ "any" ];
+      description = ''
+        IPv6 interfaces to listen on.
+      '';
+    };
+
+    directory = mkOption {
+      type = types.str;
+      default = "/run/named";
+      description = ''
+        Working directory of BIND.
+      '';
+    };
+
+    zones = mkOption {
+      type = with types; coercedTo (listOf attrs) bindZoneCoerce (attrsOf (types.submodule bindZoneOptions));
+      default = [ ];
+      description = ''
+        List of zones we claim authority over.
+      '';
+      example = {
+        "example.com" = {
+          master = false;
+          file = "/var/dns/example.com";
+          masters = [ "192.168.0.1" ];
+          slaves = [ ];
+          extraConfig = "";
+        };
+      };
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Extra lines to be added verbatim to the generated named configuration file.
+      '';
+    };
+
+    extraOptions = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Extra lines to be added verbatim to the options section of the
+        generated named configuration file.
+      '';
+    };
+
+    configFile = mkOption {
+      type = types.path;
+      default = confFile;
+      defaultText = literalExpression "confFile";
+      description = ''
+        Overridable config file to use for named. By default, this is
+        generated by NixOS.
+      '';
+    };
   };
 
-
-  ###### implementation
-
   config = mkIf cfg.enable {
-
     networking.resolvconf.useLocalResolver = mkDefault true;
 
     users.users.${bindUser} =
@@ -242,7 +248,7 @@ in
         description = "BIND daemon user";
         isSystemUser = true;
       };
-    users.groups.${bindUser} = {};
+    users.groups.${bindUser} = { };
 
     systemd.services.bind = {
       description = "BIND Domain Name Server";
@@ -255,10 +261,10 @@ in
           ${bindPkg.out}/sbin/rndc-confgen -c /etc/bind/rndc.key -u ${bindUser} -a -A hmac-sha256 2>/dev/null
         fi
 
-        ${pkgs.coreutils}/bin/mkdir -p /run/named
+        mkdir -p /run/named
         chown ${bindUser} /run/named
 
-        ${pkgs.coreutils}/bin/mkdir -p ${cfg.directory}
+        mkdir -p ${cfg.directory}
         chown ${bindUser} ${cfg.directory}
       '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This brings the BIND module's formatting in line with most other NixOS modules.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
