### PR TITLE
vvave: init at 2.1.1

### DIFF
--- a/pkgs/applications/video/vvave/default.nix
+++ b/pkgs/applications/video/vvave/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, mkDerivation
+, fetchFromGitLab
+, cmake
+, extra-cmake-modules
+, applet-window-buttons
+, karchive
+, kcoreaddons
+, ki18n
+, kio
+, kirigami2
+, mauikit
+, mauikit-accounts
+, mauikit-filebrowsing
+, qtmultimedia
+, qtquickcontrols2
+, taglib
+}:
+
+mkDerivation rec {
+  pname = "vvave";
+  version = "2.1.1";
+
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "maui";
+    repo = "vvave";
+    rev = "v${version}";
+    sha256 = "sha256-ykX1kd3106KTDTJQIGk6miSgbj+oROiXQl/nkCjTphE=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    applet-window-buttons
+    karchive
+    kcoreaddons
+    ki18n
+    kio
+    kirigami2
+    mauikit
+    mauikit-accounts
+    mauikit-filebrowsing
+    qtmultimedia
+    qtquickcontrols2
+    taglib
+  ];
+
+  meta = with lib; {
+    description = "Multi-platform media player";
+    homepage = "https://invent.kde.org/maui/vvave";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ onny ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30385,6 +30385,8 @@ with pkgs;
     jdk = jdk8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
   };
 
+  vvave = libsForQt5.callPackage ../applications/video/vvave { };
+
   vwm = callPackage ../applications/window-managers/vwm { };
 
   yeahwm = callPackage ../applications/window-managers/yeahwm { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This PR adds the Mauikit application [Vvave](https://invent.kde.org/maui/vvave), a adaptive multimedia player.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
