### PR TITLE
tuigreet: 0.6.1 -> 0.7.1

### DIFF
--- a/pkgs/os-specific/linux/tuigreet/default.nix
+++ b/pkgs/os-specific/linux/tuigreet/default.nix
@@ -5,22 +5,22 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "tuigreet";
-  version = "0.6.1";
+  version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "apognu";
     repo = pname;
     rev = version;
-    sha256 = "sha256-Exw3HPNFh1yiUfDfaIDiz2PemnVLRmefD4ydgMiHQAc=";
+    sha256 = "sha256-Ecp79q/xN6KDAD346ANzunTM3xW+z5UaRy/lblOCLaE=";
   };
 
-  cargoSha256 = "sha256-/JNGyAEZlb4YilsoXtaXekXNVev6sdVxS4pEcPFh7Bg=";
+  cargoSha256 = "sha256-eam+85c2y+eNSOlfhO7oIhGqy0HPyi3FuqxHBDkZRVE=";
 
   meta = with lib; {
     description = "Graphical console greter for greetd";
     homepage = "https://github.com/apognu/tuigreet";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ luc65r ];
+    maintainers = with maintainers; [ luc65r ivar ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION

###### Motivation for this change
Works as expected on my machine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
