### PR TITLE
raspberry pi 4 updates - eeprom, fw, armstubs, linux-rpi

### DIFF
--- a/pkgs/os-specific/linux/firmware/raspberrypi/armstubs.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/armstubs.nix
@@ -5,13 +5,13 @@ let
 in
 stdenv.mkDerivation {
   pname = "raspberrypi-armstubs";
-  version = "2021-07-05";
+  version = "2021-11-01";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "tools";
-    rev = "2e59fc67d465510179155973d2b959e50a440e47";
-    sha256 = "1ysdl4qldy6ldf8cm1igxjisi14xl3s2pi6cnqzpxb38sgihb1vy";
+    rev = "13474ee775d0c5ec8a7da4fb0a9fa84187abfc87";
+    sha256 = "sha256-s/RPMIpQSznoQfchAP9gpO7I2uuTsOV0Ep4vVz7i2o4=";
   };
 
   NIX_CFLAGS_COMPILE = [

--- a/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
@@ -1,22 +1,26 @@
-{ lib, stdenvNoCC, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchurl, unzip }:
 
-stdenvNoCC.mkDerivation rec {
+let
+  rev = "cfdbadea5f74c16b7ed5d3b4866092a054e3c3bf";
+in stdenvNoCC.mkDerivation rec {
   # NOTE: this should be updated with linux_rpi
   pname = "raspberrypi-firmware";
   # not a versioned tag, but this is what the "stable"
   # branch points to, as of 2022-01-10
   version = "20220106";
 
-  src = fetchFromGitHub {
-    owner = "raspberrypi";
-    repo = "firmware";
-    rev = "cfdbadea5f74c16b7ed5d3b4866092a054e3c3bf";
-    sha256 = "sha256-l7qyeCz4BzHLz+LMm4irCZU5j/khkW87S2Q2263e44Y=";
+  src = fetchurl {
+    url = "https://github.com/raspberrypi/firmware/archive/${rev}.zip";
+    sha256 = "sha256-llRztlI2bokCosyEJOrmH+NLl/f2H+01/+xNBcxqXn0=";
+    postFetch = "true";
   };
 
+  nativeBuildInputs = [ unzip ];
+
   installPhase = ''
-    mkdir -p $out/share/raspberrypi/boot
-    cp -R boot/* $out/share/raspberrypi/boot
+    mkdir -p $out/share/raspberrypi/
+    unzip "$src"
+    mv "firmware-${rev}/boot" "$out/share/raspberrypi/"
   '';
 
   dontConfigure = true;

--- a/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
@@ -3,13 +3,15 @@
 stdenvNoCC.mkDerivation rec {
   # NOTE: this should be updated with linux_rpi
   pname = "raspberrypi-firmware";
-  version = "1.20210805";
+  # not a versioned tag, but this is what the "stable"
+  # branch points to, as of 2022-01-10
+  version = "20220106";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "firmware";
-    rev = version;
-    sha256 = "1nndhjv4il42yw3pq8ni3r4nlp1m0r229fadrf4f9v51mgcg11i1";
+    rev = "cfdbadea5f74c16b7ed5d3b4866092a054e3c3bf";
+    sha256 = "sha256-l7qyeCz4BzHLz+LMm4irCZU5j/khkW87S2Q2263e44Y=";
   };
 
   installPhase = ''

--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -2,8 +2,14 @@
 
 let
   # NOTE: raspberrypifw & raspberryPiWirelessFirmware should be updated with this
-  modDirVersion = "5.10.52";
-  tag = "1.20210805";
+
+  # rapsberrypi isn't super consistent about tagging firmware or linux releases.
+  # Use the raspberrypi/firmware "stable" branch, and the rev used for `raspberrypifw` and this url:
+  # https://github.com/raspberrypi/firmware/blob/{{raspberrypifw->src->rev}}/extra/git_hash
+  # At that the "stable" revision, that file has the contents we use for rev:
+  rev = "a0cc201e35c06dbd8d0dd4a025731988d52da87e";
+  tag = lib.substring 0 7 rev;
+  modDirVersion = "5.10.89";
 in
 lib.overrideDerivation (buildLinux (args // {
   version = "${modDirVersion}-${tag}";
@@ -12,8 +18,8 @@ lib.overrideDerivation (buildLinux (args // {
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "linux";
-    rev = tag;
-    sha256 = "1j71xblflslfi4c3zx2srw6fahnhp3bjx4yjfqrp39kzaa41ij0b";
+    rev = rev;
+    sha256 = "sha256-gsKP1SD2W7f5JEi75ary1b/8KMkp2S8Dre4dLJnX/To=";
   };
 
   defconfig = {

--- a/pkgs/os-specific/linux/raspberrypi-eeprom/default.nix
+++ b/pkgs/os-specific/linux/raspberrypi-eeprom/default.nix
@@ -3,13 +3,18 @@
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "raspberrypi-eeprom";
-  version = "2021.04.29-138a1";
+  version = "2021.12.02";
+  # From 3fdf703f3f7bbe57eacceada3b558031229a34b0 Mon Sep 17 00:00:00 2001
+  # From: Peter Harper <peter.harper@raspberrypi.com>
+  # Date: Mon, 13 Dec 2021 11:56:11 +0000
+  # Subject: [PATCH] 2021-12-02: Promote the 2021-12-02 beta release to LATEST/STABLE
+  commit = "3fdf703f3f7bbe57eacceada3b558031229a34b0";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "rpi-eeprom";
-    rev = "v${version}";
-    sha256 = "sha256-nzAMPa4gqCAcROFa7z34IoMA3aoMHX9fYCsPFde9dac=";
+    rev = commit;
+    sha256 = "sha256-JTL2ziOkT0tnOrOS08ttNtxj3qegsacP73xZBVur7xM=";
   };
 
   buildInputs = [ python3 ];
@@ -26,7 +31,7 @@ stdenvNoCC.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin $out/share/rpi-eeprom
 
-    cp rpi-eeprom-config rpi-eeprom-update $out/bin
+    cp rpi-eeprom-config rpi-eeprom-update rpi-eeprom-digest $out/bin
     cp -r firmware/{beta,critical,old,stable} $out/share/rpi-eeprom
     cp -P firmware/default firmware/latest $out/share/rpi-eeprom
   '';


### PR DESCRIPTION
###### Motivation for this change

I think I need to update the linux-rpi kernel as well, to match the firmware update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
