### PR TITLE
firefox_decrypt: init at unstable-2021-12-29

### DIFF
--- a/pkgs/tools/security/firefox_decrypt/default.nix
+++ b/pkgs/tools/security/firefox_decrypt/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, fetchFromGitHub
+, stdenvNoCC
+, nss
+, wrapPython
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "firefox_decrypt";
+  version = "unstable-2021-12-29";
+
+  src = fetchFromGitHub {
+    owner = "unode";
+    repo = pname;
+    rev = "a3daadc09603a6cf8c4b7e49a59776340bc885e7";
+    sha256 = "0g219zqbdnhh9j09d9a0b81vr6j44zzk13ckl5fzkr10gqndiscc";
+  };
+
+  nativeBuildInputs = [ wrapPython ];
+
+  buildInputs = [ nss ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm 0755 firefox_decrypt.py "$out/bin/firefox_decrypt"
+
+    runHook postInstall
+  '';
+
+  makeWrapperArgs = [ "--prefix" "LD_LIBRARY_PATH" ":" (lib.makeLibraryPath [ nss ]) ];
+
+  postFixup = ''
+    wrapPythonPrograms
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = with lib; {
+    homepage = "https://github.com/unode/firefox_decrypt";
+    description = "A tool to extract passwords from profiles of Mozilla Firefox and derivates";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ schnusch ];
+  };
+}

--- a/pkgs/tools/security/firefox_decrypt/update.sh
+++ b/pkgs/tools/security/firefox_decrypt/update.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p common-updater-scripts git jq nix nix-prefetch-git
+git_url='https://github.com/unode/firefox_decrypt.git'
+git_branch='master'
+git_dir='/var/tmp/firefox_decrypt.git'
+nix_file="$(dirname "${BASH_SOURCE[0]}")/default.nix"
+pkg='firefox_decrypt'
+
+set -euo pipefail
+
+info() {
+    if [ -t 2 ]; then
+        set -- '\033[32m%s\033[39m\n' "$@"
+    else
+        set -- '%s\n' "$@"
+    fi
+    printf "$@" >&2
+}
+
+old_rev=$(nix-instantiate --eval --strict --json -A "$pkg.src.rev" | jq -r)
+old_version=$(nix-instantiate --eval --strict --json -A "$pkg.version" | jq -r)
+today=$(LANG=C date -u +'%Y-%m-%d')
+
+info "fetching $git_url..."
+if [ ! -d "$git_dir" ]; then
+    git init --initial-branch="$git_branch" "$git_dir"
+    git -C "$git_dir" remote add origin "$git_url"
+fi
+git -C "$git_dir" fetch origin "$git_branch"
+
+# use latest commit before today, we should not call the version *today*
+# because there might still be commits coming
+# use the day of the latest commit we picked as version
+new_rev=$(git -C "$git_dir" log -n 1 --format='format:%H' --before="${today}T00:00:00Z" "origin/$git_branch")
+new_version="unstable-$(git -C "$git_dir" log -n 1 --format='format:%cs' "$new_rev")"
+info "latest commit before $today: $new_rev"
+
+if [ "$new_rev" = "$old_rev" ]; then
+    info "$pkg is up-to-date."
+    exit
+fi
+
+new_sha256=$(nix-prefetch-git --rev "$new_rev" "$git_dir" | jq -r .sha256)
+update-source-version "$pkg" \
+    "$new_version" \
+    "$new_sha256" \
+    --rev="$new_rev"
+git add "$nix_file"
+git commit --verbose --message "$pkg: $old_version -> $new_version"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24070,6 +24070,8 @@ in
     desktopName = "Firefox DevEdition";
   };
 
+  firefox_decrypt = python3Packages.callPackage ../tools/security/firefox_decrypt { };
+
   flac = callPackage ../applications/audio/flac { };
 
   redoflacs = callPackage ../applications/audio/redoflacs { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

A tool to extract passwords from profiles of Mozilla Firefox and derivates.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
