### PR TITLE
ftjam: init at 2.5.2

### DIFF
--- a/pkgs/development/tools/build-managers/jam/default.nix
+++ b/pkgs/development/tools/build-managers/jam/default.nix
@@ -16,13 +16,21 @@ stdenv.mkDerivation rec {
   '';
 
   buildPhase = ''
+    runHook preBuild
+
     make jam0
-    ./jam0 -j$NIX_BUILD_CORES -sBINDIR=$out/bin install
+
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
+
+    ./jam0 -j$NIX_BUILD_CORES -sBINDIR=$out/bin install
     mkdir -p $out/doc/jam
     cp *.html $out/doc/jam
+
+    runHook postInstall
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/development/tools/build-managers/jam/ftjam.nix
+++ b/pkgs/development/tools/build-managers/jam/ftjam.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, fetchurl
+, bison
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ftjam";
+  version = "2.5.2";
+
+  src = fetchurl {
+    url = "https://downloads.sourceforge.net/project/freetype/${pname}/${version}/${pname}-${version}.tar.bz2";
+    hash = "sha256-6JdzUAqSkS3pGOn+v/q+S2vOedaa8ZRDX04DK4ptZqM=";
+  };
+
+  nativeBuildInputs = [
+    bison
+  ];
+
+  preConfigure = ''
+    unset AR
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    make jam0
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    ./jam0 -j$NIX_BUILD_CORES -sBINDIR=$out/bin install
+    mkdir -p $out/doc/jam
+    cp *.html $out/doc/jam
+
+    runHook postInstall
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    homepage = "https://freetype.org/jam/";
+    description = "Freetype's enhanced, backwards-compatible Jam clone";
+    license = licenses.free;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = platforms.unix;
+  };
+}
+# TODO: setup hook for Jam

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14879,6 +14879,8 @@ with pkgs;
 
   jam = callPackage ../development/tools/build-managers/jam { };
 
+  ftjam = callPackage ../development/tools/build-managers/jam/ftjam.nix { };
+
   javacc = callPackage ../development/tools/parsing/javacc {
     jdk = jdk8;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
