### PR TITLE
sile: 0.12.0 → 0.12.1

### DIFF
--- a/pkgs/tools/typesetting/sile/default.nix
+++ b/pkgs/tools/typesetting/sile/default.nix
@@ -38,11 +38,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "sile";
-  version = "0.12.0";
+  version = "0.12.1";
 
   src = fetchurl {
     url = "https://github.com/sile-typesetter/sile/releases/download/v${version}/${pname}-${version}.tar.xz";
-    sha256 = "1rkdzf4khyvsn5qg455mdhnlacxlqgi9vchy369a66qp5nrs50y9";
+    sha256 = "1dw8qs5y2m90vhjsxpnvnr8blq0ld2fvny5ir8zjharja7wny24i";
   };
 
   configureFlags = [


### PR DESCRIPTION
Upstream release, no build system changes worth mentioning.