### PR TITLE
Revert "alsa-ucm-conf: 1.2.5.1 -> 1.2.6.3"

### DIFF
--- a/pkgs/os-specific/linux/alsa-project/alsa-ucm-conf/default.nix
+++ b/pkgs/os-specific/linux/alsa-project/alsa-ucm-conf/default.nix
@@ -1,12 +1,12 @@
 { lib, stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  pname = "alsa-ucm-conf";
-  version = "1.2.6.3";
+  name = "alsa-ucm-conf-${version}";
+  version = "1.2.5.1";
 
   src = fetchurl {
-    url = "mirror://alsa/lib/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-uKA6o4emJKL2XtwgG/d3QhGQtgUpqSCHZGgjr72Wxc0=";
+    url = "mirror://alsa/lib/${name}.tar.bz2";
+    sha256 = "sha256-WEGkRBZty/R523UTA9vDVW9oUIWsfgDwyed1VnYZXZc=";
   };
 
   dontBuild = true;


### PR DESCRIPTION
Reverts https://github.com/NixOS/nixpkgs/pull/154038 as it has 5000+ rebuilds but was merged to master, and the update is actually covered by https://github.com/NixOS/nixpkgs/pull/151357.

https://nixpk.gs/pr-tracker.html?pr=154038 this is already in nixos-unstable-small so I am not sure if I am too late to notice this. To be honest I made similar mistakes a while ago and I hope reverting this as soon as possible can be fine.

I think maybe I need to ping @vcunat for this revert?