### PR TITLE
python3Packages.pytest-httpbin: 1.0.0 -> 1.0.1

### DIFF
--- a/pkgs/development/python-modules/httpbin/default.nix
+++ b/pkgs/development/python-modules/httpbin/default.nix
@@ -1,33 +1,65 @@
 { lib
+, brotlipy
 , buildPythonPackage
+, decorator
 , fetchPypi
 , flask
 , flask-limiter
-, markupsafe
-, decorator
 , itsdangerous
+, markupsafe
 , raven
 , six
-, brotlipy
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "httpbin";
   version = "0.7.0";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1yldvf3585zcwj4vxvfm4yr9wwlz3pa2mx2pazqz8x8mr687gcyb";
+    hash = "sha256-y7N3kMkVdfTxV1f0KtQdn3KesifV7b6J5OwXVIbbjfo=";
   };
 
-  propagatedBuildInputs = [ brotlipy flask flask-limiter markupsafe decorator itsdangerous raven six ];
+  propagatedBuildInputs = [
+    brotlipy
+    flask
+    flask-limiter
+    markupsafe
+    decorator
+    itsdangerous
+    raven
+    six
+  ];
 
-  # No tests
-  doCheck = false;
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    "test_httpbin.py"
+  ];
+
+  disabledTests = [
+    # Tests seems to be outdated
+    "test_anything"
+    "test_get"
+    "test_redirect_n_equals_to_1"
+    "test_redirect_n_higher_than_1"
+    "test_redirect_to_post"
+    "test_relative_redirect_n_equals_to_1"
+    "test_relative_redirect_n_higher_than_1"
+  ];
+
+  pythonImportsCheck = [
+    "httpbin"
+  ];
 
   meta = with lib; {
+    description = "HTTP Request and Response Service";
     homepage = "https://github.com/kennethreitz/httpbin";
-    description = "HTTP Request & Response Service";
     license = licenses.mit;
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pytest-httpbin/default.nix
+++ b/pkgs/development/python-modules/pytest-httpbin/default.nix
@@ -1,35 +1,46 @@
-{ buildPythonPackage
-, lib
-, fetchPypi
-, pytest
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
 , httpbin
+, pytest
+, pytestCheckHook
+, requests
 , six
 }:
 
 buildPythonPackage rec {
   pname = "pytest-httpbin";
-  version = "1.0.0";
+  version = "1.0.1";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0wlvw5qgkax7f0i5ks1562s37h2hdmn5yxnp1rajcc2289zm9knq";
+  src = fetchFromGitHub {
+    owner = "kevin1024";
+    repo = "pytest-httpbin";
+    rev = "v${version}";
+    hash = "sha256-Vngd8Vum96+rdG8Nz1+aHrO6WZjiAz+0CeIovaH8N+s=";
   };
 
-  checkInputs = [ pytest ];
+  buildInputs = [
+    pytest
+  ];
 
-  propagatedBuildInputs = [ httpbin six ];
+  propagatedBuildInputs = [
+    httpbin
+    six
+  ];
 
-  checkPhase = ''
-    py.test
-  '';
+  checkInputs = [
+    pytestCheckHook
+    requests
+  ];
 
-  # https://github.com/kevin1024/pytest-httpbin/pull/51
-  doCheck = false;
+  pythonImportsCheck = [
+    "pytest_httpbin"
+  ];
 
-  meta = {
-    description = "Easily test your HTTP library against a local copy of httpbin.org";
+  meta = with lib; {
+    description = "Test your HTTP library against a local copy of httpbin.org";
     homepage = "https://github.com/kevin1024/pytest-httpbin";
-    license = lib.licenses.mit;
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
   };
 }
-


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/kevin1024/pytest-httpbin/releases/tag/v1.0.1

Enable tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
