### PR TITLE
nordic: 2.1.0 -> unstable-2022-01-08

### DIFF
--- a/pkgs/data/themes/nordic/default.nix
+++ b/pkgs/data/themes/nordic/default.nix
@@ -2,70 +2,70 @@
 
 stdenv.mkDerivation rec {
   pname = "nordic";
-  version = "2.1.0";
+  version = "unstable-2022-01-08";
 
   srcs = [
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "0112af91943b8819f7a1af9a508cda7fe3d74051";
-      sha256 = "sha256-ccOA5/jXTx20495NpTgVu7DvsjfTEULqL3IyJ+Pd/ug";
+      rev = "85086324c2a8fa7ca538b85ad0681e03733b2c86";
+      sha256 = "sha256-p1nr71iJZm+2123WF67NkunBX2dR4ruK2Afqd7XdeGc=";
       name = "Nordic";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "b30d2c844cc6ef5d020308f1c02791de45b607a7";
-      sha256 = "sha256-g5yCCFXzipZLmUat+1r6QWHB7DWQvMKhMexHPV/DJHM";
+      rev = "46c9e6665963ccb54938d7730e520bd8c52f4307";
+      sha256 = "sha256-uFnNLshyKOvzaij7tEKb0fw0j3/GGfzznAf/aaKx7XI=";
       name = "Nordic-standard-buttons";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "6d38d6af363528f42619f663e3ecd4c08dfd2411";
-      sha256 = "sha256-jaRiSE6yfTltzZ2vr8w4d+YtSz7REOcL7vOOhQvIMlQ";
+      rev = "da5c930386427fce65ea185f164709c8a20e362f";
+      sha256 = "sha256-Ee9ymuMWs2ZgU+8FVLaviGtHMT4Sz5NWLaEGln2Z4V0=";
       name = "Nordic-darker";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "4142817c14c27b371d42796445bedc84dc94672c";
-      sha256 = "sha256-FAb1+EREcwYrfSxAl6LrPaJtkHMt67NV3bG87g1cFT4";
+      rev = "fd85fb2712ac1192e35c92149b75bfc3c440b1c7";
+      sha256 = "sha256-6WUQBeNq7EKNkYcCt/fUYloue90gxfp8bDYawkQQ6ss=";
       name = "Nordic-darker-standard-buttons";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "2a91d6f3db70412b0a80ed33546fbe93075627d8";
-      sha256 = "sha256-Su+amS7moc2IDONNvqw3bjL6Q0WLJWzHu6WvfcVDcDY";
+      rev = "259e30ce13566214c7594b038dd2c240648a07a0";
+      sha256 = "sha256-F6hC6XbT9yJl6SW9qJNlwmmBcvOrOS5yPCQALZFhgbM=";
       name = "Nordic-bluish-accent";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "3ebd334f97d638fdc888b16d69851e3ee31131f2";
-      sha256 = "sha256-h0IXtWcdDvAEVi/1cLZF4Vacdl6VAY+5uo0LGPNe0bg";
+      rev = "2a27051d87558dfa595fb94eff34241d3a1b8c30";
+      sha256 = "sha256-JIld6GVtr1tz02Do2Ft92qtza6iGrPapasd6jmMFG6k=";
       name = "Nordic-bluish-accent-standard-buttons";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = "${pname}-polar";
-      rev = "803926882f8178c72b433466a377aaa33c5b372a";
-      sha256 = "sha256-G7Vu03PoFOEU9uxb5JiHR4Tr8qk47fPo7Gg7Vt9Zzns";
+      rev = "0bea76aed39bb2a2669278b8403c4129aa47be0f";
+      sha256 = "sha256-OXmz6uHXh1zl93sgv5WEwARkEUCr4PRh0/mJyMLXpnk=";
       name = "Nordic-Polar";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = "${pname}-polar";
-      rev = "988cb8a16ece3901b8b0e7a5b86503400491cb1e";
-      sha256 = "sha256-Zx1mrzJm5o4wQwOR8ZU2OEcjD3/6UXwLrBYpMtCkQbg";
+      rev = "8fe52b6c276a7e548e87a558db6734cf9f003b06";
+      sha256 = "sha256-/IxlBvMLAK+mGRyaa7bTv/oZS24nSNeE5GsyJIeN6UU=";
       name = "Nordic-Polar-standard-buttons";
     })
   ];

--- a/pkgs/data/themes/nordic/default.nix
+++ b/pkgs/data/themes/nordic/default.nix
@@ -1,4 +1,9 @@
-{ lib, stdenv, fetchFromGitHub, gtk-engine-murrine }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, gtk-engine-murrine
+, jdupes
+}:
 
 stdenv.mkDerivation rec {
   pname = "nordic";
@@ -72,6 +77,8 @@ stdenv.mkDerivation rec {
 
   sourceRoot = ".";
 
+  nativeBuildInputs = [ jdupes ];
+
   propagatedUserEnvPkgs = [ gtk-engine-murrine ];
 
   installPhase = ''
@@ -100,6 +107,10 @@ stdenv.mkDerivation rec {
     mv -v $out/share/themes/Nordic/kde/plasma/look-and-feel $out/share/plasma/
     mv -v $out/share/themes/Nordic/kde/sddm/* $out/share/sddm/themes/Nordic/
     rm -rf $out/share/themes/Nordic/kde
+
+    # Replace duplicate files with hardlinks to the first file in each
+    # set of duplicates, reducing the installed size in about 65%
+    jdupes -L -r $out/share
 
     runHook postInstall
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to version [unstable-2022-01-08](https://github.com/EliverLara/Nordic/commits/master)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
