### PR TITLE
shunit2: 2019-08-10 (unstable) -> 2.1.8 and use resholvePackage

### DIFF
--- a/pkgs/tools/misc/shunit2/default.nix
+++ b/pkgs/tools/misc/shunit2/default.nix
@@ -9,15 +9,15 @@
 , ncurses
 }:
 
-resholvePackage {
+resholvePackage rec {
   pname = "shunit2";
-  version = "2019-08-10";
+  version = "2.1.8";
 
   src = fetchFromGitHub {
     owner = "kward";
-    repo = "shunit2";
-    rev = "ba130d69bbff304c0c6a9c5e8ab549ae140d6225";
-    sha256 = "1bsn8dhxbjfmh01lq80yhnld3w3fw1flh7nwx12csrp58zsvlmgk";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-IZHkgkVqzeh+eEKCDJ87sqNhSA+DU6kBCNDdQaUEeiM=";
   };
 
   installPhase = ''
@@ -82,8 +82,8 @@ resholvePackage {
 
   meta = with lib; {
     homepage = "https://github.com/kward/shunit2";
-    description = "A xUnit based unit test framework for Bourne based shell scripts";
-    maintainers = with maintainers; [ cdepillabout utdemir ];
+    description = "An xUnit based unit test framework for Bourne based shell scripts";
+    maintainers = with maintainers; [ abathur utdemir ];
     license = licenses.asl20;
     platforms = platforms.unix;
   };

--- a/pkgs/tools/misc/shunit2/default.nix
+++ b/pkgs/tools/misc/shunit2/default.nix
@@ -1,6 +1,15 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib
+, resholvePackage
+, fetchFromGitHub
+, bash
+, coreutils
+, gnused
+, gnugrep
+, findutils
+, ncurses
+}:
 
-stdenv.mkDerivation {
+resholvePackage {
   pname = "shunit2";
   version = "2019-08-10";
 
@@ -21,6 +30,55 @@ stdenv.mkDerivation {
   installCheckPhase = ''
     $out/bin/shunit2
   '';
+
+  solutions = {
+    shunit = {
+      # Caution: see __SHUNIT_CMD_ECHO_ESC before changing
+      interpreter = "${bash}/bin/sh";
+      scripts = [ "bin/shunit2" ];
+      inputs = [ coreutils gnused gnugrep findutils ncurses ];
+      # resholve's Nix API is analogous to the CLI flags
+      # documented in 'man resholve'
+      fake = {
+        # "missing" functions shunit2 expects the user to declare
+        function = [
+          "oneTimeSetUp"
+          "oneTimeTearDown"
+          "setUp"
+          "tearDown"
+          "suite"
+          "noexec"
+        ];
+        # shunit2 is both bash and zsh compatible, and in
+        # some zsh-specific code it uses this non-bash builtin
+        builtin = [ "setopt" ];
+      };
+      fix = {
+        # stray absolute path; make it resolve from coreutils
+        "/usr/bin/od" = true;
+        /*
+        Caution: this one is contextually debatable. shunit2
+        sets this variable after testing whether `echo -e test`
+        yields `test` or `-e test`. Since we're setting the
+        interpreter, we can pre-test this. But if we go fiddle
+        the interpreter later, I guess we _could_ break it.
+        */
+        "$__SHUNIT_CMD_ECHO_ESC" = [ "'echo -e'" ];
+        "$SHUNIT_CMD_TPUT" = [ "tput" ]; # from ncurses
+      };
+      keep = {
+        # dynamically defined in shunit2:_shunit_mktempFunc
+        eval = [ "shunit_condition_" "_shunit_test_" "_shunit_prepForSourcing" ];
+
+        # dynamic based on CLI flag
+        "$_SHUNIT_LINENO_" = true;
+      };
+      execer = [
+        # drop after https://github.com/abathur/binlore/issues/2
+        "cannot:${ncurses}/bin/tput"
+      ];
+    };
+  };
 
   meta = with lib; {
     homepage = "https://github.com/kward/shunit2";


### PR DESCRIPTION
###### Motivation for this change

Convert shunit2 to use `resholvePackage`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
