### PR TITLE
[DRAFT] pix: init at 2.1.1

### DIFF
--- a/pkgs/applications/graphics/pix/default.nix
+++ b/pkgs/applications/graphics/pix/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, mkDerivation
+, fetchFromGitLab
+, cmake
+, extra-cmake-modules
+, applet-window-buttons
+, karchive
+, kcoreaddons
+, ki18n
+, kio
+, kirigami2
+, mauikit
+, mauikit-filebrowsing
+, mauikit-imagetools
+, qtmultimedia
+, qtquickcontrols2
+, qtlocation
+, exiv2
+, kquickimageedit
+, fetchpatch
+}:
+
+mkDerivation rec {
+  pname = "pix";
+  version = "2.1.1";
+
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "maui";
+    repo = "pix";
+    rev = "b33423213703a1e899f8a4b088737778b715a36a";
+    sha256 = "sha256-RR32q2LMr9YWylUaY+c9zFLm97eMPP9OFj15EpWmtXo=";
+  };
+
+  patches = [
+    # Fix build error. Commit which fixes this issue appeared afer
+    # version 2.1.1 but should be fixed in later versions
+    # https://invent.kde.org/maui/pix/-/commit/4c77aba5fc02e085d88e4182f353140cd57acef2
+    (fetchpatch {
+      url = "https://invent.kde.org/maui/pix/-/commit/4c77aba5fc02e085d88e4182f353140cd57acef2.patch";
+      sha256 = "sha256-pNRnvjUiJ2cRhKk1wLl+keK48k2pIW5kl4dNFu0ngQg=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    applet-window-buttons
+    karchive
+    kcoreaddons
+    ki18n
+    kio
+    kirigami2
+    mauikit
+    mauikit-filebrowsing
+    mauikit-imagetools
+    qtmultimedia
+    qtquickcontrols2
+    qtlocation
+    exiv2
+    kquickimageedit
+  ];
+
+  meta = with lib; {
+    description = "Image gallery application";
+    homepage = "https://invent.kde.org/maui/pix";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/development/libraries/mauikit-imagetools/default.nix
+++ b/pkgs/development/libraries/mauikit-imagetools/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, mkDerivation
+, fetchFromGitLab
+, cmake
+, extra-cmake-modules
+, kconfig
+, kio
+, mauikit
+, qtlocation
+, exiv2
+, kquickimageedit
+}:
+
+mkDerivation rec {
+  pname = "mauikit-imagetools";
+  version = "2.1.1";
+
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "maui";
+    repo = "mauikit-imagetools";
+    rev = "v${version}";
+    hash = "sha256-oSa3Zem0s5+Q2gTmTAUlGzbVheqDZd8idO4GFCycxDg=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    kconfig
+    kio
+    mauikit
+    qtlocation
+    exiv2
+    kquickimageedit
+  ];
+
+  meta = with lib; {
+    homepage = "https://invent.kde.org/maui/mauikit-imagetools";
+    description = "MauiKit Image Tools Components";
+    license = licenses.lgpl2Plus;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27033,6 +27033,8 @@ with pkgs;
 
   pinboard-notes-backup = haskell.lib.compose.justStaticExecutables haskellPackages.pinboard-notes-backup;
 
+  pix = libsForQt5.callPackage ../applications/graphics/pix { };
+
   pixel2svg = python310Packages.callPackage ../tools/graphics/pixel2svg { };
 
   pixelnuke = callPackage ../applications/graphics/pixelnuke { };

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -150,6 +150,8 @@ in (kdeFrameworks // plasmaMobileGear // plasma5 // plasma5.thirdParty // kdeGea
 
   mauikit-filebrowsing = callPackage ../development/libraries/mauikit-filebrowsing { };
 
+  mauikit-imagetools = callPackage ../development/libraries/mauikit-imagetools { };
+
   mauikit-texteditor = callPackage ../development/libraries/mauikit-texteditor { };
 
   mlt = callPackage ../development/libraries/mlt/qt-5.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR adds the convergent app [pix](https://invent.kde.org/maui/pix), a picture viewer application based on [Mauikit](https://mauikit.org/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
