### PR TITLE
zombietrackergps: 1.03 → 1.10

### DIFF
--- a/pkgs/applications/gis/zombietrackergps/default.nix
+++ b/pkgs/applications/gis/zombietrackergps/default.nix
@@ -11,13 +11,13 @@
 
 mkDerivation rec {
   pname = "zombietrackergps";
-  version = "1.03";
+  version = "1.10";
 
   src = fetchFromGitLab {
     owner = "ldutils-projects";
     repo = pname;
     rev = "v_${version}";
-    sha256 = "1rmdy6kijmcxamm4mqmz8638xqisijlnpv8mimgxywpf90h9rrwq";
+    sha256 = "sha256-qRhCAOVWyDLD3WDptPRQVq+VwyFu83XQNaL5TMsGs4Y=";
   };
 
   buildInputs = [
@@ -33,7 +33,10 @@ mkDerivation rec {
   ];
 
   prePatch = ''
-    sed -ie "s,INCLUDEPATH += /usr/include/libldutils,INCLUDEPATH += ${ldutils}," ZombieTrackerGPS.pro
+    substituteInPlace ztgps.pro --replace "../libldutils" "libldutils"
+    substituteInPlace tests.pro --replace "../libldutils" "libldutils"
+
+    ln -s ${ldutils} libldutils
   '';
 
   preConfigure = ''
@@ -41,9 +44,16 @@ mkDerivation rec {
     export INSTALL_ROOT=$out
   '';
 
-  postConfigure = ''
-    substituteInPlace Makefile --replace '$(INSTALL_ROOT)' ""
+  preInstall = ''
+    substituteInPlace Makefile.ztgps --replace '$(INSTALL_ROOT)' ""
+    substituteInPlace Makefile.art --replace '$(INSTALL_ROOT)' ""
   '';
+
+  postInstall = ''
+    install -Dm644 build/rcc/*.rcc -t $out/share/zombietrackergps
+  '';
+
+  qmakeFlags = [ "ZombieTrackerGPS.pro" ];
 
   meta = with lib; {
     description = "GPS track manager for Qt using KDE Marble maps";

--- a/pkgs/development/libraries/ldutils/default.nix
+++ b/pkgs/development/libraries/ldutils/default.nix
@@ -8,13 +8,13 @@
 
 mkDerivation rec {
   pname = "ldutils";
-  version = "1.03";
+  version = "1.10";
 
   src = fetchFromGitLab {
     owner = "ldutils-projects";
     repo = pname;
     rev = "v_${version}";
-    sha256 = "0pi05py71hh5vlhl0kjh9wxmd7yixw10s0kr2wb4l4c0abqxr82j";
+    sha256 = "sha256-fP+tZY+ayaeuxPvywO/639sNE+IwrxaEJ245q9HTOCU=";
   };
 
   buildInputs = [
@@ -25,6 +25,8 @@ mkDerivation rec {
   nativeBuildInputs = [
     qmake
   ];
+
+  qmakeFlags = [ "ldutils.pro" ];
 
   LDUTILS_LIB=placeholder "out";
   LDUTILS_INCLUDE=placeholder "out";


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://www.zombietrackergps.net/ztgps/history.html)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
