### PR TITLE
fakeroot: Add upstream patches for RISC-V on glibc 2.33

### DIFF
--- a/pkgs/tools/system/fakeroot/default.nix
+++ b/pkgs/tools/system/fakeroot/default.nix
@@ -25,6 +25,20 @@ stdenv.mkDerivation rec {
       url = "https://raw.githubusercontent.com/archlinux/svntogit-packages/15b01cf37ff64c487f7440df4e09b090cd93b58f/fakeroot/trunk/fakeroot-1.25.3-glibc-2.33-fix-3.patch";
       sha256 = "sha256-o2Xm4C64Ny9TL8fjsZltjO1CdJ4VGwqZ+LnufVL5Sq8=";
     })
+
+    # Remove when updating
+    (fetchpatch {
+      name = "add-stat-ver-defines-for-ppc64le-riscv64-s390x.patch";
+      url = "https://salsa.debian.org/clint/fakeroot/-/commit/57731fb5071b86d70d5a3e207addaabdde23111e.patch";
+      sha256 = "sha256-vaCjAXxQRxoOoFp2YWkhjFOa/qRSxl2ztBj+p+UA2mM=";
+    })
+
+    # "downstream" patches from Debian
+    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1001961
+    (fetchpatch {
+      url = "https://salsa.debian.org/clint/fakeroot/-/raw/master/debian/patches/also-wrap-stat-library-call.patch";
+      sha256 = "sha256-C/VU+ktGBDyml/rZ4sllQ+E2PVIGxCWtxnnMMKrB9Fw=";
+    })
   ]
   # patchset from brew
   ++ lib.optionals stdenv.isDarwin [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Without the patch, EINVAL will be returned for stat calls on riscv64-linux. The [second patch](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1001961) doesn't affect riscv64-linux, but adding it for correctness because otherwise it isn't hooked at all on other platforms.

Ref: #101651

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] riscv64-linux
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
