### PR TITLE
Assorted python updates related to python310

### DIFF
--- a/pkgs/development/python-modules/catalogue/default.nix
+++ b/pkgs/development/python-modules/catalogue/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, fetchpatch
 , pytestCheckHook
 , pythonAtLeast
 , pythonOlder
@@ -19,6 +20,14 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "0idjhx2s8cy6ppd18k1zy246d97gdd6i217m5q26fwa47xh3asik";
   };
+
+  patches = [
+    # Patch 2.0.6 for python3.10. See https://github.com/explosion/catalogue/issues/27#issuecomment-1009080533
+    (fetchpatch {
+      url = "https://github.com/conda-forge/catalogue-feedstock/raw/cc38d845cf7009f23df1ffbfdb3372fd1dba4942/recipe/patches/0001-skip-entry-points-test.patch";
+      sha256 = "sha256-7dXUMMG7zW2ztoYubmhP+6dfMESz3BMHWVL5wYusEPs=";
+    })
+  ];
 
   propagatedBuildInputs = lib.optionals (pythonOlder "3.8") [
     typing-extensions

--- a/pkgs/development/python-modules/h5py/default.nix
+++ b/pkgs/development/python-modules/h5py/default.nix
@@ -17,10 +17,12 @@ in buildPythonPackage rec {
     sha256 = "8752d2814a92aba4e2b2a5922d2782d0029102d99caaf3c201a566bc0b40db29";
   };
 
-  # avoid strict pinning of numpy
+  # avoid strict pinning of numpy and h5py
   postPatch = ''
     substituteInPlace setup.py \
       --replace "numpy ==" "numpy >="
+    substituteInPlace setup.py \
+      --replace 'mpi4py =='  'mpi4py >='
   '';
 
   HDF5_DIR = "${hdf5}";

--- a/pkgs/development/python-modules/imagecodecs-lite/default.nix
+++ b/pkgs/development/python-modules/imagecodecs-lite/default.nix
@@ -12,6 +12,12 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "0s4xb17qd7vimc46rafbjnibj4sf0lnv8cwl22k1h6zb7jhqmlcm";
   };
+  # this file is generated code from cython, but distributed on
+  # pypi. removing it forces cython to regenerate it from the
+  # actual source code
+  prePatch = ''
+    rm imagecodecs/_imagecodecs_lite.c
+  '';
 
   nativeBuildInputs = [
     cython

--- a/pkgs/development/python-modules/mpi4py/default.nix
+++ b/pkgs/development/python-modules/mpi4py/default.nix
@@ -1,19 +1,21 @@
-{ lib, fetchPypi, fetchpatch, python, buildPythonPackage, mpi, openssh }:
+{ lib
+, fetchFromGitHub
+, python
+, cython
+, buildPythonPackage
+, mpi
+, openssh }:
 
 buildPythonPackage rec {
   pname = "mpi4py";
-  version = "3.0.3";
+  version = "3.1.3";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "012d716c8b9ed1e513fcc4b18e5af16a8791f51e6d1716baccf988ad355c5a1f";
+  src = fetchFromGitHub {
+    owner = "mpi4py";
+    repo = "mpi4py";
+    rev = version;
+    sha256 = "sha256-CUpRh63xmqRUveVGJoHVaOdrqDM3D+P14aV0IrwJIVw=";
   };
-
-  patches = [ (fetchpatch {
-    name = "disable-broken-test"; # upstream patch
-    url = "https://github.com/mpi4py/mpi4py/commit/e13cc3ee59ec6ec2c6ee20e384e1e649d5027e8a.patch";
-    sha256 = "0iwknrhxnfmsqjj8ahpn50c8pcdyv9p3wmcqi1jhr4i5y7lnmvvx";
-  })];
 
   passthru = {
     inherit mpi;
@@ -23,31 +25,12 @@ buildPythonPackage rec {
     substituteInPlace test/test_spawn.py --replace \
                       "unittest.skipMPI('openmpi(<3.0.0)')" \
                       "unittest.skipMPI('openmpi')"
-  '';
-
-  configurePhase = "";
-
-  installPhase = ''
-    mkdir -p "$out/lib/${python.libPrefix}/site-packages"
-    export PYTHONPATH="$out/lib/${python.libPrefix}/site-packages:$PYTHONPATH"
-
-    ${python}/bin/${python.executable} setup.py install \
-      --install-lib=$out/lib/${python.libPrefix}/site-packages \
-      --prefix="$out"
-
-    # --install-lib:
-    # sometimes packages specify where files should be installed outside the usual
-    # python lib prefix, we override that back so all infrastructure (setup hooks)
-    # work as expected
-
-    # Needed to run the tests reliably. See:
-    # https://bitbucket.org/mpi4py/mpi4py/issues/87/multiple-test-errors-with-openmpi-30
-    export OMPI_MCA_rmaps_base_oversubscribe=yes
+    conf/cythonize.sh
   '';
 
   setupPyBuildFlags = ["--mpicc=${mpi}/bin/mpicc"];
 
-  nativeBuildInputs = [ mpi openssh ];
+  nativeBuildInputs = [ cython mpi openssh ];
 
   meta = with lib; {
     description = "Python bindings for the Message Passing Interface standard";

--- a/pkgs/development/python-modules/sfepy/default.nix
+++ b/pkgs/development/python-modules/sfepy/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , numpy
 , scipy
 , matplotlib
@@ -27,6 +28,14 @@ buildPythonPackage rec {
     rev = "release_${version}";
     sha256 = "sha256-+wvFcME02la5JwzD5bvPgBBlkQKF5LWz5MC3+0s5jSs=";
   };
+
+  patches = [
+    # Fix for python3.10
+    (fetchpatch {
+      url = "https://github.com/sfepy/sfepy/commit/d8b595edbc234d5e3b9afee167bc755b3f9c9a57.patch";
+      sha256 = "sha256-NyJy+ddOpQnvA26ifJpZMBEB+yBy1HaGNTiGTsVmNbA=";
+    })
+  ];
 
   propagatedBuildInputs = [
     numpy


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix two packages for python3.10 that were not currently building.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
