### PR TITLE
[DRAFT] mauikit-station: init at 2.1.1

### DIFF
--- a/pkgs/applications/misc/maui-station/default.nix
+++ b/pkgs/applications/misc/maui-station/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, mkDerivation
+, fetchFromGitLab
+, cmake
+, extra-cmake-modules
+, applet-window-buttons
+, karchive
+, kcoreaddons
+, ki18n
+, kio
+, kirigami2
+, mauikit
+, mauikit-filebrowsing
+, qtmultimedia
+, qtquickcontrols2
+, qmltermwidget
+}:
+
+mkDerivation rec {
+  pname = "station";
+  version = "2.1.1";
+
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "maui";
+    repo = "station";
+    rev = "v${version}";
+    sha256 = "sha256-3kKN/uITyJ//8FuwK1C2cJOfie7OS4oF0tAI2KEb05g=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    applet-window-buttons
+    karchive
+    kcoreaddons
+    ki18n
+    kio
+    kirigami2
+    mauikit
+    mauikit-filebrowsing
+    qtmultimedia
+    qtquickcontrols2
+    qmltermwidget
+  ];
+
+  meta = with lib; {
+    description = "Convergent terminal emulator";
+    homepage = "https://invent.kde.org/maui/station";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ onny ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28505,6 +28505,8 @@ with pkgs;
 
   sndpeek = callPackage ../applications/audio/sndpeek { };
 
+  maui-station = libsForQt5.callPackage ../applications/misc/maui-station { };
+
   sxhkd = callPackage ../applications/window-managers/sxhkd { };
 
   mpop = callPackage ../applications/networking/mpop {


### PR DESCRIPTION
###### Motivation for this change
Adds convergent terminal application [station](https://invent.kde.org/maui/station), based on QT Mauikit framework.

Currently the app segfaults at startup, trying to fix this

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
