### PR TITLE
maubot: init at 0.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2736,6 +2736,13 @@
     githubId = 6608071;
     name = "Charles Huyghues-Despointes";
   };
+  chayleaf = {
+    email = "chayleaf-nix@pavluk.org";
+    github = "chayleaf";
+    githubId = 9590981;
+    matrix = "@chayleaf:matrix.pavluk.org";
+    name = "Anna Pavlyuk";
+  };
   chekoopa = {
     email = "chekoopa@mail.ru";
     github = "chekoopa";

--- a/pkgs/tools/networking/maubot/allow-building-plugins-from-nix-store.patch
+++ b/pkgs/tools/networking/maubot/allow-building-plugins-from-nix-store.patch
@@ -1,0 +1,13 @@
+diff --git a/maubot/cli/commands/build.py b/maubot/cli/commands/build.py
+index ec3ac26..4de85f2 100644
+--- a/maubot/cli/commands/build.py
++++ b/maubot/cli/commands/build.py
+@@ -84,7 +84,7 @@ def read_output_path(output: str, meta: PluginMeta) -> str | None:
+ 
+ 
+ def write_plugin(meta: PluginMeta, output: str | IO) -> None:
+-    with zipfile.ZipFile(output, "w") as zip:
++    with zipfile.ZipFile(output, "w", strict_timestamps=False) as zip:
+         meta_dump = BytesIO()
+         yaml.dump(meta.serialize(), meta_dump)
+         zip.writestr("maubot.yaml", meta_dump.getvalue())

--- a/pkgs/tools/networking/maubot/default.nix
+++ b/pkgs/tools/networking/maubot/default.nix
@@ -1,0 +1,107 @@
+{ lib
+, fetchpatch
+, python3
+, runCommand
+, encryptionSupport ? true
+}:
+
+let
+  python = python3.override {
+    packageOverrides = self: super: {
+      aiosqlite = super.aiosqlite.overrideAttrs (old: rec {
+        version = "0.18.0";
+        src = old.src.override {
+          rev = "refs/tags/v${version}";
+          hash = "sha256-yPGSKqjOz1EY5/V0oKz2EiZ90q2O4TINoXdxHuB7Gqk=";
+        };
+      });
+      sqlalchemy = super.buildPythonPackage rec {
+        pname = "SQLAlchemy";
+        version = "1.3.24";
+
+        src = super.fetchPypi {
+          inherit pname version;
+          sha256 = "sha256-67t3fL+TEjWbiXv4G6ANrg9ctp+6KhgmXcwYpvXvdRk=";
+        };
+
+        postInstall = ''
+          sed -e 's:--max-worker-restart=5::g' -i setup.cfg
+        '';
+
+        doCheck = false;
+      };
+    };
+  };
+
+  self = with python.pkgs; buildPythonPackage rec {
+    pname = "maubot";
+    version = "0.4.1";
+    disabled = pythonOlder "3.8";
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "sha256-Ro2PPgF8818F8JewPZ3AlbfWFNNHKTZkQq+1zpm3kk4=";
+    };
+
+    patches = [
+      # add entry point - https://github.com/maubot/maubot/pull/146
+      (fetchpatch {
+        url = "https://github.com/maubot/maubot/commit/283f0a3ed5dfae13062b6f0fd153fbdc477f4381.patch";
+        sha256 = "0yn5357z346qzy5v5g124mgiah1xsi9yyfq42zg028c8paiw8s8x";
+      })
+      ./allow-building-plugins-from-nix-store.patch
+    ];
+
+    propagatedBuildInputs = [
+      # requirements.txt
+      mautrix
+      aiohttp
+      yarl
+      sqlalchemy
+      asyncpg
+      aiosqlite
+      CommonMark
+      ruamel-yaml
+      attrs
+      bcrypt
+      packaging
+      click
+      colorama
+      questionary
+      jinja2
+    ]
+    # optional-requirements.txt
+    ++ lib.optionals encryptionSupport [
+      python-olm
+      pycryptodome
+      unpaddedbase64
+    ];
+
+    postInstall = ''
+      rm $out/example-config.yaml
+    '';
+
+    passthru.tests = {
+      simple = runCommand "${pname}-tests" { } ''
+        ${self}/bin/mbc --help > $out
+      '';
+    };
+
+    # Setuptools is trying to do python -m maubot test
+    dontUseSetuptoolsCheck = true;
+
+    pythonImportsCheck = [
+      "maubot"
+    ];
+
+    meta = with lib; {
+      description = "A plugin-based Matrix bot system written in Python";
+      homepage = "https://maubot.xyz/";
+      changelog = "https://github.com/maubot/maubot/blob/v${version}/CHANGELOG.md";
+      license = licenses.agpl3Plus;
+      maintainers = with maintainers; [ chayleaf ];
+    };
+  };
+
+in
+self

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9358,6 +9358,8 @@ with pkgs;
 
   matrix-hookshot = callPackage ../servers/matrix-synapse/matrix-hookshot { };
 
+  maubot = with python3Packages; toPythonApplication maubot;
+
   mautrix-facebook = callPackage ../servers/mautrix-facebook { };
 
   mautrix-googlechat = callPackage ../servers/mautrix-googlechat { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6071,6 +6071,8 @@ self: super: with self; {
 
   mattermostdriver = callPackage ../development/python-modules/mattermostdriver { };
 
+  maubot = callPackage ../tools/networking/maubot { };
+
   mautrix = callPackage ../development/python-modules/mautrix { };
 
   mautrix-appservice = self.mautrix; # alias 2019-12-28


### PR DESCRIPTION
To anyone who wants to use Maubot on NixOS, I recommend [my flake](https://github.com/chayleaf/maubot.nix) until it's merged.

###### Motivation for this change

https://github.com/maubot/maubot/

Maubot is a Matrix bot framework that has a Web UI and a plugin system. I think this PR can pave the way for a service later.

I still don't know how to handle optional dependencies though. In this case, there are optional dependencies for e2ee and Postgres. I simply haven't added them to the dependency list for now.

Previous attempt at adding it: https://github.com/NixOS/nixpkgs/pull/123760

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
