### PR TITLE
vscode-extensions.ms-python.python: add support for darwin platforms

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5571,6 +5571,16 @@
     githubId = 143075;
     name = "James Felix Black";
   };
+  jfchevrette = {
+    email = "jfchevrette@gmail.com";
+    github = "jfchevrette";
+    githubId = 3001;
+    name = "Jean-Francois Chevrette";
+    keys = [{
+      longkeyid = "rsa4096/0x67A0585801290DC6";
+      fingerprint = "B612 96A9 498E EECD D5E9  C0F0 67A0 5858 0129 0DC6";
+    }];
+  };
   jflanglois = {
     email = "yourstruly@julienlanglois.me";
     github = "jflanglois";

--- a/pkgs/misc/vscode-extensions/python/default.nix
+++ b/pkgs/misc/vscode-extensions/python/default.nix
@@ -72,13 +72,15 @@ in vscode-utils.buildVscodeMarketplaceExtension rec {
     icu
     curl
     openssl
+  ] ++ lib.optionals stdenv.isLinux [
     lttng-ust-2-10
     musl
   ];
 
   nativeBuildInputs = [
-    autoPatchelfHook
     python3.pkgs.wrapPython
+  ] ++ lib.optionals stdenv.isLinux [
+    autoPatchelfHook
   ];
 
   pythonPath = with python3.pkgs; [
@@ -101,6 +103,8 @@ in vscode-utils.buildVscodeMarketplaceExtension rec {
       cd pythonFiles/lib/python/debugpy/_vendored/pydevd/pydevd_attach_to_process
       declare kept_aside="${{
         "x86_64-linux" = "attach_linux_amd64.so";
+        "aarch64-darwin" = "attach_x86_64.dylib";
+        "x86_64-darwin" = "attach_x86_64.dylib";
       }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}")}"
       mv "$kept_aside" "$kept_aside.hidden"
       rm *.so *.dylib *.dll *.exe *.pdb
@@ -118,7 +122,7 @@ in vscode-utils.buildVscodeMarketplaceExtension rec {
 
   meta = with lib; {
     license = licenses.mit;
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "aarch64-darwin" "x86_64-darwin" ];
     maintainers = [ maintainers.jraygauthier ];
   };
 }

--- a/pkgs/misc/vscode-extensions/python/default.nix
+++ b/pkgs/misc/vscode-extensions/python/default.nix
@@ -123,6 +123,6 @@ in vscode-utils.buildVscodeMarketplaceExtension rec {
   meta = with lib; {
     license = licenses.mit;
     platforms = [ "x86_64-linux" "aarch64-darwin" "x86_64-darwin" ];
-    maintainers = [ maintainers.jraygauthier ];
+    maintainers = with maintainers; [ jraygauthier jfchevrette ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Add darwin platform support for VSCode extension ms-python.python

LTTng is not available on darwin and the extension does not support it on darwin

I tested that my changes did not impact the existing x86_64-linux platform support

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
