### PR TITLE
CODEOWNERS: subscribe to few pkgs, modules and tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -141,6 +141,15 @@
 /pkgs/development/tools/build-managers/rebar3   @gleber
 /pkgs/development/tools/erlang                  @gleber
 
+# Audio
+/nixos/modules/services/audio/botamusique.nix @mweinelt
+/nixos/modules/services/audio/snapserver.nix @mweinelt
+/nixos/tests/modules/services/audio/botamusique.nix @mweinelt
+/nixos/tests/snapcast.nix @mweinelt
+
+# Browsers
+/pkgs/applications/networking/browsers/firefox @mweinelt
+
 # Jetbrains
 /pkgs/applications/editors/jetbrains @edwtjo
 
@@ -167,11 +176,29 @@
 /nixos/tests/hardened.nix @joachifm
 /pkgs/os-specific/linux/kernel/hardened-config.nix @joachifm
 
+# Home Automation
+/nixos/modules/services/misc/home-assistant.nix @mweinelt
+/nixos/modules/services/misc/zigbee2mqtt.nix @mweinelt
+/nixos/tests/home-assistant.nix @mweinelt
+/nixos/tests/zigbee2mqtt.nix @mweinelt
+/pkgs/servers/home-assistant @mweinelt
+/pkgs/tools/misc/esphome @mweinelt
+
 # Network Time Daemons
 /pkgs/tools/networking/chrony @thoughtpolice
 /pkgs/tools/networking/ntp @thoughtpolice
 /pkgs/tools/networking/openntpd @thoughtpolice
 /nixos/modules/services/networking/ntp @thoughtpolice
+
+# Network
+/pkgs/tools/networking/kea/default.nix @mweinelt
+/pkgs/tools/networking/babeld/default.nix @mweinelt
+/nixos/modules/services/networking/babeld.nix @mweinelt
+/nixos/modules/services/networking/kea.nix @mweinelt
+/nixos/modules/services/networking/knot.nix @mweinelt
+/nixos/tests/babeld.nix @mweinelt
+/nixos/tests/kea.nix @mweinelt
+/nixos/tests/knot.nix @mweinelt
 
 # Dhall
 /pkgs/development/dhall-modules      @Gabriel439 @Profpatsch @ehmry


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/NixOS/ofborg/issues/568

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
