### PR TITLE
yadm: use resholvePackage

### DIFF
--- a/pkgs/applications/version-management/yadm/default.nix
+++ b/pkgs/applications/version-management/yadm/default.nix
@@ -1,10 +1,35 @@
-{ lib, stdenv, fetchFromGitHub, git, gnupg, installShellFiles }:
+{ lib
+, stdenv
+, resholvePackage
+, fetchFromGitHub
+, git
+, bash
+, openssl
+, gawk
+/*
+TODO: yadm can use git-crypt and transcrypt
+but it does so in a way that resholve 0.6.0
+can't yet do anything smart about. It looks
+like these are for interactive use, so the
+main impact should just be that users still
+need both of these packages in their profile
+to support their use in yadm.
+*/
+# , git-crypt
+# , transcrypt
+, j2cli
+, esh
+, gnupg
+, coreutils
+, gnutar
+, installShellFiles
+, runCommand
+, yadm
+}:
 
-stdenv.mkDerivation rec {
+resholvePackage rec {
   pname = "yadm";
   version = "3.1.1";
-
-  buildInputs = [ git gnupg ];
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -12,7 +37,7 @@ stdenv.mkDerivation rec {
     owner  = "TheLocehiliosan";
     repo   = "yadm";
     rev    = version;
-    sha256 = "sha256-bgiRBlqEjDq0gQ0+aUWpFDeE2piFX3Gy2gEAXgChAOk=";
+    hash   = "sha256-bgiRBlqEjDq0gQ0+aUWpFDeE2piFX3Gy2gEAXgChAOk=";
   };
 
   dontConfigure = true;
@@ -31,6 +56,72 @@ stdenv.mkDerivation rec {
       --bash completion/bash/yadm
   '';
 
+  solutions = {
+    yadm = {
+      scripts = [ "bin/yadm" ];
+      interpreter = "${bash}/bin/sh";
+      inputs = [
+        git
+        gnupg
+        openssl
+        gawk
+        # see head comment
+        # git-crypt
+        # transcrypt
+        j2cli
+        esh
+        bash
+        coreutils
+        gnutar
+      ];
+      fake = {
+        external = if stdenv.isCygwin then [ ] else [ "cygpath" ];
+      };
+      fix = {
+        "$GPG_PROGRAM" = [ "gpg" ];
+        "$OPENSSL_PROGRAM" = [ "openssl" ];
+        "$GIT_PROGRAM" = [ "git" ];
+        "$AWK_PROGRAM" = [ "awk" ];
+        # see head comment
+        # "$GIT_CRYPT_PROGRAM" = [ "git-crypt" ];
+        # "$TRANSCRYPT_PROGRAM" = [ "transcrypt" ];
+        "$J2CLI_PROGRAM" = [ "j2" ];
+        "$ESH_PROGRAM" = [ "esh" ];
+        # not in nixpkgs (yet)
+        # "$ENVTPL_PROGRAM" = [ "envtpl" ];
+        # "$LSB_RELEASE_PROGRAM" = [ "lsb_release" ];
+      };
+      keep = {
+        "$YADM_COMMAND" = true; # internal cmds
+        "$template_cmd" = true; # dynamic, template-engine
+        "$SHELL" = true; # probably user env? unsure
+        "$hook_command" = true; # ~git hooks?
+        "exec" = [ "$YADM_BOOTSTRAP" ]; # yadm bootstrap script
+
+        # not in nixpkgs
+        "$ENVTPL_PROGRAM" = true;
+        "$LSB_RELEASE_PROGRAM" = true;
+      };
+      /*
+      TODO: these should be dropped as fast as they can be dealt
+            with properly in binlore and/or resholve.
+      */
+      execer = [
+        "cannot:${j2cli}/bin/j2"
+        "cannot:${esh}/bin/esh"
+        "cannot:${git}/bin/git"
+        "cannot:${gnupg}/bin/gpg"
+      ];
+    };
+  };
+
+  passthru.tests = {
+    minimal = runCommand "${pname}-test" {} ''
+      export HOME=$out
+      ${yadm}/bin/yadm init
+    '';
+  };
+
   meta = {
     homepage = "https://github.com/TheLocehiliosan/yadm";
     description = "Yet Another Dotfiles Manager";
@@ -40,6 +131,7 @@ stdenv.mkDerivation rec {
       * Provides a way to use alternate files on a specific OS or host.
       * Supplies a method of encrypting confidential data so it can safely be stored in your repository.
     '';
+    changelog = "https://github.com/TheLocehiliosan/yadm/blob/${version}/CHANGES";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ abathur ];
     platforms = lib.platforms.unix;


### PR DESCRIPTION
###### Motivation for this change

Convert package to use `resholvePackage`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
