### PR TITLE
vimPlugins.onedark-nvim: etc

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -428,6 +428,14 @@
           wrapper for <literal>assert</literal> conditions.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <literal>pkgs.vimPlugins.onedark-nvim</literal> now refers to
+          <link xlink:href="https://github.com/navarasu/onedark.nvim">navarasu/onedark.nvim</link>
+          (formerly refers to
+          <link xlink:href="https://github.com/olimorris/onedarkpro.nvim">olimorris/onedarkpro.nvim</link>).
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-22.05-notable-changes">

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -136,6 +136,9 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - `lib.assertMsg` and `lib.assertOneOf` no longer return `false` if the passed condition is `false`, `throw`ing the given error message instead (which makes the resulting error message less cluttered). This will not impact the behaviour of code using these functions as intended, namely as top-level wrapper for `assert` conditions.
 
+- `pkgs.vimPlugins.onedark-nvim` now refers to [navarasu/onedark.nvim](https://github.com/navarasu/onedark.nvim)
+  (formerly refers to [olimorris/onedarkpro.nvim](https://github.com/olimorris/onedarkpro.nvim)).
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## Other Notable Changes {#sec-release-22.05-notable-changes}

--- a/pkgs/misc/vim-plugins/aliases.nix
+++ b/pkgs/misc/vim-plugins/aliases.nix
@@ -94,7 +94,6 @@ mapAliases (with prev; {
   neosnippet          = neosnippet-vim;
   The_NERD_Commenter  = nerdcommenter;
   The_NERD_tree       = nerdtree;
-  onedark-nvim        = onedarkpro-nvim; # added 2021-10-22
   open-browser        = open-browser-vim;
   pathogen            = vim-pathogen;
   polyglot            = vim-polyglot;


### PR DESCRIPTION
###### Motivation for this change

- `pkgs.vimPlugins.onedark-nvim` now refers to [navarasu/onedark.nvim](https://github.com/navarasu/onedark.nvim) (formerly refers to [olimorris/onedarkpro.nvim](https://github.com/olimorris/onedarkpro.nvim)).

Fixes https://github.com/NixOS/nixpkgs/pull/153045#discussion_r781641557.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  -> Somehow the test fails:
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<details>
<summary>$ nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"</summary>
<div>

```
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
From https://github.com/NixOS/nixpkgs
   e90cc18e09c..0eee9d1067c  master     -> refs/nixpkgs-review/0
$ git worktree add /home/sei40kr/.cache/nixpkgs-review/rev-cb3eb553e409183e857b5ba5e40d6f7ec63d69d3/nixpkgs 0eee9d1067cf5d7f0c49b5b16fe89b09e5f3f105
Preparing worktree (detached HEAD 0eee9d1067c)
Updating files: 100% (29265/29265), done.
HEAD is now at 0eee9d1067c Merge pull request #154403 from willcohen/zsh-darwin
$ nix-env --option system x86_64-linux -f /home/sei40kr/.cache/nixpkgs-review/rev-cb3eb553e409183e857b5ba5e40d6f7ec63d69d3/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit --no-ff cb3eb553e409183e857b5ba5e40d6f7ec63d69d3
Automatic merge went well; stopped before committing as requested
$ nix-env --option system x86_64-linux -f /home/sei40kr/.cache/nixpkgs-review/rev-cb3eb553e409183e857b5ba5e40d6f7ec63d69d3/nixpkgs -qaP --xml --out-path --show-trace --meta
2 packages updated:
nixos-install-tools spacevim

$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /home/sei40kr/.cache/nixpkgs-review/rev-cb3eb553e409183e857b5ba5e40d6f7ec63d69d3/build.nix
1 package blacklisted:
nixos-install-tools

1 package built:
spacevim

error: build log of '/nix/store/iqbh28cx0yf0ji2dkaxkgc74dd59cg1j-nixos-install-tools-22.05pre-git.drv' is not available
error: build log of '/nix/store/njvq8rr7i0vzfhnzyf2rgl96g6hb1c6z-nixos-install-tools-22.05pre-git' is not available
$ nix-shell /home/sei40kr/.cache/nixpkgs-review/rev-cb3eb553e409183e857b5ba5e40d6f7ec63d69d3/shell.nix
```

</div>
</details>