### PR TITLE
cvs2svn: use more universal reference to interpreter

### DIFF
--- a/pkgs/applications/version-management/cvs2svn/default.nix
+++ b/pkgs/applications/version-management/cvs2svn/default.nix
@@ -16,7 +16,7 @@ pypy2Packages.buildPythonApplication  rec {
 
   checkInputs = [ subversion git breezy ];
 
-  checkPhase = "pypy2 run-tests.py";
+  checkPhase = "${pypy2Packages.python.interpreter} run-tests.py";
 
   doCheck = false; # Couldn't find node 'transaction...' in expected output tree
 


### PR DESCRIPTION
###### Motivation for this change

Suggestion from @dotlambda in #154752

Will probably eventually self-merge unless there are objections

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested `--help` of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
