### PR TITLE
python*Packages.unittest2: mark as disabled for python310 and onwards

### DIFF
--- a/pkgs/development/python-modules/unittest2/default.nix
+++ b/pkgs/development/python-modules/unittest2/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pythonOlder
 , six
 , traceback2
 }:
@@ -8,6 +9,12 @@
 buildPythonPackage rec {
   version = "1.1.0";
   pname = "unittest2";
+
+  # unittest2 has not been updated since 2015 and is no longer supported on
+  # Python 3.10. `unittest2` is a compatability package between Python 2 and 3,
+  # but it's relevance is dwinding as `python2Packages` is getting phased out
+  # anyhow.
+  disabled = !(pythonOlder "3.10");
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/unittest2/default.nix
+++ b/pkgs/development/python-modules/unittest2/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   # Python 3.10. `unittest2` is a compatability package between Python 2 and 3,
   # but it's relevance is dwinding as `python2Packages` is getting phased out
   # anyhow.
-  disabled = !(pythonOlder "3.10");
+  disabled = pythonAtLeast "3.10";
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`unittest2` is no longer supported and does not work on Python 3.10. See 
* https://github.com/testing-cabal/testtools/issues/303
* https://github.com/testing-cabal/testtools/issues/312

Despite its age and apparent abandonment, unittest2 is still a dependency for a lot to packages in nixpkgs. It's my hope that this PR will start moving us towards cleaning those things up.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
