### PR TITLE
python3Packages.qcs-api-client: enable tests

### DIFF
--- a/pkgs/development/python-modules/cirq-google/default.nix
+++ b/pkgs/development/python-modules/cirq-google/default.nix
@@ -15,7 +15,6 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace requirements.txt \
-      --replace "protobuf~=3.13.0" "protobuf" \
       --replace "google-api-core[grpc] >= 1.14.0, < 2.0.0dev" "google-api-core[grpc] >= 1.14.0, < 3.0.0dev"
   '';
 
@@ -28,5 +27,11 @@ buildPythonPackage rec {
   checkInputs = [
     freezegun
     pytestCheckHook
+  ];
+
+  disabledTests = [
+    # unittest.mock.InvalidSpecError: Cannot autospec attr 'QuantumEngineServiceClient'
+    "test_get_engine_sampler_explicit_project_id"
+    "test_get_engine_sampler"
   ];
 }

--- a/pkgs/development/python-modules/cirq-rigetti/default.nix
+++ b/pkgs/development/python-modules/cirq-rigetti/default.nix
@@ -40,7 +40,9 @@ buildPythonPackage rec {
       --replace "httpx~=0.15.5" "httpx" \
       --replace "idna~=2.10" "idna" \
       --replace "pyjwt~=1.7.1" "pyjwt" \
-      --replace "qcs-api-client~=0.8.0" "qcs-api-client"
+      --replace "qcs-api-client~=0.8.0" "qcs-api-client" \
+      --replace "iso8601~=0.1.14" "iso8601" \
+      --replace "pydantic~=1.8.2" "pydantic"
     # Remove outdated test
     rm cirq_rigetti/service_test.py
   '';

--- a/pkgs/development/python-modules/qcs-api-client/default.nix
+++ b/pkgs/development/python-modules/qcs-api-client/default.nix
@@ -1,9 +1,11 @@
 { lib
 , attrs
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
+, fetchpatch
 , httpx
 , iso8601
+, poetry-core
 , pydantic
 , pyjwt
 , pytest-asyncio
@@ -19,14 +21,20 @@
 buildPythonPackage rec {
   pname = "qcs-api-client";
   version = "0.20.9";
-  format = "setuptools";
+  format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "7b4e890ca9d9996060690629eee88db49c5fa4bde520910d48dd20323d1c5574";
+  src = fetchFromGitHub {
+    owner = "rigetti";
+    repo = "qcs-api-client-python";
+    rev = "v${version}";
+    hash = "sha256-bQ+5TZzjxGnNRsENEW/sN7sF6SOcgWl4MFtLekD0D+8=";
   };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
 
   propagatedBuildInputs = [
     attrs
@@ -46,15 +54,28 @@ buildPythonPackage rec {
     respx
   ];
 
+  patches = [
+    # Switch to poetry-core, https://github.com/rigetti/qcs-api-client-python/pull/2
+    (fetchpatch {
+      name = "switch-to-poetry-core.patch";
+      url = "https://github.com/rigetti/qcs-api-client-python/commit/32f0b3c7070a65f4edf5b2552648d88435469e44.patch";
+      sha256 = "sha256-mOc+Q/5cmwPziojtxeEMWWHSDvqvzZlNRbPtOSeTinQ=";
+    })
+  ];
+
   postPatch = ''
-    substituteInPlace setup.py \
-      --replace "attrs>=20.1.0,<21.0.0" "attrs" \
-      --replace "httpx>=0.15.0,<0.16.0" "httpx" \
-      --replace "pyjwt>=1.7.1,<2.0.0" "pyjwt"
+    substituteInPlace pyproject.toml \
+      --replace 'attrs = "^20.1.0"' 'attrs = "*"' \
+      --replace 'httpx = "^0.15.0"' 'httpx = "*"' \
+      --replace 'iso8601 = "^0.1.13"' 'iso8601 = "*"' \
+      --replace 'pydantic = "^1.7.2"' 'pydantic = "*"' \
+      --replace 'pyjwt = "^1.7.1"' 'pyjwt = "*"'
   '';
 
-  # Project has no tests
-  doCheck = false;
+  disabledTestPaths = [
+    # Test is outdated
+    "tests/test_client/test_client.py"
+  ];
 
   pythonImportsCheck = [
     "qcs_api_client"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Enable tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
