### PR TITLE
python3Packages.django-extensions: 3.1.3 -> 3.1.5

### DIFF
--- a/pkgs/applications/misc/archivebox/default.nix
+++ b/pkgs/applications/misc/archivebox/default.nix
@@ -4,7 +4,7 @@
 , requests
 , mypy-extensions
 , django_3
-, django_extensions
+, django-extensions
 , dateparser
 , youtube-dl
 , python-crontab
@@ -37,7 +37,7 @@ buildPythonApplication rec {
     requests
     mypy-extensions
     django_3'
-    django_extensions
+    django-extensions
     dateparser
     youtube-dl
     python-crontab

--- a/pkgs/applications/office/paperless-ng/default.nix
+++ b/pkgs/applications/office/paperless-ng/default.nix
@@ -83,7 +83,7 @@ py.pkgs.pythonPackages.buildPythonApplication rec {
     daphne
     dateparser
     django-cors-headers
-    django_extensions
+    django-extensions
     django-filter
     django-picklefield
     django-q

--- a/pkgs/development/python-modules/django-extensions/default.nix
+++ b/pkgs/development/python-modules/django-extensions/default.nix
@@ -1,59 +1,54 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder, django
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, django
 , factory_boy
-, glibcLocales
 , mock
 , pygments
-, pytest
-, pytest-cov
 , pytest-django
-, python-dateutil
+, pytestCheckHook
 , shortuuid
-, six
-, tox
-, typing ? null
 , vobject
 , werkzeug
 }:
 
 buildPythonPackage rec {
   pname = "django-extensions";
-  version = "3.1.3";
+  version = "3.1.5";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "03mhikhh49z8bxajbjf1j790b9c9vl4zf4f86iwz7g0zrd7jqlvm";
+    sha256 = "sha256-NAMa78KhAuoJfp0Cb0Codz84sRfRQ1JhSLNYRI4GBPM=";
   };
 
-  LC_ALL = "en_US.UTF-8";
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov=django_extensions --cov-report html --cov-report term" ""
+  '';
+
+  propagatedBuildInputs = [
+    django
+  ];
+
   __darwinAllowLocalNetworking = true;
 
-  propagatedBuildInputs = [ six ]
-    ++ lib.optional (pythonOlder "3.5") typing;
-
   checkInputs = [
-    django
     factory_boy
-    glibcLocales
     mock
     pygments # not explicitly declared in setup.py, but some tests require it
-    pytest
-    pytest-cov
     pytest-django
-    python-dateutil
+    pytestCheckHook
     shortuuid
-    tox
     vobject
     werkzeug
   ];
 
-  # remove tests that need network access
-  checkPhase = ''
-    rm tests/management/commands/test_pipchecker.py
-    DJANGO_SETTINGS_MODULE=tests.testapp.settings \
-      pytest django_extensions tests
-  '';
+  disabledTestPaths = [
+    # requires network access
+    "tests/management/commands/test_pipchecker.py"
+  ];
 
   meta = with lib; {
     description = "A collection of custom extensions for the Django Framework";

--- a/pkgs/servers/mail/mailman/hyperkitty.nix
+++ b/pkgs/servers/mail/mailman/hyperkitty.nix
@@ -12,7 +12,7 @@
 , django-paintstore
 , django-q
 , django_compressor
-, django_extensions
+, django-extensions
 , djangorestframework
 , flufl_lock
 , mistune_2_0
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     django-mailman3
     django-q
     django_compressor
-    django_extensions
+    django-extensions
     djangorestframework
     flufl_lock
     mistune_2_0

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -45,6 +45,7 @@ mapAliases ({
   discogs_client = discogs-client; # added 2021-07-02
   djangorestframework-jwt = drf-jwt; # added 2021-07-20
   django_environ = django-environ; # added 2021-12-25
+  django_extensions = django-extensions; # added 2022-01-09
   django_redis = django-redis; # added 2021-10-11
   django_taggit = django-taggit; # added 2021-10-11
   dns = dnspython; # added 2017-12-10

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2212,7 +2212,7 @@ in {
 
   django-environ = callPackage ../development/python-modules/django_environ { };
 
-  django_extensions = callPackage ../development/python-modules/django-extensions { };
+  django-extensions = callPackage ../development/python-modules/django-extensions { };
 
   django-filter = callPackage ../development/python-modules/django-filter { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
