### PR TITLE
python3Packages.elegy: init at 0.8.4

### DIFF
--- a/pkgs/development/python-modules/einops/default.nix
+++ b/pkgs/development/python-modules/einops/default.nix
@@ -44,6 +44,11 @@ buildPythonPackage rec {
 
   checkPhase = ''
     export HOME=$TMPDIR
+
+    # Prevent hangs on PyTorch-related tests, see
+    # https://discuss.pytorch.org/t/pytorch-cpu-hangs-on-nn-linear/17748/4
+    export OMP_NUM_THREADS=1
+
     nosetests -v -w tests
   '';
 

--- a/pkgs/development/python-modules/elegy/default.nix
+++ b/pkgs/development/python-modules/elegy/default.nix
@@ -1,0 +1,75 @@
+{ buildPythonPackage
+, cloudpickle
+, deepdish
+, deepmerge
+, dm-haiku
+, fetchFromGitHub
+, lib
+, poetry
+, pytestCheckHook
+, pytorch
+, pyyaml
+, sh
+, tables
+, tabulate
+, tensorboardx
+, tensorflow
+, toolz
+, treex
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "elegy";
+  version = "0.8.4";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "poets-ai";
+    repo = pname;
+    rev = version;
+    sha256 = "11w8lgl31b52w2qri8j8cgzd30sn8i3769g8nkkshvgkjgca9r4g";
+  };
+
+  nativeBuildInputs = [
+    poetry
+  ];
+
+  propagatedBuildInputs = [
+    cloudpickle
+    deepdish
+    deepmerge
+    dm-haiku
+    pyyaml
+    tables
+    tabulate
+    tensorboardx
+    toolz
+    treex
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [
+    "elegy"
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytorch
+    sh
+    tensorflow
+  ];
+
+  disabledTests = [
+    # Fails with `Could not find compiler for platform Host: NOT_FOUND: could not find registered compiler for platform Host -- check target linkage`.
+    # Runs fine in docker with Ubuntu 22.04. I suspect the issue is the sandboxing in `nixpkgs` but not sure.
+    "test_saved_model_poly"
+  ];
+
+  meta = with lib; {
+    description = "Neural Networks framework based on Jax inspired by Keras and Haiku";
+    homepage = "https://github.com/poets-ai/elegy";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ndl ];
+  };
+}

--- a/pkgs/development/python-modules/treex/relax-deps.patch
+++ b/pkgs/development/python-modules/treex/relax-deps.patch
@@ -1,10 +1,13 @@
 diff --git a/pyproject.toml b/pyproject.toml
-index 7b9ef68..ec11f32 100644
+index f0ff8a0..56787ca 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
-@@ -18,7 +18,7 @@ python = "^3.7"
+@@ -16,9 +16,9 @@ secondary = true
+ [tool.poetry.dependencies]
+ python = "^3.7"
  flax = "^0.3.4"
- PyYAML = "^5.4.1"
+-PyYAML = "^5.4.1"
++PyYAML = ">=5.4.1"
  rich = "^10.7.0"
 -optax = "^0.0.9"
 +optax = ">=0.0.9"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2520,6 +2520,8 @@ in {
 
   elasticsearchdsl = self.elasticsearch-dsl;
 
+  elegy = callPackage ../development/python-modules/elegy { };
+
   elementpath = callPackage ../development/python-modules/elementpath { };
 
   elevate = callPackage ../development/python-modules/elevate { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Finishes the "extra JAX libraries / frameworks" implementation, see the discussion in #152754 I also had to adjust `relax-deps.patch` for `treex` as due to PyYAML version update in `nixpkgs` it was out of allowed range.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
