### PR TITLE
python3Packages.requests-toolbelt: disable warnings

### DIFF
--- a/pkgs/development/python-modules/requests-toolbelt/default.nix
+++ b/pkgs/development/python-modules/requests-toolbelt/default.nix
@@ -1,36 +1,48 @@
 { lib
+, betamax
 , buildPythonPackage
 , fetchPypi
-, requests
-, betamax
 , mock
-, pytest
 , pyopenssl
+, pytestCheckHook
+, requests
 }:
 
 buildPythonPackage rec {
   pname = "requests-toolbelt";
   version = "0.9.1";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "968089d4584ad4ad7c171454f0a5c6dac23971e9472521ea3b6d49d610aa6fc0";
+    hash = "sha256-loCJ1FhK1K18FxRU8KXG2sI5celHJSHqO21J1hCqb8A=";
   };
 
-  checkInputs = [ pyopenssl betamax mock pytest ];
-  propagatedBuildInputs = [ requests ];
+  propagatedBuildInputs = [
+    requests
+  ];
 
-  checkPhase = ''
-    # disabled tests access the network
-    py.test tests -k "not test_no_content_length_header \
-                  and not test_read_file \
-                  and not test_reads_file_from_url_wrapper \
-                  and not test_x509_der \
-                  and not test_x509_pem"
-  '';
+  checkInputs = [
+    betamax
+    mock
+    pyopenssl
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    "test_no_content_length_header"
+    "test_read_file"
+    "test_reads_file_from_url_wrapper"
+    "test_x509_der"
+    "test_x509_pem"
+  ];
+
+  pythonImportsCheck = [
+    "requests_toolbelt"
+  ];
 
   meta = {
-    description = "A toolbelt of useful classes and functions to be used with python-requests";
+    description = "Toolbelt of useful classes and functions to be used with requests";
     homepage = "http://toolbelt.rtfd.org";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ matthiasbeyer ];

--- a/pkgs/development/python-modules/requests-toolbelt/default.nix
+++ b/pkgs/development/python-modules/requests-toolbelt/default.nix
@@ -1,6 +1,7 @@
 { lib
 , betamax
 , buildPythonPackage
+, fetchpatch
 , fetchPypi
 , mock
 , pyopenssl
@@ -29,7 +30,17 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  patches = [
+    (fetchpatch {
+      # Fix collections.abc deprecation warning, https://github.com/requests/toolbelt/pull/246
+      name = "fix-collections-abc-deprecation.patch";
+      url = "https://github.com/requests/toolbelt/commit/7188b06330e5260be20bce8cbcf0d5ae44e34eaf.patch";
+      sha256 = "sha256-pRkG77sNglG/KsRX6JaPgk4QxmmSBXypFRp/vNA3ot4=";
+    })
+  ];
+
   disabledTests = [
+    # https://github.com/requests/toolbelt/issues/306
     "test_no_content_length_header"
     "test_read_file"
     "test_reads_file_from_url_wrapper"
@@ -41,10 +52,10 @@ buildPythonPackage rec {
     "requests_toolbelt"
   ];
 
-  meta = {
+  meta = with lib; {
     description = "Toolbelt of useful classes and functions to be used with requests";
     homepage = "http://toolbelt.rtfd.org";
-    license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ matthiasbeyer ];
+    license = licenses.asl20;
+    maintainers = with maintainers; [ matthiasbeyer ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/163470180)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
