### PR TITLE
python3Packages.websocket-client: 1.2.2 -> 1.2.3

### DIFF
--- a/pkgs/development/python-modules/websocket-client/default.nix
+++ b/pkgs/development/python-modules/websocket-client/default.nix
@@ -8,12 +8,12 @@
 
 buildPythonPackage rec {
   pname = "websocket-client";
-  version = "1.2.2";
+  version = "1.2.3";
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "21861f8645eb5725d1becfe86d7e7ae1a31d98b72556f9d44fcc5100976353cf";
+    sha256 = "1315816c0acc508997eb3ae03b9d3ff619c9d12d544c9a9b553704b1cc4f6af5";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/websocket-client/default.nix
+++ b/pkgs/development/python-modules/websocket-client/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     python-socks
-   ];
+  ];
 
   checkInputs = [
     pytestCheckHook


### PR DESCRIPTION
###### Motivation for this change
Update `websocket-client` to 1.2.3 to fix the error described in https://github.com/websocket-client/websocket-client/issues/769

Noticed the breakage when `jellyfin-mpv-shim` wasn't able to connect to my jellyfin server anymore:

```
[    INFO] JELLYFIN.jellyfin_apiclient_python.ws_client: Websocket url: wss://REDACTED/socket?api_key=REDACTED&device_id=REDACTED
[   DEBUG] urllib3.connectionpool: Starting new HTTPS connection (1): REDACTED:443
[   DEBUG] urllib3.connectionpool: https://REDACTED:443 "POST /Sessions/Capabilities/Full HTTP/1.1" 204 0
[    INFO] JELLYFIN.jellyfin_apiclient_python.ws_client: --->[ websocket ]
[   DEBUG] event_handler: Unhandled Event WebSocketConnect: None
[   ERROR] JELLYFIN.jellyfin_apiclient_python.ws_client: 'SSLDispatcher' object has no attribute 'read'
[   DEBUG] event_handler: Unhandled Event WebSocketError: 'SSLDispatcher' object has no attribute 'read'
[    INFO] JELLYFIN.jellyfin_apiclient_python.ws_client: ---<[ websocket ]
[    INFO] clients: No connection to server. Next try in 1 second(s)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
