### PR TITLE
notmuch: fix test with gnupg 2.3

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -18,6 +18,11 @@ stdenv.mkDerivation rec {
     sha256 = "wfLO7kf2iXESItcgWvKj/npKnYwy5OCyStZviN9qR9M=";
   };
 
+  patches = [
+    # https://nmbug.notmuchmail.org/nmweb/show/87o84iza9r.fsf%40starbuck.i-did-not-set--mail-host-address--so-tickle-me
+    ./test-fix-support-for-gpgsm-in-gnupg-2.3.patch
+  ];
+
   nativeBuildInputs = [
     pkg-config
     doxygen                   # (optional) api docs

--- a/pkgs/applications/networking/mailreaders/notmuch/test-fix-support-for-gpgsm-in-gnupg-2.3.patch
+++ b/pkgs/applications/networking/mailreaders/notmuch/test-fix-support-for-gpgsm-in-gnupg-2.3.patch
@@ -1,0 +1,28 @@
+From a642ad542e3d3f34e949c5c66923ca8a6e6cbbd8 Mon Sep 17 00:00:00 2001
+From: Stig Palmquist <stig@stig.io>
+Date: Tue, 11 Jan 2022 13:23:13 +0100
+Subject: [PATCH] test: fix support for gpgsm in gnupg 2.3
+
+gpgsm --list-keys output changed the label for fingerprints from
+"fingerprint: " to "sha[12] fpr: " breaking tests with gnupg 2.3. this
+adds support for both.
+---
+ test/test-lib.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/test-lib.sh b/test/test-lib.sh
+index 6bc0b723..3de608f9 100644
+--- a/test/test-lib.sh
++++ b/test/test-lib.sh
+@@ -145,7 +145,7 @@ add_gpgsm_home () {
+     mkdir -p -m 0700 "$GNUPGHOME"
+     gpgsm --batch --no-tty --no-common-certs-import --pinentry-mode=loopback --passphrase-fd 3 \
+ 	  --disable-dirmngr --import  >"$GNUPGHOME"/import.log 2>&1 3<<<'' <$NOTMUCH_SRCDIR/test/smime/0xE0972A47.p12
+-    fpr=$(gpgsm --batch --list-key test_suite@notmuchmail.org | sed -n 's/.*fingerprint: //p')
++    fpr=$(gpgsm --batch --list-key test_suite@notmuchmail.org | sed -n 's/.*\(fingerprint\|sha1 fpr\): //p')
+     echo "$fpr S relax" >> "$GNUPGHOME/trustlist.txt"
+     gpgsm --quiet --batch --no-tty --no-common-certs-import --disable-dirmngr --import < $NOTMUCH_SRCDIR/test/smime/ca.crt
+     echo "4D:E0:FF:63:C0:E9:EC:01:29:11:C8:7A:EE:DA:3A:9A:7F:6E:C1:0D S" >> "$GNUPGHOME/trustlist.txt"
+-- 
+2.34.1
+


### PR DESCRIPTION
###### Motivation for this change

Fixes #154297

`notmuch` tests broke after gnupg was upgraded from 2.2 to 2.3 in #145434, this PR patches the test

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
