### PR TITLE
opensbi: init at 1.0

### DIFF
--- a/pkgs/misc/opensbi/default.nix
+++ b/pkgs/misc/opensbi/default.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv, fetchFromGitHub
+, withPlatform ? "generic"
+, withPayload ? null
+, withFDT ? null
+}:
+
+stdenv.mkDerivation rec {
+  pname = "opensbi";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "riscv-software-src";
+    repo = "opensbi";
+    rev = "v${version}";
+    sha256 = "sha256-OgzcH+RLU680qF3+lUiWFFbif6YtjIknJriGlRqcOGs=";
+  };
+
+  installFlags = [
+    "I=$(out)"
+  ];
+
+  makeFlags = [
+    "PLATFORM=${withPlatform}"
+  ] ++ lib.optionals (withPayload != null) [
+    "FW_PAYLOAD_PATH=${withPayload}"
+  ] ++ lib.optionals (withFDT != null) [
+    "FW_FDT_PATH=${withFDT}"
+  ];
+
+  dontStrip = true;
+  dontPatchELF = true;
+
+  meta = with lib; {
+    description = "RISC-V Open Source Supervisor Binary Interface";
+    homepage = "https://github.com/riscv-software-src/opensbi";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ ius nickcao zhaofengli ];
+    platforms = [ "riscv64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8408,6 +8408,8 @@ with pkgs;
     luaPackages = lua53Packages;
   };
 
+  opensbi = callPackage ../misc/opensbi { };
+
   opensc = callPackage ../tools/security/opensc {
     inherit (darwin.apple_sdk.frameworks) Carbon PCSC;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

With 1.0, patches are no longer required for HiFive Unmatched so I think it's time to finally upstream this to Nixpkgs.

Tested by building natively on riscv64-linux as well as cross-compiling from x86_64-linux. Works on QEMU as well as on Unmatched.

Ref: #101651

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] riscv64-linux
  - [x] riscv64-linux (cross from x86_64-linux)
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
