### PR TITLE
python3Packages.cherrypy: 18.6.0 -> 18.6.1

### DIFF
--- a/pkgs/development/python-modules/cherrypy/default.nix
+++ b/pkgs/development/python-modules/cherrypy/default.nix
@@ -1,42 +1,26 @@
-{ lib, stdenv, buildPythonPackage, fetchPypi, isPy3k
+{ lib, stdenv, buildPythonPackage, fetchPypi, pythonOlder
 , setuptools-scm
 , cheroot, portend, more-itertools, zc_lockfile, routes
 , jaraco_collections
 , objgraph, pytest, pytest-cov, pathpy, requests-toolbelt, pytest-services
-, fetchpatch
 }:
 
 buildPythonPackage rec {
   pname = "cherrypy";
-  version = "18.6.0";
+  version = "18.6.1";
+  format = "setuptools";
 
-  disabled = !isPy3k;
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     pname = "CherryPy";
     inherit version;
-    sha256 = "16f410izp2c4qhn4n3l5l3qirmkf43h2amjqms8hkl0shgfqwq2n";
+    hash = "sha256-8z6HKG57PjCeBOciXY5JOC2dd3PmCSJB1/YTiTxWNJU=";
   };
 
-  patches = [
-    # 1/3 Fix compatibility with pytest 6. Will be part of the next release after 18.6
-    (fetchpatch {
-      url = "https://github.com/cherrypy/cherrypy/pull/1897/commits/59c0e19d7df8680e36afc96756dce72435121448.patch";
-      sha256 = "1jachbvp505gndccdhny0c3grzdrmvmbzq4kw55jx93ay94ni6p0";
-    })
-    # 2/3 Fix compatibility with pytest 6. Will be part of the next release after 18.6
-    (fetchpatch {
-      url = "https://github.com/cherrypy/cherrypy/pull/1897/commits/4a6287b73539adcb7b0ae72d69644a1ced1f7eaa.patch";
-      sha256 = "0nz40qmgxknkbjsdzfzcqfxdsmsxx3v104fb0h04yvs76mqvw3i4";
-    })
-    # 3/3 Fix compatibility with pytest 6. Will be part of the next release after 18.6
-    (fetchpatch {
-      url = "https://github.com/cherrypy/cherrypy/commit/3bae7f06868553b006915f05ff14d86163f59a7d.patch";
-      sha256 = "1z0bv23ybyw87rf1i8alsdi3gc2bzmdj9d0kjsghdkvi3zdp4n8q";
-    })
+  nativeBuildInputs = [
+    setuptools-scm
   ];
-
-  nativeBuildInputs = [ setuptools-scm ];
 
   propagatedBuildInputs = [
     # required
@@ -50,10 +34,10 @@ buildPythonPackage rec {
     objgraph pytest pytest-cov pathpy requests-toolbelt pytest-services
   ];
 
-  # Keyboard interrupt ends test suite run
+  
   # daemonize and autoreload tests have issue with sockets within sandbox
   # Disable doctest plugin because times out
-  checkPhase = ''
+  preCheck = ''
     substituteInPlace pytest.ini --replace "--doctest-modules" ""
     pytest \
       -k 'not KeyboardInterrupt and not daemonize and not Autoreload' \
@@ -63,11 +47,28 @@ buildPythonPackage rec {
         "--deselect=cherrypy/test/test_bus.py::BusMethodTests::test_block --deselect=cherrypy/test/test_config_server.py"}
   '';
 
+  disabledTests = [
+    # Keyboard interrupt ends test suite run
+    ""
+    ""
+    ""
+    ""
+  ];
+
+  disabledTestPaths = [
+    ""
+  ];
+
   __darwinAllowLocalNetworking = true;
 
+  pythonImportsCheck = [
+    "cherrypy"
+  ];
+
   meta = with lib; {
+    description = "Object-oriented HTTP framework";
     homepage = "https://www.cherrypy.org";
-    description = "A pythonic, object-oriented HTTP framework";
     license = licenses.bsd3;
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/cherrypy/cherrypy/blob/v18.6.1/CHANGES.rst#v1861

Fix build with Python 3.10

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
