### PR TITLE
code-server: 3.12.0 -> 4.0.1

### DIFF
--- a/pkgs/servers/code-server/playwright.patch
+++ b/pkgs/servers/code-server/playwright.patch
@@ -4,7 +4,7 @@
   * limitations under the License.
   */
  
--const { installBrowsersWithProgressBar } = require('./lib/install/installer');
+-const { installDefaultBrowsersForNpmInstall } = require('playwright-core/lib/utils/registry');
 -
--installBrowsersWithProgressBar();
+-installDefaultBrowsersForNpmInstall();
 +process.stdout.write('Browser install disabled by Nix build script\n');

--- a/pkgs/servers/code-server/remove-cloud-agent-download.patch
+++ b/pkgs/servers/code-server/remove-cloud-agent-download.patch
@@ -1,10 +1,11 @@
 --- ./ci/build/npm-postinstall.sh
 +++ ./ci/build/npm-postinstall.sh
-@@ -56,13 +56,6 @@
-     ;;
-   esac
- 
--  OS="$(uname | tr '[:upper:]' '[:lower:]')"
+@@ -58,14 +58,6 @@
+
+   OS="$(uname | tr '[:upper:]' '[:lower:]')"
+
+-  mkdir -p ./lib
+-
 -  if curl -fsSL "https://github.com/cdr/cloud-agent/releases/latest/download/cloud-agent-$OS-$ARCH" -o ./lib/coder-cloud-agent; then
 -    chmod +x ./lib/coder-cloud-agent
 -  else

--- a/pkgs/servers/code-server/remove-node-download.patch
+++ b/pkgs/servers/code-server/remove-node-download.patch
@@ -1,0 +1,27 @@
+--- ./vendor/modules/code-oss-dev/build/gulpfile.reh.js
++++ ./vendor/modules/code-oss-dev/build/gulpfile.reh.js
+@@ -277,8 +277,6 @@
+ 			.pipe(util.stripSourceMappingURL())
+ 			.pipe(jsFilter.restore);
+ 
+-		const nodePath = `.build/node/v${nodeVersion}/${platform}-${platform === 'darwin' ? 'x64' : arch}`;
+-		const node = gulp.src(`${nodePath}/**`, { base: nodePath, dot: true });
+ 
+ 		let web = [];
+ 		if (type === 'reh-web') {
+@@ -296,7 +294,6 @@
+ 			license,
+ 			sources,
+ 			deps,
+-			node,
+ 			...web
+ 		);
+ 
+@@ -376,7 +373,6 @@
+ 			const destinationFolderName = `vscode-${type}${dashed(platform)}${dashed(arch)}`;
+ 
+ 			const serverTaskCI = task.define(`vscode-${type}${dashed(platform)}${dashed(arch)}${dashed(minified)}-ci`, task.series(
+-				gulp.task(`node-${platform}-${platform === 'darwin' ? 'x64' : arch}`),
+ 				util.rimraf(path.join(BUILD_ROOT, destinationFolderName)),
+ 				packageTask(type, platform, arch, sourceFolderName, destinationFolderName)
+ 			));

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29365,8 +29365,9 @@ with pkgs;
   };
 
   code-server = callPackage ../servers/code-server {
-    inherit (darwin.apple_sdk.frameworks) AppKit Cocoa Security;
+    inherit (darwin.apple_sdk.frameworks) AppKit Cocoa CoreServices Security;
     inherit (darwin) cctools;
+    inherit (nodePackages) node-gyp;
   };
 
   vue = callPackage ../applications/misc/vue { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updates code-server to 4.0.1 (VS Code v1.63.0).

Incorporates some changes to the build process from openvscode-server and #152266:

* Refactored esbuild patches to a function
* Removed unused `zip` dependency
* Simplified `outputHash` of `yarnCache`
* Darwin builds were failing with PermissionError: [Errno 1] Operation not permitted: '/usr/sbin/pkgutil'. Version 1.62.3 originally built successfully for Darwin on OfBorg when 1.62.3 was released, but now fails to build locally on my macOS 12 machine. I could not determine what changed to cause builds to start erroring, but was able to fix the error by upgrading npm's built-in node-gyp to the nixpkgs version.
Added CoreServices framework. Fixes the following Darwin build warnings: No receipt for 'com.apple.pkg.CLTools_Executables' found at '/'., No receipt for 'com.apple.pkg.DeveloperToolsCLILeo' found at '/'., No receipt for 'com.apple.pkg.DeveloperToolsCLI' found at '/'.
* Removed the download of nodeSources, instead linking the headers from the nodeJs package as suggested by https://nixos.org/manual/nixpkgs/stable/#javascript-tool-specific under "having trouble with node-gyp?"
* @parcel/watcher does not currently build on Darwin, so uses the prebuilt binary for that module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
