### PR TITLE
python310Packages.APScheduler: disable failing tests

### DIFF
--- a/pkgs/development/python-modules/APScheduler/default.nix
+++ b/pkgs/development/python-modules/APScheduler/default.nix
@@ -2,55 +2,51 @@
 , stdenv
 , buildPythonPackage
 , fetchPypi
-, setuptools-scm
-, pytestCheckHook
+, gevent
 , pytest-asyncio
 , pytest-tornado
-, sqlalchemy
+, pytestCheckHook
+, pythonOlder
+, pytz
+, setuptools
+, setuptools-scm
+, six
 , tornado
 , twisted
-, mock
-, gevent
-, six
-, pytz
 , tzlocal
-, funcsigs
-, setuptools
-, pythonOlder
 }:
 
 buildPythonPackage rec {
-  pname = "APScheduler";
+  pname = "apscheduler";
   version = "3.8.1";
+  format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "5cf344ebcfbdaa48ae178c029c055cec7bc7a4a47c21e315e4d1f08bd35f2355";
+    pname = "APScheduler";
+    inherit version;
+    hash = "sha256-XPNE68+9qkiuF4wCnAVc7HvHpKR8IeMV5NHwi9NfI1U=";
   };
 
   buildInputs = [
     setuptools-scm
   ];
 
+  propagatedBuildInputs = [
+    pytz
+    setuptools
+    six
+    tzlocal
+  ];
+
   checkInputs = [
+    gevent
     pytest-asyncio
     pytest-tornado
     pytestCheckHook
-    sqlalchemy
     tornado
     twisted
-    mock
-    gevent
-  ];
-
-  propagatedBuildInputs = [
-    six
-    pytz
-    tzlocal
-    funcsigs
-    setuptools
   ];
 
   postPatch = ''
@@ -60,15 +56,21 @@ buildPythonPackage rec {
 
   disabledTests = [
     "test_broken_pool"
+    # gevent tests have issue on newer Python releases
+    "test_add_live_job"
+    "test_add_pending_job"
+    "test_shutdown"
   ] ++ lib.optionals stdenv.isDarwin [
     "test_submit_job"
     "test_max_instances"
   ];
 
-  pythonImportsCheck = [ "apscheduler" ];
+  pythonImportsCheck = [
+    "apscheduler"
+  ];
 
   meta = with lib; {
-    description = "A Python library that lets you schedule your Python code to be executed";
+    description = "Library that lets you schedule your Python code to be executed";
     homepage = "https://github.com/agronholm/apscheduler";
     license = licenses.mit;
     maintainers = with maintainers; [ ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/163458753)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
