### PR TITLE
buildDotnetModule: wrap executables in preFixup

### DIFF
--- a/doc/languages-frameworks/dotnet.section.md
+++ b/doc/languages-frameworks/dotnet.section.md
@@ -84,7 +84,7 @@ To package Dotnet applications, you can use `buildDotnetModule`. This has simila
      <ProjectReference Include="../foo/bar.fsproj" />
      <PackageReference Include="bar" Version="*" Condition=" '$(ContinuousIntegrationBuild)'=='true' "/>
   ```
-* `executables` is used to specify which executables get wrapped to `$out/bin`, relative to `$out/lib/$pname`. If this is unset, all executables generated will get installed. If you do not want to install any, set this to `[]`.
+* `executables` is used to specify which executables get wrapped to `$out/bin`, relative to `$out/lib/$pname`. If this is unset, all executables generated will get installed. If you do not want to install any, set this to `[]`. This gets done in the `preFixup` phase.
 * `runtimeDeps` is used to wrap libraries into `LD_LIBRARY_PATH`. This is how dotnet usually handles runtime dependencies.
 * `buildType` is used to change the type of build. Possible values are `Release`, `Debug`, etc. By default, this is set to `Release`.
 * `dotnet-sdk` is useful in cases where you need to change what dotnet SDK is being used.

--- a/pkgs/applications/blockchains/btcpayserver/default.nix
+++ b/pkgs/applications/blockchains/btcpayserver/default.nix
@@ -26,7 +26,7 @@ buildDotnetModule rec {
     makeWrapperArgs+=(--run "cd $out/lib/btcpayserver")
   '';
 
-  postInstall = ''
+  postFixup = ''
     mv $out/bin/{BTCPayServer,btcpayserver}
   '';
 

--- a/pkgs/applications/blockchains/nbxplorer/default.nix
+++ b/pkgs/applications/blockchains/nbxplorer/default.nix
@@ -17,7 +17,7 @@ buildDotnetModule rec {
   dotnet-sdk = dotnetCorePackages.sdk_3_1;
   dotnet-runtime = dotnetCorePackages.aspnetcore_3_1;
 
-  postInstall = ''
+  postFixup = ''
     mv $out/bin/{NBXplorer,nbxplorer}
   '';
 

--- a/pkgs/applications/blockchains/wasabibackend/default.nix
+++ b/pkgs/applications/blockchains/wasabibackend/default.nix
@@ -36,7 +36,7 @@ buildDotnetModule rec {
     )
   '';
 
-  postInstall = ''
+  postFixup = ''
     mv $out/bin/WalletWasabi.Backend $out/bin/WasabiBackend
   '';
 

--- a/pkgs/applications/graphics/pinta/default.nix
+++ b/pkgs/applications/graphics/pinta/default.nix
@@ -19,6 +19,7 @@ buildDotnetModule rec {
   ];
 
   runtimeDeps = [ gtk3 ];
+  buildInputs = runtimeDeps;
 
   dotnet-sdk = dotnetCorePackages.sdk_6_0;
   dotnet-runtime = dotnetCorePackages.runtime_6_0;
@@ -39,16 +40,7 @@ buildDotnetModule rec {
     sha256 = "sha256-iOKJPB2bI/GjeDxzG7r6ew7SGIzgrJTcRXhEYzOpC9k=";
   };
 
-  # FIXME: this should be propagated by wrapGAppsHook already, however for some
-  # reason it is not working. Maybe a bug in buildDotnetModule?
-  preInstall = ''
-    gappsWrapperArgs+=(
-      --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}"
-      --set GDK_PIXBUF_MODULE_FILE ${librsvg}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache
-    )
-  '';
-
-  postInstall = ''
+  postFixup = ''
     # Rename the binary
     mv $out/bin/Pinta $out/bin/pinta
 
@@ -76,12 +68,12 @@ buildDotnetModule rec {
       --replace _Keywords Keywords
   '';
 
-  meta = {
+  meta = with lib; {
     homepage = "https://www.pinta-project.com/";
     description = "Drawing/editing program modeled after Paint.NET";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ thiagokokada ];
-    platforms = with lib.platforms; linux;
+    license = licenses.mit;
+    maintainers = with maintainers; [ thiagokokada ];
+    platforms = with platforms; linux;
     mainProgram = "pinta";
   };
 }

--- a/pkgs/misc/emulators/ryujinx/default.nix
+++ b/pkgs/misc/emulators/ryujinx/default.nix
@@ -1,7 +1,7 @@
 { lib, buildDotnetModule, fetchFromGitHub, makeDesktopItem, copyDesktopItems
 , libX11, libgdiplus, ffmpeg
 , SDL2_mixer, openal, libsoundio, sndio, pulseaudio
-, gtk3, gobject-introspection, gdk-pixbuf, wrapGAppsHook
+, gtk3, gdk-pixbuf, wrapGAppsHook
 }:
 
 buildDotnetModule rec {
@@ -27,7 +27,10 @@ buildDotnetModule rec {
   nativeBuildInputs = [
     copyDesktopItems
     wrapGAppsHook
-    gobject-introspection
+  ];
+
+  buildInputs = [
+    gtk3
     gdk-pixbuf
   ];
 
@@ -78,6 +81,7 @@ buildDotnetModule rec {
     changelog = "https://github.com/Ryujinx/Ryujinx/wiki/Changelog";
     maintainers = [ maintainers.ivar ];
     platforms = [ "x86_64-linux" ];
+    mainProgram = "Ryujinx";
   };
   passthru.updateScript = ./updater.sh;
 }

--- a/pkgs/tools/X11/opentabletdriver/default.nix
+++ b/pkgs/tools/X11/opentabletdriver/default.nix
@@ -68,7 +68,7 @@ buildDotnetModule rec {
     "OpenTabletDriver.Tests.PluginRepositoryTest.ExpandRepositoryTarball"
   ];
 
-  postInstall = ''
+  postFixup = ''
     # Give a more "*nix" name to the binaries
     mv $out/bin/OpenTabletDriver.Console $out/bin/otd
     mv $out/bin/OpenTabletDriver.Daemon $out/bin/otd-daemon

--- a/pkgs/tools/games/opentracker/default.nix
+++ b/pkgs/tools/games/opentracker/default.nix
@@ -41,6 +41,7 @@ buildDotnetModule rec {
   buildInputs = [
     stdenv.cc.cc.lib
     fontconfig
+    gtk3
   ];
 
   runtimeDeps = [
@@ -58,5 +59,6 @@ buildDotnetModule rec {
     homepage = "https://github.com/trippsc2/OpenTracker";
     license = licenses.mit;
     maintainers = [ maintainers.ivar ];
+    mainProgram = "OpenTracker";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Not doing this used to break `wrapGAppsHook` because `gappsWrapperArgs` was used before it was set, as pointed out in #153364. 

###### Things done
We need `gtk3` in `buildInputs`, not just in `runtimeDeps` so I've switched over all packages using GTK. We can also no longer use `postInstall` to move binaries, as they do not exist in `$out/bin` at that point.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
