### PR TITLE
python3Packages.apache-airflow: adjust inputs and substituteInPlace

### DIFF
--- a/pkgs/development/python-modules/apache-airflow/default.nix
+++ b/pkgs/development/python-modules/apache-airflow/default.nix
@@ -13,12 +13,13 @@
 , colorlog
 , croniter
 , cryptography
+, dataclasses
 , dill
 , flask
-, flask-appbuilder
-, flask-caching
 , flask_login
 , flask_wtf
+, flask-appbuilder
+, flask-caching
 , GitPython
 , graphviz
 , gunicorn
@@ -47,6 +48,7 @@
 , python-nvd3
 , python-slugify
 , python3-openid
+, pythonOlder
 , pyyaml
 , rich
 , setproctitle
@@ -63,7 +65,6 @@
 , mkYarnPackage
 }:
 let
-
   version = "2.1.4";
 
   airflow-src = fetchFromGitHub rec {
@@ -107,6 +108,8 @@ buildPythonPackage rec {
   inherit version;
   src = airflow-src;
 
+  disabled = pythonOlder "3.6";
+
   propagatedBuildInputs = [
     alembic
     argcomplete
@@ -130,7 +133,6 @@ buildPythonPackage rec {
     httpx
     iso8601
     importlib-resources
-    importlib-metadata
     inflection
     itsdangerous
     jinja2
@@ -163,6 +165,10 @@ buildPythonPackage rec {
     termcolor
     unicodecsv
     werkzeug
+  ] ++ lib.optionals (pythonOlder "3.7") [
+    dataclasses
+  ] ++ lib.optionals (pythonOlder "3.9") [
+    importlib-metadata
   ];
 
   buildInputs = [
@@ -178,24 +184,22 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.cfg \
-      --replace "importlib_resources~=1.4" "importlib_resources" \
-      --replace "importlib_metadata~=1.7" "importlib_metadata" \
-      --replace "tenacity~=6.2.0" "tenacity" \
-      --replace "pyjwt<2" "pyjwt" \
-      --replace "flask>=1.1.0, <2.0" "flask" \
-      --replace "flask-login>=0.3, <0.5" "flask-login" \
-      --replace "flask-wtf>=0.14.3, <0.15" "flask-wtf" \
-      --replace "jinja2>=2.10.1, <2.12.0" "jinja2" \
       --replace "attrs>=20.0, <21.0" "attrs" \
       --replace "cattrs~=1.1, <1.7.0" "cattrs" \
-      --replace "markupsafe>=1.1.1, <2.0" "markupsafe" \
+      --replace "colorlog>=4.0.2, <6.0" "colorlog" \
+      --replace "croniter>=0.3.17, <1.1" "croniter" \
       --replace "docutils<0.17" "docutils" \
-      --replace "sqlalchemy>=1.3.18, <1.4" "sqlalchemy" \
-      --replace "sqlalchemy_jsonfield~=1.0" "sqlalchemy-jsonfield" \
-      --replace "werkzeug~=1.0, >=1.0.1" "werkzeug" \
+      --replace "flask-login>=0.3, <0.5" "flask-login" \
+      --replace "flask-wtf>=0.14.3, <0.15" "flask-wtf" \
+      --replace "flask>=1.1.0, <2.0" "flask" \
+      --replace "importlib_resources~=1.4" "importlib_resources" \
       --replace "itsdangerous>=1.1.0, <2.0" "itsdangerous" \
+      --replace "markupsafe>=1.1.1, <2.0" "markupsafe" \
+      --replace "pyjwt<2" "pyjwt" \
       --replace "python-slugify>=3.0.0,<5.0" "python-slugify" \
-      --replace "colorlog>=4.0.2, <6.0" "colorlog"
+      --replace "sqlalchemy_jsonfield~=1.0" "sqlalchemy-jsonfield" \
+      --replace "tenacity~=6.2.0" "tenacity" \
+      --replace "werkzeug~=1.0, >=1.0.1" "werkzeug"
 
     substituteInPlace tests/core/test_core.py \
       --replace "/bin/bash" "${stdenv.shell}"
@@ -205,19 +209,21 @@ buildPythonPackage rec {
       --replace "/tmp/sqlite_default.db" "$TMPDIR/sqlite_default.db"
   '';
 
-  # allow for gunicorn processes to have access to python packages
-  makeWrapperArgs = [ "--prefix PYTHONPATH : $PYTHONPATH" ];
+  # allow for gunicorn processes to have access to Python packages
+  makeWrapperArgs = [
+    "--prefix PYTHONPATH : $PYTHONPATH"
+  ];
 
   preCheck = ''
-   export HOME=$(mktemp -d)
-   export AIRFLOW_HOME=$HOME
-   export AIRFLOW__CORE__UNIT_TEST_MODE=True
-   export AIRFLOW_DB="$HOME/airflow.db"
-   export PATH=$PATH:$out/bin
+    export HOME=$(mktemp -d)
+    export AIRFLOW_HOME=$HOME
+    export AIRFLOW__CORE__UNIT_TEST_MODE=True
+    export AIRFLOW_DB="$HOME/airflow.db"
+    export PATH=$PATH:$out/bin
 
-   airflow version
-   airflow db init
-   airflow db reset -y
+    airflow version
+    airflow db init
+    airflow db reset -y
   '';
 
   pytestFlagsArray = [
@@ -225,7 +231,7 @@ buildPythonPackage rec {
   ];
 
   disabledTests = lib.optionals stdenv.isDarwin [
-    "bash_operator_kill"  # psutil.AccessDenied
+    "bash_operator_kill" # psutil.AccessDenied
   ];
 
   postInstall = ''

--- a/pkgs/development/python-modules/flask-login/default.nix
+++ b/pkgs/development/python-modules/flask-login/default.nix
@@ -1,27 +1,51 @@
-{ lib, buildPythonPackage, fetchPypi, pythonAtLeast
-, flask, blinker, nose, mock, semantic-version }:
+{ lib
+, blinker
+, buildPythonPackage
+, fetchPypi
+, flask
+, pytestCheckHook
+, pythonAtLeast
+, pythonOlder
+, semantic-version
+, werkzeug
+}:
 
 buildPythonPackage rec {
-  pname = "Flask-Login";
+  pname = "flask-login";
   version = "0.5.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
-    inherit pname version;
+    pname = "Flask-Login";
+    inherit version;
     sha256 = "6d33aef15b5bcead780acc339464aae8a6e28f13c90d8b1cf9de8b549d1c0b4b";
   };
 
-  checkInputs = [ nose mock semantic-version ];
-  propagatedBuildInputs = [ flask blinker ];
+  propagatedBuildInputs = [
+    flask
+    werkzeug
+  ];
 
-  checkPhase = "nosetests -d";
+  checkInputs = [
+    blinker
+    pytestCheckHook
+    semantic-version
+  ];
 
-  doCheck = pythonAtLeast "3.3";
+  disabledTests = lib.optionals (pythonAtLeast "3.10") [
+    "test_hashable"
+  ];
+
+  pythonImportsCheck = [
+    "flask_login"
+  ];
 
   meta = with lib; {
-    homepage = "https://github.com/maxcountryman/flask-login";
     description = "User session management for Flask";
+    homepage = "https://github.com/maxcountryman/flask-login";
     license = licenses.mit;
-    platforms = platforms.all;
     maintainers = with maintainers; [ abbradar ];
   };
 }

--- a/pkgs/development/python-modules/python-daemon/default.nix
+++ b/pkgs/development/python-modules/python-daemon/default.nix
@@ -3,16 +3,21 @@
 , fetchPypi
 , docutils
 , lockfile
-, mock
-, pytest_4
+, pytestCheckHook
 , testscenarios
 , testtools
 , twine
+, python
+, pythonOlder
+, fetchpatch
 }:
 
 buildPythonPackage rec {
   pname = "python-daemon";
   version = "2.3.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
@@ -29,22 +34,39 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    pytest_4
-    mock
+    pytestCheckHook
     testscenarios
     testtools
   ];
 
-  # tests disabled due to incompatibilities with testtools>=2.5.0
-  checkPhase = ''
-    runHook preCheck
-    pytest -k ' \
-      not detaches_process_context and \
-      not standard_stream_file_descriptors and \
-      not test_module_has_attribute and \
-      not test_module_attribute_has_duck_type'
-    runHook postCheck
-  '';
+  patches = [
+    # Should be fixed in the next release
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/python-daemon/raw/rawhide/f/python-daemon-safe_hasattr.patch";
+      sha256 = "sha256-p5epAlM/sdel01oZkSI1vahUZYX8r90WCJuvBnfMaus=";
+    })
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/python-daemon/raw/rawhide/f/tests-remove-duplicate-mocking.patch";
+      sha256 = "sha256-5b/dFR3Z8xaPw8AZU95apDZd4ZfmMQhAmavWkVaJog8=";
+    })
+  ];
+
+  disabledTests = [
+    "begin_with_TestCase"
+    "changelog_TestCase"
+    "ChangeLogEntry"
+    "DaemonContext"
+    "file_descriptor"
+    "get_distribution_version_info_TestCase"
+    "InvalidFormatError_TestCase"
+    "make_year_range_TestCase"
+    "ModuleExceptions_TestCase"
+    "test_metaclass_not_called"
+    "test_passes_specified_object"
+    "test_returns_expected"
+    "value_TestCase"
+    "YearRange_TestCase"
+  ];
 
   pythonImportsCheck = [
     "daemon"
@@ -56,10 +78,8 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Library to implement a well-behaved Unix daemon process";
     homepage = "https://pagure.io/python-daemon/";
-    license = with licenses; [
-      gpl3Plus
-      asl20
-    ];
+    # See "Copying" section in https://pagure.io/python-daemon/blob/main/f/README
+    license = with licenses; [ gpl3Plus asl20 ];
     maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/164061774)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
