### PR TITLE
moolticute: correct udev extraction regex

### DIFF
--- a/pkgs/applications/misc/moolticute/default.nix
+++ b/pkgs/applications/misc/moolticute/default.nix
@@ -28,7 +28,7 @@ mkDerivation rec {
 
   preInstall = ''
     mkdir -p $udev/lib/udev/rules.d
-    sed -n '/^ \+cat > "$tmpfile" <<- EOF$/,/^EOF$/p' ../data/moolticute.sh |
+     sed -n '/^UDEV_RULE=="\$(cat <<-EOF$/,/^EOF$/p' ../data/moolticute.sh |
         sed '1d;$d' > $udev/lib/udev/rules.d/50-mooltipass.rules
  '';
 

--- a/pkgs/applications/misc/moolticute/default.nix
+++ b/pkgs/applications/misc/moolticute/default.nix
@@ -35,7 +35,7 @@ mkDerivation rec {
   meta = with lib; {
     description = "GUI app and daemon to work with Mooltipass device via USB";
     longDescription = ''
-      To install udev rules, add `services.udev.packages == [ moolticute.udev ]`
+      To install udev rules, add `services.udev.packages = [ pkgs.moolticute.udev ]`
       into `nixos/configuration.nix`.
     '';
     homepage = "https://github.com/mooltipass/moolticute";

--- a/pkgs/applications/misc/moolticute/default.nix
+++ b/pkgs/applications/misc/moolticute/default.nix
@@ -28,7 +28,7 @@ mkDerivation rec {
 
   preInstall = ''
     mkdir -p $udev/lib/udev/rules.d
-     sed -n '/^UDEV_RULE=="\$(cat <<-EOF$/,/^EOF$/p' ../data/moolticute.sh |
+    sed -n '/^UDEV_RULE=="\$(cat <<-EOF$/,/^EOF$/p' ../data/moolticute.sh |
         sed '1d;$d' > $udev/lib/udev/rules.d/50-mooltipass.rules
  '';
 


### PR DESCRIPTION
if anyone needs this sooner:
```
    udev.extraRules = ''
      SUBSYSTEM=="hidraw", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="09a0", MODE="0660", SYMLINK+="mooltipass_keyboard", TAG+="uaccess", TAG+="udev-acl"
      SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="4321", MODE="0660", SYMLINK+="mooltipass_keyboard", TAG+="uaccess", TAG+="udev-acl"
      SUBSYSTEM=="hidraw", KERNELS=="*1209:4321*", MODE="0660", SYMLINK+="mooltipass_keyboard", TAG+="uaccess", TAG+="udev-acl"
      SUBSYSTEM=="usb", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="09a0", MODE="0660", SYMLINK+="mooltipass_device", TAG+="uaccess"
      SUBSYSTEM=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="4321", MODE="0660", SYMLINK+="mooltipass_device", TAG+="uaccess"
            '';
```


###### Motivation for this change
moolticute udev extraction regex had not been updated in line with the upstream source, as a result, udev rules were junk.


###### Things done


- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
