### PR TITLE
firmwareLinuxNonfree -> linux-firmware

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -374,6 +374,12 @@
           <literal>pkgs.theLoungePlugins.themes</literal>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          The <literal>firmwareLinuxNonfree</literal> package has been
+          renamed to <literal>linux-firmware</literal>.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
 </section>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -134,3 +134,5 @@ In addition to numerous new and upgraded packages, this release has the followin
   is set to `true`.
 
 - The option `services.thelounge.plugins` has been added to allow installing plugins for The Lounge. Plugins can be found in `pkgs.theLoungePlugins.plugins` and `pkgs.theLoungePlugins.themes`.
+
+- The `firmwareLinuxNonfree` package has been renamed to `linux-firmware`.

--- a/nixos/modules/hardware/all-firmware.nix
+++ b/nixos/modules/hardware/all-firmware.nix
@@ -31,7 +31,6 @@ in {
       type = types.bool;
       description = ''
         Turn on this option if you want to enable all the firmware with a license allowing redistribution.
-        (i.e. free firmware and <literal>firmware-linux-nonfree</literal>)
       '';
     };
 
@@ -51,7 +50,7 @@ in {
   config = mkMerge [
     (mkIf (cfg.enableAllFirmware || cfg.enableRedistributableFirmware) {
       hardware.firmware = with pkgs; [
-        firmwareLinuxNonfree
+        linux-firmware
         intel2200BGFirmware
         rtl8192su-firmware
         rt5677-firmware

--- a/pkgs/os-specific/linux/firmware/linux-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/linux-firmware/default.nix
@@ -1,7 +1,7 @@
 { stdenvNoCC, fetchgit, lib }:
 
 stdenvNoCC.mkDerivation rec {
-  pname = "firmware-linux-nonfree";
+  pname = "linux-firmware";
   version = "20211216";
 
   src = fetchgit {

--- a/pkgs/os-specific/linux/microcode/amd.nix
+++ b/pkgs/os-specific/linux/microcode/amd.nix
@@ -1,9 +1,9 @@
-{ lib, stdenv, firmwareLinuxNonfree, libarchive }:
+{ lib, stdenv, linux-firmware, libarchive }:
 
 stdenv.mkDerivation {
-  name = "amd-ucode-${firmwareLinuxNonfree.version}";
+  name = "amd-ucode-${linux-firmware.version}";
 
-  src = firmwareLinuxNonfree;
+  src = linux-firmware;
 
   sourceRoot = ".";
 
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
 
   buildPhase = ''
     mkdir -p kernel/x86/microcode
-    find ${firmwareLinuxNonfree}/lib/firmware/amd-ucode -name \*.bin \
+    find ${linux-firmware}/lib/firmware/amd-ucode -name \*.bin \
       -exec sh -c 'cat {} >> kernel/x86/microcode/AuthenticAMD.bin' \;
   '';
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -262,6 +262,7 @@ mapAliases ({
   firefoxWrapper = firefox;           # 2015-09
 
   firestr = throw "firestr has been removed."; # added 2019-12-08
+  firmwareLinuxNonfree = linux-firmware; # added 2022-01-09
   fish-foreign-env = throw "fish-foreign-env has been replaced with fishPlugins.foreign-env"; # added 2020-12-29, modified 2021-01-10
   flameGraph = flamegraph; # added 2018-04-25
   flashplayer = throw "flashplayer has been removed as Adobe Flash Player is now deprecated."; # added 2021-02-07

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22786,7 +22786,7 @@ with pkgs;
 
   qemu_test = lowPrio (qemu.override { hostCpuOnly = true; nixosTestRunner = true; });
 
-  firmwareLinuxNonfree = callPackage ../os-specific/linux/firmware/firmware-linux-nonfree { };
+  linux-firmware = callPackage ../os-specific/linux/firmware/linux-firmware { };
 
   qmk-udev-rules = callPackage ../os-specific/linux/qmk-udev-rules { };
 


### PR DESCRIPTION
###### Motivation for this change

This renames our `firmwareLinuxNonfree` package to `linux-firmware`.
There is prior art for this in multiple other distros[1] [2] [3].

Besides making the package more discoverable by those searching for the
usual name, this also brings it in-line with the `kebab-case` we
normally see in `nixpkgs` pnames, and removes the `Nonfree` information
from the name, which I consider redundant given it's present in
`meta.license`.

The corresponding alias has been added, so this shouldn't break
anything.

[1]: https://archlinux.org/packages/core/any/linux-firmware/
[2]: https://src.fedoraproject.org/rpms/linux-firmware
[3]: https://packages.gentoo.org/packages/sys-kernel/linux-firmware


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
