### PR TITLE
sierra-gtk-theme: 2019-12-16 -> unstable-2021-05-24

### DIFF
--- a/pkgs/data/themes/sierra/default.nix
+++ b/pkgs/data/themes/sierra/default.nix
@@ -6,10 +6,22 @@
 , jdupes
 , librsvg
 , libxml2
+, buttonVariants ? [] # default to all
+, colorVariants ? [] # default to all
+, opacityVariants ? [] # default to all
+, sizeVariants ? [] # default to all
 }:
 
-stdenv.mkDerivation rec {
+let
   pname = "sierra-gtk-theme";
+in
+lib.checkListOfEnum "${pname}: button variants" [ "standard" "alt" ] buttonVariants
+lib.checkListOfEnum "${pname}: color variants" [ "light" "dark" ] colorVariants
+lib.checkListOfEnum "${pname}: opacity variants" [ "standard" "solid" ] opacityVariants
+lib.checkListOfEnum "${pname}: size variants" [ "standard" "compact" ] sizeVariants
+
+stdenv.mkDerivation {
+  inherit pname;
   version = "unstable-2021-05-24";
 
   src = fetchFromGitHub {
@@ -39,7 +51,11 @@ stdenv.mkDerivation rec {
     patchShebangs .
 
     mkdir -p $out/share/themes
-    name= ./install.sh --dest $out/share/themes
+    name= ./install.sh --dest $out/share/themes \
+      ${lib.optionalString (buttonVariants != []) "--alt " + builtins.toString buttonVariants} \
+      ${lib.optionalString (colorVariants != []) "--color " + builtins.toString colorVariants} \
+      ${lib.optionalString (opacityVariants != []) "--opacity " + builtins.toString opacityVariants} \
+      ${lib.optionalString (sizeVariants != []) "--flat " + builtins.toString sizeVariants}
 
     # Replace duplicate files with hardlinks to the first file in each
     # set of duplicates, reducing the installed size in about 79%

--- a/pkgs/data/themes/sierra/default.nix
+++ b/pkgs/data/themes/sierra/default.nix
@@ -32,9 +32,11 @@ stdenv.mkDerivation rec {
   ];
 
   installPhase = ''
+    runHook preInstall
     patchShebangs .
     mkdir -p $out/share/themes
     name= ./install.sh --dest $out/share/themes
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/themes/sierra/default.nix
+++ b/pkgs/data/themes/sierra/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "sierra-gtk-theme";
-  version = "2019-12-16";
+  version = "unstable-2021-05-24";
 
   src = fetchFromGitHub {
     owner = "vinceliuice";
     repo = pname;
-    rev = version;
-    sha256 = "14hlz8kbrjypyd6wyrwmnj2wm9w3kc8y00ms35ard7x8lmhs56hr";
+    rev = "05899001c4fc2fec87c4d222cb3997c414e0affd";
+    sha256 = "174l5mryc34ma1r42pk6572c6i9hmzr9vj1a6w06nqz5qcfm1hds";
   };
 
   nativeBuildInputs = [ libxml2 ];

--- a/pkgs/data/themes/sierra/default.nix
+++ b/pkgs/data/themes/sierra/default.nix
@@ -1,4 +1,11 @@
-{ lib, stdenv, fetchFromGitHub, libxml2, gdk-pixbuf, librsvg, gtk-engine-murrine }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, gdk-pixbuf
+, gtk-engine-murrine
+, librsvg
+, libxml2
+}:
 
 stdenv.mkDerivation rec {
   pname = "sierra-gtk-theme";
@@ -11,11 +18,18 @@ stdenv.mkDerivation rec {
     sha256 = "174l5mryc34ma1r42pk6572c6i9hmzr9vj1a6w06nqz5qcfm1hds";
   };
 
-  nativeBuildInputs = [ libxml2 ];
+  nativeBuildInputs = [
+    libxml2
+  ];
 
-  buildInputs = [ gdk-pixbuf librsvg ];
+  buildInputs = [
+    gdk-pixbuf
+    librsvg
+  ];
 
-  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+  propagatedUserEnvPkgs = [
+    gtk-engine-murrine
+  ];
 
   installPhase = ''
     patchShebangs .

--- a/pkgs/data/themes/sierra/default.nix
+++ b/pkgs/data/themes/sierra/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    patchShebangs .
+    patchShebangs install.sh
 
     mkdir -p $out/share/themes
     name= ./install.sh --dest $out/share/themes \

--- a/pkgs/data/themes/sierra/default.nix
+++ b/pkgs/data/themes/sierra/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , gdk-pixbuf
 , gtk-engine-murrine
+, jdupes
 , librsvg
 , libxml2
 }:
@@ -19,6 +20,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    jdupes
     libxml2
   ];
 
@@ -33,9 +35,16 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
+
     patchShebangs .
+
     mkdir -p $out/share/themes
     name= ./install.sh --dest $out/share/themes
+
+    # Replace duplicate files with hardlinks to the first file in each
+    # set of duplicates, reducing the installed size in about 79%
+    jdupes -L -r $out/share
+
     runHook postInstall
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- sierra-gtk-theme: 2019-12-16 -> [unstable-2021-05-24](https://github.com/vinceliuice/Sierra-gtk-theme/commits/master)
- sierra-gtk-theme: reformat
- sierra-gtk-theme: run hooks in installPhase
- sierra-gtk-theme: replace duplicate files with hardlinks
- sierra-gtk-theme: add optional arguments

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
