### PR TITLE
lexicon: 3.5.2 -> 3.9.0

### DIFF
--- a/pkgs/development/python-modules/oci/default.nix
+++ b/pkgs/development/python-modules/oci/default.nix
@@ -1,45 +1,58 @@
 { lib
-, fetchFromGitHub
 , buildPythonPackage
 , certifi
+, circuitbreaker
 , configparser
 , cryptography
+, fetchFromGitHub
 , pyopenssl
 , python-dateutil
+, pythonOlder
 , pytz
 }:
 
 buildPythonPackage rec {
   pname = "oci";
-  version = "2.52.0";
+  version = "2.53.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "oracle";
     repo = "oci-python-sdk";
     rev = "v${version}";
-    hash = "sha256-4MlelzUPCJCZJQh8sNJHEL0WEcVWktV0TBEY0tdTHmk=";
+    hash = "sha256-TnLKT/F36jHEfT9K6DFM2GmPRccXz1GJWIF+EEQYRls=";
   };
+
+  propagatedBuildInputs = [
+    certifi
+    circuitbreaker
+    configparser
+    cryptography
+    pyopenssl
+    python-dateutil
+    pytz
+  ];
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "configparser==4.0.2" "configparser" \
-      --replace "cryptography<=3.4.7,>=3.2.1" "cryptography" \
+      --replace "configparser==4.0.2 ; python_version < '3'" "configparser" \
+      --replace "cryptography>=3.2.1,<=3.4.7" "cryptography" \
       --replace "pyOpenSSL>=17.5.0,<=19.1.0" "pyOpenSSL"
   '';
-
-  propagatedBuildInputs = [
-    certifi configparser cryptography pyopenssl python-dateutil pytz
-  ];
 
   # Tests fail: https://github.com/oracle/oci-python-sdk/issues/164
   doCheck = false;
 
-  pythonImportsCheck = [ "oci" ];
+  pythonImportsCheck = [
+    "oci"
+  ];
 
   meta = with lib; {
     description = "Oracle Cloud Infrastructure Python SDK";
-    homepage = "https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/index.html";
+    homepage = "https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/";
+    license = with licenses; [ asl20 /* or */ upl ];
     maintainers = with maintainers; [ ilian ];
-    license = with licenses; [ asl20 upl ];
   };
 }

--- a/pkgs/development/python-modules/transip/default.nix
+++ b/pkgs/development/python-modules/transip/default.nix
@@ -1,36 +1,46 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, isPy27
 , requests
 , cryptography
 , suds-jurko
-, pytest
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
-  pname = "transip-api";
+  pname = "transip";
   version = "2.0.0";
-  disabled = isPy27;
+  format = "setuptools";
+
+  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "benkonrath";
-    repo = pname;
+    repo = "transip-api";
     rev = "v${version}";
-    sha256 = "153x8ph7cp432flaqiy2zgp060ddychcqcrssxkcmjvbm86xrz17";
+    hash = "sha256-J/zcDapry8pm1zozzCDzrQED7vvCR6yoE4NcduBFfZQ=";
   };
 
-  checkInputs = [ pytest ];
+  propagatedBuildInputs = [
+    requests
+    cryptography
+    suds-jurko
+  ];
 
-  # Constructor Tests require network access
-  checkPhase = ''
-    pytest --deselect=tests/service_tests/test_domain.py::TestDomainService::test_constructor \
-           --deselect tests/service_tests/test_vps.py::TestVPSService::testConstructor \
-           --deselect tests/service_tests/test_webhosting.py::TestWebhostingService::testConstructor
-  '';
+  checkInputs = [
+    pytestCheckHook
+  ];
 
+  disabledTests = [
+    # Constructor tests require network access
+    "test_constructor"
+    "testConstructor"
+  ];
 
-  propagatedBuildInputs = [ requests cryptography suds-jurko ];
+  pythonImportsCheck = [
+    "transip"
+  ];
 
   meta = with lib; {
     description = "TransIP API Connector";

--- a/pkgs/tools/admin/lexicon/default.nix
+++ b/pkgs/tools/admin/lexicon/default.nix
@@ -31,18 +31,18 @@ in
 
 buildPythonApplication rec {
   pname = "lexicon";
-  version = "3.5.2";
+  version = "3.9.0";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "AnalogJ";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1jsc2ybbf3mbvgzkgliria494dpj23mgqnw2lh43cnd9rgsjvzn3";
+    hash = "sha256-qJFHwFzFjZVdQv4YfrlR2cMQHsEtpQbvg/DMo6C5/z0=";
   };
 
   nativeBuildInputs = [
-    poetry
+    poetry-core
   ];
 
   propagatedBuildInputs = [
@@ -52,6 +52,7 @@ buildPythonApplication rec {
     dnspython
     future
     localzone
+    oci
     pynamecheap
     pyyaml
     requests
@@ -64,20 +65,24 @@ buildPythonApplication rec {
 
   checkInputs = [
     mock
-    pytest
-    pytest-cov
+    pytestCheckHook
     pytest-xdist
     vcrpy
   ];
 
-  checkPhase = ''
-    pytest --ignore=lexicon/tests/providers/test_auto.py
-  '';
+  disabledTestPaths = [
+    # Tests require network access
+    "lexicon/tests/providers/test_auto.py"
+  ];
+
+  pythonImportsCheck = [
+    "lexicon"
+  ];
 
   meta = with lib; {
-    description = "Manipulate DNS records on various DNS providers in a standardized way";
+    description = "Manipulate DNS records of various DNS providers in a standardized way";
     homepage = "https://github.com/AnalogJ/lexicon";
-    maintainers = with maintainers; [ flyfloh ];
     license = licenses.mit;
+    maintainers = with maintainers; [ flyfloh ];
   };
 }

--- a/pkgs/tools/admin/oci-cli/default.nix
+++ b/pkgs/tools/admin/oci-cli/default.nix
@@ -1,59 +1,74 @@
-{ lib, fetchFromGitHub, python3Packages, locale }:
+{ lib
+, fetchFromGitHub
+, python3
+}:
 
 let
-  # https://github.com/oracle/oci-cli/issues/189
-  pinned_click = python3Packages.click.overridePythonAttrs (old: rec {
-    pname = "click";
-    version = "6.7";
-    src = python3Packages.fetchPypi {
-      inherit pname version;
-      hash = "sha256-8VUW30eNWlYYD7+A5o8gYBDm0WD8OfpQi2XgNf11Ews=";
+  py = python3.override {
+    packageOverrides = self: super: {
+
+      click = super.click.overridePythonAttrs (oldAttrs: rec {
+        version = "7.1.2";
+
+        src = oldAttrs.src.override {
+          inherit version;
+          hash = "sha256-0rUlXHxjSbwb0eWeCM0SrLvWPOZJ8liHVXg6qU37axo=";
+        };
+      });
+
     };
-
-    postPatch = ''
-      substituteInPlace click/_unicodefun.py \
-      --replace "'locale'" "'${locale}/bin/locale'"
-    '';
-
-    # Issue that wasn't resolved when this version was released:
-    # https://github.com/pallets/click/issues/823
-    doCheck = false;
-  });
+  };
 in
+with py.pkgs;
 
-python3Packages.buildPythonApplication rec {
+buildPythonApplication rec {
   pname = "oci-cli";
-  version = "2.23.0";
+  version = "3.4.1";
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "oracle";
     repo = "oci-cli";
     rev = "v${version}";
-    hash = "sha256-XRkycJrUSOZQAGiSyQZGA/SnlxnFumYL82kOkYd7s2o=";
+    hash = "sha256-ibk5WfNPa02D7UcP+4xg8Pi9P45yUPEm56l76IwNuRE=";
   };
 
-  propagatedBuildInputs = with python3Packages; [
-    oci arrow certifi pinned_click configparser cryptography jmespath python-dateutil
-    pytz retrying six terminaltables pyopenssl pyyaml
+  propagatedBuildInputs = [
+    arrow
+    certifi
+    click
+    configparser
+    cryptography
+    jmespath
+    oci
+    pyopenssl
+    python-dateutil
+    pytz
+    pyyaml
+    retrying
+    six
+    terminaltables
   ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "cryptography>=3.2.1,<=3.4.7" "cryptography" \
+      --replace "pyOpenSSL==19.1.0" "pyOpenSSL" \
+      --replace "PyYAML>=5.4,<6" "PyYAML" \
+      --replace "terminaltables==3.1.0" "terminaltables"
+  '';
 
   # https://github.com/oracle/oci-cli/issues/187
   doCheck = false;
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "configparser==4.0.2" "configparser" \
-      --replace "cryptography==3.2.1" "cryptography" \
-      --replace "pyOpenSSL==19.1.0" "pyOpenSSL" \
-      --replace "PyYAML==5.3.1" "PyYAML" \
-      --replace "six==1.14.0" "six" \
-      --replace "arrow==0.17.0" "arrow"
-  '';
+  pythonImportsCheck = [
+    " oci_cli "
+  ];
 
   meta = with lib; {
     description = "Command Line Interface for Oracle Cloud Infrastructure";
     homepage = "https://docs.cloud.oracle.com/iaas/Content/API/Concepts/cliconcepts.htm";
+    license = with licenses; [ asl20 /* or */ upl ];
     maintainers = with maintainers; [ ilian ];
-    license = with licenses; [ asl20 upl ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/AnalogJ/lexicon/releases

Fix build (https://hydra.nixos.org/build/163500503)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
