### PR TITLE
xiphos: 4.1.0 -> 4.2.1

### DIFF
--- a/pkgs/applications/misc/xiphos/default.nix
+++ b/pkgs/applications/misc/xiphos/default.nix
@@ -1,43 +1,70 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config
+{ lib, stdenv, fetchFromGitHub, fetchpatch, pkg-config
 , python
 , intltool
 , docbook2x, docbook_xml_dtd_412, libxslt
 , sword, clucene_core, biblesync
 , gnome-doc-utils
 , libgsf, gconf
-, gtkhtml, libglade, scrollkeeper
+, libglade, scrollkeeper
 , webkitgtk
 , dbus-glib, enchant, isocodes, libuuid, icu
+, cmake, itstool, desktop-file-utils, appstream-glib, yelp-tools
+, zip, minizip, pcre, libselinux, xorg, libsepol, libthai, libdatrie
+, libxkbcommon, libepoxy, at-spi2-core, libsysprof-capture, sqlite
+, libpsl, brotli, gtk2, glib, dbus, gtkhtml
 , wrapGAppsHook
-, wafHook
 }:
 
 stdenv.mkDerivation rec {
   pname = "xiphos";
-  version = "4.1.0";
+  version = "4.2.1";
 
   src = fetchFromGitHub {
     owner = "crosswire";
     repo = "xiphos";
     rev = version;
-    sha256 = "14il9k4i58qbc78hcadw3gqy21sb9q661d75vlj6fwpczbzj7x1a";
+    hash = "sha256-H5Q+azE2t3fgu77C9DxrkeUCJ7iJz3Cc91Ln4dqLvD8=";
   };
 
-  nativeBuildInputs = [ pkg-config wrapGAppsHook wafHook ];
-  buildInputs = [ python intltool docbook2x docbook_xml_dtd_412 libxslt
-                  sword clucene_core biblesync gnome-doc-utils libgsf gconf gtkhtml
-                  libglade scrollkeeper webkitgtk dbus-glib enchant isocodes libuuid icu ];
+  nativeBuildInputs = [ pkg-config  wrapGAppsHook cmake itstool
+    appstream-glib # for appstream-util
+    desktop-file-utils # for desktop-file-validate
+    yelp-tools # for yelp-build
+  ];
 
-  prePatch = ''
-    patchShebangs .;
-  '';
+  buildInputs = [
+    python intltool docbook2x docbook_xml_dtd_412 libxslt
+    sword clucene_core biblesync gnome-doc-utils libgsf gconf
+    libglade scrollkeeper webkitgtk dbus-glib enchant isocodes libuuid icu
+    zip minizip pcre xorg.libXdmcp libselinux libsepol libthai libdatrie
+    libxkbcommon libepoxy at-spi2-core libsysprof-capture xorg.libXtst
+    sqlite libpsl brotli gtk2 glib dbus dbus-glib gtkhtml
+  ];
+
+  cmakeFlags = [
+    "-DDBUS=OFF"
+    "-DGTKHTML=ON"
+  ];
 
   preConfigure =  ''
+    # The build script won't continue without the version saved locally.
+    echo "${version}" > cmake/source_version.txt
+
     export CLUCENE_HOME=${clucene_core};
     export SWORD_HOME=${sword};
   '';
 
-  wafConfigureFlags = [ "--enable-webkit2" ];
+  patchFlags = [ "-p0" ];
+
+  patches = [
+    # GLIB_VERSION_MIN_REQUIRED is not defined.
+    # https://github.com/crosswire/xiphos/issues/1083#issuecomment-820304874
+    (fetchpatch {
+      name ="xiphos-glibc.patch";
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/xiphos-glibc.patch?h=xiphos";
+      sha256 = "sha256-0WadztJKXW2adqsDP8iSAYVShbdqHoDvP+aVJC0cQB0=";
+    })
+  ];
 
   meta = with lib; {
     description = "A GTK Bible study tool";

--- a/pkgs/desktops/gnome-2/default.nix
+++ b/pkgs/desktops/gnome-2/default.nix
@@ -49,7 +49,7 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   gtkhtml = callPackage ./platform/gtkhtml { enchant = pkgs.enchant1; };
 
-  gtkhtml4 = callPackage ./platform/gtkhtml/4.x.nix { enchant = pkgs.enchant1; };
+  gtkhtml4 = callPackage ./platform/gtkhtml/4.x.nix { enchant = pkgs.enchant2; };
 
   gtkglext = callPackage ./platform/gtkglext { };
 

--- a/pkgs/desktops/gnome-2/platform/gtkhtml/4.x.nix
+++ b/pkgs/desktops/gnome-2/platform/gtkhtml/4.x.nix
@@ -1,16 +1,30 @@
-{ stdenv, fetchurl, pkg-config, gtk3, intltool
+{ stdenv, fetchFromGitLab, pkg-config, gtk3, intltool, autoreconfHook, fetchpatch
 , GConf, enchant, isocodes, gnome-icon-theme, gsettings-desktop-schemas }:
 
 stdenv.mkDerivation rec {
   version = "4.10.0";
   pname = "gtkhtml";
 
-  src = fetchurl {
-    url = "mirror://gnome/sources/gtkhtml/4.10/${pname}-${version}.tar.xz";
-    sha256 = "1hq6asgb5n9q3ryx2vngr4jyi8lg65lzpnlgrgcwayiczcj68fya";
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "Archive";
+    repo = "gtkhtml";
+    rev = "master";
+    sha256 = "sha256-jL8YADvhW0o6I/2Uo5FNARMAnSbvtmFp+zWH1yCVvQk=";
   };
-
   propagatedBuildInputs = [ gsettings-desktop-schemas gtk3 gnome-icon-theme GConf ];
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ intltool enchant isocodes ];
+  buildInputs = [ intltool enchant isocodes autoreconfHook ];
+
+  patchFlags = [ "-p0" ];
+
+  patches = [
+    # Enables enchant2 support.
+    # Upstream is dead, no further releases are coming.
+    (fetchpatch {
+      name ="enchant-2.patch";
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/enchant-2.patch?h=gtkhtml4&id=0218303a63d64c04d6483a6fe9bb55063fcfaa43";
+      sha256 = "sha256-jkA/GgIiJZmxkbcBGQ26OZ1nuI502BMPwbPhsZkbgbY=";
+    })
+  ];
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29680,7 +29680,7 @@ with pkgs;
     inherit (gnome2) libglade scrollkeeper;
     gtkhtml = gnome2.gtkhtml4;
     python = python27;
-    enchant = enchant1;
+    enchant = enchant2;
   };
 
   xournal = callPackage ../applications/graphics/xournal {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updated xiphos to the latest version. And got rid of the enchant1 dependency.
This helps complete this checklist: https://github.com/NixOS/nixpkgs/issues/38506

Note: I had to patch gtkhtml to accept enchant2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
