### PR TITLE
nixos/kubernetes: improvements to default node taints

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/default.nix
+++ b/nixos/modules/services/cluster/kubernetes/default.nix
@@ -231,7 +231,7 @@ in {
     })
 
 
-    (mkIf (all (el: el == "master") cfg.roles) {
+    (mkIf (cfg.roles == ["master"]) {
       # if this node is only a master make it unschedulable by default
       services.kubernetes.kubelet.unschedulable = mkDefault true;
     })

--- a/nixos/modules/services/cluster/kubernetes/kubelet.nix
+++ b/nixos/modules/services/cluster/kubernetes/kubelet.nix
@@ -41,7 +41,8 @@ let
       };
       value = mkOption {
         description = "Value of taint.";
-        type = str;
+        default = null;
+        type = nullOr str;
       };
       effect = mkOption {
         description = "Effect of taint.";
@@ -51,7 +52,7 @@ let
     };
   };
 
-  taints = concatMapStringsSep "," (v: "${v.key}=${v.value}:${v.effect}") (mapAttrsToList (n: v: v) cfg.taints);
+  taints = concatMapStringsSep "," (v: "${v.key}${lib.optionalString (v.value != null) "=${v.value}"}:${v.effect}") (mapAttrsToList (n: v: v) cfg.taints);
 in
 {
   imports = [


### PR DESCRIPTION

###### Motivation for this change

- Make the taint "value" optional:

Not all taints take the form of key=value:effect.
The "kubectl cordon" taint for example has no "value":
`node.kubernetes.io/unschedulable:NoSchedule`

- Fix unschedulable mkDefault for role == ["master"]:

When not using the "roles"-feature of the module (cfg.roles being empty) the
predicate "all (r: r == "master") cfg.roles" will always yield true.

The latter is technically a breaking change for clusters that don't use `services.kubernetes.roles`. What do you think @saschagrunert ? Will it require a rel-note?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
