### PR TITLE
yarn2nix: mkYarnPackage: allow to override doDist

### DIFF
--- a/pkgs/development/tools/yarn2nix-moretea/yarn2nix/default.nix
+++ b/pkgs/development/tools/yarn2nix-moretea/yarn2nix/default.nix
@@ -349,7 +349,7 @@ in rec {
         runHook postInstall
       '';
 
-      doDist = true;
+      doDist = attrs.doDist or true;
 
       distPhase = attrs.distPhase or ''
         # pack command ignores cwd option


### PR DESCRIPTION
override `doDist` in the argument set
allows users to disable distPhase with `doDist = false`

###### Motivation for this change

right now mkYarnPackage sets mkDerivation attribute `doDist` to `true` and does not allow users to disable it.
So users that don't need to package tarballs for distribution
 - either use overrideAttrs ([1](https://github.com/LavaDesu/powercord-overlay/blob/bdf20fb7ab0ba89fa7eecdda845ce55569376b61/drvs/powercord-unwrapped.nix#L25))
 - or reset distPhase ([2](https://github.com/cab404/vscode-direnv/blob/fd242c19ef66db7f3e7ed2687a4a50d33af2957b/flake.nix#L29))

Some write in the comments that they cannot override doDist as expected ([3](https://github.com/ngi-nix/ipfs-search/blob/05d3b9811ceea086b38caeb4393b8f4fbbfefc17/flake.nix#L80),[4](https://github.com/rpgwaiter/basedconfig/blob/ef704cf9c77271f3800dfc67a4bc1dc08ae8ac8f/pkgs/applications/audio/basedradio/default.nix#L26)) and some still set `doDist = false` to no effect ([5](https://github.com/juliosueiras/devblog-nix/blob/1cefa0769f392bd1fba8b654448200438786d56e/packages/navbar/default.nix#L20),[6](https://kolaente.dev/vikunja/desktop-nix/src/commit/05e003c402e4884853d94d33ef2567bb1d0e4226/frontend/default.nix#L24)).

This PR first reads doDist from the argument attrset and only then falls back to `true`, so `doDist = false` works as expected.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
