### PR TITLE
peertube: 3.4.1 -> 4.1.0

### DIFF
--- a/nixos/modules/services/web-apps/peertube.nix
+++ b/nixos/modules/services/web-apps/peertube.nix
@@ -334,6 +334,15 @@ in {
           plugins = lib.mkDefault "/var/lib/peertube/storage/plugins/";
           client_overrides = lib.mkDefault "/var/lib/peertube/storage/client-overrides/";
         };
+        import = {
+          videos = {
+            http = {
+              youtube_dl_release = {
+                python_path = "${pkgs.python3}/bin/python";
+              };
+            };
+          };
+        };
       }
       (lib.mkIf cfg.redis.enableUnixSocket { redis = { socket = "/run/redis/redis.sock"; }; })
     ];

--- a/nixos/modules/services/web-apps/peertube.nix
+++ b/nixos/modules/services/web-apps/peertube.nix
@@ -320,6 +320,7 @@ in {
         };
         storage = {
           tmp = lib.mkDefault "/var/lib/peertube/storage/tmp/";
+          bin = lib.mkDefault "/var/lib/peertube/storage/bin/";
           avatars = lib.mkDefault "/var/lib/peertube/storage/avatars/";
           videos = lib.mkDefault "/var/lib/peertube/storage/videos/";
           streaming_playlists = lib.mkDefault "/var/lib/peertube/storage/streaming-playlists/";
@@ -380,7 +381,7 @@ in {
 
       environment = env;
 
-      path = with pkgs; [ bashInteractive ffmpeg nodejs-16_x openssl yarn youtube-dl ];
+      path = with pkgs; [ bashInteractive ffmpeg nodejs-16_x openssl yarn python3 ];
 
       script = ''
         #!/bin/sh

--- a/pkgs/servers/peertube/default.nix
+++ b/pkgs/servers/peertube/default.nix
@@ -7,28 +7,28 @@ let
     if stdenv.hostPlatform.system == "x86_64-linux" then "linux-x64"
     else throw "Unsupported architecture: ${stdenv.hostPlatform.system}";
 
-  version = "3.4.1";
+  version = "4.0.0";
 
   source = fetchFromGitHub {
     owner = "Chocobozzz";
     repo = "PeerTube";
     rev = "v${version}";
-    sha256 = "0l1ibqmliy4aq60a16v383v4ijv1c9sf2a35k9q365mkl42jbzx1";
+    sha256 = "sha256-nSbB5hRAMDPeKH48eviBS0xrNYab53BohWLKqRD02BI=";
   };
 
   yarnOfflineCacheServer = fetchYarnDeps {
     yarnLock = "${source}/yarn.lock";
-    sha256 = "0zyxf1km79w6329jay4bcpw5bgvhnvmvl11r9hka5c6s46d3ms7n";
+    sha256 = "sha256-GTBHZMjnIi5xqEQG4tNkX0RvnVGgxnxhX/3vsA/GOLU=";
   };
 
   yarnOfflineCacheTools = fetchYarnDeps {
     yarnLock = "${source}/server/tools/yarn.lock";
-    sha256 = "12xmwc8lnalcpx3nww457avn5zw04ly4pp4kjxkvhsqs69arfl2m";
+    sha256 = "sha256-BGr5095F4FQ5ii+2xEmPMAATrqKkZiQ74FJYYo1weKc=";
   };
 
   yarnOfflineCacheClient = fetchYarnDeps {
     yarnLock = "${source}/client/yarn.lock";
-    sha256 = "1glnip6mpizif36vil61sw8i8lnn0jg5hrqgqw6k4cc7hkd2qkpc";
+    sha256 = "sha256-Cyoo/85DVehuWcgPfLkk3S1sZE3WXOr79HZs5ULF8pg=";
   };
 
   bcrypt_version = "5.0.1";
@@ -100,7 +100,6 @@ in stdenv.mkDerivation rec {
     cat > ./bin/details <<EOF
     {"version":"${youtube-dl.version}","path":null,"exec":"youtube-dl"}
     EOF
-
     # Fix wrtc node module
     cd ~/server/tools/node_modules/wrtc
     if [ "${wrtc_version}" != "$(cat package.json | jq -r .version)" ]; then

--- a/pkgs/servers/peertube/default.nix
+++ b/pkgs/servers/peertube/default.nix
@@ -6,28 +6,28 @@ let
     if stdenv.hostPlatform.system == "x86_64-linux" then "linux-x64"
     else throw "Unsupported architecture: ${stdenv.hostPlatform.system}";
 
-  version = "4.0.0";
+  version = "4.1.0";
 
   source = fetchFromGitHub {
     owner = "Chocobozzz";
     repo = "PeerTube";
     rev = "v${version}";
-    sha256 = "sha256-nSbB5hRAMDPeKH48eviBS0xrNYab53BohWLKqRD02BI=";
+    sha256 = "sha256-gW/dzWns6wK3zzNjbW19HrV2jqzjdXR5uMMNXL4Xfdw=";
   };
 
   yarnOfflineCacheServer = fetchYarnDeps {
     yarnLock = "${source}/yarn.lock";
-    sha256 = "sha256-GTBHZMjnIi5xqEQG4tNkX0RvnVGgxnxhX/3vsA/GOLU=";
+    sha256 = "sha256-L1Nr6sGjYVm42OyeFOQeQ6WEXjmNkngWilBtfQJ6bPE=";
   };
 
   yarnOfflineCacheTools = fetchYarnDeps {
     yarnLock = "${source}/server/tools/yarn.lock";
-    sha256 = "sha256-BGr5095F4FQ5ii+2xEmPMAATrqKkZiQ74FJYYo1weKc=";
+    sha256 = "sha256-maPR8OCiuNlle0JQIkZSgAqW+BrSxPwVm6CkxIrIg5k=";
   };
 
   yarnOfflineCacheClient = fetchYarnDeps {
     yarnLock = "${source}/client/yarn.lock";
-    sha256 = "sha256-Cyoo/85DVehuWcgPfLkk3S1sZE3WXOr79HZs5ULF8pg=";
+    sha256 = "sha256-wniMvtz7i3I4pn9xyzfNi1k7gQuzDl1GmEO8LqPBMKg=";
   };
 
   bcrypt_version = "5.0.1";


### PR DESCRIPTION
###### Motivation for this change
Update PeerTube to version 4.1.0

Addresses vulnerabilities [CVE-2022-0508](https://nvd.nist.gov/vuln/detail/CVE-2022-0508)  [CVE-2022-0170](https://nvd.nist.gov/vuln/detail/CVE-2022-0170) https://github.com/NixOS/nixpkgs/issues/160691

~~Not working youtube-dl~~:
```
"err": {
  "stack": "Error: Command failed with ENOENT: python /var/lib/peertube/storage/bin/youtube-dl --dump-json -f bestvideo[vcodec^=avc1][height=720]+bestaudio[ext=m4a]/bestvideo[vcodec!*=av01][vcodec!*=vp9.2][height=720]+bestaudio/bestvideo[vcodec^=avc1][height<=720]+bestaudio[ext=m4a]/bestvideo[vcodec!*=av01][vcodec!*=vp9.2]+bestaudio/best[vcodec!*=av01][vcodec!*=vp9.2]/best https://www.youtube.com/watch?v=...\nspawn python ENOENT\n    at Process.ChildProcess._handle.onexit (node:internal/child_process:282:19)\n    at onErrorNT (node:internal/child_process:477:16)\n    at processTicksAndRejections (node:internal/process/task_queues:83:21)",
  "message": "Command failed with ENOENT: python /var/lib/peertube/storage/bin/youtube-dl --dump-json -f bestvideo[vcodec^=avc1][height=720]+bestaudio[ext=m4a]/bestvideo[vcodec!*=av01][vcodec!*=vp9.2][height=720]+bestaudio/bestvideo[vcodec^=avc1][height<=720]+bestaudio[ext=m4a]/bestvideo[vcodec!*=av01][vcodec!*=vp9.2]+bestaudio/best[vcodec!*=av01][vcodec!*=vp9.2]/best https://www.youtube.com/watch?v=...\nspawn python ENOENT",
  "errno": -2,
  "code": "ENOENT",
  "syscall": "spawn python",
  "path": "python",
  "spawnargs": [
    "/var/lib/peertube/storage/bin/youtube-dl",
    "--dump-json",
    "-f",
    "bestvideo[vcodec^=avc1][height=720]+bestaudio[ext=m4a]/bestvideo[vcodec!*=av01][vcodec!*=vp9.2][height=720]+bestaudio/bestvideo[vcodec^=avc1][height<=720]+bestaudio[ext=m4a]/bestvideo[vcodec!*=av01][vcodec!*=vp9.2]+bestaudio/best[vcodec!*=av01][vcodec!*=vp9.2]/best",
    "https://www.youtube.com/watch?v=..."
  ],
  "originalMessage": "spawn python ENOENT",
  "shortMessage": "Command failed with ENOENT: python /var/lib/peertube/storage/bin/youtube-dl --dump-json -f bestvideo[vcodec^=avc1][height=720]+bestaudio[ext=m4a]/bestvideo[vcodec!*=av01][vcodec!*=vp9.2][height=720]+bestaudio/bestvideo[vcodec^=avc1][height<=720]+bestaudio[ext=m4a]/bestvideo[vcodec!*=av01][vcodec!*=vp9.2]+bestaudio/best[vcodec!*=av01][vcodec!*=vp9.2]/best https://www.youtube.com/watch?v=...\nspawn python ENOENT",
  "command": "python /var/lib/peertube/storage/bin/youtube-dl --dump-json -f bestvideo[vcodec^=avc1][height=720]+bestaudio[ext=m4a]/bestvideo[vcodec!*=av01][vcodec!*=vp9.2][height=720]+bestaudio/bestvideo[vcodec^=avc1][height<=720]+bestaudio[ext=m4a]/bestvideo[vcodec!*=av01][vcodec!*=vp9.2]+bestaudio/best[vcodec!*=av01][vcodec!*=vp9.2]/best https://www.youtube.com/watch?v=...",
  "escapedCommand": "python \"/var/lib/peertube/storage/bin/youtube-dl\" --dump-json -f \"bestvideo[vcodec^=avc1][height=720]+bestaudio[ext=m4a]/bestvideo[vcodec!*=av01][vcodec!*=vp9.2][height=720]+bestaudio/bestvideo[vcodec^=avc1][height<=720]+bestaudio[ext=m4a]/bestvideo[vcodec!*=av01][vcodec!*=vp9.2]+bestaudio/best[vcodec!*=av01][vcodec!*=vp9.2]/best\" \"https://www.youtube.com/watch?v=...\"",
  "stdout": "",
  "stderr": "",
  "failed": true,
  "timedOut": false,
  "isCanceled": false,
  "killed": false
}
```
cc @immae @matthiasbeyer @mohe2015 @stevenroose @Chocobozzz 

@Chocobozzz ~~how to force change location for yotube-dl? NixOS already has a youtube-dl package and does not need to be downloaded and installed automatically. In version 3.x it was still possible to change the location of youtube-dl~~.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
