### PR TITLE
csv-diff: init at 1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2728,6 +2728,12 @@
       fingerprint = "5B08 313C 6853 E5BF FA91  A817 0176 0B4F 9F53 F154";
     }];
   };
+  davidwilemski = {
+    email = "nix@wilemski.org";
+    github = "davidwilemski";
+    githubId = 403152;
+    name = "David Wilemski";
+  };
   davorb = {
     email = "davor@davor.se";
     github = "davorb";

--- a/pkgs/development/python-modules/dictdiffer/default.nix
+++ b/pkgs/development/python-modules/dictdiffer/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+, pytest-cov
+, pytest-isort
+, setuptools-scm
+}:
+
+buildPythonPackage {
+  pname = "dictdiffer";
+  version = "0.9.0";
+
+  src = fetchPypi {
+    pname = "dictdiffer";
+    version = "0.9.0";
+    sha256 = "sha256-F7rPX7/mE8zxttUSvXZuayH7eYgioTOqhgmLismZdXg=";
+  };
+
+
+  # dictdiffer requires pytest-py{code|doc}style package to be installed, skipping doesn't
+  # affect correctness of built package.
+  # We shouldn't need pytest-runner to build or install the package given that
+  # we are using pytestCheckHook
+  postPatch = ''
+    sed -e "s/--pycodestyle//" -i pytest.ini
+    sed -e "s/--pydocstyle//" -i pytest.ini
+    sed -e "/pytest-runner/d" -i setup.py
+  '';
+
+  buildInputs = [ setuptools-scm ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-cov
+    pytest-isort
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/inveniosoftware/dictdiffer";
+    description = "A helper module that helps you to diff and patch dictionaries";
+    license = licenses.mit;
+    maintainers = with maintainers; [ davidwilemski ];
+  };
+}
+

--- a/pkgs/tools/misc/csv-diff/default.nix
+++ b/pkgs/tools/misc/csv-diff/default.nix
@@ -1,0 +1,35 @@
+{ lib, python3, fetchFromGitHub }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "csv-diff";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "simonw";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-gKdVyW5LYAGfpnComGi93atHoHGYu95QchKklYLsBe0=";
+  };
+
+  # We shouldn't need pytest-runner to build or install the package given that
+  # we are using pytestCheckHook
+  postPatch = ''
+    sed -e "/pytest-runner/d" -i setup.py
+  '';
+
+  propagatedBuildInputs = with python3.pkgs; [
+    click
+    dictdiffer
+  ];
+
+  checkInputs = [
+    python3.pkgs.pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Python CLI tool and library for diffing CSV and JSON files";
+    homepage = "https://github.com/simonw/csv-diff";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ davidwilemski ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2704,6 +2704,8 @@ with pkgs;
 
   csv2latex = callPackage ../tools/misc/csv2latex { };
 
+  csv-diff = callPackage ../tools/misc/csv-diff { };
+
   csvs-to-sqlite = callPackage ../tools/misc/csvs-to-sqlite { };
 
   cucumber = callPackage ../development/tools/cucumber {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2122,6 +2122,8 @@ in {
 
   dict2xml = callPackage ../development/python-modules/dict2xml { };
 
+  dictdiffer = callPackage ../development/python-modules/dictdiffer { };
+
   dictionaries = callPackage ../development/python-modules/dictionaries { };
 
   dictpath = callPackage ../development/python-modules/dictpath { };


### PR DESCRIPTION

###### Motivation for this change

This tool is useful for diffing CSV files. This can be handy for workflows that deal with frequently changing CSV files, such as [git scraping](https://simonwillison.net/2020/Oct/9/git-scraping/).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
