### PR TITLE
verible: init at 0.0-1789-g43d1b6fe

### DIFF
--- a/pkgs/development/tools/verible/default.nix
+++ b/pkgs/development/tools/verible/default.nix
@@ -1,0 +1,41 @@
+{ lib, stdenv, fetchFromGitHub, buildBazelPackage, flex, bison, python3 }:
+
+buildBazelPackage rec {
+  pname = "verible";
+  version = "0.0-1789-g43d1b6fe";
+
+  src = fetchFromGitHub {
+    owner = "chipsalliance";
+    repo = "verible";
+    rev = "v${version}";
+    sha256 = "0szs1ld9rqibcjv7x0527c1fkbvm0i81jjkw7branq51z7ywgn4k";
+  };
+
+  nativeBuildInputs = [ flex bison python3 ];
+
+  # These environment variables are read in the build process to skip
+  # calling git extracting it from the repository.
+  GIT_DATE = "2021-12-21";
+  GIT_VERSION = "v${version}";
+
+  bazelTarget = ":install-binaries";
+
+  fetchAttrs = {
+    sha256 = "01zhrdn1v41m9y0nbgs3hk8knq1kg3kchrdiwhkjz4718q5y4bvc";
+  };
+
+  buildAttrs = {
+    installPhase = ''
+      bazel run :install -c opt -- $out/bin
+    '';
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/chipsalliance/verible";
+    description = ''Suite of SystemVerilog developer tools, including a
+                    style-linter, indexer, formatter, and language server.'';
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ hzeller ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10547,6 +10547,8 @@ with pkgs;
 
   verco = callPackage ../applications/version-management/verco { };
 
+  verible = callPackage ../development/tools/verible { };
+
   verilator = callPackage ../applications/science/electronics/verilator {};
 
   verilog = callPackage ../applications/science/electronics/verilog {


### PR DESCRIPTION
Initial addition of verible, a suite of SystemVerilog development
tools such as linting, formatting and a language server.

https://github.com/chipsalliance/verible

(I am also one of the maintainers of the Verible project)

Signed-off-by: Henner Zeller <h.zeller@acm.org>

###### Motivation for this change

Doing hardware development on nix, these SystemVerilog development tools are very useful. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
