### PR TITLE
pynitrokey: init at 0.4.9

### DIFF
--- a/pkgs/development/python-modules/nkdfu/default.nix
+++ b/pkgs/development/python-modules/nkdfu/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi, fire, tqdm, intelhex, libusb1 }:
+
+buildPythonPackage rec {
+  pname = "nkdfu";
+  version = "0.1";
+  format = "flit";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-Y8GonfCBi3BNMhZ99SN6/SDSa0+dbfPIMPoVzALwH5A=";
+  };
+
+  propagatedBuildInputs = [
+    fire
+    tqdm
+    intelhex
+    libusb1
+  ];
+
+  # no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "nkdfu" ];
+
+  meta = with lib; {
+    description = "Python tool for Nitrokeys' firmware update";
+    homepage = "https://github.com/Nitrokey/nkdfu";
+    license = with licenses; [ gpl2Only ];
+    maintainers = with maintainers; [ frogamic ];
+  };
+}

--- a/pkgs/tools/security/pynitrokey/default.nix
+++ b/pkgs/tools/security/pynitrokey/default.nix
@@ -1,0 +1,44 @@
+{ python3Packages, lib }:
+
+with python3Packages;
+
+buildPythonApplication rec {
+  pname = "pynitrokey";
+  version = "0.4.9";
+  format = "flit";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-mhH6mVgLRX87PSGTFkj1TE75jU1lwcaRZWbC67T+vWo=";
+  };
+
+  propagatedBuildInputs = [
+    click
+    cryptography
+    ecdsa
+    fido2
+    intelhex
+    pyserial
+    pyusb
+    requests
+    pygments
+    python-dateutil
+    urllib3
+    cffi
+    cbor
+    nkdfu
+  ];
+
+  # no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "pynitrokey" ];
+
+  meta = with lib; {
+    description = "Python client for Nitrokey devices";
+    homepage = "https://github.com/Nitrokey/pynitrokey";
+    license = with licenses; [ asl20 mit ];
+    maintainers = with maintainers; [ frogamic ];
+    mainProgram = "nitropy";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34032,6 +34032,8 @@ with pkgs;
 
   xrq = callPackage ../applications/misc/xrq { };
 
+  pynitrokey = callPackage ../tools/security/pynitrokey { };
+
   nitrokey-app = libsForQt5.callPackage ../tools/security/nitrokey-app { };
   nitrokey-udev-rules = callPackage ../tools/security/nitrokey-app/udev-rules.nix { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5370,6 +5370,8 @@ in {
 
   nix-prefetch-github = callPackage ../development/python-modules/nix-prefetch-github { };
 
+  nkdfu = callPackage ../development/python-modules/nkdfu { };
+
   nltk = callPackage ../development/python-modules/nltk { };
 
   nmapthon2 = callPackage ../development/python-modules/nmapthon2 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

pynitrokey is the CLI app for managing nitrokey devices

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
