### PR TITLE
glooctl: init at 1.10.6

### DIFF
--- a/pkgs/applications/networking/cluster/glooctl/default.nix
+++ b/pkgs/applications/networking/cluster/glooctl/default.nix
@@ -1,0 +1,36 @@
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+
+buildGoModule rec {
+  pname = "glooctl";
+  version = "1.10.6";
+
+  src = fetchFromGitHub {
+    owner = "solo-io";
+    repo = "gloo";
+    rev = "v${version}";
+    sha256 = "sha256-t63tK0hwbVnUP9UxS8g3uzL3rBvKR10vu1E85mNV3E0=";
+  };
+
+  subPackages = [ "projects/gloo/cli/cmd" ];
+  vendorSha256 = "sha256-IBuAUKbX1esx2p4Q/b3UxQH9S3VVNYZcn5vRKtmhO0A=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    mv $out/bin/cmd $out/bin/glooctl
+
+    export HOME=$TMP
+    installShellCompletion --cmd glooctl \
+      --bash <($out/bin/glooctl completion bash) \
+      --zsh <($out/bin/glooctl completion zsh)
+  '';
+
+  ldflags = [ "-s" "-w" "-X github.com/solo-io/gloo/pkg/version.Version=${version}" ];
+
+  meta = with lib; {
+    description = "glooctl is the unified CLI for Gloo";
+    homepage = "https://docs.solo.io/gloo-edge/latest/reference/cli/glooctl/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ nelsonjeppesen ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1013,6 +1013,8 @@ with pkgs;
 
   gfshare = callPackage ../tools/security/gfshare { };
 
+  glooctl = callPackage ../applications/networking/cluster/glooctl { };
+
   gobgp = callPackage ../tools/networking/gobgp { };
 
   gofu = callPackage ../applications/misc/gofu { };


### PR DESCRIPTION
###### Motivation for this change
closes https://github.com/NixOS/nixpkgs/issues/154121

Add the CLI tool to manage a Gloo-Edge cluster

> glooctl is the unified CLI for Gloo

> Gloo is a Feature-rich, Kubernetes-native, Next-Generation API Gateway Built on Envoy

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
