### PR TITLE
Vala updates 2022-01-08 (master)

### DIFF
--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -104,8 +104,8 @@ in rec {
   };
 
   vala_0_48 = generic {
-    version = "0.48.20";
-    sha256 = "sha256-RrHIF/dIUfvMOV/E+eoRlQLPh7kzPMllbhzczAvTN24=";
+    version = "0.48.21";
+    sha256 = "sha256-MFRVrrdo1u2bAYNgtVGC5IsW2xvBY6TluBQg+Y0h2Zg=";
   };
 
   vala_0_52 = generic {

--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -109,8 +109,8 @@ in rec {
   };
 
   vala_0_52 = generic {
-    version = "0.52.8";
-    sha256 = "sha256-d3t9HLVnFewyJUXQEw5/9Y2eem0b2WtuKX6eYOgRh5M=";
+    version = "0.52.9";
+    sha256 = "sha256-HpMH2B4hHxniUB6P5PtN0Z+5J8SEtV/873FOjFFdAHk=";
   };
 
   vala_0_54 = generic {


### PR DESCRIPTION
###### Motivation for this change

https://gitlab.gnome.org/GNOME/vala/raw/0.48.21/NEWS
https://gitlab.gnome.org/GNOME/vala/raw/0.52.9/NEWS
https://gitlab.gnome.org/GNOME/vala/raw/0.54.6/NEWS

Same changes for 0.48, 0.52 (#154086) and 0.54 (#154088):

Various improvements and bug fixes:
  - codegen:
    + Allow boxing of non-external SimpleType structs [<a href="https://gitlab.gnome.org/GNOME/vala/issues/1273">#1273</a>]
    + Cast given default-value of struct with possible member initializer [<a href="https://gitlab.gnome.org/GNOME/vala/issues/1272">#1272</a>]
    + Clear existing length values when revisiting a slice expression [<a href="https://gitlab.gnome.org/GNOME/vala/issues/1274">#1274</a>]
  - vala:
    + Allow unsafe assignment of integer to enum while reporting a notice
    + Non nullable enum types are simple types [<a href="https://gitlab.gnome.org/GNOME/vala/issues/1268">#1268</a>]
    + Correctly replace "in" expression in pre-/postconditions of method [<a href="https://gitlab.gnome.org/GNOME/vala/issues/1269">#1269</a>]

Bindings:

  - gio-2.0: Add custom MemoryOutputStream.with_*data() wrappers [<a href="https://gitlab.gnome.org/GNOME/vala/issues/1271">#1271</a>]

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).