### PR TITLE
pleroma,nixos/pleroma: move cookie into package

### DIFF
--- a/nixos/modules/services/networking/pleroma.nix
+++ b/nixos/modules/services/networking/pleroma.nix
@@ -32,6 +32,15 @@ in {
         description = "Directory where the pleroma service will save the uploads and static files.";
       };
 
+      cookie = mkOption {
+        type = types.nullOr (types.oneOf [ types.str types.path ]);
+        default = null;
+        description = ''
+          Override the release cookie used for pleroma. If it's a path the content will be used.
+          Pleroma will read the Cookie from /var/lib/pleroma/.cookie if this is not set.
+        '';
+      };
+
       configs = mkOption {
         type = with types; listOf str;
         description = ''
@@ -100,7 +109,6 @@ in {
       after = [ "network-online.target" "postgresql.service" ];
       wantedBy = [ "multi-user.target" ];
       restartTriggers = [ config.environment.etc."/pleroma/config.exs".source ];
-      environment.RELEASE_COOKIE = "/var/lib/pleroma/.cookie";
       serviceConfig = {
         User = cfg.user;
         Group = cfg.group;
@@ -117,12 +125,13 @@ in {
         # has not been updated. But the no-op process is pretty fast.
         # Better be safe than sorry migration-wise.
         ExecStartPre =
-          let preScript = pkgs.writers.writeBashBin "pleromaStartPre" ''
-            if [ ! -f /var/lib/pleroma/.cookie ]
-            then
-              echo "Creating cookie file"
-              dd if=/dev/urandom bs=1 count=16 | hexdump -e '16/1 "%02x"' > /var/lib/pleroma/.cookie
-            fi
+          let preScript = pkgs.writers.writeBashBin "pleromaStartPre" (if cfg.cookie == null then ''
+              if [ ! -f /var/lib/pleroma/.cookie ]
+              then
+                echo "Creating cookie file"
+                dd if=/dev/urandom bs=1 count=16 | hexdump -e '16/1 "%02x"' > /var/lib/pleroma/.cookie
+              fi
+            '' else "") + ''
             ${cfg.package}/bin/pleroma_ctl migrate
           '';
           in "${preScript}/bin/pleromaStartPre";
@@ -141,6 +150,8 @@ in {
         NoNewPrivileges = true;
         CapabilityBoundingSet = "~CAP_SYS_ADMIN";
       };
+    } // lib.mkIf (cfg.cookie != null) {
+      environment.RELEASE_COOKIE = cfg.cookie;
     };
 
   };

--- a/pkgs/servers/pleroma/0001-nixos-move-RELEASE_COOKIE-to-var-lib-pleroma-.cookie.patch
+++ b/pkgs/servers/pleroma/0001-nixos-move-RELEASE_COOKIE-to-var-lib-pleroma-.cookie.patch
@@ -1,0 +1,24 @@
+From d49df5552a27e5591ce415062a8e3fbe331edd98 Mon Sep 17 00:00:00 2001
+From: Finn Behrens <me@kloenk.dev>
+Date: Wed, 12 Jan 2022 11:03:21 +0100
+Subject: [PATCH] nixos: move RELEASE_COOKIE to /var/lib/pleroma/.cookie
+
+---
+ rel/env.sh.eex | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/rel/env.sh.eex b/rel/env.sh.eex
+index e1b87102d..7a66fff75 100644
+--- a/rel/env.sh.eex
++++ b/rel/env.sh.eex
+@@ -10,3 +10,7 @@
+ # Set the release to work across nodes
+ export RELEASE_DISTRIBUTION="${RELEASE_DISTRIBUTION:-name}"
+ export RELEASE_NODE="${RELEASE_NODE:-<%= @release.name %>@127.0.0.1}"
++export RELEASE_COOKIE="${RELEASE_COOKIE:-/var/lib/<%= @release.name %>/.cookie}"
++if [ -f "$RELEASE_COOKIE" ]; then
++  export RELEASE_COOKIE="$(cat $RELEASE_COOKIE)"
++fi
+-- 
+2.32.0 (Apple Git-132)
+

--- a/pkgs/servers/pleroma/default.nix
+++ b/pkgs/servers/pleroma/default.nix
@@ -17,6 +17,8 @@ beamPackages.mixRelease rec {
     sha256 = "sha256-RcqqNNNCR4cxETUCyjChkpq+cQ1QzNOHHzdqBLtOc6g=";
   };
 
+  patches = [ ./0001-nixos-move-RELEASE_COOKIE-to-var-lib-pleroma-.cookie.patch ];
+
   mixNixDeps = import ./mix.nix {
     inherit beamPackages lib;
     overrides = (final: prev: {


### PR DESCRIPTION
###### Motivation for this change
Currently the cookie is `/var/lib/pleroma/.cookie`, this is very predictable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
