### PR TITLE
grype: 0.28.0 -> 0.30.0

### DIFF
--- a/pkgs/tools/security/grype/default.nix
+++ b/pkgs/tools/security/grype/default.nix
@@ -1,23 +1,19 @@
-{ lib
-, buildGoModule
-, docker
-, fetchFromGitHub
-}:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
 
 buildGoModule rec {
   pname = "grype";
-  version = "0.28.0";
+  version = "0.30.0";
 
   src = fetchFromGitHub {
     owner = "anchore";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-Mc0bO9BDcIXEoHwhQDbX9g84kagcT3gVz8PPxXpG7dw=";
+    sha256 = "sha256-nUNjC1NNscqv+cirC/4/FlrbOomBXxnOoHvCVpBUOUs=";
   };
 
-  vendorSha256 = "sha256-su0dg9Gidd8tQKM5IzX6/GC5jk8SCIO+qsI3UGlvpwg=";
+  vendorSha256 = "sha256-XUj9Az/N/ZzCJF6a7EipPTntwlFYuVhg8JoS+GJES+w=";
 
-  propagatedBuildInputs = [ docker ];
+  nativeBuildInputs = [ installShellFiles ];
 
   ldflags = [
     "-s" "-w" "-X github.com/anchore/grype/internal/version.version=${version}"
@@ -26,14 +22,22 @@ buildGoModule rec {
   # Tests require a running Docker instance
   doCheck = false;
 
+  postInstall = ''
+    installShellCompletion --cmd grype \
+      --bash <($out/bin/grype completion bash) \
+      --fish <($out/bin/grype completion fish) \
+      --zsh <($out/bin/grype completion zsh)
+  '';
+
   meta = with lib; {
+    homepage = "https://github.com/anchore/grype";
+    changelog = "https://github.com/anchore/grype/releases/tag/v${version}";
     description = "Vulnerability scanner for container images and filesystems";
     longDescription = ''
-      As a vulnerability scanner is grype abale to scan the contents of a container
-      image or filesystem to find known vulnerabilities.
+      As a vulnerability scanner grype is able to scan the contents of a
+      container image or filesystem to find known vulnerabilities.
     '';
-    homepage = "https://github.com/anchore/grype";
     license = with licenses; [ asl20 ];
-    maintainers = with maintainers; [ fab ];
+    maintainers = with maintainers; [ fab jk ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump grype to `0.30.0`

Also:

Added myself as a maintainer
Removed docker as a propagated build input - grype can be used without the docker service and having it as a propagated build input doesn't guarentee the service/socket is running
Added completions
Cleaned up meta

cc: @fabaff

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
