### PR TITLE
photon-rss: init at unstable-2022-01-11

### DIFF
--- a/pkgs/applications/networking/feedreaders/photon/default.nix
+++ b/pkgs/applications/networking/feedreaders/photon/default.nix
@@ -1,0 +1,27 @@
+{ buildGoModule, fetchFromSourcehut, lib, xorg }:
+
+buildGoModule rec {
+  pname = "photon";
+  version = "unstable-2022-01-11";
+
+  src = fetchFromSourcehut {
+    owner = "~ghost08";
+    repo = "photon";
+    rev = "5d1f7dd8d0d526096886b03c7bc0ef56cbdd6d79";
+    sha256 = "sha256-2RSGLWfthcChd5YhDSBfLSch6wuTUv1Sh1f7flgzQwc=";
+  };
+
+  buildInputs = [ xorg.libX11 ];
+
+  proxyVendor = true;
+
+  vendorSha256 = "sha256-MLNgaxxvPGRzBEWRuKTDskl0J2IVushW11E5prpYsE4=";
+
+  meta = with lib; {
+    description = "RSS/Atom reader with the focus on speed, usability and a bit of unix philosophy";
+    homepage = "https://sr.ht/~ghost08/photon";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ kmein ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8699,6 +8699,8 @@ with pkgs;
 
   phodav = callPackage ../tools/networking/phodav { };
 
+  photon-rss = callPackage ../applications/networking/feedreaders/photon { };
+
   pim6sd = callPackage ../servers/pim6sd { };
 
   phosh = callPackage ../applications/window-managers/phosh { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
