### PR TITLE
avizo: unstable-2021-07-21 -> 1.1

### DIFF
--- a/pkgs/applications/misc/avizo/default.nix
+++ b/pkgs/applications/misc/avizo/default.nix
@@ -5,20 +5,27 @@
 , gobject-introspection, gdk-pixbuf, wrapGAppsHook
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "avizo";
-  version = "unstable-2021-07-21";
+  # Note: remove the 'use-sysconfig' patch on the next update
+  version = "1.1";
 
   src = fetchFromGitHub {
     owner = "misterdanb";
     repo = "avizo";
-    rev = "7b3874e5ee25c80800b3c61c8ea30612aaa6e8d1";
-    sha256 = "sha256-ixAdiAH22Nh19uK5GoAXtAZJeAfCGSWTcGbrvCczWYc=";
+    rev = version;
+    sha256 = "sha256-0BJodJ6WaHhuSph2D1AC+DMafctgiSCyaZ8MFn89AA8=";
   };
 
   nativeBuildInputs = [ meson ninja pkg-config vala gobject-introspection wrapGAppsHook ];
 
   buildInputs = [ dbus dbus-glib gdk-pixbuf glib gtk-layer-shell gtk3 librsvg ];
+
+  patches = [
+    # Remove on next update
+    # See https://github.com/misterdanb/avizo/pull/30
+    ./use-sysconfdir-instead-of-etc.patch
+  ];
 
   postInstall = ''
     substituteInPlace "$out"/bin/volumectl \

--- a/pkgs/applications/misc/avizo/use-sysconfdir-instead-of-etc.patch
+++ b/pkgs/applications/misc/avizo/use-sysconfdir-instead-of-etc.patch
@@ -1,0 +1,15 @@
+diff --git a/meson.build b/meson.build
+index 1c789be..cd4b07a 100644
+--- a/meson.build
++++ b/meson.build
+@@ -12,7 +12,9 @@ app_resources_service = gnome.compile_resources(
+   source_dir : '.',
+   c_name : 'avizo_resources')
+ 
+-install_data('config.ini', install_dir: '/etc/xdg/avizo')
++sysconfdir = get_option('sysconfdir')
++
++install_data('config.ini', install_dir: join_paths(sysconfdir, 'xdg/avizo'))
+ install_data('volumectl', install_dir: 'bin')
+ install_data('lightctl', install_dir: 'bin')
+ 


### PR DESCRIPTION
###### Motivation for this change

Includes a temporary `meson.build` patch that will need to be removed on the next update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
