### PR TITLE
python3Packages.sqlite-utils: 3.19 -> 3.22

### DIFF
--- a/pkgs/development/python-modules/sqlite-utils/default.nix
+++ b/pkgs/development/python-modules/sqlite-utils/default.nix
@@ -5,7 +5,7 @@
 , pythonOlder
 , click
 , click-default-group
-, dateutils
+, python-dateutil
 , sqlite-fts4
 , tabulate
 , pytestCheckHook
@@ -14,32 +14,18 @@
 
 buildPythonPackage rec {
   pname = "sqlite-utils";
-  version = "3.19";
+  version = "3.22";
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "509099fce5f25faada6e76b6fb90e8ef5ba0f1715177933a816718be0c8e7244";
+    sha256 = "24803ea4d63e2123d2040db2da43fea95fabada80e1af1fe1da69643ae376689";
   };
-
-  patches = [
-    # https://github.com/simonw/sqlite-utils/pull/347
-    (fetchpatch {
-      name = "sqlite-utils-better-test_rebuild_fts.patch";
-      url = "https://github.com/simonw/sqlite-utils/pull/347/commits/1a7ef2fe2064ace01d5535fb771f941296fb642a.diff";
-      sha256 = "sha256-WKCQGMqr8WYjG7cmAH5pYBhgikowbt3r6hObwtMDDUY=";
-    })
-  ];
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace '"pytest-runner"' ""
-  '';
 
   propagatedBuildInputs = [
     click
     click-default-group
-    dateutils
+    python-dateutil
     sqlite-fts4
     tabulate
   ];


### PR DESCRIPTION

###### Motivation for this change

Clean up package:
- remove test patch, as it's included in 3.20 (simonw/sqlite-utils@ee13f98c2c7ca3b819bd0fc55da3108cb6a6434a)
- pytest-runner is removed from setup.py in (simonw/sqlite-utils@f3fd8613113d21d44238a6ec54b375f5aa72c4e0)
- replace `dateutils` with `python-dateutil` (simonw/sqlite-utils@bc4c42d68879c710c851dba3c98deda96ca6caa8)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
