### PR TITLE
pandoc-drawio-filter: init at 1.0

### DIFF
--- a/pkgs/tools/misc/pandoc-drawio-filter/default.nix
+++ b/pkgs/tools/misc/pandoc-drawio-filter/default.nix
@@ -1,0 +1,78 @@
+{ buildPythonApplication
+, drawio
+, fetchFromGitHub
+, lib
+, pandoc
+, pandocfilters
+, runCommand
+, runtimeShell
+, texlive
+, writeScriptBin
+, xvfb-run
+}:
+
+let
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "tfc";
+    repo = "pandoc-drawio-filter";
+    rev = version;
+    sha256 = "sha256-2XJSAfxqEmmamWIAM3vZqi0mZjUUugmR3zWw8Imjadk=";
+  };
+
+  wrappedDrawio = writeScriptBin "drawio" ''
+    #!${runtimeShell}
+
+    # Electron really wants a configuration directory to not die with:
+    # "Error: Failed to get 'appData' path"
+    # so we give it some temp dir as XDG_CONFIG_HOME
+    tmpdir=$(mktemp -d)
+
+    function cleanup {
+      rm -rf "$tmpdir"
+    }
+    trap cleanup EXIT
+
+    # Drawio needs to run in a virtual X session, because Electron
+    # refuses to work and dies with an unhelpful error message otherwise:
+    # "The futex facility returned an unexpected error code."
+    XDG_CONFIG_HOME="$tmpdir" ${xvfb-run}/bin/xvfb-run ${drawio}/bin/drawio $@
+  '';
+
+  pandoc-drawio-filter = buildPythonApplication {
+    pname = "pandoc-drawio-filter";
+
+    inherit src version;
+
+    propagatedBuildInputs = [
+      wrappedDrawio
+      pandocfilters
+    ];
+
+    passthru.tests.example-doc =
+      let
+        env = {
+          nativeBuildInputs = [
+            pandoc
+            pandoc-drawio-filter
+            texlive.combined.scheme-tetex
+          ];
+        };
+      in
+      runCommand "$pandoc-drawio-filter-example-doc.pdf" env ''
+        cp -r ${src}/example/* .
+        pandoc -F pandoc-drawio example.md -T pdf -o $out
+      '';
+
+    meta = with lib; {
+      homepage = "https://github.com/tfc/pandoc-drawio-filter";
+      description = "Pandoc filter which converts draw.io diagrams to PDF";
+      license = licenses.mit;
+      maintainers = with maintainers; [ tfc ];
+    };
+  };
+
+in
+
+pandoc-drawio-filter

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8094,6 +8094,8 @@ with pkgs;
 
   pandoc-imagine = python3Packages.callPackage ../tools/misc/pandoc-imagine { };
 
+  pandoc-drawio-filter = python3Packages.callPackage ../tools/misc/pandoc-drawio-filter { };
+
   pandoc-plantuml-filter = python3Packages.callPackage ../tools/misc/pandoc-plantuml-filter { };
 
   patray = callPackage ../tools/audio/patray { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add the `pandoc-drawio-filter` tool to nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
