### PR TITLE
calibre-web: relax lxml constraint

### DIFF
--- a/pkgs/servers/calibre-web/default.nix
+++ b/pkgs/servers/calibre-web/default.nix
@@ -16,6 +16,22 @@ python3.pkgs.buildPythonApplication rec {
     sha256 = "sha256-rR5pUB3A0WNQxq7ZJ6ykua7hMlzs49aMmVbBUOkOVfA=";
   };
 
+  propagatedBuildInputs = with python3Packages; [
+    backports_abc
+    flask-babel
+    flask_login
+    flask_principal
+    flask_wtf
+    iso-639
+    lxml
+    pypdf3
+    requests
+    sqlalchemy
+    tornado
+    unidecode
+    Wand
+  ];
+
   patches = [
     # default-logger.patch switches default logger to /dev/stdout. Otherwise calibre-web tries to open a file relative
     # to its location, which can't be done as the store is read-only. Log file location can later be configured using UI
@@ -36,39 +52,24 @@ python3.pkgs.buildPythonApplication rec {
     mv cps src/calibreweb
 
     substituteInPlace setup.cfg \
-      --replace "requests>=2.11.1,<2.25.0" "requests" \
       --replace "cps = calibreweb:main" "calibre-web = calibreweb:main" \
+      --replace "flask-wtf>=0.14.2,<0.16.0" "flask-wtf>=0.14.2" \
+      --replace "lxml>=3.8.0,<4.7.0" "lxml>=3.8.0" \
       --replace "PyPDF3>=1.0.0,<1.0.4" "PyPDF3>=1.0.0" \
-      --replace "unidecode>=0.04.19,<1.3.0" "unidecode>=0.04.19" \
-      --replace "flask-wtf>=0.14.2,<0.16.0" "flask-wtf>=0.14.2"
+      --replace "requests>=2.11.1,<2.25.0" "requests" \
+      --replace "unidecode>=0.04.19,<1.3.0" "unidecode>=0.04.19"
   '';
 
   # Upstream repo doesn't provide any tests.
   doCheck = false;
 
-  propagatedBuildInputs = with python3Packages; [
-    backports_abc
-    flask-babel
-    flask_login
-    flask_principal
-    flask_wtf
-    iso-639
-    lxml
-    pypdf3
-    requests
-    sqlalchemy
-    tornado
-    unidecode
-    Wand
-  ];
-
   passthru.tests.calibre-web = nixosTests.calibre-web;
 
   meta = with lib; {
     description = "Web app for browsing, reading and downloading eBooks stored in a Calibre database";
-    maintainers = with maintainers; [ pborzenkov ];
     homepage = "https://github.com/janeczku/calibre-web";
     license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ pborzenkov ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/163718563)

Fixes #154352

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
