### PR TITLE
nixos/kresd: add RFC 42 style .settings [experimental]

### DIFF
--- a/nixos/modules/services/networking/kresd.nix
+++ b/nixos/modules/services/networking/kresd.nix
@@ -2,6 +2,13 @@
 let
   cfg = config.services.kresd;
 
+  # TODO: partial override of defaults doesn't work,
+  # but perhaps it will be OK as empty anyway?
+  settings_default = { };
+
+  withManager = true;
+  manager = pkgs.knot-resolver-manager;
+
   # Convert systemd-style address specification to kresd config line(s).
   # On Nix level we don't attempt to precisely validate the address specifications.
   # The optional IPv6 scope spec comes *after* port, perhaps surprisingly.
@@ -20,13 +27,31 @@ let
         net.listen(${addrSpec}, ${port}, { kind = '${kind}', freebind = true })
       '';
 
-  configFile = pkgs.writeText "kresd.conf" (
-    ""
-    + lib.concatMapStrings (mkListen "dns") cfg.listenPlain
-    + lib.concatMapStrings (mkListen "tls") cfg.listenTLS
-    + lib.concatMapStrings (mkListen "doh2") cfg.listenDoH
-    + cfg.extraConfig
-  );
+    json-oneline = pkgs.writeTextFile {
+      name = "kresd-oneline.json";
+      text = builtins.toJSON cfg.settings;
+    };
+    # - use jq to get a pretty JSON
+    # - then validate it, so that most errors get found during OS build (not activation)
+    json = pkgs.runCommandLocal "kresd.json" {} ''
+      '${pkgs.jq}/bin/jq' < '${json-oneline}' > "$out"
+      '${manager}/bin/kresctl' validate --no-strict "$out"
+    '';
+    #*/
+
+  configFile = if cfg.settings == settings_default
+    then pkgs.writeText "kresd.lua" (
+      ""
+      + lib.concatMapStrings (mkListen "dns") cfg.listenPlain
+      + lib.concatMapStrings (mkListen "tls") cfg.listenTLS
+      + lib.concatMapStrings (mkListen "doh2") cfg.listenDoH
+      + cfg.extraConfig
+    )
+    else let
+      checks = cfg.extraConfig == ""; # FIXME: cfg.instances + cfg.listen*
+      in assert checks; pkgs.runCommandLocal "kresd.lua" {} ''
+        ${manager}/bin/kresctl convert --no-strict '${json}' "$out"
+      '';
 in {
   meta.maintainers = [ lib.maintainers.vcunat /* upstream developer */ ];
 
@@ -56,6 +81,22 @@ in {
     };
     package = lib.mkPackageOption pkgs "knot-resolver" {
       example = "knot-resolver.override { extraFeatures = true; }";
+    };
+    settings = lib.mkOption { # see RFC 42
+      type = lib.types.submodule { # TODO: avoid regeneration of docs on config changes
+        freeformType = (pkgs.formats.yaml {}).type;
+      };
+      default = settings_default;
+      description = ''
+        Highly experimental!!!
+        Nix-based (RFC 42) configuration for Knot Resolver.
+
+        FIXME many issues, e.g.:
+         - old listen{Plain,TLS,DoH} config gets silently ignored
+
+        <link xlink:href="https://example.com/docs/foo"/>
+        for supported values.
+      '';
     };
     extraConfig = lib.mkOption {
       type = lib.types.lines;
@@ -100,12 +141,13 @@ in {
         You can dynamically start/stop them at will, so this is just system default.
       '';
     };
-    # TODO: perhaps options for more common stuff like cache size or forwarding
+    # TODO: option to create tmpfs for cache?  (It's bad for disk on a busy resolver.)
   };
 
   ###### implementation
   config = lib.mkIf cfg.enable {
-    environment.etc."knot-resolver/kresd.conf".source = configFile; # not required
+    environment.etc."knot-resolver/kresd.lua".source = configFile; # not required
+    environment.etc."knot-resolver/kresd.json".source = json; # not required
 
     networking.resolvconf.useLocalResolver = lib.mkDefault true;
 
@@ -116,16 +158,25 @@ in {
       };
     users.groups.knot-resolver.gid = null;
 
-    systemd.packages = [ cfg.package ]; # the units are patched inside the package a bit
+    #FIXME: ?conditionalize, reuse upstream unit & clean up, etc.
+    systemd.services.knot-resolver.wantedBy = [ "multi-user.target" ]; # TODO: more
+    systemd.services.knot-resolver.path = [ (lib.getBin cfg.package) ];
+    systemd.services.knot-resolver.serviceConfig = {
+      ExecStart = "${manager}/bin/knot-resolver --config=${json}";
+      Environment = "KRES_LOGGING_TARGET=syslog";
+      # Actually, it's unclear whether reloading will really be useful,
+      # but why not fix it anyway.  (We'd need to recognize config-only changes.)
+      ExecReload = "${manager}/bin/kresctl reload --config=${json}";
 
-    systemd.targets.kresd = { # configure units started by default
-      wantedBy = [ "multi-user.target" ];
-      wants = [ "kres-cache-gc.service" ]
-        ++ map (i: "kresd@${toString i}.service") (lib.range 1 cfg.instances);
-    };
-    systemd.services."kresd@".serviceConfig = {
-      ExecStart = "${cfg.package}/bin/kresd --noninteractive "
-        + "-c ${cfg.package}/lib/knot-resolver/distro-preconfig.lua -c ${configFile}";
+      Type = "notify";
+      TimeoutStartSec = "10s";
+      KillSignal = "SIGINT";
+      WorkingDirectory = "/run/knot-resolver";
+      User = "knot-resolver";
+      Group = "knot-resolver";
+      CapabilityBoundingSet = "CAP_NET_BIND_SERVICE CAP_SETPCAP";
+      AmbientCapabilities   = "CAP_NET_BIND_SERVICE CAP_SETPCAP";
+
       # Ensure /run/knot-resolver exists
       RuntimeDirectory = "knot-resolver";
       RuntimeDirectoryMode = "0770";
@@ -137,6 +188,18 @@ in {
       CacheDirectoryMode = "0770";
     };
     # We don't mind running stop phase from wrong version.  It seems less racy.
-    systemd.services."kresd@".stopIfChanged = false;
+    systemd.services.knot-resolver.stopIfChanged = false;
+
+
+    # TODO: also install shell completions, maybe man pages, etc.
+    environment.systemPackages = [
+      (pkgs.runCommandLocal "knot-resolver-cmds"
+        { nativeBuildInputs = [ pkgs.makeWrapper ]; }
+        # Wrapping, as config might've changed the location of the management socket.
+        ''
+          makeWrapper '${manager}/bin/kresctl' "$out/bin/kresctl" \
+            --add-flags --config=${json}
+        '')
+    ];
   };
 }

--- a/nixos/modules/services/networking/kresd.nix
+++ b/nixos/modules/services/networking/kresd.nix
@@ -88,14 +88,13 @@ in {
       };
       default = settings_default;
       description = ''
-        Highly experimental!!!
-        Nix-based (RFC 42) configuration for Knot Resolver.
+        Nix-based (RFC 42) configuration for Knot Resolver 6.x.
 
         FIXME many issues, e.g.:
          - old listen{Plain,TLS,DoH} config gets silently ignored
 
-        <link xlink:href="https://example.com/docs/foo"/>
-        for supported values.
+        For configuration reference (described as YAML) see
+        <https://www.knot-resolver.cz/documentation/latest/config-overview.html>
       '';
     };
     extraConfig = lib.mkOption {

--- a/pkgs/servers/dns/knot-resolver/manager.nix
+++ b/pkgs/servers/dns/knot-resolver/manager.nix
@@ -1,0 +1,44 @@
+{ lib, knot-resolver, writeText, python3 }:
+
+with python3.pkgs;
+
+buildPythonPackage rec {
+  pname = "knot-resolver";
+  inherit (knot-resolver) version src;
+
+  patches = [
+      # Rewrap the two supervisor's binaries, so that they obtain access to python modules
+      # defined in the manager.  Those are then used as extensions of supervisord.
+      # Manager needs this fixed bin/supervisord on its $PATH.
+      (writeText "rewrap-supervisor.patch" ''
+        --- a/setup.py
+        +++ b/setup.py
+        @@ -30,2 +30,4 @@
+         {'console_scripts': ['knot-resolver = knot_resolver.manager.main:main',
+        +                     'supervisord = supervisor.supervisord:main',
+        +                     'supervisorctl = supervisor.supervisorctl:main',
+                              'kresctl = knot_resolver.client.main:main']}
+      '')
+  ];
+
+  # Propagate meson config from the C part to the python part.
+  postPatch = ''
+    cp '${knot-resolver.config_py}'/knot_resolver/constants.py ./python/knot_resolver/constants.py
+  '';
+
+  # Deps can be seen in ./manager/pyproject.toml
+  propagatedBuildInputs = [
+    aiohttp
+    jinja2
+    pyyaml
+    prometheus-client
+    supervisor
+  ];
+
+  doCheck = false; # FIXME
+  checkInputs = [ pytestCheckHook pytest-asyncio pyparsing ];
+
+  meta = with lib; { #FIXME
+    maintainers = [ maintainers.vcunat /* upstream developer */ ];
+  };
+}

--- a/pkgs/servers/dns/knot-resolver/manager.nix
+++ b/pkgs/servers/dns/knot-resolver/manager.nix
@@ -1,24 +1,27 @@
-{ lib, knot-resolver, writeText, python3 }:
+{
+  lib,
+  knot-resolver,
+  writeText,
+  python3Packages,
+}:
 
-with python3.pkgs;
-
-buildPythonPackage rec {
+python3Packages.buildPythonPackage {
   pname = "knot-resolver";
   inherit (knot-resolver) version src;
 
   patches = [
-      # Rewrap the two supervisor's binaries, so that they obtain access to python modules
-      # defined in the manager.  Those are then used as extensions of supervisord.
-      # Manager needs this fixed bin/supervisord on its $PATH.
-      (writeText "rewrap-supervisor.patch" ''
-        --- a/setup.py
-        +++ b/setup.py
-        @@ -30,2 +30,4 @@
-         {'console_scripts': ['knot-resolver = knot_resolver.manager.main:main',
-        +                     'supervisord = supervisor.supervisord:main',
-        +                     'supervisorctl = supervisor.supervisorctl:main',
-                              'kresctl = knot_resolver.client.main:main']}
-      '')
+    # Rewrap the two supervisor's binaries, so that they obtain access to python modules
+    # defined in the manager.  Those are then used as extensions of supervisord.
+    # Manager needs this fixed bin/supervisord on its $PATH.
+    (writeText "rewrap-supervisor.patch" ''
+      --- a/setup.py
+      +++ b/setup.py
+      @@ -30,2 +30,4 @@
+       {'console_scripts': ['knot-resolver = knot_resolver.manager.main:main',
+      +                     'supervisord = supervisor.supervisord:main',
+      +                     'supervisorctl = supervisor.supervisorctl:main',
+                            'kresctl = knot_resolver.client.main:main']}
+    '')
   ];
 
   # Propagate meson config from the C part to the python part.
@@ -26,8 +29,8 @@ buildPythonPackage rec {
     cp '${knot-resolver.config_py}'/knot_resolver/constants.py ./python/knot_resolver/constants.py
   '';
 
-  # Deps can be seen in ./manager/pyproject.toml
-  propagatedBuildInputs = [
+  # Deps can be seen in ${src}/pyproject.toml
+  propagatedBuildInputs = with python3Packages; [
     aiohttp
     jinja2
     pyyaml
@@ -36,9 +39,9 @@ buildPythonPackage rec {
   ];
 
   doCheck = false; # FIXME
-  checkInputs = [ pytestCheckHook pytest-asyncio pyparsing ];
+  checkInputs = with python3Packages; [ pytestCheckHook pytest-asyncio pyparsing ];
 
-  meta = with lib; { #FIXME
-    maintainers = [ maintainers.vcunat /* upstream developer */ ];
+  meta = knot-resolver.meta // {
+    mainProgram = "knot-resolver";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24696,6 +24696,7 @@ with pkgs;
   knot-resolver = callPackage ../servers/dns/knot-resolver {
     systemd = systemdMinimal; # in closure already anyway
   };
+  knot-resolver-manager = callPackage ../servers/dns/knot-resolver/manager.nix { };
 
   rdkafka = callPackage ../development/libraries/rdkafka { };
 


### PR DESCRIPTION
This is a WIP on integrating [Knot Resolver 6.x](https://www.knot-resolver.cz/documentation/latest/upgrading-to-6.html) into NixOS.  It brings huge changes, mainly to configuration.

_If you're interested, let me know here or in another way.  I can refresh this PR, etc._
- Upstream Knot Resolver 6.x uses configuration model that is YAML/JSON-based.
- In NixOS it's natural to supply nix-written `settings` attr-tree, as it naturally converts to JSON, which is a subset of YAML.
- The (future) upstream tool is used to thoroughly type-check the config in advance (during `nixos-rebuild`).