### PR TITLE
nixos/networkd: add/update Link/Netdev Options

### DIFF
--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -104,6 +104,8 @@ let
           "BroadcastMulticastQueueLength"
         ])
         (assertValueOneOf "Mode" ["private" "vepa" "bridge" "passthru" "source"])
+        (assertInt "BroadcastMulticastQueueLength")
+        (assertRange "BroadcastMulticastQueueLength" 0 4294967294)
       ];
 
       ipvlanChecks = [

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -24,7 +24,7 @@ let
           "AlternativeName"
           "TransmitQueues"
           "ReceiveQueues"
-          "TransmitQueueLength="
+          "TransmitQueueLength"
           "MTUBytes"
           "BitsPerSecond"
           "Duplex"
@@ -56,7 +56,7 @@ let
         (assertValueOneOf "MACAddressPolicy" ["persistent" "random" "none"])
         (assertMacAddress "MACAddress")
         (assertInt "TransmitQueues")
-        (assertRange "TransmitQueues" 0 4096)
+        (assertRange "TransmitQueues" 1 4096)
         (assertInt "ReceiveQueues")
         (assertRange "ReceiveQueues" 0 4096)
         (assertInt "TransmitQueueLength")
@@ -87,6 +87,7 @@ let
         (assertInt "RxJumboBufferSize")
         (assertInt "TxBufferSize")
         (assertValueOneOf "RxFlowControl" boolValues)
+        (assertValueOneOf "TxFlowControl" boolValues)
         (assertValueOneOf "AutoNegotiationFlowControl" boolValues)
         (assertByteFormat "GenericSegmentOffloadMaxBytes")
         (assertInt "GenericSegmentOffloadMaxSegments")
@@ -102,7 +103,7 @@ let
           "SourceMACAddress"
           "BroadcastMulticastQueueLength"
         ])
-        (assertValueOneOf "Mode" ["private" "vepa" "bridge" "passthru"])
+        (assertValueOneOf "Mode" ["private" "vepa" "bridge" "passthru" "source"])
       ];
 
       ipvlanChecks = [
@@ -203,7 +204,6 @@ let
         (assertValueOneOf "VLANFiltering" boolValues)
         (assertValueOneOf "VLANProtocol" ["802.1q" "802.1ad"])
         (assertValueOneOf "STP" boolValues)
-        (assertInt "MulticastIGMPVersion")
         (assertValueOneOf "MulticastIGMPVersion" [2 3])
       ];
 
@@ -300,7 +300,7 @@ let
         (assertInt "Id")
         (assertRange "Id" 0 16777215)
         (assertInt "TOS")
-        (assertRange "TOS" 1 25)
+        (assertRange "TOS" 1 255)
         (assertValueOneOf "UDPChecksum" boolValues)
         (assertValueOneOf "UDP6ZeroChecksumTx" boolValues)
         (assertValueOneOf "UDP6ZeroChecksumRx" boolValues)
@@ -468,11 +468,8 @@ let
           "Port"
           "PeerPort"
           "Protocol"
-          "Peer"
-          "Local"
         ])
         (assertValueOneOf "Encapsulation" ["FooOverUDP" "GenericUDPEncapsulation"])
-        (assertHasField "Port")
         (assertPort "Port")
         (assertPort "PeerPort")
       ];
@@ -1297,7 +1294,7 @@ let
       type = with types; listOf (submodule l2tpSessionOptions);
       description = ''
         Each item in this array specifies an option in the
-        <literal>[WireGuardPeer]</literal> section of the unit. See
+        <literal>[L2TPSession]</literal> section of the unit. See
         <citerefentry><refentrytitle>systemd.netdev</refentrytitle>
         <manvolnum>5</manvolnum></citerefentry> for details.
         Use <literal>PresharedKeyFile</literal> instead of
@@ -1984,7 +1981,7 @@ let
           [L2TP]
           ${attrsToSection def.l2tpConfig}
         ''
-        + flip concatMapStrings def.addresses (x: ''
+        + flip concatMapStrings def.l2tpSessions (x: ''
           [L2TPSession]
           ${attrsToSection x.l2tpSessionConfig}
         '')

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -179,6 +179,33 @@ let
         (assertMacAddress "MACAddress")
       ];
 
+      sectionBridge = checkUnitConfig "Bridge" [
+        (assertOnlyFields [
+          "HelloTimeSec"
+          "MaxAgeSec"
+          "ForwardDelaySec"
+          "AgeingTimeSec"
+          "Priority"
+          "GroupForwardMask"
+          "DefaultPVID"
+          "MulticastQuerier"
+          "MulticastSnooping"
+          "VLANFiltering"
+          "VLANProtocol"
+          "STP"
+          "MulticastIGMPVersion"
+        ])
+        (assertInt "Priority")
+        (assertRange "Priority" 0 65535)
+        (assertValueOneOf "MulticastQuerier" boolValues)
+        (assertValueOneOf "MulticastSnooping" boolValues)
+        (assertValueOneOf "VLANFiltering" boolValues)
+        (assertValueOneOf "VLANProtocol" ["802.1q" "802.1ad"])
+        (assertValueOneOf "STP" boolValues)
+        (assertInt "MulticastIGMPVersion")
+        (assertValueOneOf "MulticastIGMPVersion" [2 3])
+      ];
+
       sectionVLAN = checkUnitConfig "VLAN" [
         (assertOnlyFields [
           "Id"
@@ -960,6 +987,18 @@ let
       '';
     };
 
+    bridgeConfig = mkOption {
+      default = {};
+      example = { VLANProtocol = "802.1ad"; };
+      type = types.addCheck (types.attrsOf unitOption) check.netdev.sectionBridge;
+      description = ''
+        Each attribute in this set specifies an option in the
+        <literal>[Bridge]</literal> section of the unit.  See
+        <citerefentry><refentrytitle>systemd.netdev</refentrytitle>
+        <manvolnum>5</manvolnum></citerefentry> for details.
+      '';
+    };
+
     vlanConfig = mkOption {
       default = {};
       example = { Id = 4; };
@@ -1601,6 +1640,10 @@ let
         + ''
           [NetDev]
           ${attrsToSection def.netdevConfig}
+        ''
+        + optionalString (def.bridgeConfig != { }) ''
+          [Bridge]
+          ${attrsToSection def.bridgeConfig}
         ''
         + optionalString (def.vlanConfig != { }) ''
           [VLAN]

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -96,6 +96,15 @@ let
 
     netdev = let
 
+      macvlanChecks = [
+        (assertOnlyFields [
+          "Mode"
+          "SourceMACAddress"
+          "BroadcastMulticastQueueLength"
+        ])
+        (assertValueOneOf "Mode" ["private" "vepa" "bridge" "passthru"])
+      ];
+
       tunChecks = [
         (assertOnlyFields [
           "MultiQueue"
@@ -176,12 +185,8 @@ let
         (assertValueOneOf "ReorderHeader" boolValues)
       ];
 
-      sectionMACVLAN = checkUnitConfig "MACVLAN" [
-        (assertOnlyFields [
-          "Mode"
-        ])
-        (assertValueOneOf "Mode" ["private" "vepa" "bridge" "passthru"])
-      ];
+      sectionMACVLAN = checkUnitConfig "MACVLAN" macvlanChecks;
+
 
       sectionVXLAN = checkUnitConfig "VXLAN" [
         (assertOnlyFields [

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -464,12 +464,17 @@ let
 
       sectionFooOverUDP = checkUnitConfig "FooOverUDP" [
         (assertOnlyFields [
-          "Port"
           "Encapsulation"
+          "Port"
+          "PeerPort"
           "Protocol"
+          "Peer"
+          "Local"
         ])
-        (assertPort "Port")
         (assertValueOneOf "Encapsulation" ["FooOverUDP" "GenericUDPEncapsulation"])
+        (assertHasField "Port")
+        (assertPort "Port")
+        (assertPort "PeerPort")
       ];
 
       sectionPeer = checkUnitConfig "Peer" [

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -480,6 +480,13 @@ let
         (assertMacAddress "MACAddress")
       ];
 
+      sectionVXCAN = checkUnitConfig "VXCAN" [
+        (assertOnlyFields [
+          "Peer"
+        ])
+        (assertHasField "Peer")
+      ];
+
       sectionTun = checkUnitConfig "Tun" tunChecks;
 
       sectionTap = checkUnitConfig "Tap" tunChecks;
@@ -1371,6 +1378,17 @@ let
       '';
     };
 
+    vxcanConfig = mkOption {
+      default = {};
+      type = types.addCheck (types.attrsOf unitOption) check.netdev.sectionVXCAN;
+      description = ''
+        Each attribute in this set specifies an option in the
+        <literal>[VXCAN]</literal> section of the unit.  See
+        <citerefentry><refentrytitle>systemd.netdev</refentrytitle>
+        <manvolnum>5</manvolnum></citerefentry> for details.
+      '';
+    };
+
     tunConfig = mkOption {
       default = {};
       example = { User = "openvpn"; };
@@ -1989,6 +2007,10 @@ let
         + optionalString (def.peerConfig != { }) ''
           [Peer]
           ${attrsToSection def.peerConfig}
+        ''
+        + optionalString (def.vxcanConfig != { }) ''
+          [VXCAN]
+          ${attrsToSection def.vxcanConfig}
         ''
         + optionalString (def.tunConfig != { }) ''
           [Tun]

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -277,6 +277,35 @@ let
         (assertValueOneOf "IPDoNotFragment" (boolValues + ["inherit"]))
       ];
 
+      sectionGENEVE = checkUnitConfig "GENEVE" [
+        (assertOnlyFields [
+          "Id"
+          "Remote"
+          "TOS"
+          "TTL"
+          "UDPChecksum"
+          "UDP6ZeroChecksumTx"
+          "UDP6ZeroChecksumRx"
+          "DestinationPort"
+          "FlowLabel"
+          "IPDoNotFragment"
+          "Independent"
+        ])
+        (assertHasField "Id")
+        (assertInt "Id")
+        (assertRange "Id" 0 16777215)
+        (assertInt "TOS")
+        (assertRange "TOS" 1 25)
+        (assertValueOneOf "UDPChecksum" boolValues)
+        (assertValueOneOf "UDP6ZeroChecksumTx" boolValues)
+        (assertValueOneOf "UDP6ZeroChecksumRx" boolValues)
+        (assertPort "DestinationPort")
+        (assertInt "FlowLabel")
+        (assertRange "FlowLabel" 0 1048575)
+        (assertValueOneOf "IPDoNotFragment" (boolValues + ["inherit"]))
+        (assertValueOneOf "Independent" boolValues)
+      ];
+
       sectionTunnel = checkUnitConfig "Tunnel" [
         (assertOnlyFields [
           "Local"
@@ -1072,6 +1101,17 @@ let
       '';
     };
 
+    geneveConfig = mkOption {
+      default = {};
+      type = types.addCheck (types.attrsOf unitOption) check.netdev.sectionGENEVE;
+      description = ''
+        Each attribute in this set specifies an option in the
+        <literal>[GENEVE]</literal> section of the unit.  See
+        <citerefentry><refentrytitle>systemd.netdev</refentrytitle>
+        <manvolnum>5</manvolnum></citerefentry> for details.
+      '';
+    };
+
     tunnelConfig = mkOption {
       default = {};
       example = { Remote = "192.168.1.1"; };
@@ -1682,6 +1722,10 @@ let
         + optionalString (def.vxlanConfig != { }) ''
           [VXLAN]
           ${attrsToSection def.vxlanConfig}
+        ''
+        + optionalString (def.geneveConfig != { }) ''
+          [GENEVE]
+          ${attrsToSection def.geneveConfig}
         ''
         + optionalString (def.tunnelConfig != { }) ''
           [Tunnel]

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -210,13 +210,17 @@ let
       sectionVLAN = checkUnitConfig "VLAN" [
         (assertOnlyFields [
           "Id"
+          "Protocol"
           "GVRP"
           "MVRP"
           "LooseBinding"
           "ReorderHeader"
+          "EgressQOSMaps"
+          "IngressQOSMaps"
         ])
         (assertInt "Id")
         (assertRange "Id" 0 4094)
+        (assertValueOneOf "Protocol" ["802.1q" "802.1ad"])
         (assertValueOneOf "GVRP" boolValues)
         (assertValueOneOf "MVRP" boolValues)
         (assertValueOneOf "LooseBinding" boolValues)

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -22,6 +22,9 @@ let
           "Name"
           "AlternativeNamesPolicy"
           "AlternativeName"
+          "TransmitQueues"
+          "ReceiveQueues"
+          "TransmitQueueLength="
           "MTUBytes"
           "BitsPerSecond"
           "Duplex"
@@ -41,10 +44,23 @@ let
           "OtherChannels"
           "CombinedChannels"
           "RxBufferSize"
+          "RxMiniBufferSize"
+          "RxJumboBufferSize"
           "TxBufferSize"
+          "RxFlowControl"
+          "TxFlowControl"
+          "AutoNegotiationFlowControl"
+          "GenericSegmentOffloadMaxBytes"
+          "GenericSegmentOffloadMaxSegments"
         ])
         (assertValueOneOf "MACAddressPolicy" ["persistent" "random" "none"])
         (assertMacAddress "MACAddress")
+        (assertInt "TransmitQueues")
+        (assertRange "TransmitQueues" 0 4096)
+        (assertInt "ReceiveQueues")
+        (assertRange "ReceiveQueues" 0 4096)
+        (assertInt "TransmitQueueLength")
+        (assertRange "TransmitQueueLength" 0 4294967294)
         (assertByteFormat "MTUBytes")
         (assertByteFormat "BitsPerSecond")
         (assertValueOneOf "Duplex" ["half" "full"])
@@ -67,7 +83,14 @@ let
         (assertInt "CombinedChannels")
         (assertRange "CombinedChannels" 1 4294967295)
         (assertInt "RxBufferSize")
+        (assertInt "RxMiniBufferSize")
+        (assertInt "RxJumboBufferSize")
         (assertInt "TxBufferSize")
+        (assertValueOneOf "RxFlowControl" boolValues)
+        (assertValueOneOf "AutoNegotiationFlowControl" boolValues)
+        (assertByteFormat "GenericSegmentOffloadMaxBytes")
+        (assertInt "GenericSegmentOffloadMaxSegments")
+        (assertRange "GenericSegmentOffloadMaxSegments" 1 65535)
       ];
     };
 

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -173,6 +173,7 @@ let
           "fou"
           "xfrm"
           "ifb"
+          "bareudp"
           "batadv"
         ])
         (assertByteFormat "MTUBytes")
@@ -304,6 +305,17 @@ let
         (assertRange "FlowLabel" 0 1048575)
         (assertValueOneOf "IPDoNotFragment" (boolValues + ["inherit"]))
         (assertValueOneOf "Independent" boolValues)
+      ];
+
+      sectionBareUDP = checkUnitConfig "BareUDP" [
+        (assertOnlyFields [
+          "DestinationPort"
+          "EtherType"
+        ])
+        (assertHasField "DestinationPort")
+        (assertPort "DestinationPort")
+        (assertHasField "EtherType")
+        (assertValueOneOf "EtherType" ["ipv4" "ipv6" "mpls-uc" "mpls-mc"])
       ];
 
       sectionTunnel = checkUnitConfig "Tunnel" [
@@ -1112,6 +1124,17 @@ let
       '';
     };
 
+    bareudpConfig = mkOption {
+      default = {};
+      type = types.addCheck (types.attrsOf unitOption) check.netdev.sectionBareUDP;
+      description = ''
+        Each attribute in this set specifies an option in the
+        <literal>[BareUDP]</literal> section of the unit.  See
+        <citerefentry><refentrytitle>systemd.netdev</refentrytitle>
+        <manvolnum>5</manvolnum></citerefentry> for details.
+      '';
+    };
+
     tunnelConfig = mkOption {
       default = {};
       example = { Remote = "192.168.1.1"; };
@@ -1726,6 +1749,10 @@ let
         + optionalString (def.geneveConfig != { }) ''
           [GENEVE]
           ${attrsToSection def.geneveConfig}
+        ''
+        + optionalString (def.bareudpConfig != { }) ''
+          [BareUDP]
+          ${attrsToSection def.bareudpConfig}
         ''
         + optionalString (def.tunnelConfig != { }) ''
           [Tunnel]

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -612,6 +612,8 @@ let
           "OriginatorIntervalSec"
           "GatewayBandwithDown"
           "GatewayBandwithUp"
+          "GatewayBandwidthDown"
+          "GatewayBandwidthUp"
           "RoutingAlgorithm"
         ])
         (assertValueOneOf "GatewayMode" ["off" "client" "server"])

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -228,6 +228,8 @@ let
 
       sectionIPVLAN = checkUnitConfig "IPVLAN" ipvlanChecks;
 
+      sectionIPVTAP = checkUnitConfig "IPVTAP" ipvlanChecks;
+
       sectionVXLAN = checkUnitConfig "VXLAN" [
         (assertOnlyFields [
           "VNI"
@@ -1047,6 +1049,18 @@ let
       '';
     };
 
+    ipvtapConfig = mkOption {
+      default = {};
+      example = { Mode = "L2"; };
+      type = types.addCheck (types.attrsOf unitOption) check.netdev.sectionIPVTAP;
+      description = ''
+        Each attribute in this set specifies an option in the
+        <literal>[IPVTAP]</literal> section of the unit.  See
+        <citerefentry><refentrytitle>systemd.netdev</refentrytitle>
+        <manvolnum>5</manvolnum></citerefentry> for details.
+      '';
+    };
+
     vxlanConfig = mkOption {
       default = {};
       type = types.addCheck (types.attrsOf unitOption) check.netdev.sectionVXLAN;
@@ -1660,6 +1674,10 @@ let
         + optionalString (def.ipvlanConfig != { }) ''
           [IPVLAN]
           ${attrsToSection def.ipvlanConfig}
+        ''
+        + optionalString (def.ipvtapConfig != { }) ''
+          [IPVTAP]
+          ${attrsToSection def.ipvtapConfig}
         ''
         + optionalString (def.vxlanConfig != { }) ''
           [VXLAN]

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -187,6 +187,8 @@ let
 
       sectionMACVLAN = checkUnitConfig "MACVLAN" macvlanChecks;
 
+      sectionMACVTAP = checkUnitConfig "MACVTAP" macvlanChecks;
+
 
       sectionVXLAN = checkUnitConfig "VXLAN" [
         (assertOnlyFields [
@@ -971,6 +973,18 @@ let
       '';
     };
 
+    macvtapConfig = mkOption {
+      default = {};
+      example = { Mode = "private"; };
+      type = types.addCheck (types.attrsOf unitOption) check.netdev.sectionMACVTAP;
+      description = ''
+        Each attribute in this set specifies an option in the
+        <literal>[MACVTAP]</literal> section of the unit.  See
+        <citerefentry><refentrytitle>systemd.netdev</refentrytitle>
+        <manvolnum>5</manvolnum></citerefentry> for details.
+      '';
+    };
+
     vxlanConfig = mkOption {
       default = {};
       type = types.addCheck (types.attrsOf unitOption) check.netdev.sectionVXLAN;
@@ -1572,6 +1586,10 @@ let
         + optionalString (def.macvlanConfig != { }) ''
           [MACVLAN]
           ${attrsToSection def.macvlanConfig}
+        ''
+        + optionalString (def.macvtapConfig != { }) ''
+          [MACVTAP]
+          ${attrsToSection def.macvtapConfig}
         ''
         + optionalString (def.vxlanConfig != { }) ''
           [VXLAN]

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -105,6 +105,15 @@ let
         (assertValueOneOf "Mode" ["private" "vepa" "bridge" "passthru"])
       ];
 
+      ipvlanChecks = [
+        (assertOnlyFields [
+          "Mode"
+          "Flags"
+        ])
+        (assertValueOneOf "Mode" ["L2" "L3" "L3S"])
+        (assertValueOneOf "Flags" ["bridge" "private" "vepa"])
+      ];
+
       tunChecks = [
         (assertOnlyFields [
           "MultiQueue"
@@ -117,6 +126,7 @@ let
         (assertValueOneOf "PacketInfo" boolValues)
         (assertValueOneOf "VNetHeader" boolValues)
       ];
+
     in {
 
       sectionNetdev = checkUnitConfig "Netdev" [
@@ -189,6 +199,7 @@ let
 
       sectionMACVTAP = checkUnitConfig "MACVTAP" macvlanChecks;
 
+      sectionIPVLAN = checkUnitConfig "IPVLAN" ipvlanChecks;
 
       sectionVXLAN = checkUnitConfig "VXLAN" [
         (assertOnlyFields [
@@ -985,6 +996,18 @@ let
       '';
     };
 
+    ipvlanConfig = mkOption {
+      default = {};
+      example = { Mode = "L2"; };
+      type = types.addCheck (types.attrsOf unitOption) check.netdev.sectionIPVLAN;
+      description = ''
+        Each attribute in this set specifies an option in the
+        <literal>[IPVLAN]</literal> section of the unit.  See
+        <citerefentry><refentrytitle>systemd.netdev</refentrytitle>
+        <manvolnum>5</manvolnum></citerefentry> for details.
+      '';
+    };
+
     vxlanConfig = mkOption {
       default = {};
       type = types.addCheck (types.attrsOf unitOption) check.netdev.sectionVXLAN;
@@ -1590,6 +1613,10 @@ let
         + optionalString (def.macvtapConfig != { }) ''
           [MACVTAP]
           ${attrsToSection def.macvtapConfig}
+        ''
+        + optionalString (def.ipvlanConfig != { }) ''
+          [IPVLAN]
+          ${attrsToSection def.ipvlanConfig}
         ''
         + optionalString (def.vxlanConfig != { }) ''
           [VXLAN]

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -482,6 +482,7 @@ let
           "Name"
           "MACAddress"
         ])
+        (assertHasField "Name")
         (assertMacAddress "MACAddress")
       ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adding missing systemd networkd NetDev Options.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

This are quite a bunch of Options and it's quite possible that i made some copy paste error or something like that. So i would appreciate it if someone could look over it quite closely. 

I also haven't used all of them and it's possible that i've missed an option which is allowed to exist multiple times. Regarding that: for the L2TPSession Option i've tried to replicate what was done for the WireguardPeer Option but if someone could look at it closely that would be great.