### PR TITLE
python310Packages.quandl: adjust inputs

### DIFF
--- a/pkgs/development/python-modules/quandl/default.nix
+++ b/pkgs/development/python-modules/quandl/default.nix
@@ -1,34 +1,36 @@
-{ lib, fetchPypi, buildPythonPackage, isPy3k, pythonOlder
-# runtime dependencies
-, pandas, numpy, requests, inflection, python-dateutil, six, more-itertools, importlib-metadata
-# test suite dependencies
-, nose, unittest2, flake8, httpretty, mock, jsondate, parameterized, faker, factory_boy
-# additional runtime dependencies are required on Python 2.x
-, pyopenssl, ndg-httpsclient, pyasn1
+{ lib
+, buildPythonPackage
+, factory_boy
+, faker
+, fetchPypi
+, httpretty
+, importlib-metadata
+, inflection
+, jsondate
+, mock
+, more-itertools
+, numpy
+, pandas
+, parameterized
+, pytestCheckHook
+, python-dateutil
+, pythonOlder
+, requests
+, six
 }:
 
 buildPythonPackage rec {
   pname = "quandl";
   version = "3.7.0";
-  disabled = !isPy3k;
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit version;
     pname = "Quandl";
     sha256 = "6e0b82fbc7861610b3577c5397277c4220e065eee0fed4e46cd6b6021655b64c";
   };
-
-  checkInputs = [
-    nose
-    unittest2
-    flake8
-    httpretty
-    mock
-    jsondate
-    parameterized
-    faker
-    factory_boy
-  ];
 
   propagatedBuildInputs = [
     pandas
@@ -38,15 +40,23 @@ buildPythonPackage rec {
     python-dateutil
     six
     more-itertools
-  ] ++ lib.optionals (!isPy3k) [
-    pyopenssl
-    ndg-httpsclient
-    pyasn1
   ] ++ lib.optionals (pythonOlder "3.8") [
     importlib-metadata
   ];
 
-  pythonImportsCheck = [ "quandl" ];
+  checkInputs = [
+    factory_boy
+    faker
+    httpretty
+    jsondate
+    mock
+    parameterized
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "quandl"
+  ];
 
   meta = with lib; {
     description = "Quandl Python client library";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/163515591)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
