### PR TITLE
New games!

### DIFF
--- a/pkgs/games/blockattack/default.nix
+++ b/pkgs/games/blockattack/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, SDL2
+, SDL2_image
+, SDL2_mixer
+, SDL2_ttf
+, boost
+, cmake
+, gettext
+, physfs
+, pkg-config
+, zip
+}:
+
+stdenv.mkDerivation rec {
+  pname = "blockattack";
+  version = "2.7.0";
+
+  src = fetchFromGitHub {
+    name = "${pname}-${version}-src";
+    owner = "blockattack";
+    repo = "blockattack-game";
+    rev = "v${version}";
+    hash = "sha256-ySLm3AdoJRiMRdla45OJh8ZIFYNh+HzjG2VnFqoWuZA=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    gettext
+    zip
+  ];
+
+  buildInputs = [
+    SDL2
+    SDL2_image
+    SDL2_mixer
+    SDL2_ttf
+    SDL2_ttf
+    boost
+    physfs
+  ];
+
+  preConfigure = ''
+    patchShebangs packdata.sh source/misc/translation/*.sh
+    chmod +x ./packdata.sh
+    ./packdata.sh
+  '';
+
+  meta = with lib; {
+    homepage = "https://blockattack.net/";
+    description = "An open source clone of Panel de Pon (aka Tetris Attack)";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = platforms.unix;
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/games/the-legend-of-edgar/default.nix
+++ b/pkgs/games/the-legend-of-edgar/default.nix
@@ -1,0 +1,75 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, SDL2
+, SDL2_image
+, SDL2_mixer
+, SDL2_ttf
+, gettext
+, libpng
+, pkg-config
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "the-legend-of-edgar";
+  version = "1.35";
+
+  src = fetchFromGitHub {
+    name = "${pname}-${version}-src";
+    owner = "riksweeney";
+    repo = "edgar";
+    rev = version;
+    hash = "sha256-ojy4nEW9KiSte/AoFUMPrKCxvIeQpMVIL4ileHiBydo=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    gettext
+  ];
+
+  buildInputs = [
+    SDL2
+    SDL2_image
+    SDL2_mixer
+    SDL2_ttf
+    libpng
+    zlib
+  ];
+
+  dontConfigure = true;
+
+  makefile = "makefile";
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "BIN_DIR=${placeholder "out"}/bin/"
+  ];
+
+  # TODO: remove the setting below when the next version arrives
+  # https://github.com/riksweeney/edgar/pull/57
+  preBuild = ''
+    export CFLAGS=$(sdl2-config --cflags)
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.parallelrealities.co.uk/games/edgar";
+    description = "A 2D platform game with a persistent world";
+    longDescription = ''
+      When Edgar's father fails to return home after venturing out one dark and
+      stormy night, Edgar fears the worst: he has been captured by the evil
+      sorcerer who lives in a fortress beyond the forbidden swamp.
+
+      Donning his armour, Edgar sets off to rescue him, but his quest will not
+      be easy...
+
+      The Legend of Edgar is a platform game, not unlike those found on the
+      Amiga and SNES. Edgar must battle his way across the world, solving
+      puzzles and defeating powerful enemies to achieve his quest.
+    '';
+    license = licenses.gpl1Plus;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = platforms.unix;
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31146,6 +31146,8 @@ with pkgs;
 
   tcl2048 = callPackage ../games/tcl2048 { };
 
+  the-legend-of-edgar = callPackage ../games/the-legend-of-edgar { };
+
   the-powder-toy = callPackage ../games/the-powder-toy {
     lua = lua5_1;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30226,6 +30226,8 @@ with pkgs;
 
   ballerburg = callPackage ../games/ballerburg { } ;
 
+  blockattack = callPackage ../games/blockattack { } ;
+
   colobot = callPackage ../games/colobot {};
 
   doom-bcc = callPackage ../games/zdoom/bcc-git.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

blockattack: init at 2.7.0
the-legend-of-edgar: init at 1.35

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
