### PR TITLE
tree-sitter updater: use GITHUB_TOKEN if present

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -27,7 +27,8 @@ let
   # to update:
   # 1) change all these hashes
   # 2) nix-build -A tree-sitter.updater.update-all-grammars
-  # 3) run the ./result script that is output by that (it updates ./grammars)
+  # 3) OPTIONAL: Set GITHUB_TOKEN env variable to avoid api rate limit
+  # 4) run the ./result script that is output by that (it updates ./grammars)
   version = "0.20.1";
   sha256 = "sha256-JKbL05hFWI0jhAnRT9D0SWCoRPFqoMD4+LQQ1zyWc7g=";
   cargoSha256 = "sha256-64O+3GrDqhRGth20B2/+jNDYSnwvT3SqYVqYNthiCB0=";

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -360,9 +360,15 @@ let
   # generic bash script to find the latest github release for a repo
   latestGithubRelease = { orga, repo }: writeShellScript "latest-github-release" ''
     set -euo pipefail
-    res=$(${curl}/bin/curl \
-      --silent \
-      "https://api.github.com/repos/${urlEscape orga}/${urlEscape repo}/releases/latest")
+
+    args=( '--silent' )
+    if [ -n "$GITHUB_TOKEN" ]; then
+      args+=( "-H" "Authorization: token ''${GITHUB_TOKEN}" )
+    fi
+    args+=( "https://api.github.com/repos/${urlEscape orga}/${urlEscape repo}/releases/latest" )
+
+    res=$(${curl}/bin/curl "''${args[@]}")
+
     if [[ "$(printf "%s" "$res" | ${jq}/bin/jq '.message?')" =~ "rate limit" ]]; then
       echo "rate limited" >&2
     fi
@@ -378,9 +384,14 @@ let
   # find the latest repos of a github organization
   latestGithubRepos = { orga }: writeShellScript "latest-github-repos" ''
     set -euo pipefail
-    res=$(${curl}/bin/curl \
-      --silent \
-      'https://api.github.com/orgs/${urlEscape orga}/repos?per_page=100')
+
+    args=( '--silent' )
+    if [ -n "$GITHUB_TOKEN" ]; then
+      args+=( "-H" "Authorization: token ''${GITHUB_TOKEN}" )
+    fi
+    args+=( 'https://api.github.com/orgs/${urlEscape orga}/repos?per_page=100' )
+
+    res=$(${curl}/bin/curl "''${args[@]}")
 
     if [[ "$(printf "%s" "$res" | ${jq}/bin/jq '.message?')" =~ "rate limit" ]]; then
       echo "rate limited" >&2   #


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The updater makes a lot of requets to the github API, which is rate limited. After #151146 I'm hitting the rate limit when I try to update the grammars. This PR updates the generated script to use a github token (if present), been able to make more requests


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


ping @Kranzes @Profpatsch 
