### PR TITLE
kup: init at 0.9.1

### DIFF
--- a/pkgs/applications/misc/kup/default.nix
+++ b/pkgs/applications/misc/kup/default.nix
@@ -1,0 +1,60 @@
+{ lib,
+  stdenv,
+  fetchFromGitLab,
+  extra-cmake-modules,
+  shared-mime-info,
+  wrapQtAppsHook,
+  kcoreaddons,
+  kdbusaddons,
+  ki18n,
+  kio,
+  solid,
+  kidletime,
+  knotifications,
+  kconfig,
+  kinit,
+  kjobwidgets,
+  plasma-framework,
+  libgit2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "kup";
+  version = "0.9.1";
+
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    repo = pname;
+    owner = "system";
+    rev = "${pname}-${version}";
+    sha256 = "1s180y6vzkxxcjpfdvrm90251rkaf3swzkjwdlpm6m4vnggq0hvs";
+  };
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+    shared-mime-info
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    kcoreaddons
+    kdbusaddons
+    ki18n
+    kio
+    solid
+    kidletime
+    knotifications
+    kconfig
+    kinit
+    kjobwidgets
+    plasma-framework
+    libgit2
+  ];
+
+  meta = with lib; {
+    description = "Backup tool for KDE";
+    homepage = "https://apps.kde.org/kup";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.pwoelfel ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26706,6 +26706,8 @@ with pkgs;
 
   kubetail = callPackage ../applications/networking/cluster/kubetail { } ;
 
+  kup = libsForQt5.callPackage ../applications/misc/kup { };
+
   kupfer = callPackage ../applications/misc/kupfer { };
 
   kvirc = libsForQt514.callPackage ../applications/networking/irc/kvirc { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Kup is a very simple to use backup application, and one of the standard KDE applications.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
