### PR TITLE
poetry2nix: 1.24.1 -> 1.26.0

### DIFF
--- a/pkgs/development/tools/poetry2nix/poetry2nix/fetch_from_legacy.py
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/fetch_from_legacy.py
@@ -63,30 +63,36 @@ context.verify_mode = ssl.CERT_NONE
 req = urllib.request.Request(index_url)
 if username and password:
     import base64
-    password_b64 = base64.b64encode(bytes(f"{username}:{password}", "utf-8")).decode("utf-8")
-    req.add_header("Authorization", f"Basic {password_b64}")
-response = urllib.request.urlopen(
-    req,
-    context=context)
+
+    password_b64 = base64.b64encode(":".join((username, password)).encode()).decode(
+        "utf-8"
+    )
+    req.add_header("Authorization", "Basic {}".format(password_b64))
+response = urllib.request.urlopen(req, context=context)
 index = response.read()
 
 parser = Pep503()
 parser.feed(str(index))
 if package_filename not in parser.sources:
-    print("The file %s has not be found in the index %s" % (
-        package_filename, index_url))
+    print(
+        "The file %s has not be found in the index %s" % (package_filename, index_url)
+    )
     exit(1)
 
 package_file = open(package_filename, "wb")
 # Sometimes the href is a relative path
-if urlparse(parser.sources[package_filename]).netloc == '':
+if urlparse(parser.sources[package_filename]).netloc == "":
     parsed_url = urlparse(index_url)
-    package_url = urlunparse((
-        parsed_url.scheme,
-        parsed_url.netloc,
-        parser.sources[package_filename],
-        None, None, None,
-    ))
+    package_url = urlunparse(
+        (
+            parsed_url.scheme,
+            parsed_url.netloc,
+            parsed_url.path + "/" + parser.sources[package_filename],
+            None,
+            None,
+            None,
+        )
+    )
 else:
     package_url = parser.sources[package_filename]
 
@@ -106,10 +112,8 @@ print("Downloading %s" % real_package_url)
 
 req = urllib.request.Request(real_package_url)
 if username and password:
-    req.add_unredirected_header("Authorization", f"Basic {password_b64}")
-response = urllib.request.urlopen(
-    req,
-    context=context)
+    req.add_unredirected_header("Authorization", "Basic {}".format(password_b64))
+response = urllib.request.urlopen(req, context=context)
 
 with response as r:
     shutil.copyfileobj(r, package_file)

--- a/pkgs/development/tools/poetry2nix/poetry2nix/hooks/pyproject-without-special-deps.py
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/hooks/pyproject-without-special-deps.py
@@ -22,7 +22,12 @@ def main(input, output, fields_to_remove):
                 if any_removed:
                     dep["version"] = "*"
 
-    json.dump(data, output, separators=(",", ":"))
+    # Set ensure_ascii to False because TOML is valid UTF-8 so text that can't
+    # be represented in ASCII is perfectly legitimate
+    # HACK: Setting ensure_asscii to False breaks Python2 for some dependencies (like cachy==0.3.0)
+    json.dump(
+        data, output, separators=(",", ":"), ensure_ascii=sys.version_info.major < 3
+    )
 
 
 if __name__ == "__main__":

--- a/pkgs/development/tools/poetry2nix/poetry2nix/pep425.nix
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/pep425.nix
@@ -84,7 +84,13 @@ let
             )
           else
             (x: x.platform == "any")
-        else (x: hasInfix "macosx" x.platform || x.platform == "any");
+        else
+          if stdenv.isDarwin
+          then
+            if stdenv.targetPlatform.isAarch64
+            then (x: x.platform == "any" || (hasInfix "macosx" x.platform && lib.lists.any (e: hasSuffix e x.platform) [ "arm64" "aarch64" ]))
+            else (x: x.platform == "any" || (hasInfix "macosx" x.platform && hasSuffix "x86_64" x.platform))
+          else (x: x.platform == "any");
       filterWheel = x:
         let
           f = toWheelAttrs x.file;
@@ -93,7 +99,7 @@ let
       filtered = builtins.filter filterWheel filesWithoutSources;
       choose = files:
         let
-          osxMatches = [ "10_12" "10_11" "10_10" "10_9" "10_8" "10_7" "any" ];
+          osxMatches = [ "12_0" "11_0" "10_12" "10_11" "10_10" "10_9" "10_8" "10_7" "any" ];
           linuxMatches = [ "manylinux1_" "manylinux2010_" "manylinux2014_" "any" ];
           chooseLinux = x: lib.take 1 (findBestMatches linuxMatches x);
           chooseOSX = x: lib.take 1 (findBestMatches osxMatches x);


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
