### PR TITLE
SwayNotificationCenter: init at 0.3

### DIFF
--- a/pkgs/applications/misc/swaynotificationcenter/default.nix
+++ b/pkgs/applications/misc/swaynotificationcenter/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pkg-config
+, vala
+, gtk3
+, glib
+, gtk-layer-shell
+, dbus
+, dbus-glib
+, json-glib
+, librsvg
+, libhandy
+, gobject-introspection
+, gdk-pixbuf
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "SwayNotificationCenter";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "ErikReider";
+    repo = "SwayNotificationCenter";
+    rev = "v${version}";
+    hash = "sha256-gXo/V2FHkHZBRmaimqJCzi0BqS4tP9IniIlubBmK5u0=";
+  };
+
+  nativeBuildInputs = [ gobject-introspection meson ninja pkg-config vala wrapGAppsHook ];
+
+  buildInputs = [ dbus dbus-glib gdk-pixbuf glib gtk-layer-shell gtk3 json-glib libhandy librsvg ];
+
+  meta = with lib; {
+    description = "Simple notification daemon with a GUI built for Sway";
+    homepage = "https://github.com/ErikReider/SwayNotificationCenter";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.berbiche ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26005,6 +26005,8 @@ with pkgs;
 
   swaylock-effects = callPackage ../applications/window-managers/sway/lock-effects.nix { };
 
+  swaynotificationcenter = callPackage ../applications/misc/swaynotificationcenter { };
+
   tiramisu = callPackage ../applications/misc/tiramisu { };
 
   rootbar = callPackage ../applications/misc/rootbar {};


### PR DESCRIPTION
###### Motivation for this change

Package https://github.com/ErikReider/SwayNotificationCenter.

I have been using this notification daemon for few weeks now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
