### PR TITLE
nomad-pack: init at nightly

### DIFF
--- a/pkgs/applications/networking/cluster/nomad-pack/default.nix
+++ b/pkgs/applications/networking/cluster/nomad-pack/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, fetchFromGitHub
+, buildGoModule
+}:
+
+buildGoModule rec {
+  pname = "nomad-pack";
+  version = "2022-02-11";
+  rev   = "568ac5e42bc41172a1fa3c8b18af2f42b9e341ff";
+
+  src = fetchFromGitHub {
+    owner = "hashicorp";
+    repo = pname;
+    inherit rev;
+    sha256 = "sha256-0hvnGdUT72sWvMER67ZBxcC+VTbuFMIos2NudOjeTB8=";
+  };
+
+  vendorSha256 = "sha256-wmoXZIogKj4i9+AsEjY7QaT2Tn4LQyGQcEFHrRO0W9s=";
+
+  # skip running go tests as they require network access
+  doCheck = false;
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/nomad-pack --version
+    runHook postInstallCheck
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/hashicorp/nomad-pack";
+    changelog = "https://github.com/hashicorp/nomad-pack/blob/main/CHANGELOG.md";
+    description = "Nomad Pack is a templating and packaging tool used with HashiCorp Nomad.";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ techknowlogick ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8052,6 +8052,8 @@ with pkgs;
 
   nomad-driver-podman = callPackage ../applications/networking/cluster/nomad-driver-podman { };
 
+  nomad-pack = callPackage ../applications/networking/cluster/nomad-pack { };
+
   nomino = callPackage ../tools/misc/nomino { };
 
   notable = callPackage ../applications/misc/notable { };


### PR DESCRIPTION
###### Motivation for this change
nomad-pack is a package templating tool for hashicorp's nomad (analogous to kubernete's helm). Currently in "tech preview", however still useful in its current state.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
