### PR TITLE
faraday-agent-dispatcher: init at 2.1.3

### DIFF
--- a/pkgs/tools/security/faraday-agent-dispatcher/default.nix
+++ b/pkgs/tools/security/faraday-agent-dispatcher/default.nix
@@ -1,0 +1,69 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "faraday-agent-dispatcher";
+  version = "2.1.3";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "infobyte";
+    repo = "faraday_agent_dispatcher";
+    rev = version;
+    hash = "sha256-lqCW1/wRXfN7C9c6TPvninueOgrhzNdjRJ9fuueMyH0=";
+  };
+
+  nativeBuildInputs = with python3.pkgs; [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    aiohttp
+    click
+    faraday-agent-parameters-types
+    faraday-plugins
+    itsdangerous
+    python-gvm
+    python-owasp-zap-v2-4
+    pyyaml
+    requests
+    syslog-rfc5424-formatter
+    websockets
+  ];
+
+  checkInputs = with python3.pkgs; [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace '"pytest-runner",' ""
+  '';
+
+  preCheck = ''
+    export HOME=$(mktemp -d);
+  '';
+
+  disabledTests = [
+    "test_execute_agent"
+  ];
+
+  disabledTestPaths = [
+    # Tests require a running Docker instance
+    "tests/plugins-docker/test_executors.py"
+  ];
+
+  pythonImportsCheck = [
+    "faraday_agent_dispatcher"
+  ];
+
+  meta = with lib; {
+    description = "Tool to send result from tools to the Faraday Platform";
+    homepage = "https://github.com/infobyte/faraday_agent_dispatcher";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5335,6 +5335,8 @@ with pkgs;
 
   fabric-installer = callPackage ../tools/games/minecraft/fabric-installer { };
 
+  faraday-agent-dispatcher = callPackage ../tools/security/faraday-agent-dispatcher { };
+
   faraday-cli = callPackage ../tools/security/faraday-cli { };
 
   fastlane = callPackage ../tools/admin/fastlane { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Tool to send result from tools to the Faraday Platform

https://github.com/infobyte/faraday_agent_dispatcher

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
