### PR TITLE
vimPlugins.nvim-treesitter.withPlugins: fix for macOS

### DIFF
--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -499,11 +499,12 @@ self: super: {
   # or for all grammars:
   # pkgs.vimPlugins.nvim-treesitter.withPlugins (_: tree-sitter.allGrammars)
   nvim-treesitter = super.nvim-treesitter.overrideAttrs (old: {
-    passthru.withPlugins =
-      grammarFn: self.nvim-treesitter.overrideAttrs (_: {
+    passthru.withPlugins = grammarFn:
+      self.nvim-treesitter.overrideAttrs (_: {
+        patches = lib.optional stdenv.isDarwin
+          ./patches/nvim-treesitter/macos-dyld.patch;
         postPatch =
-          let
-            grammars = tree-sitter.withPlugins grammarFn;
+          let grammars = tree-sitter.withPlugins grammarFn;
           in
           ''
             rm -r parser

--- a/pkgs/misc/vim-plugins/patches/nvim-treesitter/macos-dyld.patch
+++ b/pkgs/misc/vim-plugins/patches/nvim-treesitter/macos-dyld.patch
@@ -1,0 +1,60 @@
+Following patch makes nvim-treesitter look for tree-sittter parsers suffixed
+with .dylib instead of .so, which is how it's on Darwin
+
+diff --git a/lua/nvim-treesitter/health.lua b/lua/nvim-treesitter/health.lua
+index 996a87f..4f71512 100644
+--- a/lua/nvim-treesitter/health.lua
++++ b/lua/nvim-treesitter/health.lua
+@@ -117,7 +117,7 @@ function M.check()
+   -- Parser installation checks
+   local parser_installation = { "Parser/Features H L F I J" }
+   for _, parser_name in pairs(info.installed_parsers()) do
+-    local installed = #api.nvim_get_runtime_file("parser/" .. parser_name .. ".so", false)
++    local installed = #api.nvim_get_runtime_file("parser/" .. parser_name .. ".dylib", false)
+ 
+     -- Only append information about installed parsers
+     if installed >= 1 then
+diff --git a/lua/nvim-treesitter/info.lua b/lua/nvim-treesitter/info.lua
+index ed5a90b..8dc7078 100644
+--- a/lua/nvim-treesitter/info.lua
++++ b/lua/nvim-treesitter/info.lua
+@@ -15,7 +15,7 @@ local function install_info()
+   local parser_list = parsers.available_parsers()
+   table.sort(parser_list)
+   for _, ft in pairs(parser_list) do
+-    local is_installed = #api.nvim_get_runtime_file("parser/" .. ft .. ".so", false) > 0
++    local is_installed = #api.nvim_get_runtime_file("parser/" .. ft .. ".dylib", false) > 0
+     api.nvim_out_write(ft .. string.rep(" ", max_len - #ft + 1))
+     if is_installed then
+       api.nvim_out_write "[✓] installed\n"
+diff --git a/lua/nvim-treesitter/install.lua b/lua/nvim-treesitter/install.lua
+index 5362c86..f0faa7f 100644
+--- a/lua/nvim-treesitter/install.lua
++++ b/lua/nvim-treesitter/install.lua
+@@ -86,7 +86,7 @@ local function get_installed_revision(lang)
+ end
+ 
+ local function is_installed(lang)
+-  return #api.nvim_get_runtime_file("parser/" .. lang .. ".so", false) > 0
++  return #api.nvim_get_runtime_file("parser/" .. lang .. ".dylib", false) > 0
+ end
+ 
+ local function needs_update(lang)
+@@ -244,7 +244,7 @@ local function run_install(cache_folder, install_folder, lang, repo, with_sync,
+     local repo_location = string.gsub(repo.location or project_name, "/", path_sep)
+     compile_location = cache_folder .. path_sep .. repo_location
+   end
+-  local parser_lib_name = install_folder .. path_sep .. lang .. ".so"
++  local parser_lib_name = install_folder .. path_sep .. lang .. ".dylib"
+ 
+   generate_from_grammar = repo.requires_generate_from_grammar or generate_from_grammar
+ 
+@@ -485,7 +485,7 @@ function M.uninstall(...)
+         return api.nvim_err_writeln(err)
+       end
+ 
+-      local parser_lib = install_dir .. path_sep .. lang .. ".so"
++      local parser_lib = install_dir .. path_sep .. lang .. ".dylib"
+ 
+       local command_list = {
+         shell.select_rm_file_cmd(parser_lib, "Uninstalling parser for " .. lang),


### PR DESCRIPTION
On macOS shared library extension is .dylib, but upstream assumes .so
extension, so when users install nvim-treesitter.withPlugins which
already includes compiled parsers, nvim-treesitter looks for .so
files, and fails to find them on macOS resulting in compiling them
again in $HOME/.local/share/nvim/site/parser with .so extension.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
