### PR TITLE
[staging] python3Packages.funcsigs: disable tests, avoid unittest2

### DIFF
--- a/pkgs/development/python-modules/funcsigs/default.nix
+++ b/pkgs/development/python-modules/funcsigs/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchPypi
-, isPyPy, isPy3k, unittest2
+, isPyPy, isPy3k
 }:
 
 buildPythonPackage rec {
@@ -11,10 +11,13 @@ buildPythonPackage rec {
     sha256 = "0l4g5818ffyfmfs1a924811azhjj8ax9xd1cffr1mzd3ycn0zfx7";
   };
 
-  buildInputs = [ unittest2 ];
-
   # https://github.com/testing-cabal/funcsigs/issues/10
   patches = lib.optional (isPyPy && isPy3k) [ ./fix-pypy3-tests.patch ];
+
+  # requires, unittest2 and package hasn't been maintained since 2013
+  doCheck = false;
+
+  pythonImportsCheck = [ "funcsigs" ];
 
   meta = with lib; {
     description = "Python function signatures from PEP362 for Python 2.6, 2.7 and 3.2+";


### PR DESCRIPTION
###### Motivation for this change
unittest2 is no longer compatible with python 3.10, and unmaintained.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
