### PR TITLE
gprojector: init at 3.0.2

### DIFF
--- a/pkgs/applications/science/astronomy/gprojector/default.nix
+++ b/pkgs/applications/science/astronomy/gprojector/default.nix
@@ -1,0 +1,48 @@
+{ stdenv
+, lib
+, jdk
+, makeDesktopItem
+, makeWrapper
+, ...
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gprojector";
+  version = "3.0.2";
+
+  src = builtins.fetchTarball {
+    url = "https://www.giss.nasa.gov/tools/gprojector/download/G.ProjectorJ-${version}.tgz";
+    sha256 = "sha256:01bp1pyhy7jk1s24j7cl2qx8wjn2dcsjf2ahnsbccxvnicwrkw92";
+  };
+
+  desktopItem = makeDesktopItem {
+    name = "gprojector";
+    exec = "gprojector";
+    desktopName = "G.Projector";
+    comment = meta.description;
+    categories = "Science;";
+    extraEntries = "StartupWMClass = gov-nasa-giss-projector-GProjector";
+  };
+  
+  buildInputs = [ jdk ];
+  nativeBuildInputs = [ makeWrapper desktopItem ];
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share
+    cp -r $src/jars $out/share/java
+    cp -r $desktopItem/share/applications $out/share/applications
+    makeWrapper ${jdk}/bin/java $out/bin/gprojector --add-flags "-Xms512M -Xmx2000M -jar $out/share/java/G.Projector.jar"
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "G.Projector transforms an input map image into any of about 200 global and regional map projections.";
+    homepage = "https://www.giss.nasa.gov/tools/gprojector/";
+    maintainers = with lib.maintainers; [ alyaeanyx ];
+    license = lib.licenses.unfree;
+    inherit (jdk.meta) platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6036,6 +6036,8 @@ with pkgs;
     hamlib = hamlib_4;
   };
 
+  gprojector = callPackage ../applications/science/astronomy/gprojector { };
+
   gptfdisk = callPackage ../tools/system/gptfdisk { };
 
   grafx2 = callPackage ../applications/graphics/grafx2 {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
G.Projector is a program by the NASA GISS to apply various map projections to a given map image. Marked as a draft because I still need to figure out the license and the platforms.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
