### PR TITLE
tela-circle-icon-theme: init at unstable-2021-12-24

### DIFF
--- a/pkgs/data/icons/tela-circle-icon-theme/default.nix
+++ b/pkgs/data/icons/tela-circle-icon-theme/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, gtk3
+, hicolor-icon-theme
+, jdupes
+, allColorVariants ? false
+, circularFolder ? false
+, colorVariants ? [] # default is standard
+}:
+
+let
+  pname = "tela-circle-icon-theme";
+in
+lib.checkListOfEnum "${pname}: color variants" [ "standard" "black" "blue" "brown" "green" "grey" "orange" "pink" "purple" "red" "yellow" "manjaro" "ubuntu" ] colorVariants
+
+stdenvNoCC.mkDerivation rec {
+  inherit pname;
+  version = "unstable-2021-12-24";
+
+  src = fetchFromGitHub {
+    owner = "vinceliuice";
+    repo = pname;
+    rev = "aa1f1446b6dbc6acfe3ee247e6841369c68e1495";
+    sha256 = "03f79h6kv5vbf92fhpi1wivzvcrfvvdvkhbmy805x4b4wl7qynki";
+  };
+
+  nativeBuildInputs = [
+    gtk3
+    jdupes
+  ];
+
+  propagatedBuildInputs = [
+    hicolor-icon-theme
+  ];
+
+  dontDropIconThemeCache = true;
+
+  # These fixup steps are slow and unnecessary for this package.
+  # Package may installs almost 400 000 small files.
+  dontPatchELF = true;
+  dontRewriteSymlinks = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    patchShebangs install.sh
+
+    ./install.sh -d $out/share/icons \
+      ${lib.optionalString circularFolder "-c"} \
+      ${if allColorVariants then "-a" else builtins.toString colorVariants}
+
+    jdupes -L -r $out/share/icons
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Flat and colorful personality icon theme";
+    homepage = "https://github.com/vinceliuice/Tela-circle-icon-theme";
+    license = licenses.gpl3Only;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23962,6 +23962,8 @@ with pkgs;
 
   theano = callPackage ../data/fonts/theano { };
 
+  tela-circle-icon-theme = callPackage ../data/icons/tela-circle-icon-theme { };
+
   tela-icon-theme = callPackage ../data/icons/tela-icon-theme { };
 
   template-glib = callPackage ../development/libraries/template-glib { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add t[ela-circle-icon-theme](https://github.com/vinceliuice/Tela-circle-icon-theme), a flat and colorful personality icon theme.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
