### PR TITLE
python3.pkgs.pygls: unpin pydantic

### DIFF
--- a/pkgs/development/python-modules/pygls/default.nix
+++ b/pkgs/development/python-modules/pygls/default.nix
@@ -29,6 +29,12 @@ buildPythonPackage rec {
     pydantic
     typeguard
   ];
+  # We don't know why an early version of pydantic is required, see:
+  # https://github.com/openlawlibrary/pygls/issues/221
+  preBuild = ''
+    substituteInPlace setup.cfg \
+      --replace "pydantic>=1.7,<1.9" "pydantic"
+  '';
 
   checkInputs = [
     mock


### PR DESCRIPTION
###### Motivation for this change

Build fails otherwise.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
