### PR TITLE
python310Packages.deprecations: fix tests

### DIFF
--- a/pkgs/development/python-modules/deprecation/default.nix
+++ b/pkgs/development/python-modules/deprecation/default.nix
@@ -1,4 +1,11 @@
-{ lib, buildPythonPackage, fetchPypi, python, packaging, unittest2 }:
+{ lib, buildPythonPackage, fetchPypi
+, fetchpatch
+, packaging
+, python
+, pythonAtLeast
+, pythonOlder
+, unittest2
+}:
 
 buildPythonPackage rec {
   pname = "deprecation";
@@ -9,9 +16,22 @@ buildPythonPackage rec {
     sha256 = "1zqqjlgmhgkpzg9ss5ki8wamxl83xn51fs6gn2a8cxsx9vkbvcvj";
   };
 
+  patches = lib.optionals (pythonAtLeast "3.10") [
+    # fixes for python 3.10 test suite
+    (fetchpatch {
+      url = "https://github.com/briancurtin/deprecation/pull/57/commits/e13e23068cb8d653a02a434a159e8b0b7226ffd6.patch";
+      sha256 = "sha256-/5zr2V1s5ULUZnbLXsgyHxZH4m7/a27QYuqQt2Savc8=";
+      includes = [ "tests/test_deprecation.py" ];
+    })
+  ];
+
   propagatedBuildInputs = [ packaging ];
 
-  checkInputs = [ unittest2 ];
+  # avoiding mass rebuilds for python3.9, but no longer
+  # needed with patch
+  checkInputs = lib.optional (pythonOlder "3.10") [
+    unittest2
+  ];
 
   checkPhase = ''
     ${python.interpreter} -m unittest discover


### PR DESCRIPTION
###### Motivation for this change
related: https://github.com/briancurtin/deprecation/pull/57

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
