### PR TITLE
handbrake: 1.4.2 -> 1.5.1

### DIFF
--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -81,13 +81,13 @@
 }:
 
 let
-  version = "1.4.2";
+  version = "1.5.1";
 
   src = fetchFromGitHub {
     owner = "HandBrake";
     repo = "HandBrake";
     rev = version;
-    sha256 = "sha256-Usz2+U1Wb8yJ5W2HqV0FqBaaE25fuVKk/NwKBHaKzwk=";
+    sha256 = "1kk11zl1mk37d4cvbc75gfndmma7vy3vkp4gmkyl92kiz6zadhyy";
   };
 
   versionFile = writeText "version.txt" ''


### PR DESCRIPTION
###### Motivation for this change

Next release.

`1.5.0` was published initially, and `1.5.1` is fixup release: https://github.com/HandBrake/HandBrake/releases

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
