### PR TITLE
sgx-ssl: init at lin_2.15.1_1.1.1l

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12149,6 +12149,12 @@
     githubId = 1183303;
     name = "Jakob Klepp";
   };
+  trundle = {
+    name = "Andreas Stührk";
+    email = "andy@hammerhartes.de";
+    github = "Trundle";
+    githubId = 332418;
+  };
   tscholak = {
     email = "torsten.scholak@googlemail.com";
     github = "tscholak";

--- a/pkgs/os-specific/linux/sgx/ssl/default.nix
+++ b/pkgs/os-specific/linux/sgx/ssl/default.nix
@@ -67,9 +67,14 @@ stdenv.mkDerivation rec {
     "DESTDIR=$(out)"
   ];
 
-  # Build and run the test app
+  # Build the test app
+  #
+  # Running the test app is currently only supported on Intel CPUs
+  # and will fail on non-Intel CPUs even in SGX simulation mode.
+  # Therefore, we only build the test app without running it until
+  # upstream resolves the issue: https://github.com/intel/intel-sgx-ssl/issues/113
   doInstallCheck = true;
-  installCheckTarget = "all test";
+  installCheckTarget = "all";
   installCheckFlags = [
     "SGX_MODE=SIM"
     "-C sgx/test_app"

--- a/pkgs/os-specific/linux/sgx/ssl/default.nix
+++ b/pkgs/os-specific/linux/sgx/ssl/default.nix
@@ -1,0 +1,90 @@
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+, fetchurl
+, lib
+, perl
+, sgx-sdk
+, which
+, debug ? false
+}:
+let
+  sgxVersion = sgx-sdk.versionTag;
+  opensslVersion = "1.1.1l";
+in
+stdenv.mkDerivation rec {
+  pname = "sgx-ssl" + lib.optionalString debug "-debug";
+  version = "lin_${sgxVersion}_${opensslVersion}";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "intel-sgx-ssl";
+    rev = version;
+    hash = "sha256-ibPXs90ni2fkxJ09fNO6wWVpfCFdko6MjBFkEsyIih8=";
+  };
+
+  postUnpack =
+    let
+      opensslSourceArchive = fetchurl {
+        url = "https://www.openssl.org/source/openssl-${opensslVersion}.tar.gz";
+        hash = "sha256-C3o+XlnDSCf+DDp0t+yLrvMCuY+oAIjX+RU6oW+na9E=";
+      };
+    in
+    ''
+      ln -s ${opensslSourceArchive} $sourceRoot/openssl_source/openssl-${opensslVersion}.tar.gz
+    '';
+
+  patches = [
+    # https://github.com/intel/intel-sgx-ssl/pull/111
+    ./intel-sgx-ssl-pr-111.patch
+  ];
+
+  postPatch = ''
+    patchShebangs Linux/build_openssl.sh
+
+    # Run the test in the `installCheckPhase`, not the `buildPhase`
+    substituteInPlace Linux/sgx/Makefile \
+      --replace '$(MAKE) -C $(TEST_DIR) all' \
+                'bash -c "true"'
+  '';
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    perl
+    sgx-sdk
+    stdenv.glibc
+    which
+  ];
+
+  makeFlags = [
+    "-C Linux"
+  ] ++ lib.optionals debug [
+    "DEBUG=1"
+  ];
+
+  installFlags = [
+    "DESTDIR=$(out)"
+  ];
+
+  # Build and run the test app
+  doInstallCheck = true;
+  installCheckTarget = "all test";
+  installCheckFlags = [
+    "SGX_MODE=SIM"
+    "-C sgx/test_app"
+    "-j 1" # Makefile doesn't support multiple jobs
+  ];
+  preInstallCheck = ''
+    # Expects the enclave file in the current working dir
+    ln -s sgx/test_app/TestEnclave.signed.so .
+  '';
+
+  meta = with lib; {
+    description = "Cryptographic library for Intel SGX enclave applications based on OpenSSL";
+    homepage = "https://github.com/intel/intel-sgx-ssl";
+    maintainers = with maintainers; [ trundle veehaitch ];
+    platforms = [ "x86_64-linux" ];
+    license = with licenses; [ bsd3 openssl ];
+  };
+}

--- a/pkgs/os-specific/linux/sgx/ssl/intel-sgx-ssl-pr-111.patch
+++ b/pkgs/os-specific/linux/sgx/ssl/intel-sgx-ssl-pr-111.patch
@@ -1,0 +1,99 @@
+From 1683c336e11b3cbe2b48c1be1c9460a661523c71 Mon Sep 17 00:00:00 2001
+From: Vincent Haupert <mail@vincent-haupert.de>
+Date: Sat, 8 Jan 2022 17:22:31 +0100
+Subject: [PATCH 1/3] Linux: fix Nix detection
+
+Detect the `OS_ID` of Nix by probing for the presence of the `NIX_STORE`
+environment variable instead of `NIX_PATH`. The latter is only set in a
+`nix-shell` session but isn't when building a derivation through
+`nix-build`. In contrast, the `NIX_STORE` environment variable is set in
+both cases.
+
+Signed-off-by: Vincent Haupert <mail@vincent-haupert.de>
+---
+ Linux/sgx/buildenv.mk | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Linux/sgx/buildenv.mk b/Linux/sgx/buildenv.mk
+index cd8818e..dac23c7 100644
+--- a/Linux/sgx/buildenv.mk
++++ b/Linux/sgx/buildenv.mk
+@@ -65,7 +65,7 @@ $(shell mkdir -p $(PACKAGE_LIB))
+ UBUNTU_CONFNAME:=/usr/include/x86_64-linux-gnu/bits/confname.h
+ ifneq ("$(wildcard $(UBUNTU_CONFNAME))","")
+ 	OS_ID=1
+-else ifeq ($(origin NIX_PATH),environment)
++else ifeq ($(origin NIX_STORE),environment)
+ 	OS_ID=3
+ else
+ 	OS_ID=2
+
+From f493525face589d759223bfa45bb802c31ddce4f Mon Sep 17 00:00:00 2001
+From: Vincent Haupert <mail@vincent-haupert.de>
+Date: Sat, 8 Jan 2022 17:33:22 +0100
+Subject: [PATCH 2/3] Linux: call binaries relative to PATH
+
+Using an absolute path to call binaries is incompatible with
+distributions which do not follow the Filesystem Hierachy Standard;
+Nix is an example. Also, it is inconsistent with the rest of the code
+base, let alone superfluous.
+
+Signed-off-by: Vincent Haupert <mail@vincent-haupert.de>
+---
+ Linux/build_openssl.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Linux/build_openssl.sh b/Linux/build_openssl.sh
+index 7d77b79..e8b59a1 100755
+--- a/Linux/build_openssl.sh
++++ b/Linux/build_openssl.sh
+@@ -38,7 +38,7 @@ SGXSSL_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ echo $SGXSSL_ROOT
+ 
+ OPENSSL_INSTALL_DIR="$SGXSSL_ROOT/../openssl_source/OpenSSL_install_dir_tmp"
+-OPENSSL_VERSION=`/bin/ls $SGXSSL_ROOT/../openssl_source/*1.1.1*.tar.gz | /usr/bin/head -1 | /bin/grep -o '[^/]*$' | /bin/sed -s -- 's/\.tar\.gz//'`
++OPENSSL_VERSION=`ls $SGXSSL_ROOT/../openssl_source/*1.1.1*.tar.gz | head -1 | grep -o '[^/]*$' | sed -s -- 's/\.tar\.gz//'`
+ if [ "$OPENSSL_VERSION" == "" ] 
+ then
+ 	echo "In order to run this script, OpenSSL tar.gz package must be located in openssl_source/ directory."
+
+From fdb883d30fff72b5cfb8c61a2288d3d948f64224 Mon Sep 17 00:00:00 2001
+From: Vincent Haupert <mail@vincent-haupert.de>
+Date: Tue, 11 Jan 2022 10:56:39 +0100
+Subject: [PATCH 3/3] Linux: properly extract GCC major version
+
+Calling `gcc -dumpversion` yields the full version string, e.g.,
+`10.3.0`. The `build_openssl.sh` bash script uses the `-ge` number
+comparison operator to check if the returned version is at least
+8. This results in an error if the returned GCC version includes a patch
+version; "10.3.0" isn't a valid number.
+
+This commit fixes the version detection by only extracting the relevant
+major version of GCC.
+
+Signed-off-by: Vincent Haupert <mail@vincent-haupert.de>
+---
+ Linux/build_openssl.sh | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/Linux/build_openssl.sh b/Linux/build_openssl.sh
+index e8b59a1..6e4046f 100755
+--- a/Linux/build_openssl.sh
++++ b/Linux/build_openssl.sh
+@@ -82,6 +82,7 @@ fi
+ MITIGATION_OPT=""
+ MITIGATION_FLAGS=""
+ CC_VERSION=`gcc -dumpversion`
++CC_VERSION_MAJOR=`echo "$CC_VERSION" | cut -f1 -d.`
+ for arg in "$@"
+ do
+     case $arg in
+@@ -99,7 +100,7 @@ do
+         ;;
+     -mfunction-return=thunk-extern)
+         MITIGATION_FLAGS+=" $arg"
+-        if [[ $CC_VERSION -ge 8 ]] ; then
++        if [[ "$CC_VERSION_MAJOR" -ge 8 ]] ; then
+             MITIGATION_FLAGS+=" -fcf-protection=none"
+         fi
+         shift

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22872,6 +22872,8 @@ with pkgs;
 
   sgx-sdk = callPackage ../os-specific/linux/sgx/sdk { };
 
+  sgx-ssl = callPackage ../os-specific/linux/sgx/ssl { };
+
   sgx-psw = callPackage ../os-specific/linux/sgx/psw { };
 
   shadow = callPackage ../os-specific/linux/shadow { };


### PR DESCRIPTION
###### Motivation for this change

Adds SGX SSL, Intel's port of OpenSSL that can be used in enclave applications.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
