### PR TITLE
wg-netmanager: init at 0.2.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4361,6 +4361,12 @@
     githubId = 27668;
     name = "Tobias Pflug";
   };
+  gin66 = {
+    email = "jochen@kiemes.de";
+    github = "gin66";
+    githubId = 5549373;
+    name = "Jochen Kiemes";
+  };
   giogadi = {
     email = "lgtorres42@gmail.com";
     github = "giogadi";

--- a/pkgs/tools/networking/wg-netmanager/default.nix
+++ b/pkgs/tools/networking/wg-netmanager/default.nix
@@ -1,0 +1,40 @@
+# Test compilation/test with:
+#	nix build -f ~/src/nixpkgs wg-netmanager
+#
+# Test execution with:
+#   nix-env -f ~/src/nixpkgs -iA wg-netmanager
+
+{ lib, stdenv, fetchFromGitHub, rustPlatform, darwin }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "wg-netmanager";
+  version = "0.2.8";
+
+  src = fetchFromGitHub {
+    owner = "gin66";
+    repo = "wg_netmanager";
+    rev = "wg_netmanager-v${version}";
+    sha256 = "16g5dfd4w0qx7pcgx6xw0py6w0s3dxwfb53j1xpsiz81412b71i4";
+  };
+
+  # related to the Cargo.lock file
+  cargoSha256 = "0f0qd6l3ra64rny2zsmsj4x3zrilqhnlp4l2l5sqglgkxg8g17jz";
+
+  buildInputs = lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
+
+  # Testing this project requires sudo, Docker and network access, etc.
+  doCheck = true;
+
+  # Test 01 tries to create a wireguard interface, which requires ip.
+  # No idea, how to include ip during testing
+  checkFlags = "--test 02_";
+
+  meta = with lib; {
+    description = "Wireguard network manager";
+	longDescription = "Wireguard network manager, written in rust, simplifies the setup of wireguard nodes, identifies short connections between nodes residing in the same subnet, identifies unreachable aka dead nodes and maintains the routes between all nodes automatically. To achieve this, wireguard network manager needs to be running on each node.";
+    homepage = "https://github.com/gin66/wg_netmanager";
+    license = licenses.mit;
+    maintainers = with maintainers; [ gin66 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/networking/wg-netmanager/default.nix
+++ b/pkgs/tools/networking/wg-netmanager/default.nix
@@ -1,5 +1,5 @@
 # Test compilation/test with:
-#	nix build -f ~/src/nixpkgs wg-netmanager
+#   nix build -f ~/src/nixpkgs wg-netmanager
 #
 # Test execution with:
 #   nix-env -f ~/src/nixpkgs -iA wg-netmanager
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     description = "Wireguard network manager";
-	longDescription = "Wireguard network manager, written in rust, simplifies the setup of wireguard nodes, identifies short connections between nodes residing in the same subnet, identifies unreachable aka dead nodes and maintains the routes between all nodes automatically. To achieve this, wireguard network manager needs to be running on each node.";
+    longDescription = "Wireguard network manager, written in rust, simplifies the setup of wireguard nodes, identifies short connections between nodes residing in the same subnet, identifies unreachable aka dead nodes and maintains the routes between all nodes automatically. To achieve this, wireguard network manager needs to be running on each node.";
     homepage = "https://github.com/gin66/wg_netmanager";
     license = licenses.mit;
     maintainers = with maintainers; [ gin66 ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10762,6 +10762,8 @@ with pkgs;
 
   wg-friendly-peer-names = callPackage ../tools/networking/wg-friendly-peer-names { };
 
+  wg-netmanager = callPackage ../tools/networking/wg-netmanager { };
+
   woff2 = callPackage ../development/web/woff2 { };
 
   woof = callPackage ../tools/misc/woof { };


### PR DESCRIPTION
###### Motivation for this change
New package wg-netmanager, which maintains a net connected via wireguard

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
