### PR TITLE
libjxl: Use own libhwy package, fix RISC-V build

### DIFF
--- a/pkgs/development/libraries/libhwy/default.nix
+++ b/pkgs/development/libraries/libhwy/default.nix
@@ -1,0 +1,47 @@
+{ lib, stdenv, cmake, ninja, gtest, fetchpatch, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "libhwy";
+  version = "0.15.0";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "highway";
+    rev = version;
+    sha256 = "sha256-v2HyyHtBydr7QiI83DW1yRv2kWjUOGxFT6mmdrN9XPo=";
+  };
+
+  patches = [
+    # Remove on next release
+    # https://github.com/google/highway/issues/460
+    (fetchpatch {
+      name = "hwy-add-missing-includes.patch";
+      url = "https://github.com/google/highway/commit/8ccab40c2f931aca6004d175eec342cc60f6baec.patch";
+      sha256 = "sha256-wlp5gIvK2+OlKtsZwxq/pXTbESkUtimHXaYDjcBzmQ0=";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake ninja ];
+
+  checkInputs = [ gtest ];
+
+  # Required for case-insensitive filesystems ("BUILD" exists)
+  dontUseCmakeBuildDir = true;
+
+  cmakeFlags = [
+    "-GNinja"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ] ++ lib.optional doCheck "-DHWY_SYSTEM_GTEST:BOOL=ON";
+
+  # hydra's darwin machines run into https://github.com/libjxl/libjxl/issues/408
+  doCheck = !stdenv.hostPlatform.isDarwin;
+
+  meta = with lib; {
+    description = "Performance-portable, length-agnostic SIMD with runtime dispatch";
+    homepage = "https://github.com/google/highway";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ zhaofengli ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17961,6 +17961,8 @@ with pkgs;
 
   libhugetlbfs = callPackage ../development/libraries/libhugetlbfs { };
 
+  libhwy = callPackage ../development/libraries/libhwy { };
+
   libHX = callPackage ../development/libraries/libHX { };
 
   libibmad = callPackage ../development/libraries/libibmad { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR devendors the highway library from libjxl in favor of the upstream version, for [RISC-V fixes](https://github.com/google/highway/issues/467). This is required due to changes to the floating-point API in RISC-V toolchains (see previous link), and Debian is [doing the same](https://github.com/google/highway/issues/467#issuecomment-996492115) to solve the issue.

Tested to build natively on riscv64-linux, x86_64-linux, and aarch64-darwin.

Ref: #101651

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] riscv64-linux
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
