### PR TITLE
gofumpt: add tests

### DIFF
--- a/pkgs/development/tools/gofumpt/default.nix
+++ b/pkgs/development/tools/gofumpt/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, runCommand, gofumpt }:
 
 buildGoModule rec {
   pname = "gofumpt";
@@ -13,7 +13,22 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-RZPfdj+rimKGvRZKaXOirkd7ietri55rBofwa/l2z8s=";
 
-  doCheck = false;
+  # editorconfig-checker-disable
+  passthru.tests = {
+    simple = runCommand "gofumpt-test" { } ''
+      ${gofumpt}/bin/gofumpt > $out <<EOF
+      package main
+      import  "fmt" 
+
+      func main (    ){
+      fmt.  Println("Hello World!") 
+      }
+      EOF
+
+      [ "$(cat $out)" = "$(cat ${./hello.go})" ]
+    '';
+  };
+  # editorconfig-checker-enable
 
   meta = with lib; {
     description = "A stricter gofmt";

--- a/pkgs/development/tools/gofumpt/hello.go
+++ b/pkgs/development/tools/gofumpt/hello.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello World!")
+}


### PR DESCRIPTION
###### Motivation for this change
Followup to https://github.com/NixOS/nixpkgs/pull/154522


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
