### PR TITLE
lispPackages.cl-mustache: init at 20200325-git

### DIFF
--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-mustache.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-mustache.nix
@@ -1,0 +1,26 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "cl-mustache";
+  version = "20200325-git";
+
+  description = "Mustache Template Renderer";
+
+  deps = [ args."uiop" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/cl-mustache/2020-03-25/cl-mustache-20200325-git.tgz";
+    sha256 = "1x1rsmgqc39imx4ay3b35dzvzccaqjayz90qv2cylqbbq9sg9arr";
+  };
+
+  packageName = "cl-mustache";
+
+  asdFilesToKeep = ["cl-mustache.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM cl-mustache DESCRIPTION Mustache Template Renderer SHA256
+    1x1rsmgqc39imx4ay3b35dzvzccaqjayz90qv2cylqbbq9sg9arr URL
+    http://beta.quicklisp.org/archive/cl-mustache/2020-03-25/cl-mustache-20200325-git.tgz
+    MD5 52381d17458d88d6a8b760f351bf517d NAME cl-mustache FILENAME cl-mustache
+    DEPS ((NAME uiop FILENAME uiop)) DEPENDENCIES (uiop) VERSION 20200325-git
+    SIBLINGS (cl-mustache-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
@@ -60,6 +60,7 @@ cl-l10n
 cl-libuv
 cl-locale
 cl-markup
+cl-mustache
 cl-mysql
 cl-paths-ttf
 cl-pattern

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -4312,6 +4312,15 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "cl-mustache" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."cl-mustache" or (x: {}))
+       (import ./quicklisp-to-nix-output/cl-mustache.nix {
+         inherit fetchurl;
+           "uiop" = quicklisp-to-nix-packages."uiop";
+       }));
+
+
   "cl-markup" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."cl-markup" or (x: {}))


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
