### PR TITLE
python310Packages.limiter: 0.1.2 -> 0.2.0

### DIFF
--- a/pkgs/development/python-modules/limiter/default.nix
+++ b/pkgs/development/python-modules/limiter/default.nix
@@ -7,15 +7,16 @@
 
 buildPythonPackage rec {
   pname = "limiter";
-  version = "0.1.2";
+  version = "0.2.0";
+  format = "setuptools";
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.10";
 
   src = fetchFromGitHub {
     owner = "alexdelorenzo";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0cdqw08qw3cid1yjknlh4hqfl46xh4madkjrl7sxk2c1pbwils8r";
+    hash = "sha256-h3XiCR/8rcCBwdhO6ExrrUE9piba5mssad3+t41scSk=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/spyse-python/default.nix
+++ b/pkgs/development/python-modules/spyse-python/default.nix
@@ -11,6 +11,7 @@
 buildPythonPackage rec {
   pname = "spyse-python";
   version = "2.2.3";
+  format = "setuptools";
 
   disabled = pythonOlder "3.8";
 
@@ -34,7 +35,8 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace setup.py \
       --replace "'dataclasses~=0.6'," "" \
-      --replace "responses~=0.13.3" "responses>=0.13.3"
+      --replace "responses~=0.13.3" "responses>=0.13.3" \
+      --replace "limiter~=0.1.2" "limiter>=0.1.2"
   '';
 
   pythonImportsCheck = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/alexdelorenzo/limiter/releases/tag/v0.2.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
