### PR TITLE
logiops: init at 0.2.3

### DIFF
--- a/pkgs/tools/system/logiops/default.nix
+++ b/pkgs/tools/system/logiops/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "An unofficial userspace driver for HID++ Logitech devices";
     homepage = "https://github.com/PixlOne/logiops";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ jonringer ];
   };
 }

--- a/pkgs/tools/system/logiops/default.nix
+++ b/pkgs/tools/system/logiops/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, fetchpatch
+, libconfig
+, libevdev
+, pkg-config
+, systemd
+
+# runtime dependency
+, util-linux
+}:
+
+stdenv.mkDerivation rec {
+  pname = "logiops";
+  version = "0.2.3";
+
+  src = fetchFromGitHub {
+    owner = "PixlOne";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1wgv6m1kkxl0hppy8vmcj1237mr26ckfkaqznj1n6cy82vrgdznn";
+  };
+
+  patches = [
+    # Allow for systemd service to be installed at a specified path
+    (fetchpatch {
+      url = "https://github.com/PixlOne/logiops/pull/290/commits/926dfbbcfbfb153e87e0b93cdd90a0c33f1b9ff0.patch";
+      sha256 = "sha256-F1wzK/ha3f3Ssj2HTZbH1s3uB1LeTasBt1Dghk250GY=";
+    })
+  ];
+
+  cmakeFlags = [
+    "-DSYSTEMD_SERVICES_INSTALL_DIR=${placeholder "out"}/share/systemd/system"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libconfig
+    libevdev
+    systemd # libudev
+  ];
+
+  postFixup = ''
+    sed -i -e 's|/bin/kill|${util-linux}/bin/kill|g' $out/share/systemd/system/*.service
+  '';
+
+  meta = with lib; {
+    description = "An unofficial userspace driver for HID++ Logitech devices";
+    homepage = "https://github.com/PixlOne/logiops";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23604,6 +23604,8 @@ with pkgs;
 
   lmodern = callPackage ../data/fonts/lmodern { };
 
+  logiops = callPackage ../tools/system/logiops { };
+
   logitech-udev-rules = callPackage ../os-specific/linux/logitech-udev-rules {};
 
   # lohit-fonts.assamese lohit-fonts.bengali lohit-fonts.devanagari lohit-fonts.gujarati lohit-fonts.gurmukhi


### PR DESCRIPTION
###### Motivation for this change
https://www.reddit.com/r/NixOS/comments/s2h9gg/cannot_install_logiops/

related pr: https://github.com/PixlOne/logiops/pull/290

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
