### PR TITLE
minigalaxy: adds support for windows games

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8536,6 +8536,12 @@
     githubId = 450276;
     name = "Nick Hu";
   };
+  nickjanus = {
+    email = "nixpkgs@nondesignated.com";
+    github = "nickjanus";
+    githubId = 4349104;
+    name = "Nick Janus";
+  };
   nicknovitski = {
     email = "nixpkgs@nicknovitski.com";
     github = "nicknovitski";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -171,6 +171,7 @@
   ./programs/liboping.nix
   ./programs/light.nix
   ./programs/mosh.nix
+  ./programs/minigalaxy.nix
   ./programs/mininet.nix
   ./programs/msmtp.nix
   ./programs/mtr.nix

--- a/nixos/modules/programs/minigalaxy.nix
+++ b/nixos/modules/programs/minigalaxy.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.minigalaxy;
+
+  minigalaxy = pkgs.minigalaxy.override {
+    withWine = cfg.withWine;
+  };
+in {
+  options.programs.minigalaxy = {
+    enable = mkEnableOption "minigalaxy";
+
+    withWine = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Include wine in minigalaxy's PATH
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ minigalaxy ];
+  };
+
+  meta.maintainers = with maintainers; [ nickjanus ];
+}

--- a/pkgs/applications/misc/minigalaxy/wrapper.nix
+++ b/pkgs/applications/misc/minigalaxy/wrapper.nix
@@ -1,0 +1,19 @@
+{ lib
+, pkgs
+, minigalaxy-unwrapped
+, wine
+, withWine ? true
+}:
+
+pkgs.symlinkJoin {
+  name = "minigalaxy wrapper";
+  paths = [
+    minigalaxy-unwrapped
+  ];
+  buildInputs = [
+    pkgs.makeWrapper
+  ];
+  postBuild = lib.optionalString withWine ''
+    wrapProgram $out/bin/minigalaxy --prefix PATH : ${lib.makeBinPath [ wine ]}
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27051,7 +27051,8 @@ with pkgs;
 
   minicom = callPackage ../tools/misc/minicom { };
 
-  minigalaxy = callPackage ../applications/misc/minigalaxy { };
+  minigalaxy-unwrapped = callPackage ../applications/misc/minigalaxy { };
+  minigalaxy = callPackage ../applications/misc/minigalaxy/wrapper.nix { };
 
   minimodem = callPackage ../applications/radio/minimodem { };
 


### PR DESCRIPTION
###### Motivation for this change
Minigalaxy looks for wine in its path when user flips on support for windows games. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
