### PR TITLE
python3Packages.aioitertools: fix python 3.10

### DIFF
--- a/pkgs/development/python-modules/aioitertools/default.nix
+++ b/pkgs/development/python-modules/aioitertools/default.nix
@@ -1,7 +1,9 @@
 { lib
 
 , buildPythonPackage
+, fetchpatch
 , fetchPypi
+, pythonAtLeast
 , pythonOlder
 , typing-extensions
 , coverage
@@ -18,6 +20,15 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "8b02facfbc9b0f1867739949a223f3d3267ed8663691cc95abd94e2c1d8c2b46";
   };
+
+  patches = lib.optionals (pythonAtLeast "3.10") [
+    (fetchpatch {
+      # Fix TypeError: wait() got an unexpected keyword argument 'loop'
+      # See https://github.com/omnilib/aioitertools/issues/84
+      url = "https://raw.githubusercontent.com/archlinux/svntogit-community/packages/python-aioitertools/trunk/python310.patch";
+      sha256 = "sha256-F10sduGaLBcxEoP83N/lGpZIlzkM2JTnQnhHKFwc7P0=";
+    })
+  ];
 
   propagatedBuildInputs = [ typing-extensions ];
   checkInputs = [ coverage toml ];


### PR DESCRIPTION
###### Motivation for this change
Python 3.10 removes the loop= argument from asyncio functions and breaks aioitertools, as described in this issue https://github.com/omnilib/aioitertools/issues/84 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
