### PR TITLE
cbc: enable threads and switch to openblas

### DIFF
--- a/pkgs/development/libraries/science/math/or-tools/default.nix
+++ b/pkgs/development/libraries/science/math/or-tools/default.nix
@@ -3,10 +3,9 @@
 , fetchFromGitHub
 , cmake
 , abseil-cpp
-, bzip2
-, zlib
 , lsb-release
 , which
+, pkg-config
 , protobuf
 , cbc
 , ensureNewerSourcesForZipFilesHook
@@ -31,13 +30,13 @@ stdenv.mkDerivation rec {
   # obviously don't want to do this so instead we provide the
   # dependencies straight from nixpkgs and use the make build method.
 
-  # Cbc is linked against bzip2 and declares this in its pkgs-config file,
-  # but this makefile doesn't use pkgs-config, so we also have to add lbz2
+  # Cbc is linked against bzip2 and some other stuff and declares this in
+  # its pkgs-config file, but this makefile doesn't use pkgs-config, so
+  # we add that too
   configurePhase = ''
     substituteInPlace makefiles/Makefile.third_party.unix.mk \
       --replace 'COINUTILS_LNK = $(STATIC_COINUTILS_LNK)' \
-                'COINUTILS_LNK = $(STATIC_COINUTILS_LNK) -lbz2'
-
+                "COINUTILS_LNK = $(STATIC_COINUTILS_LNK) $(pkg-config --libs cbc)"
     cat <<EOF > Makefile.local
       UNIX_ABSL_DIR=${abseil-cpp}
       UNIX_PROTOBUF_DIR=${protobuf}
@@ -61,6 +60,7 @@ stdenv.mkDerivation rec {
     substituteInPlace ortools/linear_solver/samples/simple_mip_program.cc \
       --replace 'SCIP' 'CBC'
   '';
+
   makeFlags = [
     "prefix=${placeholder "out"}"
     "PROTOBUF_PYTHON_DESC=${python.pkgs.protobuf}/${python.sitePackages}/google/protobuf/descriptor_pb2.py"
@@ -84,13 +84,13 @@ stdenv.mkDerivation rec {
     lsb-release
     swig4
     which
+    pkg-config
     ensureNewerSourcesForZipFilesHook
     python.pkgs.setuptools
     python.pkgs.wheel
   ];
   buildInputs = [
-    zlib
-    bzip2
+    cbc
     python
   ];
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This library was currently being compiled without support for threads (no parallel solves). I enabled that, and also switched the blas to openblas rather than the internal bundled netlib blas.

Also updated or-tools to build with this version of Cbc and hopefully be more robust in the future to changes in its dependencies (pulling stuff from pkg-config), and bumped abseil-cpp to the latest LTS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
