### PR TITLE
JupyterHub module improvements

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -277,6 +277,27 @@
           follow with upstream changes.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          JupyterHub module (<literal>services.jupyterhub</literal>) has
+          been reworked to run the service as a non-root user. Default
+          spawner has been changed to <literal>SudoSpawner</literal>,
+          which shouldn’t break existing setups and user data but spawns
+          notebooks in a different way. <literal>jupyterhubEnv</literal>
+          and <literal>jupyterlabEnv</literal> have been removed in
+          favor of <literal>jupyterhubExtraPackages</literal> and
+          <literal>jupyterlabExtraPackages</literal>, which allow more
+          composability. The module now adds some packages to these
+          lists automatically depending on which spawners and
+          authenticators are used. We now also support
+          <literal>DockerSpawner</literal>, which doesn’t allow
+          declarative kernels but may be favored for cases when using
+          standard images and Conda packages is preferred. Finally,
+          <literal>stateDirectory</literal> option has been removed and
+          we now always use <literal>/var/lib/jupyterhub</literal> as
+          the state directory.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-22.05-notable-changes">

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -89,6 +89,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - `services.thelounge.private` was removed in favor of `services.thelounge.public`, to follow with upstream changes.
 
+- JupyterHub module (`services.jupyterhub`) has been reworked to run the service as a non-root user. Default spawner has been changed to `SudoSpawner`, which shouldn't break existing setups and user data but spawns notebooks in a different way. `jupyterhubEnv` and `jupyterlabEnv` have been removed in favor of `jupyterhubExtraPackages` and `jupyterlabExtraPackages`, which allow more composability. The module now adds some packages to these lists automatically depending on which spawners and authenticators are used. We now also support `DockerSpawner`, which doesn't allow declarative kernels but may be favored for cases when using standard images and Conda packages is preferred. Finally, `stateDirectory` option has been removed and we now always use `/var/lib/jupyterhub` as the state directory.
+
 ## Other Notable Changes {#sec-release-22.05-notable-changes}
 
 - The option [services.redis.servers](#opt-services.redis.servers) was added

--- a/nixos/modules/services/development/jupyterhub/default.nix
+++ b/nixos/modules/services/development/jupyterhub/default.nix
@@ -6,11 +6,57 @@ let
 
   cfg = config.services.jupyterhub;
 
-  kernels = (pkgs.jupyter-kernel.create  {
+  # https://github.com/jupyterhub/systemdspawner#root-access
+  runAsRoot = cfg.spawner == "systemdspawner.SystemdSpawner";
+  localProcess = elem cfg.spawner ["systemdspawner.SystemdSpawner" "sudospawner.SudoSpawner"];
+
+  kernels = (pkgs.jupyter-kernel.create {
     definitions = if cfg.kernels != null
       then cfg.kernels
       else  pkgs.jupyter-kernel.default;
   });
+
+  jupyterhubEnv = pkgs.python3.withPackages (p: [
+    p.jupyterhub
+  ] ++ optional (cfg.spawner == "sudospawner.SudoSpawner") p.sudospawner
+    ++ optional (cfg.spawner == "systemdspawner.SystemdSpawner") p.jupyterhub-systemdspawner
+    ++ optional (cfg.spawner == "dockerspawner.DockerSpawner") p.dockerspawner
+    ++ optional (hasPrefix "oauthenticator." cfg.authentication) p.oauthenticator
+    ++ cfg.jupyterhubExtraPackages p);
+
+  sudospawnerCmd = pkgs.stdenv.mkDerivation {
+    name = "sudospawner-with-runner";
+
+    nativeBuildInputs = [ pkgs.python3.pkgs.wrapPython ];
+    pythonPath = [ pkgs.python3.pkgs.sudospawner ];
+
+    buildCommand = ''
+      mkdir -p $out/bin
+
+      cat >$out/bin/jupyterhub-singleuser <<EOF
+      #!${pkgs.stdenv.shell}
+      export JUPYTER_PATH="${kernels}"
+      exec ${jupyterlabEnv}/bin/jupyterhub-singleuser "\$@"
+      EOF
+      chmod +x $out/bin/jupyterhub-singleuser
+
+      # sudospawner executes `jupyterhub-singleruser` binary from its directory.
+      # Make an executable here so that it calls our script.
+      cat >$out/bin/sudospawner <<EOF
+      #!${pkgs.python3.interpreter}
+      from sudospawner import mediator
+      mediator.main()
+      EOF
+      chmod +x $out/bin/sudospawner
+
+      wrapPythonProgramsIn $out/bin "$pythonPath"
+    '';
+  };
+
+  jupyterlabEnv = pkgs.python3.withPackages (p: [
+    p.jupyterhub
+    p.jupyterlab
+  ] ++ cfg.jupyterlabExtraPackages p);
 
   jupyterhubConfig = pkgs.writeText "jupyterhub_config.py" ''
     c.JupyterHub.bind_url = "http://${cfg.host}:${toString cfg.port}"
@@ -18,39 +64,108 @@ let
     c.JupyterHub.authenticator_class = "${cfg.authentication}"
     c.JupyterHub.spawner_class = "${cfg.spawner}"
 
-    c.SystemdSpawner.default_url = '/lab'
-    c.SystemdSpawner.cmd = "${cfg.jupyterlabEnv}/bin/jupyterhub-singleuser"
-    c.SystemdSpawner.environment = {
-      'JUPYTER_PATH': '${kernels}'
-    }
+    c.Spawner.default_url = '/lab'
+
+    ${optionalString (cfg.spawner == "sudospawner.SudoSpawner") ''
+      c.SudoSpawner.sudospawner_path = "${sudospawnerCmd}/bin/sudospawner";
+    ''}
+    ${optionalString (cfg.spawner == "systemdspawner.SystemdSpawner") ''
+      c.SystemdSpawner.cmd = "${jupyterlabEnv}/bin/jupyterhub-singleuser"
+      c.SystemdSpawner.environment = {
+        'JUPYTER_PATH': '${kernels}'
+      }
+    ''}
+    ${optionalString (cfg.spawner == "dockerspawner.DockerSpawner") ''
+      import socket
+      import fcntl
+      import struct
+      from pathlib import Path
+
+      # Make JupyterHub accessible from Docker containers.
+      def get_ip_address(ifname):
+          s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+          try:
+              return socket.inet_ntoa(fcntl.ioctl(
+                  s.fileno(),
+                  0x8915, # SIOCGIFADDR
+                  struct.pack(b'256s', ifname[:15].encode('ascii'))
+              )[20:24])
+          finally:
+              s.close()
+
+      c.JupyterHub.hub_ip = get_ip_address('docker0')
+
+      # Create user home directory.
+      def create_dir_hook(spawner):
+          user_home = Path('/var/lib/jupyterhub/user_data/') / spawner.escaped_name
+          if not user_home.exists():
+              user_home.mkdir()
+              shared_data = user_home / 'shared_data'
+              if not shared_data.exists():
+                shared_data.mkdir()
+
+      c.DockerSpawner.pre_spawn_hook = create_dir_hook
+
+      c.DockerSpawner.volumes = {
+        '/var/lib/jupyterhub/user_data/{username}': '/home/jovyan',
+        '/var/lib/jupyterhub/shared_envs': '/opt/conda/envs',
+        '/var/lib/jupyterhub/shared_config': '/usr/local/share/jupyter',
+        '/var/lib/jupyterhub/shared_data': '/home/jovyan/shared_data',
+      }
+    ''}
 
     ${cfg.extraConfig}
   '';
+
+  preStart = pkgs.writeScript "docker-pre-start" ''
+    #!${pkgs.stdenv.shell}
+
+    ${optionalString (cfg.spawner == "dockerspawner.DockerSpawner") ''
+      # Remove old images (so they are updated).
+      docker rm $(docker ps --filter status=exited --filter name=jupyter -q) || true
+
+      # Mounted directories need to have sticky group permission compatible with docker image users (uid 100).
+      install -d -o jupyterhub -g jupyterhub -m 775 /var/lib/jupyterhub/{user_data,shared_envs,shared_config,shared_data}
+      setfacl -d -m g:100:rwx /var/lib/jupyterhub/{user_data,shared_envs,shared_config,shared_data}
+      setfacl -m g:100:rwx /var/lib/jupyterhub/{user_data,shared_envs,shared_config,shared_data}
+    ''}
+  '';
+
 in {
   meta.maintainers = with maintainers; [ costrouc ];
 
   options.services.jupyterhub = {
-    enable = mkEnableOption "Jupyterhub development server";
+    enable = mkEnableOption "JupyterHub development server";
 
     authentication = mkOption {
       type = types.str;
       default = "jupyterhub.auth.PAMAuthenticator";
       description = ''
-        Jupyterhub authentication to use
+        JupyterHub authentication to use.
 
         There are many authenticators available including: oauth, pam,
         ldap, kerberos, etc.
+
+        We support <literal>jupyterhub.auth.PAMAuthenticator</literal> and
+        authenticators provided by <literal>oauthenticator</literal> package.
+        Other authenticators require adding necessary packages and possibly
+        extra configuration.
       '';
     };
 
     spawner = mkOption {
       type = types.str;
-      default = "systemdspawner.SystemdSpawner";
+      default = "sudospawner.SudoSpawner";
       description = ''
-        Jupyterhub spawner to use
+        JupyterHub spawner to use.
 
         There are many spawners available including: local process,
-        systemd, docker, kubernetes, yarn, batch, etc.
+        sudo, systemd, docker, kubernetes, yarn, batch, etc.
+
+        We support <literal>sudospawner</literal>,
+        <literal>systemdspawner</literal> and <literal>dockerspawner</literal>
+        spawners. Other spawners require adding necessary packages and possibly
+        extra configuration.
       '';
     };
 
@@ -58,13 +173,13 @@ in {
       type = types.lines;
       default = "";
       description = ''
-        Extra contents appended to the jupyterhub configuration
+        Extra contents appended to the JupyterHub configuration.
 
-        Jupyterhub configuration is a normal python file using
-        Traitlets. https://jupyterhub.readthedocs.io/en/stable/getting-started/config-basics.html. The
-        base configuration of this module was designed to have sane
-        defaults for configuration but you can override anything since
-        this is a python file.
+        JupyterHub configuration is a normal python file using
+        <link xlink:href="https://jupyterhub.readthedocs.io/en/stable/getting-started/config-basics.html">Traitlets</link>.
+        The base configuration of this module was designed to have sane
+        defaults for configuration but you can override anything since this is
+        a Python file.
       '';
       example = ''
         c.SystemdSpawner.mem_limit = '8G'
@@ -72,20 +187,18 @@ in {
       '';
     };
 
-    jupyterhubEnv = mkOption {
-      type = types.package;
-      default = pkgs.python3.withPackages (p: with p; [
-        jupyterhub
+    jupyterhubExtraPackages = mkOption {
+      type = types.functionTo (types.listOf types.package);
+      default = p: with p; [
         jupyterhub-systemdspawner
-      ]);
+      ];
       defaultText = literalExpression ''
-        pkgs.python3.withPackages (p: with p; [
-          jupyterhub
+        p: with p; [
           jupyterhub-systemdspawner
-        ])
+        ]
       '';
       description = ''
-        Python environment to run jupyterhub
+        Extra Python packages in JupyterHub environment.
 
         Customizing will affect the packages available in the hub and
         proxy. This will allow packages to be available for the
@@ -94,26 +207,21 @@ in {
       '';
     };
 
-    jupyterlabEnv = mkOption {
-      type = types.package;
-      default = pkgs.python3.withPackages (p: with p; [
-        jupyterhub
-        jupyterlab
-      ]);
-      defaultText = literalExpression ''
-        pkgs.python3.withPackages (p: with p; [
-          jupyterhub
-          jupyterlab
-        ])
-      '';
+    jupyterlabExtraPackages = mkOption {
+      type = types.functionTo (types.listOf types.package);
+      default = p: [];
+      defaultText = literalExpression "p: with p; []";
       description = ''
-        Python environment to run jupyterlab
+        Extra Python packages in JupyterLab environment.
 
         Customizing will affect the packages available in the
-        jupyterlab server and the default kernel provided. This is the
+        JupyterLab server and the default kernel provided. This is the
         way to customize the jupyterlab extensions and jupyter
         notebook extensions. This will not normally need to
         be changed.
+
+        This has no effect if a non-local process spawner is used, such as
+        Docker spawner.
       '';
     };
 
@@ -147,12 +255,14 @@ in {
         }
       '';
       description = ''
-        Declarative kernel config
+        Declarative kernel configuration.
 
         Kernels can be declared in any language that supports and has
         the required dependencies to communicate with a jupyter server.
         In python's case, it means that ipykernel package must always be
         included in the list of packages of the targeted environment.
+
+        This has no effect if a non-default spawner is used.
       '';
     };
 
@@ -160,7 +270,7 @@ in {
       type = types.port;
       default = 8000;
       description = ''
-        Port number Jupyterhub will be listening on
+        Port number JupyterHub will be listening on.
       '';
     };
 
@@ -168,35 +278,71 @@ in {
       type = types.str;
       default = "0.0.0.0";
       description = ''
-        Bind IP JupyterHub will be listening on
-      '';
-    };
-
-    stateDirectory = mkOption {
-      type = types.str;
-      default = "jupyterhub";
-      description = ''
-        Directory for jupyterhub state (token + database)
+        Bind IP JupyterHub will be listening on.
       '';
     };
   };
 
-  config = mkMerge [
-    (mkIf cfg.enable  {
-      systemd.services.jupyterhub = {
-        description = "Jupyterhub development server";
-
-        after = [ "network.target" ];
-        wantedBy = [ "multi-user.target" ];
-
-        serviceConfig = {
-          Restart = "always";
-          ExecStart = "${cfg.jupyterhubEnv}/bin/jupyterhub --config ${jupyterhubConfig}";
-          User = "root";
-          StateDirectory = cfg.stateDirectory;
-          WorkingDirectory = "/var/lib/${cfg.stateDirectory}";
-        };
-      };
-    })
+  imports = [
+    (mkRemovedOptionModule [ "services" "jupyterhub" "jupyterhubEnv" ] ''
+      Please use `services.jupyterhub.jupyterhubExtraPackages` instead!
+    '')
+    (mkRemovedOptionModule [ "services" "jupyterhub" "jupyterlabEnv" ] ''
+      Please use `services.jupyterhub.jupyterlabExtraPackages` instead!
+    '')
+    (mkRemovedOptionModule [ "services" "jupyterhub" "stateDirectory" ] ''
+      `/var/lib/jupyterlab` is always used as the state directory now.
+    '')
   ];
+
+  config = mkIf cfg.enable {
+    systemd.services.jupyterhub = {
+      description = "JupyterHub development server";
+
+      after = [ "network.target" ] ++ optional (cfg.spawner == "dockerspawner.DockerSpawner") "docker.service";
+      wantedBy = [ "multi-user.target" ];
+
+      path =
+        optional (cfg.spawner == "sudospawner.SudoSpawner") "/run/wrappers"
+        ++ optionals (cfg.spawner == "dockerspawner.DockerSpawner") [
+          pkgs.acl
+          pkgs.docker
+        ];
+
+      serviceConfig = {
+        Restart = "always";
+        ExecStart = "${jupyterhubEnv}/bin/jupyterhub --config ${jupyterhubConfig}";
+        ExecStartPre = "+${preStart}";
+        User = mkIf (!runAsRoot) "jupyterhub";
+        Group = mkIf (!runAsRoot) "jupyterhub";
+        StateDirectory = "jupyterhub";
+        WorkingDirectory = "/var/lib/jupyterhub";
+      };
+    };
+
+    security.sudo = mkIf (cfg.spawner == "sudospawner.SudoSpawner") {
+      enable = true;
+      extraConfig = ''
+        Cmnd_Alias JUPYTER_CMD = ${sudospawnerCmd}/bin/sudospawner
+        jupyterhub ALL=(%users) NOPASSWD:JUPYTER_CMD
+      '';
+    };
+
+    virtualisation.docker = mkIf (cfg.spawner == "dockerspawner.DockerSpawner") {
+      enable = true;
+      # Needed to get interface IP address.
+      enableOnBoot = true;
+    };
+
+    users.users.jupyterhub = mkIf (!runAsRoot) {
+      extraGroups =
+        optional (cfg.authentication == "jupyterhub.auth.PAMAuthenticator") "shadow"
+        ++ optional (cfg.spawner == "dockerspawner.DockerSpawner") "docker";
+      group = "jupyterhub";
+      home = "/var/lib/jupyterhub";
+      isSystemUser = true;
+    };
+
+    users.groups.jupyterhub = mkIf (!runAsRoot) {};
+  };
 }

--- a/pkgs/development/python-modules/sudospawner/default.nix
+++ b/pkgs/development/python-modules/sudospawner/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, jupyterhub
+, notebook
+, escapism
+}:
+
+buildPythonPackage rec {
+  pname = "sudospawner";
+  version = "0.5.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5dbddd8164e05e4bb3a31eeb1a5baf5a5c6268f1cd14b3f063cde609b8bfbbe1";
+  };
+
+  propagatedBuildInputs = [
+    jupyterhub
+    escapism
+    notebook
+  ];
+
+  # tests require sudo
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Spawner for JupyterHub using sudo";
+    homepage = "https://jupyter.org";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.abbradar ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9407,6 +9407,8 @@ in {
 
   subzerod = callPackage ../development/python-modules/subzerod { };
 
+  sudospawner = callPackage ../development/python-modules/sudospawner { };
+
   suds-jurko = callPackage ../development/python-modules/suds-jurko { };
 
   sumo = callPackage ../development/python-modules/sumo { };


### PR DESCRIPTION
The aim of these improvements is to make JupyterHub more secure, support
more spawners (including Docker) and make it more smart for common use
cases.

* Change the default spawner from SystemdSpawner to SudoSpawner. This
allows us to run jupyterhub as non-root user, which should greatly
improve overall security. The only binary that is run with elevated user
privileges is `sudospawner`, which (hopefully) only allows limited
number of operations, such as spawning kernels for different users.
SystemdSpawner is still supported and can be chosen using the
configuration option. In this case jupyterhub is run as root user. No
user data migration is needed, only the method itself of spawning singleuser
notebooks is different.
* Add support for DockerSpawner, using as foundation excellent [work](https://github.com/acelpb/acelpb/blob/e538241d6f1ec81b63274f3dd14448ea599c8cb3/modules/jupyterhub.nix)
by @acelpb. Extra features include hub IP address detection, creation of home and shared
data directories and periodic cleanup of images so that they are kept up
to date.
* Automatically include needed Python packages and configuration for
some spawners and authentication modules. To make that possible we
deprecate `jupyter{lab,hub}Env` options in favor of more composable
`jupyter{lab,hub}ExtraPackages`.
* Drop `stateDirectory` option as possible gains from it (IMO) don't
justify increased module complexity.
* Small style changes.

We also update, add and fix several packages to get all this working.

###### Motivation for this change

Merge our custom JupyterHub module and @acelpb's work into mainline NixOS one with additional improvements.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
