### PR TITLE
pijuice: init at 1.7

### DIFF
--- a/pkgs/development/python-modules/pijuice/default.nix
+++ b/pkgs/development/python-modules/pijuice/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, pythonOlder
+, smbus-cffi
+, urwid
+}:
+
+buildPythonPackage rec {
+  pname = "pijuice";
+  version = "1.7";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "PiSupply";
+    repo = "PiJuice";
+    # rev hash retrieved from the latest modification on file Software/Source/VERSION, as this project
+    # does not use Github tags facility
+    rev = "3ba6719ab614a3dc7495d5d9c900dd4ea977c7e3";
+    sha256 = "GoNN07YgVaktpeY5iYDbfpy5fxkU1x0V3Sb1hgGAQt4=";
+  };
+
+  patches = [
+    # The pijuice_cli.cli file doesn't have a shebang as the first line of the
+    # script. Without it, the pythonWrapPrograms hook will not wrap the program.
+    # Add a python shebang here so that the the hook is triggered.
+    ./patch-shebang.diff
+  ];
+
+  PIJUICE_BUILD_BASE = 1;
+
+  preBuild = ''
+    cd Software/Source
+  '';
+
+  propagatedBuildInputs = [ smbus-cffi urwid ];
+
+  # Remove the following files from the package:
+  #
+  # pijuice_cli - A precompiled ELF binary that is a setuid wrapper for calling
+  #               pijuice_cli.py
+  #
+  # pijuiceboot - a precompiled ELF binary for flashing firmware. Not needed for
+  #               the python library.
+  #
+  # pijuice_sys.py - A program that acts as a system daemon for monitoring the
+  #                  pijuice.
+  preFixup = ''
+    rm $out/bin/pijuice_cli
+    rm $out/bin/pijuice_sys.py
+    rm $out/bin/pijuiceboot
+    mv $out/bin/pijuice_cli.py $out/bin/pijuice_cli
+   '';
+
+  meta = with lib; {
+    description = "Library and resources for PiJuice HAT for Raspberry Pi";
+    homepage = "https://github.com/PiSupply/PiJuice";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ hexagonal-sun ];
+  };
+}

--- a/pkgs/development/python-modules/pijuice/patch-shebang.diff
+++ b/pkgs/development/python-modules/pijuice/patch-shebang.diff
@@ -1,0 +1,9 @@
+diff --git a/Software/Source/src/pijuice_cli.py b/Software/Source/src/pijuice_cli.py
+index c366fee..37af383 100644
+--- a/Software/Source/src/pijuice_cli.py
++++ b/Software/Source/src/pijuice_cli.py
+@@ -1,3 +1,4 @@
++#!/usr/bin/python3
+ # This python script to be executed as user pijuice by the setuid program pijuice_cli 
+ # Python 3 only
+ #

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27431,6 +27431,8 @@ with pkgs;
 
   pijul = callPackage ../applications/version-management/pijul { };
 
+  pijuice = with python3Packages; toPythonApplication pijuice;
+
   ping = callPackage ../applications/networking/ping { };
 
   piper = callPackage ../os-specific/linux/piper { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5946,6 +5946,8 @@ in {
 
   piexif = callPackage ../development/python-modules/piexif { };
 
+  pijuice = callPackage ../development/python-modules/pijuice { };
+
   pika = callPackage ../development/python-modules/pika { };
 
   pika-pool = callPackage ../development/python-modules/pika-pool { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add Pijuce package at 1.7 version.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
