### PR TITLE
extra-cmake-modules: Use associative array to recognize paths

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/setup-hook.sh
+++ b/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/setup-hook.sh
@@ -59,23 +59,24 @@ xdgDataSubdirs=( \
     "wallpapers" "applications" "desktop-directories" "mime" "appdata" "dbus-1" \
 )
 
-ecmHostPathSeen=( )
+# ecmHostPathsSeen is an associative array of the paths that have already been
+# seen by ecmHostPathHook.
+declare -gA ecmHostPathsSeen
 
-ecmUnseenHostPath() {
-    for pkg in "${ecmHostPathSeen[@]}"
-    do
-        if [ "${pkg:?}" == "$1" ]
-        then
-            return 1
-        fi
-    done
-
-    ecmHostPathSeen+=("$1")
-    return 0
+ecmHostPathIsNotSeen() {
+    if [[ -n "${ecmHostPathsSeen["$1"]:-}" ]]; then
+        # The path has been seen before.
+        return 1
+    else
+        # The path has not been seen before.
+        # Now it is seen, so record it.
+        ecmHostPathsSeen["$1"]=1
+        return 0
+    fi
 }
 
 ecmHostPathHook() {
-    ecmUnseenHostPath "$1" || return 0
+    ecmHostPathIsNotSeen "$1" || return 0
 
     local xdgConfigDir="$1/etc/xdg"
     if [ -d "$xdgConfigDir" ]


### PR DESCRIPTION
Fixes #99308.

Use an associative array to recognize paths that have already been seen by the
host path hook. This takes advantage of fast lookup of associative array keys in
Bash. The previous solution scanned a linear array, which was accidentally
quadratic.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
