### PR TITLE
fcitx5-unikey: init at 5.0.7

### DIFF
--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-unikey.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-unikey.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchFromGitHub, cmake, extra-cmake-modules, fcitx5, fcitx5-qt
-, ninja, gettext, qt5 }:
+, ninja, gettext, wrapQtAppsHook
+}:
 
 stdenv.mkDerivation rec {
   pname = "fcitx5-unikey";
@@ -12,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "BFIqMmjIC29Z4rATZEf+qQWrULU9Wkuk6WOUXDEPO10=";
   };
 
-  nativeBuildInputs = [ cmake extra-cmake-modules qt5.wrapQtAppsHook ];
+  nativeBuildInputs = [ cmake extra-cmake-modules wrapQtAppsHook ];
 
   buildInputs = [ fcitx5 fcitx5-qt ninja gettext ];
 

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-unikey.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-unikey.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, fetchFromGitHub, cmake, extra-cmake-modules, fcitx5, fcitx5-qt
+, ninja, gettext, qt5 }:
+
+stdenv.mkDerivation rec {
+  pname = "fcitx5-unikey";
+  version = "5.0.7";
+
+  src = fetchFromGitHub {
+    owner = "fcitx";
+    repo = "fcitx5-unikey";
+    rev = version;
+    sha256 = "BFIqMmjIC29Z4rATZEf+qQWrULU9Wkuk6WOUXDEPO10=";
+  };
+
+  nativeBuildInputs = [ cmake extra-cmake-modules qt5.wrapQtAppsHook ];
+
+  buildInputs = [ fcitx5 fcitx5-qt ninja gettext ];
+
+  meta = with lib; {
+    description = "Unikey engine support for Fcitx5";
+    homepage = "https://github.com/fcitx/fcitx5-unikey";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ berberman ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5220,6 +5220,8 @@ with pkgs;
     };
   };
 
+  fcitx5-unikey = libsForQt5.callPackage ../tools/inputmethods/fcitx5/fcitx5-unikey.nix { };
+
   fcitx5-configtool = libsForQt5.callPackage ../tools/inputmethods/fcitx5/fcitx5-configtool.nix { };
 
   fcitx5-lua = callPackage ../tools/inputmethods/fcitx5/fcitx5-lua.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fcitx 5 support for Unikey, a Vietnamese input method

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
