### PR TITLE
linuxPackages.liquidtux: set meta.broken

### DIFF
--- a/pkgs/os-specific/linux/liquidtux/default.nix
+++ b/pkgs/os-specific/linux/liquidtux/default.nix
@@ -29,5 +29,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     platforms = [ "x86_64-linux" "i686-linux" ];
     maintainers = with maintainers; [ nickhu ];
+    broken = lib.versionOlder kernel.version "5.10";
   };
 }


### PR DESCRIPTION
This avoids Hydra (and others) attempting builds that would fail.
https://github.com/NixOS/nixpkgs/pull/150997#issuecomment-998686413

<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
