### PR TITLE
quicklisp-to-nix: document --cacheFaslDir option in help screen

### DIFF
--- a/pkgs/development/lisp-modules/quicklisp-to-nix/ql-to-nix.lisp
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix/ql-to-nix.lisp
@@ -260,9 +260,10 @@ This function stores results for memoization purposes in files within
 (defun print-usage-and-quit ()
   "Does what it says on the tin."
   (format *error-output* "Usage:
-    ~A [--help] [--cacheSystemInfoDir <path>] <work-dir>
+    ~A [--help] [--cacheSystemInfoDir <path>] [--cacheFaslDir <path>] <work-dir>
 Arguments:
     --cacheSystemInfoDir Store computed system info in the given directory
+    --cacheFaslDir Store intermediate fast load files in the given directory
     --help Print usage and exit
     <work-dir> Path to directory with quicklisp-to-nix-systems.txt
 " (uiop:argv0))

--- a/pkgs/development/lisp-modules/quicklisp-to-nix/ql-to-nix.lisp
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix/ql-to-nix.lisp
@@ -44,7 +44,7 @@
 (wrap :ql-dist short-description)
 
 (defun escape-filename (s)
-  (format 
+  (format
    nil "~a~{~a~}"
    (if (scan "^[a-zA-Z_]" s) "" "_")
    (loop


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
