### PR TITLE
home-assistant: 2021.12.8 -> 2021.12.9

### DIFF
--- a/pkgs/development/python-modules/aioharmony/default.nix
+++ b/pkgs/development/python-modules/aioharmony/default.nix
@@ -9,13 +9,13 @@
 
 buildPythonPackage rec {
   pname = "aioharmony";
-  version = "0.2.8";
+  version = "0.2.9";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0adf08955810a227db489556dc3ca808e4f825a00183f613797856114c2a2a47";
+    sha256 = "sha256-T30pLzPWD+5pb0ShkpNdiBFO45RdiMYgCOSg8rx+t+Y=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/hass-nabucasa/default.nix
+++ b/pkgs/development/python-modules/hass-nabucasa/default.nix
@@ -15,13 +15,13 @@
 
 buildPythonPackage rec {
   pname = "hass-nabucasa";
-  version = "0.50.0";
+  version = "0.51.0";
 
   src = fetchFromGitHub {
     owner = "nabucasa";
     repo = pname;
     rev = version;
-    sha256 = "sha256-0E8eiHzqbxHbtAd97MbvFMRDWTu25E9x/44oNGC4mUM=";
+    sha256 = "sha256-qN7AXs4hJpuP+GaxjOPR2CqKMYyDJxTrCuE5HreZnhU=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/pycognito/default.nix
+++ b/pkgs/development/python-modules/pycognito/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "pycognito";
-  version = "2021.03.1";
+  version = "2022.01.0";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "pvizeli";
     repo = pname;
     rev = version;
-    sha256 = "sha256-V3R6i1/FZrjcfRqJhczjURr/+x++iCvZ3aCK9wdEL1A=";
+    sha256 = "sha256-mmlw3irMC0SFjfEinXHyoPNfTvCcO02zGyqQLj9STSY=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/yalexs/default.nix
+++ b/pkgs/development/python-modules/yalexs/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "yalexs";
-  version = "1.1.15";
+  version = "1.1.17";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "bdraco";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-EK9jmbU3A2rNx/H8WOsZiGA7tqzg/XJkW/DV5s+2Y3U=";
+    sha256 = "sha256-kCLL+0ZiraTW7swgdfS9vkLcr/s6lTccFQbC02rdNDY=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2021.12.8";
+  version = "2021.12.9";
   components = {
     "abode" = ps: with ps; [ abodepy ];
     "accuweather" = ps: with ps; [ accuweather ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -193,6 +193,9 @@ let
     # Pinned due to API changes in 0.1.0
     (mkOverride "poolsense" "0.0.8" "09y4fq0gdvgkfsykpxnvmfv92dpbknnq5v82spz43ak6hjnhgcyp")
 
+    # Requirements for recorder not found: ['sqlalchemy==1.4.27'].
+    (mkOverride "sqlalchemy" "1.4.27" "031jbd0svrvwr3n52iibp9mkwsj9wicnck45yd26da5kmsfkas6p")
+
     # Pinned due to API changes in 0.4.0
     (self: super: {
       vilfo-api-client = super.vilfo-api-client.overridePythonAttrs (oldAttrs: rec {
@@ -215,19 +218,6 @@ let
           repo = "python-vultr";
           rev = "v${version}";
           sha256 = "1qjvvr2v9gfnwskdl0ayazpcmiyw9zlgnijnhgq9mcri5gq9jw5h";
-        };
-      });
-    })
-
-    # Remove with 2021.12.6 as the requirement will be 1.1.16 (at least)
-    (self: super: {
-      yalexs = super.yalexs.overridePythonAttrs (oldAttrs: rec {
-        version = "1.1.13";
-        src = fetchFromGitHub {
-          owner = "bdraco";
-          repo = "yalexs";
-          rev = "v${version}";
-          sha256 = "sha256-lnx8+VyDyO7Wg+QW+CC0FUg77Ndfjar6PLsDYwEpaCQ=";
         };
       });
     })
@@ -292,7 +282,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "2021.12.8";
+  hassVersion = "2021.12.9";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -309,7 +299,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    hash = "sha256:HxSEXaqNHh2hSr1fmu3xpC212PXhzvnD4CwR1Ulw9ok=";
+    hash = "sha256:17lh16c9kklx4q416ns12qjh1hc0g79y56kdkj1pvybblg0a07lm";
   };
 
   # leave this in, so users don't have to constantly update their downstream patch handling

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,11 +4,11 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20211229.0";
+  version = "20211229.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-2hACC2542jz1DID7nV28keVVDDBOLW1QDYTLM4S1ZJ0=";
+    sha256 = "sha256-glVjJ9iOmhAIGD65PHQu9l7Wc/lr5XRya2mi20/UVgs=";
   };
 
   # there is nothing to strip in this package


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/home-assistant/core/releases/tag/2021.12.9

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
