### PR TITLE
pkgs/os-specific/linux/virtio_vmmci: init at 0.4.0

### DIFF
--- a/pkgs/os-specific/linux/virtio_vmmci/default.nix
+++ b/pkgs/os-specific/linux/virtio_vmmci/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, lib, fetchFromGitHub, kernel }:
+
+stdenv.mkDerivation rec {
+  name = "virtio_vmmci";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "voutilad";
+    repo = "virtio_vmmci";
+    rev = "${version}";
+    sha256 = "104xnpcy5kb4y7ipy1fx1v6byddzs63bv2dqjy3yl23n764fsy43";
+  };
+
+  hardeningDisable = [ "pic" "format" ];
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  extraConfig = ''
+    CONFIG_RTC_HCTOSYS yes
+  '';
+
+  makeFlags = kernel.makeFlags ++ [
+    "DEPMOD=echo"
+    "INSTALL_MOD_PATH=$(out)"
+    "KERNELRELEASE=${kernel.modDirVersion}"
+    "KERNELDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  meta = with lib; {
+    description = "An OpenBSD VMM Control Interface (vmmci) for Linux";
+    homepage = "https://github.com/voutilad/virtio_vmmci";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ qbit ];
+    platforms = platforms.linux;
+  };
+
+  enableParallelBuilding = true;
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -429,6 +429,8 @@ in {
 
     vhba = callPackage ../misc/emulators/cdemu/vhba.nix { };
 
+    virtio_vmmci  = callPackage ../os-specific/linux/virtio_vmmci { };
+
     virtualbox = callPackage ../os-specific/linux/virtualbox {
       virtualbox = pkgs.virtualboxHardened;
     };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

virtio_vmmci  (OpenBSD VMM Control Interface) is another (153923) kernel module that expands helps running Linux on OpenBSD's hypervisor.

###### Motivation for this change

Similar to 153923, this modules is used by NixOS hosts running inside OpenBSD's vmm. This one teaches Linux how to handle shutdown requests from OpenBSD (and a few other things).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
