### PR TITLE
liburing: fix build on armv6l

### DIFF
--- a/pkgs/development/libraries/liburing/default.nix
+++ b/pkgs/development/libraries/liburing/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
   # upstream releases an update
   patches = lib.optional stdenv.isAarch32 [
     (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/axboe/liburing/pull/433.patch";
+      url = "https://github.com/axboe/liburing/commit/e75a6cfa085fc9b5dbf5140fc1efb5a07b6b829e.diff";
       sha256 = "sha256-qQEQXYm5mkws2klLxwuuoPSPRkpP1s6tuylAAEp7+9E=";
     })
   ];

--- a/pkgs/development/libraries/liburing/default.nix
+++ b/pkgs/development/libraries/liburing/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   pname = "liburing";
-  version = "2.1";
+  version = "2.1"; # remove patch when updating
 
   src = fetchgit {
     url    = "http://git.kernel.dk/${pname}";
@@ -42,6 +42,15 @@ stdenv.mkDerivation rec {
   '' + lib.optionalString stdenv.hostPlatform.isGnu ''
     cp ./examples/ucontext-cp $bin/bin/io_uring-ucontext-cp
   '';
+
+  # fix for compilation on 32-bit ARM, merged by upstream but not released; remove when
+  # upstream releases an update
+  patches = lib.optional stdenv.isAarch32 [
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/axboe/liburing/pull/433.patch";
+      sha256 = "sha256-qQEQXYm5mkws2klLxwuuoPSPRkpP1s6tuylAAEp7+9E=";
+    })
+  ];
 
   meta = with lib; {
     description = "Userspace library for the Linux io_uring API";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`liburing` doesn't compile when targeting 32-bit ARM because it invokes the `mmap` syscall directly; that syscall doesn't exist under that name on aarch32. Upstream has merged a pull request to fix the bug (https://github.com/axboe/liburing/pull/433), but hasn't made a release yet; this adds it as a patch in the meantime.

Full disclosure: Due to the current brokenness of NixOS on 32-bit ARM, I haven't tested this beyond confirming `liburing` compiles. This PR causes no rebuilds on non-aarch32 platforms, though, so it shouldn't make anything worse.

(Keen observers might note that this isn't the first time this has happened; we added a patch for a similar bug, now removed, in #120454.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] armv6l-linux (cross-compiling from aarch64-linux)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
