### PR TITLE
python3Packages.tensorflow-datasets: init at 4.4.0

### DIFF
--- a/pkgs/development/python-modules/tensorflow-datasets/corruptions.patch
+++ b/pkgs/development/python-modules/tensorflow-datasets/corruptions.patch
@@ -1,0 +1,22 @@
+diff --git a/tensorflow_datasets/image_classification/corruptions.py b/tensorflow_datasets/image_classification/corruptions.py
+index 066c4460..cb9a6667 100644
+--- a/tensorflow_datasets/image_classification/corruptions.py
++++ b/tensorflow_datasets/image_classification/corruptions.py
+@@ -35,7 +35,7 @@ FROST_FILENAMES = []
+ 
+ 
+ def _imagemagick_bin():
+-  return 'imagemagick'  # pylint: disable=unreachable
++  return 'convert'  # pylint: disable=unreachable
+ 
+ 
+ # /////////////// Corruption Helpers ///////////////
+@@ -675,7 +675,7 @@ def spatter(x, severity=1):
+     #     ker = np.array([[-1,-2,-3],[-2,0,0],[-3,0,1]], dtype=np.float32)
+     #     ker -= np.mean(ker)
+     ker = np.array([[-2, -1, 0], [-1, 1, 1], [0, 1, 2]])
+-    dist = cv2.filter2D(dist, cv2.CVX_8U, ker)
++    dist = cv2.filter2D(dist, cv2.CV_8U, ker)
+     dist = cv2.blur(dist, (3, 3)).astype(np.float32)
+ 
+     m = cv2.cvtColor(liquid_layer * dist, cv2.COLOR_GRAY2BGRA)

--- a/pkgs/development/python-modules/tensorflow-datasets/default.nix
+++ b/pkgs/development/python-modules/tensorflow-datasets/default.nix
@@ -48,6 +48,7 @@ buildPythonPackage rec {
   };
 
   patches = [
+    # addresses https://github.com/tensorflow/datasets/issues/3673
     ./corruptions.patch
   ];
 

--- a/pkgs/development/python-modules/tensorflow-datasets/default.nix
+++ b/pkgs/development/python-modules/tensorflow-datasets/default.nix
@@ -1,0 +1,140 @@
+{ apache-beam
+, attrs
+, beautifulsoup4
+, buildPythonPackage
+, dill
+, dm-tree
+, fetchFromGitHub
+, ffmpeg
+, future
+, imagemagick
+, importlib-resources
+, jinja2
+, langdetect
+, lib
+, matplotlib
+, mwparserfromhell
+, networkx
+, nltk
+, numpy
+, opencv4
+, pandas
+, pillow
+, promise
+, protobuf
+, pycocotools
+, pydub
+, pytestCheckHook
+, requests
+, scikitimage
+, scipy
+, six
+, tensorflow
+, tensorflow-metadata
+, termcolor
+, tifffile
+, tqdm
+}:
+
+buildPythonPackage rec {
+  pname = "tensorflow-datasets";
+  version = "4.4.0";
+
+  src = fetchFromGitHub {
+    owner = "tensorflow";
+    repo = "datasets";
+    rev = "v${version}";
+    sha256 = "11kbpv54nwr0xf7z5mkj2lmrfqfmcdq8qcpapnqck1kiawr3yad6";
+  };
+
+  patches = [
+    ./corruptions.patch
+  ];
+
+  propagatedBuildInputs = [
+    attrs
+    dill
+    dm-tree
+    future
+    importlib-resources
+    numpy
+    promise
+    protobuf
+    requests
+    six
+    tensorflow-metadata
+    termcolor
+    tqdm
+  ];
+
+  pythonImportsCheck = [
+    "tensorflow_datasets"
+  ];
+
+  checkInputs = [
+    apache-beam
+    beautifulsoup4
+    ffmpeg
+    imagemagick
+    jinja2
+    langdetect
+    matplotlib
+    mwparserfromhell
+    networkx
+    nltk
+    opencv4
+    pandas
+    pillow
+    pycocotools
+    pydub
+    pytestCheckHook
+    scikitimage
+    scipy
+    tensorflow
+    tifffile
+  ];
+
+  disabledTestPaths = [
+    # Sandbox violations: network access, filesystem write attempts outside of build dir, ...
+    "tensorflow_datasets/core/dataset_builder_test.py"
+    "tensorflow_datasets/core/dataset_info_test.py"
+    "tensorflow_datasets/core/features/features_test.py"
+    "tensorflow_datasets/core/github_api/github_path_test.py"
+    "tensorflow_datasets/core/utils/gcs_utils_test.py"
+    "tensorflow_datasets/scripts/cli/build_test.py"
+
+    # Requires `pretty_midi` which is not packaged in `nixpkgs`.
+    "tensorflow_datasets/audio/groove_test.py"
+
+    # Requires `crepe` which is not packaged in `nixpkgs`.
+    "tensorflow_datasets/audio/nsynth_test.py"
+
+    # Requires `gcld3` and `pretty_midi` which are not packaged in `nixpkgs`.
+    "tensorflow_datasets/core/lazy_imports_lib_test.py"
+
+    # Requires `tensorflow_io` which is not packaged in `nixpkgs`.
+    "tensorflow_datasets/image/lsun_test.py"
+
+    # Fails with `TypeError: Constant constructor takes either 0 or 2 positional arguments`
+    # deep in TF AutoGraph. Doesn't reproduce in Docker with Ubuntu 22.04 => might be related
+    # to the differences in some of the dependencies?
+    "tensorflow_datasets/rl_unplugged/rlu_atari/rlu_atari_test.py"
+
+    # Requires `tensorflow_docs` which is not packaged in `nixpkgs` and the test is for documentation anyway.
+    "tensorflow_datasets/scripts/documentation/build_api_docs_test.py"
+
+    # Not a test, should not be executed.
+    "tensorflow_datasets/testing/test_utils.py"
+
+    # Require `gcld3` and `nltk.punkt` which are not packaged in `nixpkgs`.
+    "tensorflow_datasets/text/c4_test.py"
+    "tensorflow_datasets/text/c4_utils_test.py"
+  ];
+
+  meta = with lib; {
+    description = "Library of datasets ready to use with TensorFlow";
+    homepage = "https://www.tensorflow.org/datasets/overview";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ndl ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9557,6 +9557,8 @@ in {
     lmdb-core = pkgs.lmdb;
   };
 
+  tensorflow-datasets = callPackage ../development/python-modules/tensorflow-datasets { };
+
   tensorflow-estimator = callPackage ../development/python-modules/tensorflow-estimator { };
 
   tensorflow-metadata = callPackage ../development/python-modules/tensorflow-metadata { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`tensorflow-datasets` is a collection of ML datasets with a common API to access these that's often used both in TF-based and other ML applications.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
