### PR TITLE
cisco-packet-tracer: 8.0.1 -> 8.1.0

### DIFF
--- a/pkgs/applications/networking/cisco-packet-tracer/8.nix
+++ b/pkgs/applications/networking/cisco-packet-tracer/8.nix
@@ -27,7 +27,7 @@
 }:
 
 let
-  version = "8.0.1";
+  version = "8.1.0";
 
   ptFiles = stdenv.mkDerivation {
     name = "PacketTracer8Drv";
@@ -35,8 +35,8 @@ let
 
     dontUnpack = true;
     src = requireFile {
-      name = "CiscoPacketTracer_${builtins.replaceStrings ["."] [""] version}_Ubuntu_64bit.deb";
-      sha256 = "77a25351b016faed7c78959819c16c7013caa89c6b1872cb888cd96edd259140";
+      name = "Cisco_Packet_Tracer_${builtins.replaceStrings ["."] [""] version}_Ubuntu_64bit.deb";
+      sha256 = "1y5wqbr94mj76prjf3d1j7wrpycgk8wxv66ij4qw63ikgms11j3x";
       url = "https://www.netacad.com";
     };
 
@@ -72,6 +72,7 @@ let
       libXrandr
       libXrender
       libXScrnSaver
+      libXtst
       xcbutilimage
       xcbutilkeysyms
       xcbutilrenderutil


### PR DESCRIPTION
###### Motivation for this change

The debian package for 8.0.1 is not available on the given URL anymore. 

This PR updates to the newest version and adds the new dependency.

###### Things done

Only tested whether it launches.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

