### PR TITLE
gnome: switch to makeScopeWithSplicing

### DIFF
--- a/pkgs/desktops/gnome/default.nix
+++ b/pkgs/desktops/gnome/default.nix
@@ -1,6 +1,14 @@
-{ config, pkgs, lib }:
+{ config, pkgs, lib, splicePackages, newScope
+, pkgsBuildBuild, pkgsBuildHost, pkgsBuildTarget, pkgsHostHost, pkgsTargetTarget }:
 
-lib.makeScope pkgs.newScope (self: with self; {
+lib.makeScopeWithSplicing splicePackages newScope {
+  selfBuildBuild = pkgsBuildBuild.gnome;
+  selfBuildHost = pkgsBuildHost.gnome;
+  selfBuildTarget = pkgsBuildTarget.gnome;
+  selfHostHost = pkgsHostHost.gnome;
+  selfTargetTarget = pkgsTargetTarget.gnome or {};
+} (self: { }) (spliced0: { })
+(self: let inherit (self) callPackage; in {
   updateScript = callPackage ./update.nix { };
 
   /* Remove packages of packagesToRemove from packages, based on their names
@@ -19,7 +27,7 @@ lib.makeScope pkgs.newScope (self: with self; {
       lib.filter (x: !(builtins.elem (lib.getName x) namesToRemove)) packages;
 
   libsoup = pkgs.libsoup.override { gnomeSupport = true; };
-  libchamplain = pkgs.libchamplain.override { libsoup = libsoup; };
+  libchamplain = pkgs.libchamplain.override { libsoup = self.libsoup; };
 
 # ISO installer
 # installerIso = callPackage ./installer.nix {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
makeScope breaks splicing thus makes cross compilation hard in package sets like gnome, by switching to makeScopeWithSplicing, the situation can be dramatically improved.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
