### PR TITLE
treewide: rename name to pname&version

### DIFF
--- a/pkgs/os-specific/linux/kernel/perf.nix
+++ b/pkgs/os-specific/linux/kernel/perf.nix
@@ -12,7 +12,8 @@ with lib;
 assert versionAtLeast kernel.version "3.12";
 
 stdenv.mkDerivation {
-  name = "perf-linux-${kernel.version}";
+  pname = "perf-linux";
+  version = kernel.version;
 
   inherit (kernel) src;
 

--- a/pkgs/os-specific/linux/kmod-debian-aliases/default.nix
+++ b/pkgs/os-specific/linux/kmod-debian-aliases/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, lib }:
 
 stdenv.mkDerivation rec {
-  name = "kmod-debian-aliases-${version}.conf";
+  pname = "kmod-debian-aliases.conf";
   version = "22-1.1";
 
   src = fetchurl {

--- a/pkgs/os-specific/linux/libevdevc/default.nix
+++ b/pkgs/os-specific/linux/libevdevc/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, coreutils, pkg-config, glib, jsoncpp }:
 
 stdenv.mkDerivation rec {
-  name = "libevdevc";
+  pname = "libevdevc";
   version = "2.0.1";
   src = fetchFromGitHub {
     owner = "hugegreenbug";

--- a/pkgs/os-specific/linux/libgestures/default.nix
+++ b/pkgs/os-specific/linux/libgestures/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, pkg-config, glib, jsoncpp }:
 
 stdenv.mkDerivation rec {
-  name = "libgestures-${version}";
+  pname = "libgestures";
   version = "2.0.1";
   src = fetchFromGitHub {
     owner = "hugegreenbug";

--- a/pkgs/os-specific/linux/net-tools/mptcp.nix
+++ b/pkgs/os-specific/linux/net-tools/mptcp.nix
@@ -1,7 +1,7 @@
 { lib, nettools, fetchFromGitHub  }:
 
 nettools.overrideAttrs(oa: rec {
-  name = "net-tools-mptcp";
+  pname = "net-tools-mptcp";
   version = "0.95";
 
   src = fetchFromGitHub {

--- a/pkgs/os-specific/linux/pommed-light/default.nix
+++ b/pkgs/os-specific/linux/pommed-light/default.nix
@@ -10,13 +10,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  pkgname = "pommed-light";
+  pname = "pommed-light";
   version = "1.51lw";
-  name = "${pkgname}-${version}";
 
   src = fetchFromGitHub {
     owner = "bytbox";
-    repo = pkgname;
+    repo = "pommed-light";
     rev = "v${version}";
     sha256 = "18fvdwwhcl6s4bpf2f2i389s71c8k4g0yb81am9rdddqmzaw27iy";
   };

--- a/pkgs/os-specific/linux/statifier/default.nix
+++ b/pkgs/os-specific/linux/statifier/default.nix
@@ -1,8 +1,8 @@
 { lib, multiStdenv, fetchurl }:
 
-let version = "1.7.4"; in
-multiStdenv.mkDerivation {
-  name = "statifier-${version}";
+multiStdenv.mkDerivation rec {
+  pname = "statifier";
+  version = "1.7.4";
 
   src = fetchurl {
     url = "mirror://sourceforge/statifier/statifier-${version}.tar.gz";

--- a/pkgs/os-specific/linux/sysvinit/default.nix
+++ b/pkgs/os-specific/linux/sysvinit/default.nix
@@ -1,9 +1,8 @@
 { lib, stdenv, fetchurl, withoutInitTools ? false }:
 
-let version = "3.01"; in
-
-stdenv.mkDerivation {
-  name = (if withoutInitTools then "sysvtools" else "sysvinit") + "-" + version;
+stdenv.mkDerivation rec {
+  pname = if withoutInitTools then "sysvtools" else "sysvinit";
+  version = "3.01";
 
   src = fetchurl {
     url = "mirror://savannah/sysvinit/sysvinit-${version}.tar.xz";

--- a/pkgs/os-specific/linux/tmon/default.nix
+++ b/pkgs/os-specific/linux/tmon/default.nix
@@ -1,7 +1,8 @@
 { lib, stdenv, kernel, ncurses }:
 
 stdenv.mkDerivation {
-  name = "tmon-${kernel.version}";
+  pname = "tmon";
+  version = kernel.version;
 
   inherit (kernel) src;
 

--- a/pkgs/os-specific/linux/uclibc/default.nix
+++ b/pkgs/os-specific/linux/uclibc/default.nix
@@ -54,7 +54,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "uclibc-ng-${version}";
+  pname = "uclibc-ng";
   inherit version;
 
   src = fetchurl {

--- a/pkgs/os-specific/linux/unstick/default.nix
+++ b/pkgs/os-specific/linux/unstick/default.nix
@@ -1,12 +1,12 @@
 { stdenv, lib, fetchFromGitHub, meson, ninja, pkg-config, libseccomp }:
 
 stdenv.mkDerivation rec {
-  name = "unstick";
+  pname = "unstick";
   version = "0.1.0";
 
   src = fetchFromGitHub {
     owner = "kwohlfahrt";
-    repo = name;
+    repo = "unstick";
     rev = "effee9aa242ca12dc94cc6e96bc073f4cc9e8657";
     sha256 = "08la3jmmzlf4pm48bf9zx4cqj9gbqalpqy0s57bh5vfsdk74nnhv";
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#103997

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
