### PR TITLE
bluemail: init at 1.131.4-1795

### DIFF
--- a/pkgs/applications/networking/mailreaders/bluemail/default.nix
+++ b/pkgs/applications/networking/mailreaders/bluemail/default.nix
@@ -1,0 +1,82 @@
+{ stdenv
+, lib
+, fetchurl
+, dpkg
+, autoPatchelfHook
+, pango
+, gtk3
+, alsa-lib
+, nss
+, libXdamage
+, libdrm
+, mesa
+, libxshmfence
+, makeWrapper
+, wrapGAppsHook
+, gcc-unwrapped
+, udev
+}:
+
+stdenv.mkDerivation rec {
+  pname = "bluemail";
+  version = "1.131.4-1795";
+
+  # Taking a snapshot of the DEB release because there are no tagged version releases.
+  # For new versions, download the upstream release, extract it and check for the version string.
+  # In case there's a new version, create a snapshot of it on https://archive.org before updating it here.
+  src = fetchurl {
+    url = "https://web.archive.org/web/20220921124548/https://download.bluemail.me/BlueMail/deb/BlueMail.deb";
+    sha256 = "sha256-deO+D9HSfj1YEDSO5Io0MA7H8ZK9iFSRwB/e+8GkgOU=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+    dpkg
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    pango
+    gtk3
+    alsa-lib
+    nss
+    libXdamage
+    libdrm
+    mesa
+    libxshmfence
+    udev
+  ];
+
+  unpackCmd = "${dpkg}/bin/dpkg-deb -x $src debcontents";
+
+  dontBuild = true;
+  dontStrip = true;
+  dontWrapGApps = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv opt/BlueMail/* $out
+    ln -s $out/bluemail $out/bin/bluemail
+  '';
+
+  makeWrapperArgs = [
+    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ gcc-unwrapped.lib gtk3 udev ]}"
+    "--prefix PATH : ${lib.makeBinPath [ stdenv.cc ]}"
+  ];
+
+  preFixup = ''
+    wrapProgram $out/bin/bluemail \
+      ''${makeWrapperArgs[@]} \
+      ''${gappsWrapperArgs[@]}
+  '';
+
+  meta = with lib; {
+    description = "Free, secure, universal email app, capable of managing an unlimited number of mail accounts";
+    homepage = "https://bluemail.me";
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24514,6 +24514,8 @@ with pkgs;
 
   bluejeans-gui = callPackage ../applications/networking/instant-messengers/bluejeans { };
 
+  bluemail = callPackage ../applications/networking/mailreaders/bluemail { };
+
   blugon = callPackage ../applications/misc/blugon { };
 
   bombadillo = callPackage ../applications/networking/browsers/bombadillo { };


### PR DESCRIPTION
###### Motivation for this change
Adds package and mail app [BlueMail](https://bluemail.me/), graphical desktop mail client which also includes a calendar.

Fixes https://github.com/NixOS/nixpkgs/issues/154270 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
