### PR TITLE
gitmux: inti at 0.7.10

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/gitmux/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitmux/default.nix
@@ -1,0 +1,35 @@
+{ fetchFromGitHub, buildGoModule, lib, testers, gitmux }:
+
+buildGoModule rec {
+  pname = "gitmux";
+  version = "0.7.10";
+
+  src = fetchFromGitHub {
+    owner = "arl";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-kBrE3jU7N8+kdT4tqC6gIGPz3soagStzLy5Iz4vNFI0=";
+  };
+
+  vendorSha256 = "sha256-V6xe+19NiHYIIN4rgkyzdP4eGnRXo0aW4fVbdlIcvig=";
+
+  # GitHub source does contain a regression test for the module
+  # but it requires networking as it git clones a repo from github
+  doCheck = false;
+
+  ldflags = [ "-X main.version=${version}" ];
+
+  passthru.tests.version = testers.testVersion {
+    package = gitmux;
+    command = "gitmux -V";
+  };
+
+  subPackages = [ "." ];
+
+  meta = with lib; {
+    description = "Git in your tmux status bar";
+    homepage = "https://github.com/arl/gitmux";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nialov ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1827,6 +1827,8 @@ with pkgs;
 
   gitls = callPackage ../applications/version-management/git-and-tools/gitls { };
 
+  gitmux = callPackage ../applications/version-management/git-and-tools/gitmux { };
+
   gitnuro = callPackage ../applications/version-management/git-and-tools/gitnuro { };
 
   gitsign = callPackage ../applications/version-management/git-and-tools/gitsign { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add `gitmux` which is a `go` app made for the simple purpose of printing `git status` prettily in `tmux` statusbar.

It is distributed as a single binary and therefore I've not added this as a `tmuxPlugin` as you could in theory use it for other purposes as `tmux` is not required (prints to stdout which can be captured by `tmux`). As I'm writing this request I'm wondering if `git` should be added as a runtime dependency as that is what it uses to provide its main functionality (get `git status` in current directory). It can create default config files and such for itself without `git` however and doesn't error without it either.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
