### PR TITLE
craftos-pc: 2.4.5 -> 2.6.4

### DIFF
--- a/pkgs/misc/emulators/craftos-pc/default.nix
+++ b/pkgs/misc/emulators/craftos-pc/default.nix
@@ -1,33 +1,34 @@
 { lib, stdenv, fetchFromGitHub, poco, openssl, SDL2, SDL2_mixer, ncurses, libpng
-, libharu, ApplicationServices, pngpp, libX11, Cocoa, xlibsWrapper }:
+, libharu, ApplicationServices, pngpp, libX11, Cocoa, xlibsWrapper, Carbon }:
 
-let
-  craftos2-lua = fetchFromGitHub {
-    owner = "MCJack123";
-    repo = "craftos2-lua";
-    rev = "v2.6";
-    sha256 = "sha256-82PAxwt50zGLul/HJ9Z1KUFd83F7hPVO8J70tdzYHy4=";
-  };
-in
+# let
+
+#   craftos2-lua = fetchFromGitHub {
+#     owner = "MCJack123";
+#     repo = "craftos2-lua";
+#     rev = "v${version}";
+#     sha256 = "sha256-82PAxwt00zGLul/HJ9Z1KUFd83F7hPVO8J70tdzYHy4=";
+#   };
+# in
 
 stdenv.mkDerivation rec {
   pname = "craftos-pc";
-  version = "2.6";
+  version = "2.6.4";
 
   src = fetchFromGitHub {
     owner = "MCJack123";
     repo = "craftos2";
     rev = "v${version}";
-    sha256 = "sha256-x3SBZwpgcTUOCJBck+dkPmN94T3xoRPIo3c5EYIZ8iQ=";
+    sha256 = "sha256-VICaTvDcZ29OwfHq+ubt4yASo3aj6QSE4XSzJAQlDuc=";
+    fetchSubmodules = true;
   };
 
+  
   buildInputs = [ poco openssl SDL2 SDL2_mixer ncurses libpng libharu pngpp libX11 xlibsWrapper ]
-     ++ lib.optionals stdenv.isDarwin [ ApplicationServices Cocoa ];
+     ++ lib.optionals stdenv.isDarwin [ ApplicationServices Cocoa Carbon ];
 
   preBuild = ''
-    cp -R ${craftos2-lua}/* ./craftos2-lua/
-    chmod -R u+w ./craftos2-lua
-    make -C craftos2-lua ${if stdenv.isLinux then "linux" else "macosx"}
+    make -j $NIX_BUILD_CORES -C craftos2-lua ${if stdenv.isLinux then "linux" else "macosx${lib.optionalString stdenv.isAarch64 "-arm"}"}
   '';
 
   installPhase = ''

--- a/pkgs/misc/emulators/craftos-pc/default.nix
+++ b/pkgs/misc/emulators/craftos-pc/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, poco, openssl, SDL2, SDL2_mixer, ncurses, libpng
-, libharu, ApplicationServices, pngpp, libX11, Cocoa }:
+, libharu, ApplicationServices, pngpp, libX11, Cocoa, xlibsWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "craftos-pc";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  buildInputs = [ poco openssl SDL2 SDL2_mixer ncurses libpng libharu pngpp libX11 ]
+  buildInputs = [ poco openssl SDL2 SDL2_mixer ncurses libpng libharu pngpp libX11 xlibsWrapper ]
      ++ lib.optionals stdenv.isDarwin [ ApplicationServices Cocoa ];
 
   preBuild = ''

--- a/pkgs/misc/emulators/craftos-pc/default.nix
+++ b/pkgs/misc/emulators/craftos-pc/default.nix
@@ -1,31 +1,23 @@
-{ lib, stdenv, fetchFromGitHub, poco, openssl, SDL2, SDL2_mixer }:
-
-let
-  craftos2-lua = fetchFromGitHub {
-    owner = "MCJack123";
-    repo = "craftos2-lua";
-    rev = "v2.4.4";
-    sha256 = "1q63ki4sxx8bxaa6ag3xj153p7a8a12ivm0k33k935p41k6y2k64";
-  };
-in
+{ lib, stdenv, fetchFromGitHub, poco, openssl, SDL2, SDL2_mixer, ncurses, libpng
+, libharu, ApplicationServices, pngpp, libX11, Cocoa }:
 
 stdenv.mkDerivation rec {
   pname = "craftos-pc";
-  version = "2.4.5";
+  version = "2.6";
 
   src = fetchFromGitHub {
     owner = "MCJack123";
     repo = "craftos2";
     rev = "v${version}";
-    sha256 = "00a4p365krbdprlv4979d13mm3alhxgzzj3vqz2g67795plf64j4";
+    sha256 = "sha256-ml3RkZb4YGNGyJJkHW3wLRp1Rzpeb0tEJ0jS1Rmmzns=";
+    fetchSubmodules = true;
   };
 
-  buildInputs = [ poco openssl SDL2 SDL2_mixer ];
+  buildInputs = [ poco openssl SDL2 SDL2_mixer ncurses libpng libharu pngpp libX11 ]
+     ++ lib.optionals stdenv.isDarwin [ ApplicationServices Cocoa ];
 
   preBuild = ''
-    cp -R ${craftos2-lua}/* ./craftos2-lua/
-    chmod -R u+w ./craftos2-lua
-    make -C craftos2-lua linux
+    make -C craftos2-lua ${if stdenv.isLinux then "linux" else "macosx"}
   '';
 
   installPhase = ''
@@ -37,7 +29,7 @@ stdenv.mkDerivation rec {
     description = "An implementation of the CraftOS-PC API written in C++ using SDL";
     homepage = "https://www.craftos-pc.cc";
     license = licenses.mit;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = [ maintainers.siraben ];
   };
 }

--- a/pkgs/misc/emulators/craftos-pc/default.nix
+++ b/pkgs/misc/emulators/craftos-pc/default.nix
@@ -1,6 +1,15 @@
 { lib, stdenv, fetchFromGitHub, poco, openssl, SDL2, SDL2_mixer, ncurses, libpng
 , libharu, ApplicationServices, pngpp, libX11, Cocoa, xlibsWrapper }:
 
+let
+  craftos2-lua = fetchFromGitHub {
+    owner = "MCJack123";
+    repo = "craftos2-lua";
+    rev = "v2.6";
+    sha256 = "sha256-82PAxwt50zGLul/HJ9Z1KUFd83F7hPVO8J70tdzYHy4=";
+  };
+in
+
 stdenv.mkDerivation rec {
   pname = "craftos-pc";
   version = "2.6";
@@ -9,14 +18,15 @@ stdenv.mkDerivation rec {
     owner = "MCJack123";
     repo = "craftos2";
     rev = "v${version}";
-    sha256 = "sha256-ml3RkZb4YGNGyJJkHW3wLRp1Rzpeb0tEJ0jS1Rmmzns=";
-    fetchSubmodules = true;
+    sha256 = "sha256-x3SBZwpgcTUOCJBck+dkPmN94T3xoRPIo3c5EYIZ8iQ=";
   };
 
   buildInputs = [ poco openssl SDL2 SDL2_mixer ncurses libpng libharu pngpp libX11 xlibsWrapper ]
      ++ lib.optionals stdenv.isDarwin [ ApplicationServices Cocoa ];
 
   preBuild = ''
+    cp -R ${craftos2-lua}/* ./craftos2-lua/
+    chmod -R u+w ./craftos2-lua
     make -C craftos2-lua ${if stdenv.isLinux then "linux" else "macosx"}
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2464,7 +2464,7 @@ with pkgs;
   };
 
   craftos-pc = callPackage ../misc/emulators/craftos-pc {
-    inherit (darwin.apple_sdk.frameworks) ApplicationServices Cocoa;
+    inherit (darwin.apple_sdk.frameworks) ApplicationServices Cocoa Carbon;
   };
 
   gcdemu = callPackage ../misc/emulators/cdemu/gui.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2463,7 +2463,9 @@ with pkgs;
     gflags = null; # only required for examples/tests
   };
 
-  craftos-pc = callPackage ../misc/emulators/craftos-pc { };
+  craftos-pc = callPackage ../misc/emulators/craftos-pc {
+    inherit (darwin.apple_sdk.frameworks) ApplicationServices Cocoa;
+  };
 
   gcdemu = callPackage ../misc/emulators/cdemu/gui.nix { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Looking for help with a build failure on x86_64-darwin http://ix.io/3LWi @NixOS/darwin-maintainers 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
