### PR TITLE
pinsel: init at unstable-2021-09-13

### DIFF
--- a/pkgs/tools/misc/pinsel/default.nix
+++ b/pkgs/tools/misc/pinsel/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, gtk3, lua, glib }:
+
+stdenv.mkDerivation rec {
+  pname = "pinsel";
+  version = "unstable-2021-09-13";
+
+  src = fetchFromGitHub {
+    owner = "Nooo37";
+    repo = pname;
+    rev = "24b0205ca041511b3efb2a75ef296539442f9f54";
+    sha256 = "sha256-w+jiKypZODsmZq3uWGNd8PZhe1SowHj0thcQTX8WHfQ=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config glib ];
+
+  buildInputs = [ lua gtk3 ];
+
+  makeFlags = [ "INSTALLDIR=${placeholder "out"}/bin" ];
+
+  preInstall = ''
+    mkdir -p $out/bin
+  '';
+
+  meta = with lib; {
+    description = "Minimal screenshot annotation tool with lua config";
+    homepage = "https://github.com/Nooo37/pinsel";
+    # no license
+    license = licenses.unfree;
+    maintainers = with maintainers; [ lom ];
+    mainProgram = "pinsel";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8720,6 +8720,8 @@ with pkgs;
 
   pinnwand = callPackage ../servers/pinnwand { };
 
+  pinsel = callPackage ../tools/misc/pinsel { };
+
   piping-server-rust = callPackage ../servers/piping-server-rust {
     inherit (darwin.apple_sdk.frameworks) CoreServices Security;
   };


### PR DESCRIPTION
###### Motivation for this change

Program seems to be a bit crashy, when you press the wrong buttons (unrelated to nix though). But otherwise seems to work fine.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
