### PR TITLE
graphite-gtk-theme: unstable-2022-01-04 -> unstable-2022-01-07

### DIFF
--- a/pkgs/data/themes/graphite/default.nix
+++ b/pkgs/data/themes/graphite/default.nix
@@ -15,18 +15,11 @@
 let
   pname = "graphite-gtk-theme";
 
-  throwIfNotSubList = name: given: valid:
-    let
-      unexpected = lib.subtractLists valid given;
-    in
-      lib.throwIfNot (unexpected == [])
-        "${name}: ${builtins.concatStringsSep ", " (builtins.map builtins.toString unexpected)} unexpected; valid ones: ${builtins.concatStringsSep ", " (builtins.map builtins.toString valid)}";
-
 in
-throwIfNotSubList "${pname}: theme variants" themeVariants [ "default" "purple" "pink" "red" "orange" "yellow" "green" "teal" "blue" "all" ]
-throwIfNotSubList "${pname}: color variants" colorVariants [ "standard" "light" "dark" ]
-throwIfNotSubList "${pname}: size variants" sizeVariants [ "standard" "compact" ]
-throwIfNotSubList "${pname}: tweaks" tweaks [ "nord" "black" "midblack" "rimless" "normal" ]
+lib.checkListOfEnum "${pname}: theme variants" [ "default" "purple" "pink" "red" "orange" "yellow" "green" "teal" "blue" "all" ] themeVariants
+lib.checkListOfEnum "${pname}: color variants" [ "standard" "light" "dark" ] colorVariants
+lib.checkListOfEnum "${pname}: size variants" [ "standard" "compact" ] sizeVariants
+lib.checkListOfEnum "${pname}: tweaks" [ "nord" "black" "midblack" "rimless" "normal" ] tweaks
 
 stdenvNoCC.mkDerivation {
   inherit pname;

--- a/pkgs/data/themes/graphite/default.nix
+++ b/pkgs/data/themes/graphite/default.nix
@@ -30,13 +30,13 @@ throwIfNotSubList "${pname}: tweaks" tweaks [ "nord" "black" "midblack" "rimless
 
 stdenvNoCC.mkDerivation {
   inherit pname;
-  version = "unstable-2022-01-04";
+  version = "unstable-2022-01-07";
 
   src = fetchFromGitHub {
     owner = "vinceliuice";
     repo = pname;
-    rev = "947cac4966377d8f5b5a4e2966ec2b9a6041d205";
-    sha256 = "11pl8hzk4fwniqdib0ffvjilpspr1n5pg1gw39kal13wxh4sdg28";
+    rev = "78e5421fee63b4c2a2a3d2e321538367b01a24ec";
+    sha256 = "1vfvv1gfbr9yr9mz0kb7c7ij6pxcryni1fjs87gn4hpyzns431wk";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- graphite-gtk-theme: unstable-2022-01-04 -> unstable-2022-01-07
- graphite-gtk-theme: use lib.checkListOfEnum to validate arguments

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
