### PR TITLE
vala: 0.54.5 → 0.54.6

### DIFF
--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -114,8 +114,8 @@ in rec {
   };
 
   vala_0_54 = generic {
-    version = "0.54.5";
-    sha256 = "ACjaFoXe3KmTeSv7X0YNtbpUjJqkQyOxiZ9zOokSFYc=";
+    version = "0.54.6";
+    sha256 = "SdYNlqP99sQoc5dEK8bW2Vv0CqffZ47kkSjEsRum5Gk=";
   };
 
   vala = vala_0_54;


### PR DESCRIPTION
###### Motivation for this change

https://gitlab.gnome.org/GNOME/vala/raw/0.48.21/NEWS
https://gitlab.gnome.org/GNOME/vala/raw/0.52.9/NEWS
https://gitlab.gnome.org/GNOME/vala/raw/0.54.6/NEWS

Same changes for 0.48, 0.52 (#154086) and 0.54 (#154088):


Various improvements and bug fixes:
  - codegen:
    + Allow boxing of non-external SimpleType structs [<a href="https://gitlab.gnome.org/GNOME/vala/issues/1273">#1273</a>]
    + Cast given default-value of struct with possible member initializer [<a href="https://gitlab.gnome.org/GNOME/vala/issues/1272">#1272</a>]
    + Clear existing length values when revisiting a slice expression [<a href="https://gitlab.gnome.org/GNOME/vala/issues/1274">#1274</a>]
  - vala:
    + Allow unsafe assignment of integer to enum while reporting a notice
    + Non nullable enum types are simple types [<a href="https://gitlab.gnome.org/GNOME/vala/issues/1268">#1268</a>]
    + Correctly replace "in" expression in pre-/postconditions of method [<a href="https://gitlab.gnome.org/GNOME/vala/issues/1269">#1269</a>]

Bindings:

  - gio-2.0: Add custom MemoryOutputStream.with_*data() wrappers [<a href="https://gitlab.gnome.org/GNOME/vala/issues/1271">#1271</a>]


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
