### PR TITLE
zsh: Support building from Git checkouts

### DIFF
--- a/pkgs/shells/zsh/default.nix
+++ b/pkgs/shells/zsh/default.nix
@@ -1,12 +1,19 @@
-{ lib, stdenv, fetchurl, fetchpatch, ncurses, pcre, buildPackages }:
+{ lib
+, stdenv
+, fetchurl
+, fetchpatch
+, autoreconfHook
+, yodl
+, perl
+, groff
+, util-linux
+, texinfo
+, ncurses
+, pcre
+, buildPackages }:
 
 let
   version = "5.8";
-
-  documentation = fetchurl {
-    url = "mirror://sourceforge/zsh/zsh-${version}-doc.tar.xz";
-    sha256 = "1i6wdzq6rfjx5yjrpzan1jf50hk2pfzy5qib9mb7cnnbjfar6klv";
-  };
 in
 
 stdenv.mkDerivation {
@@ -30,6 +37,8 @@ stdenv.mkDerivation {
     })
   ];
 
+  nativeBuildInputs = [ autoreconfHook yodl perl groff util-linux texinfo ];
+
   buildInputs = [ ncurses pcre ];
 
   configureFlags = [
@@ -47,9 +56,7 @@ stdenv.mkDerivation {
 
   # XXX: think/discuss about this, also with respect to nixos vs nix-on-X
   postInstall = ''
-    mkdir -p $out/share/info
-    tar xf ${documentation} -C $out/share
-    ln -s $out/share/zsh-*/Doc/zsh.info* $out/share/info/
+    make install.info install.html
 
     mkdir -p $out/etc/
     cat > $out/etc/zprofile <<EOF


### PR DESCRIPTION
###### Motivation for this change

A pregenerated `./configure` script is included with `zsh` release
tarballs which makes it so that `zsh` won't build Git checkouts without
`autoreconfHook`.

There are also other files that were pregenerated and included in
releases so a few other tools are necessary to successfully build `zsh`.
We can also build the docs ourselves instead of using the `docs`
tarball.

This means that users can now easily override the `zsh` derivation:

    pkgs.zsh.overrideAttrs (old: {
      src = fetchgit {
        url = "https://git.code.sf.net/p/zsh/code.git";
        rev = "zsh-5.8";
        sha256 = "sha256-Gou2UgafLHnZnG2X8DulidOTO1idTQpnZ3DicZuhCZc=";
      };
    })

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
