### PR TITLE
nixos/intel-sgx: add option for Intel SGX DCAP compatibility

### DIFF
--- a/nixos/modules/hardware/cpu/intel-sgx.nix
+++ b/nixos/modules/hardware/cpu/intel-sgx.nix
@@ -1,10 +1,24 @@
 { config, lib, ... }:
 with lib;
 let
-  cfg = config.hardware.cpu.intel.sgx.provision;
-  defaultGroup = "sgx_prv";
+  cfg = config.hardware.cpu.intel.sgx;
+  defaultPrvGroup = "sgx_prv";
 in
 {
+  options.hardware.cpu.intel.sgx.enableDcapCompat = mkOption {
+    description = ''
+      Whether to enable backward compatibility for SGX software build for the
+      out-of-tree Intel SGX DCAP driver.
+
+      Creates symbolic links for the SGX devices <literal>/dev/sgx_enclave</literal>
+      and <literal>/dev/sgx_provision</literal> to make them available as
+      <literal>/dev/sgx/enclave</literal>  and <literal>/dev/sgx/provision</literal>,
+      respectively.
+    '';
+    type = types.bool;
+    default = true;
+  };
+
   options.hardware.cpu.intel.sgx.provision = {
     enable = mkEnableOption "access to the Intel SGX provisioning device";
     user = mkOption {
@@ -15,7 +29,7 @@ in
     group = mkOption {
       description = "Group to assign to the SGX provisioning device.";
       type = types.str;
-      default = defaultGroup;
+      default = defaultPrvGroup;
     };
     mode = mkOption {
       description = "Mode to set for the SGX provisioning device.";
@@ -24,24 +38,32 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
-    assertions = [
-      {
-        assertion = hasAttr cfg.user config.users.users;
-        message = "Given user does not exist";
-      }
-      {
-        assertion = (cfg.group == defaultGroup) || (hasAttr cfg.group config.users.groups);
-        message = "Given group does not exist";
-      }
-    ];
+  config = mkMerge [
+    (mkIf cfg.provision.enable {
+      assertions = [
+        {
+          assertion = hasAttr cfg.provision.user config.users.users;
+          message = "Given user does not exist";
+        }
+        {
+          assertion = (cfg.provision.group == defaultPrvGroup) || (hasAttr cfg.provision.group config.users.groups);
+          message = "Given group does not exist";
+        }
+      ];
 
-    users.groups = optionalAttrs (cfg.group == defaultGroup) {
-      "${cfg.group}" = { };
-    };
+      users.groups = optionalAttrs (cfg.provision.group == defaultPrvGroup) {
+        "${cfg.provision.group}" = { };
+      };
 
-    services.udev.extraRules = ''
-      SUBSYSTEM=="misc", KERNEL=="sgx_provision", OWNER="${cfg.user}", GROUP="${cfg.group}", MODE="${cfg.mode}"
-    '';
-  };
+      services.udev.extraRules = with cfg.provision; ''
+        SUBSYSTEM=="misc", KERNEL=="sgx_provision", OWNER="${user}", GROUP="${group}", MODE="${mode}"
+      '';
+    })
+    (mkIf cfg.enableDcapCompat {
+      services.udev.extraRules = ''
+        SUBSYSTEM=="misc", KERNEL=="sgx_enclave",   SYMLINK+="sgx/enclave"
+        SUBSYSTEM=="misc", KERNEL=="sgx_provision", SYMLINK+="sgx/provision"
+      '';
+    })
+  ];
 }

--- a/nixos/modules/services/security/aesmd.nix
+++ b/nixos/modules/services/security/aesmd.nix
@@ -73,6 +73,11 @@ in
 
     hardware.cpu.intel.sgx.provision.enable = true;
 
+    # Make sure the AESM service can find the SGX devices until
+    # https://github.com/intel/linux-sgx/issues/772 is resolved
+    # and updated in nixpkgs.
+    hardware.cpu.intel.sgx.enableDcapCompat = mkForce true;
+
     systemd.services.aesmd =
       let
         storeAesmFolder = "${sgx-psw}/aesm";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The Intel SGX DCAP driver makes the SGX application enclave device and
the SGX provisioning enclave available below the path `/dev/sgx/`. Since
Linux 5.11, a derivation of the DCAP driver is part of the kernel and
available through the X86_SGX config option; NixOS enables this option
by default.

In contrast to the out-of-tree DCAP driver, the in-tree SGX driver uses
a flat hierarchy for the SGX devices resulting in the paths
`/dev/sgx_enclave` for the application enclave device and
`/dev/sgx_provison` for the provisioning enclave device.

As of this commit, even the latest version of the Intel SGX PSW
libraries still tries to open the (legacy) DCAP paths only. This means
that SGX software currently cannot find the required SGX devices even if
the system actually supports SGX through the in-tree driver. Intel wants
to change this behavior [in an upcoming release](https://github.com/intel/linux-sgx/issues/772) of intel/linux-sgx.

Having said that, SGX software assuming the SGX devices below
`/dev/sgx/` will prevail. Therefore, this commit introduces the NixOS
configuration option `hardware.cpu.intel.sgx.enableDcapCompat` which
creates the necessary symlinks to support existing SGX software. The
option defaults to true as it is currently the only way to support SGX
software. Also, enabling the SGX AESM service enables the option.

The permissions of the devices `/dev/sgx_enclave` and
`/dev/sgx_provison` remain the same, i.e., are not affected regardless
of having the new option enabled or not.

Ref: https://github.com/NixOS/nixpkgs/pull/153237

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
