### PR TITLE
signal-cli: 0.9.2 -> 0.10.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signal-cli/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-cli/default.nix
@@ -1,13 +1,13 @@
-{ stdenv, lib, fetchurl, makeWrapper, openjdk11_headless, libmatthew_java, dbus, dbus_java }:
+{ stdenv, lib, fetchurl, makeWrapper, openjdk17_headless, libmatthew_java, dbus, dbus_java }:
 
 stdenv.mkDerivation rec {
   pname = "signal-cli";
-  version = "0.9.2";
+  version = "0.10.0";
 
   # Building from source would be preferred, but is much more involved.
   src = fetchurl {
     url = "https://github.com/AsamK/signal-cli/releases/download/v${version}/signal-cli-${version}.tar.gz";
-    sha256 = "sha256-CumrIlOPmvQ3x7Ua5I2G7ZlTSAbhLgAQMPUg4I5WCeQ=";
+    sha256 = "sha256-2JofDCq9HsF+2DO5wzObzAALbJmJ9HJgmuuSJQDu1vY=";
   };
 
   buildInputs = lib.optionals stdenv.isLinux [ libmatthew_java dbus dbus_java ];
@@ -18,15 +18,15 @@ stdenv.mkDerivation rec {
     cp -r lib $out/lib
     cp bin/signal-cli $out/bin/signal-cli
   '' + (if stdenv.isLinux then ''
-    makeWrapper ${openjdk11_headless}/bin/java $out/bin/signal-cli \
-      --set JAVA_HOME "${openjdk11_headless}" \
+    makeWrapper ${openjdk17_headless}/bin/java $out/bin/signal-cli \
+      --set JAVA_HOME "${openjdk17_headless}" \
       --add-flags "-classpath '$out/lib/*:${libmatthew_java}/lib/jni'" \
       --add-flags "-Djava.library.path=${libmatthew_java}/lib/jni:${dbus_java}/share/java/dbus:$out/lib" \
       --add-flags "org.asamk.signal.Main"
   '' else ''
     wrapProgram $out/bin/signal-cli \
-      --prefix PATH : ${lib.makeBinPath [ openjdk11_headless ]} \
-      --set JAVA_HOME ${openjdk11_headless}
+      --prefix PATH : ${lib.makeBinPath [ openjdk17_headless ]} \
+      --set JAVA_HOME ${openjdk17_headless}
   '');
 
   # Execution in the macOS (10.13) sandbox fails with


### PR DESCRIPTION
###### Motivation for this change

https://github.com/AsamK/signal-cli/blob/master/CHANGELOG.md#0100---2021-12-11

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

On NixOS 21.11, I tested `register`, `verify`, `receive`, and sending messages in both CLI and user dbus mode.

cc @erictapen 