### PR TITLE
nixops: fix

### DIFF
--- a/pkgs/development/python-modules/iso8601/0.nix
+++ b/pkgs/development/python-modules/iso8601/0.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "iso8601";
+  version = "0.1.16";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-NlMvd8yABZTo8WZB7a5/G695MvBdjlCFRblfxTxtyFs=";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "iso8601" ];
+
+  pythonImportsCheck = [ "iso8601" ];
+
+  meta = with lib; {
+    description = "Simple module to parse ISO 8601 dates";
+    homepage = "https://pyiso8601.readthedocs.io/";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-forked/1.3.nix
+++ b/pkgs/development/python-modules/pytest-forked/1.3.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools-scm
+, py
+, pytest
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-forked";
+  version = "1.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "6aa9ac7e00ad1a539c41bec6d21011332de671e938c7637378ec9710204e37ca";
+  };
+
+  nativeBuildInputs = [ setuptools-scm ];
+
+  buildInputs = [
+    pytest
+  ];
+
+  propagatedBuildInputs = [
+    py
+  ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  meta = {
+    description = "Run tests in isolated forked subprocesses";
+    homepage = "https://github.com/pytest-dev/pytest-forked";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-timeout/1.nix
+++ b/pkgs/development/python-modules/pytest-timeout/1.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, pytestCheckHook
+, pexpect
+, pytest-cov
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-timeout";
+  version = "1.4.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0xnsigs0kmpq1za0d4i522sp3f71x5bgpdh3ski0rs74yqy13cr0";
+  };
+
+  buildInputs = [ pytest ];
+
+  checkInputs = [ pytestCheckHook pexpect pytest-cov ];
+
+  disabledTests = [
+    "test_suppresses_timeout_when_pdb_is_entered"
+    # Remove until https://github.com/pytest-dev/pytest/pull/7207 or similar
+    "test_suppresses_timeout_when_debugger_is_entered"
+  ];
+  pytestFlagsArray = [
+    "-ra"
+  ];
+
+  meta = with lib; {
+    description = "py.test plugin to abort hanging tests";
+    homepage = "https://github.com/pytest-dev/pytest-timeout/";
+    changelog = "https://github.com/pytest-dev/pytest-timeout/#changelog";
+    license = licenses.mit;
+    maintainers = with maintainers; [ makefu costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-timeout/default.nix
+++ b/pkgs/development/python-modules/pytest-timeout/default.nix
@@ -1,5 +1,6 @@
 { lib
 , buildPythonPackage
+, pythonOlder
 , fetchPypi
 , pytest
 , pytestCheckHook
@@ -11,6 +12,8 @@ buildPythonPackage rec {
   pname = "pytest-timeout";
   version = "2.0.1";
   format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/pyyaml/5.nix
+++ b/pkgs/development/python-modules/pyyaml/5.nix
@@ -1,0 +1,42 @@
+
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, cython
+, libyaml
+, isPy27
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "PyYAML";
+  version = "5.4.1.1";
+
+  src = fetchFromGitHub {
+    owner = "yaml";
+    repo = "pyyaml";
+    rev = version;
+    sha256 = "1v386gzdvsjg0mgix6v03rd0cgs9dl81qvn3m547849jm8r41dx8";
+  };
+
+  nativeBuildInputs = [ cython ];
+
+  buildInputs = [ libyaml ];
+
+  checkPhase = let
+    testdir = if isPy27 then "tests/lib" else "tests/lib3";
+  in ''
+    runHook preCheck
+    PYTHONPATH="${testdir}:$PYTHONPATH" ${python.interpreter} -m test_all
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [ "yaml" ];
+
+  meta = with lib; {
+    description = "The next generation YAML parser and emitter for Python";
+    homepage = "https://github.com/yaml/pyyaml";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -124,6 +124,8 @@ with self; with super; {
 
   pytest-runner = callPackage ../development/python-modules/pytest-runner/2.nix { };
 
+  pytest-timeout = callPackage ../development/python-modules/pytest-timeout/1.nix { };
+
   pytest-xdist = callPackage ../development/python-modules/pytest-xdist/1.nix { };
 
   pyyaml = callPackage ../development/python-modules/pyyaml/5.nix { };

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -118,6 +118,8 @@ with self; with super; {
 
   pytest = pytest_4;
 
+  pytest-forked = callPackage ../development/python-modules/pytest-forked/1.3.nix { };
+
   pytest-runner = callPackage ../development/python-modules/pytest-runner/2.nix { };
 
   pytest-xdist = callPackage ../development/python-modules/pytest-xdist/1.nix { };

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -126,6 +126,8 @@ with self; with super; {
 
   pytest-xdist = callPackage ../development/python-modules/pytest-xdist/1.nix { };
 
+  pyyaml = callPackage ../development/python-modules/pyyaml/5.nix { };
+
   qpid-python = callPackage ../development/python-modules/qpid-python { };
 
   recoll = disabled super.recoll;

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -52,6 +52,8 @@ with self; with super; {
 
   ipaddr = callPackage ../development/python-modules/ipaddr { };
 
+  iso8601 = callPackage ../development/python-modules/iso8601/0.nix { };
+
   itsdangerous = callPackage ../development/python-modules/itsdangerous/1.nix { };
 
   jinja2 = callPackage ../development/python-modules/jinja2/2.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @NixOS/nixops-committers 