### PR TITLE
tracker: Unconditionally add checkInputs to nativeBuildInputs

### DIFF
--- a/pkgs/development/libraries/tracker/default.nix
+++ b/pkgs/development/libraries/tracker/default.nix
@@ -61,7 +61,8 @@ stdenv.mkDerivation rec {
     python3 # for data-generators
     systemd # used for checks to install systemd user service
     dbus # used for checks and pkg-config to install dbus service/s
-  ];
+  ] ++ checkInputs; # gi is in the main meson.build and checked regardless of
+                    # whether tests are enabled
 
   buildInputs = [
     glib
@@ -77,7 +78,6 @@ stdenv.mkDerivation rec {
 
   checkInputs = with python3.pkgs; [
     pygobject3
-    tappy
   ];
 
   mesonFlags = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`gi` is required by the main `meson.build` and checked at the start of the build process, regardless of whether tests are enabled or not. As a result, builds are broken when `doCheck = false`.

Also removing tappy which is no longer needed: https://gitlab.gnome.org/GNOME/tracker/-/merge_requests/385

Ref: #101651

```
[snip]
Run-time dependency libsoup-3.0 found: YES 3.0.2
Library m found: YES
Library dl found: YES
Program asciidoc found: YES (/nix/store/cs2zga4mgm4r6jcrh8szqdd54mwbqnzh-asciidoc-9.1.0/bin/asciidoc)
Program xsltproc found: YES (/nix/store/xigx9nnnq4j5bx13sc6xh1154anjrqs7-libxslt-1.1.34-bin/bin/xsltproc)
Program python3 (gi) found: NO

meson.build:83:0: ERROR: python3 is missing modules: gi

A full log can be found at /build/tracker-3.2.1/build/meson-logs/meson-log.txt
builder for '/nix/store/dxfi43by4vh08pks154hl90gh3jhd5sx-tracker-3.2.1.drv' failed with exit code 1
```

<details>
<summary>Previous description</summary>

<del>It is required in the main `meson.build` and checked at the start of the build process. On riscv64-linux, simply having it in `checkInputs` doesn't add it to `PYTHONPATH` but it somehow does on x86_64-linux.</del>
</details>


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] riscv64-linux
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
