### PR TITLE
wownero: use fetchFromGitea

### DIFF
--- a/pkgs/applications/blockchains/wownero/default.nix
+++ b/pkgs/applications/blockchains/wownero/default.nix
@@ -1,26 +1,28 @@
-{ lib, stdenv, fetchgit, cmake, boost, miniupnpc_2, openssl, unbound
-, readline, libsodium, rapidjson, fetchurl
+{ lib, stdenv, fetchFromGitea, cmake, boost, miniupnpc_2, openssl, unbound
+, readline, libsodium, rapidjson
 }:
 
 with lib;
-
-let
-  randomwowVersion = "1.1.7";
-  randomwow = fetchurl {
-    url = "https://github.com/wownero/RandomWOW/archive/${randomwowVersion}.tar.gz";
-    sha256 = "1xp76zf01hnhnk6rjvqjav9n9pnvxzxlzqa5rc574d1c2qczfy3q";
-  };
-in
-
 stdenv.mkDerivation rec {
   pname = "wownero";
   version = "0.8.0.1";
+  randomwowVersion = "1.1.7";
 
-  src = fetchgit {
-    url = "https://git.wownero.com/wownero/wownero.git";
+  src = fetchFromGitea {
+    domain = "git.wownero.com";
+    owner = "wownero";
+    repo = "wownero";
     rev = "v${version}";
-    sha256 = "15443xv6q1nw4627ajk6k4ghhahvh82lb4gyb8nvq753p2v838g3";
+    sha256 = "sha256-+cUdousEiZMNwqhTvjoqw/k21x3dg7Lhb/5KyNUGrjQ=";
     fetchSubmodules = false;
+  };
+
+  randomwow = fetchFromGitea {
+    domain = "git.wownero.com";
+    owner = "wownero";
+    repo = "RandomWOW";
+    rev = randomwowVersion;
+    sha256 = "sha256-JzyRlHwM8rmJ5OaKHz+6vHGfpSz+X4zkFAKn4Jmo+EE=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -31,8 +33,7 @@ stdenv.mkDerivation rec {
 
   postUnpack = ''
     rm -r $sourceRoot/external/RandomWOW
-    unpackFile ${randomwow}
-    mv RandomWOW-${randomwowVersion} $sourceRoot/external/RandomWOW
+    ln -s ${randomwow} $sourceRoot/external/RandomWOW
   '';
 
   cmakeFlags = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
i saw, that the repo on github is archived, so is search for the new one

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
