### PR TITLE
codeblocks: fix builds

### DIFF
--- a/pkgs/applications/editors/codeblocks/default.nix
+++ b/pkgs/applications/editors/codeblocks/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pkg-config, file, zip, wxGTK30-gtk3, gtk3
+{ lib, stdenv, fetchurl, fetchpatch, pkg-config, file, zip, wxGTK31-gtk3, gtk3
 , contribPlugins ? false, hunspell, gamin, boost, wrapGAppsHook
 }:
 
@@ -15,14 +15,55 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config file zip wrapGAppsHook ];
-  buildInputs = [ wxGTK30-gtk3 gtk3 ]
+  buildInputs = [ wxGTK31-gtk3 gtk3 ]
     ++ optionals contribPlugins [ hunspell gamin boost ];
   enableParallelBuilding = true;
-  patches = [ ./writable-projects.patch ];
+  patches = [
+    ./writable-projects.patch
+    ./fix-clipboard-flush.patch
+    # Fix build on non-x86 machines
+    (fetchpatch {
+      name = "remove-int3.patch";
+      url = "https://github.com/arnholm/codeblocks_sfmirror/commit/d76c015c456561d2c7987935a5f4dc6c0932b0c4.patch";
+      sha256 = "sha256-dpH33vGf2aNdYTeLwxglYDNbvwoY2bGSG6YFRyoGw+A=";
+    })
+    (fetchpatch {
+      name = "remove-pragmas.patch";
+      url = "https://github.com/arnholm/codeblocks_sfmirror/commit/966949d5ab7f3cb86e2a2c7ef4e853ee209b5a1a.patch";
+      sha256 = "sha256-XjejjGOvDk3gl1/n9R69XATGLj5n7tOZNyG8vIlwfyg=";
+    })
+    # Fix build with GCC 11
+    (fetchpatch {
+      name = "use-gcc11-openfilelist.patch";
+      url = "https://github.com/arnholm/codeblocks_sfmirror/commit/a5ea6ff7ff301d739d3dc8145db1578f504ee4ca.patch";
+      sha256 = "sha256-kATaLej8kJf4xm0VicHfRetOepX8O9gOhwdna0qylvQ=";
+    })
+    (fetchpatch {
+      name = "use-gcc11-ccmanager.patch";
+      url = "https://github.com/arnholm/codeblocks_sfmirror/commit/04b7c50fb8c6a29b2d84579ee448d2498414d855.patch";
+      sha256 = "sha256-VPy/M6IvNBxUE4hZRbLExFm0DJf4gmertrqrvsXQNz4=";
+    })
+    # Fix build with wxGTK 3.1.5
+    (fetchpatch {
+      name = "use-wxgtk315.patch";
+      url = "https://github.com/arnholm/codeblocks_sfmirror/commit/2345b020b862ec855038dd32a51ebb072647f28d.patch";
+      sha256 = "sha256-RRjwZA37RllnG8cJdBEnASpEd8z0+ru96fjntO42OvU=";
+    })
+    (fetchpatch {
+      name = "fix-getstring.patch";
+      url = "https://github.com/arnholm/codeblocks_sfmirror/commit/dbdf5c5ea9e3161233f0588a7616b7e4fedc7870.patch";
+      sha256 = "sha256-DrEMFluN8vs0LERa7ULGshl7HdejpsuvXAMjIr/K1fQ=";
+    })
+  ];
   preConfigure = "substituteInPlace ./configure --replace /usr/bin/file ${file}/bin/file";
   postConfigure = optionalString stdenv.isLinux "substituteInPlace libtool --replace ldconfig ${stdenv.cc.libc.bin}/bin/ldconfig";
-  configureFlags = [ "--enable-pch=no" ]
-    ++ optionals contribPlugins [ "--with-contrib-plugins" "--with-boost-libdir=${boost}/lib" ];
+  configureFlags = [ "--enable-pch=no" ] ++ optionals contribPlugins [
+    ("--with-contrib-plugins" + optionalString stdenv.isDarwin "=all,-FileManager,-NassiShneiderman")
+    "--with-boost-libdir=${boost}/lib"
+  ];
+  postInstall = optionalString stdenv.isDarwin ''
+    ln -s $out/lib/codeblocks/plugins $out/share/codeblocks/plugins
+  '';
 
   meta = {
     maintainers = [ maintainers.linquize ];

--- a/pkgs/applications/editors/codeblocks/fix-clipboard-flush.patch
+++ b/pkgs/applications/editors/codeblocks/fix-clipboard-flush.patch
@@ -1,0 +1,24 @@
+diff --git a/src/src/app.cpp b/src/src/app.cpp
+index 81130fd..f98d37b 100644
+--- a/src/src/app.cpp
++++ b/src/src/app.cpp
+@@ -602,7 +602,8 @@ bool CodeBlocksApp::OnInit()
+     m_BatchWindowAutoClose = true;
+     m_pSingleInstance      = nullptr;
+ 
+-    wxTheClipboard->Flush();
++    if (wxTheClipboard->IsOpened())
++        wxTheClipboard->Flush();
+ 
+     wxCmdLineParser& parser = *Manager::GetCmdLineParser();
+     parser.SetDesc(cmdLineDesc);
+@@ -851,7 +852,8 @@ bool CodeBlocksApp::OnInit()
+ 
+ int CodeBlocksApp::OnExit()
+ {
+-    wxTheClipboard->Flush();
++    if (wxTheClipboard->IsOpened())
++        wxTheClipboard->Flush();
+ 
+     if (g_DDEServer) delete g_DDEServer;
+ 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This pull request allows codeblocks to be built on all four platforms.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
