### PR TITLE
fsverity-utils: init at 1.5

### DIFF
--- a/pkgs/os-specific/linux/fsverity-utils/default.nix
+++ b/pkgs/os-specific/linux/fsverity-utils/default.nix
@@ -1,0 +1,51 @@
+{ stdenv
+, lib
+, fetchgit
+, openssl
+, enableShared ? !stdenv.hostPlatform.isStatic
+, enableManpages ? false
+, pandoc
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fsverity-utils";
+  version = "1.5";
+
+  outputs = [ "out" "lib" "dev" ] ++ lib.optional enableManpages "man";
+
+  src = fetchgit {
+    url = "https://git.kernel.org/pub/scm/linux/kernel/git/ebiggers/fsverity-utils.git";
+    rev = "v${version}";
+    sha256 = "sha256-ygBOkp2PBe8Z2ak6SXEJ6HHuT4NRKmIsbJDHcY+h8PQ=";
+  };
+
+  patches = lib.optionals (!enableShared) [
+    ./remove-dynamic-libs.patch
+  ];
+
+  enableParallelBuilding = true;
+  strictDeps = true;
+
+  nativeBuildInputs = lib.optional enableManpages pandoc;
+  buildInputs = [ openssl ];
+
+  makeFlags = [ "DESTDIR=$(out)" "PREFIX=" ] ++ lib.optional enableShared "USE_SHARED_LIB=1";
+
+  doCheck = true;
+
+  installTargets = [ "install" ] ++ lib.optional enableManpages "install-man";
+
+  postInstall = ''
+    mkdir -p $lib
+    mv $out/lib $lib/lib
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.kernel.org/doc/html/latest/filesystems/fsverity.html#userspace-utility";
+    changelog = "https://git.kernel.org/pub/scm/linux/kernel/git/ebiggers/fsverity-utils.git/tree/NEWS.md";
+    description = "A set of userspace utilities for fs-verity";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jk ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/fsverity-utils/remove-dynamic-libs.patch
+++ b/pkgs/os-specific/linux/fsverity-utils/remove-dynamic-libs.patch
@@ -1,0 +1,27 @@
+diff --git a/Makefile b/Makefile
+index 2304a21..697ccd4 100644
+--- a/Makefile
++++ b/Makefile
+@@ -149,13 +149,11 @@ libfsverity.so.$(SOVERSION):$(SHARED_LIB_OBJ)
+ 	$(QUIET_CCLD) $(CC) -o $@ -Wl,-soname=$@ -shared $+ \
+ 		$(CFLAGS) $(LDFLAGS) $(LDLIBS)
+ 
+-DEFAULT_TARGETS += libfsverity.so.$(SOVERSION)
+ 
+ # Create the symlink libfsverity.so => libfsverity.so.$(SOVERSION)
+ libfsverity.so:libfsverity.so.$(SOVERSION)
+ 	$(QUIET_LN) ln -sf $+ $@
+ 
+-DEFAULT_TARGETS += libfsverity.so
+ 
+ ##############################################################################
+ 
+@@ -263,8 +261,6 @@ install:all
+ 	install -d $(DESTDIR)$(LIBDIR)/pkgconfig $(DESTDIR)$(INCDIR) $(DESTDIR)$(BINDIR)
+ 	install -m755 $(FSVERITY) $(DESTDIR)$(BINDIR)
+ 	install -m644 libfsverity.a $(DESTDIR)$(LIBDIR)
+-	install -m755 libfsverity.so.$(SOVERSION) $(DESTDIR)$(LIBDIR)
+-	ln -sf libfsverity.so.$(SOVERSION) $(DESTDIR)$(LIBDIR)/libfsverity.so
+ 	install -m644 include/libfsverity.h $(DESTDIR)$(INCDIR)
+ 	sed -e "s|@PREFIX@|$(PREFIX)|" \
+ 		-e "s|@LIBDIR@|$(LIBDIR)|" \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22950,6 +22950,8 @@ with pkgs;
   # unstable until the first 1.x release
   fscrypt-experimental = callPackage ../os-specific/linux/fscrypt { };
 
+  fsverity-utils = callPackage ../os-specific/linux/fsverity-utils { };
+
   fwanalyzer = callPackage ../tools/filesystems/fwanalyzer { };
 
   fwupd = callPackage ../os-specific/linux/firmware/fwupd { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Package fsverity-utils for nixos

<https://git.kernel.org/pub/scm/linux/kernel/git/ebiggers/fsverity-utils.git/tree/README.md>

<https://www.kernel.org/doc/html/latest/filesystems/fsverity.html#userspace-utility>

<https://repology.org/project/fsverity-utils/versions>

might help with: https://github.com/NixOS/nix/issues/4917
*edit:* corrected the link, the issue is in nix not nixpkgs repo

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
