### PR TITLE
firefox{,-bin}: 95.0.2 -> 96.0; firefox-91-esr: 91.4.1esr -> 91.5.0esr

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "95.0.2";
+  version = "96.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/ach/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ach/firefox-96.0.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "30c3158285d010145b154249c1182a2a705881b18194166bbbf72d6f2fae45ce";
+      sha256 = "88a69911dce4985251028b16a163b4db36fef47698ff73cd7f685ca3a1dd5243";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/af/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/af/firefox-96.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "293b4f0d6ca7bb1ab8f51acb8a97894e81ef6ff36832a84b05f4789856001654";
+      sha256 = "7b7cebc75eb6097a6a950599fb0b1b4e695bf12bfbc3272bbb9e79f3770e14d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/an/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/an/firefox-96.0.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "27a437c1a44594e7b6c7b2200031635cb5c10d529337b764d97e7c5529c9e82b";
+      sha256 = "5de8de362b479fead0b4dbe0d9e81a8692465b11a63479aca012d611eff0fa14";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/ar/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ar/firefox-96.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "f40e52d8c0012a87153291f55b3418fa6a9569f370b394b86b0d48a80935bcec";
+      sha256 = "9d45cf623e4e8fc959844174284da573a9a6bab2fb00fa9bd6511ad0941a31e7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/ast/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ast/firefox-96.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "5ad7e850cca208ae3125c3e628a0ed9bd9b5a7393d6e25b88a83cffa6dc9c7f0";
+      sha256 = "6921a5883382c99dae6e902e079ae76e1112a86fe3aa74eed485e6c2aa5d99c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/az/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/az/firefox-96.0.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "3953a2a6f71ccabcbc6811e92baa7e86d548fa5935f5b149c54ccff94f8a7648";
+      sha256 = "44b78fd0f6e6feeec020ad6c71581ee875e9db5c06b55699514067a8190fc9f1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/be/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/be/firefox-96.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "07e1692b749114e441e99509e5da570d2104c598f4335b16fe807bc01baa2943";
+      sha256 = "abfc8a54d035fb5b8112168cabc13f48674a8a1c870096697dd648f3a801cc5e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/bg/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/bg/firefox-96.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "a15479f6066404f7def523febf56ea51fc5d51e29302ae65e6022e7c6f6eb3b5";
+      sha256 = "7245000ff9486713add7d487e95d860cbc412fc61f292ca308553f4a447fd12b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/bn/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/bn/firefox-96.0.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "641cf4adc3bc2ee15e60e458aa3c25959355ab511087d2601391694533bd2f11";
+      sha256 = "6186942376927d18e722575894b2337958faf2eab8ed20d092722f640eb3ae1a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/br/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/br/firefox-96.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "0b2e5ff481047324de3bf832e88893b6ff0c632c4e2c3275ad35d36149870ead";
+      sha256 = "1d4610801d2357632e469df842b70844892af9b74d4934af8a7fda5846c96116";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/bs/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/bs/firefox-96.0.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "03a65771f51281b8f6f116c794671f8cb42e2a3832027380785785cc47c16e46";
+      sha256 = "7ee573e4aaba51b660d25bc6a1a90659d3240d530b8baaaaba64ef989ede6be1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/ca-valencia/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ca-valencia/firefox-96.0.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "e42666332c27cd4b8e904f0c9c332971a8d17e12697fe18c7c93a8415f620f0c";
+      sha256 = "c9199f12b1ea4a22d01d5a51a51a085b1b37cbc731516406b34bd7c96a4b2e8f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/ca/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ca/firefox-96.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "915ee8e30d27dec75019956f960a4777cf33a8eaaf86955d9c0d8fe81a2a6e8b";
+      sha256 = "1527b802e525aa3a7d3edac7b2cb1fa68730d8499ee8d9904f60dc40842e2cd9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/cak/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/cak/firefox-96.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "31e2dfc109314c942e52e0783c1df09959b7bc27961c419a7dcea709d0a27e50";
+      sha256 = "77c713bbff9d83b67baeb791f551a71ee0353418e95af0b070e3806bec77e501";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/cs/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/cs/firefox-96.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "5657b42bf6c9baddb68740d05ff75f791d53d5fbe36159db3f3afd16b22e275d";
+      sha256 = "1fdaddf381023516e4a1e476cd9f3c6d8293b2bfe755f5b35256e405956f7607";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/cy/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/cy/firefox-96.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "c553331598f9666a8acb0c54eb47872d6e0e81d5884a4296e69adf3fb93a447a";
+      sha256 = "782e40391e1715f39961d759323ecec10860225b65be0989c923b1ae08c3bc6a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/da/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/da/firefox-96.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "affb6428a8075a20ab8ed161972297d7841e533ab63d37172fba0fd221933031";
+      sha256 = "68ab324a88c81b8309dd599e0a57e1553d3a7162c7d63639f5e2ad3ab4ff10e9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/de/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/de/firefox-96.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "2bc45b8224591336c7ae61e0a2bcc0e3c9e172845cd9d267df118657c4d9e0bb";
+      sha256 = "50b3677c2c6168d3d6b86b8c6d7deacd65d99d6d9ef9b91b7a1322515222b6cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/dsb/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/dsb/firefox-96.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "ab7f31ca329192242baa95738bc762e300f8208cdd9bb825d39fa6f1965b3681";
+      sha256 = "65f7ee8892636790e509637392583b918db56379ae05f482824217f26511288e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/el/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/el/firefox-96.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "2fa3ae5de7cc898a838edd5beb33b706f50536864df60dd958506a0c86a86c77";
+      sha256 = "5fe2fa3ff7284bd6b2519736e159d31150fa13459e8203eeb7b4f2a741dd11a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/en-CA/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/en-CA/firefox-96.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "02ed1a2a567a9554d07a98a6ecae87c1fba977d84c3467347ebaf67142a51584";
+      sha256 = "70aeacbae6a2f924cc63eab43857303002c2d199b1ed00b8514a1d8cb32b3c2a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/en-GB/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/en-GB/firefox-96.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "cc4c7a8215f2cdf91cba03c1e9b2b41c35e7d3867946a9f1f829556f8848d59c";
+      sha256 = "89c7f6d491021a1094c19480de5e07d2d55e869ef2027be15bfff4179047e2e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/en-US/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/en-US/firefox-96.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "f78a41215d168a2a215528a08877b3cc51e0caa3f1a840c27075b3112ef3d7d7";
+      sha256 = "6f6cf571331e1a5f574116943b5de4cdd6c9072f6775ebec5dcb89991ed96b0a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/eo/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/eo/firefox-96.0.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "125bd4c7c0b758610165a360a7d754cbe74a75564428314dac88aaaca070b0e7";
+      sha256 = "11222993c2357eae6cd28e4fc31a51345088510af60545738d342ef5d3d7e62c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/es-AR/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/es-AR/firefox-96.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "98f889c83e063bb14c1b0893507322a43676383490527c5a4c3c43540d19bcad";
+      sha256 = "37119a97e6bdc0d708bee83ef22642d44cd34ca02348939d7dbb8daa0f520071";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/es-CL/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/es-CL/firefox-96.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "af09fd6032a2b40a5af5207acb35240462f827abd46edc0336fce79498230b55";
+      sha256 = "f6805e64b01c5cf5b35cc74449a2c4f103cad153a0a396c14cce52ead176c2ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/es-ES/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/es-ES/firefox-96.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "31fb87e5c96a328db0729cc17900ecd4ced722cb85790fda5781125fb1402f8d";
+      sha256 = "e8e33a2219363c2d9a22e66a0b047848764d946b19b0f8539ab0ad9f3844d81e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/es-MX/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/es-MX/firefox-96.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "c56edc5a194cae8d442ed2119e3e5988923b308b38849879da801fad73814d93";
+      sha256 = "5593fd719736c8d0a841a6407b5fef77a10add5e72b47cabf713ae3659c76460";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/et/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/et/firefox-96.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "b9aa36097f1d91e49442b9da2313e6e4604e50a496d41472a707b45d452e22e5";
+      sha256 = "aec0605c75e747c46ddd1d702eb84144edb6f65fbc2c9bc8dd487a8259d15344";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/eu/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/eu/firefox-96.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "e47e56023251ea1660e29d0c0e0b6827caad83fd6250a19d4951ebfb29411dbb";
+      sha256 = "6d481223fd80a84369c8afda02d2223108308e4449bc8e21e5f304519c362558";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/fa/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/fa/firefox-96.0.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "97b597c2c932a26d9addb602ad912dc718b0a195910da42089498ab1e6c8065b";
+      sha256 = "34689658d29304e17da97121a41602399d80fa07feaea83e1647e37dac51552e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/ff/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ff/firefox-96.0.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "606034717d76da565c643ac69e3799f7777741130f607073b701786e6fc103a6";
+      sha256 = "6b67ea39fbf17c982ef2dd7f9ecef83d239fd43e9a6ab7ce5d41abfb8917db1b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/fi/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/fi/firefox-96.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "e2a5df47c570ff5fa9eb6e3206d4ef3ae653c7b787916962138cad40745aaf39";
+      sha256 = "3a602bdd77f6da214f3f23a2428871ccd00b09e44d4e5aa42e1ceeb16bd36df3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/fr/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/fr/firefox-96.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "d21aeaadad2390663b353445559518d25140f9dc6bf5673e36f44f107690971d";
+      sha256 = "53acf00bb148595adc58fb80d9546237d662666f7cc6240fab19d393f74e1377";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/fy-NL/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/fy-NL/firefox-96.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "6d15d80b73a5295e2ee3cac50f3eb15b5992c2519fe916eeae3df52f90a28927";
+      sha256 = "92e290420735d72e0372184d268bccffb142e154f96ad3d4a1d4e4b71b5c7050";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/ga-IE/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ga-IE/firefox-96.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "3aca43ca905a894173ee2063d170ef4d348bfbfef9bd2a6b9ffdab3effef6725";
+      sha256 = "04423b1cc5b0f6f955e7071d7b7bc3b4989b061a85a634ee38740917e303a93e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/gd/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/gd/firefox-96.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "05f8f4832397706aedea72f049b9f8cbbe9056aff20aaddf0d8ea61a9ae5dd41";
+      sha256 = "15ca404e594c678238369ae4e51afa46eadcda19a68b6ef2c9d465981346214b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/gl/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/gl/firefox-96.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "5cd94e5d8d7f884fa7b747a814c6f80551dfecac683b55c0e6553407c43c4f13";
+      sha256 = "0397c87a2807b010256b97c1e490fe5b9c2f3c0b7642566053771ddbb34064c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/gn/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/gn/firefox-96.0.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "063f3d55e2d9ca33c051f49176e663ef40896deb87980d90eac56484b87f2aa5";
+      sha256 = "98987dd795dbfbe2c72a1e4e0199b1fc2a31403879920e140bd940667e79d0d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/gu-IN/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/gu-IN/firefox-96.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "1f74c4a721f414ee37f8b4090e425971da64354dc31c338c4d9cdb07ac84485c";
+      sha256 = "7a98f3d1d4cc8974df23181383c1de9a524f02e47e0f8a6625d20fe713130e54";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/he/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/he/firefox-96.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "d70277a80d159ae3bea155cf2f813179393317a1bbe2885d6c8fda4aa607d0c6";
+      sha256 = "1087c87aeb9465b848985c94ad647a1bc1307ade09349de6c85ae5176f32fec4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/hi-IN/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/hi-IN/firefox-96.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "0b562e989e9dce6c04c3d556e09991ab28df4cb9cbf514a98b584c2ce8503d7b";
+      sha256 = "f78ef9cceec602bfb645ab15ff4546d267943403f63570a38a5153c80a721ea0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/hr/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/hr/firefox-96.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "df5788906b8b0d506e75054f133fef9bdd8fadc14fbaa570409afb3a8b8af8c1";
+      sha256 = "988a13c49fa7b1c6e3c05beb18b675c64bb6f520ed6190079d55e69cfeac6c48";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/hsb/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/hsb/firefox-96.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "f0f9f54b037b5e519c80f5742202cdb509bffdd1558af4e4025b59e169711eb6";
+      sha256 = "821a634c479a9b4eae5f8f706d40d256406997ba7d62bb4d29ddb4539c83a937";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/hu/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/hu/firefox-96.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "eb11850c9df446876e21ec6d292b0bd0f8073f66347504b7d7384365d0097b2a";
+      sha256 = "da0659564688659c17b591a8844d481a86c7d2a01499e7cd785accf840012c04";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/hy-AM/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/hy-AM/firefox-96.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "bd23fe1e26a17d328d6f98fc8cdade954c2072297d95197b52288e4ac95dc812";
+      sha256 = "f4404195096809fe9d652821fbfd053ee9892f28262cc9cc47db7bf160e0e824";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/ia/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ia/firefox-96.0.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "a4fedb53f10455ea42f313a63c0dcab601b8b53043e736d307f3752e2e01e298";
+      sha256 = "d539c129c240a96cca32d4b4da252f146444c47d375d07cb5e47a1fcdb82983d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/id/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/id/firefox-96.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "59e05c58d03dcb6c55e160414a5209e3590c92364eb4a7edcc381ee4076cad7e";
+      sha256 = "d597990b39d8cfcefe626c741750e1bdddd30db9e8a7736d244538f180f53597";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/is/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/is/firefox-96.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "d8f4626e7dd9fbddd37caadeec90985b5aeae052553cbc4e8a96cd8916688227";
+      sha256 = "acdcabe2ecdc14804fbcb7a5f1e0b589893c90ae190a106a9988a6a60db64c89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/it/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/it/firefox-96.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "cd03b57ee4b1bda04c4ef3d6d76db0e0b25c2e802f5b93390bcb39111231f2b6";
+      sha256 = "4262d0a7e6b83bad6787b48bb9aa3a31d96d4cd5a9779bfdd667ca622f9f3d2c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/ja/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ja/firefox-96.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "93d3b15e2c9fd8eab8636e194f3db3bf164008f009d26e8e8858fd9b67556f10";
+      sha256 = "5640e018babb721fd74187e6795c64a398ffc0a233ed0b48a118444f3d2104c0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/ka/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ka/firefox-96.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "614e9544235c6c6be9a05ca5193993a3122aa4580d62a69b71cf024c1a5be2d9";
+      sha256 = "fb5fc8d8a1c8ab2d97a61493347c65b27709e7f725a8e7fa4f7cc3a0c793922e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/kab/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/kab/firefox-96.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "83f64f8b96369d3027081155f9a73eea31dad343daf16a67b4daa81208963809";
+      sha256 = "f32255c7fba167688340d0765fd6dcf6d8d6c403dc83ee6e7e9a00d984057000";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/kk/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/kk/firefox-96.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "6053e9164deaced2b0d0dddc3ecd8a6282da862f426e935231e530b0dce5eace";
+      sha256 = "10464c863efb4697e2526481e5dc06e4222189f0c1ae389675f266f73fb70698";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/km/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/km/firefox-96.0.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "10061378569908531c59f89c39c4364d8ba5cffbb8d2431d24cb936e61d949b7";
+      sha256 = "aa01663ee6e1f15bfaaeeb9e7ff4fa33f00c7017e98dfc4316d7515940e0a8e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/kn/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/kn/firefox-96.0.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "3a958d7739948f6a051761af519b96e4209a27141d7487d37ced02eac115be20";
+      sha256 = "837347aadfe019fd8baf15fb1775f06c6ff5f1c7c099777a845317ccf24e0e6b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/ko/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ko/firefox-96.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "4a00e445bcebf1bb09b30958ee7ced9bb74fc99d459f13c001be625dfeafb2ae";
+      sha256 = "18691cec2710cb89a13f5851e98951762768615ca6e45e77d9e791abad6f2132";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/lij/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/lij/firefox-96.0.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "5581da8f54ea490834504bdf6c6ba38ba94e580a3f5ded68864ca1de9db51ccc";
+      sha256 = "3515f22f97f7d0baa631ab2fea3335cbab3c5377a5184f73be9650fe121da728";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/lt/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/lt/firefox-96.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "9fbb08c96b44ab8e79c9d1f4c485b3e82abe0c0c44ced0b2e79640bd036042dd";
+      sha256 = "ed23664bcd177dc490fdfa623d8644c34351c4a91c71465337c8b3dfb79ed726";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/lv/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/lv/firefox-96.0.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "26d5a0d071e6df933f5fa602e5ac92908d6bee3aea3a0878dd9fb78e0fafaa34";
+      sha256 = "8f12bd4da0fc6506121d167090f2caff7c3cd53516f0b3d0d3a02426f40799b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/mk/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/mk/firefox-96.0.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "77eaffb3409fe962c042033304f0272a9b6a1d83a67c04039e0bfbe3fa77a406";
+      sha256 = "33f9faf3f55aabf6c8dc1b7e2430b0de02ec5979f5100aaef88b683d3daeec35";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/mr/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/mr/firefox-96.0.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "bbec138ef10b1d2dfa70e92b6911d5ba93d4a83c19d32af0e7d0f7b2273a440d";
+      sha256 = "4b57c9d1f351f3986324f3be01c2c4c8ffece6777a6f18790a02a57a53232817";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/ms/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ms/firefox-96.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "f00ac99116a2ed626af9e384114414a385121f4c5ac9d6fdf88d514391c310be";
+      sha256 = "9beb813a7781e9669d8e140e4a6279b04f9b16a0e790fcf53564e8f700ad0718";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/my/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/my/firefox-96.0.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "c8f24d949500f9829d539df0cad530431809a7fa74904e60646a3b0d68c49010";
+      sha256 = "3c5b78c390f3a77b490903b13ce2bdadb51f6e42b57ade221732f0c5203d052f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/nb-NO/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/nb-NO/firefox-96.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "46a25d5703164b941fa33bbd8d51098129cf69aed3d29471b50bf47b0fa402ec";
+      sha256 = "05b79768c73e6d853eccd5f8b1d85d1d1abba18c3c286c20e2c22705dfa93e37";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/ne-NP/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ne-NP/firefox-96.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "7d10b7aeca90d46e0e58f7ae275432bdd99bf0f85009c85cb7c4b24f4801d552";
+      sha256 = "5083d2ca8a0e46fb4b9ed6f7cc06fa5e009f2db5f7192749a273ad9294000d75";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/nl/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/nl/firefox-96.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "534b7103ae81a7804a9c7a08e99d208daeaa9ca0e90d7f7e33c57357f07ca432";
+      sha256 = "6ea95d1eaffb658f0df4ae1c3b0648fc46ceb073859315775344254dce8571a3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/nn-NO/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/nn-NO/firefox-96.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "9bffdc0f5f5b53ec578a5dc2681b122b0d7a744e0c57955973c49df6f0f6e46a";
+      sha256 = "00c36e18988bd6a73a08bbb065f668a9f20ee06d640ff26d22da5d7410898ff7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/oc/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/oc/firefox-96.0.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "292c4b1fa823d2260b34065f648e18aa56b27254fd59cb226df13de7861ebc8c";
+      sha256 = "a77c95cc9261d717dd62ffddc6d04b1ba6538a63a7922bdec8bb0aceca8843be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/pa-IN/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/pa-IN/firefox-96.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "325bb3da2c70e34507f139697c4ece086a0002e488745ff33540778634b51c93";
+      sha256 = "f2b636fc5c6ee58de46cc100e5eadd74e086274284b1723af429045afa3988dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/pl/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/pl/firefox-96.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "4f8dc3240001f4fad31c9e3e7f70499e0ac4d9e6c7080b727e7eb71b8e91003b";
+      sha256 = "77afaeaf13c0e3c50b288fc5baf58d00cf0a4879b901a5681fecd95b6b477d2b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/pt-BR/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/pt-BR/firefox-96.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "88ae3bb932005d9271eb5d82951f32c2333296c2c24f23881ab8a1a3d563bc76";
+      sha256 = "4e81866ec2708ea25ecaf021be1ba73e6a8314909fb2bf9814f97aeb3b8ee487";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/pt-PT/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/pt-PT/firefox-96.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "a7a80f21b5e5a0e6e40c6865ef3526f1eec3c983f8d49caaba35a2e5ca5401c6";
+      sha256 = "4fd989c61e24027f42dcaf0ae1ca9ed90bac1492683ff0c6f3acd5d22c6070cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/rm/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/rm/firefox-96.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "9d16c2bcf15bf2b36f5ca664a0476e080d756b14566880c0a3c8590f707a1cba";
+      sha256 = "7c433f0566a49c0141e42f3eabded921af8a286a335d17f4fac47867d17787f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/ro/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ro/firefox-96.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "db0cf0ac7b6383fdaa8a3ef5e6d59f3677009908ddfd12221e0f97b19b58be6b";
+      sha256 = "26ce6ad767b7be95620309310007ef2ba2cafa3b22f8f1379b70276ecaf3f3ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/ru/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ru/firefox-96.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "f1def34584ce90445355eaeb64bad5ace27e1c6447b3a1346dd2e5d32ef1428a";
+      sha256 = "290a34b589bd7cf99586c9dcc1b64c65cde55a40c1851c1ce7445374523f55c8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/sco/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/sco/firefox-96.0.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "e1c3953c2ebb12fb6975727b68ad9667b983d1d1c7fdccdbe0c52e5cf12c815c";
+      sha256 = "3a9ff8651552d7955db6d2bf3f308c3c378aa9bd6d2e0bfca014fd95a0e9b315";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/si/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/si/firefox-96.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "268bf3da414e1e00696262e0104b77d71e2b61b6b6fe1fc23cff33ede4108f58";
+      sha256 = "e6f17fa62c22ed2144233707b0d58e53c8e0df4cc92cb5f8e202d6dcb651a34f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/sk/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/sk/firefox-96.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "39c018398173f92334775077b0b11379f859597b162f5b186747e9c403206718";
+      sha256 = "6b42eef534552215fdaee354a9a259756626ad2ee96b0bc867625d958286142a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/sl/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/sl/firefox-96.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "0bd6c112fd967944205fd08055ca7a5096c23bc7ea8e0d09738883635a3653cf";
+      sha256 = "d069528bbc8066bdffc8b1d0e1f91967a82e7b9698f761a2815a777b0b616878";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/son/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/son/firefox-96.0.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "c7a7b276935012c9be0cda1531f6206163434ac5810580a65a1b0f0f2c839660";
+      sha256 = "567a3232153e1a249ce49da88d9576f85d783fd2ef4256180e7f09a44c520ddb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/sq/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/sq/firefox-96.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "27d6cd975c7f68d4622b0a2e1b7847d0f3e301b2e9e76008e047d522917e7d3b";
+      sha256 = "7cad9d6be53e0095f41147aa373ef23729d0c5a636ae8af0680bcc054d343e5f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/sr/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/sr/firefox-96.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "68a99dc76c9c7179f12bb892920aa02f3a9019186a8999a06448a0e19fa93ff7";
+      sha256 = "c04396c4c313769edceb0b0c5a98a41c55fe27af973ff6fb3b9a2116e39a52d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/sv-SE/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/sv-SE/firefox-96.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "d0d64191bab8421feadb1abe91b471a6b059041b2935e0bc43f6d9c959d2dfaf";
+      sha256 = "0a24b924e3f91b0d5e45fc8f7f1969ac52a0a3f4dc9705ff6b4186c7e4fa042d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/szl/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/szl/firefox-96.0.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "3c698e152b2aba10d46ee06a5ee0425afd4c7e7354984b45d883ed5e286890f7";
+      sha256 = "55b2afae883c7de7fd1e33159e1c487f535f6d71f8db7e200c77e884da1c9290";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/ta/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ta/firefox-96.0.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "ca9883cbe4558e38ac9cda62b0f43f3c173c9dc479214b6a746805e43aeda031";
+      sha256 = "38abeca5e1f9e945566b8034ea3bc2c2a1cbb081f02635c152d13a8454e73bd7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/te/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/te/firefox-96.0.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "251915074e437e83c1165005b41c28d0b17b4234bd3caff8197ac660bb35eeac";
+      sha256 = "970c4b0d5bfa24d03bac85bcccaf05d8d70e9884c2d73c7d3cad8539b46d0995";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/th/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/th/firefox-96.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "7275ebab122274b2ec633a760bb2dc7b1257d3523051266ecccd55661cdd7b45";
+      sha256 = "7f94c556f04a78f9232c4f2ab537719e30ba6e9b5705f175768f9f41cc7921b0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/tl/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/tl/firefox-96.0.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "0217bdd9c71f993360ca97fe185d020d222c4e250138499088d521e0f21c984c";
+      sha256 = "dbeb26032ece7026a088c8130b28dc57659816ce52f61efe31cfe5b0f4d82e78";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/tr/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/tr/firefox-96.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "d9923e72ed18af3204df15d7a414f5c41627ab80e9566b1cc16f4cd0d5bcbb16";
+      sha256 = "a4f95b402f158e6edeaaa4e1e5c7ecb220e88577a9e847a52c12e8d616dddef1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/trs/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/trs/firefox-96.0.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "3ec42470cfd25149f8291ae6634825648e64d0bdd115c75cc2aaefb7db953d03";
+      sha256 = "3c22a4fa31761cd06df14e1e6a7cd7d3066287cfa9c97f34d8ceb75031fc378e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/uk/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/uk/firefox-96.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "a059f9ea668d4c70ce6574f59762f917baef5cc62bb0af0c7e422577a55828f5";
+      sha256 = "7f6bb67e318d7c2ba322dea1636ddcb94b32180b687d4cba4c8ca885a6fbdd5a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/ur/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ur/firefox-96.0.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "d68ffb37896e8c1405f919adf301053266c3bee0f729a7889be1d234343dd9f8";
+      sha256 = "253fc6fdf04d0cfa7e5304ffba9eb427cbbb76e387d94dcd5470e4556348ee20";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/uz/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/uz/firefox-96.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "54ffc455910dcb2aa83e1736e36672cfae84658486d5117fd0c1b97f61f829b4";
+      sha256 = "0965894c437f9995a2cd696d87ec5da2ab21050bd3500a92558877355b07fc02";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/vi/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/vi/firefox-96.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "9b46375c46b831db3680d592400e68ad953dc778e77742a4f24f36af73e9e810";
+      sha256 = "abecf56f27ad4b464d881db55d8d7e455aea36f492b18863fd9eaf4195640796";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/xh/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/xh/firefox-96.0.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "e728b54cde7f96a6c036a7d65c14ab14df2a073227f33709485e52a5f34bc565";
+      sha256 = "e6d453b35154f0faa9c8d76808e201a9105fc6dab9158a8a688fca101d0fdb95";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/zh-CN/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/zh-CN/firefox-96.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "5856e43a3f3a7bfa7710b42f15209e0d0ce39a98d8509e0e19f957b972e7c1e7";
+      sha256 = "9b32e92f96b2ba0df0d54e041bdebce747ab0815f5be9327aa6596d876321070";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-x86_64/zh-TW/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/zh-TW/firefox-96.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "9defb0e1cac327e91f4a950448d553dec01d5e359008d365991e1e188453dafc";
+      sha256 = "05664f6db9bfd37f09a20e37a0971cec8234f13d4480e3c02c3d280194068871";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/ach/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ach/firefox-96.0.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "158fa1d03e0b7bafe9603c7b2f30e78819dbce67b07b2ec78c4fd89f05303729";
+      sha256 = "775d3c5fb18f7219d1f1492c84ec2c62c188da71526a4896c139792e3b6c2d36";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/af/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/af/firefox-96.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "a6ce2aaac2061d36b294de9871bbfbb4321f4ad1f421460a6e3d799ef54b608d";
+      sha256 = "5781a804cd6b3205ea137ef3890ef1973240384fe2b89f4f168ecaacf5a5ea65";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/an/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/an/firefox-96.0.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "1e8d592f2431a2e5df7453dee984bd29bf94d3ad1781474effa14ffe9de3ba3f";
+      sha256 = "2507de35b2d8e28b9c950256e2a5f58d9529e1f75b3a2ae3449ffdc412fcff5f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/ar/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ar/firefox-96.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "ae55b1595118148889049b9ddf25ed9e32e6d6b2cc66b0e90821cf79d6bf2ff0";
+      sha256 = "9f340350cc9fd2af4af50b1aa1e3bb4371eccad04a567fd428c5cb5225773d6a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/ast/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ast/firefox-96.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "17e76ef25a9028042f3e35b725ff0171bfd82678c6ab826115785ce6ff2d2010";
+      sha256 = "0d72eddbc07dd7682ba36d731552b9e5a9eba28d10703446d1df7016783c51f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/az/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/az/firefox-96.0.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "2ffd85a5982a0ed0c359d1f8f8712407aa6ff10823d21750cfb16d925fa0c5f7";
+      sha256 = "afe6aec818678974c3590f10d32f8238c83c34311af29cbd88f847256b6c2aeb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/be/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/be/firefox-96.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "e78fa23ab27503921d3d4e2f79dfd391d0e200552f2bb48cd27a6cdd47468ab7";
+      sha256 = "d3ef2a3df301eb00e769f634f413e1b7a7134e1ffd4bc5e5add9ae63b04b2060";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/bg/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/bg/firefox-96.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "4e866bb3705f17fdcd7b98313b025e52544dd7bee2f523e886b3654455480b62";
+      sha256 = "4368ae3a9e1bc1c3b6f29e5931da3b48fde38f9289ac3b435de6d25035ecb381";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/bn/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/bn/firefox-96.0.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "e170018a2e2f6a568148ec5073c5f82fa401894f5310b887dafe36e388b8876f";
+      sha256 = "4b3a502e6929c1b07ab4ba1ea436005e6b9dd8334dd262c2ae07cf12732ac8f1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/br/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/br/firefox-96.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "73ea87a78ab765589c7e76237044bcdffd783183ea6b8afc67f2871231692143";
+      sha256 = "ec1988c78c09c606f19ebc971dbb310d63f751c941f855251c1f52dc52a898d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/bs/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/bs/firefox-96.0.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "900d9625d1cbaed04155e5e024cf7872d454f6b22ee37a57739c702c6a328657";
+      sha256 = "45a9ffa6b755efaa4e4cbb9d8789158f0c0da7428d60d6afda29dc49356230ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/ca-valencia/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ca-valencia/firefox-96.0.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "bfd22c146671bfb21b7f36c17691754cbd8c6abb29eeb0703d3a030df51364f2";
+      sha256 = "b632eb69763a4284958be3a31bbeaf5d3a782e0c7b7a765b65e0e2b82de72d56";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/ca/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ca/firefox-96.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "1b1e3fcdcaf4c299cd8c0f5b109493646e74c46bf9a0b09dc5f33b33062a398f";
+      sha256 = "88869f236c16676b6dfcbf86cab21224e36870ad539c4cb918ec67c6662af0b7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/cak/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/cak/firefox-96.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "ce307ae50893ac9e424eedbedea8cb1a9358e287ee2893a8d0894003cbdfe609";
+      sha256 = "857ed1a071d5f9545209272b699987645322389e7eb541617d74c4ee967567f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/cs/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/cs/firefox-96.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "c6230333dc66ccf20b68879c31a69061874b5a0869786d87d8190c88d5a02664";
+      sha256 = "9c65991015af9ef40b9595e905831d0e4baf88b52ae2b678966ef56ca89dfb6f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/cy/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/cy/firefox-96.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "3f87de3d75fd4a7f66af64bcb3eda0dc43a8717797840235dd64c0acd5eca1a8";
+      sha256 = "bd4366031cd402481ac7021c2b891a9a0af34d1c8f3bc04077f22098366e8263";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/da/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/da/firefox-96.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "eac9b4c6bc7737c82fd631608157448ad9c78e793c4c7b4e319e36a6e5ff61b1";
+      sha256 = "c3900f2a4584bcb6d41a1744e4f82bf12ab451213293ec19a474750f707907cd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/de/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/de/firefox-96.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "71b618dee298b67383c8567addc0e2d93d4bcf2d196ca7db87ec20a3315ccace";
+      sha256 = "5d29d0d70371163d751be0636b912176ae665f65d9f32bf62e01f69dc0349a91";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/dsb/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/dsb/firefox-96.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "cbeb7eeffef1c0437644182dd5475e770bf0118a351eadb3c7892c69fed7e0a4";
+      sha256 = "0682f59ce11000f78b908e063daa07a0e4f53913e9beb731f604fe372ed4f7e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/el/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/el/firefox-96.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "2d9bd41145a737c8b25826d7af978219a61199b9d045651b6aa68029e5027187";
+      sha256 = "5418f2235bc8bd565d88f3eac49b2d2fe82a9117aa600612a68ef27c127115a2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/en-CA/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/en-CA/firefox-96.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "65d83800562d29c0b042dcd9ae4d7fb230f8248ba0bd0cf8bd40505884f839c9";
+      sha256 = "d52c73155cf23a5a746ce3689571a1b9dd437ea182bdb21b556dfa0aa13818d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/en-GB/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/en-GB/firefox-96.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "bf4cc0aea5826f1bcdcf493f241cf23509f626f81fafbf436430b0f0507f674d";
+      sha256 = "ec3fe9fca914d607f44fe048d33afd1945018e69c2fe31cc7d8d35eded88d91a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/en-US/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/en-US/firefox-96.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "86e33e0163773378fcef227884d3c439f61c2d0d6ec3cdafde1740816812c811";
+      sha256 = "dfd82a4d8dc06cbf64b1a772dffcc7975b8cd128af2725785c68f5918ff903aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/eo/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/eo/firefox-96.0.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "18fa6af5ca174cefd1b8f266e1c6bb6576facc8acd28b6b9a8f6121fba1d6426";
+      sha256 = "9ceae21a7f36761e30debb370d0bfb97de5a489c277e8679b6f29872595d8751";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/es-AR/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/es-AR/firefox-96.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "efce9ac44d6156558ee28c7bc4b1489f1554afa632ed0dda2dafe2272e885d6f";
+      sha256 = "cdfd1b2289039eea5b2f05cd3af0c18f0c909246ec7f7c3f04e7f1485be9e894";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/es-CL/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/es-CL/firefox-96.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "920e9183e71935da136d2142ed0b1a9e5a764e7d4bcd6ac2c65e3e405ee0d82f";
+      sha256 = "df7e0cebfb8209a29bf43af5dfdf5f496437c6017f3c8c428f0830feb17a929c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/es-ES/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/es-ES/firefox-96.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "3c6cd25f55dc3aa17f1d613878b3b40bee28847a80b36fcb7d0c3b4ee5e6462b";
+      sha256 = "41dbe20494da17a73aeed807805cb86b70cb443bcd41aacf8fbdf2445846f58c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/es-MX/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/es-MX/firefox-96.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "7b076daa30e58362534aa2373931d0f984967824f3592dd92ffecc7597c4826c";
+      sha256 = "74e8c4b50e0e95a0bf95bf4436a3ee7a35df9e6e19703a8632a697f47199b545";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/et/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/et/firefox-96.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "d9188331a592ee8e7f40c3cc70fd5947164408bb18066195af5966b25deffa44";
+      sha256 = "a2830273d08f6b0cb9d95e9875866e09b3327d411c2bc202bbf5b4c9e32ef05f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/eu/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/eu/firefox-96.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "48414c68c2c67719d43845799dcbb64a13d513aadadc8299e5ced7ac7dad89d3";
+      sha256 = "b1e7b452cc57b1df9bf9c4b0936a43625f88900e2682c3081b026a3842321be8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/fa/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/fa/firefox-96.0.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "1cfc92b1100d803a148feea5bd0d40af26dbd976fb30b29e79125687bc5ab247";
+      sha256 = "572c26e61a98706ca36760627000794f9f22c2ead6763e0e7c3d8fc4182853a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/ff/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ff/firefox-96.0.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "0e576c6cc65b92123294b7d230ea3431704ac107be56ed93486c93021019cc2b";
+      sha256 = "f931798b40ad9bd538c78b7bfdb84a170cc4dd97a35ede3b90cb0b17a7dd33be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/fi/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/fi/firefox-96.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "031de60746e0acba133c58091ff8993e9f03822b8eb2dde8636719685b10a5f0";
+      sha256 = "413320e2e3e339864139ea1cbd38bb35a2182a5c651491b56d6c6cc3fc16f001";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/fr/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/fr/firefox-96.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "072876a0c2f8d78271b83faba916c61b9e14f783a9afc6af08158e7e988c850c";
+      sha256 = "0c98180aa71d229b8615d10f2f0d472aa9103aba961e7b72309ae4c4dbf201a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/fy-NL/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/fy-NL/firefox-96.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "cde0cb368aee49b281ef4f0893eaa15345ca60623c57dc7f93d8320216fd1edd";
+      sha256 = "b79e8afc2333db64744811be301d30732efbbd5058870aea60be605356911dfa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/ga-IE/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ga-IE/firefox-96.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "cab5ecdbdb5e3286726b06e7fa8adb43d49f8c8316ee240ccc849c339bac3076";
+      sha256 = "5389751c882932ea285c0694dd06b02b723acea7a40494a0f5c8005613cbc31a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/gd/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/gd/firefox-96.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "ee5c4c06b9b899b14374dc6abeee533e130e90242acd866e02b0c759ca6ed397";
+      sha256 = "ecd23ae7a86a14e8a2be920ed0df8d9db7d4d9d9cebfcd1dcd31242935df437c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/gl/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/gl/firefox-96.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "e8fb73e3495d3c4dc1e827b21d50458e6ebfd56f3735c5c87ed88fb9bc9d379c";
+      sha256 = "7304d29ecedb07d8b192b7c08d390ed6e59e7ecfcae3808d74ccdb24d82a5267";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/gn/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/gn/firefox-96.0.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "3511c27b51f12f26238e5862edff7b171cb9eb6b0843843d62ae6ad4f23891d7";
+      sha256 = "6e4c6f2262e5bb4573c471631584a4e0421b799f643ccfe2503f7409663d4046";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/gu-IN/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/gu-IN/firefox-96.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "34fb15517f0e8472655950e0269050b897b5d2986aec4545dc6aa4e4314054a6";
+      sha256 = "b484b4c95bf9ff0ff622563caa2b8efaec483b76ebf6de0b6ea5392ce6dfa687";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/he/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/he/firefox-96.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "263e6ec46f8347a27be1b8ae44ecfd3bd4475d2142fc0bbf21eedf791fa6e522";
+      sha256 = "1e86f10829c12a635d6c8fea6afc496e440d1e91b44280befb2dbf46244091cd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/hi-IN/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/hi-IN/firefox-96.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "c19cee388dfb212fa28ab7b93379db8bd60964dfb3a8a6f5371f5b4384fcefad";
+      sha256 = "53fe58cc3cb8a6fff3e7870ac3435b4a096bb428c52597c75eccc11c199eb4eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/hr/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/hr/firefox-96.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "b3af09b207e11d6ba87b39f33e7c8ddffc80482fd3f5d910d2079481b3db4268";
+      sha256 = "e03229a236dd34c9dc199afbb44d0fd10ed3b8b68b43ffa09b717ef5536bdf78";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/hsb/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/hsb/firefox-96.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "ea52879ce3a7b7a0921746d56163af72d824a287ead51a97b491682a479ebd05";
+      sha256 = "d8fa249baa33bed71e51d4e0008c4a524748e84394401f681fcdeb4ebfda93a2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/hu/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/hu/firefox-96.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "e83307c88b9246e098a1063b61a886148c930bd891cbc75f8b6a1257f9746363";
+      sha256 = "10eab8a65010ec5116d70739e85fbff2f9d93d336a5f8ac26c9b4621bb6adb31";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/hy-AM/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/hy-AM/firefox-96.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "f414105b7cb3485004af9e798d8159a0eb801e8f384b8b6926d34fd07af6ec0f";
+      sha256 = "fcd08666ba84487167a7f1ba93bda53c2a01d8cea07002581a796932559589ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/ia/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ia/firefox-96.0.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "ef3879f8e5ada797c0011ddf3a6fcf6407f2ee1e858f254ad2d500233c7703ba";
+      sha256 = "8f1b6585bef3546d3450d498bc22b4111edc48a5161c613f9593dab960ea51ad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/id/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/id/firefox-96.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "6c888381f1d10e4ffe6ed3a056933400e8adcb64e4a5c6da2524f92ce0eda62f";
+      sha256 = "fd6dadbee240001e31b0c55b290b61f6187395d6c6d92ef547552d16def9fe67";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/is/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/is/firefox-96.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "3d256a5d9382866e93f0b6f5a0cf1dac1bd724ef5f7c693ed0e355ad34db8476";
+      sha256 = "6813330e8fc3b04134ba91af756f7e2afab4f352f4402844032a56283948a3a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/it/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/it/firefox-96.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "fda1bea7c61c172dcba91e07e22f2e205f08e99b63ceba5d96576a432af47b60";
+      sha256 = "570607d27fe8bb210bf5f6694c0cbe505d78a4e7753767a63eff5205d4cfd9ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/ja/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ja/firefox-96.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "ae5aac021a845ff644d893de7a39a96aec33b128b1537e583fd48a06ff87e07f";
+      sha256 = "966b3e9d6c069d0ea2c3ca2cc1090a7ecaecc7e75a20bd06d988bfd7a1785320";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/ka/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ka/firefox-96.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "043e54c91838a71c1b9ceae8fa40112c54dcd5a530d96cf0874b1eba76220878";
+      sha256 = "7c4efd6d06eb594b0e23031eae5a46696b629c192606ab94364b3c96a3985bd8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/kab/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/kab/firefox-96.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "fd7368cd63c612606cf57eee9476e009abd9c2f35a200f9887c50b34f36fddf0";
+      sha256 = "c0a044eb514c5c8dc7f670f55169df5612806ead901fc9be93b930a87c58c632";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/kk/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/kk/firefox-96.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "b4a7e455aae1894b2b9418e3f0b14350f0a3446923684fcf61a8e6abdf131681";
+      sha256 = "1a10eb4f758fbb4597cdb67f7ee8e3caab41548a816d02892e34fc245748f07b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/km/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/km/firefox-96.0.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "2635a41aa81a9ca863652b5e726bc2022369993059d64a6ad81a2f751e65ff1d";
+      sha256 = "c4d65e12d05ae7a88b86a46f86f7d562ad4e6e0d00e8f179ae5c0e02eacf3d11";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/kn/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/kn/firefox-96.0.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "adf9111e992ce6504aae6dc2bde5519e58ce474ce52317fbb503138fb49a490c";
+      sha256 = "f0db59ca26eb8ba8a2731c77ae3fba2df34d9bab7985b8bb25a0e5e085fa99e9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/ko/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ko/firefox-96.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "b47532250fa7baff58d47052a51c966ed52b6e8009bc36b67958e67631e2de1b";
+      sha256 = "d0d1268e6e5d179e366a9be43a07eae1d595c61d322024e8829c6c0474e21c88";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/lij/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/lij/firefox-96.0.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "92d270be61a7a30876d00bd1e2741c0db4363f34f87a97456b700c5af28252c9";
+      sha256 = "ab1ba9d76e9ea282ed34aee8656e12bc169c0725bfb1f005824a522c94f91f2c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/lt/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/lt/firefox-96.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "8c4efa500b88d76ca8b0abde737552ab905db34807816df0d2614e3d47a00dd7";
+      sha256 = "284dfd1e39c91b86116d06743fb08ff93d63ad102930fb5dbbb759355e596d5c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/lv/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/lv/firefox-96.0.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "db86073e2910f6d54466e8015fd8ed68b02f08c6ba4595ce21c3547addada57d";
+      sha256 = "e7f764b9cd295e3b157bbee214ba26178d8bafd3dfda7fcde7742d23e745ba4d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/mk/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/mk/firefox-96.0.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "91a39fbc897197d48792bb1ed82e4e6a2bc969efdbe31c9d6cdaed60e4af4884";
+      sha256 = "32f6bf3ff2976393e3e1992b3f65af41ae948553bfbc015f343b2c6daa689777";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/mr/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/mr/firefox-96.0.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "97e775f3926ee3f158d30a16dfa5dcebf67b9d337e51ddad43235d1c7ac77cfc";
+      sha256 = "beb39f170e77fd7a0d46b7f9cbc6cef1bdfdd83688eb0a2aeae77aa17a39dabd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/ms/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ms/firefox-96.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "32cd9715073cb1b987abf73f909185c96231d9bc9ea07972ff6c58a1e1ef5dde";
+      sha256 = "c698053be91b78f6424fbcb739250e8f507f8a1de9f5a995790db533be3474d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/my/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/my/firefox-96.0.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "4e70811af633f19718076fd1d0ce4008e6cc8ab6b24842fb1eeb184b505cef50";
+      sha256 = "6f922f29a6ceca5ad09033df03b4683c4dee4ec9f4fb02a2bcb6275beabf706c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/nb-NO/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/nb-NO/firefox-96.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "97dda05d66002f87bf7b4ba2d08c18402ce2462ef2fb3e3876d4a55520329823";
+      sha256 = "70302578ef21d062d8d8a6fefda85827051bf66690f3f80ca68384f56045bb98";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/ne-NP/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ne-NP/firefox-96.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "7ea002b8d50f49e64123612d0a43100411a5edc975d40081b1d99e47b6413242";
+      sha256 = "d16eb28cfd200cee6066a6d03e84bc90b14dfbc0e5010f2eb2d23208b586dd35";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/nl/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/nl/firefox-96.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "da9bd1e61d17d5625d9c9114315b63b37b062a3af13e91fa480af0e0aff35366";
+      sha256 = "d2269a95fc075d27c1590816f0d6b953f8435a9ef1c38af46ae30142495937bf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/nn-NO/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/nn-NO/firefox-96.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "096683e5c3cc1794c099197c6126df8d3f74b677a5c583559d0bfb884d380bef";
+      sha256 = "ec1431f428483221a89bbea288ffeb40dd28d19fff58ac988d377fe184bef032";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/oc/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/oc/firefox-96.0.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "5823e9978b4abbfe5edd656165dc2d8a49a1cc1b65fd8e4fedc0d8dc642af695";
+      sha256 = "9541418a5d1f3feb445d1adb5b9e1a6d06d7e2cdcd0a517e321cd4ea6b72ac85";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/pa-IN/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/pa-IN/firefox-96.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "56f1acdbd9c9613923aabdc69f80878f21acf3ff10a713eddb9e2224c35d7399";
+      sha256 = "0c2e402172cbc84975bbc073e32d48ad8353b39b8eb936bc81d90d249ce7bd55";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/pl/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/pl/firefox-96.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "ec6c676224031272a81cf624db09d5c9a26fe02ac0fca72255a7af25ceab70fc";
+      sha256 = "1b7c0b1ff2e112dae86e425aec72746e1f320c4794aae66f6cdbc0a5fbd68458";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/pt-BR/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/pt-BR/firefox-96.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "2c86036d927857fa93778ad5b56ef134cd3bd95ba6be032c8fd6f94a9b01dac0";
+      sha256 = "c8b18b3c756614b774606693a0c74f5c91272431a8582e5a71d63dc9ea0b2c1f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/pt-PT/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/pt-PT/firefox-96.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "331e81e86dfd3802432457bb78f5c65cc35c2ee459503b5158c0d9a44ddf38d7";
+      sha256 = "36dcd7d573301179f47e7d073d7fe9089b703f91018ac652b7048423ae2102e0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/rm/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/rm/firefox-96.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "8d238b1fa93a4aacdc6f54a456fe523a9ac61d834420cf2b349062dc35e8d228";
+      sha256 = "c70b472fbf5447e5eb2b2e43ddc0127fa8d1f97557ca6940c5086346c84c295b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/ro/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ro/firefox-96.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "caff2dde8dde6829c5401f0408c0c1cf146453583b407efed01f5dd629d70bf1";
+      sha256 = "c913a3c2b05a57eacf83b4a95f6c8ef770ad632f183381750e6faad93152eb20";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/ru/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ru/firefox-96.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "762466026aeaf8c8d0bee290113d658712cf02d09b130ac0cfb638d7d2806eda";
+      sha256 = "98db217f5f77b15f760bbab79892e3bc511ef0be3ad55d75cc1278a5fcc3dab3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/sco/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/sco/firefox-96.0.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "e75313594dfd1390e452667746073e6eab67f62da7e5bb8f9d9c3c399e0873c2";
+      sha256 = "12f2422d485bfbe780e8db94b1cbfd187d430230c5036d4b00596d89bb64bd3c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/si/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/si/firefox-96.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "4672751457c6bab937736fb5085fa24588e97543989d9e340859876c5537d793";
+      sha256 = "5ad07f521cc312b92ea40a3ee8f575b01524ab20be1315f5cbbe6ecdfecd64f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/sk/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/sk/firefox-96.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "bd17ebe6aad0ab05854d20c66de4d695d9fe967d867f46c29e2c8c40da709b2a";
+      sha256 = "a71cfb4fc3fd0a18172819763f3780a292c77c0441837aafa97d8db8736fa854";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/sl/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/sl/firefox-96.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "c68745642e9c3581bb7f4bbcf17eab7f62c397caac5b2b7fc14668a0b2ac3daf";
+      sha256 = "4b3b9d9ebd5035ca309724c6980422ab0b64db3af6c9d1ba08938a7dcdd65297";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/son/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/son/firefox-96.0.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "895170b400df833df90608a44e17b99405dbc932cf15ec5e1b5e91febc2fd629";
+      sha256 = "ac7c0714a079b11894260f391330b4a5a555b5fe0274d826929f181954c1f692";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/sq/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/sq/firefox-96.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "ee67428d035b065e4d6c129e0659a508bf6eca7e0d64802edbabdc460db479ee";
+      sha256 = "9334c0ffb21c09c5529412d67156eb096d1fc08be0bb0360449b00ce24da25ad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/sr/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/sr/firefox-96.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "954800db592b449bdd7c37141198702cc1a3a2b8b217f71f5ca4ee7e9dcbb04d";
+      sha256 = "a8b29a1a317566ba3b37e75d3c105008487daf44a0ab3907ce0cbc9d47d25848";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/sv-SE/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/sv-SE/firefox-96.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "ca2604feb91c22f5dee9e59f3c1098ad12c34b5082fc45841d54ecea4e6c8e4c";
+      sha256 = "05563bd29b8a89ddf517e8d4d997d177abb2e21722b14ebf0dd141d0211832af";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/szl/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/szl/firefox-96.0.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "3e434f5a395d1f0230affedb75d97976f5571a3f90801f92a606f1ff39377393";
+      sha256 = "3e49f4d70b6314bc0a92d252e2504ddfb4447c6f7d3611561c8f73065dfe770c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/ta/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ta/firefox-96.0.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "ba25db7b2fd274e2e29f3cb10bc5a5d2af8c4ab5e75fe62164a538316d7171cc";
+      sha256 = "8b6a00cc80951cc0438d0acf05b105ad7e5ff720bfcf3b84ca96c519430b06f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/te/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/te/firefox-96.0.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "f0bb3fe0d28a1e7440e07060c36d8a4c62a7d8e7d7567c793997f23504018406";
+      sha256 = "d988737a9e5a6afaf70ee0b8834a5b443bdb282f058f346b564fcfce0c1f2b7b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/th/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/th/firefox-96.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "705f294d3b735821cbc6cc93ce25264e4e2eb398194926ecaac2bb03fe51ef8a";
+      sha256 = "611552a0dee6a811c92ce5e90f6e85dc8685a3c015dc6fbb4816ab3ba886f31c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/tl/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/tl/firefox-96.0.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "2f12aa7ac32ec89b5ca09289a8d6296fe9fbf332b53b7d183b75fb9b1dca3b11";
+      sha256 = "e8196540096bb834647e8ade99b5ce143b96e5d9157936fb9635b6e5df12e277";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/tr/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/tr/firefox-96.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "5353938c7b90e557cb5e14e2f8556e9a14698e135b94eba0475c4303b293642a";
+      sha256 = "965ff28ceae8270b873b94be3a99c6363abb841e50454d5013eeba132f61bea2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/trs/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/trs/firefox-96.0.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "428ec7d2ba7ab418f6c3eb51f1cfe81ee798360333211195bc15c3372522107e";
+      sha256 = "5c57ca45aa8150a8c2a723091565750593df71b8b4d4615601af61daeb5c6107";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/uk/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/uk/firefox-96.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "b32b3419816ae3e5cf738baa307a30c364652e3344d002468fbf2cb021e2561e";
+      sha256 = "57789c73d243297ffad9e483a9921ce151d24ad60ba1b05caf9c6eff051b5fcf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/ur/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ur/firefox-96.0.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "1219c56cef41202253988164a8708f09a5f7cdcc7454887326a9e04eb355388e";
+      sha256 = "ff0e216802ce19e11ec239e5dd063d4bd599917442c692e6745326ea48d1570e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/uz/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/uz/firefox-96.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "68cc0b19902ba281441aab7d0f90b25ee839cbd9017ca7aee6330589dd1a83a0";
+      sha256 = "05c07f003c18da0cc2b1087a53da126ccf53964bc4fbd79ce182e840f994aa50";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/vi/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/vi/firefox-96.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "577dd4afc185e80a7132334897fabe4017f36df51a388084704c18980dcf995a";
+      sha256 = "f3df214f93b857276d412b0415f2b02b623617d4a4f9a34a17c1d5afef10f036";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/xh/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/xh/firefox-96.0.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "b53674150eb3726b22a2cef24d762390e63e43283e303f2b9e04f54f988b1f8f";
+      sha256 = "df5e1b4a027b66fc0a6e8a68332a7b8db0180233bdf7e90d74301b82318397cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/zh-CN/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/zh-CN/firefox-96.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "b59cc02e88c94d3dd681d59f705b0c554a0998ce3670f9bde435f75a07a6b97e";
+      sha256 = "f3b3ee9eb3f42ec7b4d8f2bfa45f733b03c420d1b10c8719f0254feca5c482d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/95.0.2/linux-i686/zh-TW/firefox-95.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/zh-TW/firefox-96.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "8dfb5d549ca2a63b0be9b2e32df95122a1f40f2066cfc3d3144e506a37c72371";
+      sha256 = "3752ae6594afc74d8c460c7569a5467ef8f432f154256d42ae4e7e24cd8b2687";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -9,7 +9,7 @@
 , yasm, libGLU, libGL, sqlite, unzip, makeWrapper
 , hunspell, libevent, libstartup_notification
 , libvpx
-, icu69, libpng, glib, pciutils
+, icu70, libpng, glib, pciutils
 , autoconf213, which, gnused, rustPackages
 , rust-cbindgen, nodejs, nasm, fetchpatch
 , gnum4
@@ -129,12 +129,14 @@ buildStdenv.mkDerivation ({
   inherit src unpackPhase meta;
 
   patches = [
-    # Upstream bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1745560:
-    ./fix-build-with-wayland-1.20.patch
   ] ++
   lib.optional (lib.versionAtLeast version "86") ./env_var_for_system_dir-ff86.patch ++
   lib.optional (lib.versionAtLeast version "90" && lib.versionOlder version "95") ./no-buildconfig-ffx90.patch ++
-  lib.optional (lib.versionAtLeast version "95") ./no-buildconfig-ffx95.patch ++
+  lib.optional (lib.versionAtLeast version "96") ./no-buildconfig-ffx96.patch ++
+
+  # Fix wayland 1.20 compatibility (https://bugzilla.mozilla.org/show_bug.cgi?id=1745560:)
+  lib.optional (lib.versionOlder version "96") ./fix-build-with-wayland-1.20.patch ++
+
   patches;
 
   # Ignore trivial whitespace changes in patches, this fixes compatibility of
@@ -150,9 +152,10 @@ buildStdenv.mkDerivation ({
     xorg.xorgproto
     xorg.libXdamage
     xorg.libXext
+    xorg.libXtst
     libevent libstartup_notification /* cairo */
     libpng glib
-    nasm icu69 libvpx
+    nasm icu70 libvpx
     # >= 66 requires nasm for the AV1 lib dav1d
     # yasm can potentially be removed in future versions
     # https://bugzilla.mozilla.org/show_bug.cgi?id=1501796

--- a/pkgs/applications/networking/browsers/firefox/no-buildconfig-ffx96.patch
+++ b/pkgs/applications/networking/browsers/firefox/no-buildconfig-ffx96.patch
@@ -1,5 +1,5 @@
 diff --git a/docshell/base/nsAboutRedirector.cpp b/docshell/base/nsAboutRedirector.cpp
-index 038136a..1709f1f 100644
+index e7be91a248..5eb98534ee 100644
 --- a/docshell/base/nsAboutRedirector.cpp
 +++ b/docshell/base/nsAboutRedirector.cpp
 @@ -66,9 +66,6 @@ static const RedirEntry kRedirMap[] = {
@@ -13,13 +13,13 @@ index 038136a..1709f1f 100644
       nsIAboutModule::URI_SAFE_FOR_UNTRUSTED_CONTENT |
           nsIAboutModule::ALLOW_SCRIPT},
 diff --git a/toolkit/content/jar.mn b/toolkit/content/jar.mn
-index 9ac4305..916b4ad 100644
+index 74c0ae8f34..a5d9645a96 100644
 --- a/toolkit/content/jar.mn
 +++ b/toolkit/content/jar.mn
-@@ -39,8 +39,6 @@ toolkit.jar:
-    content/global/plugins.html
+@@ -41,8 +41,6 @@ toolkit.jar:
     content/global/plugins.css
     content/global/plugins.js
+ #endif
 -*   content/global/buildconfig.html
 -   content/global/buildconfig.css
     content/global/contentAreaUtils.js

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -32,10 +32,10 @@ rec {
 
   firefox-esr-91 = common rec {
     pname = "firefox-esr";
-    version = "91.4.1esr";
+    version = "91.5.0esr";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "1b9f17c4e58e3753f8507754bba93e3b7f76df5b6845d6173719fbdd98b70af2a90242df42fe274217f56d0280e5dbae17962f5b6bf111421260790f770f5337";
+      sha512 = "1712415b6b73c6a21edfefc39eaba5fcbbca54032f78627c0005d291501d16ef4daffb8b9a160d1d5361113ceba04eb5ddb21d903e3dd8d58838aa9596f2d781";
     };
 
     meta = {

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -7,10 +7,10 @@ in
 rec {
   firefox = common rec {
     pname = "firefox";
-    version = "95.0.2";
+    version = "96.0";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "1b9eb91d72a6975b4d2558a7c5de0e008095398b9862498623656ab6d8056e3cffc12263f58aa07feeddc91ccfb512aa4b582dfeadb142d548d96c3d50204196";
+      sha512 = "39f553474537eb4e521f4182e38f0ddff039fa6b40b939d461937d2cef27f7182097b478f08f90d64fdcbe9c063e78f14f6863a8a82a16207ec7a1d3fdfda4ff";
     };
 
     meta = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://www.mozilla.org/en-US/firefox/96.0/releasenotes/
https://www.mozilla.org/en-US/firefox/91.5.0/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
