### PR TITLE
tailor, cvs2svn: switch to pypy2

### DIFF
--- a/pkgs/applications/version-management/cvs2svn/default.nix
+++ b/pkgs/applications/version-management/cvs2svn/default.nix
@@ -1,9 +1,9 @@
 { lib, fetchurl, makeWrapper
-, python2Packages
+, pypy2Packages
 , cvs, subversion, git, breezy
 }:
 
-python2Packages.buildPythonApplication  rec {
+pypy2Packages.buildPythonApplication  rec {
   pname = "cvs2svn";
   version = "2.5.0";
 
@@ -16,7 +16,7 @@ python2Packages.buildPythonApplication  rec {
 
   checkInputs = [ subversion git breezy ];
 
-  checkPhase = "python run-tests.py";
+  checkPhase = "pypy2 run-tests.py";
 
   doCheck = false; # Couldn't find node 'transaction...' in expected output tree
 

--- a/pkgs/applications/version-management/tailor/default.nix
+++ b/pkgs/applications/version-management/tailor/default.nix
@@ -1,6 +1,6 @@
-{ fetchurl, python2Packages }:
+{ fetchurl, pypy2Packages }:
 
-python2Packages.buildPythonApplication rec {
+pypy2Packages.buildPythonApplication rec {
   pname = "tailor";
   version = "0.9.35";
 


### PR DESCRIPTION
###### Motivation for this change

CPython2 EOL, indefinite support plans for PyPy2

Will self-merge as the change is minimal

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested `--help` of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
