### PR TITLE
kodi.packages.arteplussept: init at 1.1.1

### DIFF
--- a/pkgs/applications/video/kodi/addons/arteplussept/default.nix
+++ b/pkgs/applications/video/kodi/addons/arteplussept/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildKodiAddon, fetchzip, addonUpdateScript, requests, xbmcswift2 }:
+
+buildKodiAddon rec {
+  pname = "arteplussept";
+  namespace = "plugin.video.arteplussept";
+  version = "1.1.1";
+
+  src = fetchzip {
+    url = "https://mirrors.kodi.tv/addons/matrix/${namespace}/${namespace}-${version}.zip";
+    hash = "sha256-IYodi0Uz16Qg4MHCz/K06pEXblrsBxHD25fb6LrW8To=";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    xbmcswift2
+  ];
+
+  passthru = {
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.arteplussept";
+    };
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/known-as-bmf/plugin.video.arteplussept";
+    description = "Watch videos available on Arte+7";
+    license = licenses.mit;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/applications/video/kodi/addons/orftvthek/default.nix
+++ b/pkgs/applications/video/kodi/addons/orftvthek/default.nix
@@ -3,13 +3,13 @@
 buildKodiAddon rec {
   pname = "orftvthek";
   namespace = "plugin.video.orftvthek";
-  version = "0.12.3-1";
+  version = "0.12.3+matrix.1";
 
   src = fetchFromGitHub {
     owner = "s0faking";
     repo = namespace;
     rev = version;
-    sha256 = "sha256-+J1NtmjbDWtS8d4nO9P/lR5GNmvtc1YjTW+bulGaU2Q=";
+    sha256 = "sha256-GB9VkC9Vbi7TJXl/vF3ViF/tAcHGH0KxYQ0zkfMLZCY=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/applications/video/kodi/addons/xbmcswift2/default.nix
+++ b/pkgs/applications/video/kodi/addons/xbmcswift2/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildKodiAddon, fetchFromGitHub }:
+
+buildKodiAddon rec {
+  pname = "xbmcswift2";
+  namespace = "script.module.xbmcswift2";
+  version = "19.0.7";
+
+  src = fetchFromGitHub {
+    owner = "XBMC-Addons";
+    repo = namespace;
+    rev = version;
+    sha256 = "sha256-Z+rHz3wncoNvV1pwhRzJFB/X0H6wdfwg88otVh27wg8=";
+  };
+
+  passthru = {
+    pythonPath = "lib";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/XBMC-Addons/script.module.xbmcswift2";
+    description = "Framework to ease development of Kodi addons";
+    license = licenses.gpl3Only;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -160,4 +160,6 @@ let self = rec {
 
   websocket = callPackage ../applications/video/kodi/addons/websocket { };
 
+  xbmcswift2 = callPackage ../applications/video/kodi/addons/xbmcswift2 { };
+
 }; in self

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -52,6 +52,8 @@ let self = rec {
 
   a4ksubtitles = callPackage ../applications/video/kodi/addons/a4ksubtitles { };
 
+  arteplussept = callPackage ../applications/video/kodi/addons/arteplussept { };
+
   controllers = {
     default = callPackage ../applications/video/kodi/addons/controllers { controller = "default"; };
 


### PR DESCRIPTION
Add the Arte+7 Kodi plugin.

This PR also includes a tiny fix for the Kodi ORF TVThek plugin (add +matrix to version string for compatibility; add automatic updates). I did not open a separate PR for this, because I thought it is easier like so, but please let me know, if you require a separate PR.

Ping @aanderse for review.

I tested the plugins and they work on my Linux machine.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
