### PR TITLE
plasma-applet-commandoutput: init at 2022-01-11

### DIFF
--- a/pkgs/applications/misc/plasma-applet-commandoutput/cmake.patch
+++ b/pkgs/applications/misc/plasma-applet-commandoutput/cmake.patch
@@ -1,0 +1,21 @@
+diff -Naur org.kde.plasma.commandoutput/CMakeLists.txt org.kde.plasma.commandoutput.patch/CMakeLists.txt
+--- org.kde.plasma.commandoutput/CMakeLists.txt	1970-01-01 01:00:00.000000000 +0100
++++ org.kde.plasma.commandoutput.patch/CMakeLists.txt	2016-04-19 11:23:35.137866949 +0200
+@@ -0,0 +1,15 @@
++# Set minimum CMake version (required for CMake 3.0 or later)
++cmake_minimum_required(VERSION 2.8.12)
++
++# Use Extra CMake Modules (ECM) for common functionality.
++# See http://api.kde.org/ecm/manual/ecm.7.html
++# and http://api.kde.org/ecm/manual/ecm-kde-modules.7.html
++find_package(ECM REQUIRED NO_MODULE)
++# Needed by find_package(KF5Plasma) below.
++set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR} ${CMAKE_MODULE_PATH})
++
++# Locate plasma_install_package macro.
++find_package(KF5Plasma REQUIRED)
++
++# Add installatation target ("make install").
++plasma_install_package(package org.kde.plasma.commandoutput)
+
+

--- a/pkgs/applications/misc/plasma-applet-commandoutput/default.nix
+++ b/pkgs/applications/misc/plasma-applet-commandoutput/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, cmake, extra-cmake-modules, plasma-framework, kwindowsystem, plasma-pa, fetchFromGitHub }:
+{ lib, stdenv, cmake, extra-cmake-modules, plasma-framework, kwindowsystem, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   pname = "plasma-applet-commandoutput";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   patches = [ ./cmake.patch ];
   postPatch = "rm build";
   nativeBuildInputs = [ cmake extra-cmake-modules ];
-  buildInputs = [ plasma-framework kwindowsystem plasma-pa ];
+  buildInputs = [ plasma-framework kwindowsystem ];
 
   dontWrapQtApps = true;
 

--- a/pkgs/applications/misc/plasma-applet-commandoutput/default.nix
+++ b/pkgs/applications/misc/plasma-applet-commandoutput/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, cmake, extra-cmake-modules, plasma-framework, kwindowsystem, plasma-pa, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "plasma-applet-commandoutput";
+  version = "2022-01-11";
+
+  src = fetchFromGitHub {
+    owner = "Zren";
+    repo = "plasma-applet-commandoutput";
+    rev = "d4c93a1fad82ff4d2fcc622f592b28a60878f49f";
+    sha256 = "0hg5i8yq159263yz7jyhpi893c5c2kl59w03p9nnpw656xr6102b";
+  };
+
+  # Adds the CMakeLists.txt not provided by upstream
+  patches = [ ./cmake.patch ];
+  postPatch = "rm build";
+  nativeBuildInputs = [ cmake extra-cmake-modules ];
+  buildInputs = [ plasma-framework kwindowsystem plasma-pa ];
+
+  dontWrapQtApps = true;
+
+  meta = with lib; {
+    description = "Run command every second and displays the output.";
+    homepage = "https://github.com/Zren/plasma-applet-commandoutput";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ matthiasbeyer ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31433,6 +31433,8 @@ with pkgs;
 
   plasma-applet-volumewin7mixer = libsForQt5.callPackage ../applications/misc/plasma-applet-volumewin7mixer { };
 
+  plasma-applet-commandoutput = libsForQt5.callPackage ../applications/misc/plasma-applet-commandoutput { };
+
   plasma-pass = libsForQt5.callPackage ../tools/security/plasma-pass { };
 
   inherit (callPackages ../applications/misc/redshift {


### PR DESCRIPTION
###### Motivation for this change

Want to try this.

CC @mdevlamynck because they packaged another plasma applet from this author and might be interested as well?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
