### PR TITLE
touchegg: 2.0.12 -> 2.0.13

### DIFF
--- a/pkgs/tools/inputmethods/touchegg/default.nix
+++ b/pkgs/tools/inputmethods/touchegg/default.nix
@@ -1,6 +1,8 @@
-{ stdenv, lib
+{ stdenv
+, lib
 , fetchFromGitHub
 , fetchpatch
+, nix-update-script
 , systemd
 , libinput
 , pugixml
@@ -16,15 +18,28 @@
 
 stdenv.mkDerivation rec {
   pname = "touchegg";
-  version = "2.0.12";
+  version = "2.0.13";
+
   src = fetchFromGitHub {
     owner = "JoseExposito";
     repo = pname;
     rev = version;
-    sha256 = "sha256-oJzehs7oLFTDn7GSm6bY/77tEfyEdlANn69EdCApdPA=";
+    sha256 = "sha256-wfXA4+HSLFHMvdsnyiTfRxPqdSsvd0RMkKIacf+rLZI=";
   };
 
-  PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
+  patches = lib.optionals withPantheon [
+    # Disable per-application gesture by default to make sure the default
+    # config does not conflict with Pantheon switchboard settings.
+    (fetchpatch {
+      url = "https://github.com/elementary/os-patches/commit/7d9b133e02132d7f13cf2fe850b2fe4c015c3c5e.patch";
+      sha256 = "sha256-ZOGVkxiXoTORXC6doz5r9IObAbYjhsDjgg3HtzlTSUc=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+  ];
 
   buildInputs = [
     systemd
@@ -43,19 +58,13 @@ stdenv.mkDerivation rec {
     libxcb
   ]);
 
-  nativeBuildInputs = [
-    pkg-config
-    cmake
-  ];
+  PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
 
-  patches = lib.optionals withPantheon [
-    # Disable per-application gesture by default to make sure the default
-    # config does not conflict with Pantheon switchboard settings.
-    (fetchpatch {
-      url = "https://github.com/elementary/os-patches/commit/ada4e726540a2bb57b606c98e2531cfaaea57211.patch";
-      sha256 = "0is9acwvgiqdhbiw11i3nq0rp0zldcza779fbj8k78cp329rbqb4";
-    })
-  ];
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = pname;
+    };
+  };
 
   meta = with lib; {
     homepage = "https://github.com/JoseExposito/touchegg";


### PR DESCRIPTION
###### Motivation for this change

```

  - Improve pinch detection when the fingers are placed horizontally or vertically

    https://github.com/JoseExposito/touchegg/issues/541

  - Allow to run in multiple X displays

    https://github.com/JoseExposito/touchegg/issues/538

  - Allow to configure the number of times a repeated action is executed

    https://github.com/JoseExposito/touchegg/issues/553

```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
