### PR TITLE
gnomeExtensions.volume-mixer: add override to fix extension

### DIFF
--- a/pkgs/desktops/gnome/extensions/extensionOverrides.nix
+++ b/pkgs/desktops/gnome/extensions/extensionOverrides.nix
@@ -3,10 +3,13 @@
 , gjs
 , gnome
 , gobject-introspection
-, xprop
+, pulseaudio
+, python3
+, substituteAll
 , touchegg
 , vte
 , wrapGAppsHook
+, xprop
 }:
 let
   # Helper method to reduce redundancy
@@ -60,6 +63,18 @@ super: lib.trivial.pipe super [
         substituteInPlace $file --replace "gjs" "${gjs}/bin/gjs"
       done
     '';
+  }))
+
+  (patchExtension "shell-volume-mixer@derhofbauer.at" (old: {
+    patches = [
+      (substituteAll {
+        src = ./extensionOverridesPatches/shell-volume-mixer_at_derhofbauer.at.patch;
+        inherit pulseaudio;
+        inherit python3;
+      })
+    ];
+
+    meta.maintainers = with lib.maintainers; [ rhoriguchi ];
   }))
 
   (patchExtension "unite@hardpixel.eu" (old: {

--- a/pkgs/desktops/gnome/extensions/extensionOverridesPatches/shell-volume-mixer_at_derhofbauer.at.patch
+++ b/pkgs/desktops/gnome/extensions/extensionOverridesPatches/shell-volume-mixer_at_derhofbauer.at.patch
@@ -1,0 +1,32 @@
+diff --git a/lib/utils/paHelper.js b/lib/utils/paHelper.js
+index be28d21..a410a63 100755
+--- a/lib/utils/paHelper.js
++++ b/lib/utils/paHelper.js
+@@ -57,13 +57,7 @@ async function execHelper(type, index = undefined) {
+         return null;
+     }
+
+-    const python = await findPython();
+-
+-    if (!python) {
+-        return null;
+-    }
+-
+-    const args = ['/usr/bin/env', python, paUtilPath, type];
++    const args = ['@python3@/bin/python', paUtilPath, type];
+
+     if (!isNaN(index)) {
+         args.push(index);
+diff --git a/pautils/lib/libpulse.py b/pautils/lib/libpulse.py
+index a32c272..8225f2f 100755
+--- a/pautils/lib/libpulse.py
++++ b/pautils/lib/libpulse.py
+@@ -16,7 +16,7 @@
+ from ctypes import *
+
+ try:
+-    lib = CDLL('libpulse.so.0')
++    lib = CDLL('@pulseaudio@/lib/libpulse.so.0')
+ except:
+     lib = CDLL('libpulse.so')
+


### PR DESCRIPTION
###### Motivation for this change

This extension assumes python is under `/usr/bin/env`. Also, there's no easy way to add `pulseaudio` to `LD_LIBRARY_PATH` without wrapping python.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
