### PR TITLE
prometheus-bind-exporter: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/servers/monitoring/prometheus/bind-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/bind-exporter.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "bind_exporter";
-  version = "0.4.0";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "prometheus-community";
     repo = "bind_exporter";
-    sha256 = "152xi6kf1wzb7663ixv27hsdbf1x6s51fdp85zhghg1y700ln63v";
+    sha256 = "sha256-ta+uy0FUEMcL4SW1K3v2j2bfDRmdAIz42MKPsNj4FbA=";
   };
 
-  vendorSha256 = "172aqrckkhlyhpkanrcs66m13p5qp4fd2w8xv02j2kqq13klwm1a";
+  vendorSha256 = "sha256-L0jZM83u423tiLf7kcqnXsQi7QBvNEXhuU+IwXXAhE0=";
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) bind; };
 


### PR DESCRIPTION
###### Motivation for this change

I need [this fix](https://github.com/prometheus-community/bind_exporter/pull/97) from upstream.

###### Things done

I tested [the new package version](https://gitlab.com/roosemberth/dotfiles/-/commit/8ee5d22607f6c9d9c3109fcf9fbf20a499a7986d) on [my own infra](https://gitlab.com/roosemberth/dotfiles/-/commit/07c23aad2c970472ccd61612e85b8dfb4ac1ef2e). Works as expected.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
